### PR TITLE
Increase safety around lodged items

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -504,6 +504,7 @@ class SafetyProcess
 
   def execute(game_state)
     custom_require.call('tendme') if bleeding? && !Script.running?('tendme')
+    fput 'exit' if health < 40
     fix_standing
     tend_lodged
     game_state.danger = in_danger?(game_state.danger)
@@ -531,8 +532,6 @@ class SafetyProcess
       Flags.reset('ct-engaged')
       retreat
     end
-
-    fput 'exit' if health < 40
 
     keep_away
     true

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -203,16 +203,14 @@ module DRCH
   def bind_wound(part, person = 'my')
     snap = [DRC.left_hand, DRC.right_hand]
     if 'You skillfully remove' == DRC.bput("tend #{person} #{part}", 'You work carefully at tending', 'That area has already been tended to', 'That area is not bleeding', 'You fumble', 'You \w+ remove', 'You (carelessly|foolishly)', 'You deftly remove')
-      waitrt?
-      fput("drop my #{DRC.left_hand}") if DRC.left_hand != snap.first
-      fput("drop my #{DRC.right_hand}") if DRC.right_hand != snap.last
+      DRC.bput("drop my #{DRC.left_hand}", 'You drop', 'What were you') if DRC.left_hand != snap.first
+      DRC.bput("drop my #{DRC.right_hand}", 'You drop', 'What were you') if DRC.right_hand != snap.last
       bind_wound(part, person)
     end
     waitrt?
   end
 
   def unwrap_wound(part)
-    waitrt?
     DRC.bput("unwrap my #{part}", 'You unwrap your bandages') # Are there other messages?
     pause 5
     bind_wound(part)


### PR DESCRIPTION
I'd like to run this for a bit before merging since it's in such a critical path, but wanted to share the code for feedback.

The `fput`s for dropping removed lodged items would fail in combat if additional roundtime was incurred, leaving the character with full hands.

Additionally, the exit call in `SafetyProcess` would never be reached if there were trouble in `fix_standing` or `tend_lodged`.  Let's pull that up. Having a call like that in a predicate was weird anyway.