### PR TITLE
Theurgy clean-up in Crossing-training

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -307,6 +307,12 @@ class CrossingTraining
 
   def train_theurgy
     wait_for_script_to_complete('theurgy')
+    return unless @researching
+    if 'not researching anything' == fput('research status', 'not researching anything', 'Fundamental', 'Augmentation', 'Stream', 'Sorcery', 'Utility', 'Warding')
+      Flags.reset('research-partial')
+      Flags.reset('research-complete')
+      @researching = nil
+    end
   end
 
   def train_mining


### PR DESCRIPTION
this basically just updates research flags after theurgy.lic is closed and crossing-training thinks you are researching.