### PR TITLE
Astrology: closed telescopes, rtr fix, predict event setting

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -24,7 +24,7 @@ class Astrology
     @ap_training = settings.astral_plane_training['train_in_ap']
     @ap_source = settings.astral_plane_training['train_source']
     @ap_destination = settings.astral_plane_training['train_destination']
-		@predict_event = settings.predict_event
+    @predict_event = settings.predict_event
     do_buffs(settings)
     if args.rtr
       check_ripples
@@ -222,9 +222,9 @@ class Astrology
 
     if @have_telescope
       bput('get telescope', 'you get', 'You are already', "That can't be picked up")
-			if bput("center telescope on #{body}", 'You put your eye', 'open it to make any use of it').match('open it')
-      bput('open my telescope', 'extend your telescope')
-			return observe(body)
+      if bput("center telescope on #{body}", 'You put your eye', 'open it to make any use of it').match('open it')
+        bput('open my telescope', 'extend your telescope')
+        return observe(body)
       end
       result = bput('peer telescope', 'You peer aimlessly through your telescope', 'You see nothing regarding the future', 'Roundtime')
       bput('stow telescope', 'you put', "That can't be picked up")
@@ -269,7 +269,7 @@ class Astrology
 
   def train_astrology
     check_ripples
-    check_astral 
+    check_astral
     check_weather
     check_events(check_pools) if @predict_event
     check_moons

--- a/astrology.lic
+++ b/astrology.lic
@@ -220,7 +220,10 @@ class Astrology
 
     if @have_telescope
       bput('get telescope', 'you get', 'You are already', "That can't be picked up")
-      bput("center telescope on #{body}", 'You put your eye')
+			if bput("center telescope on #{body}", 'You put your eye', 'open it to make any use of it').match('open it')
+      bput('open my telescope', 'extend your telescope')
+			return observe(body)
+      end
       result = bput('peer telescope', 'You peer aimlessly through your telescope', 'You see nothing regarding the future', 'Roundtime')
       bput('stow telescope', 'you put', "That can't be picked up")
       result

--- a/astrology.lic
+++ b/astrology.lic
@@ -101,6 +101,7 @@ class Astrology
       return if ['detect any portents'].include? result
       pools = check_pools
       break if pools['future events'] == prev_size
+			break if pools['future events'] == 10
       prev_size = pools['future events']
     end
     bput('predict event', 'You focus inwardly')

--- a/astrology.lic
+++ b/astrology.lic
@@ -117,10 +117,6 @@ class Astrology
   def check_ripples
     pause 1
     return unless DRSpells.active_spells.include?('Read the Ripples')
-    if Flags['rtr-expire'].nil?
-      Flags.add('rtr-expire', get_data('spells').spell_data['Read the Ripples']['expire'])
-      echo "Flags['rtr-expire']: #{Flags['rtr-expire']}" if UserVars.astrology_debug
-    end
     while DRSpells.active_spells.include?('Read the Ripples')
       line = get?
 

--- a/astrology.lic
+++ b/astrology.lic
@@ -24,6 +24,7 @@ class Astrology
     @ap_training = settings.astral_plane_training['train_in_ap']
     @ap_source = settings.astral_plane_training['train_source']
     @ap_destination = settings.astral_plane_training['train_destination']
+		@predict_event = settings.predict_event
     do_buffs(settings)
     if args.rtr
       check_ripples
@@ -101,7 +102,7 @@ class Astrology
       return if ['detect any portents'].include? result
       pools = check_pools
       break if pools['future events'] == prev_size
-			break if pools['future events'] == 10
+      break if pools['future events'] == 10
       prev_size = pools['future events']
     end
     bput('predict event', 'You focus inwardly')
@@ -114,6 +115,7 @@ class Astrology
   end
 
   def check_ripples
+    pause 1
     return unless DRSpells.active_spells.include?('Read the Ripples')
     if Flags['rtr-expire'].nil?
       Flags.add('rtr-expire', get_data('spells').spell_data['Read the Ripples']['expire'])
@@ -267,9 +269,9 @@ class Astrology
 
   def train_astrology
     check_ripples
-    check_astral
+    check_astral 
     check_weather
-    check_events(check_pools)
+    check_events(check_pools) if @predict_event
     check_moons
     check_heavens
     predict_all(check_pools)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -92,7 +92,7 @@ module DRCA
     when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/
       fput('release spell')
     when /^At the ritual's peak, your prophetic connection blooms a thousand-fold/
-      Flags.reset('rtr-expire')
+      Flags.add('rtr-expire', get_data('spells').spell_data['Read the Ripples']['expire'])
     end
     waitrt?
 

--- a/profiles/Crannach-back.yaml
+++ b/profiles/Crannach-back.yaml
@@ -6,7 +6,12 @@ hunting_info:
   stop_on:
     - Twohanded Blunt
   :duration: 30
