### PR TITLE
walk to safe room on setup

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -78,6 +78,8 @@ class CrossingTraining
     @bad_classes += ['Arcana'] if DRStats.barbarian?
     @bad_classes += ['Arcana', 'Inner Magic', 'Targeted Magic', 'Life Magic', 'Holy Magic', 'Lunar Magic', 'Elemental Magic', 'Arcane Magic', 'Attunement', 'Utility', 'Augmentation', 'Debilitation', 'Warding'] if DRStats.trader?
     @bad_classes += ['Arcana', 'Targeted Magic', 'Life Magic', 'Holy Magic', 'Lunar Magic', 'Elemental Magic', 'Arcane Magic', 'Attunement', 'Warding'] if DRStats.thief?
+
+    DRCT.walk_to @settings.safe_room
   end
 
   def empty_trash


### PR DESCRIPTION
Weeks reported an issue where he tries to cast OM in the bank. This is likely because sell-loot has been modified to not move outside the bank after depositing. If the player is running training-manager then it will call sell-loot, sell-loot finishes and then calls crossing-trainer, which checks for OM. This change moves the player to their safe_room on startup, where OM can be cast.