### PR TITLE
Release invisibility spells

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -149,6 +149,15 @@ module DRCA
     result == 'absorbs all of the energy'
   end
 
+  def release_invisibility
+    get_data('spells')
+      .spell_data
+      .select { |name, properties| properties['invisibility'] }
+      .select { |name, properties| DRSpells.active_spells.keys.include?(name) }
+      .map { |name, properties| properties['abbrev'] }
+      .each { |abbrev| fput("release #{abbrev}") }
+  end
+
   def release_cyclics
     get_data('spells')
       .spell_data

--- a/common-money.lic
+++ b/common-money.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-money
 =end
 
-custom_require.call(%w(common common-travel))
+custom_require.call(%w(common common-travel common-arcana))
 
 module DRCM
   module_function
@@ -48,6 +48,7 @@ module DRCM
   def withdraw_exact_amount?(amount_as_string, hometown)
     bank_id = get_data('town')[hometown]['deposit']['id']
     DRCT.walk_to(bank_id)
+    DRCA.release_invisibility
     'The clerk counts' == DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells')
   end
 

--- a/common.lic
+++ b/common.lic
@@ -5,9 +5,11 @@
 
 $ORDINALS = %w(first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth)
 $TRASH_STORAGE = %w(bin gloop barrel bucket urn log)
+custom_require.call(%(common-arcana))
 
 module DRC
   module_function
+  include DRCA
 
   def bput(message, *matches)
     waitrt?
@@ -102,7 +104,10 @@ module DRC
     result = DRC.bput("rummage /#{parameter} my #{container}", 'but there is nothing in there like that\.', 'looking for .* and see .*', 'While it\'s closed', 'I don\'t know what you are referring to', 'You feel about')
 
     case result
-    when 'but there is nothing in there like that.', 'While it\'s closed', 'I don\'t know what you are referring to', 'You feel about'
+    when 'You feel about'
+      release_invisibility
+      return rummage(parameter, container)
+    when 'but there is nothing in there like that.', 'While it\'s closed', 'I don\'t know what you are referring to'
       return []
     end
 

--- a/pick.lic
+++ b/pick.lic
@@ -178,12 +178,12 @@ class LockPicker
 
     waitrt?
     loot(box)
-
     dismantle(box)
     waitrt?
   end
 
   def dismantle(box)
+    release_invisibility
     command = "dismantle my #{box} #{@settings.lockpick_dismantle}"
     case bput(command, 'repeat this request in the next 15 seconds', 'Roundtime')
     when 'repeat this request in the next 15 seconds'

--- a/profiles/base-spells.yaml
+++ b/profiles/base-spells.yaml
@@ -125,6 +125,18 @@ khri_preps:
 - You already have the .* combination running
 
 spell_data:
+  Eyes of the Blind:
+    ability: utility
+    abbrev: EOTB
+    invisibility: true
+  Refractive Field:
+    ability: utility
+    abbrev: RF
+    invisibility: true
+  Blend:
+    ability: utility
+    abbrev: Blend
+    invisibility: true
   Ghost Shroud:
     ability: Warding
     abbrev: GHS
@@ -258,6 +270,7 @@ spell_data:
     ability: Utility
     abbrev: SOV
     cyclic: true
+    invisibility: true
   Truffenyi's Rally:
     ability: Augmentation
     abbrev: TR


### PR DESCRIPTION
This adds support for releasing invisiblity spells, addressing the issue of attempting to use the bank while invisible, rummaging in containers, and dismantling boxes (which breaks pick.lic)