### PR TITLE
Craft changes

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -11,6 +11,7 @@ class Carve
   def initialize
     settings = get_settings
     @bag = settings.crafting_container('backpack')
+    @belt = settings.engineering_belt(nil)
 
     arg_definitions = [
       [
@@ -31,18 +32,12 @@ class Carve
     carve_item
   end
 
-  def get_or_fail(item)
-    waitrt?
-    case bput("get my #{item}", '^You get', '^You are already', '^You pick up', '^What do you', '^What were you')
-    when 'What do you', 'What were you'
-      echo("You seem to be missing: #{item}")
-      exit
-    end
+  def get_item(name)
+    get_crafting_item(name, @belt)
   end
 
-  def store_thing(item)
-    waitrt?
-    bput("put my #{item} in my #{@bag}", 'You put your', 'What were you referring to')
+  def stow_item(name)
+    stow_crafting_item(name, @bag, @belt)
   end
 
   def turn_to(section)
@@ -50,13 +45,13 @@ class Carve
   end
 
   def carve_item
-    get_or_fail('carving book')
+    get_item('carving book')
     turn_to("chapter #{@chapter}")
     turn_to("page #{find_recipe(@chapter, @recipe_name)}")
     bput('study my book', 'Roundtime')
-    store_thing('book')
-    get_or_fail('chisel')
-    get_or_fail("#{@material} rock")
+    stow_item('book')
+    get_item('chisel')
+    get_item("#{@material} rock")
     carve('cut my rock with my chisel')
   end
 
@@ -72,26 +67,26 @@ class Carve
               'Roundtime')
     when 'rough, jagged edges'
       waitrt?
-      store_thing(checkright)
-      get_or_fail('rifflers')
+      stow_item(checkright)
+      get_item('rifflers')
       command = "rub my #{@noun} with my rifflers"
     when 'determine it is no longer level', 'developed an uneven texture along its surface'
       waitrt?
-      store_thing(checkright)
-      get_or_fail('rasp')
+      stow_item(checkright)
+      get_item('rasp')
       command = "rub my #{@noun} with my rasp"
     when 'you see some discolored areas'
       waitrt?
-      store_thing(checkright)
-      get_or_fail('polish')
+      stow_item(checkright)
+      get_item('polish')
       command = "apply my polish to my #{@noun}"
     # when 'Applying the final touches'
     when 'You cannot figure out how to do that.'
       finish
     else
       waitrt?
-      store_thing(checkright) unless checkright == 'chisels'
-      get_or_fail('chisels') unless checkright == 'chisels'
+      stow_item(checkright) unless checkright == 'chisels'
+      get_item('chisels') unless checkright == 'chisels'
       command = "cut my #{@noun} with my chisels"
     end
     waitrt?
@@ -100,7 +95,14 @@ class Carve
 
   def finish
     waitrt?
-    store_thing(checkright)
+    stow_item(checkright)
+    case bput("tap my pebble", "lying at your feet", "I could not find", "inside your")
+    when "lying at your feet"
+      fput("get my pebble")
+      fput("put my pebble in my #{@bag}")
+    else
+      exit
+    end
     # NOTE: using 2 volume recipes leaves no leftover material when ordering a small rock
     # fput("get my #{@material} lumber")
     # fput("put my #{@material} lumber in my #{@bag}")

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -12,9 +12,9 @@ module DRCC
     ['nothing in there'].include?(DRC.bput('look in cruc', 'nothing in there', 'you see'))
   end
 
-  def find_empty_crucible
+  def find_empty_crucible(idle_room = nil, crucibles)
     DRCT.find_empty_room(
-      DRC.sort_destinations([8774, 19_030, 8773, 8777, 8779]), 8775, proc { DRRoom.pcs.empty? && empty_crucible? }
+      DRC.sort_destinations(crucibles), idle_room, proc { DRRoom.pcs.empty? && empty_crucible? }
     )
   end
 
@@ -22,16 +22,16 @@ module DRCC
     ['surface looks clean and ready'].include?(DRC.bput('look on anvil', 'surface looks clean and ready', 'anvil you see'))
   end
 
-  def find_anvil(idle_room = nil)
-    DRCT.find_empty_room(DRC.sort_destinations([8909, 8910, 8911, 8777, 8778, 760, 19_252, 19_211, 50_270, 19_267]), idle_room, proc { DRRoom.pcs.empty? && clean_anvil? })
+  def find_anvil(idle_room = nil, anvils)
+    DRCT.find_empty_room(DRC.sort_destinations(anvils), idle_room, proc { DRRoom.pcs.empty? && clean_anvil? })
   end
 
-  def find_grindstone
-    DRCT.find_empty_room(DRC.sort_destinations([8909, 8910, 8911, 19_264, 50_270, 19_267, 19_261, 19_252, 19_255]), 8775)
+  def find_grindstone(idle_room = nil, grindstones)
+    DRCT.find_empty_room(DRC.sort_destinations(grindstones), idle_room)
   end
 
-  def find_sewing_room
-    DRCT.find_empty_room([19_037, 19_036, 16_670, 19_063, 19_064, 19_065], 16_661)
+  def find_sewing_room(idle_room = nil, sewingrooms)
+    DRCT.find_empty_room(DRC.sort_destinations(sewingrooms), idle_room)
   end
 
   def find_shaping_room(override = nil)

--- a/common-money.lic
+++ b/common-money.lic
@@ -36,7 +36,12 @@ module DRCM
   def wealth
     fput 'wealth'
     waitfor('Wealth:')
-    wealth = matchfind '\\(? copper Kronars\\)\\.', 'No Kronars?'
+    case get_settings['hometown']
+    when "Crossing"
+      wealth = matchfind "\\(? copper Kronars\\)\\.", "No Kronars?"
+    when "Riverhaven"
+      wealth = matchfind "\\(? copper Lirums\\)\\.", "No Lirums?"
+    end
     wealth == '.' ? 0 : wealth.to_i
   end
 

--- a/forge.lic
+++ b/forge.lic
@@ -91,7 +91,12 @@ class Forge
     turn_to("page #{find_recipe(10, 'metal weapon honing')}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    find_grindstone
+    
+    settings = get_settings
+    grindstones = get_data('crafting')['blacksmithing'][settings.hometown]['grindstones']
+    idle_room = get_data('crafting')['blacksmithing'][settings.hometown]['idle-room']
+    find_grindstone(idle_room, grindstones)
+
     Flags.add('hone-done', 'the metal now needs protection by pouring oil on it')
     do_hone
   end
@@ -101,7 +106,12 @@ class Forge
     turn_to("page #{find_recipe(10, 'metal weapon balancing')}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    find_grindstone
+
+    settings = get_settings
+    grindstones = get_data('crafting')['blacksmithing'][settings.hometown]['grindstones']
+    idle_room = get_data('crafting')['blacksmithing'][settings.hometown]['idle-room']
+    find_grindstone(idle_room, grindstones)
+
     Flags.add('hone-done', 'the metal now needs protection by pouring oil on it')
     do_hone
   end
@@ -293,7 +303,11 @@ class Forge
   end
 
   def grind_item
-    find_grindstone
+    settings = get_settings
+    grindstones = get_data('crafting')['blacksmithing'][settings.hometown]['grindstones']
+    idle_room = get_data('crafting')['blacksmithing'][settings.hometown]['idle-room']
+    find_grindstone(idle_room, grindstones)
+
     spin_grindstone
     bput("push grind with my #{@item}", 'Roundtime', 'needs protection')
     waitrt?

--- a/makesteel.lic
+++ b/makesteel.lic
@@ -4,10 +4,15 @@ custom_require.call(%w(common common-crafting common-items common-money drinfomo
 
 count = variable.last.to_i
 
-DRCM.ensure_copper_on_hand(2000 * count)
+settings = get_settings
+bank_info = get_data('town')[settings.hometown]['deposit']['id']
+crucibles = get_data('crafting')['blacksmithing'][settings.hometown]['crucibles']
+idle_room = get_data('crafting')['blacksmithing'][settings.hometown]['idle-room']
+@stock_room = get_data('crafting')['blacksmithing'][settings.hometown]['stock-room']
+DRCM.ensure_copper_on_hand(2000 * count, bank_info)
 
 def order_stow(num)
-  DRCI.order_item(8775, num)
+  DRCI.order_item(@stock_room, num)
   fput('stow nugget')
 end
 
@@ -18,7 +23,7 @@ count.times do
   order_stow(2)
 end
 
-DRCC.find_empty_crucible
+DRCC.find_empty_crucible(idle_room, crucibles)
 
 (count * 4).times do
   fput('get my nugget')

--- a/profiles/Lukrani-duffel.yaml
+++ b/profiles/Lukrani-duffel.yaml
@@ -1,0 +1,3 @@
+picking_box_source: duffel bag
+picking_box_storage: rucksack
+

--- a/profiles/Lukrani-haversack.yaml
+++ b/profiles/Lukrani-haversack.yaml
@@ -1,0 +1,3 @@
+picking_box_source: haversack
+picking_box_storage: rucksack
+

--- a/profiles/Lukrani-setup.yaml
+++ b/profiles/Lukrani-setup.yaml
@@ -320,5 +320,6 @@ engineering_belt:
   - shaper
   - drawknife
   - rasp
-hometown: Riverhaven
-engineering_room: 519
+hometown: Crossing
+#engineering_room: 519
+engineering_room: 19479

--- a/profiles/Lukrani-setup.yaml
+++ b/profiles/Lukrani-setup.yaml
@@ -1,0 +1,322 @@
+weapon_training:
+  Bow: battle shortbow
+  Crossbow: battle crossbow
+  Large Blunt: sledgehammer
+  Twohanded Edged: greatsword
+  Large Edged: broadsword
+  Polearms: partisan
+stances:
+  Bow:
+  - Shield Usage
+  - Evasion
+  - Parry Ability
+  Crossbow:
+  - Shield Usage
+  - Evasion
+  - Parry Ability
+  Polearms:
+  - Evasion
+  - Parry Ability
+  - Shield Usage
+  Heavy Thrown:
+  - Shield Usage
+  - Evasion
+  - Parry Ability
+  Large Blunt:
+  - Evasion
+  - Parry Ability
+  - Shield Usage
+  Twohanded Edged:
+  - Evasion
+  - Parry Ability
+  - Shield Usage
+  Large Edged:
+  - Evasion
+  - Parry Ability
+  - Shield Usage
+aim_fillers:
+  Bow:
+  - hide
+  - stalk
+  - analyze
+  Crossbow:
+  - hide
+  - stalk
+  - analyze
+aim_fillers_stealh:
+  Bow:
+  - hide
+  - stalk
+  - analyze
+  Crossbow:
+  - hide
+  - stalk
+  - analyze
+offensive_spells:
+- skill: Debilitation
+  name: Deadfall
+  abbrev: df
+  mana: 1
+  cambrinth:
+   - 14
+- skill: Targeted Magic
+  name: Stampede
+  abbrev: stamp
+  mana: 2
+  cambrinth:
+    - 5
+buff_spells:
+  Essence of Yew:
+    abbrev: ey
+    recast: 2
+    mana: 5
+    cambrinth:
+      - 28
+  Bear Strength:
+    abbrev: bes
+    recast: -1
+    mana: 5
+    cyclic: true
+    expire: this is a cyclic
+  See the Wind:
+    abbrev: stw
+    recast: 1
+    mana: 18
+    cambrinth:
+      - 32
+  Instinct:
+    abbrev: inst
+    recast: 1
+    mana: 21
+    cabmrinth:
+     - 32
+  Earth Meld:
+    abbrev: em
+    recast: 1
+    mana: 5
+    cambrinth:
+     - 32
+  Senses of the Tiger:
+    abbrev: sott
+    recast: 1
+    mana: 21
+    cambrinth:
+     - 32
+  Skein of Shadows:
+    abbrev: sks
+    recast: 1
+    mana: 13
+    cambrinth:
+     - 17
+  Oath of the Firstborn:
+    abbrev: oath
+    recast: 1
+    mana: 6
+    cambrinth:
+     - 32
+skinning:
+  skin: true
+  arrange_count: 5
+  arrange_types:
+    sluagh: bone
+    boar: part
+    barghest: bone
+    crocodile: bone
+dance_actions:
+- circle
+- analyze
+- hide
+- punch
+dance_actions_stealth:
+- circle
+- analyze
+- hide
+- punch
+target_action_count: 10
+dance_threshold: 0
+dance_skill: Brawling
+gear:
+- :name: balaclava
+  :adjective: ring
+  :is_leather: false
+  :hinders_lockpicking: true
+  :is_worn: true
+  :swappable: false
+- :name: shortbow
+  :adjective: battle
+  :is_worn: false
+- :name: knuckles
+  :adjective: spiked
+  :is_leather: false
+  :hinders_lockpicking: true
+  :is_worn: true
+  :swappable: false
+- :name: gloves
+  :adjective: lamellar
+  :is_leather: false
+  :hinders_lockpicking: true
+  :is_worn: true
+  :swappable: false
+- :name: shield
+  :adjective: small
+  :is_leather: true
+  :hinders_lockpicking: true
+  :is_worn: true
+  :swappable: false
+- :name: leathers
+  :adjective: garg
+  :is_leather: true
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: spikes
+  :adjective: elbow
+  :is_leather: false
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: stick
+  :adjective: parry
+  :is_leather: false
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: crossbow
+  :adjective: battle
+  :tie_to: braided toolstrap
+- :name: tabard
+  :adjective: segmented
+  :is_leather: true
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: vambraces
+  :adjective: segmented
+  :is_leather: true
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: greaves
+  :adjective: segmented
+  :is_leather: true
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: sledgehammer
+  :is_leather: false
+  :swappable: false
+- :name: sling
+  :adjective: staff
+  :swappable: false
+- :name: spear
+  :is_leather: false
+  :swappable: false
+  :tie_to: studded toolstrap
+- :name: spikes
+  :adjective: knee
+  :is_leather: false
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: footwraps
+  :adjective: bone
+  :is_leather: true
+  :hinders_lockpicking: false
+  :is_worn: true
+  :swappable: false
+- :name: greatsword
+  :is_leather: false
+  :swappable: false
+- :name: broadsword
+  :is_leather: false
+  :swappable: false
+- :name: partisan
+  :swappable: false
+  :is_worn: true
+gear_sets:
+  standard:
+  - partisan
+  - ring balaclava
+  - spiked knuckles
+  - lamellar gloves
+  - small shield
+  - parry stick
+  - elbow spikes
+  - segmented tabard
+  - segmented vambraces
+  - segmented greaves
+  - knee spikes
+  - bone footwraps
+charged_maneuvers:
+  Brawling: palmstrike
+  Bow:
+  Crossbow:
+  Large Blunt:
+  Polearms:
+  Large Edged:
+  Twohanded Edged:
+lockpick_buffs:
+  spells:
+  - abbrev: hol
+    mana: 20
+storage_containers:
+- rucksack
+- duffel bag
+picking_box_source: rucksack
+picking_box_storage: rucksack
+stop_pick_on_mindlock: true
+use_lockpick_ring: false
+harvest_traps: false
+use_stealth_attacks: true
+ambush: false
+dual_load: true
+training_abilities:
+  Hunt: 80
+  Perc: 120
+  App Quick: 60
+held_cambrinth: false
+cambrinth_cap: 5
+cambrinth: armband
+spare_gem_pouch:container: thigh bag
+gem_pouch_adjective: gem
+loot_additions:
+- nugget
+- quadrello
+- stone spike
+- shard
+- coffer
+- strongbox
+- chest
+- caddy
+- trunk
+- casket
+- skippet
+- crate
+- box
+- bark
+- map
+- scroll
+- tablet
+- roll
+- leaf
+- electrum nugget
+- lead nugget
+- tin nugget
+- stones
+loot_subtractions:
+- rock
+crafting_container: rucksack
+forging_tools:
+  - ball-peen hammer
+  - tongs
+  - bellow
+  - shovel
+engineering_belt:
+  name: carp belt
+  items:
+  - carving knife
+  - shaper
+  - drawknife
+  - rasp
+hometown: Crossing
+engineering_room: 850

--- a/profiles/Lukrani-setup.yaml
+++ b/profiles/Lukrani-setup.yaml
@@ -320,6 +320,6 @@ engineering_belt:
   - shaper
   - drawknife
   - rasp
-hometown: Crossing
-#engineering_room: 519
-engineering_room: 19479
+hometown: Riverhaven
+engineering_room: 519
+#engineering_room: 19479

--- a/profiles/Lukrani-setup.yaml
+++ b/profiles/Lukrani-setup.yaml
@@ -64,7 +64,7 @@ offensive_spells:
   abbrev: stamp
   mana: 2
   cambrinth:
-    - 5
+    - 18
 buff_spells:
   Essence of Yew:
     abbrev: ey
@@ -262,6 +262,7 @@ lockpick_buffs:
 storage_containers:
 - rucksack
 - duffel bag
+- haversack
 picking_box_source: rucksack
 picking_box_storage: rucksack
 stop_pick_on_mindlock: true
@@ -305,12 +306,13 @@ loot_additions:
 - stones
 loot_subtractions:
 - rock
-crafting_container: rucksack
+crafting_container: pack
 forging_tools:
   - ball-peen hammer
   - tongs
   - bellow
   - shovel
+  - pliers
 engineering_belt:
   name: carp belt
   items:
@@ -318,5 +320,5 @@ engineering_belt:
   - shaper
   - drawknife
   - rasp
-hometown: Crossing
-engineering_room: 850
+hometown: Riverhaven
+engineering_room: 519

--- a/profiles/base-crafting.yaml
+++ b/profiles/base-crafting.yaml
@@ -1,49 +1,152 @@
 blacksmithing:
-  npc: Yalda
-  npc_last_name: Yalda
-  npc-rooms:
-  - 8771
-  - 8772
-  - 8775
-  - 8776
-  - 8777
-  - 8778
-  - 8773
-  - 8779
-  - 8774
-  - 19030
-  logbook: forging
-  pattern-book: blacksmithing
-  finisher: oil
-  finisher-full: flask of oil
-  finisher-room: 8776
-  finisher-number: 6
-  repair-room: 8776
-  repair-npc: clerk
-  stock-volume: 5
-  stock-room: 8775
-  stock-number: 11
-  stock-name: bronze ingot
-  trash-room: 8773
-  part-room: 8776
+  Crossing:
+    npc: Yalda
+    npc_last_name: Yalda
+    npc-rooms:
+      - 8771
+      - 8772
+      - 8775
+      - 8776
+      - 8777
+      - 8778
+      - 8773
+      - 8779
+      - 8774
+      - 19030
+    anvils:
+      - 8909
+      - 8910
+      - 8911
+      - 8777
+      - 8778
+      - 760
+      - 19_252
+      - 19_211
+      - 50_270
+      - 19_267
+    crucibles:
+      - 8774
+      - 19_030
+      - 8773
+      - 8777
+      - 8779
+    grindstones:
+      - 8909
+      - 8910
+      - 8911
+      - 19_264
+      - 50_270
+      - 19_267
+      - 19_261
+      - 19_252
+      - 19_255
+    logbook: forging
+    pattern-book: blacksmithing
+    finisher: oil
+    finisher-full: flask of oil
+    finisher-room: 8776
+    finisher-number: 6
+    repair-room: 8776
+    repair-npc: clerk
+    stock-volume: 5
+    stock-room: 8775
+    stock-number: 11
+    stock-name: bronze ingot
+    trash-room: 8773
+    idle-room: 8775
+  Riverhaven:
+    npc: Fereldrin
+    npc_last_name: Fereldrin
+    npc-rooms:
+      - 8785
+      - 8783
+      - 8784
+      - 8786
+    anvils:
+      - 8791
+      - 9341
+      - 8789
+      - 8788
+      - 9343
+      - 371
+      - 362
+    crucibles:
+      - 9342
+      - 8787
+      - 9340
+      - 8790
+      - 8792
+    grindstones:
+      - 8791
+      - 9341
+      - 8789
+      - 9343
+      - 8788
+      - 371
+      - 362
+    logbook: forging
+    pattern-book: blacksmithing
+    finisher: oil
+    finisher-full: flask of oil
+    finisher-room: 8784
+    finisher-number: 6
+    repair-room: 8783
+    repair-npc: clerk
+    stock-volume: 5
+    stock-room: 8785
+    stock-number: 11
+    stock-name: bronze ingot
+    trash-room: 8787
+    idle-room: 8785
+
 tailoring:
-  npc: Milline
-  npc_last_name: Milline
-  npc-rooms:
-  - 16657
-  - 16656
-  - 16659
-  - 16665
-  - 16668
-  - 16667
-  - 16661
-  - 16663
-  logbook: outfitting
-  repair-room: 16659
-  repair-npc: clerk
-  stock-room: 16667
-  stock-number: 13
-  pattern-book: tailoring
+  Crossing:
+    npc: Milline
+    npc_last_name: Milline
+    npc-rooms:
+    - 16657
+    - 16656
+    - 16659
+    - 16665
+    - 16668
+    - 16667
+    - 16661
+    - 16663
+    sewing-rooms:
+    - 19_037
+    - 19_036
+    - 16_670
+    - 19_063
+    - 19_064
+    - 19_065
+    logbook: outfitting
+    repair-room: 16659
+    repair-npc: clerk
+    stock-room: 16667
+    stock-number: 13
+    pattern-book: tailoring
+    idle-room: 
+  Riverhaven:
+    npc: Hagim
+    npc_last_name: Hagim
+    npc-rooms:
+    - 9719
+    - 9720
+    - 9718
+    - 9715
+    - 9717
+    - 9716
+    - 9714
+    sewing-rooms:
+    - 19063
+    - 9721
+    logbook: outfitting
+    repair-room: 9719
+    repair-npc: clerk
+    stock-room: 9716
+    stock-number: 13
+    pattern-book: tailoring
+    idle-room: 9720
 
 shaping:
   Crossing:
@@ -79,27 +182,49 @@ shaping:
     stock-volume: 10
     pattern-book: shaping
     part-room: 9110
+
 carving:
-  npc: Talia
-  npc_last_name: Volmogen
-  npc-rooms:
-  - 8867
-  - 8864
-  - 8865
-  - 8868
-  - 19209
-  logbook: engineering
-  polish: polish
-  polish-full: jar of surface polish
-  polish-room: 8865
-  polish-number: 4
-  repair-room: 19209
-  repair-npc: Rangu
-  stock-room: 8864
-  stock-number: 1
-  stock-name: alabaster
-  stock-volume: 3
-  pattern-book: carving
+  Crossing:
+    npc: Talia
+    npc_last_name: Volmogen
+    npc-rooms:
+    - 8867
+    - 8864
+    - 8865
+    - 8868
+    - 19209
+    logbook: engineering
+    polish: polish
+    polish-full: jar of surface polish
+    polish-room: 8865
+    polish-number: 4
+    repair-room: 19209
+    repair-npc: Rangu
+    stock-room: 8864
+    stock-number: 1
+    stock-name: alabaster
+    stock-volume: 3
+    pattern-book: carving
+  Riverhaven:
+    npc: Paarupensteen
+    npc_last_name: Paarupensteen
+    npc-rooms:
+    - 8853
+    - 8854
+    logbook: engineering
+    polish: polish
+    polish-full: jar of surface polish
+    polish-room: 8857
+    polish-number: 4
+    repair-room: 8856
+    repair-npc: Valomenica
+    stock-room: 9110
+    stock-number: 1
+    stock-name: alabaster
+    stock-volume: 3
+    pattern-book: carving
+    idle-room:
+
 remedies:
   npc: Lanshado
   npc_last_name: Lanshado
@@ -122,15 +247,60 @@ remedies:
   catalyst_number: 2
   catalyst_volume: 10
 
+recipe_parts:
+  Crossing:
+    small padding:
+      part-room: 
+      part-number: 11
+    short pole:
+      part-room: 
+      part-number: 11
+  Riverhaven:
+    small padding:
+      part-room: 9716
+      part-number: 11
+    long pole:
+      part-room: 8784
+      part-number:
+    short pole:
+      part-room: 8784 
+      part-number:
+    long cord:
+      part-room: 8784
+      part-number:
+    short.cord:
+      part-room: 8784
+      part-number:
+    hilt:
+      part-room: 8784
+      part-number:
+    haft:
+      part-room: 8784
+      part-number:
+    thread:
+      part-room: 9716
+      part-number: 6
+    pins:
+      part-room: 9717
+      part-number: 5
+
 crafting_recipes:
-- name: a practice longbow
-  noun: longbow
-  volume: 6
-  type: shaping
+- name: a metal ring mask
+  noun: mask
+  volume: 3
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding  
+- name: a short metal drawknife
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
   work_order: true
   chapter: 3
   part:
-  - bow.string
+  - short pole
 - name: a slender metal rod
   noun: rod
   volume: 1
@@ -173,14 +343,6 @@ crafting_recipes:
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a short metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short.pole
 - name: some squat metal rifflers
   noun: rifflers
   volume: 8
@@ -332,6 +494,12 @@ crafting_recipes:
 - name: a stone armband
   noun: armband
   volume: 3
+  type: carving
+  work_order: true
+  chapter: 4
+- name: a stone earcuff
+  noun: earcuff
+  volume: 1
   type: carving
   work_order: true
   chapter: 4
@@ -923,6 +1091,12 @@ crafting_recipes:
   chapter: 9
   part:
   - haft
+- name: a stone armband
+  noun: armband
+  volume: 3
+  type: carving
+  work_order: true
+  chapter: 4
 - name: a metal splitting maul
   noun: maul
   volume: 15

--- a/profiles/base-crafting.yaml
+++ b/profiles/base-crafting.yaml
@@ -46,23 +46,39 @@ tailoring:
   pattern-book: tailoring
 
 shaping:
-  npc: Talia
-  npc_last_name: Volmogen
-  npc-rooms:
-  - 8867
-  - 8864
-  - 8865
-  - 8868
-  - 19209
-  logbook: engineering
-  repair-room: 19209
-  repair-npc: Rangu
-  stock-room: 8864
-  stock-number: 11
-  stock-name: balsa
-  stock-volume: 10
-  pattern-book: shaping
-  part-room: 8776
+  Crossing:
+    npc: Talia
+    npc_last_name: Volmogen
+    npc-rooms:
+    - 8867
+    - 8864
+    - 8865
+    - 8868
+    - 19209
+    logbook: engineering
+    repair-room: 19209
+    repair-npc: Rangu
+    stock-room: 8864
+    stock-number: 11
+    stock-name: balsa
+    stock-volume: 10
+    pattern-book: shaping
+    part-room: 8864
+  Riverhaven:
+    npc: Paarupensteen
+    npc_last_name: Paarupensteen
+    npc-rooms:
+    - 8853
+    - 8854
+    logbook: engineering
+    repair-room: 8856
+    repair-npc: Valomenica
+    stock-room: 9110
+    stock-number: 11
+    stock-name: balsa
+    stock-volume: 10
+    pattern-book: shaping
+    part-room: 9110
 carving:
   npc: Talia
   npc_last_name: Volmogen
@@ -107,6 +123,14 @@ remedies:
   catalyst_volume: 10
 
 crafting_recipes:
+- name: a practice longbow
+  noun: longbow
+  volume: 6
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
+  - bow.string
 - name: a slender metal rod
   noun: rod
   volume: 1

--- a/profiles/base-crafting.yaml
+++ b/profiles/base-crafting.yaml
@@ -203,7 +203,7 @@ carving:
     stock-room: 8864
     stock-number: 1
     stock-name: alabaster
-    stock-volume: 3
+    stock-volume: 1
     pattern-book: carving
   Riverhaven:
     npc: Paarupensteen
@@ -221,66 +221,119 @@ carving:
     stock-room: 9110
     stock-number: 1
     stock-name: alabaster
-    stock-volume: 3
+    stock-volume: 1
     pattern-book: carving
-    idle-room:
 
 remedies:
-  npc: Lanshado
-  npc_last_name: Lanshado
-  npc-rooms:
-  - 8859
-  - 8860
-  - 8861
-  - 8862
-  - 8863
-  logbook: alchemy
-  repair-room: 8860
-  repair-npc: clerk
-  stock-room: 8862
-  stock-number: 1
-  stock-name: water
-  stock-volume: 10
-  pattern-book: remed
-  catalyst: coal nugget
-  catalyst-room: 8775
-  catalyst_number: 2
-  catalyst_volume: 10
+  Crossing:
+    npc: Lanshado
+    npc_last_name: Lanshado
+    npc-rooms:
+    - 8859
+    - 8860
+    - 8861
+    - 8862
+    - 8863
+    logbook: alchemy
+    repair-room: 8860
+    repair-npc: clerk
+    stock-room: 8862
+    stock-number: 1
+    stock-name: water
+    stock-volume: 10
+    pattern-book: remed
+    catalyst: coal nugget
+    catalyst-room: 8775
+    catalyst_number: 2
+    catalyst_volume: 10
+  Riverhaven:
+    npc: Carmifex
+    npc_last_name: Carmifex
+    npc-rooms:
+    - 19041
+    - 19055
+    - 19043
+    - 19059
+    - 19045
+    - 19047
+    - 19049
+    - 19051
+    - 19053
+    logbook: alchemy
+    repair-room: 19039
+    repair-npc: clerk
+    stock-room: 19041
+    stock-number: 1
+    stock-name: water
+    stock-volume: 10
+    pattern-book: remed
+    catalyst: coal nugget
+    catalyst-room: 8785
+    catalyst_number: 2
+    catalyst_volume: 10
 
 recipe_parts:
-  Crossing:
-    small padding:
-      part-room: 
+  small padding:
+    Crossing:
+      part-room: 16667
       part-number: 11
-    short pole:
-      part-room: 
-      part-number: 11
-  Riverhaven:
-    small padding:
+    Riverhaven:
       part-room: 9716
       part-number: 11
-    long pole:
+  long pole:
+    Crossing:
+      part-room: 8776
+      part-number:
+    Riverhaven:
       part-room: 8784
       part-number:
-    short pole:
-      part-room: 8784 
+  short-pole:
+    Crossing:
+      part-room: 8776
       part-number:
-    long cord:
+    Riverhaven:
       part-room: 8784
       part-number:
-    short.cord:
+  long cord:
+    Crossing:
+      part-room: 8776
+      part-number:
+    Riverhaven:
       part-room: 8784
       part-number:
-    hilt:
+  short.cord:
+    Crossing: 
+      part-room: 8776
+      part-number:
+    Riverhaven:
       part-room: 8784
       part-number:
-    haft:
+  hilt:
+    Crossing:
+      part-room: 8776
+      part-number:
+    Riverhaven:
       part-room: 8784
       part-number:
-    thread:
+  haft:
+    Crossing:
+      part-room: 8776
+      part-number:
+    Riverhaven:
+      part-room: 8784
+      part-number:
+  thread:
+    Crossing:
+      part-room: 16667
+      part-number: 6
+    Riverhaven:
       part-room: 9716
       part-number: 6
-    pins:
+  pins:
+    Crossing:
+      part-room:  16668
+      part-number: 5
+    Riverhaven:
       part-room: 9717
       part-number: 5
 

--- a/sew.lic
+++ b/sew.lic
@@ -75,7 +75,7 @@ class Sew
 
   def check_thread
     return if exists?('cotton thread')
-    data = get_data('crafting')['recipe_parts'][@hometown]['thread']
+    data = get_data('crafting')['recipe_parts']['thread'][@hometown]
     ensure_copper_on_hand(1000, @bank_info)
     order_item(data['part-room'], data['part-number'])
     stow_item('cotton thread')
@@ -83,7 +83,7 @@ class Sew
 
   def check_pins
     return unless Flags['sew-pins']
-    data = get_data('crafting')['recipe_parts'][@hometown]['pins']
+    data = get_data('crafting')['recipe_parts']['pins'][@hometown]
     ensure_copper_on_hand(125, @bank_info)
     item = checkleft
     stow_item(item)

--- a/sew.lic
+++ b/sew.lic
@@ -13,8 +13,10 @@ class Sew
 
   def initialize
     settings = get_settings
+    @hometown = settings.hometown
     @bag = settings.crafting_container('backpack')
     @belt = settings.tailoring_belt(nil)
+    @bank_info = get_data('town')[settings.hometown]['deposit']['id']
 
     arg_definitions = [
       [
@@ -73,17 +75,19 @@ class Sew
 
   def check_thread
     return if exists?('cotton thread')
-    ensure_copper_on_hand(1000)
-    order_item(16_667, 6)
+    data = get_data('crafting')['recipe_parts'][@hometown]['thread']
+    ensure_copper_on_hand(1000, @bank_info)
+    order_item(data['part-room'], data['part-number'])
     stow_item('cotton thread')
   end
 
   def check_pins
     return unless Flags['sew-pins']
-    ensure_copper_on_hand(125)
+    data = get_data('crafting')['recipe_parts'][@hometown]['pins']
+    ensure_copper_on_hand(125, @bank_info)
     item = checkleft
     stow_item(item)
-    order_item(16_668, 5)
+    order_item(data['part-room'], data['part-number'])
     stow_item('pin')
     get_item(item)
   end
@@ -101,6 +105,7 @@ class Sew
 
   def sew
     check_thread
+    check_pins
     get_item('tailoring book')
     turn_to("page #{find_recipe(@chapter, @recipe_name)}")
     bput('study my book', 'Roundtime')

--- a/shape.lic
+++ b/shape.lic
@@ -60,8 +60,27 @@ class Shape
               'a wood shaper is needed',
               'carved with a carving knife',
               'rubbed out with a rasp',
+              'pushed with clamps',
               'Applying the final touches',
+              'finished bow string',
+              'application of stain',
               'That tool does not seem suitable for that task.')
+    when 'application of stain'
+      waitrt?
+      stow_item(checkright) if checkright
+      get_item('stain')
+      command = "apply my stain to my #{@noun}"
+    when 'finished bow string'
+      waitrt?
+      stow_item(checkright)
+      get_item('bow string')
+      bput("assemble my string with my #{@noun}", "You loop")
+      command = "analyze my #{@noun}"
+    when 'pushed with clamps'
+      waitrt?
+      stow_item(checkright)
+      get_item('clamps')
+      command = "push my #{@noun} with my clamps" 
     when 'a wood shaper is needed'
       waitrt?
       stow_item(checkright)

--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -37,7 +37,11 @@ class SmeltDeeds
   end
 
   def smelt(metal)
-    find_empty_crucible
+    settings = get_settings
+    crucibles = get_data('crafting')['blacksmithing'][settings.hometown]['crucibles']
+    idle_room = get_data('crafting')['blacksmithing'][settings.hometown]['idle-room']
+   
+    find_empty_crucible(idle_room, crucibles)
 
     prepare_crucible(metal)
 

--- a/smith.lic
+++ b/smith.lic
@@ -35,7 +35,6 @@ class Smith
     @bank_info = get_data('town')[settings.hometown]['deposit']['id']
     recipes = data.crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = recipe_lookup(recipes, args.item_name)
-    echo "RECIPE #{recipe}"
     parts = recipe['part'] || []
     smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance)
   end
@@ -62,8 +61,7 @@ class Smith
     ensure_copper_on_hand(700, @bank_info)
 
     parts.each do |part|
-      data = get_data('crafting')['recipe_parts'][@hometown][part]
-      echo "PARTNUMBER #{data['part-number']}"
+      data = get_data('crafting')['recipe_parts'][part][@hometown]
       if data['part-number']
         order_item(data['part-room'], data['part-number'])
       else
@@ -81,8 +79,6 @@ class Smith
 
   def craft_item(recipe, discipline, material)
     check_oil(discipline)
-    echo "STOCK ROOM: #{discipline['stock-room']}"
-    echo "ANVILS: #{discipline['anvils']}"
     find_anvil(discipline['stock-room'], discipline['anvils'])
     wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
   end

--- a/smith.lic
+++ b/smith.lic
@@ -28,14 +28,15 @@ class Smith
     args = parse_args(arg_definitions)
 
     data = get_data('crafting')
-
-    discipline = data['blacksmithing']
+    settings = get_settings
+    discipline = data['blacksmithing'][settings.hometown]
+    @hometown = settings.hometown
     @container = get_settings.crafting_container
+    @bank_info = get_data('town')[settings.hometown]['deposit']['id']
     recipes = data.crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = recipe_lookup(recipes, args.item_name)
-
+    echo "RECIPE #{recipe}"
     parts = recipe['part'] || []
-
     smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance)
   end
 
@@ -58,29 +59,37 @@ class Smith
   end
 
   def buy_parts(parts, discipline)
-    ensure_copper_on_hand(700)
+    ensure_copper_on_hand(700, @bank_info)
 
     parts.each do |part|
-      buy_item(discipline['part-room'], part)
+      data = get_data('crafting')['recipe_parts'][@hometown][part]
+      echo "PARTNUMBER #{data['part-number']}"
+      if data['part-number']
+        order_item(data['part-room'], data['part-number'])
+      else
+        buy_item(data['part-room'], part)
+      end
       bput("stow #{part}", 'You put')
     end
   end
 
   def buy_ingot(discipline)
-    ensure_copper_on_hand(700)
+    ensure_copper_on_hand(700, @bank_info)
     order_item(discipline['stock-room'], discipline['stock-number'])
     stow_hands
   end
 
   def craft_item(recipe, discipline, material)
     check_oil(discipline)
-    find_anvil(discipline['stock-room'])
+    echo "STOCK ROOM: #{discipline['stock-room']}"
+    echo "ANVILS: #{discipline['anvils']}"
+    find_anvil(discipline['stock-room'], discipline['anvils'])
     wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
   end
 
   def check_oil(discipline)
     unless search?(discipline['finisher-full'])
-      ensure_copper_on_hand(1000)
+      ensure_copper_on_hand(1000, @bank_info)
       order_item(discipline['finisher-room'], discipline['finisher-number'])
       stow_hands
     end
@@ -96,7 +105,7 @@ class Smith
 
   def temper_item(discipline, recipe)
     check_oil(discipline)
-    find_anvil(discipline['stock-room'])
+    find_anvil(discipline['stock-room'], discipline['anvils'])
     fput("get my #{recipe['noun']}")
     wait_for_script_to_complete('forge', ['temper', recipe['noun']])
   end

--- a/workorders.lic
+++ b/workorders.lic
@@ -166,7 +166,6 @@ class WorkOrders
   def carve_items(info, item, quantity)
     ensure_copper_on_hand(5000, @bank_info)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
-
     quantity.times do |count|
       if (count % items_per_stock).zero?
         dispose("#{info['stock-name']} stone") if count > 0 && spare_stock
@@ -371,7 +370,6 @@ class WorkOrders
 
     stow_hands
     loop do
-      echo "Finding #{npc_last_name} in #{npc_rooms}"
       find_npc(npc_rooms, npc_last_name)
       bput("get my #{logbook} logbook", 'You get') unless checkleft || checkright
       case bput("ask #{npc} for #{diff} #{discipline} work", '^To whom', 'order for .* I need \d+ of .* quality', 'order for .* I need \d+ stacks \(5 uses each\) of .* quality', 'You realize you have items bundled with the logbook', 'You want to ask about shadowlings')

--- a/workorders.lic
+++ b/workorders.lic
@@ -28,7 +28,8 @@ class WorkOrders
     settings = get_settings
     crafting_data = get_data('crafting')
     @bag = settings.crafting_container('backpack')
-    info = crafting_data[discipline]
+    @bank_info = get_data('town')[settings.hometown]['deposit']['id']
+    info = crafting_data[discipline][settings.hometown]
 
     @recipes = crafting_data.crafting_recipes.select { |recipe| recipe['work_order'] && recipe['type'] =~ /#{discipline}/i }
 
@@ -163,7 +164,7 @@ class WorkOrders
   end
 
   def carve_items(info, item, quantity)
-    ensure_copper_on_hand(5000)
+    ensure_copper_on_hand(5000, @bank_info)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
 
     quantity.times do |count|
@@ -204,7 +205,7 @@ class WorkOrders
   end
 
   def shape_items(info, item, quantity)
-    ensure_copper_on_hand(5000)
+    ensure_copper_on_hand(5000, @bank_info)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
 
     quantity.times do |count|
@@ -216,6 +217,7 @@ class WorkOrders
         end
         order_item(info['stock-room'], info['stock-number'])
         stow_hands
+        buy_parts(recipe['part'], info['part-room']) || []
         find_shaping_room(@engineering_room)
       end
 
@@ -226,6 +228,14 @@ class WorkOrders
 
     dispose("#{info['stock-name']} lumber") if scrap
     go_door if XMLData.room_title.include?('Workshop')
+  end
+
+  def buy_parts(parts, partroom)
+    ensure_copper_on_hand(300, @bank_info)
+    parts.each do |part|
+      buy_item(partroom, part)
+      bput("stow #{part}", "You put")
+    end
   end
 
   def order_yarn(stock_room, stock_needed, stock_number)
@@ -239,7 +249,7 @@ class WorkOrders
   end
 
   def sew_items(info, item, quantity)
-    ensure_copper_on_hand(5000)
+    ensure_copper_on_hand(5000, @bank_info)
     recipe = @recipes.find { |r| r['name'] == item }
 
     existing = if 'What were' == bput("get yarn from my #{@bag}", 'What were', 'You get')
@@ -267,7 +277,7 @@ class WorkOrders
   end
 
   def remedy_items(info, item, quantity)
-    ensure_copper_on_hand(5000)
+    ensure_copper_on_hand(5000, @bank_info)
     recipe = @recipes.find { |r| r['name'] == item }
 
     existing = if 'What were' == bput("get coal nugget from my #{@bag}", 'What were', 'You get')
@@ -327,7 +337,7 @@ class WorkOrders
 
     remaining_volume = 0
 
-    ensure_copper_on_hand(5000)
+    ensure_copper_on_hand(5000, @bank_info)
 
     quantity.times do
       if remaining_volume < recipe['volume']
@@ -358,6 +368,7 @@ class WorkOrders
 
     stow_hands
     loop do
+      echo "Finding #{npc_last_name} in #{npc_rooms}"
       find_npc(npc_rooms, npc_last_name)
       bput("get my #{logbook} logbook", 'You get') unless checkleft || checkright
       case bput("ask #{npc} for #{diff} #{discipline} work", '^To whom', 'order for .* I need \d+ of .* quality', 'order for .* I need \d+ stacks \(5 uses each\) of .* quality', 'You realize you have items bundled with the logbook', 'You want to ask about shadowlings')

--- a/workorders.lic
+++ b/workorders.lic
@@ -176,8 +176,9 @@ class WorkOrders
         end
 
         order_item(info['stock-room'], info['stock-number'])
-        stow_hands
         fput('tap my deed')
+        stow_hands
+        
         fput("get #{info['stock-name']} rock")
         if search?(info['polish-full'])
           fput('get my surface polish')
@@ -260,7 +261,9 @@ class WorkOrders
     stock_needed = ((quantity * recipe['volume'] - existing) / 100.0).ceil
     order_yarn(info['stock-room'], stock_needed, info['stock-number'])
 
-    find_sewing_room
+    data = get_data('crafting')['tailoring']['Riverhaven']
+    find_sewing_room(data['idle-room'], data['sewing-rooms'])
+    #find_sewing_room(@engineering_room)
 
     quantity.times do
       wait_for_script_to_complete('sew', ['log', 'knitting', recipe['chapter'], item, recipe['noun']])


### PR DESCRIPTION
Workorders for all disciplines work with hometown setting now (Crossing & Riverhaven)
Parts has it's own section (recipe_parts) in base-crafting.yaml
All room #'s taken out of crafting scripts and pulled from base-crafting.yaml
Carve script updated with get_item/stow_item same as shape script
ensure_copper_on_hand in common-money updated to check hometown
