### PR TITLE
Match on not-hidden during ambush stun

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -902,7 +902,7 @@ class TrainerProcess
     EquipmentManager.instance.wield_weapon(game_state.ambush_stun_weapon, 'Small Blunt')
 
     if hide?
-      bput('ambush stun', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime')
+      bput('ambush stun', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime')
       pause
       waitrt?
     end


### PR DESCRIPTION
Added [, 'You must be hidden or invisible to ambush'] to line 905 to account for not being hidden on ambush stun due to critter perception