### PR TITLE
Use gem pouch adjective when checking for gems

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -22,7 +22,7 @@ class SellLoot
     settings = get_settings
     keep_amount, keep_type = parse(settings.sell_loot_money_on_hand(nil).split(' '))
 
-    sell_gems('pouch') if settings.sell_loot_pouch(true)
+    sell_gems("#{settings.gem_pouch_adjective} pouch") if settings.sell_loot_pouch(true)
 
     check_spare_pouch(settings.spare_gem_pouch_container, settings.gem_pouch_adjective) if settings.spare_gem_pouch_container
 


### PR DESCRIPTION
Using 'pouch' conflicts with other worn pouches