### PR TITLE
Adding comma substitution when dealing with coins.

### DIFF
--- a/textsubs.lic
+++ b/textsubs.lic
@@ -878,4 +878,7 @@ TextSubs.add("A (#{prediction_power}) (crimson|fiery|molten|ruby|scarlet) (#{pre
 TextSubs.add('Your skill in (.*) has fogged over\.', 'Your skill in \1 has fogged over (-15%).')
 TextSubs.add('Your skill in (.*) is at a zenith of enlightenment\.', 'Your skill in \1 is at a zenith of enlightenment (+15%).')
 
+# Commas when dealing with coins
+TextSubs.add('\d{1,3}(?=(\d{3})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')
+
 clear until script.gets.nil?


### PR DESCRIPTION
Adding a new text substitution for numbers with more than three digits that _precede a denomination on the same line_. For example;

> Wealth:
>  432 gold, **1186** silver, **1234** bronze, and **11373** copper **Kronar**s (**574313** copper **Kronar**s).

Becomes;

```
Wealth:
  432 gold, 1,186 silver, 1,234 bronze, and 11,373 copper Kronars (574,313 copper Kronars).
```

Tested directly with sell-loot, bankbot, and crossing-repair. No unexpected behavior.