### PR TITLE
Create common-items

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -7,10 +7,11 @@
   You can turn on debug mode by passing 'debug' as an argument with ;combat-trainer debug
 =end
 
-custom_require.call(%w(common common-summoning common-travel drinfomon equipmanager events spellmonitor))
+custom_require.call(%w(common common-items common-summoning common-travel drinfomon equipmanager events spellmonitor))
 
 class SetupProcess
   include DRC
+  include DRCI
   include DRCS
   include DRCT
 

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -91,10 +91,4 @@ module DRCC
       end
     end
   end
-
-  def dispose(item, trash_room = nil)
-    DRCT.walk_to(trash_room) unless trash_room.nil?
-    DRC.bput("get my #{item}", 'You get')
-    DRC.dispose_trash(item.to_s)
-  end
 end

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -92,12 +92,6 @@ module DRCC
     end
   end
 
-  def order_item(room, item_number)
-    DRCT.walk_to(room)
-    fput("order #{item_number}")
-    fput("order #{item_number}")
-  end
-
   def dispose(item, trash_room = nil)
     DRCT.walk_to(trash_room) unless trash_room.nil?
     DRC.bput("get my #{item}", 'You get')

--- a/common-items.lic
+++ b/common-items.lic
@@ -18,8 +18,15 @@ module DRCI
       amount = Regexp.last_match(1)
     when /for a mere (.*) kronars/
       amount = Regexp.last_match(1)
-  end
+    end
 
     fput("offer #{amount}") if amount
+  end
+
+  def order_item(room, item_number)
+    DRCT.walk_to(room)
+
+    fput("order #{item_number}")
+    fput("order #{item_number}")
   end
 end

--- a/common-items.lic
+++ b/common-items.lic
@@ -1,0 +1,25 @@
+# quiet
+=begin
+  Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#common-items
+=end
+
+custom_require.call(%w(common common-travel))
+
+module DRCI
+  module_function
+
+  def buy_item(room, item)
+    DRCT.walk_to(room)
+
+    case DRC.bput("buy #{item}", /prepared to offer it to you for (.*) kronars/, /Let me but ask the humble sum of (.*) coins/, /for a mere (.*) kronars/, 'You decide to purchase')
+    when /prepared to offer it to you for (.*) kronars/
+      amount = Regexp.last_match(1)
+    when /Let me but ask the humble sum of (.*) coins/
+      amount = Regexp.last_match(1)
+    when /for a mere (.*) kronars/
+      amount = Regexp.last_match(1)
+  end
+
+    fput("offer #{amount}") if amount
+  end
+end

--- a/common-items.lic
+++ b/common-items.lic
@@ -33,6 +33,23 @@ module DRCI
   def dispose(item, trash_room = nil)
     DRCT.walk_to(trash_room) unless trash_room.nil?
     DRC.bput("get my #{item}", 'You get')
-    DRC.dispose_trash(item.to_s)
+    dispose_trash(item)
+  end
+
+  def dispose_trash(item)
+    return if item.nil?
+    trashcan = DRRoom.room_objs
+                     .map { |long_name| get_noun(long_name) }
+                     .find { |obj| $TRASH_STORAGE.include?(obj) }
+    if trashcan == 'gloop'
+      trashcan = 'bucket' if DRRoom.room_objs.include? 'bucket of viscous gloop'
+      trashcan = 'cauldron' if DRRoom.room_objs.include? 'small bubbling cauldron of viscous gloop'
+    end
+
+    if trashcan
+      DRC.bput("put my #{item} in #{trashcan}", '^You drop', '^You put')
+    else
+      fput "drop my #{item}"
+    end
   end
 end

--- a/common-items.lic
+++ b/common-items.lic
@@ -29,4 +29,10 @@ module DRCI
     fput("order #{item_number}")
     fput("order #{item_number}")
   end
+
+  def dispose(item, trash_room = nil)
+    DRCT.walk_to(trash_room) unless trash_room.nil?
+    DRC.bput("get my #{item}", 'You get')
+    DRC.dispose_trash(item.to_s)
+  end
 end

--- a/common.lic
+++ b/common.lic
@@ -187,23 +187,6 @@ module DRC
     end
   end
 
-  def dispose_trash(item)
-    return if item.nil?
-    trashcan = DRRoom.room_objs
-                     .map { |long_name| get_noun(long_name) }
-                     .find { |obj| $TRASH_STORAGE.include?(obj) }
-    if trashcan == 'gloop'
-      trashcan = 'bucket' if DRRoom.room_objs.include? 'bucket of viscous gloop'
-      trashcan = 'cauldron' if DRRoom.room_objs.include? 'small bubbling cauldron of viscous gloop'
-    end
-
-    if trashcan
-      bput("put my #{item} in #{trashcan}", '^You drop', '^You put')
-    else
-      fput "drop my #{item}"
-    end
-  end
-
   def stow_hands
     pause 1
     bput('stow right', 'You put') if checkright

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -6,11 +6,12 @@
   You can turn on debug mode with ;e UserVars.crossing_trainer_debug = true
 =end
 
-custom_require.call(%w(drinfomon equipmanager events spellmonitor common common-crafting common-money common-travel common-summoning))
+custom_require.call(%w(drinfomon equipmanager events spellmonitor common common-crafting common-items common-money common-travel common-summoning))
 
 class CrossingTraining
   include DRC
   include DRCC
+  include DRCI
   include DRCM
   include DRCS
   include DRCT

