### PR TITLE
Update bescort.lic with Muspar'i Sand Barge

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -132,6 +132,10 @@ class Bescort
         { name: 'mode', options: %w(acen fang ratha), description: 'Where do you need to get to?' }
       ],
       [
+        { name: 'sandbarge', regex: /sandbarge/i, description: 'The sand barge between Hvaral, Oasis, and Muspari' },
+        { name: 'mode', options: %w(mus_hra mus_oas oas_mus oas_hra hra_mus hra_oas), description: 'Where are you coming from?_Where do you need to get' }
+      ],
+      [
         { name: 'iceroad', regex: /iceroad/i, description: 'The ice road between Shard and Hibarnhvidar' },
         { name: 'mode', options: %w(shard hibarnhvidar), description: 'Where do you need to get to?' }
       ],
@@ -161,6 +165,8 @@ class Bescort
       astral_walk(args.mode)
     elsif args.mammoth
       take_mammoth(args.mode)
+	elsif args.sandbarge
+	  take_sandbarge(args.mode)
     elsif args.iceroad
       iceroad(args.mode)
     elsif args.basalt
@@ -448,6 +454,43 @@ class Bescort
     end
   end
 
+  def take_sandbarge(mode)
+    case mode
+    when 'mus_hra'
+      manual_go2(6872)
+      port_type = 'dock'
+	  port_call = 'The sand barge pulls into dock'
+    when 'mus_oas'
+      manual_go2(6872)
+	  port_type = 'oasis'
+      port_call = 'The sand barge pulls up to a desert oasis'
+	when 'oas_mus'
+      manual_go2(7579)
+      port_type = 'platform'
+	  port_call = 'The sand barge pulls into dock'
+    when 'oas_hra'
+      manual_go2(7578)
+      port_type = 'dock'
+	  port_call = 'The sand barge pulls into dock'
+    when 'hra_mus'
+      manual_go2(3766)
+      port_type = 'platform'
+      port_call = 'The sand barge pulls into dock'
+    when 'hra_oas'
+      manual_go2(3766)
+	  port_type = 'oasis'
+      port_call = 'The sand barge pulls up to a desert oasis'
+    end
+    case bput('go barge', 'What were you referring to', "One of the barge's crew members watching")
+    when /What were you referring to/
+      waitfor 'A sand barge pulls'
+	  take_sandbarge(mode)
+    when /One of the barge's crew members watching/
+      waitfor "#{port_call}"
+	  fput("go #{port_type}")
+	end
+  end  
+  
   def take_crawling_plague(mode)
     case mode
     when 'island'


### PR DESCRIPTION
Bescort.lic update to add sand barge support to Muspar'i.
;e Map.list[3766].wayto={"3765"=>"east", "6872"=>StringProc.new("start_script('bescort', ['sandbarge', 'hra_mus']);wait_while{running?('bescort')};")}
;e Map.list[3766].timeto={"3765"=>0.2, "6872"=>0.2}