### PR TITLE
combat-trainer meraud commune tweak

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1245,8 +1245,9 @@ class TrainerProcess
       reset_ability(game_state, 'Meraud')
       return
     end
-    if /meraud/i =~ bput('commune sense', 'roundtime', 'A spark of Meraud')
+    if /meraud/i =~ bput('commune sense', 'roundtime', 'Meraud', 'Meraud\'s')
       reset_ability(game_state, 'Meraud', 60)
+      game_state.blessed_room = true
       return
     end
     waitrt?


### PR DESCRIPTION
Currently the commune sense for meraud commune doesn't register the many ways that it can manifest itself (the line changes from a plethora of options) but all include the word Meraud or Meraud's - so this should catch them all and refrain from blessing an already blessed room - also it now will toggle on last_rites if the room is already blessed. )