### PR TITLE
Astral travel attempts to recast gate on non-catastrophic failure

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -575,9 +575,27 @@ class Bescort
     result != 'Roundtime'
   end
 
+  def open_gate(shard, entering_ap)
+    Flags.reset('gate-failure')
+    prepare?('mg', 5)
+    if entering_ap
+      bput("focus #{shard}", 'Roundtime') if DRStats.circle < 100
+      3.times { harness_mana(20) }
+      waitcastrt?
+      DRStats.circle > 99 ? cast('cast grazhir') : cast("cast #{shard}")
+    else
+      bput("focus #{shard}", 'Roundtime')
+      waitcastrt?
+      cast("cast #{shard}")
+    end
+    pause 0.25
+    open_gate(shard, entering_ap?) if Flags['gate-failure']
+  end
+
   def astral_walk(mode)
     Flags.add('harness-check', /You (.*) maintain your place among the shifting streams of mana\./)
     Flags.add('pattern-shift', 'A wave of rippling air sweeps through the conduit!  The streams of mana writhe violently before settling into new patterns')
+    Flags.add('gate-failure', "With supreme effort, you are able to bring the spell to an end without harm.")
 
     room_id_to_shard = {
       9999 => "Asharshpar'i",
@@ -641,22 +659,17 @@ class Bescort
       exit
     end
 
-    prepare?('mg', 5)
-    bput("focus #{source_shard}", 'Roundtime') if DRStats.circle < 100
-    waitcastrt?
-    3.times { harness_mana(20) }
-    DRStats.circle > 99 ? cast('cast grazhir') : cast("cast #{source_shard}")
+    open_gate(source_shard, true)
     pause 0.25 until XMLData.room_exits.empty?
     power_walk(direction_to_pattern['center']) while XMLData.room_exits.empty?
     walk_to mode_to_pillar_roomid[mode]
     bput("focus #{destination_shard}", 'You move into the chaotic tides of energy')
     power_walk(direction_to_pattern['exit']) while DRRoom.room_objs.empty?
-    prepare?('mg', 5)
-    bput("focus #{destination_shard}", 'Roundtime')
-    waitcastrt?
-    cast("cast #{destination_shard}")
+    open_gate(destination_shard, false)
     fput('rel mana')
   end
 end
+
+
 
 Bescort.new

--- a/bescort.lic
+++ b/bescort.lic
@@ -589,7 +589,7 @@ class Bescort
       cast("cast #{shard}")
     end
     pause 0.25
-    open_gate(shard, entering_ap?) if Flags['gate-failure']
+    open_gate(shard, entering_ap) if Flags['gate-failure']
   end
 
   def astral_walk(mode)

--- a/bescort.lic
+++ b/bescort.lic
@@ -595,7 +595,7 @@ class Bescort
   def astral_walk(mode)
     Flags.add('harness-check', /You (.*) maintain your place among the shifting streams of mana\./)
     Flags.add('pattern-shift', 'A wave of rippling air sweeps through the conduit!  The streams of mana writhe violently before settling into new patterns')
-    Flags.add('gate-failure', "With supreme effort, you are able to bring the spell to an end without harm.")
+    Flags.add('gate-failure', 'With supreme effort, you are able to bring the spell to an end without harm.')
 
     room_id_to_shard = {
       9999 => "Asharshpar'i",
@@ -669,7 +669,5 @@ class Bescort
     fput('rel mana')
   end
 end
-
-
 
 Bescort.new


### PR DESCRIPTION
Addresses #989 

Created a method for focusing on shard and casting gate, `cast_gate`. Added a flag to check for the failure. If failure is detected then call `cast_gate` again
