### PR TITLE
Adding comma substitution for number strings

### DIFF
--- a/textsubs.lic
+++ b/textsubs.lic
@@ -36,6 +36,7 @@ before_dying do
 end
 
 # defaults
+
 TextSubs.add('\d{1,3}(?=(\d{3})+(?!\d))', '\&,')
 TextSubs.add('^(\s+)no (puncture|slice|impact|fire|cold|electric) damage', '\1no (0/27) \2 damage')
 TextSubs.add('^(\s+)dismal (puncture|slice|impact|fire|cold|electric) damage', '\1dismal (1/27) \2 damage')

--- a/textsubs.lic
+++ b/textsubs.lic
@@ -36,7 +36,7 @@ before_dying do
 end
 
 # defaults
-
+TextSubs.add('\d{1,3}(?=(\d{3})+(?!\d))', '\&,')
 TextSubs.add('^(\s+)no (puncture|slice|impact|fire|cold|electric) damage', '\1no (0/27) \2 damage')
 TextSubs.add('^(\s+)dismal (puncture|slice|impact|fire|cold|electric) damage', '\1dismal (1/27) \2 damage')
 TextSubs.add('^(\s+)poor (puncture|slice|impact|fire|cold|electric) damage', '\1poor (2/27) \2 damage')


### PR DESCRIPTION
Adding a new text substitution for numbers with more than three digits. For example;

```
Wealth:
  432 gold, 1186 silver, 1234 bronze, and 11373 copper Kronars (574313 copper Kronars).
```
Becomes;

```
Wealth:
  432 gold, 1,186 silver, 1,234 bronze, and 11,373 copper Kronars (574,313 copper Kronars).
```

