### PR TITLE
Use more descriptive names for built-in lich functions

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -13,7 +13,7 @@ loop do
   line = script.gets?
   pause 0.05 unless line
   fput(%w(tdp time age).sample) if line =~ /you have been idle too long/i
-  if checkdead
+  if dead?
     echo '*' * 30
     echo 'Afk - detected death departing in 3 minutes'
     echo '*' * 30

--- a/afk.lic
+++ b/afk.lic
@@ -29,7 +29,7 @@ loop do
     fput('depart item')
     echo "Exiting at #{Time.now}"
     fput('exit')
-  elsif checkhealth < 50
+  elsif health < 50
     echo 'Afk - detected low health'
     fput('health')
     pause 1

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -642,7 +642,7 @@ class SpellProcess
 
   def check_buffs(game_state)
     return if game_state.casting
-    return if checkmana < 40
+    return if mana < 40
 
     recastable_buffs = @buff_spells
                        .select { |_, data| data['recast'] || data['recast_every'] || data['expire'] }
@@ -676,7 +676,7 @@ class SpellProcess
   def check_offensive(game_state)
     return if game_state.casting
     return if game_state.npcs.empty?
-    return if checkmana < 40
+    return if mana < 40
     ready_spells = @offensive_spells
                    .select { |spell| spell['expire'] ? Flags["ct-#{spell['abbrev']}"] : true }
                    .select { |spell| game_state.dancing? ? spell['harmless'] : true }
@@ -689,7 +689,7 @@ class SpellProcess
              @offensive_spell_cycle.rotate!
              ready_spells.find { |spell| spell['name'] == name }
            end
-    return if DRSkill.getxp(data['skill']) >= 34 && checkmana < 70 # make this a spell option
+    return if DRSkill.getxp(data['skill']) >= 34 && mana < 70 # make this a spell option
     prepare_spell(data, game_state)
     Flags.reset('ct-spelllost')
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -391,7 +391,7 @@ class SafetyProcess
   end
 
   def execute(game_state)
-    custom_require.call('tendme') if checkbleeding && !Script.running?('tendme')
+    custom_require.call('tendme') if bleeding? && !Script.running?('tendme')
     fix_standing
     tend_lodged
     game_state.danger = in_danger?(game_state.danger)
@@ -1389,7 +1389,7 @@ class GameState
   def next_clean_up_step
     case @clean_up_step
     when nil
-      @clean_up_step = if @stop_on_bleeding && checkbleeding
+      @clean_up_step = if @stop_on_bleeding && bleeding?
                          'clear_magic'
                        else
                          'kill'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -413,14 +413,14 @@ class SafetyProcess
   end
 
   def in_danger?(danger)
-    return false if checkhealth >= 75
+    return false if health >= 75
 
     unless danger
       Flags.reset('ct-engaged')
       retreat
     end
 
-    fput 'exit' if checkhealth < 40
+    fput 'exit' if health < 40
 
     keep_away
     true
@@ -666,7 +666,7 @@ class SpellProcess
   def check_health(game_state)
     return if game_state.casting
     return unless @is_empath
-    return if checkhealth > 91
+    return if health > 91
 
     echo('Healing') if $debug_mode_ct
     data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1] }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1028,7 +1028,7 @@ class AttackProcess
       end
 
       command = game_state.offhand? ? 'attack left' : 'attack'
-      if (game_state.backstab? || game_state.ambush?) && checkhidden
+      if (game_state.backstab? || game_state.ambush?) && hiding?
         if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
           command += ' back'
         else

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -27,7 +27,7 @@ module DRCA
   def activate_khri?(kneel, preps, ability)
     return false if DRSpells.active_spells[ability]
     DRCT.retreat if kneel
-    DRC.bput('kneel', 'You kneel', 'You are already', 'You rise') if kneel && !checkkneeling
+    DRC.bput('kneel', 'You kneel', 'You are already', 'You rise') if kneel && !kneeling?
     result = DRC.bput(ability, preps)
     waitrt?
     DRC.fix_standing

--- a/common.lic
+++ b/common.lic
@@ -185,7 +185,7 @@ module DRC
 
   def fix_standing
     loop do
-      break if checkstanding
+      break if standing?
       bput('stand', 'You stand', 'You are so unbalanced', 'As you stand', 'You are already', 'weight of all your possessions', 'You are overburdened and cannot')
     end
   end

--- a/common.lic
+++ b/common.lic
@@ -235,7 +235,7 @@ module DRC
   end
 
   def hide?
