### PR TITLE
Support releasing invisibility spells

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -149,15 +149,6 @@ module DRCA
     result == 'absorbs all of the energy'
   end
 
-  def release_invisibility
-    get_data('spells')
-      .spell_data
-      .select { |name, properties| properties['invisibility'] }
-      .select { |name, properties| DRSpells.active_spells.keys.include?(name) }
-      .map { |name, properties| properties['abbrev'] }
-      .each { |abbrev| fput("release #{abbrev}") }
-  end
-
   def release_cyclics
     get_data('spells')
       .spell_data

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -149,6 +149,15 @@ module DRCA
     result == 'absorbs all of the energy'
   end
 
+  def release_invisibility
+    get_data('spells')
+      .spell_data
+      .select { |name, properties| properties['invisibility'] }
+      .select { |name, properties| DRSpells.active_spells.keys.include?(name) }
+      .map { |name, properties| properties['abbrev'] }
+      .each { |abbrev| fput("release #{abbrev}") }
+  end
+
   def release_cyclics
     get_data('spells')
       .spell_data

--- a/common-money.lic
+++ b/common-money.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-money
 =end
 
-custom_require.call(%w(common common-travel common-arcana))
+custom_require.call(%w(common common-travel))
 
 module DRCM
   module_function

--- a/common-money.lic
+++ b/common-money.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-money
 =end
 
-custom_require.call(%w(common common-travel))
+custom_require.call(%w(common common-travel common-arcana))
 
 module DRCM
   module_function
@@ -48,6 +48,7 @@ module DRCM
   def withdraw_exact_amount?(amount_as_string, hometown)
     bank_id = get_data('town')[hometown]['deposit']['id']
     DRCT.walk_to(bank_id)
+    DRCA.release_invisibility
     'The clerk counts' == DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells')
   end
 

--- a/common-money.lic
+++ b/common-money.lic
@@ -48,7 +48,7 @@ module DRCM
   def withdraw_exact_amount?(amount_as_string, hometown)
     bank_id = get_data('town')[hometown]['deposit']['id']
     DRCT.walk_to(bank_id)
-    DRCA.release_invisibility
+    DRC.release_invisibility
     'The clerk counts' == DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells')
   end
 

--- a/common.lic
+++ b/common.lic
@@ -260,9 +260,9 @@ module DRC
   def release_invisibility
     get_data('spells')
       .spell_data
-      .select { |name, properties| properties['invisibility'] }
-      .select { |name, properties| DRSpells.active_spells.keys.include?(name) }
-      .map { |name, properties| properties['abbrev'] }
+      .select { |_name, properties| properties['invisibility'] }
+      .select { |name, _properties| DRSpells.active_spells.keys.include?(name) }
+      .map { |_name, properties| properties['abbrev'] }
       .each { |abbrev| fput("release #{abbrev}") }
   end
 end

--- a/common.lic
+++ b/common.lic
@@ -103,7 +103,7 @@ module DRC
 
     case result
     when 'You feel about'
-      # Reduntant copy of DRCA.release_invisibility to avoid deadlocking from including commona-arcana
+      # Redundant copy of DRCA.release_invisibility to avoid deadlocking from including commona-arcana
       get_data('spells')
         .spell_data
         .select { |name, properties| properties['invisibility'] }

--- a/common.lic
+++ b/common.lic
@@ -5,11 +5,9 @@
 
 $ORDINALS = %w(first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth)
 $TRASH_STORAGE = %w(bin gloop barrel bucket urn log)
-custom_require.call(%(common-arcana))
 
 module DRC
   module_function
-  include DRCA
 
   def bput(message, *matches)
     waitrt?
@@ -105,7 +103,13 @@ module DRC
 
     case result
     when 'You feel about'
-      release_invisibility
+      # Reduntant copy of DRCA.release_invisibility to avoid deadlocking from including commona-arcana
+      get_data('spells')
+        .spell_data
+        .select { |name, properties| properties['invisibility'] }
+        .select { |name, properties| DRSpells.active_spells.keys.include?(name) }
+        .map { |name, properties| properties['abbrev'] }
+        .each { |abbrev| fput("release #{abbrev}") }
       return rummage(parameter, container)
     when 'but there is nothing in there like that.', 'While it\'s closed', 'I don\'t know what you are referring to'
       return []

