### PR TITLE
Fix holy oil / alchemist oil error in forge

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1304,8 +1304,8 @@ class TrainerProcess
     end
     waitrt?
     @equipment_manager.stow_weapon(game_state.weapon_name)
-    fput "get #{@water_holder}"
-    if /that/i =~ bput("sprinkle #{@water_holder} on #{checkname}", 'You sprinkle', 'Sprinkle that')
+    fput "get #{@water_holder} from my #{@theurgy_supply_container}"
+    if /that/i =~ bput("sprinkle #{@water_holder} on #{checkname}", 'You sprinkle', 'Sprinkle what?', 'Sprinkle that')
       fput "put #{@water_holder} in my #{@theurgy_supply_container}"
       @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
       @training_abilities.delete('Meraud')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1306,7 +1306,7 @@ class TrainerProcess
     @equipment_manager.stow_weapon(game_state.weapon_name)
     fput "get #{@water_holder}"
     if /that/i =~ bput("sprinkle #{@water_holder} on #{checkname}", 'You sprinkle', 'Sprinkle that')
-      fput "stow #{@water_holder}"
+      fput "put #{@water_holder} in my #{@theurgy_supply_container}"
       @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
       @training_abilities.delete('Meraud')
       return

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -660,6 +660,10 @@ spell_data:
     abbrev: PYRE
     cyclic: true
     mana: 7
+  Protection from Evil:
+    skill: Warding
+    abbrev: PFE
+    mana: 5
   Psychic Shield:
     skill: Warding
     abbrev: PSY

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -109,6 +109,7 @@ cast_messages:
 - Traces of your prior ritual still linger about you
 - You swipe your fingertips
 - ^Your spirit lashes out
+- You open your arms in a hieratic gesture
 
 khri_preps:
 - With deep breaths

--- a/forge.lic
+++ b/forge.lic
@@ -398,12 +398,19 @@ class Forge
   def pour_oil
     ords = %w(second third fourth fifth sixth)
     get_item('oil')
-    while "You can't pour" == bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour")
-      stow_item('oil')
-      get_item("#{ords.shift} oil")
+    while ords.any?
+	  case bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour", 'You pour all of')
+	  when 'Roundtime', 'Applying the final touches'
+	    waitrt?
+        stow_item('oil')
+	    break
+	  when 'You pour all of'
+	    get_item('oil')
+	  else
+        stow_item('oil')
+        get_item("#{ords.shift} oil")
+      end
     end
-    waitrt?
-    stow_item('oil')
   end
 
   def add_oil

--- a/forge.lic
+++ b/forge.lic
@@ -398,7 +398,7 @@ class Forge
   def pour_oil
     ords = %w(second third fourth fifth sixth)
     get_item('oil')
-    while "You can't pour" || "You pour all of your holy oil" == bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour", "You pour all of your holy oil")
+    while "You can't pour" == bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour")
       stow_item('oil')
       get_item("#{ords.shift} oil")
     end

--- a/forge.lic
+++ b/forge.lic
@@ -398,7 +398,7 @@ class Forge
   def pour_oil
     ords = %w(second third fourth fifth sixth)
     get_item('oil')
-    while "You can't pour" == bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour")
+    while "You can't pour" || "You pour all of your holy oil" == bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour", "You pour all of your holy oil")
       stow_item('oil')
       get_item("#{ords.shift} oil")
     end


### PR DESCRIPTION
Fix for unhandled error when holy oil, or standard oil from an alchemist, was picked up and poured on a forged item. In pour_oil as written this would result in an unfinished item that would be stowed. If doing workorders it would result in an unfinished workorder.

The change has been tested against multiple holy oils / oils on a character. It has not been tested against an oil that results in the message "You can't pour". I haven't found an oil that gives that message. It should handle that issue the same as the original pour_oil method.