### PR TITLE
re: issue #1170, Refilling lockpick rings

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -80,13 +80,14 @@ module DRCI
     result =~ /You tap/
   end
 
-  def refill_lockpick_container(lockpick_type, hometown, container)
+  def refill_lockpick_container(lockpick_type, hometown, container, cost = 125)
     app_result = DRC.bput("app my lockpick #{container}", 'and it appears to be full', 'and it might hold an additional \d+', '\d+ lockpicks would probably fit')
     waitrt?
     return unless app_result =~ /(\d+)/
 
     room = get_data('town')[hometown]['locksmithing']['id']
     count = Regexp.last_match(1).to_i
+    ensure_copper_on_hand(cost * count, hometown)
     count.times do
       buy_item(room, "#{lockpick_type} lockpick")
       DRC.bput("put my lockpick on my lockpick #{container}", 'You put')

--- a/common-items.lic
+++ b/common-items.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-items
 =end
 
-custom_require.call(%w(common common-travel common-money))
+custom_require.call(%w(common common-travel))
 
 module DRCI
   module_function
@@ -86,9 +86,8 @@ module DRCI
     return count
   end
 
-  def refill_lockpick_container(lockpick_type, hometown, container, count, cost = 500)
+  def refill_lockpick_container(lockpick_type, hometown, container, count)
     room = get_data('town')[hometown]['locksmithing']['id']
-    DRCM.ensure_copper_on_hand(cost * count, hometown)
     count.times do
       buy_item(room, "#{lockpick_type} lockpick")
       DRC.bput("put my lockpick on my lockpick #{container}", 'You put')

--- a/common-items.lic
+++ b/common-items.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-items
 =end
 
-custom_require.call(%w(common common-travel))
+custom_require.call(%w(common common-travel common-money))
 
 module DRCI
   module_function
@@ -80,19 +80,19 @@ module DRCI
     result =~ /You tap/
   end
 
-  def refill_lockpick_container(lockpick_type, hometown, container, cost = 125)
-    app_result = DRC.bput("app my lockpick #{container}", 'and it appears to be full', 'and it might hold an additional \d+', '\d+ lockpicks would probably fit')
+  def count_lockpick_container(container)
+    count = DRC.bput("app my lockpick #{container}", 'and it appears to be full', 'and it might hold an additional \d+', '\d+ lockpicks would probably fit').scan(/\d+/).first.to_i
     waitrt?
-    return unless app_result =~ /(\d+)/
+    return count
+  end
 
+  def refill_lockpick_container(lockpick_type, hometown, container, count, cost = 500)
     room = get_data('town')[hometown]['locksmithing']['id']
-    count = Regexp.last_match(1).to_i
-    ensure_copper_on_hand(cost * count, hometown)
+    DRCM.ensure_copper_on_hand(cost * count, hometown)
     count.times do
       buy_item(room, "#{lockpick_type} lockpick")
       DRC.bput("put my lockpick on my lockpick #{container}", 'You put')
     end
-
     # Be polite to Thieves, who need the room to be empty
     move('out')
   end

--- a/pick.lic
+++ b/pick.lic
@@ -177,7 +177,7 @@ class LockPicker
       return
     end
     ensure_copper_on_hand(cost * lockpick_count, @settings.hometown)
-    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container, count)
+    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container, lockpick_count)
   end
 
   def attempt_open(box)

--- a/pick.lic
+++ b/pick.lic
@@ -176,8 +176,7 @@ class LockPicker
       return
     end
 
-    ensure_copper_on_hand(cost * 5, @settings.hometown)
-    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container)
+    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container, cost)
   end
 
   def attempt_open(box)

--- a/pick.lic
+++ b/pick.lic
@@ -177,7 +177,7 @@ class LockPicker
       return
     end
     ensure_copper_on_hand(cost * lockpick_count, @settings.hometown)
-    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container, count, cost)
+    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container, count)
   end
 
   def attempt_open(box)

--- a/pick.lic
+++ b/pick.lic
@@ -169,14 +169,15 @@ class LockPicker
 
   def refill_ring
     return unless @settings.use_lockpick_ring
-
+    lockpick_count = count_lockpick_container(@settings.lockpick_container)
+    return unless lockpick_count
     cost = @lockpick_costs[@settings.lockpick_type]
     if cost.nil?
       echo "***UNKNOWN LOCKPICK TYPE: #{@settings.lockpick_type}, UNABLE TO REFILL YOUR LOCKPICK RING***"
       return
     end
-
-    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container, cost)
+    ensure_copper_on_hand(cost * lockpick_count, @settings.hometown)
+    refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @settings.lockpick_container, count, cost)
   end
 
   def attempt_open(box)


### PR DESCRIPTION
- Removed the **ensure_copper_on_hand** helper from **pick.lic** and put it inside **refill_lockpick_container**.
- Added an optional **cost** (defaults to 125) variable to **refill_lockpick_container**.
- pick.lic now passes the lockpick cost to **refill_lockpick_container**
- **refill_lockpick_container** determines how much coin to withdraw based on the appraisal regex. **count** * **cost**.
