### PR TITLE
Match for non-melee range during ambush stun

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -902,7 +902,7 @@ class TrainerProcess
     EquipmentManager.instance.wield_weapon(game_state.ambush_stun_weapon, 'Small Blunt')
 
     if hide?
-      bput('ambush stun', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime')
+      bput('ambush stun','You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime')
       pause
       waitrt?
     end


### PR DESCRIPTION
I added [ 'You aren\'t close enough to attack',] on line 905 to account for the rare instance that I am out of range when using ambush stun (due to use of 'shove' in dance routine).