### PR TITLE
Necromancer Combat-Trainer Tweaks

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -307,8 +307,7 @@ class LootProcess
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         do_necro_ritual(DRRoom.dead_npcs.first, 'consume', game_state) unless game_state.wounds.empty?
       end
-
-      do_necro_ritual(DRRoom.dead_npcs.first, @ritual_type, game_state) unless game_state.prepare_consume
+      do_necro_ritual(DRRoom.dead_npcs.first, @ritual_type, game_state) unless game_state.prepare_consume || (DRSkill.getxp('Thanatology') > 31 && @skin)
     end
     return false if %w(consume harvest dissect).include?(@last_ritual)
     true
@@ -348,11 +347,10 @@ class LootProcess
     return if Time.now - @loot_timer < @loot_delay
 
     game_state.mob_died = true
+    arrange_mob(DRRoom.dead_npcs.first, game_state) if @skin
     can_skin = check_rituals(game_state)
-    if @skin && can_skin
-      arrange_mob(DRRoom.dead_npcs.first, game_state)
-      check_skinning(DRRoom.dead_npcs.first, game_state)
-    end
+    check_skinning(DRRoom.dead_npcs.first, game_state) if @skin && can_skin
+
     unless game_state.casting_consume || game_state.prepare_consume
       while 'and get ready to search it' == bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it')
         pause

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -347,9 +347,8 @@ class LootProcess
     return if Time.now - @loot_timer < @loot_delay
 
     game_state.mob_died = true
-    arrange_mob(DRRoom.dead_npcs.first, game_state) if @skin
-    can_skin = check_rituals(game_state)
-    check_skinning(DRRoom.dead_npcs.first, game_state) if @skin && can_skin
+    arrange_mob(DRRoom.dead_npcs.first, game_state)
+    check_skinning(DRRoom.dead_npcs.first, game_state) if check_rituals(game_state)
 
     unless game_state.casting_consume || game_state.prepare_consume
       while 'and get ready to search it' == bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it')
@@ -362,6 +361,7 @@ class LootProcess
   end
 
   def arrange_mob(mob_noun, game_state)
+    return unless @skin
     return unless @arrange_count > 0
     return unless game_state.skinnable?(mob_noun)
 
@@ -385,6 +385,7 @@ class LootProcess
   end
 
   def check_skinning(mob_noun, game_state)
+    return unless @skin
     return unless game_state.skinnable?(mob_noun)
 
     pause 0.25


### PR DESCRIPTION
To soak up skinning exp, arranging is checked before checking rituals. Additionally, when thanatology is above a threshold (31/34), then you will skin if your skinning setting is True.