--- a/common.lic
+++ b/common.lic
@@ -5,9 +5,11 @@
 
 $ORDINALS = %w(first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth)
 $TRASH_STORAGE = %w(bin gloop barrel bucket urn log)
+custom_require.call(%(common-arcana))
 
 module DRC
   module_function
+  include DRCA
 
   def bput(message, *matches)
     waitrt?
@@ -102,7 +104,10 @@ module DRC
     result = DRC.bput("rummage /#{parameter} my #{container}", 'but there is nothing in there like that\.', 'looking for .* and see .*', 'While it\'s closed', 'I don\'t know what you are referring to', 'You feel about')
 
     case result
-    when 'but there is nothing in there like that.', 'While it\'s closed', 'I don\'t know what you are referring to', 'You feel about'
+    when 'You feel about'
+      release_invisibility
+      return rummage(parameter, container)
+    when 'but there is nothing in there like that.', 'While it\'s closed', 'I don\'t know what you are referring to'
       return []
     end
 

--- a/common.lic
+++ b/common.lic
@@ -103,13 +103,7 @@ module DRC
 
     case result
     when 'You feel about'
-      # Redundant copy of DRCA.release_invisibility to avoid deadlocking from including commona-arcana
-      get_data('spells')
-        .spell_data
-        .select { |name, properties| properties['invisibility'] }
-        .select { |name, properties| DRSpells.active_spells.keys.include?(name) }
-        .map { |name, properties| properties['abbrev'] }
-        .each { |abbrev| fput("release #{abbrev}") }
+      release_invisibility
       return rummage(parameter, container)
     when 'but there is nothing in there like that.', 'While it\'s closed', 'I don\'t know what you are referring to'
       return []
@@ -261,5 +255,14 @@ module DRC
 
   def right_hand
     GameObj.right_hand.name == 'Empty' ? nil : fix_dr_bullshit(GameObj.right_hand.name)
+  end
+
+  def release_invisibility
+    get_data('spells')
+      .spell_data
+      .select { |name, properties| properties['invisibility'] }
+      .select { |name, properties| DRSpells.active_spells.keys.include?(name) }
+      .map { |name, properties| properties['abbrev'] }
+      .each { |abbrev| fput("release #{abbrev}") }
   end
 end

--- a/common.lic
+++ b/common.lic
@@ -5,7 +5,7 @@
 
 $ORDINALS = %w(first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth)
 $TRASH_STORAGE = %w(bin gloop barrel bucket urn log)
-
+custom_require.call(%w(spellmonitor))
 module DRC
   module_function
 

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -2,11 +2,10 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#crossing-repair
 =end
 
-custom_require.call(%w(common common-arcana common-money common-travel drinfomon equipmanager))
+custom_require.call(%w(common common-money common-travel drinfomon equipmanager))
 
 class CrossingRepair
   include DRC
-  include DRCA
   include DRCM
   include DRCT
 

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -2,10 +2,11 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#crossing-repair
 =end
 
-custom_require.call(%w(common common-money common-travel drinfomon equipmanager))
+custom_require.call(%w(common common-arcana common-money common-travel drinfomon equipmanager))
 
 class CrossingRepair
   include DRC
+  include DRCA
   include DRCM
   include DRCT
 
@@ -24,6 +25,7 @@ class CrossingRepair
   end
 
   def repair(repairer, item, repeat = false)
+    release_invisibility
     if repeat
       fput('swap') unless right_hand
       command = "give #{repairer}"

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -126,6 +126,18 @@ khri_preps:
 - You already have the .* combination running
 
 spell_data:
+  Eyes of the Blind:
+    ability: utility
+    abbrev: EOTB
+    invisibility: true
+  Refractive Field:
+    ability: utility
+    abbrev: RF
+    invisibility: true
+  Blend:
+    ability: utility
+    abbrev: Blend
+    invisibility: true
   Ghost Shroud:
     ability: Warding
     abbrev: GHS
@@ -259,6 +271,7 @@ spell_data:
     ability: Utility
     abbrev: SOV
     cyclic: true
+    invisibility: true
   Truffenyi's Rally:
     ability: Augmentation
     abbrev: TR

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -57,7 +57,6 @@ class HuntingBuddy
 
       wait_for_script_to_complete('bescort', @exit) if @exit
       release_cyclics
