### PR TITLE
add aliases for searching and listing hunting zones

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -35,7 +35,7 @@
   # List all hunting zones from base-hunting alphabetically by name
   ['hz', "#{$clean_lich_char}en get_data('hunting').hunting_zones.sort.each{ |x| echo x }"],
   # Search for a hunting zone, e.g. 'fz wark' will return warklin hunting zone rooms
-  ['fz', "#{$clean_lich_char}en echo get_data('hunting').hunting_zones.find{|k,v| k =~ /\?/}"]
+  ['fz', "#{$clean_lich_char}en echo get_data('hunting').hunting_zones.find{|k,v| k =~ /\?/i}"]
 ].each do |trigger, target|
   UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
 end

--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -31,7 +31,11 @@
   ['dm', "#{$clean_lich_char}repos download-mapdb"],
   ['rm', "#{$clean_lich_char}e Map.reload"],
 
-  ['map', "#{$clean_lich_char}narost"]
+  ['map', "#{$clean_lich_char}narost"],
+  # List all hunting zones from base-hunting alphabetically by name
+  ['hz', "#{$clean_lich_char}en get_data('hunting').hunting_zones.sort.each{ |x| echo x }"],
+  # Search for a hunting zone, e.g. 'fz wark' will return warklin hunting zone rooms
+  ['fz', "#{$clean_lich_char}en echo get_data('hunting').hunting_zones.find{|k,v| k =~ /\?/}"]
 ].each do |trigger, target|
   UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
 end


### PR DESCRIPTION
`hz` will list hunting zones alphabetically:
```
>hz                                                                                                         
--- Lich: exec1 active.                                                                                     
[exec1: ["adanf_spirit_dancers", [10771, 10102, 10103, 10104, 10105, 10119, 10113, 10111, 10112]]]          
[exec1: ["adanf_warriors_and_mages", [9471, 9472, 9473, 9474, 9475, 9476, 9477, 9478, 9479, 9480, 9481]]]   
[exec1: ["assassins", [4580, 4578, 4580, 4549, 4581]]]                                                      
[exec1: ["bawdy_swain", [4851, 4852, 4853, 4854]]]                                                          
[exec1: ["beisswurms", [7263, 7264, 7265, 7266, 7267]]]                                                     
[exec1: ["black_apes", [8756, 8750, 8749, 8756, 8740, 8759, 8739, 8741, 8747, 8745]]]                       
[exec1: ["black_goblins", [4167, 4168, 4170, 4169]]]                                                        
[exec1: ["black_marble_gargoyles", [31500, 31502, 31504, 31508, 31512, 31514, 31519, 31521, 31523, 31524]]]
... 
```

`fz` will search hunting zones for the first match / partial match
```
>fz priests                                                           
--- Lich: exec1 active.
[exec1: ["dragon_priests", [6379, 6380, 6381, 6382, 6383, 6384, 6385]]]
--- Lich: exec1 has exited.
```