### PR TITLE
Update loot-corn-maze.lic

### DIFF
--- a/loot-corn-maze.lic
+++ b/loot-corn-maze.lic
@@ -15,7 +15,9 @@ class LootCornMaze
         if ready_to_loot
           targets.each do |target|
             if /manage/ =~ bput("search #{target.split.last}", "Sadly, you don't find anything", 'You manage to find', 'already been picked clean', 'I could not find what you were referring to')
-              fput("stow #{checkright || checkleft}")
+              if left_hand || right_hand
+                fput("stow #{checkright || checkleft}")
+              end
             end
           end
         end


### PR DESCRIPTION
[DRPrime]-DR:Leustyin: "But there's a bug in that if you need to search a landmark for the task it auto-stows, which confuses it since it tries to stow something that you're no longer holding"  (08:32:35)

-

This is to basically just check your hands with left_hand right_hand in common before calling the stow.