### PR TITLE
Use a TM Focus in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -174,7 +174,7 @@ class SetupProcess
     end
 
     # Invoke Focus
-    if game_state.weapon_skill == 'Targeted Magic'
+    if game_state.weapon_skill == 'Targeted Magic' && game_state.weapon_name
       bput("invoke #{game_state.weapon_name}", 'You')
       waitrt?
     end 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1077,10 +1077,13 @@ class SpellProcess
     @custom_cast = data['cast']
     @symbiosis = data['symbiosis']
     @after = data['after']
+    @skill = data['skill']
+    @prep = data['prep']
     @command = data['command']
     @reset_expire = data['expire'] ? data['abbrev'] : nil
     Flags.reset('ct-spellcast')
     @before = data['before']
+    game_state.action_taken if (@skill == 'Targeted Magic' || @prep == 'target') && game_state.weapon_skill == 'Targeted Magic'
   end
 end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -172,6 +172,12 @@ class SetupProcess
     else
       @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
     end
+
+    # Invoke Focus
+    if game_state.weapon_skill == 'Targeted Magic'
+      bput("invoke #{game_state.weapon_name}", 'You')
+      waitrt?
+    end 
   end
 end
 
@@ -1465,7 +1471,7 @@ class AttackProcess
       game_state.no_stab_current_mob = false
     end
 
-    if game_state.dancing? || (@is_empath && !(@undead && DRSpells.active_spells['Absolution']))
+    if game_state.dancing? || game_state.weapon_skill == 'Targeted Magic' || (@is_empath && !(@undead && DRSpells.active_spells['Absolution']))
       if game_state.finish_killing?
         echo('AttackProcess::clean_up') if $debug_mode_ct
         game_state.next_clean_up_step

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -10,7 +10,7 @@ slack_username: jonas
 #safe_room: 4377 # Hib - Momma's Bed and Breakfast, Back Yard (vines)
 safe_room_id: 6345
 safe_room_empath: Yndass
-safe_room: 6345 # M'riss - Armadillo Swarm (has nothing)
+safe_room: &safe_room 6345 # M'riss - Armadillo Swarm (has nothing)
 # safe_room: 12047 # Hib - Trabe Plateau, Steps of Arishalan
 # safe_room: 2732 # Shard - Stormfells, Stonewend (has grass)
 # safe_room: 2855 # Shard - Dark Clearing (has vines)
@@ -64,7 +64,7 @@ weapon_training:
   Crossbow: battle crossbow
   Large Edged: icy-blue blade
   Brawling: ''
-  #Brawling: tetractys
+#  Targeted Magic: tetractys
 
 dance_skill: Brawling
 use_stealth_attacks: true
@@ -177,14 +177,12 @@ gear_sets:
   - some silver-chased elbow spikes
   - some brass knuckles
   - ring hauberk
-    #- jagged scythe
   - oaken staff
   stealing:
   - oaken staff
   - small shield
   - some silver-chased elbow spikes
   - parry stick
-    #  - jagged scythe
   - oaken staff
 ### CAMBRINTH ###
 cambrinth: nestled armband
@@ -404,6 +402,7 @@ crossing_training:
 - Astrology
 - Utility
 - Warding
+- Sorcery
 - Appraisal
 - Augmentation
 - Warding
@@ -422,6 +421,12 @@ train_appraisal_with_gear: true
 train_appraisal_with_pouches: true
 full_pouch_container: greatcoat
 train_with_spells: true
+crossing_training_sorcery:
+  abbrev: mapp
+  mana: 5
+  cambrinth:
+  - 45
+crossing_training_sorcery_room: *safe_room 
 use_research: false
 textbook: true
 combat_spell_training:

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -1,13 +1,16 @@
 ---
-#hometown: Shard
 hometown: Hibarnhvidar
-
+#hometown: Shard
+braid_item: grass
 ### STATUS MONITOR ###
 status_monitor_no_window: true
 slack_username: jonas
 
 ### SAFE ROOMS ###
-safe_room: 4377 # Hib - Momma's Bed and Breakfast, Back Yard
+#safe_room: 4377 # Hib - Momma's Bed and Breakfast, Back Yard (vines)
+safe_room_id: 6345
+safe_room_empath: Yndass
+safe_room: 6345 # M'riss - Armadillo Swarm (has nothing)
 # safe_room: 12047 # Hib - Trabe Plateau, Steps of Arishalan
 # safe_room: 2732 # Shard - Stormfells, Stonewend (has grass)
 # safe_room: 2855 # Shard - Dark Clearing (has vines)