-      fput('release EOTB') if DRSpells.active_spells.keys.include?('Eyes of the Blind')
     end
     walk_to(@settings.safe_room)
     EquipmentManager.instance.wear_equipment_set?('standard')

--- a/pick.lic
+++ b/pick.lic
@@ -177,12 +177,12 @@ class LockPicker
 
     waitrt?
     loot(box)
-
     dismantle(box)
     waitrt?
   end
 
   def dismantle(box)
+    release_invisibility
     command = "dismantle my #{box} #{@settings.lockpick_dismantle}"
     case bput(command, 'repeat this request in the next 15 seconds', 'Roundtime')
     when 'repeat this request in the next 15 seconds'

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -407,7 +407,7 @@ mines_to_mine:
 - ice_caves # Shard
 mine_implement: shovel
 mine_while_training: false
-mining_buddy_mine_every_room: false
+mining_buddy_mine_every_room: true
 mining_buddy_vein_list:
 # uncommon
 # - Silver
@@ -451,4 +451,4 @@ favor_goal: 30
 
 ignored_npcs:
 - shadowling
-- shadow servant
+- Shadow Servant

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -1,8 +1,10 @@
 ---
 hometown: Shard
 slack_username: jonas
+
 # Safe Rooms
-safe_room: 2624 # Shard - House of hte Silver Star Gardens
+
+safe_room: 2624 # Shard - House of the Silver Star, Gardens
 # safe_room: 8926 # Dirge - Xaji's Oasis
 # safe_room: 8204 # Shard Trader Guild - Stargazers Loft (dont dump trash here, Mistanna gets mad)
 # safe_room: 2855 # Shard - Dark Clearing
@@ -10,12 +12,12 @@ safe_room: 2624 # Shard - House of hte Silver Star Gardens
 # safe_room_empath: Xaji
 # safe_room_id: 1230
 # safe_room_tip_amount: 2000
-# safe_room: 5733 #temple cemetary
-# safe_room: 851 #Ranger
-# safe_room: 984 #WM
-#safe_room: 1410 #Siergeld Regard
-#safe_room: 1645 #Tree
-#safe_room: 19162 #MM - has no vines for mech
+# safe_room: 5733 # Crossing - Temple cemetary
+# safe_room: 851 # Crossing - Ranger Guild
+# safe_room: 984 # Crossing - WM Guild
+#safe_room: 1410 # Crossing - Siergeld Regard
+#safe_room: 1645 # Crossing - Spooky Tree ooOoOoO
+#safe_room: 19162 # Crossing - MM Guild (No vines)
 
 # HUNTING
 hunting_file_list:
@@ -102,12 +104,6 @@ gear:
   :is_worn: false
   :bound: false
   :is_leather: false
-  :swappable: false
-- :name: spear
-  :adjective: mahogany-hafted
-  :is_worn: true
-  :is_leather: false
-  :bound: false
   :swappable: false
 - :name: hauberk
   :adjective: ring
@@ -338,17 +334,14 @@ waggle_sets:
       mana: 15
       cambrinth:
         - 45
-    Locate:
-      abbrev: locate
-      mana: 15
-      cast: c
+
 # Locksmithing
 stop_pick_on_mindlock: true
 picking_box_source: duffel bag
 picking_box_storage: duffel bag
 use_lockpick_ring: true
 lockpick_type: grandmaster
-lockpick_dismantle: focus #fokis
+lockpick_dismantle: focus
 harvest_traps: true
 
 
@@ -356,18 +349,11 @@ harvest_traps: true
 loot_additions:
 - card
 - dira
-- heart's inferno
-- jasper
-- tasialm
-- heliodor
-- crystal ring
 - ju'ladan oil #enchanting
-# loot_subtractions: # Good for quests
-# - arrow
+loot_subtractions:
+- arrow
 loot_specials:
-- name: jadeite stones
-  bag: pack
-- name: kyanite stones
+- name: stones
   bag: pack
 - name: star diopside
   bag: pack
@@ -386,18 +372,19 @@ sell_loot_bundle: true
 # Noncombat Settings
 
 crossing_training:
-- Performance
 - Locksmithing
-- Utility
 - Astrology
