### PR TITLE
Update common-money.lic

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -49,7 +49,16 @@ module DRCM
     bank_id = get_data('town')[hometown]['deposit']['id']
     DRCT.walk_to(bank_id)
     DRC.release_invisibility
-    'The clerk counts' == DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells')
+    loop do
+      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', "The clerk glares at you.")
+      when 'The clerk counts'
+        break true
+      when "The clerk glares at you."
+        pause 15
+      when 'The clerk tells'
+        break false
+      end
+    end
   end
 
   def debt(hometown)


### PR DESCRIPTION
This is for the rare instance of the clerk refusing to let you withdraw money if you've made too many withdraws in some time window. The cooldown appears to be between 14-15 seconds. 15 seconds consistently worked during tests.

> The clerk glares at you.  "I don't know what you think you're doing Ruik, but I don't like it much."  

Could alternatively do a `x.times do` instead of `loop do` to avoid some unforeseen infinite loop. It just looked kinda arbitrary and messy to do it though.