### PR TITLE
Added regexs for Fallen Barb

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -86,6 +86,12 @@ spellAction = proc do |server_string|
   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Fading\)}
     DRSpells.active_spells[Regexp.last_match(1)] = 0
     DRSpells.refresh_data[Regexp.last_match(1)] = true
+  elsif server_string =~ %r{<pushStream id="percWindow"/> (.*) \((\d+) roisaen\)}
+    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2)
+    DRSpells.refresh_data[Regexp.last_match(1)] = true
+  elsif server_string =~ %r{<popStream/><pushStream id="percWindow"/> (.+) \((\d+) roisaen\)}
+    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2)
+    DRSpells.refresh_data[Regexp.last_match(1)] = true
   end
 
   server_string


### PR DESCRIPTION
I'm not sure if it's because he's a barbarian, or because of the Fallen, but the XML sent across for my Barbarian in the Fallen is a different format than the regex here.

Here's the raw XML sent:

```
<clearStream id="percWindow"/>
<pushStream id="percWindow"/> Panther (65 roisaen)
<popStream/><pushStream id="percWindow"/> Turtle (65 roisaen)
<popStream/><pushStream id="percWindow"/> Monkey (65 roisaen)
<popStream/><pushStream id="percWindow"/> Piranha (65 roisaen)
<popStream/><prompt time="1470622380">&gt;</prompt>
```

It wouldn't surprise me if the XML sent doesn't match Prime, sometimes they forget to move changes over here. Does spellmonitor work in prime for barb abilities?