### PR TITLE
modified stow_lootables function in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -191,10 +191,13 @@ class LootProcess
 
     @spare_gem_pouch_container = settings.spare_gem_pouch_container
     echo("  @spare_gem_pouch_container: #{@spare_gem_pouch_container}") if $debug_mode_ct
-
+    
 	@picking_box_storage = settings.picking_box_storage
 	echo("	@picking_box_storage: #{@picking_box_storage}") if $debug_mode_ct
-
+	
+	@store_extra_loot = settings.store_extra_loot
+	echo("	@store_extra_boxes: #{store_extra_loot}") if $debug_mode_ct
+	
     @gem_pouch_adjective = settings.gem_pouch_adjective
     echo("  @gem_pouch_adjective: #{@gem_pouch_adjective}") if $debug_mode_ct
 
@@ -282,13 +285,15 @@ class LootProcess
         matches.each { |_| stow_loot(item, game_state); }
       end
     return unless tried_loot
-    if checkleft != pair.first && !@lootables.grep(/#{checkleft}/).empty?
-		bput("stow left in my #{@picking_box_storage}", 'You put')
+	if @store_extra_loot     
+		if checkleft != pair.first && !@lootables.grep(/#{checkleft}/).empty?
+			bput("stow left in my #{@picking_box_storage}", 'You put')
+		end
+		if checkright != pair.last && !@lootables.grep(/#{checkright}/).empty?
+			bput("stow right in my #{@picking_box_storage}", 'You put')
+    	end
 	end
-	if checkright != pair.last && !@lootables.grep(/#{checkright}/).empty?
-		bput("stow right in my #{@picking_box_storage}", 'You put')
-    end
-    pause 1
+	pause 1
     if checkleft != pair.first && !@lootables.grep(/#{checkleft}/).empty?
       echo("out of room, failed to store #{checkleft}")
       game_state.unlootable(checkleft.downcase)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -192,6 +192,9 @@ class LootProcess
     @spare_gem_pouch_container = settings.spare_gem_pouch_container
     echo("  @spare_gem_pouch_container: #{@spare_gem_pouch_container}") if $debug_mode_ct
 
+	@picking_box_storage = settings.picking_box_storage
+	echo("	@picking_box_storage: #{@picking_box_storage}") if $debug_mode_ct
+
     @gem_pouch_adjective = settings.gem_pouch_adjective
     echo("  @gem_pouch_adjective: #{@gem_pouch_adjective}") if $debug_mode_ct
 
@@ -279,6 +282,12 @@ class LootProcess
         matches.each { |_| stow_loot(item, game_state); }
       end
     return unless tried_loot
+    if checkleft != pair.first && !@lootables.grep(/#{checkleft}/).empty?
+		bput("stow left in my #{@picking_box_storage}", 'You put')
+	end
+	if checkright != pair.last && !@lootables.grep(/#{checkright}/).empty?
+		bput("stow right in my #{@picking_box_storage}", 'You put')
+    end
     pause 1
     if checkleft != pair.first && !@lootables.grep(/#{checkleft}/).empty?
       echo("out of room, failed to store #{checkleft}")
@@ -291,6 +300,8 @@ class LootProcess
       dispose_trash(checkright)
     end
   end
+
+  
 
   def dispose_body(game_state)
     return unless @loot_bodies

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -400,7 +400,7 @@ mine_while_training: false
 
 
 
-
+store_extra_loot: false
 # Lockpicking settings
 stop_pick_on_mindlock: true
 use_lockpick_ring: true


### PR DESCRIPTION
Modified stow_lootables function in combat-trainer to attempt to stow loot items in the picking_box_storage container set in YAML before declaring it unlootable and dropping it.  If picking_box_storage is not set or unable to store in set container, it finishes declaring it unlootable and dropping it.

I set this up mainly for boxes, as pick.lic will look in pick_box_storage after picking_box_source is empty. I don't see it unsustainably filling the container with loot. However, perhaps a function somewhere to clean up this container might be necessary. IE a fill my gempouch with my pick_box_storage?