-
+  #- :zone: black_marble_gargoyles
+  # args:
+  #stop_on:
+  #- Stealth
+  #- Shield Usage
+  #:duration: 60
 weapon_training:
         # Large Blunt: throwing hammer
         # Polearms: jagged scythe
@@ -20,7 +25,11 @@ dance_skill: Polearms
 buff_spells:
 
 offensive_spells:
-
+  - skill: Sorcery
+    name: Footman's Strike
+    cambrinth:
+    - 16
+    cast_only_to_train: true
 training_abilities:
   PercMana: 240
 

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -34,18 +34,22 @@ priority_defense: Evasion
 hunting_info:
   - :zone: black_goblins
     args:
-    - r5
+    - r6
     stop_on:
     - Evasion
     - Targeted Magic
     :duration: 60
+    before:
+    - go2 4377
+    - astrology
   - :zone: black_marble_gargoyles
     args:
-    - d0
     stop_on:
     - Stealth
-    - Shield Usage
     :duration: 60
+    before:
+    - go2 4377
+    - astrology
 
 training_abilities:
   Hunt: 80
@@ -55,11 +59,11 @@ training_abilities:
 
 weapon_training:
   Crossbow: battle crossbow
-#  Large Edged: icy-blue blade
+  Large Edged: icy-blue blade
   Brawling: ''
 dance_skill: Brawling
 use_stealth_attacks: true
-use_weak_attacks: true
+use_weak_attacks: false
 ignored_npcs:
 - shadowling
 - Shadow Servant
@@ -147,10 +151,6 @@ gear:
   :is_worn: true
   :is_leather: true
   :hinders_lockpicking: false
-- :name: lorica
-  :adjective: scale
-  :is_worn: true
-  :is_leather: false
 - :name: vambraces
   :adjective: plate
   :is_worn: true
@@ -163,7 +163,6 @@ gear_sets:
   - a polished steel parry stick
   - some silver-chased elbow spikes
   - some brass knuckles
-#  - plate mask
   - ring hauberk
   - jagged scythe
   - oaken staff
@@ -182,7 +181,7 @@ stored_cambrinth: false
 
 prep_scaling_factor: 0.98
 
-tk_ammo: clippers
+tk_ammo: rapier 
 offensive_spells:
   - skill: Debilitation
     name: Mind Shout
@@ -195,7 +194,7 @@ offensive_spells:
   - name: Telekinetic Storm
     cambrinth:
     - 48
-    slivers: true
+    slivers: false
   - name: Mental Blast
     harmless: true
     cambrinth:
@@ -206,11 +205,6 @@ offensive_spells:
 #    cambrinth:
 #      - 30
 #    cast_only_to_train: true
-  - skill: Sorcery
-    name: Footman's Strike
-    cambrinth:
-    - 14
-    cast_only_to_train: true
 
 buff_spells:
   Psychic Shield:
@@ -249,7 +243,7 @@ divination_bones_storage:
   tied: false
 have_telescope: true
 astral_plane_training:
-  train_in_ap: true # Train astrology in the astral plane? Need circle > 99 for now...
+  train_in_ap: false # Train astrology in the astral plane? Need circle > 99 for now...
   train_destination: crossing # Walk here when training
   train_source: steppes # Walk back when done
 quit_on_death_in_ap: true # Overrides AFK and quits on death (this is a bescort setting)
@@ -418,7 +412,7 @@ training_spells:
     symbiosis: true
   Utility:
     abbrev: pg
-symbiosis: true
+    symbiosis: true
 cyclic_training_spells:
   Utility:
     abbrev: SOV

--- a/profiles/Fallanor-setup.yaml
+++ b/profiles/Fallanor-setup.yaml
@@ -37,7 +37,7 @@ weapon_training:
 hunting_info:
 - :zone: dire_bears
   args:
-  - r2
+  - r3
   stop_on:
   - Small Blunt
   :duration: 60

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -547,3 +547,4 @@ astral_plane_training:
   train_destination:
   train_source:
 quit_on_death_in_ap: false
+predict_event: false


### PR DESCRIPTION
I moved the rtr flag out of astrology. If  a `common-arcana` cast detects the success message for rtr then the flag is added which also functions as a reset. This should be the only usage of the flag. Previously, common-arcana reset a flag which had never been set, so the 'match' was never given. This means the flag was never raised. The check for the RTR flag during astrology buffs was faulty, so RTR was never cast. It was really bad, and im sorry about that.

I made a setting for event prediction. Event prediction is not useful for high level moon mages and takes a lot of time to do, so turning it off is a great option for high level mages. Another argument for the setting is, it's a learned skill; a newbie mage cannot utilize it until taught by another mage. The default is off.

There was a minor bug with event prediction where predict event loops unless the prediction pool has filled since the previous observation. This is done to prevent endless observations. The check didn't consider if the pool was full already, so this resulted in a redundant observation and pool check (15+ rt). Now, a full event pool results in breaking out of the event prediction loop.

If a closed telescope was centered on a celestial body, one got an error message. Now the telescope will be opened after getting that error message and retry the observation.