### PR TITLE
Adding support for no locksmith ID's in towns

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -88,6 +88,12 @@ module DRCI
 
   def refill_lockpick_container(lockpick_type, hometown, container, count)
     room = get_data('town')[hometown]['locksmithing']['id']
+    
+    if room.nil?
+      echo '***No locksmith location found for current Hometown! Skipping refilling!***'
+      return
+    end
+
     count.times do
       buy_item(room, "#{lockpick_type} lockpick")
       DRC.bput("put my lockpick on my lockpick #{container}", 'You put')


### PR DESCRIPTION
Getting stuck in extreme time issues when refilling lockpick rings in towns that have no valid locksmith, fixing this.