### PR TITLE
Shard Repair

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -40,7 +40,7 @@ module DRCM
     wealth == '.' ? 0 : wealth.to_i
   end
 
-  def ensure_copper_on_hand(copper, bank_id)
+  def ensure_copper_on_hand(copper, bank_id=1900)
     return true if wealth >= copper
     DRCT.walk_to bank_id
     withdrawals = minimize_coins(copper)

--- a/common-money.lic
+++ b/common-money.lic
@@ -40,9 +40,9 @@ module DRCM
     wealth == '.' ? 0 : wealth.to_i
   end
 
-  def ensure_copper_on_hand(copper)
+  def ensure_copper_on_hand(copper, bank_id)
     return true if wealth >= copper
-    DRCT.walk_to 1900
+    DRCT.walk_to bank_id
     withdrawals = minimize_coins(copper)
     withdrawals.each { |amount| return false if 'The clerk tells' == DRC.bput("withdraw #{amount}", 'The clerk count', 'The clerk tells') }
     true

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -12,7 +12,7 @@ class CrossingRepair
   def initialize
     setup
 
-    ensure_copper_on_hand(@repair_withdrawal_amount)
+    ensure_copper_on_hand(@repair_withdrawal_amount, @bank_info)
 
     @repair_info.each do |repairer, items|
       echo "Repairing at #{repairer}" if UserVars.crossing_repair_debug
@@ -32,8 +32,8 @@ class CrossingRepair
       command = "give my #{item.short_name} to #{repairer}"
     end
 
-    case bput(command, "There isn't a scratch on that", "I don't work on those here", 'Just give it to me again', "You don't need to specify the object")
-    when "There isn't a scratch on that"
+    case bput(command, "There isn't a scratch on that", "I don't work on those here", 'Just give it to me again', "You don't need to specify the object",  "I will not repair something that isn't broken")
+    when "There isn't a scratch on that",  "I will not repair something that isn't broken"
       EquipmentManager.instance.empty_hands
     when "I don't work on those here"
       echo "*** ITEM HAS IMPROPER is_leather FLAG: #{item.short_name} ***"
@@ -95,6 +95,7 @@ class CrossingRepair
     settings = get_settings
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
     hometown = get_data('town')[settings.hometown]
+    @bank_info = hometown['deposit']['id']
     @repair_info = {
       hometown['metal_repair'] => EquipmentManager.instance.items.reject(&:leather),
       hometown['leather_repair'] => EquipmentManager.instance.items.select(&:leather)


### PR DESCRIPTION
It looks like crossing-repair has already been modified to use base-town! These are the changes necessary to make it work in Shard.