### PR TITLE
Increase pause for lower ranks

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -686,7 +686,13 @@ class SpellProcess
     return if UserVars.moons['visible'].empty?
 
     fput('pre moonblade')
-    pause
+    if DRSkill.getrank('Lunar Magic') < 300
+      pause 3
+    elsif DRSkill.getrank('Lunar Magic') < 400
+      pause 2
+    else
+      pause
+    end
     fput("cast #{UserVars.moons['visible'].first}")
     fput('break moonblade')
   end


### PR DESCRIPTION
Replaced the 1 second pause for snap casting a moonblade for tks shards to scale based on rank. Tested with ranks within that range and seems to fit properly. 