### PR TITLE
Store Town Room Data in Base-Town.yaml

### DIFF
--- a/profiles/base-town.yaml
+++ b/profiles/base-town.yaml
@@ -1,0 +1,26 @@
+---
+Crossing:
+  leather-repair:
+    id: 1544
+    name: randal
+  metal-repair:
+    id: 19093
+    name: catrox
+  bank:
+    id: 1900
+  exchange:
+    id: 1902
+  gemshop:
+    id: 4652
+    name: appraiser
+  tannery:
+    id: 8266
+    name: falken
+Leth Deriel:
+Shard:
+Therenborough:
+Riverhaven:
+Langenfirth:
+Ratha:
+Aesry:
+Mer'Kresh:

--- a/profiles/base-town.yaml
+++ b/profiles/base-town.yaml
@@ -1,15 +1,16 @@
 ---
 Crossing:
-  leather-repair:
+  leather_repair:
     id: 1544
     name: randal
-  metal-repair:
+  metal_repair:
     id: 19093
     name: catrox
   bank:
     id: 1900
   exchange:
     id: 1902
+    currency: kronars
   gemshop:
     id: 4652
     name: appraiser
@@ -18,6 +19,17 @@ Crossing:
     name: falken
 Leth Deriel:
 Shard:
+  bank:
+    id: 19276
+  exchange:
+    id: 19280
+    currency: dokoras
+  gemshop:
+    id: 19309
+    name: fatimi
+  tannery:
+    id: 19340
+    name: tremagis
 Therenborough:
 Riverhaven:
 Langenfirth:

--- a/profiles/base-town.yaml
+++ b/profiles/base-town.yaml
@@ -6,7 +6,7 @@ Crossing:
   metal_repair:
     id: 19093
     name: catrox
-  bank:
+  deposit:
     id: 1900
   exchange:
     id: 1902
@@ -19,7 +19,7 @@ Crossing:
     name: falken
 Leth Deriel:
 Shard:
-  bank:
+  deposit:
     id: 19276
   exchange:
     id: 19280

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2,7 +2,7 @@
 # See https://github.com/rpherbig/dr-scripts/wiki/YAML-Settings for documentation
 
 
-
+hometown: Crossing
 
 # Combat settings
 aim_fillers:

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -51,8 +51,9 @@ class SellLoot
 
   def deposit_coins(withdrawals)
     walk_to @hometown['exchange']['id']
-    fput 'exchange all lir for kro'
-    fput 'exchange all dok for kro'
+    exchange_to = @hometown['exchange']['currency']
+    currencies = ["dokoras", "kronars", "lirums"] - [exchange_to]
+    currencies.each {|currency| fput "exchange all #{currency} for #{exchange_to}"}
 
     walk_to @hometown['bank']['id']
     fput 'deposit all'

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -55,7 +55,7 @@ class SellLoot
     currencies = ["dokoras", "kronars", "lirums"] - [exchange_to]
     currencies.each {|currency| fput "exchange all #{currency} for #{exchange_to}"}
 
-    walk_to @hometown['bank']['id']
+    walk_to @hometown['deposit']['id']
     fput 'deposit all'
     withdrawals.each { |amount| fput "withdraw #{amount}" }
     fput 'check balance'

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -13,9 +13,10 @@ class SellLoot
   def initialize
     EquipmentManager.instance.empty_hands
 
-    settings = get_settings
-    keep_amount, keep_type = parse(settings.sell_loot_money_on_hand(nil).split(' '))
+    settings = get_settings(%w(town))
+    @hometown = settings[settings.hometown]
 
+    keep_amount, keep_type = parse(settings.sell_loot_money_on_hand(nil).split(' '))
     sell_gems("#{settings.gem_pouch_adjective} pouch") if settings.sell_loot_pouch(true)
 
     check_spare_pouch(settings.spare_gem_pouch_container, settings.gem_pouch_adjective) if settings.spare_gem_pouch_container
@@ -49,22 +50,20 @@ class SellLoot
   end
 
   def deposit_coins(withdrawals)
-    walk_to 1902
+    walk_to @hometown['exchange']['id']
     fput 'exchange all lir for kro'
     fput 'exchange all dok for kro'
 
-    walk_to 1900
+    walk_to @hometown['bank']['id']
     fput 'deposit all'
     withdrawals.each { |amount| fput "withdraw #{amount}" }
     fput 'check balance'
-    move 'out'
-    move 'out'
   end
 
   def sell_bundle
     return unless exists?('bundle')
 
-    walk_to 8266
+    walk_to @hometown['tannery']['id']
 
     bput('remove my bundle', 'You remove', 'You sling')
     bput('sell my bundle', 'ponders over the bundle')
@@ -74,7 +73,7 @@ class SellLoot
   def check_spare_pouch(container, adj)
     fput("open my #{container}")
     return if inside?("#{adj} pouch", container)
-    walk_to 4652
+    walk_to @hometown['gemshop']['id']
     fput("ask app for #{adj} pouch")
     fput("put my pouch in my #{container}")
   end
@@ -87,11 +86,11 @@ class SellLoot
 
     gems = get_gems(container)
     unless gems.empty?
-      walk_to 4652
+      walk_to @hometown['gemshop']['id']
 
       gems.each do |gem|
         fput "get my #{gem}"
-        fput "sell my #{gem} to appraiser"
+        fput "sell my #{gem} to #{@hometown['gemshop']['name']}"
       end
     end
 


### PR DESCRIPTION
The idea is to remove hardcoded room numbers in scripts which use town services. The user sets `hometown` in their setup file. The scripts which use town services will select the room ID's and any other information from base-town.yaml based on the `hometown` setting. 

sell-loot.lic is modified as an example