-    unless checkhidden
+    unless hiding?
       case bput('hide', 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself')
       when 'too busy performing'
         bput('stop play', 'You stop playing', 'In the name of')
@@ -244,6 +244,6 @@ module DRC
       pause
       waitrt?
     end
-    checkhidden
+    hiding?
   end
 end

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -294,7 +294,7 @@ class CrossingTraining
 
   def train_magic(skill)
     if @settings.train_with_spells(true)
-      return if checkmana < 40
+      return if mana < 40
       @use_research && @settings.research_skills([]).include?(skill) ? do_research(skill) : cast_spell(@settings.training_spells({})[skill], skill)
     else
       cast_nonspell(skill)

--- a/healme.lic
+++ b/healme.lic
@@ -69,7 +69,7 @@ class HealMe
   def spam_heal(base, camb)
     Flags.add('hm-heal-done', 'Your body is completely healed')
     until Flags['hm-heal-done']
-      pause 1 while checkmana < 25
+      pause 1 while mana < 25
       Flags.reset('hm-spellcast')
       bput("prepare heal #{base}", @settings.prep_messages)
       charge_and_invoke(@settings, camb) unless camb.empty?
@@ -80,7 +80,7 @@ class HealMe
   end
 
   def cast_spell(spell, preps, part, internal = false)
-    pause 1 while checkmana < 25
+    pause 1 while mana < 25
     Flags.reset('hm-spellcast')
     bput("prepare #{spell} #{preps.first}", @settings.prep_messages)
     charge_and_invoke(@settings, preps[1..-1]) unless preps[1..-1].empty?

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -84,7 +84,7 @@ class HuntingBuddy
     pause 1 until $COMBAT_TRAINER.running
     counter = 0
     loop do
-      if @settings.stop_hunting_if_bleeding && checkbleeding
+      if @settings.stop_hunting_if_bleeding && bleeding?
         echo('***STATUS*** stopping due to bleeding')
         @stopped_for_bleeding = true
         break

--- a/mine.lic
+++ b/mine.lic
@@ -47,7 +47,7 @@ class Mine
     fput('exit') if Flags['mine-exit']
     fix_standing
 
-    if checkbleeding
+    if bleeding?
       snapshot = Room.current.id
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -85,7 +85,7 @@ class MiningBuddy
 
   def mine_rooms(rooms)
     rooms.each do |room|
-      wait_for_script_to_complete('safe-room') if checkbleeding
+      wait_for_script_to_complete('safe-room') if bleeding?
       check_repair if mine?(room)
     end
   end

--- a/pick.lic
+++ b/pick.lic
@@ -305,7 +305,7 @@ class LockPicker
       beep
       echo('**SPRUNG TRAP**')
 
-      pause 0.5 while checkstunned
+      pause 0.5 while stunned?
       if checkbleeding
         snapshot = Room.current.id
         wait_for_script_to_complete('safe-room')

--- a/pick.lic
+++ b/pick.lic
@@ -306,7 +306,7 @@ class LockPicker
       echo('**SPRUNG TRAP**')
 
       pause 0.5 while stunned?
-      if checkbleeding
+      if bleeding?
         snapshot = Room.current.id
         wait_for_script_to_complete('safe-room')
         walk_to(snapshot)

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -58,7 +58,7 @@ class SafeRoom
   end
 
   def lie_down
-    bput('lie', 'You lie') if checkstanding
+    bput('lie', 'You lie') if standing?
   end
 
   def use_pc_empath?(room_id, empath)

--- a/status-monitor.lic
+++ b/status-monitor.lic
@@ -157,7 +157,7 @@ class GameFilter
 end
 
 def update_health_bar(entry)
-  hp = checkhealth
+  hp = health
   if hp >= 75
     entry.modify_base(Gtk::STATE_NORMAL, Gdk::Color.parse('green'))
   else
@@ -231,8 +231,8 @@ begin
   loop do
     line = script.gets?
     back = line.dup if args.debug
-    if prev_health != checkhealth
-      prev_health = checkhealth
+    if prev_health != health
+      prev_health = health
       Gtk.queue { update_health_bar(healthbar_et) }
     end
     if filter.unseen?(filter.clean(line))

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -45,7 +45,7 @@ module Harness
     $displayed_messages ||= []
   end
 
-  def checkdead
+  def dead?
     $dead || false
   end
 

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -49,7 +49,7 @@ module Harness
     $dead || false
   end
 
-  def checkhealth
+  def health
     $health || 100
   end
 


### PR DESCRIPTION
Lich offers quite a few aliases for its built-in functions. I think many are more descriptive than the original names we've been using.

I changed the ones I'm confident in. There are a few other options which I am undecided on (feedback welcome!):
* `checkmana` -> `mana`
* `checkhealth` -> `health`
* `checkname` -> `myname?`
* `checkright` -> `righthand`
* `checkleft` -> `lefthand`