### PR TITLE
Self activated/stand-alone necromancer healing script

### DIFF
--- a/necroHeal.lic
+++ b/necroHeal.lic
@@ -1,0 +1,45 @@
+=begin
+
+  Documentation: https://elanthipedia.play.net/Lich_script_development#necroheal
+  ## ** Placeming comments here until finalized and added to pedia.
+
+  Necromancer stand-alone healing script
+  
+  Uses all settings defined in HEAL YAML FILE (default)
+  Consume logic via combat trainer
+  
+  TO DO:
+  - See pull request #1462 for harvested materials.
+  - See if there is a background way to use common-healing to determine wound status
+  - Add YAML variable to swap YAML file name
+  
+=end
+
+  if DRCH.check_health.empty?
+    echo 'Not wounded, exiting heal script'
+    exit
+  end
+
+
+  ## Sets flag to check for game line to determine when no wounds exist
+  ## Flag uses consume logic from combat-training. If no wounds are left
+  ## then harvest or dissection is used. Flags trigger off these rituals.
+  Flags.add('noWounds', 'You carefully position the corpse and make a cut', 'You bend over .* to make a few quick')
+  
+  ## Checks for status of wound flag in background
+  Thread.new {
+    loop {
+      sleep 3
+      if Flags['noWounds']
+        $HUNTING_BUDDY.stop_hunting # graceful exit
+        sleep 0.3 until !Script.running('comabt-trainer')
+      end
+    }
+  }
+
+    
+  ## Run YAML script via combat trainer
+  DRC.wait_for_script_to_complete('hunting-buddy', ['heal'])
+  
+  echo 'Healing done!'
+  

--- a/necroHeal.lic
+++ b/necroHeal.lic
@@ -1,7 +1,7 @@
 =begin
 
   Documentation: https://elanthipedia.play.net/Lich_script_development#necroheal
-  ## ** Placement comments here until finalized and added to pedia.
+  ## ** Placeming comments here until finalized and added to pedia.
 
   Necromancer stand-alone healing script
   
@@ -14,6 +14,9 @@
   - Add YAML variable to swap YAML file name
   
 =end
+
+custom_require.call(%w(common common-healing events))
+
 
   if DRCH.check_health.empty?
     echo 'Not wounded, exiting heal script'
@@ -31,13 +34,24 @@
     loop {
       sleep 3
       $HUNTING_BUDDY.stop_hunting if Flags['noWounds'] # graceful exit 
-    end
     }
   }
 
-    
+  
   ## Run YAML script via combat trainer
-  DRC.wait_for_script_to_complete('hunting-buddy', ['heal'])
+  #DRC.wait_for_script_to_complete('hunting-buddy', ['heal'])
+  
+  ## This section is designed for when running necroheal along with training manager
+  ## It allows a second copy of hunting-buddy to run on top of the current
+  ## hunting-buddy, invoke necroheal, and unpause the original hunting buddy
+
+  pause_script 'hunting-buddy' if running?('hunting-buddy') 
+  force_start_script 'hunting-buddy', [ 'heal' ]
+  
+  matchtimeout 180, "Your inventory" if running?('hunting-buddy')
+  sleep 1 until !running?('combat-trainer')
+  matchtimeout 180, "Your inventory" if running?('hunting-buddy')
   
   echo 'Healing done!'
-  
+  unpause_script 'hunting-buddy' if running?('hunting-buddy') 
+

--- a/necroHeal.lic
+++ b/necroHeal.lic
@@ -30,10 +30,8 @@
   Thread.new {
     loop {
       sleep 3
-      if Flags['noWounds']
-        $HUNTING_BUDDY.stop_hunting # graceful exit
-        sleep 0.3 until !Script.running('comabt-trainer')
-      end
+      $HUNTING_BUDDY.stop_hunting if Flags['noWounds'] # graceful exit 
+    end
     }
   }
 

--- a/necroHeal.lic
+++ b/necroHeal.lic
@@ -1,7 +1,7 @@
 =begin
 
   Documentation: https://elanthipedia.play.net/Lich_script_development#necroheal
-  ## ** Placeming comments here until finalized and added to pedia.
+  ## ** Placement comments here until finalized and added to pedia.
 
   Necromancer stand-alone healing script
   


### PR DESCRIPTION
EDIT: New PR, trying to fix some git issues.

New version of necroheal with changes/suggestions from prior PR. Had to delete prior PR due to some accidental git commit issues.

Current healing methods consist of turning on consume healing during training via combat-trainer via training-manager. There is currently no solution for healing outside training-manager, so this script is designed for activation either stand-alone from command bar, or anywhere else a script can be activated.

The script is far simpler in this version after using suggestions from everyone. Thank you!

I ended up not being able to use the check_health flag of common-healing to detect wounds because check_health uses the "health command". Combat-trainer also uses the health command and having both commands spam health is not ideal. Ideally, if combat-trainer variable gamestate can be accessed outside of combat trainer, then I would be able to use the check_health that way. I'm not entirely sure how i would go about doing this.

Thanks!

See PR #1487 for additional comments
See PR #1471 for original comments and script.