### PR TITLE
Updated Ambush Stun in combat-trainer

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -1,0 +1,1013 @@
+---
+# See https://github.com/rpherbig/dr-scripts/wiki/YAML-Settings for documentation
+
+
+hometown: Crossing
+
+# Combat settings
+aim_fillers:
+  Crossbow:
+  - bob
+  - bob
+  Bow:
+  - bob
+  - bob
+  - bob
+  Slings:
+  - bob
+  - bob
+  - bob
+stances:
+  Bow:
+  - Evasion
+  - Shield Usage
+  - Parry Ability
+  Crossbow:
+  - Evasion
+  - Shield Usage
+  - Parry Ability
+  Slings:
+  - Evasion
+  - Shield Usage
+  - Parry Ability
+  Offhand Weapon:
+  - Evasion
+  - Shield Usage
+  - Parry Ability
+stance_override:
+skinning:
+  skin: true
+  arrange_all: false
+  arrange_count: 0
+  tie_bundle: false
+charged_maneuvers:
+  Brawling: palmstrike
+  Bow: powershot
+  Crossbow: powershot
+  Slings: powershot
+  Small Edged: cleave
+  Large Edged: cleave
+  Twohanded Edged: rush
+  Small Blunt: crash
+  Large Blunt: crash
+  Twohanded Blunt: crash
+  Staves: twirl
+  Polearms: impale
+dance_threshold: 0
+dance_skill: Small Edged
+dance_actions:
+- analyze
+- circle
+- bob
+- weave
+manipulate_threshold:
+training_abilities:
+  Hunt: 80
+fatigue_regen_threshold: 90
+fatigue_regen_action: bob
+summoned_weapons:
+summoned_weapons_element:
+summoned_weapons_ingot:
+buff_spells:
+offensive_spells:
+offensive_spell_cycle: []
+aim_fillers_stealth:
+buff_nonspells:
+dance_actions_stealth:
+thanatology:
+necromancer_healing:
+weapon_training:
+combat_trainer_target_increment: 3
+combat_trainer_action_count: 10
+dual_load: false
+is_empath: false
+use_stealth_attacks: false
+stealth_attack_aimed_action: poach
+backstab:
+ambush: false
+performance_monitor_weapons:
+retreat_threshold:
+use_weak_attacks: false
+loot_bodies: true
+dump_junk: false
+
+
+
+
+# Hunting settings
+escort_zones:
+  # https://elanthipedia.play.net/Blue-belly_crocodile
+  blue_crocs:
+    base: 1358
+    area: crocs
+    enter: enter
+  # https://elanthipedia.play.net/Giant_black_leucro
+  leucro1:
+    base: 1176
+    area: wilds
+    enter: leucro1
+  leucro2:
+    base: 1176
+    area: wilds
+    enter: leucro2
+  # https://elanthipedia.play.net/Forest_geni
+  geni:
+    base: 1176
+    area: wilds
+    enter: geni
+  # https://elanthipedia.play.net/Giant_thicket_viper
+  thicket_vipers:
+    base: 1176
+    area: northern_trade
+    enter: thicket_vipers
+hunting_zones:
+  # https://elanthipedia.play.net/Rat
+  rats:
+  - 6049
+  - 6048
+  - 6047
+  - 6046
+  - 6050
+  - 6053
+  - 6054
+  # https://elanthipedia.play.net/Sleazy_Lout
+  louts:
+  - 686
+  - 687
+  - 688
+  - 19199
+  - 690
+  #https://elanthipedia.play.net/Origami_Creature
+  origami:
+  - 8433
+  - 8434
+  - 8430
+  - 8431
+  - 8429
+  - 8428
+  - 8427
+  - 8426
+  # https://elanthipedia.play.net/Musk_Hog
+  hogs:
+  - 1438
+  - 1439
+  - 1440
+  - 1441
+  - 1442
+  - 1443
+  - 1444
+  - 1445
+  - 1446
+  - 1447
+  - 1448
+  # https://elanthipedia.play.net/Forager_goblin
+  # https://elanthipedia.play.net/Field_Goblin
+  # https://elanthipedia.play.net/Scavenger_goblin
+  goblins:
+  - 1473
+  - 1479
+  - 1483
+  - 1480
+  - 1481
+  - 1486
+  - 1482
+  # https://elanthipedia.play.net/S%27lai_Scout
+  scouts: # This is about half of the area
+  - 7292
+  - 7293
+  - 7294
+  - 7295
+  - 7296
+  - 7297
+  - 7298
+  - 7299
+  # https://elanthipedia.play.net/Faenrae_reaver
+  # https://elanthipedia.play.net/Wind_Hound
+  reavers:
+  - 1850
+  - 1851
+  - 1852
+  - 1856
+  - 1848
+  - 1849
+  # https://elanthipedia.play.net/Wood_Troll_(1)
+  wood_trolls1:
+  - 1047
+  - 1048
+  - 1049
+  - 1052
+  - 1053
+  - 1055
+  - 1056
+  - 1057
+  - 1058
+  - 1059
+  - 1060
+  - 1061
+  # https://elanthipedia.play.net/Beisswurm
+  beisswurms:
+  - 7263
+  - 7264
+  - 7265
+  - 7266
+  - 7267
+  # https://elanthipedia.play.net/Cave_bear
+  cave_bears:
+  - 7235
+  - 7236
+  - 7237
+  - 7238
+  # https://elanthipedia.play.net/Malodorous_bucca
+  buccas:
+  - 19215
+  - 19219
+  - 19220
+  # https://elanthipedia.play.net/Rock_Troll_(1)
+  rock_trolls:
+  - 8946
+  - 8947
+  - 8954
+  - 8955
+  - 8948
+  - 8949
+  # trolls past the rockslide
+  rock_trolls2:
+  - 9059
+  - 9060
+  - 9061
+  - 9062
+  # https://elanthipedia.play.net/Endrus_serpent
+  endrus_serpents:
+  - 9527
+  - 9528
+  - 9529
+  - 9530
+  - 9531
+  - 9532
+  - 9533
+  - 9534
+  - 9535
+  # https://elanthipedia.play.net/Snowbeast
+  snowbeasts: # 2264 causes a loop, do not use
+  - 2255
+  - 2268
+  - 2263
+  - 2256
+  - 2265
+  - 2266
+  - 2272
+  - 2259
+  - 2260
+  - 2262
+  - 2267
+  - 2269
+  - 2270
+  - 2261
+  # https://elanthipedia.play.net/Young_Ogre
+  young_ogres:
+  - 1588
+  - 1591
+  - 1592
+  - 1593
+  - 1590
+  - 1589
+  - 1587
+  # https://elanthipedia.play.net/Fire_Sprite
+  fire_sprites1: # 80-100 Locksmithing/Skinning
+  - 1770
+  - 1771
+  - 1772
+  - 1773
+  - 1774
+  - 1775
+  - 1776
+  - 1777
+  - 1778
+  # https://elanthipedia.play.net/Blue-belly_crocodile
+  # Near Shard (Ilithi Province), NOT Zoluren Province
+  blue_belly_crocs_shard:
+  - 9692
+  - 9693
+  - 9694
+  # https://elanthipedia.play.net/Dire_Bear
+  dire_bears: # 1555 is bugged, do not use
+  - 1563
+  - 1565
+  - 1582
+  - 1581
+  - 1578
+  - 1566
+  # https://elanthipedia.play.net/Orc_Bandit
+  orc_bandits:
+  - 8634
+  - 8736
+  - 8641
+  - 8638
+  - 8640
+  thugs: # 110-150 Locksmithing
+  - 6091
+  - 6092
+  - 6097
+  - 6097
+  # https://elanthipedia.play.net/Pale_Grey_Death_Spirit
+  pale_gray_spirits:
+  - 19384
+  - 19387
+  - 19390
+  - 19393
+  # https://elanthipedia.play.net/River_Sprite
+  river_sprites:
+  - 19754
+  - 19799
+  - 19847
+  - 19778
+  - 9055
+  # https://elanthipedia.play.net/Young_blue-dappled_prereni
+  young_blue_dappled_prereni:
+  - 9676
+  - 9677
+  - 9678
+  - 9679
+  # https://elanthipedia.play.net/Small_Peccary
+  # https://elanthipedia.play.net/Swamp_Troll_(2)
+  small_peccary_and_swamp_trolls:
+  - 3565
+  - 3566
+  - 3567
+  - 3568
+  - 3569
+  - 3570
+  - 3571
+  - 3572
+  - 3573
+  - 3574
+  - 3575
+  - 3576
+  - 3577
+  - 3578
+  # https://elanthipedia.play.net/Orc_reiver
+  orc_reivers:
+  - 8694
+  - 8695
+  - 8696
+  - 8697
+  - 8699
+  - 8700
+  - 8701
+  - 8702
+  - 8703
+  # https://elanthipedia.play.net/Cave_troll
+  cave_trolls:
+  - 19194
+  - 19195
+  - 19203
+  - 19204
+  - 19193
+  gryphons1: # first two tier gryphons in Rossman's Landing.  250-350 skill range
+  - 8627
+  - 8626
+  - 8624
+  - 8625
+  - 8628
+  - 8629
+  - 8630
+  gryphons3:
+  - 8632
+  - 8631
+  - 8682
+  - 8684
+  - 8685
+  - 8687
+  - 8689
+  - 8683
+  - 8686
+  - 8690
+  - 8688
+  - 8691
+  gryphons4:
+  - 8728
+  - 8727
+  - 8729
+  - 8730
+  - 8731
+  - 8732
+  - 8723
+  - 8726
+  - 8725
+  - 8724
+  # https://elanthipedia.play.net/Quartz_gargoyle
+  quartz_gargs:
+  - 8290
+  - 8291
+  - 8289
+  # https://elanthipedia.play.net/Rock_guardian
+  rock_guardians:
+  - 19413
+  - 19412
+  - 19410
+  - 19409
+  - 19407
+  - 1386
+  # https://elanthipedia.play.net/Bristle-backed_peccary
+  bristle_peccs:
+  - 7707
+  - 7716
+  - 7713
+  - 7706
+  - 7719
+  # https://elanthipedia.play.net/Yellow_bristled_gremlin
+  yellow_gremlins:
+  - 8410
+  - 8408
+  - 8409
+  # https://elanthipedia.play.net/Lesser_Dusky-Scaled_Basilisk
+  dusky_basilisk:
+  - 19435
+  - 19436
+  - 19437
+  - 19438
+  # https://elanthipedia.play.net/Misshapen_Germish%27din
+  germishdin:
+  - 2321
+  - 2323
+  - 2329
+  - 2324
+  - 2325
+  - 2326
+  - 2320
+  - 2319
+  - 2322
+  - 2331
+  - 2332
+  - 2327
+  - 2328
+  - 2334
+  - 2333
+  - 2335
+  # https://elanthipedia.play.net/Armored_warklin
+  # https://elanthipedia.play.net/Warklin_mauler
+  warklin:
+  - 7272
+  - 7273
+  - 7274
+  - 7275
+  - 7276
+  - 7277
+  - 7278
+  - 7279
+  - 7271
+  # https://elanthipedia.play.net/Black_goblin
+  black_goblins:
+  - 4167
+  - 4168
+  - 4170
+  - 4169
+  # https://elanthipedia.play.net/Storm_bull
+  storm_bulls:
+  - 2450
+  - 2451
+  - 2452
+  - 2453
+  - 2454
+  - 2455
+  - 2456
+  - 2457
+  - 2458
+  - 2461
+  - 2462
+  - 2463
+  - 2464
+  - 2465
+  toads:
+  - 50266
+  - 50267
+  orc_warcats:
+  - 19188
+  - 19101
+  - 19099
+  - 19100
+  - 19097
+  - 19191
+  - 19192
+  young_wyverns:
+  - 9029
+  - 9028
+  - 9030
+  - 9033
+  - 9032
+  - 9031
+  - 9034
+  - 9035
+  - 19181
+  - 9036
+
+training_manager_hunting_priority: false
+training_manager_priority_skills:
+hunting_info:
+
+
+
+
+stun_weapon:
+stun_weapon_skill:
+stun_skill: Debilitation
+
+# Repair settings
+repair_withdrawal_amount: 10_000
+
+
+
+
+
+# Safe-room settings
+safe_room_id:
+safe_room_take:
+safe_room_give:
+safe_room_tip_threshold:
+safe_room_tip_amount:
+safe_room_empath:
+
+
+
+
+
+# Spellcasting (and Khri) settings
+cambrinth: armband
+cambrinth_cap: 32
+held_cambrinth: false
+stored_cambrinth: false
+prep_scaling_factor: 0.98
+kneel_khri: false
+
+
+
+
+# Looting settings
+loot_additions: []
+loot_subtractions: []
+loot_specials: {}
+lootables:
+# ammunition
+- bolt
+- arrow
+- rock
+# valuable loot
+- coin
+- coins
+- map
+- scroll
+- vellum
+- bark
+- parchment
+- tablet
+- papyrus
+- ostracon
+- seishaka leaf
+- papyrus roll
+- pass
+- note
+# gems
+- tsavorite
+- zircon
+- quartz
+- chalcedony
+- diopside
+- coral
+- moonstone
+- onyx
+- topaz
+- amber
+- pearl
+- chryso
+- lazuli
+- turquoise
+- bloodstone
+- hematite
+- morganite
+- sapphire
+- agate
+- carnelian
+- diamond
+- crystal
+- emerald
+- ruby
+- tourmaline
+- tanzanite
+- jade
+- ivory
+- sunstone
+- iolite
+- beryl
+- garnet
+- alexandrite
+- amethyst
+- citrine
+- aquamarine
+- star-stone
+- crystal
+- kunzite
+- stones
+- spinel
+- opal
+- peridot
+- andalusite
+- chrysoprase
+- chrysoberyl
+- package
+- permit
+trash_nouns:
+- leaf
+- pestle
+- mortar
+- label
+- runestone
+- flower
+- flowers
+- arrowhead
+- root
+- stem
+- grass
+- needle
+- sap
+- glue
+- hilt
+- thread
+- flint
+- nugget
+- dira
+- stems
+- leaves
+- bar
+- lotion
+- vine
+- rope
+- vines
+- rock
+- hairbrush
+# TODO: Add stick, but only if we can differentiate it from a parry stick
+
+gem_nouns:
+- tsavorite
+- zircon
+- quartz
+- chalcedony
+- diopside
+- coral
+- moonstone
+- onyx
+- topaz
+- amber
+- pearl
+- chryso
+- lazuli
+- turquoise
+- bloodstone
+- hematite
+- morganite
+- sapphire
+- agate
+- carnelian
+- diamond
+- crystal
+- emerald
+- ruby
+- tourmaline
+- tanzanite
+- jade
+- ivory
+- sunstone
+- iolite
+- beryl
+- garnet
+- alexandrite
+- amethyst
+- citrine
+- aquamarine
+- star-stone
+- crystal
+- kunzite
+- stones
+- spinel
+- opal
+- peridot
+- andalusite
+- chrysoprase
+- chrysoberyl
+
+
+
+
+# Non-combat settings
+exp_timers:
+  Stealth: 300
+  First Aid: 400
+  Locksmithing: 600
+  Theurgy: 720
+  Thievery: 600
+  Attunement: 130
+listen: false
+safe_room: 851
+hide_to_steal: true
+bin_stolen: false
+stealing_bag: backpack
+hand_armor: gloves
+exit_on_skills_capped: false
+crossing_training_sorcery:
+crossing_training_sorcery_room: 1137
+crossing_training_requires_movement:
+- Appraisal
+- Athletics
+- Attunement
+- Empathy
+- Engineering
+- Forging
+- Outfitting
+- Scouting
+- Sorcery
+- Stealth
+- Thievery
+- Theurgy
+- Trading
+forage_item:
+braid_item:
+training_spells:
+research_training_spells:
+cyclic_research_skills:
+train_with_spells: true
+training_nonspells:
+crossing_training:
+use_research: false
+research_skills:
+water_holder:
+flint_lighter:
+astrology_buffs:
+scouting_buffs:
+crossing_training_stationary_skills_only: false
+
+
+
+
+
+# Crafting settings
+crafting_container: backpack
+forging_tools:
+- diagonal-peen hammer
+- tong
+- bellow
+- shovel
+knitting_tools:
+- knitting needle
+shaping_tools:
+- carving knife
+- shaper
+- drawknife
+- rasp
+work_order_disciplines:
+train_workorders:
+forge_container: backpack
+carving_tools:
+forging_belt:
+engineering_belt:
+outfitting_belt:
+tailoring_belt:
+mark_crafted_goods: false
+
+
+
+
+
+# Mining settings
+mines_to_mine:
+- wicked_burrow
+- stone_clan
+- waterfall
+mining_skip_populated: true
+mining_buddy_rooms:
+  wicked_burrow:
+  - 19079
+  - 19080
+  - 19081
+  - 19082
+  - 19084
+  - 19122
+  - 19123
+  - 19124
+  - 19088
+  - 19089
+  stone_clan:
+  - 7262
+  - 7263
+  - 7264
+  - 7265
+  - 7266
+  - 7267
+# high mountains - behind the waterfall
+  waterfall:
+  - 19219
+  - 19220
+  warklins:
+  - 7272
+  - 7273
+  - 7274
+  - 7275
+  - 7276
+  - 7277
+  - 7278
+  - 7279
+  - 7271
+  abandoned_mine:
+  - 7235
+  - 7236
+  - 7237
+  - 7238
+  dark_tunnels:
+  - 8560
+  - 8563
+  - 8562
+  - 8561
+  - 8564
+  - 8567
+  - 8568
+  - 8573
+  - 8572
+  - 8571
+  - 8570
+  - 8574
+  - 8569
+  - 8575
+  safari:
+  - 9211
+  - 9212
+  - 9213
+  - 9214
+  - 9236
+  - 9215
+  - 9216
+  - 9217
+  - 9218
+  - 9219
+  - 9220
+  - 9223
+  - 9224
+  - 9230
+  - 9231
+  - 9232
+  - 9233
+  - 9234
+  - 9235
+  # https://elanthipedia.play.net/RanikMap69a
+  ice_caves:
+  - 9701
+  - 9702
+  - 9703
+  - 9704
+  - 9705
+  - 9709
+  - 9710
+  - 9711
+  - 9712
+  - 9713
+
+mining_buddy_mine_every_room: false
+mining_buddy_vein_list:
+# uncommon
+- Silver
+# rare
+- Gold
+- Platinum
+- Lumium
+- Niniam
+- Electrum
+- Muracite
+- Darkstone
+# very rare
+- Damite
+- Kertig
+- Haralun
+- Glaes
+- Animite
+mining_implement: shovel
+mine_use_packet: true
+mine_while_training: false
+
+
+
+
+
+# Lockpicking settings
+stop_pick_on_mindlock: true
+use_lockpick_ring: true
+lockpick_type: ordinary
+harvest_traps: true
+picking_box_source: duffel bag
+picking_box_storage: backpack
+picking_pet_box_source:
+lockpick_dismantle:
+lockpick_buffs:
+lockpick_room_id:
+
+
+
+
+
+
+# Sell loot settings
+sell_loot_pouch: true
+sell_loot_bundle: true
+sell_loot_money_on_hand: 3 silver
+
+# Misc settings
+storage_containers:
+gear:
+gear_sets:
+empath_healing:
+
+osrel_no_harness: false
+osrel_amount:
+
+spare_gem_pouch_container:
+gem_pouch_adjective:
+
+workorder_diff: challenging
+trail_override:
+ignored_npcs: []
+
+favor_god: Hodierna
+favor_goal:
+hunting_buddies: []
+have_telescope: false
+theurgy_supply_container: backpack
+
+stealing_high_acceptable_count: 1
+stealing_low_acceptable_count: 2
+steal_past_mindlock: false
+stealing_buffs:
+npc_stealing_attempt_count: 0
+
+writing_instrument:
+dont_stalk: false
+
+stop_hunting_if_bleeding: true
+engineering_room:
+
+tithe: false
+
+cleaning_cloth: chamois cloth
+cast_only_to_train: false
+priority_defense:
+tk_ammo:
+
+listen_skills:
+- Large Edged
+- Twohanded Edged
+- Small Blunt
+- Light Thrown
+- Brawling
+- Offhand Weapon
+- Melee Mastery
+- Missile Mastery
+- Life Magic
+- Attunement
+- Arcana
+- Augmentation
+- Utility
+- Warding
+- Athletics
+- Perception
+- First Aid
+- Outdoorsmanship
+- Scholarship
+- Mechanical Lore
+- Appraisal
+- Performance
+- Tactics
+- Stealth
+- Bow
+- Evasion
+- Parry Ability
+- Small Edged
+- Defending
+- Light Armor
+- Chain Armor
+- Shield Usage
+- Targeted Magic
+- Debilitation
+- Brigandine
+- Plate Armor
+- Large Blunt
+- Twohanded Blunt
+- Slings
+- Crossbow
+- Staves
+- Polearms
+- Heavy Thrown
+- Locksmithing
+- Skinning
+- Forging
+- Engineering
+- Outfitting
+- Alchemy
+
+dont_steal_list: []
+waggle_sets: {}
+mine_for_outdoorsmanship: false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -946,7 +946,7 @@ class TrainerProcess
 
   def initialize(settings)
     echo('New TrainerProcess') if $debug_mode_ct
