### PR TITLE
Added unload possiblity to unload_weapon

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -321,7 +321,7 @@ class EquipmentManager
   end
 
   def unload_weapon(name)
-    result = bput("unload my #{name}", 'You unload', 'Your .* fall from')
+    result = bput("unload my #{name}", 'You unload', 'Your .* fall from', 'As you release the string')
     waitrt?
     bput('stow left', 'You put') if result == 'You unload'
   end


### PR DESCRIPTION
When you unload a crossbow that uses fatigue, this is the message you get:

As you release the string of your light crossbow, the emerald bolt fades and disappears.
You stop aiming.

Niche weapon, obviously, but I have one and I figure the extra match doesn't hurt?