### PR TITLE
Ensure water_holder goes into theurgy_supply_container

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1304,8 +1304,8 @@ class TrainerProcess
     end
     waitrt?
     @equipment_manager.stow_weapon(game_state.weapon_name)
-    fput "get #{@water_holder}"
-    if /that/i =~ bput("sprinkle #{@water_holder} on #{checkname}", 'You sprinkle', 'Sprinkle that')
+    fput "get #{@water_holder} from my #{@theurgy_supply_container}"
+    if /that/i =~ bput("sprinkle #{@water_holder} on #{checkname}", 'You sprinkle', 'Sprinkle what?', 'Sprinkle that')
       fput "put #{@water_holder} in my #{@theurgy_supply_container}"
       @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
       @training_abilities.delete('Meraud')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1306,7 +1306,7 @@ class TrainerProcess
     @equipment_manager.stow_weapon(game_state.weapon_name)
     fput "get #{@water_holder}"
     if /that/i =~ bput("sprinkle #{@water_holder} on #{checkname}", 'You sprinkle', 'Sprinkle that')
-      fput "stow #{@water_holder}"
+      fput "put #{@water_holder} in my #{@theurgy_supply_container}"
       @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
       @training_abilities.delete('Meraud')
       return

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -109,6 +109,7 @@ cast_messages:
 - Traces of your prior ritual still linger about you
 - You swipe your fingertips
 - ^Your spirit lashes out
+- You open your arms in a hieratic gesture
 
 khri_preps:
 - With deep breaths


### PR DESCRIPTION
After adding Meraud to CT I ran into issues where my water_holder was in my default store container rather than my theurgy_supply_container. This should correct that issue.