-- First Aid
+- Utility
 - Augmentation
 - Warding
 - Attunement
+- Performance
+- First Aid
 - Outdoorsmanship
-# - Athletics
 - Forging
+# - Athletics
 
+mine_for_outdoorsmanship: true
 listen: true
 have_telescope: true
 # braid_item:
@@ -421,6 +408,24 @@ mines_to_mine:
 mine_implement: shovel
 mine_while_training: false
 mining_buddy_mine_every_room: false
+mining_buddy_vein_list:
+# uncommon
+# - Silver
+# rare
+# - Gold
+# - Platinum
+- Lumium
+- Niniam
+- Electrum
+- Muracite
+- Darkstone
+# very rare
+- Damite
+- Kertig
+- Haralun
+- Glaes
+- Animite
+
 
 train_workorders:
 - Blacksmithing

--- a/profiles/Jonas-back.yaml
+++ b/profiles/Jonas-back.yaml
@@ -1,97 +1,21 @@
 ---
 hunting_info:
-- :zone: young_blue_dappled_prereni
+- :zone: river_sprites
   args:
   - d0
   - back
   stop_on:
-  - Skinning
+  - Polearms
   :duration: 60
 
-gear:
-- :name: spear
-  :adjective: mahogany-hafted
-  :is_worn: true
-  :is_leather: false
-  :bound: false
-  :swappable: false
-- :name: spike
-  :adjective: throwing
-  :is_leather: false
-- :name: axe
-  :adjective: throwing
-  :is_leather: false
-- :adjective: small
-  :name: shield
-  :is_leather: true
-  :hinders_lockpicking: true
-  :is_worn: true
-- :adjective: battle
-  :name: crossbow
-  :is_worn: false
-  :is_leather: true
-- :adjective: quilted
-  :name: gloves
-  :is_leather: true
-  :hinders_lockpicking: true
-  :is_worn: true
-- :adjective: quilted
-  :name: hauberk
-  :is_leather: true
-  :hinders_lockpicking: true
-  :is_worn: true
-- :adjective: steel
-  :name: knuckles
-  :is_leather: false
-  :hinders_lockpicking: true
-  :is_worn: true
-- :adjective: elbow
-  :name: spikes
-  :is_leather: false
-  :is_worn: true
-- :adjective: knee
-  :name: spikes
-  :is_leather: false
-  :is_worn: true
-- :adjective: quilted
-  :name: mask
-  :is_leather: true
-  :hinders_lockpicking: true
-  :is_worn: true
-- :adjective: quilted
-  :name: hood
-  :is_leather: true
-  :hinders_lockpicking: true
-  :is_worn: true
-- :adjective: parry
-  :name: stick
-  :is_leather: false
-  :is_worn: true
-
-gear_sets:
-  standard:
-  - small shield
-  - steel knuckles
-  - quilted gloves
-  - quilted hauberk
-  - quilted hood
-  - quilted mask
-  - elbow spikes
-  - parry stick
-  - mahogany-hafted spear
-
 weapon_training:
-  Heavy Thrown: mahogany-hafted spear
-  Polearms: mahogany-hafted spear
+  Heavy Thrown: haon-hafted spear
+  Polearms: haon-hafted spear
 offensive_spells:
 use_stealth_attacks: false
 training_abilities:
   App: 60
 
-skinning:
-  skin: true
-  arrange_count: 4
-  tie_bundle: true
 # Necromancer Related
 thanatology:
   necro: true

--- a/profiles/Jonas-back.yaml
+++ b/profiles/Jonas-back.yaml
@@ -8,20 +8,90 @@ hunting_info:
   - Skinning
   :duration: 60
 