--- a/makesteel.lic
+++ b/makesteel.lic
@@ -1,13 +1,13 @@
 
 
-custom_require.call(%w(common common-crafting common-money drinfomon))
+custom_require.call(%w(common common-crafting common-items common-money drinfomon))
 
 count = variable.last.to_i
 
 DRCM.ensure_copper_on_hand(2000 * count)
 
 def order_stow(num)
-  DRCC.order_item(8775, num)
+  DRCI.order_item(8775, num)
   fput('stow nugget')
 end
 

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -2,11 +2,11 @@
   Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#mining-buddy
 =end
 
-custom_require.call(%w(common common-crafting common-money common-travel drinfomon))
+custom_require.call(%w(common common-items common-money common-travel drinfomon))
 
 class MiningBuddy
   include DRC
-  include DRCC
+  include DRCI
   include DRCM
   include DRCT
 

--- a/pick.lic
+++ b/pick.lic
@@ -2,10 +2,11 @@
   Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#pick
 =end
 
-custom_require.call(%w(common common-money common-travel drinfomon equipmanager events spellmonitor))
+custom_require.call(%w(common common-items common-money common-travel drinfomon equipmanager events spellmonitor))
 
 class LockPicker
   include DRC
+  include DRCI
   include DRCM
   include DRCT
 
@@ -132,18 +133,11 @@ class LockPicker
 
   def buy_lockpicks(type, count)
     echo "buying #{count} lockpicks" if UserVars.lockpick_debug
-    walk_to 19_125
 
-    count.to_i.times do
-      buy_lockpick(type)
+    count.times do
+      buy_item(19_125, "#{type} lockpick")
+      fput('put my lockpick on my lockpick ring')
     end
-  end
-
-  def buy_lockpick(type)
-    response = bput("buy #{type} lockpick", /prepared to offer it to you for (?<amount>.*) kronars/)
-    /prepared to offer it to you for (?<amount>.*) kronars/ =~ response
-    fput("offer #{amount}")
-    fput('put my lockpick on my lockpick ring')
   end
 
   def attempt_open(box)

--- a/sew.lic
+++ b/sew.lic
@@ -2,11 +2,12 @@
   Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#sew
 =end
 
-custom_require.call(%w(common common-crafting common-money common-travel))
+custom_require.call(%w(common common-crafting common-items common-money common-travel))
 
 class Sew
   include DRC
   include DRCC
+  include DRCI
   include DRCM
   include DRCT
 

--- a/smith.lic
+++ b/smith.lic
@@ -3,11 +3,12 @@
   Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#smith
 =end
 
-custom_require.call(%w(common common-crafting common-money common-travel drinfomon))
+custom_require.call(%w(common common-crafting common-items common-money common-travel drinfomon))
 
 class Smith
   include DRC
   include DRCC
+  include DRCI
   include DRCM
   include DRCT
 
@@ -57,10 +58,9 @@ class Smith
 
   def buy_parts(parts, discipline)
     ensure_copper_on_hand(700)
-    walk_to(discipline['part-room'])
 
     parts.each do |part|
-      fput("buy #{part}")
+      buy_item(discipline['part-room'], part)
       bput("stow #{part}", 'You put')
     end
   end

--- a/spin.lic
+++ b/spin.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#spin
 =end
 
-custom_require.call(%w(common common-crafting common-money common-travel))
+custom_require.call(%w(common common-items common-money common-travel))
 
 arg_definitions = [
   [
@@ -22,7 +22,7 @@ data = mat_data[args.material]
 DRCM.ensure_copper_on_hand(data[:cost] * data[:count])
 
 data[:count].times do
-  DRCC.order_item(16_667, data[:index])
+  DRCI.order_item(16_667, data[:index])
   fput('combine fiber with fiber')
 end
 

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -4,7 +4,7 @@
 
 $settings = get_settings
 
-custom_require.call(%w(common common-travel common-money drinfomon))
+custom_require.call(%w(common common-items common-money common-travel drinfomon))
 
 def comm_eluned
   fput "stow #{GameObj.right_hand.noun}" if GameObj.right_hand.name != 'Empty'
@@ -28,26 +28,17 @@ def comm_tasmine
 end
 
 def buy_incense
-  DRCT.walk_to '19073'
-  fput 'order incense'
-  fput 'offer 60'
-  fput 'offer 60'
+  DRCI.buy_item(19_073, 'incense')
   fput "put incense in my #{$settings.theurgy_supply_container}"
 end
 
 def buy_flint
-  DRCT.walk_to '8265'
-  fput 'order flint'
-  fput 'offer 140'
-  fput 'offer 140'
+  DRCI.buy_item(8265, 'flint')
   fput "put flint in my #{$settings.theurgy_supply_container}"
 end
 
 def buy_wine
-  DRCT.walk_to '19073'
-  fput 'order wine'
-  fput 'offer 240'
-  fput 'offer 240'
+  DRCI.buy_item(19_073, 'wine')
   fput "put wine in my #{$settings.theurgy_supply_container}"
 end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -3,11 +3,12 @@
   Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#workorders
 =end
 
-custom_require.call(%w(common common-crafting common-money common-travel drinfomon))
+custom_require.call(%w(common common-crafting common-items common-money common-travel drinfomon))
 
 class WorkOrders
   include DRC
   include DRCC
+  include DRCI
   include DRCM
   include DRCT
 


### PR DESCRIPTION
My goal here is to find repeated logic and implement some helpers. I want us to be able to write scripts at a higher level of abstraction instead of reinventing the wheel.

I noticed a bunch of item related logic (ordering and buying) and cleaned up some of it previously, but it meant that scripts like `mining-buddy` were including `common-crafting`, which seems a bit odd.

That item logic really isn't crafting-specific, so I'm going to pull a few methods out of common and common-crafting.