### PR TITLE
combat-trainer (Offensive Spells - specific targeting)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -734,6 +734,7 @@ class SpellProcess
     return if game_state.npcs.empty?
     return if mana < 40
     ready_spells = @offensive_spells
+                   .select { |spell| spell['target_enemy'] ? DRRoom.npcs.include?(spell['target_enemy']) : true }
                    .select { |spell| spell['min_threshold'] ? game_state.npcs.length >= spell['min_threshold'] : true }
                    .select { |spell| spell['max_threshold'] ? game_state.npcs.length <= spell['max_threshold'] : true }
                    .select { |spell| spell['expire'] ? Flags["ct-#{spell['abbrev']}"] : true }
@@ -761,6 +762,10 @@ class SpellProcess
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
     echo("prepare spell: #{data}") if $debug_mode_ct
+    if data['target_enemy']
+      echo("  Target found: #{data['target_enemy']}") if $debug_mode_ct
+      fput ("face #{data['target_enemy']}")
+    end
     if data['cyclic']
       fput('release care') if DRSpells.active_spells['Caress of the Sun']
       fput("release #{data['abbrev']}") # make bputs. better spells

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -403,11 +403,20 @@ class CrossingTraining
   end
 
   def research
+    if @settings.cyclic_research
+	  research_spell = @settings.crossing_cyclic_research_spells([])
+                       .min_by { |s| DRSkill.getxp(s) }
+      cyclic_research(research_spell)
+	  end
     if 'You cannot begin' == bput("research #{@researching} 300", 'You focus', 'You tentatively', 'You confidently', 'Abandoning the normal', 'You cannot begin')
       fput('research cancel')
       fput('research cancel')
       research
     end
+  end
+  
+  def cyclic_research(research_spell)
+    cast_spell(@settings.research_training_spells({})[research_spell], research_spell)
   end
 
   def check_research


### PR DESCRIPTION
The idea is that you can add specific targets for spells which will trigger them to be cast - and will face the target before preparing it/targeting it.  Useful in area's where you might need a little more bang for the casual roaming baddie you can't handle.  Or if there are ever undead/evil things mixed with non-undead/evil things.

in YAML you would use:
target_enemy: noun (note: that this will not work in areas where the nouns are the same ie silverback bear and dire bear both share the noun bear.  I cannot find a way to pull more information from DRRoom.