### PR TITLE
Merge Spell Data with Combat-Trainer & Support heavy tm/debil

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -566,7 +566,11 @@ class SpellProcess
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
     @spell_data = get_data('spells').spell_data
-
+    @offensive_spells.each.with_index do |spell, i| 
+      if @spell_data[spell['name']]
+        @offensive_spells[i] = spell.merge(@spell_data[spell['name']]) 
+      end
+    end
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -575,8 +575,8 @@ class SpellProcess
     
     @buff_spells
       .select { |spell| @spell_data[spell]}
-      .each do |spell|
-        @buff_spells[spell] = @spell_data[spell].merge(spell)
+      .each do |name, _data|
+        @buff_spells[name] = @spell_data[name].merge(@buff_spells[name])
       end
     echo(" @buff_spells merged with base-spells: #{@buff_spells}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -654,7 +654,7 @@ class SpellProcess
       @offensive_spells
         .select { |spell| spell['expire'] }
         .reject { |spell| spell['cyclic'] }
-        .reject { |spell| !spell['expire_on_death'] }
+        .reject { |spell| spell['heavy'] }
         .each { |spell| Flags["ct-#{spell['abbrev']}"] = true }
     end
     check_slivers(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -565,8 +565,6 @@ class SpellProcess
     @offensive_spell_cycle = settings.offensive_spell_cycle
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
-    @spell_data = get_data('spells').spell_data
-   
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -566,11 +566,11 @@ class SpellProcess
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
     @spell_data = get_data('spells').spell_data
-    @offensive_spells.each.with_index do |spell, i| 
-      if @spell_data[spell['name']]
-        @offensive_spells[i] = spell.merge(@spell_data[spell['name']]) 
+    @offensive_spells
+      .select { |spell| @spell_data[spell['name']] }
+      .each_with_index do |spell, i|
+        @offensive_spells[i] = @spell_data[spell['name']].merge(spell) 
       end
-    end
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 
@@ -975,7 +975,6 @@ class SpellProcess
     release_cyclics if data['cyclic']
     command = 'pre'
     command = data['skill'] != 'Targeted Magic' ? 'pre' : 'tar' if data['skill']
-    command = @spell_data[data['name']]['prep'] if @spell_data[data['name']]['prep']
     command = data['prep_type'] if data['prep_type']
 
     @spell_timers[data['abbrev']] = Time.now if data['recast_every']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -650,6 +650,7 @@ class SpellProcess
       @offensive_spells
         .select { |spell| spell['expire'] }
         .reject { |spell| spell['cyclic'] }
+        .reject { |spell| !spell['expire_on_death'] }
         .each { |spell| Flags["ct-#{spell['abbrev']}"] = true }
     end
     check_slivers(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -968,7 +968,6 @@ class SpellProcess
     end
     release_cyclics if data['cyclic']
     command = 'pre'
-    command = data['skill'] != 'Targeted Magic' ? 'pre' : 'tar' if data['skill']
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -566,20 +566,7 @@ class SpellProcess
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
     @spell_data = get_data('spells').spell_data
-    @offensive_spells
-      .select { |spell| @spell_data[spell['name']] }
-      .each_with_index do |spell, i|
-        @offensive_spells[i] = @spell_data[spell['name']].merge(spell) 
-      end
-    echo("  @offensive_spells merged with base-spells: #{@offensive_spells}") if $debug_mode_ct
-    
-    @buff_spells
-      .select { |spell| @spell_data[spell]}
-      .each do |name, _data|
-        @buff_spells[name] = @spell_data[name].merge(@buff_spells[name])
-      end
-    echo(" @buff_spells merged with base-spells: #{@buff_spells}") if $debug_mode_ct
-
+   
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -572,7 +572,14 @@ class SpellProcess
         @offensive_spells[i] = @spell_data[spell['name']].merge(spell) 
       end
     echo("  @offensive_spells merged with base-spells: #{@offensive_spells}") if $debug_mode_ct
- 
+    
+    @buff_spells
+      .select { |spell| @spell_data[spell]}
+      .each do |spell|
+        @buff_spells[spell] = @spell_data[spell].merge(spell)
+      end
+    echo(" @buff_spells merged with base-spells: #{@buff_spells}") if $debug_mode_ct
+
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -571,6 +571,8 @@ class SpellProcess
       .each_with_index do |spell, i|
         @offensive_spells[i] = @spell_data[spell['name']].merge(spell) 
       end
+    echo("  @offensive_spells merged with base-spells: #{@offensive_spells}") if $debug_mode_ct
+ 
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 
@@ -975,6 +977,7 @@ class SpellProcess
     release_cyclics if data['cyclic']
     command = 'pre'
     command = data['skill'] != 'Targeted Magic' ? 'pre' : 'tar' if data['skill']
+    command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
     @spell_timers[data['abbrev']] = Time.now if data['recast_every']

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -235,7 +235,7 @@ spell_data:
     skill: Debilitation
     abbrev: MS
     mana: 20
-    expire_on_death: false
+    heavy: true
     expire: recovered to craft another major manifestation of offensive magic
   Moongate:
     skill: Utility

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -175,14 +175,27 @@ spell_data:
     skill: Augmentation
     abbrev: BES
     cyclic: true
+  Bless:
+    skill: Utility
+    abbrev: bless
+    mana: 1
   Blessing of the Fae:
     skill: Augmentation
     abbrev: BOTF
     cyclic: true
+  Cage of Light:
+    skill: Warding
+    abbrev: CoL
+    mana: 15
+    moon: true
   Caress of the Sun:
     skill: Utility
     abbrev: CARE
     cyclic: true
+  Centering:
+    skill: Augmentation
+    abbrev: centering
+    mana: 1
   Cheetah Swiftness:
     skill: Augmentation
     abbrev: CS
@@ -232,6 +245,14 @@ spell_data:
     skill: Targeted Magic
     abbrev: IZ
     cyclic: true
+  Major Physical Protection:
+    skill: Augmentation
+    abbrev: MAPP
+    mana: 5
+  Manifest Force:
+    skill: Warding
+    abbrev: MaF
+    mana: 5
   Mental Blast:
     skill: Debilitation
     abbrev: MB
@@ -242,14 +263,26 @@ spell_data:
     mana: 20
     heavy: true
     expire: recovered to craft another major manifestation of offensive magic
+  Minor Physical Protection:
+    skill: Warding
+    abbrev: MPP
+    mana: 1
   Moongate:
     skill: Utility
     abbrev: MG
     cyclic: true
+  Partial Displacement:
+    skill: Targeted Magic
+    abbrev: PD
+    mana: 2
   Phoenix's Pyre:
     skill: Targeted Magic
     abbrev: PYRE
     cyclic: true
+  Psychic Shield:
+    skill: Warding
+    abbrev: PSY
+    mana: 5
   Regenerate:
     skill: Utility
     abbrev: REGENERATE
@@ -282,6 +315,14 @@ spell_data:
     skill: Utility
     abbrev: SANCTUARY
     cyclic: true
+  Seer's Sense:
+    skill: Augmentation # It is also utility
+    abbrev: SEER
+    mana: 15
+  Shadows:
+    skill: Augmentation
+    abbrev: shadows
+    mana: 1
   Sleep:
     skill: Debilitation
     abbrev: SLEEP
@@ -300,6 +341,7 @@ spell_data:
     abbrev: SLS
     cyclic: true
     prep: prepare
+    night: true
   Steps of Vuan:
     skill: Utility
     abbrev: SOV

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -135,180 +135,180 @@ khri_preps:
 
 spell_data:
   Eyes of the Blind:
-    ability: utility
+    skill: utility
     abbrev: EOTB
     invisibility: true
   Refractive Field:
-    ability: utility
+    skill: utility
     abbrev: RF
     invisibility: true
   Blend:
-    ability: utility
+    skill: utility
     abbrev: Blend
     invisibility: true
   Ghost Shroud:
-    ability: Warding
+    skill: Warding
     abbrev: GHS
     cyclic: true
   Abandoned Heart:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: ABAN
     cyclic: true
   Aesandry Darlaeth:
-    ability: Augmentation
+    skill: Augmentation
     abbrev: AD
     cyclic: true
   Aether Cloak:
-    ability: Warding
+    skill: Warding
     abbrev: AC
     cyclic: true
   Aether Wolves:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: AEWO
     cyclic: true
   Albreda's Balm:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: ALB
     cyclic: true
   Bear Strength:
-    ability: Augmentation
+    skill: Augmentation
     abbrev: BES
     cyclic: true
   Blessing of the Fae:
-    ability: Augmentation
+    skill: Augmentation
     abbrev: BOTF
     cyclic: true
   Caress of the Sun:
-    ability: Utility
+    skill: Utility
     abbrev: CARE
     cyclic: true
   Cheetah Swiftness:
-    ability: Augmentation
+    skill: Augmentation
     abbrev: CS
     cyclic: true
   Damaris' Lullaby:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: DALU
     cyclic: true
   Electrostatic Eddy:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: EE
     cyclic: true
   Eye of Kertigen:
-    ability: Utility
+    skill: Utility
     abbrev: EYE
     cyclic: true
   Faenella's Grace:
-    ability: Augmentation
+    skill: Augmentation
     abbrev: FAE
     cyclic: true
   Fire Rain:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: FR
     cyclic: true
   Glythtide's Joy:
-    ability: Warding
+    skill: Warding
     abbrev: GJ
     cyclic: true
   Guardian Spirit:
-    ability: Utility
+    skill: Utility
     abbrev: GS
     cyclic: true
     prep: pre
   Hodierna's Lilt:
-    ability: Utility
+    skill: Utility
     abbrev: HODI
     cyclic: true
   Hydra Hex:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: HYH
     cyclic: true
   Icutu Zaharenela:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: IZ
     cyclic: true
   Mental Blast:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: MB
     mana: 20
   Mind Shout:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: MS
     mana: 20
     expire_on_death: false
     expire: recovered to craft another major manifestation of offensive magic
   Moongate:
-    ability: Utility
+    skill: Utility
     abbrev: MG
     cyclic: true
   Phoenix's Pyre:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: PYRE
     cyclic: true
   Regenerate:
-    ability: Utility
+    skill: Utility
     abbrev: REGENERATE
     cyclic: true
   Resurrection:
-    ability: Utility
+    skill: Utility
     abbrev: REZZ
     cyclic: true
   Revelation:
-    ability: Utility
+    skill: Utility
     abbrev: REV
     cyclic: true
   Rimefang:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: RIM
     cyclic: true
   Ring of Spears:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: ROS
     cyclic: true
   Rite of Contrition:
-    ability: Utility
+    skill: Utility
     abbrev: ROC
     cyclic: true
   Rite of Grace:
-    ability: Utility
+    skill: Utility
     abbrev: ROG
     cyclic: true
   Sanctuary:
-    ability: Utility
+    skill: Utility
     abbrev: SANCTUARY
     cyclic: true
   Sleep:
-    ability: Debilitation
+    skill: Debilitation
     abbrev: SLEEP
     mana: 1
   Soul Attrition:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: SA
     cyclic: true
   Starlight Sphere:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: SLS
     cyclic: true
     prep: pre
   Steps of Vuan:
-    ability: Utility
+    skill: Utility
     abbrev: SOV
     cyclic: true
     invisibility: true
   Telekinetic Storm:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: TKS
     mana: 15
   Truffenyi's Rally:
-    ability: Augmentation
+    skill: Augmentation
     abbrev: TR
     cyclic: true
   Universal Solvent:
-    ability: Targeted Magic
+    skill: Targeted Magic
     abbrev: USOL
     cyclic: true
   Holy Warrior:
-    ability: Warding
+    skill: Warding
     abbrev: HOW
     cyclic: true
 

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -139,10 +139,6 @@ spell_data:
     skill: utility
     abbrev: EOTB
     invisibility: true
-  Refractive Field:
-    skill: utility
-    abbrev: RF
-    invisibility: true
   Blend:
     skill: utility
     abbrev: Blend
@@ -171,6 +167,10 @@ spell_data:
     skill: Debilitation
     abbrev: ALB
     cyclic: true
+  Aura Sight:
+    skill: Augmentation
+    abbrev: AUS
+    mana: 5
   Bear Strength:
     skill: Augmentation
     abbrev: BES
@@ -183,11 +183,19 @@ spell_data:
     skill: Augmentation
     abbrev: BOTF
     cyclic: true
+  Burn:
+    skill: Targeted Magic
+    abbrev: burn
+    mana: 7
   Cage of Light:
     skill: Warding
     abbrev: CoL
     mana: 15
     moon: true
+  Calm:
+    skill: Debilitation
+    abbrev: calm
+    mana: 1
   Caress of the Sun:
     skill: Utility
     abbrev: CARE
@@ -208,6 +216,14 @@ spell_data:
     skill: Debilitation
     abbrev: DALU
     cyclic: true
+  Dazzle: # Requires either the sun or moons to be visible and being outdoors
+    skill: Debilitation
+    abbrev: dazzle
+    mana: 1 
+  Distant Gaze:
+    skill: Utility
+    abbrev: DG
+    mana: 15
   Electrostatic Eddy:
     skill: Debilitation
     abbrev: EE
@@ -228,6 +244,11 @@ spell_data:
     skill: Targeted Magic
     abbrev: FR
     cyclic: true
+  Focus Moonbeam:
+    skill: Utility
+    abbrev: FM
+    mana: 1
+    moon: true
   Glythtide's Joy:
     skill: Warding
     abbrev: GJ
@@ -245,10 +266,15 @@ spell_data:
     skill: Debilitation
     abbrev: HYH
     cyclic: true
+    triggers_justice: true
   Icutu Zaharenela:
     skill: Targeted Magic
     abbrev: IZ
     cyclic: true
+  Locate:
+    skill: Utility
+    abbrev: locate
+    mana: 15
   Major Physical Protection:
     skill: Augmentation
     abbrev: MAPP
@@ -267,10 +293,16 @@ spell_data:
     mana: 20
     heavy: true
     expire: recovered to craft another major manifestation of offensive magic
+    triggers_justice: true
   Minor Physical Protection:
     skill: Warding
     abbrev: MPP
     mana: 1
+  Moonblade:
+    skill: Utility
+    abbrev: moonblade
+    mana: 15
+    moon: true
   Moongate:
     skill: Utility
     abbrev: MG
@@ -279,6 +311,10 @@ spell_data:
     skill: Targeted Magic
     abbrev: PD
     mana: 2
+  Piercing Gaze:
+    skill: Utility
+    abbrev: PG
+    mana: 5
   Phoenix's Pyre:
     skill: Targeted Magic
     abbrev: PYRE
@@ -287,10 +323,19 @@ spell_data:
     skill: Warding
     abbrev: PSY
     mana: 5
+  Refractive Field:
+    skill: Utility
+    abbrev: RF
+    mana: 5
+    invisibility: true
   Regenerate:
     skill: Utility
     abbrev: REGENERATE
     cyclic: true
+  Rend:
+    skill: Utility
+    abbrev: rend
+    mana: 5
   Resurrection:
     skill: Utility
     abbrev: REZZ
@@ -327,6 +372,10 @@ spell_data:
     skill: Augmentation
     abbrev: shadows
     mana: 1
+  Shear:
+    skill: Warding
+    abbrev: shear
+    mana: 30
   Sleep:
     skill: Debilitation
     abbrev: SLEEP
@@ -349,12 +398,21 @@ spell_data:
   Steps of Vuan:
     skill: Utility
     abbrev: SOV
+    mana: 5
     cyclic: true
     invisibility: true
   Telekinetic Storm:
     skill: Targeted Magic
     abbrev: TKS
     mana: 15
+  Telekinetic Throw:
+    skill: Targeted Magic
+    abbrev: TKT
+    mana: 1
+  Tenebrous Sense:
+    skill: Augmentation
+    abbrev: TS
+    mana: 5
   Truffenyi's Rally:
     skill: Augmentation
     abbrev: TR
@@ -363,6 +421,11 @@ spell_data:
     skill: Targeted Magic
     abbrev: USOL
     cyclic: true
+    triggers_justice: true
+  Unleash:
+    skill: Utility
+    abbrev: unleash
+    mana: 15
   Holy Warrior:
     skill: Warding
     abbrev: HOW

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -52,6 +52,7 @@ prep_messages:
 - You begin to sing
 - Low, hummed tones form a soft backdrop
 - You weave the soft melody
+- You are still too fatigued from your previous efforts to manifest another major feat of offensive magic
 
 cast_messages:
 - ^Your spell backfires
@@ -202,6 +203,10 @@ spell_data:
     skill: Augmentation
     abbrev: FAE
     cyclic: true
+  Fists of Faenella:
+    skill: Targeted Magic
+    abbrev: FF
+    mana: 2
   Fire Rain:
     skill: Targeted Magic
     abbrev: FR
@@ -281,6 +286,11 @@ spell_data:
     skill: Debilitation
     abbrev: SLEEP
     mana: 1
+  Soul Sickness:
+    skill: Debilitation
+    abbrev: SICK
+    mana: 1
+    expire: The spiritual weight lifts off
   Soul Attrition:
     skill: Targeted Magic
     abbrev: SA
@@ -289,7 +299,7 @@ spell_data:
     skill: Targeted Magic
     abbrev: SLS
     cyclic: true
-    prep: pre
+    prep: prepare
   Steps of Vuan:
     skill: Utility
     abbrev: SOV

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -200,6 +200,10 @@ spell_data:
     skill: Augmentation
     abbrev: CS
     cyclic: true
+  Clear Vision:
+    skill: Augmentation
+    abbrev: CV
+    mana: 1
   Damaris' Lullaby:
     skill: Debilitation
     abbrev: DALU

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -227,6 +227,10 @@ spell_data:
     ability: Targeted Magic
     abbrev: IZ
     cyclic: true
+  Mental Blast:
+    ability: Debilitation
+    abbrev: MB
+    mana: 20
   Mind Shout:
     ability: Debilitation
     abbrev: MS
@@ -273,6 +277,10 @@ spell_data:
     ability: Utility
     abbrev: SANCTUARY
     cyclic: true
+  Sleep:
+    ability: Debilitation
+    abbrev: SLEEP
+    mana: 1
   Soul Attrition:
     ability: Targeted Magic
     abbrev: SA
@@ -287,6 +295,10 @@ spell_data:
     abbrev: SOV
     cyclic: true
     invisibility: true
+  Telekinetic Storm:
+    ability: Targeted Magic
+    abbrev: TKS
+    mana: 15
   Truffenyi's Rally:
     ability: Augmentation
     abbrev: TR

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -227,6 +227,12 @@ spell_data:
     ability: Targeted Magic
     abbrev: IZ
     cyclic: true
+  Mind Shout:
+    ability: Debilitation
+    abbrev: MS
+    mana: 20
+    expire_on_death: false
+    expire: recovered to craft another major manifestation of offensive magic
   Moongate:
     ability: Utility
     abbrev: MG

--- a/dependency.lic
+++ b/dependency.lic
@@ -774,19 +774,14 @@ class SetupFiles
 
     s.lootables = (base_lootables + boxes + gems + scrolls + s.loot_additions - s.loot_subtractions).uniq
     
-    s.offensive_spells
-      .select { |spell| spells[spell['name']] }
-      .each_with_index do |spell, i|
-        s.offensive_spells[i] = spells[spell['name']].merge(spell)
-      end
-    
+    s.offensive_spells.map!{ |spell| spells[spell['name']] ? spells[spell['name']].merge(spell) : spell  }
+
     s.offensive_spells
       .each_with_index
-      .select { |spell, _i| spell['skill'].downcase == 'targeted magic' }
+      .select { |spell, _i| (spell['skill'].downcase == 'targeted magic') || (spells[spell['name']]['skill'].downcase == 'targeted magic' && spell['skill'].downcase == 'sorcery')}
       .reject { |spell, _i| spell['prep'] }
-      .select { |spell, _i| spells[spell['name']]['skill'].downcase == 'targeted magic' && spell['skill'].downcase == 'sorcery' }
       .each { |data, i| s.offensive_spells[i]['prep'] = 'target' } 
-    
+    echo s.offensive_spells
     s.buff_spells
       .select { |spell| spells[spell] }
       .each do |name, _data|

--- a/dependency.lic
+++ b/dependency.lic
@@ -795,7 +795,9 @@ class SetupFiles
         spells.select { |_name, data| data['abbrev'].downcase == spell['abbrev'].downcase }
               .each { |_name, data| s.lockpick_buffs['spells'][i] = data.merge(spell) } 
       end
-
+    s.waggle_sets
+      .select { |set_name, set_spells| set_spells.select { |spell_name, spell_data| spells[spell_name].each {s.waggle_sets[set_name][spell_name] = spells[spell_name].merge(spell_data) } } }
+  
     s
   end
 end

--- a/dependency.lic
+++ b/dependency.lic
@@ -781,7 +781,7 @@ class SetupFiles
       .select { |spell, _i| (spell['skill'].downcase == 'targeted magic') || (spells[spell['name']]['skill'].downcase == 'targeted magic' && spell['skill'].downcase == 'sorcery')}
       .reject { |spell, _i| spell['prep'] }
       .each { |data, i| s.offensive_spells[i]['prep'] = 'target' } 
-    echo s.offensive_spells
+    
     s.buff_spells
       .select { |spell| spells[spell] }
       .each do |name, _data|

--- a/dependency.lic
+++ b/dependency.lic
@@ -783,7 +783,13 @@ class SetupFiles
       .each do |name, _data|
         s.buff_spells[name] = spells[name].merge(s.buff_spells[name])
       end
-    
+    s.lockpick_buffs['spells']
+      .each_with_index
+      .select do |spell, i| 
+        spells.select { |_name, data| data['abbrev'].downcase == spell['abbrev'].downcase }
+              .each { |_name, data| s.lockpick_buffs['spells'][i] = data.merge(spell) } 
+      end
+
     s
   end
 end

--- a/dependency.lic
+++ b/dependency.lic
@@ -789,6 +789,12 @@ class SetupFiles
         spells.select { |_name, data| data['abbrev'].downcase == spell['abbrev'].downcase }
               .each { |_name, data| s.lockpick_buffs['spells'][i] = data.merge(spell) } 
       end
+    s.astrology_buffs['spells']
+      .each_with_index
+      .select do |spell, i| 
+        spells.select { |_name, data| data['abbrev'].downcase == spell['abbrev'].downcase }
+              .each { |_name, data| s.lockpick_buffs['spells'][i] = data.merge(spell) } 
+      end
 
     s
   end

--- a/dependency.lic
+++ b/dependency.lic
@@ -770,38 +770,43 @@ class SetupFiles
     boxes = @base_files['base-items.yaml'][:box_nouns]
     gems = @base_files['base-items.yaml'][:gem_nouns]
     scrolls = @base_files['base-items.yaml'][:scroll_nouns]
-    spells = @base_files['base-spells.yaml'][:spell_data]
-
-    
+    spells = @base_files['base-spells.yaml'][:spell_data] 
 
     s.lootables = (base_lootables + boxes + gems + scrolls + s.loot_additions - s.loot_subtractions).uniq
+    
     s.offensive_spells
       .select { |spell| spells[spell['name']] }
       .each_with_index do |spell, i|
         s.offensive_spells[i] = spells[spell['name']].merge(spell)
       end
+    
     s.offensive_spells
       .each_with_index
-      .select { |spell, _i| (spell['skill'].downcase == 'targeted magic' && !spell['prep']) || (spells[spell['name']]['skill'].downcase == 'targeted magic' && spell['skill'].downcase == 'sorcery')}
-      .each { |data, i| s.offensive_spells[i]['prep'] = 'target' }
-    echo s.offensive_spells  
+      .select { |spell, _i| spell['skill'].downcase == 'targeted magic' }
+      .reject { |spell, _i| spell['prep'] }
+      .select { |spell, _i| spells[spell['name']]['skill'].downcase == 'targeted magic' && spell['skill'].downcase == 'sorcery' }
+      .each { |data, i| s.offensive_spells[i]['prep'] = 'target' } 
+    
     s.buff_spells
       .select { |spell| spells[spell] }
       .each do |name, _data|
         s.buff_spells[name] = spells[name].merge(s.buff_spells[name])
       end
+    
     s.lockpick_buffs['spells']
       .each_with_index
       .select do |spell, i| 
         spells.select { |_name, data| data['abbrev'].downcase == spell['abbrev'].downcase }
               .each { |_name, data| s.lockpick_buffs['spells'][i] = data.merge(spell) } 
       end
+    
     s.astrology_buffs['spells']
       .each_with_index
       .select do |spell, i| 
         spells.select { |_name, data| data['abbrev'].downcase == spell['abbrev'].downcase }
               .each { |_name, data| s.lockpick_buffs['spells'][i] = data.merge(spell) } 
       end
+    
     s.waggle_sets
       .select { |set_name, set_spells| set_spells.select { |spell_name, spell_data| spells[spell_name].each {s.waggle_sets[set_name][spell_name] = spells[spell_name].merge(spell_data) } } }
   

--- a/dependency.lic
+++ b/dependency.lic
@@ -770,8 +770,20 @@ class SetupFiles
     boxes = @base_files['base-items.yaml'][:box_nouns]
     gems = @base_files['base-items.yaml'][:gem_nouns]
     scrolls = @base_files['base-items.yaml'][:scroll_nouns]
-    s.lootables = (base_lootables + boxes + gems + scrolls + s.loot_additions - s.loot_subtractions).uniq
+    spells = @base_files['base-spells.yaml'][:spell_data]
 
+    s.lootables = (base_lootables + boxes + gems + scrolls + s.loot_additions - s.loot_subtractions).uniq
+    s.offensive_spells
+      .select { |spell| spells[spell['name']] }
+      .each_with_index do |spell, i|
+        s.offensive_spells[i] = spells[spell['name']].merge(spell)
+      end
+    s.buff_spells
+      .select { |spell| spells[spell] }
+      .each do |name, _data|
+        s.buff_spells[name] = spells[name].merge(s.buff_spells[name])
+      end
+    
     s
   end
 end

--- a/dependency.lic
+++ b/dependency.lic
@@ -772,12 +772,19 @@ class SetupFiles
     scrolls = @base_files['base-items.yaml'][:scroll_nouns]
     spells = @base_files['base-spells.yaml'][:spell_data]
 
+    
+
     s.lootables = (base_lootables + boxes + gems + scrolls + s.loot_additions - s.loot_subtractions).uniq
     s.offensive_spells
       .select { |spell| spells[spell['name']] }
       .each_with_index do |spell, i|
         s.offensive_spells[i] = spells[spell['name']].merge(spell)
       end
+    s.offensive_spells
+      .each_with_index
+      .select { |spell, _i| (spell['skill'].downcase == 'targeted magic' && !spell['prep']) || (spells[spell['name']]['skill'].downcase == 'targeted magic' && spell['skill'].downcase == 'sorcery')}
+      .each { |data, i| s.offensive_spells[i]['prep'] = 'target' }
+    echo s.offensive_spells  
     s.buff_spells
       .select { |spell| spells[spell] }
       .each do |name, _data|

--- a/profiles/Crannach-back.yaml
+++ b/profiles/Crannach-back.yaml
@@ -1,6 +1,6 @@
 ---
 hunting_info:
-- :zone: elder_blue_dappled_prereni
+- :zone: adanf_warriors_and_mages
   args:
     - d0
     - back
@@ -31,18 +31,18 @@ skinning:
 
 gear_sets:
   standard:
-  - battle crossbow
-  - round sipar
+  - oaken staff
+  - small shield
   - leather gloves
   - ring helm
   - a polished steel parry stick
   - some silver-chased elbow spikes
   - some brass knuckles
   - plate mask
-  - ring hauberk
+  - scale lorica
   - jagged scythe
   stealing:
-  - battle crossbow
   - some silver-chased elbow spikes
   - parry stick
   - jagged scythe
+  - oaken staff

--- a/profiles/Crannach-back.yaml
+++ b/profiles/Crannach-back.yaml
@@ -13,6 +13,7 @@ weapon_training:
  Polearms: jagged scythe
  Heavy Thrown: throwing hammer
 
+use_weak_attacks: false
 use_stealth_attacks: true
 dance_skill: Polearms
 

--- a/profiles/Crannach-back.yaml
+++ b/profiles/Crannach-back.yaml
@@ -14,7 +14,7 @@ weapon_training:
  Heavy Thrown: throwing hammer
 
 use_weak_attacks: false
-use_stealth_attacks: true
+use_stealth_attacks: false
 dance_skill: Polearms
 
 buff_spells:
@@ -41,6 +41,7 @@ gear_sets:
   - some brass knuckles
   - plate mask
   - scale lorica
+  - plate vambraces
   - jagged scythe
   stealing:
   - some silver-chased elbow spikes

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -10,6 +10,7 @@ status_monitor:
   ignore_talking: true
 status_monitor_no_window: true
 slack_username: jonas
+
 ### SAFE ROOMS ###
 safe_room: 2732 # Shard - Stormfells, Stonewend (has grass)
 # safe_room: 2855 # Shard - Dark Clearing (has vines)
@@ -23,7 +24,7 @@ safe_room: 2732 # Shard - Stormfells, Stonewend (has grass)
 # safe_room: 1645 # Crossing - Spooky Tree ooOoOoO
 # safe_room: 19162 # Crossing - MM Guild (No vines)
 
-# HUNTING
+### HUNTING ###
 hunting_file_list:
 - tm
 - setup
@@ -47,7 +48,7 @@ training_abilities:
   Hunt: 80
   App Quick: 60
   PercMana: 240
-#  Tactics: 20
+  Tactics: 60
 
 weapon_training:
   Crossbow: battle crossbow
@@ -171,8 +172,7 @@ stored_cambrinth: false
 prep_scaling_factor: 0.98
 
 offensive_spells:
-  - skill: Debilitation
-    name: Mind Shout
+  - name: Mind Shout
     cambrinth:
     - 17
     harmless: true
@@ -180,8 +180,7 @@ offensive_spells:
     mana: 9
     cast: cast heart
     night: true
-  - skill: Targeted Magic
-    name: Telekinetic Storm
+  - name: Telekinetic Storm
     abbrev: tks
     mana: 15
     cambrinth:

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -2,9 +2,6 @@
 hometown: Shard
 #hometown: Hibarnhvidar
 
-climbing_target: coriks_wall
-
-
 ### STATUS MONITOR ###
 status_monitor:
   ignore_talking: true
@@ -57,8 +54,14 @@ weapon_training:
 dance_skill: Brawling
 use_stealth_attacks: true
 use_weak_attacks: true
-
+ignored_npcs:
+- shadowling
+- Shadow Servant
+#################
+### EQUIPMENT ###
+#################
 gear:
+#### WEAPONS ####
 - :name: staff
   :adjective: oaken
   :is_leather: true
@@ -67,6 +70,10 @@ gear:
   :adjective: jagged
   :is_worn: true
   :is_leather: false
+- :name: hammer
+  :adjective: throwing
+  :is_leather: false
+##### ARMOR #####
 - :name: lorica
   :adjective: scale
   :is_worn: true
@@ -76,9 +83,6 @@ gear:
   :is_leather: false
   :is_worn: true
   :hinders_lockpicking: true
-- :name: hammer
-  :adjective: throwing
-  :is_leather: false
 - :adjective: small
   :name: shield
   :is_leather: false
@@ -141,7 +145,6 @@ gear:
   :adjective: plate
   :is_worn: true
   :is_leather: false
-
 gear_sets:
   standard:
   - small shield
@@ -161,8 +164,6 @@ gear_sets:
   - parry stick
   - jagged scythe
   - oaken staff
-hand_armor: ring gloves
-
 ### CAMBRINTH ###
 cambrinth: nestled armband
 cambrinth_cap: 48
@@ -231,18 +232,9 @@ buff_spells:
     - 48
     recast: 1
 
-training_spells:
-  Augmentation:
-    abbrev: aus
-    symbiosis: true
-  Warding:
-    abbrev: maf
-    symbiosis: true
-  Utility:
-    abbrev: pg
-    symbiosis: true
-
+#################
 ### ASTROLOGY ###
+#################
 have_telescope: true
 astral_plane_training:
   train_in_ap: true # Train astrology in the astral plane? Need circle > 99 for now...
@@ -260,6 +252,9 @@ astrology_buffs:
       cambrinth:
       - 44
 
+#############
+### ;BUFF ###
+#############
 waggle_sets:
   default:
     Aura Sight:
@@ -330,15 +325,16 @@ waggle_sets:
       mana: 15
       cambrinth:
         - 45
+####################
 ### LOCKSMITHING ###
+####################
 lockpick_buffs:
-  Piercing Gaze:
-    abbrev: pg
+  spells:
+  - abbrev: pg
     mana: 30
     cambrinth:
     - 32
-  Clear Vision:
-    abbrev: cv
+  - abbrev: cv
     mana: 40
     cambrinth:
     - 32
@@ -349,9 +345,13 @@ use_lockpick_ring: true
 lockpick_type: grandmaster
 lockpick_dismantle: focus
 harvest_traps: true
-
-
-# Looting, Skinning & Selling
+############
+### LOOT ###
+############
+gem_pouch_adjective: fuzzy
+spare_gem_pouch_container: kit
+sell_loot_pouch: false
+sell_loot_bundle: true
 loot_additions:
 - card
 - dira
@@ -359,23 +359,18 @@ loot_additions:
 loot_subtractions:
 - arrow
 loot_specials:
-- name: stones
+- name: jadeite stones
   bag: pack
-- name: star diopside
+- name: star sapphire
   bag: pack
-
-gem_pouch_adjective: fuzzy
-spare_gem_pouch_container: kit
-sell_loot_pouch: false
-
 skinning:
   skin: true
   arrange_all: false
   arrange_count: 0
   tie_bundle: true
-sell_loot_bundle: true
-
-# Noncombat Settings
+#####################
+### TOWN TRAINING ###
+#####################
 crossing_training:
 - Locksmithing
 - Astrology
@@ -384,29 +379,41 @@ crossing_training:
 - Warding
 - Attunement
 - First Aid
-# - Outdoorsmanship
 - Mechanical Lore
 - Forging
 - Athletics
-
-listen: true
-
-braid_item: grass
-
 exp_timers:
   First Aid: 360
   Locksmithing: 600
   Attunement: 130
   Astrology: 30
   Thievery: 600
-
 train_with_spells: true
 use_research: true
+training_spells:
+  Augmentation:
+    abbrev: aus
+    symbiosis: true
+  Warding:
+    abbrev: maf
+    symbiosis: true
+  Utility:
+    abbrev: pg
+    symbiosis: true
 research_skills:
   - Utility
   - Augmentation
+climbing_target: coriks_wall
+listen: true
 
+#################
+### MECH LORE ###
+#################
+hand_armor: ring gloves
+braid_item: grass
+##############
 ### MINING ###
+##############
 mine_for_outdoorsmanship: false
 mines_to_mine:
 - ice_caves # Shard
@@ -430,8 +437,9 @@ mining_buddy_vein_list:
 - Haralun
 - Glaes
 - Animite
-
+################
 ### CRAFTING ###
+################
 train_workorders:
 - Blacksmithing
 crafting_container: pack
@@ -454,7 +462,3 @@ mark_crafted_goods: true
 # Favors
 favor_god: Meraud
 favor_goal: 30
-
-ignored_npcs:
-- shadowling
-- Shadow Servant

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -38,19 +38,27 @@ training_abilities:
   Hunt: 80
   App Quick: 60
   PercMana: 240
-  # Tactics: 20
+#  Tactics: 20
 
 weapon_training:
-  Crossbow: battle crossbow
-  Large Edged: icy-blue blade
+#  Crossbow: battle crossbow
+#  Large Edged: icy-blue blade
   Brawling: ''
 dance_skill: Brawling
-use_stealth_attacks: false
+use_stealth_attacks: true
 use_weak_attacks: true
 
 gear:
+- :name: staff
+  :adjective: oaken
+  :is_leather: true
+  :is_worn: true
 - :name: scythe
   :adjective: jagged
+  :is_worn: true
+  :is_leather: false
+- :name: lorica
+  :adjective: scale
   :is_worn: true
   :is_leather: false
 - :name: claymore
@@ -72,7 +80,7 @@ gear:
 - :name: crossbow
   :adjective: battle
   :is_leather: true
-  :is_worn: true
+  :is_worn: false
 - :adjective: ring
   :name: helm
   :is_leather: false
@@ -116,7 +124,6 @@ gear:
 
 gear_sets:
   standard:
-  - battle crossbow
   - round sipar
   - ring gloves
   - ring helm
@@ -126,12 +133,13 @@ gear_sets:
   - plate mask
   - ring hauberk
   - jagged scythe
+  - oaken staff
   stealing:
-  - battle crossbow
   - some silver-chased elbow spikes
   - parry stick
   - jagged scythe
-hand_armor: gloves
+  - oaken staff
+hand_armor: ring gloves
 
 # Magik
 cambrinth: nestled armband
@@ -142,6 +150,15 @@ stored_cambrinth: false
 prep_scaling_factor: 0.98
 
 offensive_spells:
+  - skill: Debilitation
+    name: Mind Shout
+    abbrev: ms
+    mana: 20
+    cambrinth:
+    - 17
+    expire: recovered to craft another major manifestation of offensive magic 
+    expire_on_death: false
+    harmless: true
   - skill: Targeted Magic
     name: Starlight Sphere
     abbrev: sls
@@ -191,15 +208,21 @@ buff_spells:
   Seer's Sense:
     abbrev: seer
     recast: 1
-    mana: 15
+    mana: 36
     cambrinth:
-    - 40
+    - 48
   Cage of Light:
     abbrev: col
     mana: 15
     moon: true
     cambrinth:
     - 45
+    recast: 1
+  Shadows:
+    abbrev: shadows
+    mana: 52
+    cambrinth:
+    - 48
     recast: 1
 
 training_spells:
@@ -421,7 +444,8 @@ forging_tools:
 - tong
 - bellow
 - shovel
-
+- stamp
+- pliers
 # Favors
 favor_god: Meraud
 favor_goal: 30

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -179,25 +179,16 @@ offensive_spells:
   - name: Starlight Sphere
     mana: 9
     cast: cast heart
-    night: true
   - name: Telekinetic Storm
-    abbrev: tks
-    mana: 15
     cambrinth:
     - 48
     slivers: true
-  - skill: Debilitation
-    name: Mental Blast
-    abbrev: mb
+  - name: Mental Blast
     harmless: true
-    mana: 20
     cambrinth:
       - 15
     cast_only_to_train: true
-  - skill: Targeted Magic
-    name: Partial Displacement
-    abbrev: pd
-    mana: 2
+  - name: Partial Displacement
     harmless: true
     cambrinth:
       - 30
@@ -214,32 +205,27 @@ offensive_spells:
 
 buff_spells:
   Psychic Shield:
-    abbrev: psy
     recast: 1
     mana: 30
     cambrinth:
     - 48
   Manifest Force:
-    abbrev: maf
     recast: 1
     mana: 30
     cambrinth:
     - 48
   Seer's Sense:
-    abbrev: seer
     recast: 1
     mana: 36
     cambrinth:
     - 48
   Cage of Light:
-    abbrev: col
     mana: 15
     moon: true
     cambrinth:
     - 45
     recast: 1
   Shadows:
-    abbrev: shadows
     mana: 52
     cambrinth:
     - 48

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -1,8 +1,11 @@
 ---
 hometown: Shard
+#hometown: Hibarnhvidar
 slack_username: jonas
 climbing_target: coriks_wall
 mark_crafted_goods: true
+status_monitor:
+  ignore_talking: true
 status_monitor_no_window: true
 # Safe Rooms
 
@@ -24,10 +27,10 @@ hunting_file_list:
 - back
 training_manager_hunting_priority: true
 training_manager_priority_skills:
-- Polearms
+- Brigandine
 
 hunting_info:
-  - :zone: mountain_giants
+  - :zone: black_marble_gargoyles
     args:
     - d0
     stop_on:
@@ -72,8 +75,8 @@ gear:
 - :name: hammer
   :adjective: throwing
   :is_leather: false
-- :adjective: round
-  :name: sipar
+- :adjective: small
+  :name: shield
   :is_leather: false
   :hinders_lockpicking: true
   :is_worn: true
@@ -121,10 +124,18 @@ gear:
   :is_worn: true
   :is_leather: false
   :hinders_lockpicking: true
-
+- :name: staff
+  :adjective: oaken
+  :is_worn: true
+  :is_leather: true
+  :hinders_lockpicking: false
+- :name: lorica
+  :adjective: scale
+  :is_worn: true
+  :is_leather: false
 gear_sets:
   standard:
-  - round sipar
+  - small shield
   - ring gloves
   - ring helm
   - a polished steel parry stick
@@ -135,6 +146,8 @@ gear_sets:
   - jagged scythe
   - oaken staff
   stealing:
+  - oaken staff
+  - small shield
   - some silver-chased elbow spikes
   - parry stick
   - jagged scythe
@@ -165,7 +178,14 @@ offensive_spells:
     mana: 9
     cast: cast heart
     night: true
-    cyclic: true
+    cyclic: true 
+  - skill: Targeted Magic
+    name: Telekinetic Storm
+    abbrev: tks
+    mana: 15
+    cambrinth:
+    - 48
+    slivers: true
   - skill: Debilitation
     name: Mental Blast
     abbrev: mb
@@ -227,7 +247,7 @@ buff_spells:
 
 training_spells:
   Augmentation:
-    abbrev: cv
+    abbrev: aus
     symbiosis: true
   Warding:
     abbrev: maf

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -1,14 +1,16 @@
 ---
 hometown: Shard
 #hometown: Hibarnhvidar
-slack_username: jonas
+
 climbing_target: coriks_wall
-mark_crafted_goods: true
+
+
+### STATUS MONITOR ###
 status_monitor:
   ignore_talking: true
 status_monitor_no_window: true
-# Safe Rooms
-
+slack_username: jonas
+### SAFE ROOMS ###
 safe_room: 2732 # Shard - Stormfells, Stonewend (has grass)
 # safe_room: 2855 # Shard - Dark Clearing (has vines)
 # safe_room: 2624 # Shard - House of the Silver Star, Gardens
@@ -23,6 +25,7 @@ safe_room: 2732 # Shard - Stormfells, Stonewend (has grass)
 
 # HUNTING
 hunting_file_list:
+- tm
 - setup
 - back
 training_manager_hunting_priority: true
@@ -33,9 +36,11 @@ hunting_info:
   - :zone: black_marble_gargoyles
     args:
     - d0
-    stop_on:
     - setup
-    - Targeted Magic
+    stop_on:
+    - Evasion
+    - Stealth
+    - Shield Usage
     :duration: 60
 
 training_abilities:
@@ -64,9 +69,6 @@ gear:
 - :name: lorica
   :adjective: scale
   :is_worn: true
-  :is_leather: false
-- :name: claymore
-  :is_worn: false
   :is_leather: false
 - :name: mask
   :adjective: plate
@@ -134,6 +136,11 @@ gear:
   :adjective: scale
   :is_worn: true
   :is_leather: false
+- :name: vambraces
+  :adjective: plate
+  :is_worn: true
+  :is_leather: false
+
 gear_sets:
   standard:
   - small shield
@@ -155,7 +162,7 @@ gear_sets:
   - oaken staff
 hand_armor: ring gloves
 
-# Magik
+### CAMBRINTH ###
 cambrinth: nestled armband
 cambrinth_cap: 48
 held_cambrinth: false
@@ -169,13 +176,10 @@ offensive_spells:
     cambrinth:
     - 17
     harmless: true
-  - skill: Targeted Magic
-    name: Starlight Sphere
-    abbrev: sls
+  - name: Starlight Sphere
     mana: 9
     cast: cast heart
     night: true
-    cyclic: true 
   - skill: Targeted Magic
     name: Telekinetic Storm
     abbrev: tks
@@ -253,13 +257,13 @@ training_spells:
     abbrev: pg
     symbiosis: true
 
+### ASTROLOGY ###
+have_telescope: true
 astral_plane_training:
   train_in_ap: true # Train astrology in the astral plane? Need circle > 99 for now...
   train_destination: crossing # Walk here when training
   train_source: shard # Walk back when done
-
 quit_on_death_in_ap: true # Overrides AFK and quits on death (this is a bescort setting)
-
 astrology_buffs:
   spells:
     - abbrev: pg
@@ -270,18 +274,6 @@ astrology_buffs:
       mana: 21
       cambrinth:
       - 44
-
-lockpick_buffs:
-  Piercing Gaze:
-    abbrev: pg
-    mana: 30
-    cambrinth:
-      - 32
-  Clear Vision:
-    abbrev: cv
-    mana: 40
-    cambrinth:
-      - 32
 
 waggle_sets:
   default:
@@ -353,8 +345,18 @@ waggle_sets:
       mana: 15
       cambrinth:
         - 45
-
-# Locksmithing
+### LOCKSMITHING ###
+lockpick_buffs:
+  Piercing Gaze:
+    abbrev: pg
+    mana: 30
+    cambrinth:
+    - 32
+  Clear Vision:
+    abbrev: cv
+    mana: 40
+    cambrinth:
+    - 32
 stop_pick_on_mindlock: true
 picking_box_source: duffel bag
 picking_box_storage: duffel bag
@@ -403,7 +405,7 @@ crossing_training:
 - Athletics
 
 listen: true
-have_telescope: true
+
 braid_item: grass
 
 exp_timers:
@@ -419,7 +421,7 @@ research_skills:
   - Utility
   - Augmentation
 
-# Mining & Crafting
+### MINING ###
 mine_for_outdoorsmanship: false
 mines_to_mine:
 - ice_caves # Shard
@@ -444,7 +446,7 @@ mining_buddy_vein_list:
 - Glaes
 - Animite
 
-
+### CRAFTING ###
 train_workorders:
 - Blacksmithing
 crafting_container: pack
@@ -463,6 +465,7 @@ forging_tools:
 - shovel
 - stamp
 - pliers
+mark_crafted_goods: true
 # Favors
 favor_god: Meraud
 favor_goal: 30

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -28,12 +28,13 @@ hunting_file_list:
 training_manager_hunting_priority: true
 training_manager_priority_skills:
 - Brigandine
-
+priority_defense: Evasion
 hunting_info:
   - :zone: black_marble_gargoyles
     args:
     - d0
     stop_on:
+    - setup
     - Targeted Magic
     :duration: 60
 
@@ -44,8 +45,8 @@ training_abilities:
 #  Tactics: 20
 
 weapon_training:
-#  Crossbow: battle crossbow
-#  Large Edged: icy-blue blade
+  Crossbow: battle crossbow
+  Large Edged: icy-blue blade
   Brawling: ''
 dance_skill: Brawling
 use_stealth_attacks: true
@@ -165,12 +166,8 @@ prep_scaling_factor: 0.98
 offensive_spells:
   - skill: Debilitation
     name: Mind Shout
-    abbrev: ms
-    mana: 20
     cambrinth:
     - 17
-    expire: recovered to craft another major manifestation of offensive magic 
-    expire_on_death: false
     harmless: true
   - skill: Targeted Magic
     name: Starlight Sphere
@@ -417,7 +414,7 @@ exp_timers:
   Thievery: 600
 
 train_with_spells: true
-use_research: false
+use_research: true
 research_skills:
   - Utility
   - Augmentation
@@ -435,7 +432,7 @@ mining_buddy_vein_list:
 # rare
 # - Gold
 # - Platinum
-# - Lumium
+- Lumium
 # - Niniam
 # - Electrum
 - Muracite

--- a/profiles/Fallanor-setup.yaml
+++ b/profiles/Fallanor-setup.yaml
@@ -1,0 +1,184 @@
+safe_room: 992
+### STATUS MONITOR ###
+status_monitor_no_window: true
+slack_username: jonas
+
+######################
+### COMBAT TRAINER ###
+######################
+priority_defense: Evasion
+training_abilities:
+  Tactics: 60
+  Hunt: 80
+  App Quick: 60
+  Perc: 120
+  Pray: 610
+  Meraud: 1200
+
+########################
+### TRAINING MANAGER ###
+########################
+training_manager_priority_skills:
+- Light Armor
+hunting_file_list:
+#- setup
+- back
+training_manager_hunting_priority: true
+crossing_training:
+- Theurgy
+- Locksmithing
+- Augmentation
+- Utility
+- Warding
+- Appraisal
+- Athletics
+- Perception
+- Attunement
+- Scholarship
+- Outdoorsmanship
+- Mechanical Lore
+
+##################
+###  EQUIPMENT ###
+##################
+gear:
+### ARMOR ###
+- :adjective: chain
+  :name: helm
+  :is_leather: false
+  :is_worn: true
+  :hinders_lockpicking: true
+- :adjective: ring
+  :name: vambraces
+  :is_leather: false
+  :is_worn: true
+  :hinders_lockpicking: true
+- :adjective: ring
+  :name: greaves
+  :is_leather: false
+  :is_worn: true
+  :hinders_lockpicking: true
+- :adjective: ring
+  :name: lorica
+  :is_leather: false
+  :is_worn: true
+  :hinders_lockpicking: true
+- :adjective: mail
+  :name: gauntlets
+  :is_leather: false
+  :is_worn: true
+  :hinders_lockpicking: true
+- :adjective: hunting
+  :name: leathers
+  :is_leather: true
+  :is_worn: true
+- :adjective: parry
+  :name: stick
+  :is_leather: false
+  :is_worn: true
+- :adjective: target
+  :name: shield
+  :is_leather: false
+  :is_worn: true
+  :hinders_lockpicking: true
+### WEAPONS ###
+- :adjective: brass
+  :name: knuckles
+  :is_leather: false
+  :is_worn: true
+  :hinders_lockpicking: true
+- :adjective: elbow
+  :name: spikes
+  :is_worn: true
+  :is_leather: false
+  :hinders_lockpicking: true
+- :adjective: hickory
+  :name: bow
+  :is_leather: true
+  :is_worn: true
+- :adjective: glaes 
+  :name: jambiya
+  :is_leather: false
+  :is_worn: false
+- :adjective: oak-hafted
+  :name: cudgel
+  :is_leather: false
+
+gear_sets:
+  standard:
+  - target shield
+  - brass knuckles
+  - parry stick
+  - elbow spikes
+  - chain helm
+  - ring greaves
+  - ring vambraces
+  - ring lorica
+  - hickory bow
+  - mail gauntlets
+
+### MECH LORE ###
+hand_armor: mail gauntlets
+
+### CAMBRINTH ###
+cambrinth: cambrinth ring
+cambrinth_cap: 5
+
+### COMBAT MAGIC ###
+buff_spells:
+  Minor Physical Protection:
+    mana: 17
+    cambrinth:
+    - 5
+    recast: 3
+  Major Physical Protection:
+    mana: 10
+    cambrinth:
+    - 5
+  Centering:
+    mana: 26
+    cambrinth:
+    - 5
+    recast: 3
+  Bless:
+    mana: 10
+    cambrinth:
+    - 5
+    recast: 3
+  
+offensive_spells:
+- name: Fists of Faenella
+  cambrinth:
+  - 1
+#- name: Soul Sickness
+#  cambrinth:
+#  - 2
+
+### MAGIC TRAINING (TOWN) ###
+training_spells:
+  Augmentation:
+    abbrev: Centering
+  Warding:
+    abbrev: mpp
+  Utility:
+    abbrev: bless
+
+### LOCKSMITHING ###
+lockpick_type: stout
+lockpick_dismantle: pray
+picking_box_source: haversack
+use_lockpick_ring: true
+
+### THEURGY ###
+tithe: true
+theurgy_supply_container: sculptors toolkit
+water_holder: chalice
+flint_lighter: jambiya
+favor_goal: 10
+favor_god: Faenella
+
+############
+### LOOT ###
+############
+gem_pouch_adjective: black
+

--- a/profiles/Jonas-setup.yaml
+++ b/profiles/Jonas-setup.yaml
@@ -1,29 +1,32 @@
 ---
 # safe_room: 1645 # Crossing - Spooky Tree ooOoOoO
 # safe_room: 2855 # Shard - Dark Clearing (has vines)
+safe_room: 2854 # Shard - Through the break (vines)
 # safe_room: 2732 # Shard - Stormfells, Stonewend (has grass)
 # safe_room: 2715 # Shard - Old Mine, Bar in Blackthorn Canyon (has rocks!)
 # safe_room: 11440 # Haven - Treetop
-safe_room: 8349 # Fang Cove - Fangs Peak
+# safe_room: 8349 # Fang Cove - Fangs Peak
 # Hunting Settings
 
 status_monitor_no_window: true
-braid_item: grass
-hometown: Fang Cove
+# braid_item: grass
+hometown: Shard
 slack_username: jonas
-climbing_target:
+climbing_target: coriks_wall
 hunting_file_list:
-# - setup
-- back
+- usol
+- setup
+#- back
 training_manager_hunting_priority: true
 training_manager_priority_skills:
-- Small Blunt
+- Light Armor
 hunting_info:
-- :zone: yellow_gremlins
+- :zone: adanf_warriors_and_mages
   stop_on:
   - Crossbow
   args:
-  - r2
+  - setup
+  - r4
   :duration: 60
 
 weapon_training:
@@ -210,14 +213,14 @@ waggle_sets:
 
 crossing_training:
 - Attunement
-# - Outfitting
+- Outfitting
 - Locksmithing
 - First Aid
 - Augmentation
 - Utility
 - Warding
 - Outdoorsmanship
-# - Athletics
+- Athletics
 - Mechanical Lore
 
 exp_timers:


### PR DESCRIPTION
This will pull data from base-spells and merge it with the users offensive spell definitions. This means that we can start leaving stuff out of our setup files if its included in base-spells. I did an example in Crannach-setup where I define mind shout without mana, abbreviation, expire, or the expire_on_death flag. 

If the expire_on_death flag is set to false, then the flag will not be reset after every mob kill. This is necessary for heavy tm/debil spells which expire over time rather than mob death.