### PR TITLE
Meditate Focus Lockpicking Support

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -34,9 +34,9 @@ class LockPicker
 
     lockpick_buffs = @settings.lockpick_buffs
 
-    do_buffs(lockpick_buffs)
-
     fput 'sit'
+
+    do_buffs(lockpick_buffs)
 
     boxes.each do |box|
       if stop_picking?
@@ -52,6 +52,10 @@ class LockPicker
 
     if lockpick_buffs['khri']
       lockpick_buffs['khri'].each { |name| fput("khri stop #{name}") }
+    end
+
+    if lockpick_buffs['meditate']
+      fput('meditate stop')
     end
 
     refill_ring
@@ -161,6 +165,10 @@ class LockPicker
     buffs['khri']
       .map { |name| "Khri #{name}" }
       .each { |name| activate_khri?(@settings.kneel_khri, name) }
+
+    buffs['meditate'].each do |med|
+      bput("meditate #{med}", 'You feel a jolt as your vision snaps shut')
+    end
   end
 
   def refill_ring


### PR DESCRIPTION
Finishing support for this. It waits for the buffing to complete before moving on. I also made it sit before it buffs everyone. I don't see a reason why this would be an issue and it simply takes of needing another setting for sitting. It also removes the buff at the end, like the Khri's. 

Working log: http://pastebin.com/PfmAk8rx

Resolves #777