@@ -24,32 +27,33 @@ safe_room: 4377 # Hib - Momma's Bed and Breakfast, Back Yard
 ### HUNTING ###
 ###############
 hunting_file_list:
+  #- stealth
+  #- back
 - setup
-- back
 training_manager_hunting_priority: true
 training_manager_priority_skills:
-- Slings 
+  - Targeted Magic
 priority_defense: Evasion
 hunting_info:
-  - :zone: black_apes
+  - :zone: black_goblins
     args:
     stop_on:
     - Evasion
     - Targeted Magic
     :duration: 60
     before:
-    - go2 4377
+    - go2 6345
     - astrology
     - appraisal
-  - :zone: black_marble_gargoyles
-    args:
-    stop_on:
-    - Stealth
-    :duration: 60
-    before:
-    - go2 4377
-    - astrology
-    - appraisal
+#  - :zone: black_marble_gargoyles
+#    args:
+#    stop_on:
+#    - Stealth
+#    :duration: 60
+#    before:
+#    - go2 6345
+#    - astrology
+#    - appraisal
 training_abilities:
   Hunt: 80
   App Quick: 90
@@ -60,12 +64,15 @@ weapon_training:
   Crossbow: battle crossbow
   Large Edged: icy-blue blade
   Brawling: ''
+  #Brawling: tetractys
+
 dance_skill: Brawling
 use_stealth_attacks: true
 use_weak_attacks: false
 ignored_npcs:
 - shadowling
 - Shadow Servant
+
 #################
 ### EQUIPMENT ###
 #################
@@ -82,13 +89,16 @@ gear:
 - :name: hammer
   :adjective: throwing
   :is_leather: false
-- :name: maul
-  :adjective: woodworker's
-  :is_leather: true
-  :wield: true
+  #- :name: maul
+  #  :adjective: woodworker's
+  #  :is_leather: true
+  #  wield: true
 - :name: sling
   :adjective: hide
   :is_leather: true
+- :name: tetractys
+  :is_leather: false
+  :tm_focus: true
 ##### ARMOR #####
 - :name: lorica
   :adjective: scale
@@ -412,7 +422,8 @@ train_appraisal_with_gear: true
 train_appraisal_with_pouches: true
 full_pouch_container: greatcoat
 train_with_spells: true
-use_research: true
+use_research: false
+textbook: true
 combat_spell_training:
   Augmentation:
     abbrev: aus
@@ -449,7 +460,7 @@ research_skills:
   - Augmentation
 climbing_target: coriks_wall
 listen: true
-
+listen_observe: true
 #################
 ### MECH LORE ###
 #################

--- a/profiles/Crannach-tm.yaml
+++ b/profiles/Crannach-tm.yaml
@@ -1,0 +1,15 @@
+hunting_info:
+  - :zone: black_goblins
+    args:
+    - r4
+    - tm
+    stop_on:
+    - Sorcery
+    :duration: 60
+weapon_training:
+  Targeted Magic: tetractys
+offensive_spells:
+  - skill: Sorcery
+    name: Footman's Strike
+    cambrinth:
+      - 23

--- a/profiles/Crannach-tm.yaml
+++ b/profiles/Crannach-tm.yaml
@@ -6,8 +6,10 @@ hunting_info:
     stop_on:
     - Sorcery
     :duration: 60
+tk_ammo:
 weapon_training:
-  Targeted Magic: tetractys
+  Targeted Magic: tetractys # Use a TM focus
+  # Targeted Magic: '' # List it like this (like brawling) to just cast TM spells without the focus
 offensive_spells:
   - skill: Sorcery
     name: Footman's Strike


### PR DESCRIPTION
Wield a tm focus like a weapon, invoke it after wielding it. Using targeted magic as your weapon training skill means you wont attack with weapons.

The base requirement is to have:
```
weapon_training:
  Targeted Magic: tetractys
```
Where tetractys is the name of your focus.

Alternatively, you can cast TM without attacking with weapons by listing 
```
weapon_training:
  Targeted Magic: ''
```

Crannach-tm.yaml has been uploaded as a simple example