### PR TITLE
Fix bug in common-healing with detecting wounds

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -59,7 +59,7 @@ $severity_to_text = {
     /severe scarring and ugly gashes about the #{re_part}/,
     /major swelling and bruising around the (?<part>head)/,
     /an occasional twitch on the fore(?<part>head)/,
-    /a bruised, swollen and bleeding #{re_part}/,
+    /a bruised,* swollen and bleeding #{re_part}/,
     /deeply scarred gashes across the #{re_part}/,
     /a severely swollen, bruised and crossed #{re_part}/,
     /a constant twitching in the #{re_part}/,
@@ -81,7 +81,7 @@ $severity_to_text = {
     /a confused look with sporadic twitching of the fore(?<part>head)/,
     /a bruised, swollen and slashed #{re_part}/,
     /a punctured and shriveled #{re_part}/,
-    /a severely swollen, bruised and cloudy #{re_part}/,
+    /a severely swollen,* bruised and cloudy #{re_part}/,
     /a clouded #{re_part}/,
     /gaping holes in the #{re_part}/,
     /a broken #{re_part} with gaping holes/,
@@ -94,7 +94,7 @@ $severity_to_text = {
     /a painful (?<part>chest) area and difficulty getting a breath without pain/,
     /a severely bloated and discolored #{re_part} with strange round lumps under the skin/,
     /(?<abdomen>a definite greenish pallor and emaciated look)/,
-    /(?<skin>a painful, inflamed body rash)/,
+    /(?<skin>a painful,* inflamed body rash)/,
     /some shriveled and oddly folded (?<part>skin)/,
     /(?<skin>partial paralysis of the entire body)/,
     /(?<skin>numbness in your arms and legs)/
@@ -104,10 +104,10 @@ $severity_to_text = {
     /a mangled and malformed (?<part>head)/,
     /a ghastly bloated (?<part>head) with bleeding from the ears/,
     /a confused look with sporadic twitching of the fore(?<part>head)/,
-    /a bruised, swollen and shattered #{re_part}/,
+    /a bruised,* swollen and shattered #{re_part}/,
     /a painfully mangled and malformed #{re_part} in a shattered eye socket/,
-    /a severely swollen, bruised and blind #{re_part}/,
-    /severely scarred, mangled and malformed #{re_part}/,
+    /a severely swollen,* bruised and blind #{re_part}/,
+    /severely scarred,* mangled and malformed #{re_part}/,
     /a completely clouded #{re_part}/,
     /a shattered #{re_part} with gaping wounds/,
     /shattered (?<part>chest) area with gaping wounds/,
@@ -133,7 +133,7 @@ $severity_to_text = {
     /(?<head>a blank stare)/,
     /a pulpy cavity for a #{re_part}/,
     /an empty #{re_part} socket overgrown with bits of odd shaped flesh/,
-    /a severely swollen, bruised and blind #{re_part}/,
+    /a severely swollen,* bruised and blind #{re_part}/,
     /a blind #{re_part}/,
     /a completely useless #{re_part} with nearly all flesh and bone torn away/,
     /a completely destroyed #{re_part} with nearly all flesh and bone torn away revealing a gaping hole/,
@@ -155,6 +155,7 @@ $severity_to_text = {
     /(?<skin>general numbness all over and have difficulty thinking)/
   ]
 }
+$comma_detector = /(?<=swollen|bruised|scarred|painful),(?=\s(?:swollen|bruised|mangled|inflamed))/
 
 module DRCH
   module_function
@@ -169,6 +170,7 @@ module DRCH
         break
       end
     end
+    wounds_line.gsub!($comma_detector, "")  # Remove commas from individual wounds
     wounds = Hash.new { |h, k| h[k] = [] }
     part = nil
     wounds_line.split(',').each do |wound|


### PR DESCRIPTION
Handles issue #1609 in which common-healing doesn't detect any wound with a comma in it.

I made a regex with a positive lookahead and lookbehind for the specific wounds with commas in them. Once the wound line is pulled out, the regex is used to delete the detected commas. I made the commas in the wounds to severity hashmap optional by appending `*` after them.