### PR TITLE
add mammoth crossing logic to bescort

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -420,19 +420,16 @@ class Bescort
   end
 
   def take_mammoth(mode)
-    # Tall Mammoth arrives to Acen: The waves along the waterline increase drastically as a rapidly approaching speck appears on the horizon.  As it draws nearer, trumpeting blasts roll out over the river and sprays of mist erupt from the creature.  At last, the massive sea mammoth strides ashore, and the passengers eagerly descend the ladders hanging from its seaweed covered bulk.
-    # Aboard mammoth dumps at Fang: The burly beast trumpets a series of watery blasts, sending salty sea spray flying over the passengers.  Land crests the horizon and very swiftly approaches.  With another watery spray, the mammoth treads the shallows.  The sounds of a small community can be heard ahead.
-    # Aboard mammoth dumps at Acen: The handler atop the beast's head calls back, "Here we are, ladies and gentlemen!  Eshchayoo is pleased to have brought you on your great journey!"  He leaps down, drops the ladders from the sea mammoth's sides and begins assisting passengers off.
     if mode == 'fang'
       manual_go2(2239)
-      mammoth_type = "tall"
+      mammoth_type = 'tall'
     elsif mode == 'acen'
       manual_go2(8301)
       mammoth_type = 'tall'
     end
     case bput("join #{mammoth_type} mammoth", 'What were you referring to', 'You join the Merelew driver')
     when /What were you referring to/
-      waitfor 'The waves along the waterline increase drastically'
+      waitfor 'The waves along the waterline increase drastically', 'A watery trumpeting sound heralds the swift approach'
       take_mammoth(mode)
     when /You join the Merelew driver/
       waitfor 'The burly beast trumpets a series of watery blasts', 'Here we are, ladies and gentlemen'

--- a/bescort.lic
+++ b/bescort.lic
@@ -122,6 +122,10 @@ class Bescort
       [
         { name: 'ways', regex: /ways/i, description: 'Astral travelling' },
         { name: 'mode', options: %w(shard crossing leth riverhaven merkresh fang raven throne muspari aesry taisgath theren steppes), description: 'Where do you need to get to?' }
+      ],
+      [
+        { name: 'mammoth', regex: /mammoth/i, description: 'The mammoth between Acenamacra and Fang Cove'},
+        { name: 'mode', options: %w(acen fang), description: 'Where do you need to get to?'}
       ]
     ]
 
@@ -143,6 +147,8 @@ class Bescort
       croc_swamp(args.mode)
     elsif args.ways
       astral_walk(args.mode)
+    elsif args.mammoth
+      take_mammoth(args.mode)
     end
   end
 
@@ -411,6 +417,26 @@ class Bescort
     swim(moveset[2]) while XMLData.room_exits.include?(moveset[0])
 
     move 'climb bridge'
+  end
+
+  def take_mammoth(mode)
+    # Tall Mammoth arrives to Acen: The waves along the waterline increase drastically as a rapidly approaching speck appears on the horizon.  As it draws nearer, trumpeting blasts roll out over the river and sprays of mist erupt from the creature.  At last, the massive sea mammoth strides ashore, and the passengers eagerly descend the ladders hanging from its seaweed covered bulk.
+    # Aboard mammoth dumps at Fang: The burly beast trumpets a series of watery blasts, sending salty sea spray flying over the passengers.  Land crests the horizon and very swiftly approaches.  With another watery spray, the mammoth treads the shallows.  The sounds of a small community can be heard ahead.
+    # Aboard mammoth dumps at Acen: The handler atop the beast's head calls back, "Here we are, ladies and gentlemen!  Eshchayoo is pleased to have brought you on your great journey!"  He leaps down, drops the ladders from the sea mammoth's sides and begins assisting passengers off.
+    if mode == 'fang'
+      manual_go2(2239)
+      mammoth_type = "tall"
+    elsif mode == 'acen'
+      manual_go2(8301)
+      mammoth_type = 'tall'
+    end
+    case bput("join #{mammoth_type} mammoth", 'What were you referring to', 'You join the Merelew driver')
+    when /What were you referring to/
+      waitfor 'The waves along the waterline increase drastically'
+      take_mammoth(mode)
+    when /You join the Merelew driver/
+      waitfor 'The burly beast trumpets a series of watery blasts', 'Here we are, ladies and gentlemen'
+    end
   end
 
   def take_rh_ferry(north)


### PR DESCRIPTION
This mammoth code is just for fang cove and acenamacra. There is another mammoth at Fang Cove that goes to Ratha that could be added later. Using the mammoth is free and it dumps you at your destination, so no need to explicitly exit the 'vehicle'. 
edited for pun quota(i need to work on it though)