### PR TITLE
Minor fix to safe-room to use hometown in getting money

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -29,13 +29,13 @@ class SafeRoom
     copper = settings.safe_room_tip_threshold || 4_000
 
     if use_pc_empath?(settings.safe_room_id, settings.safe_room_empath)
-      ensure_copper_on_hand(copper)
+      ensure_copper_on_hand(copper, settings.hometown)
       tip(settings.safe_room_tip_threshold, settings.safe_room_tip_amount, settings.safe_room_empath)
     elsif DRStats.empath?
       walk_to(settings.safe_room)
       wait_for_script_to_complete('healme')
     elsif !DRStats.necromancer?
-      ensure_copper_on_hand(copper)
+      ensure_copper_on_hand(copper, settings.hometown)
       Flags.add('healthy', 'Dokt waves a large hand at you', 'Dokt gives you a quick glance', 'go have yourself a birthday party')
       Flags.add('moved', 'grabs you and drags you')
       Flags.add('idle', 'you have been idle too long')


### PR DESCRIPTION
The default argument for ensure_copper_on_hand is Crossing, so a user in Shard with hometown: Shard would check their wealth for Kronars and run to Crossing to get money. This passes the users hometown as an argument to ensure_copper instead, so the proper bank is used.