### PR TITLE
Account for stowing braided vines/grass/ropes

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -40,7 +40,7 @@ module DRCI
   def dispose_trash(item)
     return if item.nil?
     trashcans = DRRoom.room_objs
-                      .map { |long_name| get_noun(long_name) }
+                      .map { |long_name| DRC.get_noun(long_name) }
                       .select { |obj| $TRASH_STORAGE.include?(obj) }
 
     trashcans.each do |trashcan|

--- a/common.lic
+++ b/common.lic
@@ -192,8 +192,14 @@ module DRC
 
   def stow_hands
     pause 1
-    bput('stow right', 'You put') if checkright
-    bput('stow left', 'You put') if checkleft
+    stow_hand('right') if checkright
+    stow_hand('left') if checkleft
+  end
+
+  def stow_hand(hand)
+    braid_regex = /The braided (.+) is too long/
+    result = bput("stow #{hand}", 'You put', braid_regex)
+    DRCI.dispose_trash(DRC.get_noun(Regexp.last_match(1))) if braid_regex.match(result)
   end
 
   def bind_wound(part, person = 'my')


### PR DESCRIPTION
When you try to stow a braided item, you get a message like this:

The braided vines is too long
The braided heavy rope is too long

Which hung the stow_hands method. So I added conditions to bput to catch that, and then dispose of the braided thing.

I'm not sold on the implementation, so if you don't like it, I can convert this to an issue.