### PR TITLE
Combat Trainer: Necromancer ritual debugging

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -320,6 +320,7 @@ class LootProcess
     return unless ritual
     return if game_state.construct?(mob_noun)
 
+    echo "Attempting necromancer ritual #{ritual} on #{mob_noun}" if $debug_mode_ct
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w(consume harvest arise).include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
     case bput(perform_message, @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], 'roundtime', @rituals['construct'], @rituals['failures'])
@@ -333,8 +334,14 @@ class LootProcess
       waitrt?
       bput('drop material', 'you discard it')
     when @rituals['construct']
+      echo "Detected an attempt to do ritual on a construct" if $debug_mode_ct
       game_state.construct(mob_noun)
+    when 'roundtime'
+      echo "Ritual messaging matched on roundtime" if $debug_mode_ct
+    when @ritual['failures']
+      echo "Failure detected" if $debug_mode_ct
     end
+    echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct
   end
 
   def dispose_body(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -319,6 +319,7 @@ class LootProcess
     return unless DRStats.necromancer?
     return unless ritual
     return if game_state.construct?(mob_noun)
+
     echo "Attempting necromancer ritual #{ritual} on #{mob_noun}" if $debug_mode_ct
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w(consume harvest arise).include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
@@ -335,10 +336,10 @@ class LootProcess
       waitrt?
       bput('drop material', 'you discard it')
     when @rituals['construct']
-      echo "Detected an attempt to do ritual on a construct" if $debug_mode_ct
+      echo 'Detected an attempt to do ritual on a construct' if $debug_mode_ct
       game_state.construct(mob_noun)
     when *@rituals['failures']
-      echo "Failure detected" if $debug_mode_ct
+      echo 'Failure detected' if $debug_mode_ct
     end
     echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -323,7 +323,7 @@ class LootProcess
     echo "Attempting necromancer ritual #{ritual} on #{mob_noun}" if $debug_mode_ct
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w(consume harvest arise).include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
-    case bput(perform_message, @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], 'roundtime', @rituals['construct'], @rituals['failures'])
+    case bput(perform_message, @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
     when @rituals['preserve'], @rituals['dissect']
       @last_ritual = ritual
     when @rituals['consume']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -319,11 +319,12 @@ class LootProcess
     return unless DRStats.necromancer?
     return unless ritual
     return if game_state.construct?(mob_noun)
-
     echo "Attempting necromancer ritual #{ritual} on #{mob_noun}" if $debug_mode_ct
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w(consume harvest arise).include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
-    case bput(perform_message, @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
+    result = bput(perform_message, @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
+    echo result if $debug_mode_ct
+    case result
     when @rituals['preserve'], @rituals['dissect']
       @last_ritual = ritual
     when @rituals['consume']
@@ -338,7 +339,7 @@ class LootProcess
       game_state.construct(mob_noun)
     when 'roundtime'
       echo "Ritual messaging matched on roundtime" if $debug_mode_ct
-    when @ritual['failures']
+    when *@rituals['failures']
       echo "Failure detected" if $debug_mode_ct
     end
     echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -337,8 +337,6 @@ class LootProcess
     when @rituals['construct']
       echo "Detected an attempt to do ritual on a construct" if $debug_mode_ct
       game_state.construct(mob_noun)
-    when 'roundtime'
-      echo "Ritual messaging matched on roundtime" if $debug_mode_ct
     when *@rituals['failures']
       echo "Failure detected" if $debug_mode_ct
     end


### PR DESCRIPTION
Adding some messages to debug the material dropping problem. They could be condensed/removed after resolving the issue. Also removed roundtime from the bput match string as its listed in the ritual message data under failures.