### PR TITLE
Reopened: Updated Ambush Stun in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -946,7 +946,6 @@ class TrainerProcess
 
   def initialize(settings)
     echo('New TrainerProcess') if $debug_mode_ct
-
     @training_abilities = settings.training_abilities({})
     echo("  @training_abilities: #{@training_abilities}") if $debug_mode_ct
 
@@ -954,7 +953,7 @@ class TrainerProcess
                    'Perc' => 'Attunement', 'Astro' => 'Astrology', 'App' => 'Appraisal',
                    'App Quick' => 'Appraisal', 'App Careful' => 'Appraisal', 'Tactics' => 'Tactics',
                    'Scream' => 'Bardic Lore', 'Perc Health' => 'Empathy', 'Khri Prowess' => 'Debilitation',
-                   'Stealth' => 'Stealth', 'Ambush Stun' => 'Debilitation', 'Favor Orb' => 'Anything',
+                   'Stealth' => 'Stealth', 'Ambush Stun' => settings.stun_skill, 'Favor Orb' => 'Anything',
                    'Charged Maneuver' => 'Expertise', 'Meraud' => 'Theurgy' }
     @favor_god = settings.favor_god
     if settings.favor_goal && @favor_god && /delicate/ =~ bput("tap #{@favor_god} orb", 'The orb is delicate', 'I could not find')
@@ -964,9 +963,15 @@ class TrainerProcess
     @no_app = []
 
     @dont_stalk = settings.dont_stalk
-
+    echo("  @dont_stalk: #{@dont_stalk}") if $debug_mode_ct
+	@stun_weapon = settings.stun_weapon
+    echo("  @stun_weapon: #{@stun_weapon}") if $debug_mode_ct
+    @stun_weapon_skill = settings.stun_weapon_skill
+    echo("  @stun_weapon_skill: #{@stun_weapon_skill}")
     @water_holder = settings.water_holder
+    echo("  @water_holder: #{@water_holder}") if $debug_mode_ct
     @flint_lighter = settings.flint_lighter
+    echo("  @flint_lighter: #{@flint_lighter}") if $debug_mode_ct
   end
 
   def execute(game_state)
@@ -1055,7 +1060,7 @@ class TrainerProcess
     dead_count = DRRoom.dead_npcs.size
 
     EquipmentManager.instance.stow_weapon(game_state.weapon_name)
-    EquipmentManager.instance.wield_weapon(game_state.ambush_stun_weapon, 'Small Blunt')
+    EquipmentManager.instance.wield_weapon(@stun_weapon, @stun_weapon_skill)
 
     if hide?
       bput('ambush stun', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime')
@@ -1063,7 +1068,7 @@ class TrainerProcess
       waitrt?
     end
 
-    EquipmentManager.instance.stow_weapon(game_state.ambush_stun_weapon)
+    EquipmentManager.instance.stow_weapon(@stun_weapon)
     EquipmentManager.instance.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
     DRRoom.dead_npcs.size > dead_count
   end
@@ -1613,10 +1618,6 @@ class GameState
     @clean_up_step == 'done'
   end
 
-  def ambush_stun_weapon
-    weapon_training['Small Blunt']
-  end
-
   def update_weapon_info(weapon_skill)
     @last_weapon_skill = @current_weapon_skill
     @current_weapon_skill = weapon_skill
@@ -1844,7 +1845,7 @@ class GameState
   end
 
   def can_ambush_stun?
-    weapon_training['Small Blunt'] && !npcs.empty? && !aimed_skill?
+	!npcs.empty? && !aimed_skill?
   end
 
   def use_weak_attacks?
@@ -1883,3 +1884,4 @@ end
 
 $COMBAT_TRAINER = CombatTrainer.new
 $COMBAT_TRAINER.start_combat
+

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -964,10 +964,10 @@ class TrainerProcess
 
     @dont_stalk = settings.dont_stalk
     echo("  @dont_stalk: #{@dont_stalk}") if $debug_mode_ct
-	@stun_weapon = settings.stun_weapon
+    @stun_weapon = settings.stun_weapon
     echo("  @stun_weapon: #{@stun_weapon}") if $debug_mode_ct
     @stun_weapon_skill = settings.stun_weapon_skill
-    echo("  @stun_weapon_skill: #{@stun_weapon_skill}")
+    echo("  @stun_weapon_skill: #{@stun_weapon_skill}") if $debug_mode_ct
     @water_holder = settings.water_holder
     echo("  @water_holder: #{@water_holder}") if $debug_mode_ct
     @flint_lighter = settings.flint_lighter

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -508,6 +508,9 @@ hunting_info:
 
 
 
+stun_weapon:
+stun_weapon_skill:
+stun_skill: Debilitation
 
 # Repair settings
 repair_withdrawal_amount: 10_000


### PR DESCRIPTION
updated Ambush Stun in combat-trainer to use new YAML settings.

stun_weapon is the actual weapon to use: IE broadsword
stun_weapon_skill is the skill this weapon trains or the skill you want to swap it to train
stun_skill is either Debilitation or Backstab

This will allow thieves to use either an edged or blunt weapon to Ambush Stun. Edged weapons work but they don't do head damage like blunts do. This will also allow thieves to pick which skill to train with Ambush Stun. I, personally, found it better to stop on a primary skill over a tertiary.

Should probably also remove the aimed_skill check in line 1843; however I haven't had any issues.

Had to close the last pull request and open this one. Sorry. This should address all issues from #738. 
