### PR TITLE
no_kill_all/no_pause_all added to various 'background' scripts.

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -5,6 +5,7 @@
 custom_require.call(%w(drinfomon common))
 
 no_pause_all
+no_kill_all
 
 def exit_game
   echo "Current room: #{Room.current.id}"

--- a/dependency.lic
+++ b/dependency.lic
@@ -37,6 +37,7 @@ require 'rest-firebase'
 
 toggle_unique
 no_pause_all
+no_kill_all
 
 class Object
   # IMPORT FUTURE LAWLZ

--- a/jail-buddy.lic
+++ b/jail-buddy.lic
@@ -5,6 +5,7 @@
 custom_require.call(%w(common))
 
 no_pause_all
+no_kill_all
 
 def check_sack
   return unless DRC.right_hand =~ /sack/ || DRC.left_hand =~ /sack/

--- a/roomnumbers.lic
+++ b/roomnumbers.lic
@@ -3,6 +3,7 @@
 =end
 
 no_pause_all
+no_kill_all
 
 pause 2
 

--- a/skill-recorder.lic
+++ b/skill-recorder.lic
@@ -4,6 +4,9 @@
 
 custom_require.call(%w(drinfomon spellmonitor))
 
+no_pause_all
+no_kill_all
+
 UserVars.thief_tunnels = {}
 
 loop do

--- a/smartlisten.lic
+++ b/smartlisten.lic
@@ -5,6 +5,8 @@
 
 custom_require.call(%w(common drinfomon))
 
+no_kill_all
+
 listen_skills = get_settings.listen_skills
 
 if DRStats.barbarian?

--- a/textsubs.lic
+++ b/textsubs.lic
@@ -4,6 +4,7 @@
 =end
 
 no_pause_all
+no_kill_all
 
 class TextSubs
   @@subs = {}


### PR DESCRIPTION
I've been using something very similar to this for a while now, I got sick of having to restart all my background scripts if I did `;ka`

All of the committed scripts in this PR now have both `no_pause_all` and `no_kill_all` with the exception of **smartlisten.lic** (only added `no_kill_all`), since its easy to imagine scenarios where people would want to pause it when doing `;pa`.

**jail-buddy.lic** helps those with constant warrants if they get nabbed while forging in the outdoor room, etc. I've found myself having to start it manually after getting arrested while doing non-criminal stuff around town.  