### PR TITLE
Changed cc alias to use #{clean_lich_char} instead of hardcoded ;

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -3,7 +3,7 @@
 =end
 
 [
-  ['cc', ';circlecheck'],
+  ['cc', '#{$clean_lich_char}circlecheck'],
   ['as', 'accept \r stow \?'],
   ['gs', 'get \? \r stow \?'],
 

--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -3,7 +3,7 @@
 =end
 
 [
-  ['cc', '#{$clean_lich_char}circlecheck'],
+  ['cc', "#{$clean_lich_char}circlecheck"],
   ['as', 'accept \r stow \?'],
   ['gs', 'get \? \r stow \?'],
 


### PR DESCRIPTION
This fixes an issue with calling setupaliases while using Outlander FE. Outlander uses ; as a separator character for calling multiple commands at once.