-
+	@stun_skill = settings.stun_skill
     @training_abilities = settings.training_abilities({})
     echo("  @training_abilities: #{@training_abilities}") if $debug_mode_ct
 
@@ -954,7 +954,7 @@ class TrainerProcess
                    'Perc' => 'Attunement', 'Astro' => 'Astrology', 'App' => 'Appraisal',
                    'App Quick' => 'Appraisal', 'App Careful' => 'Appraisal', 'Tactics' => 'Tactics',
                    'Scream' => 'Bardic Lore', 'Perc Health' => 'Empathy', 'Khri Prowess' => 'Debilitation',
-                   'Stealth' => 'Stealth', 'Ambush Stun' => 'Debilitation', 'Favor Orb' => 'Anything',
+                   'Stealth' => 'Stealth', 'Ambush Stun' => @stun_skill, 'Favor Orb' => 'Anything',
                    'Charged Maneuver' => 'Expertise', 'Meraud' => 'Theurgy' }
     @favor_god = settings.favor_god
     if settings.favor_goal && @favor_god && /delicate/ =~ bput("tap #{@favor_god} orb", 'The orb is delicate', 'I could not find')
@@ -964,7 +964,7 @@ class TrainerProcess
     @no_app = []
 
     @dont_stalk = settings.dont_stalk
