### PR TITLE
gtk not checked unless necessary

### DIFF
--- a/status-monitor.lic
+++ b/status-monitor.lic
@@ -2,13 +2,6 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#status-monitor
 =end
 
-unless HAVE_GTK
-  respond
-  respond 'error: ruby-gtk bindings are not installed or failed to load'
-  respond
-  exit
-end
-
 status_tags
 
 arg_definitions = [
@@ -193,6 +186,13 @@ if nowindow
       filter.spam_line = nil
     end
   end
+end
+
+unless HAVE_GTK
+  respond
+  respond 'error: ruby-gtk bindings are not installed or failed to load'
+  respond
+  exit
 end
 
 window = nil


### PR DESCRIPTION
Moved gtk check in status-monitor to beneath no window loop so that `status_monitor_no_window: true` could be accessed without gtk.