### PR TITLE
Add more match options for summon_admittance

### DIFF
--- a/common-summoning.lic
+++ b/common-summoning.lic
@@ -116,7 +116,7 @@ module DRCS
   end
 
   def summon_admittance
-    case DRC.bput('summon admittance', 'You align yourself to it', 'further increasing your proximity', 'You are a bit too distracted')
+    case DRC.bput('summon admittance', 'You align yourself to it', 'further increasing your proximity', 'Going any further while in this plane would be fatal', 'Summon allows Warrior Mages to draw', 'You are a bit too distracted')
     when 'You are a bit too distracted'
       DRCT.retreat
       summon_admittance


### PR DESCRIPTION
Summon allows Warrior Mages to draw - is when non-Warrior Mages try and use summon
Going any further while in this plane would be fatal - is when a WM is at maximum elemental charge