-
+	@stun_weapon = settings.stun_weapon
     @water_holder = settings.water_holder
     @flint_lighter = settings.flint_lighter
   end
@@ -1055,7 +1055,7 @@ class TrainerProcess
     dead_count = DRRoom.dead_npcs.size
 
     EquipmentManager.instance.stow_weapon(game_state.weapon_name)
-    EquipmentManager.instance.wield_weapon(game_state.ambush_stun_weapon, 'Small Blunt')
+    EquipmentManager.instance.wield_weapon(@stun_weapon)
 
     if hide?
       bput('ambush stun', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime')
@@ -1063,7 +1063,7 @@ class TrainerProcess
       waitrt?
     end
 
-    EquipmentManager.instance.stow_weapon(game_state.ambush_stun_weapon)
+    EquipmentManager.instance.stow_weapon(@stun_weapon)
     EquipmentManager.instance.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
     DRRoom.dead_npcs.size > dead_count
   end
@@ -1613,10 +1613,6 @@ class GameState
     @clean_up_step == 'done'
   end
 
-  def ambush_stun_weapon
-    weapon_training['Small Blunt']
-  end
-
   def update_weapon_info(weapon_skill)
     @last_weapon_skill = @current_weapon_skill
     @current_weapon_skill = weapon_skill
@@ -1844,7 +1840,7 @@ class GameState
   end
 
   def can_ambush_stun?
-    weapon_training['Small Blunt'] && !npcs.empty? && !aimed_skill?
+	!npcs.empty? && !aimed_skill?
   end
 
   def use_weak_attacks?
@@ -1883,3 +1879,4 @@ end
 
 $COMBAT_TRAINER = CombatTrainer.new
 $COMBAT_TRAINER.start_combat
+

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -946,7 +946,6 @@ class TrainerProcess
 
   def initialize(settings)
     echo('New TrainerProcess') if $debug_mode_ct
-	@stun_skill = settings.stun_skill
     @training_abilities = settings.training_abilities({})
     echo("  @training_abilities: #{@training_abilities}") if $debug_mode_ct
 
@@ -954,7 +953,7 @@ class TrainerProcess
                    'Perc' => 'Attunement', 'Astro' => 'Astrology', 'App' => 'Appraisal',
                    'App Quick' => 'Appraisal', 'App Careful' => 'Appraisal', 'Tactics' => 'Tactics',
                    'Scream' => 'Bardic Lore', 'Perc Health' => 'Empathy', 'Khri Prowess' => 'Debilitation',
-                   'Stealth' => 'Stealth', 'Ambush Stun' => @stun_skill, 'Favor Orb' => 'Anything',
+                   'Stealth' => 'Stealth', 'Ambush Stun' => settings.stun_skill, 'Favor Orb' => 'Anything',
                    'Charged Maneuver' => 'Expertise', 'Meraud' => 'Theurgy' }
     @favor_god = settings.favor_god
     if settings.favor_goal && @favor_god && /delicate/ =~ bput("tap #{@favor_god} orb", 'The orb is delicate', 'I could not find')
@@ -964,9 +963,13 @@ class TrainerProcess
     @no_app = []
 
     @dont_stalk = settings.dont_stalk
+    echo("  @dont_stalk: #{@dont_stalk}") if $debug_mode_ct
 	@stun_weapon = settings.stun_weapon
+    echo("  @stun_weapon: #{@stun_weapon}") if $debug_mode_ct
     @water_holder = settings.water_holder
+    echo("  @water_holder: #{@water_holder}") if $debug_mode_ct
     @flint_lighter = settings.flint_lighter
+    echo("  @flint_lighter: #{@flint_lighter}") if $debug_mode_ct
   end
 
   def execute(game_state)


### PR DESCRIPTION
updated Ambush Stun in combat-trainer to use two new YAML settings. 

stun_weapon is the actual weapon to use: IE broadsword
stun_skill is either Debilitation or Backstab

This will allow thieves to use either an edged or blunt weapon to Ambush Stun. Edged weapons work but they don't do head damage like blunts do. This will also allow thieves to pick which skill to train with Ambush Stun. I, personally, found it better to stop on a primary skill over a tertiary.

Should probably also remove the aimed_skill check in line 1843; however I haven't had any issues.