### PR TITLE
Multi-difficulty support for workorders.lic

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -56,8 +56,11 @@ class WorkOrders
       exit
     end
 
-    item, quantity = request_work_order(info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], settings.workorder_diff) unless repair
-
+    if settings.workorder_diff.is_a?(Hash)
+      item, quantity = request_work_order(info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], settings.workorder_diff[discipline]) unless repair
+    else
+      item, quantity = request_work_order(info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], settings.workorder_diff) unless repair
+    end
     tools = []
 
     case discipline


### PR DESCRIPTION
Allows additional support for the current yaml setting:
```
workorder_diff: hard
```
to handle assigning individual disciples their own difficulty:
```
workorder_diff:
  shaping: hard
  blacksmithing: challenging
```
etc