### PR TITLE
Added YAML option to allow rituals to train based on First Aid exp.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -357,8 +357,7 @@ class LootProcess
 
   def should_perform_ritual(prepare_consume)
     !prepare_consume &&
-    ((@necro_train_first_aid && DRSkill.getxp('First Aid') < 32) ||
-    DRSkill.getxp('Thanatology') < 32)
+    ((@necro_train_first_aid && DRSkill.getxp('First Aid') < 32) || DRSkill.getxp('Thanatology') < 32)
   end
 
   def check_rituals?(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -177,7 +177,7 @@ class SetupProcess
     if game_state.weapon_skill == 'Targeted Magic' && game_state.weapon_name
       bput("invoke #{game_state.weapon_name}", 'You')
       waitrt?
-    end 
+    end
   end
 end
 
@@ -355,6 +355,12 @@ class LootProcess
     end
   end
 
+  def should_perform_ritual(game_state)
+    unless game_state.prepare_consume
+      (DRSkill.getxp('Thanatology') <= 30 || (@necro_train_first_aid && DRSkill.getxp('First Aid') <= 30)) || !@skin
+    end
+  end
+
   def check_rituals?(game_state)
     return true unless DRStats.necromancer?
     mob_noun = DRRoom.dead_npcs.first
@@ -366,15 +372,7 @@ class LootProcess
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         do_necro_ritual(mob_noun, 'consume', game_state) unless game_state.wounds.empty?
       end
-      if !game_state.prepare_consume || !@skin
-        if DRSkill.getxp('Thanatology') <= 30
-          do_necro_ritual(mob_noun, @ritual_type, game_state)
-        elsif DRSkill.getxp('First Aid') <= 30 && @necro_train_first_aid
-          do_necro_ritual(mob_noun, @ritual_type, game_state)
-        end
-      end
-      ## Old necro training block
-      #do_necro_ritual(mob_noun, @ritual_type, game_state) unless game_state.prepare_consume || (DRSkill.getxp('Thanatology') > 30 && @skin)
+      do_necro_ritual(mob_noun, @ritual_type, game_state) if should_perform_ritual(game_state)
     end
     return false if %w(consume harvest dissect).include?(@last_ritual)
     true

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -223,8 +223,8 @@ class LootProcess
     @necro_heal = thanatology['heal'] || false
     echo("  @necro_heal: #{@necro_heal}") if $debug_mode_ct
 
-    @necro_trainFA = thanatology['train_FA'] || false
-    echo("  @necro_trainFA: #{@train_FA}") if $debug_mode_ct
+    @necro_train_first_aid = thanatology['train_first_aid'] || false
+    echo("  @necro_train_first_aid: #{@necro_train_first_aid}") if $debug_mode_ct
 
     @necro_store = thanatology['store'] || false
     echo("  @necro_store: #{@necro_store}") if $debug_mode_ct
@@ -369,7 +369,7 @@ class LootProcess
       if !game_state.prepare_consume || !@skin
         if DRSkill.getxp('Thanatology') <= 30
           do_necro_ritual(mob_noun, @ritual_type, game_state)
-        elsif DRSkill.getxp('First Aid') <= 30 && @train_FA
+        elsif DRSkill.getxp('First Aid') <= 30 && @necro_train_first_aid
           do_necro_ritual(mob_noun, @ritual_type, game_state)
         end
       end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -355,10 +355,10 @@ class LootProcess
     end
   end
 
-  def should_perform_ritual(game_state)
-    unless game_state.prepare_consume
-      (DRSkill.getxp('Thanatology') <= 30 || (@necro_train_first_aid && DRSkill.getxp('First Aid') <= 30)) || !@skin
-    end
+  def should_perform_ritual(prepare_consume)
+    !prepare_consume &&
+    ((@necro_train_first_aid && DRSkill.getxp('First Aid') < 32) ||
+    DRSkill.getxp('Thanatology') < 32)
   end
 
   def check_rituals?(game_state)
@@ -372,7 +372,7 @@ class LootProcess
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         do_necro_ritual(mob_noun, 'consume', game_state) unless game_state.wounds.empty?
       end
-      do_necro_ritual(mob_noun, @ritual_type, game_state) if should_perform_ritual(game_state)
+      do_necro_ritual(mob_noun, @ritual_type, game_state) if should_perform_ritual(game_state.prepare_consume)
     end
     return false if %w(consume harvest dissect).include?(@last_ritual)
     true

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -177,7 +177,7 @@ class SetupProcess
     if game_state.weapon_skill == 'Targeted Magic' && game_state.weapon_name
       bput("invoke #{game_state.weapon_name}", 'You')
       waitrt?
-    end
+    end 
   end
 end
 
@@ -222,6 +222,9 @@ class LootProcess
 
     @necro_heal = thanatology['heal'] || false
     echo("  @necro_heal: #{@necro_heal}") if $debug_mode_ct
+
+    @necro_trainFA = thanatology['train_FA'] || false
+    echo("  @necro_trainFA: #{@train_FA}") if $debug_mode_ct
 
     @necro_store = thanatology['store'] || false
     echo("  @necro_store: #{@necro_store}") if $debug_mode_ct
@@ -363,7 +366,15 @@ class LootProcess
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         do_necro_ritual(mob_noun, 'consume', game_state) unless game_state.wounds.empty?
       end
-      do_necro_ritual(mob_noun, @ritual_type, game_state) unless game_state.prepare_consume || (DRSkill.getxp('Thanatology') > 30 && @skin)
+      if !game_state.prepare_consume || !@skin
+        if DRSkill.getxp('Thanatology') <= 30
+          do_necro_ritual(mob_noun, @ritual_type, game_state)
+        elsif DRSkill.getxp('First Aid') <= 30 && @train_FA
+          do_necro_ritual(mob_noun, @ritual_type, game_state)
+        end
+      end
+      ## Old necro training block
+      #do_necro_ritual(mob_noun, @ritual_type, game_state) unless game_state.prepare_consume || (DRSkill.getxp('Thanatology') > 30 && @skin)
     end
     return false if %w(consume harvest dissect).include?(@last_ritual)
     true


### PR DESCRIPTION
Added YAML option to allow rituals to train based on First Aid exp.  Current test is for thanatology exp only.

If train_first_aid is set to true, combat-trainer will continue to perform rituals until both Thanatology and First aid experience are above 30.

thanatology:
  ritual_type: dissect
  heal: false
  train_first_aid: true

Issue #1476 