### PR TITLE
Adding support for Scouting and F2P error messages.

### DIFF
--- a/scouting.lic
+++ b/scouting.lic
@@ -49,14 +49,10 @@ class Scouting
 
   def take_trail(room_id)
     walk_to(room_id)
-    case bput('scout trail', 'You notice a trailmarker', 'Because your account is free')
-    when 'You notice a trailmarker'
-      return if 'I could not find what you were referring to' == bput('go trail', 'You set off into the wild', 'That would be difficult', 'I could not find what you were referring to')
-      waitfor('As your journey ends')
-      pause 0.5 until Room.current.id
-    when 'Because your account is free'
-      return
-    end
+    return if 'Because your account is free' == bput('scout trail', 'You notice a trailmarker', 'Because your account is free')
+    return if 'I could not find what you were referring to' == bput('go trail', 'You set off into the wild', 'That would be difficult', 'I could not find what you were referring to')
+    waitfor('As your journey ends')
+    pause 0.5 until Room.current.id
   end
 end
 

--- a/scouting.lic
+++ b/scouting.lic
@@ -49,10 +49,14 @@ class Scouting
 
   def take_trail(room_id)
     walk_to(room_id)
-    bput('scout trail', 'You notice a trailmarker')
-    return if 'I could not find what you were referring to' == bput('go trail', 'You set off into the wild', 'That would be difficult', 'I could not find what you were referring to', 'Because your account is free')
-    waitfor('As your journey ends')
-    pause 0.5 until Room.current.id
+    case bput('scout trail', 'You notice a trailmarker', 'Because your account is free')
+    when 'You notice a trailmarker'
+      return if 'I could not find what you were referring to' == bput('go trail', 'You set off into the wild', 'That would be difficult', 'I could not find what you were referring to')
+      waitfor('As your journey ends')
+      pause 0.5 until Room.current.id
+    when 'Because your account is free'
+      return
+    end
   end
 end
 

--- a/scouting.lic
+++ b/scouting.lic
@@ -50,7 +50,7 @@ class Scouting
   def take_trail(room_id)
     walk_to(room_id)
     bput('scout trail', 'You notice a trailmarker')
-    return if 'I could not find what you were referring to' == bput('go trail', 'You set off into the wild', 'That would be difficult', 'I could not find what you were referring to')
+    return if 'I could not find what you were referring to' == bput('go trail', 'You set off into the wild', 'That would be difficult', 'I could not find what you were referring to', 'Because your account is free')
     waitfor('As your journey ends')
     pause 0.5 until Room.current.id
   end


### PR DESCRIPTION
Adding support for this:

```
--- Lich: go2 has exited.                                                                                      
[scouting]>scout trail                                                                                         
You have difficulty navigating that trail.                                                                     
[Because your account is free, you don't have access to the province this trail leads to.  To purchase access, 
  visit https://store.play.net/store/purchase/dr .]                                                            
You are unable to locate a trail in the area.                                                                  
>         
```                                                                                                     
