### PR TITLE
combat-trainer tells equipmanager about settings

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1024,6 +1024,7 @@ class CombatTrainer
 
     setup(settings)
     settings.storage_containers([]).each { |container| fput("open my #{container}") }
+    EquipmentManager.instance.refresh(settings)
     EquipmentManager.instance.wear_equipment_set?('standard')
   end
 

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -23,15 +23,15 @@ class EquipmentManager
 
   attr_accessor :items
 
-  def refresh
+  def refresh(settings=nil)
     echo('refresh') if UserVars.equipmanager_debug
     @items = nil
-    items
+    items(settings)
   end
 
-  def items
+  def items(settings=nil)
     return @items if @items
-    settings = get_settings
+    settings = settings || get_settings
     @gear_sets = settings.gear_sets({})
     @items = settings.gear([]).map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective]) }
   end

--- a/profiles/Mooselurk-back.yaml
+++ b/profiles/Mooselurk-back.yaml
@@ -14,13 +14,6 @@ buff_spells:
     recast_every: 1200
     mana: 35
 dance_skill: Polearms
-training_abilities:
-  Hunt:
-    :check: Perception
-    :cooldown: 80
-  Stealth:
-    :check: Stealth
-    :cooldown: 60
 weapon_training:
   Staves: moonstaff
   Heavy Thrown: war hammer

--- a/profiles/Mooselurk-back.yaml
+++ b/profiles/Mooselurk-back.yaml
@@ -1,15 +1,13 @@
 combat_trainer_target_increment: 10
 combat_trainer_action_count: 20
 offensive_spells:
+skinning:
+  skin: false
 buff_spells:
   Shadows:
     abbrev: shadows
     recast: 1
-    mana: 30
-  Refractive Field:
-    abbrev: rf
-    recast: 1
-    mana: 40
+    mana: 10
   Moonblade:
     abbrev: moonblade
     moon: true

--- a/profiles/Mooselurk-setup.yaml
+++ b/profiles/Mooselurk-setup.yaml
@@ -1,6 +1,9 @@
 ---
+training_manager_hunting_priority: true
+training_manager_priority_skills:
+- Plate Armor
 hunting_info:
-- :zone: rock_trolls
+- :zone: snowbeasts
   args:
     - d0
     - r5
@@ -63,7 +66,7 @@ gear:
   :is_worn: true
   :swappable: false
   :tie_to: 
-- :adjective: burlap
+- :adjective:
   :name: vest
   :is_leather: true
   :hinders_lockpicking: 

--- a/profiles/Mooselurk-setup.yaml
+++ b/profiles/Mooselurk-setup.yaml
@@ -4,6 +4,14 @@ hunting_info:
   args:
     - d0
     - r5
+    - stealth
+  stop_on:
+    - Stealth
+  :duration: 30
+- :zone: young_ogres
+  args:
+    - d0
+    - r5
     - back
   :duration: 30
 - :zone: young_ogres
@@ -20,6 +28,13 @@ gear:
   :is_worn: true
   :swappable: false
   :tie_to: 
+- :adjective: rugged
+  :name: gloves
+  :is_leather: true
+  :hinders_lockpicking: true
+  :is_worn: true
+  :swappable: false
+  :tie_to: 
 - :adjective: scale
   :name: greaves
   :is_leather: false
@@ -27,9 +42,23 @@ gear:
   :is_worn: true
   :swappable: false
   :tie_to: 
+- :adjective: rugged
+  :name: greaves
+  :is_leather: true
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+  :tie_to: 
 - :adjective: ring
   :name: balaclava
   :is_leather: false
+  :hinders_lockpicking: true
+  :is_worn: true
+  :swappable: false
+  :tie_to: 
+- :adjective: rugged
+  :name: cowl
+  :is_leather: true
   :hinders_lockpicking: true
   :is_worn: true
   :swappable: false

--- a/profiles/Mooselurk-stealth.yaml
+++ b/profiles/Mooselurk-stealth.yaml
@@ -4,6 +4,7 @@ gear_sets:
   - rugged gloves
   - rugged greaves
   - rugged cowl
+  - storm-bull buckler
   naked: []
 offensive_spells:
 skinning:
@@ -14,12 +15,6 @@ buff_spells:
     recast: 1
     mana: 20
 dance_skill: Polearms
-stances:
-  Polearms:
-  - evasion
-  - parry
-  Slings:
-  - evasion
 training_abilities:
   Stealth:
     :check: Stealth

--- a/profiles/Mooselurk-stealth.yaml
+++ b/profiles/Mooselurk-stealth.yaml
@@ -1,0 +1,29 @@
+gear_sets:
+  standard:
+  - burlap vest
+  - rugged gloves
+  - rugged greaves
+  - rugged cowl
+  naked: []
+offensive_spells:
+skinning:
+  skin: false
+buff_spells:
+  Shadows:
+    abbrev: shadows
+    recast: 1
+    mana: 20
+dance_skill: Polearms
+stances:
+  Polearms:
+  - evasion
+  - parry
+  Slings:
+  - evasion
+training_abilities:
+  Stealth:
+    :check: Stealth
+    :cooldown: 60
+weapon_training:
+  Polearms: spear
+  Slings: a sling


### PR DESCRIPTION
This lets the equipment manager get access to settings from secondary yaml files loaded for hunting.

I've run it for a bit and things seem fine.