### PR TITLE
Fix for the 'You don't need to. . .' bug in crossing-repair

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -32,9 +32,7 @@ class CrossingRepair
       fput('swap') unless right_hand
       command = "give #{repairer}"
     else
-      unless item.name.split.last == (left_hand.split.last || right_hand.split.last)
-	return unless @equipment_manager.get_item?(item)
-      end
+      return unless @equipment_manager.get_item?(item)
       command = "give my #{item.short_name} to #{repairer}"
     end
 
@@ -44,10 +42,8 @@ class CrossingRepair
     when "I don't work on those here"
       echo "*** ITEM HAS IMPROPER is_leather FLAG: #{item.short_name} ***"
       @equipment_manager.empty_hands
-    when "You don't need to specify the object"
+    when "You don't need to specify the object", 'Just give it to me again'
       repair(repairer, item, true)
-    when 'Just give it to me again'
-      repair(repairer, item, false)
     when "Please don't lose this ticket!", "You hand.*#{repairer}"
       bput('stow my ticket', 'You put')
     end

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -32,11 +32,13 @@ class CrossingRepair
       fput('swap') unless right_hand
       command = "give #{repairer}"
     else
-      return unless @equipment_manager.get_item?(item)
+      unless item.name.split.last == left_hand.split.last || right_hand.split.last
+				return unless @equipment_manager.get_item?(item)
+      end
       command = "give my #{item.short_name} to #{repairer}"
     end
 
-    case bput(command, "There isn't a scratch on that", "I don't work on those here", 'Just give it to me again', "You don't need to specify the object", "I will not repair something that isn't broken", "You hand.*#{repairer}")
+    case bput(command, "There isn't a scratch on that", "I don't work on those here", 'Just give it to me again', "You don't need to specify the object", "I will not repair something that isn't broken", "Please don't lose this ticket!", "You hand.*#{repairer}")
     when "There isn't a scratch on that", "I will not repair something that isn't broken"
       @equipment_manager.empty_hands
     when "I don't work on those here"
@@ -45,11 +47,12 @@ class CrossingRepair
     when "You don't need to specify the object"
       repair(repairer, item, true)
     when 'Just give it to me again'
-      fput command
+      repair(repairer, item, false)
+    when "Please don't lose this ticket!", "You hand.*#{repairer}"
       bput('stow my ticket', 'You put')
     end
   end
-
+  
   def tickets_left?(repairer)
     if 'What were you referring' == bput("get my #{repairer['name']} ticket", 'What were you referring', 'You get')
       return false

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -32,8 +32,8 @@ class CrossingRepair
       fput('swap') unless right_hand
       command = "give #{repairer}"
     else
-      unless item.name.split.last == left_hand.split.last || right_hand.split.last
-				return unless @equipment_manager.get_item?(item)
+      unless item.name.split.last == (left_hand.split.last || right_hand.split.last)
+	return unless @equipment_manager.get_item?(item)
       end
       command = "give my #{item.short_name} to #{repairer}"
     end

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -52,7 +52,7 @@ class CrossingRepair
       bput('stow my ticket', 'You put')
     end
   end
-  
+
   def tickets_left?(repairer)
     if 'What were you referring' == bput("get my #{repairer['name']} ticket", 'What were you referring', 'You get')
       return false

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -234,6 +234,7 @@ class CrossingTraining
     end
 
     wait_for_script_to_complete('sorcery')
+    wait_for_script_to_complete('safe-room')  
   end
 
   def check_teaching

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -233,7 +233,7 @@ class CrossingTraining
       return
     end
 
-    wait_for_script_to_complete('sorcery') 
+    wait_for_script_to_complete('sorcery')
   end
 
   def check_teaching

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -233,8 +233,7 @@ class CrossingTraining
       return
     end
 
-    wait_for_script_to_complete('sorcery')
-    wait_for_script_to_complete('safe-room')  
+    wait_for_script_to_complete('sorcery') 
   end
 
   def check_teaching


### PR DESCRIPTION
In case of hand-exploding backlash. For crossing-trainer.lic
I am new to this githubbery