-# weapon_training:
-#   Heavy Thrown: haon-hafted spear
-#   Polearms: haon-hafted spear
+gear:
+- :name: spear
+  :adjective: mahogany-hafted
+  :is_worn: true
+  :is_leather: false
+  :bound: false
+  :swappable: false
+- :name: spike
+  :adjective: throwing
+  :is_leather: false
+- :name: axe
+  :adjective: throwing
+  :is_leather: false
+- :adjective: small
+  :name: shield
+  :is_leather: true
+  :hinders_lockpicking: true
+  :is_worn: true
+- :adjective: battle
+  :name: crossbow
+  :is_worn: false
+  :is_leather: true
+- :adjective: quilted
+  :name: gloves
+  :is_leather: true
+  :hinders_lockpicking: true
+  :is_worn: true
+- :adjective: quilted
+  :name: hauberk
+  :is_leather: true
+  :hinders_lockpicking: true
+  :is_worn: true
+- :adjective: steel
+  :name: knuckles
+  :is_leather: false
+  :hinders_lockpicking: true
+  :is_worn: true
+- :adjective: elbow
+  :name: spikes
+  :is_leather: false
+  :is_worn: true
+- :adjective: knee
+  :name: spikes
+  :is_leather: false
+  :is_worn: true
+- :adjective: quilted
+  :name: mask
+  :is_leather: true
+  :hinders_lockpicking: true
+  :is_worn: true
+- :adjective: quilted
+  :name: hood
+  :is_leather: true
+  :hinders_lockpicking: true
+  :is_worn: true
+- :adjective: parry
+  :name: stick
+  :is_leather: false
+  :is_worn: true
+
+gear_sets:
+  standard:
+  - small shield
+  - steel knuckles
+  - quilted gloves
+  - quilted hauberk
+  - quilted hood
+  - quilted mask
+  - elbow spikes
+  - parry stick
+  - mahogany-hafted spear
+
+weapon_training:
+  Heavy Thrown: mahogany-hafted spear
+  Polearms: mahogany-hafted spear
 offensive_spells:
 use_stealth_attacks: false
 training_abilities:
-  Hunt: 80
   App: 60
 
 skinning:
   skin: true
-  # arrange_count: 1
+  arrange_count: 4
   tie_bundle: true
-  arrange_all: true
 # Necromancer Related
 thanatology:
   necro: true

--- a/profiles/Jonas-setup.yaml
+++ b/profiles/Jonas-setup.yaml
@@ -1,8 +1,8 @@
 ---
-# safe_room: 1645 # Spooky Tree ooOoOoO
-# safe_room: 2855 # Dark Clearing
-# safe_room: 2717 # Ironwood Tree
-safe_room: 2715 # Old Mine, Bar in Blackthorn Canyon (has rocks!)
+safe_room: 1645 # Crossing - Spooky Tree ooOoOoO
+# safe_room: 2855 # Shard - Dark Clearing
+# safe_room: 2717 # Shard - Ironwood Tree
+# safe_room: 2715 # Shard - Old Mine, Bar in Blackthorn Canyon (has rocks!)
 # Hunting Settings
 
 hometown: Shard
@@ -14,14 +14,12 @@ training_manager_hunting_priority: true
 training_manager_priority_skills:
 - Light Armor
 hunting_info:
-- :zone: blue_dappled_prereni
+- :zone: leucro2
   stop_on:
   - Crossbow
   args:
   - d0
-  - thanatology
   :duration: 60
-
 
 weapon_training:
   Crossbow: battle crossbow
@@ -50,11 +48,11 @@ priority_defense: Evasion
 # Gear & Equipment
 
 gear:
-# - :name: spear
-#   :adjective: haon-hafted
-#   :is_leather: false
-#   :is_worn: true
-#   :bound: true
+- :name: spear
+  :adjective: haon-hafted
+  :is_leather: false
+  :is_worn: true
+  :bound: true
 - :name: spike
   :adjective: throwing
   :is_leather: false
@@ -158,7 +156,7 @@ necromancer_healing:
     abbrev: devo
     mana: 30
     cambrinth:
-    - 4
+    - 5
   Consume Flesh:
     abbrev: cf
     mana: 15
@@ -198,17 +196,17 @@ waggle_sets:
       cyclic: true
 
 crossing_training:
-# - Appraisal
-- Outfitting
+- Appraisal
+# - Outfitting
+- Alchemy
 - Locksmithing
 - First Aid
 - Augmentation
 - Utility
 - Warding
 - Outdoorsmanship
-# - Athletics
+- Athletics
 - Performance
-# - Alchemy
 
 exp_timers:
   Stealth: 300


### PR DESCRIPTION
This releases invisibility spells in a very similar fashion to the cyclic release. Addresses #945 
The idea is to use the common method `release_invisibility` before doing an action which would fail on the grounds of being invisible