### PR TITLE
Fixed for Vowels

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -115,7 +115,7 @@ class LockPicker
   def attempt_open(box)
     waitrt?
     echo "attempt_open(#{box})" if UserVars.lockpick_debug
-    bput("get my #{box} from my #{@settings.picking_box_source}", 'You get a .* from inside your ')
+    bput("get my #{box} from my #{@settings.picking_box_source}", 'You get .* from inside your ')
 
     unless disarm?(box)
       bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in your ')

--- a/pick.lic
+++ b/pick.lic
@@ -210,7 +210,7 @@ class LockPicker
     return if checkleft
     waitrt?
 
-    case bput('get my lockpick', 'referring to\?', '^You get a ')
+    case bput('get my lockpick', 'referring to\?', '^You get ')
     when 'referring to?'
       echo 'OUT OF LOCKPICKS'
       beep


### PR DESCRIPTION
When getting an ordinary lockpick it will use "an" for the vowel. I think removing "a" would be the best option and doing the greedy regex from there.