### PR TITLE
Oshu_manor.lic - Some over-zealous empty-hand checks added.

### DIFF
--- a/oshu_manor.lic
+++ b/oshu_manor.lic
@@ -1,8 +1,9 @@
-custom_require.call(%w(common common-travel events drinfomon))
+custom_require.call(%w(common common-travel common-items events drinfomon))
 
 class Oshu
   include DRC
   include DRCT
+  include DRCI
 
   def initialize
     settings = get_settings
@@ -14,7 +15,13 @@ class Oshu
     Flags.add('blasted', 'The blast catches you fully and sends you careening northward through the air!')
     Flags.add('head-reset', 'A stone gargoyle head suddenly makes a series of loud grinding')
     Flags.add('grave_exit', 'You dig to the surface')
+
+    hands_free
     grave_digger
+  end
+
+  def hands_free
+    stow_hands if ( left_hand || right_hand )
   end
 
   def safe_to_dig?
@@ -34,6 +41,7 @@ class Oshu
       break if safe_to_dig?
     end
     grave_digger if Room.current.id == 2317
+    hands_free
     fput('dig grave')
     waitrt?
     loop do
@@ -47,7 +55,16 @@ class Oshu
 
   def puzzle_begin
     walk_to(2350)
-    bput('push statue', 'and it settles into its new position with a click', 'The granite statue has already been pushed')
+    hands_free
+    case bput('push statue', 'and it settles into its new position with a click', 'The granite statue has already been pushed', 'You must have both hands free to do that.')
+    when 'You must have both hands free to do that.'
+      hands_free
+      puzzle_begin
+    end
+    to_house
+  end
+
+  def to_house
     walk_to(2340)
     move('go house')
     move('south')
@@ -75,6 +92,7 @@ class Oshu
   end
 
   def head_game
+    hands_free
     fput'look head'
     pause 1
     last_lines = reget(20)


### PR DESCRIPTION
Someone discovered that not having empty hands will break the script, further testing showed that it could break in multiple areas if one or both hands are full.

I added `hands_free` to do a `stow_hands` only if anything is actually in hand. This avoids the 1 second pause from calling `stow_hands` directly.