### PR TITLE
Fix for lockpicks with Vowel names

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -210,7 +210,7 @@ class LockPicker
     return if checkleft
     waitrt?
 
-    case bput('get my lockpick', 'referring to\?', '^You get a ')
+    case bput('get my lockpick', 'referring to\?', '^You get ')
     when 'referring to?'
       echo 'OUT OF LOCKPICKS'
       beep


### PR DESCRIPTION
When getting an ordinary lockpick it will use an for the vowel(Ordinary, Iron, ect). I think removing a would be the best option.. Thanks for @rcuhljr for pointing out my mistake in the last pull request.