### PR TITLE
Added an offline mode argument to allow it to be ran when the json is invalid

### DIFF
--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -172,7 +172,7 @@ def process_moon_message(moon, message)
     echo("should rise #{moon}:#{Regexp.last_match(1)}") if $debug_mode_mm
     offset = Regexp.last_match(1) ? Regexp.last_match(1).to_i : 1
     echo("offset: #{offset}") if $debug_mode_mm
-    timer = (Settings['set'][moon] - (offset * 30 * 60))
+    timer = offset * 30 * 60
     echo("timer: #{moon}:#{timer / 60}") if $debug_mode_mm
   elsif message =~ /sets/
     timer = (Settings['rise'][moon])
@@ -190,25 +190,29 @@ def process_moon_message(moon, message)
     end
     is_up = true
   end
-  event = is_up ? 'set' : 'rise'
-  echo("timer: #{moon}:#{timer / 60}") if $debug_mode_mm
-  if $offline
-    fluff_str = event == 'set' ? 'is up for' : 'will rise in';
-    UserVars.moons[moon].delete(event)
-    UserVars.moons[moon][event] = snapshot + timer
-    UserVars.moons[moon]['timer'] = minutes_apart(UserVars.moons[moon][event], snapshot)
-    UserVars.moons[moon]['pretty'] = "#{moon} #{fluff_str} #{UserVars.moons[moon]['timer']} minutes"
-    UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
-    if event == 'rise'
-      UserVars.moons['visible'].push(moon) unless UserVars.moons['visible'].include?(moon)
-    else
-      UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
+  if !timer.nil?
+    event = is_up ? 'set' : 'rise'
+    echo("timer: #{moon}:#{timer / 60}") if $debug_mode_mm
+    if $offline
+      fluff_str = event == 'set' ? 'is up for' : 'will rise in';
+      UserVars.moons[moon].delete(event)
+      UserVars.moons[moon][event] = snapshot + timer
+      UserVars.moons[moon]['timer'] = minutes_apart(UserVars.moons[moon][event], snapshot)
+      UserVars.moons[moon]['pretty'] = "#{moon} #{fluff_str} #{UserVars.moons[moon]['timer']} minutes"
+      UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
+      if event == 'rise'
+        UserVars.moons['visible'].push(moon) unless UserVars.moons['visible'].include?(moon)
+      else
+        UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
+      end
     end
+    echo("settings for #{moon}:#{minutes_apart(UserVars.moons[moon][event], snapshot)} <> #{UserVars.moons[moon]['timer']}:#{UserVars.moons['visible'].include?(moon)}") if $debug_mode_mm
+    moon_change(moon, is_up, timer) if !$offline
+    Setting[moon] = snapshot
+    update_moon_window if CharSettings['moon_window']
+  else
+    echo("Got nil time, dumping message: #{message}") if $debug_mode_mm
   end
-  echo("settings for #{moon}:#{minutes_apart(UserVars.moons[moon][event], snapshot)} <> #{UserVars.moons[moon]['timer']}:#{UserVars.moons['visible'].include?(moon)}") if $debug_mode_mm
-  moon_change(moon, is_up, timer) if !$offline
-  Setting[moon] = Time.now
-  update_moon_window if CharSettings['moon_window']
 end
 
 def advance_moon_time

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#moonwatch
 =end
 
-custom_require.call(%w[common])
+custom_require.call(%w[common events])
 
 arg_definitions = [
   [
@@ -17,22 +17,20 @@ arg_definitions = [
 
 args = parse_args(arg_definitions)
 $debug_mode_mm = UserVars.moon_debug || args.debug
-
+$offline = args.offline
 enable_moon_connection
 pause 3
 
-ENGLISH_VALUE = {}
-ENGLISH_VALUE['hundred'] = 100
-%w[zero one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen].each_with_index{ |word,i| ENGLISH_VALUE[word] = i }
-
-%w[zero ten twenty thirty forty fifty sixty seventy eighty ninety].each_with_index{ |word,i| ENGLISH_VALUE[word] = i*10 }
-
-%w[one thousand million billion trillion].each_with_index{ |word,i| ENGLISH_VALUE[word] = 10**(i*3) }
 
 if args.alias
-  UpstreamHook.run("<c>#{$clean_lich_char}alias add --global moon = #{$clean_lich_char}eq self.print_moon_status")
+  UpstreamHook.run("<c>#{$clean_lich_char}"+ 'alias add --global moon = '"#{$clean_lich_char}"+ 'eq respond("#{UserVars.moons[\'katamba\'][\'pretty\']} : #{UserVars.moons[\'yavash\'][\'pretty\']} : #{UserVars.moons[\'xibar\'][\'pretty\']}")')
 end
+
+
 CharSettings['moon_window'] = !CharSettings['moon_window'] if args.window
+
+UserVars.moons = { 'katamba' => {}, 'yavash' => {}, 'xibar' => {}, 'visible' => [] }
+UserVars.sun = {}
 
 Settings['xibar'] ||= Time.now
 Settings['yavash'] ||= Time.now
@@ -43,6 +41,7 @@ Settings['rise'] = {}
 Settings['rise']['yavash'] = 175 * 60
 Settings['rise']['xibar'] = 172 * 60
 Settings['rise']['katamba'] = 174 * 60
+Settings['rise']['sun'] = Time.now.utc.to_s
 
 # Time until moon sets after rising
 
@@ -51,6 +50,7 @@ Settings['set'] = {}
 Settings['set']['yavash'] = 177 * 60
 Settings['set']['xibar'] = 174 * 60
 Settings['set']['katamba'] = 177 * 60
+Settings['set']['sun'] = Time.now.utc.to_s
 
 if CharSettings['moon_window']
   _respond("<streamWindow id='moonWindow' title='Moons' location='center' save='true' />")
@@ -58,38 +58,26 @@ if CharSettings['moon_window']
   CharSettings['moon_window_cache'] = nil
 end
 
-def print_moon_status
-  respond("#{UserVars.moons['katamba']['pretty']}")
-  respond("#{UserVars.moons['yavash']['pretty']}")
-  respond("#{UserVars.moons['xibar']['pretty']}")
-end
 
 def check_for_new_moons
   UserVars.moons.each do |moon, data|
     next if moon == 'visible' || data['timer'] >= 0
-    set = 'should rise' == DRC.bput("perc #{moon}", 'should rise', 'roundtime')
-    moon_change(moon, !set) if data[(set ? 'set' : 'rise')]
+    DRC.bput("perc #{moon}", 'should rise', 'roundtime')
+    # moon_change(moon, !set) if data[(set ? 'set' : 'rise')]
     waitrt?
   end
 end
 
-
-def string_to_number(string)
-  values = string.downcase.split( /\W+/ ).map{ |word|
-    ENGLISH_VALUE[word]
-  }
-  time = 0
-  values.each_with_index {|num, idx|
-    next_idx = idx + 1
-    if (values[next_idx] > 99)
-      next_num = values.slice(next_idx)
-      values.delete_at(next_idx)
-      time = time + (num * next_num)
-    else
-      time = time + num
-    end
-  }
-  return time
+def text_to_time(degrees, bearing, magnitude)
+  val_map = { 'one' => 1, 'two' => 2, 'three' => 3, 'four' => 4, 'five' => 5, 'six' => 6, 'seven' => 7, 'eight' => 8, 'nine' => 9, 'ten' => 10, 'eleven' => 11, 'twelve' => 12, 'thirteen' => 13, 'fourteen' => 14, 'fifteen' => 15, 'sixteen' => 16, 'seventeen' => 17, 'eighteen' => 18, 'nineteen' => 19, 'twenty' => 20, 'thirty' => 30, 'fourty' => 40, 'fifty' => 50, 'sixty' => 60, 'seventy' => 70, 'eighty' => 80, 'ninety' => 90 }
+  value = degrees.scan(/one|two|three|four\b|five\b|six\b|seven\b|eight\b|nine\b|ten\b|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety/)
+  value = value.map { |item| val_map[item] }.inject(&:+)
+  scaled_time = if bearing == 'eastern'
+                  magnitude - (value / 90.0) * (magnitude / 2)
+                else
+                  magnitude / 2 - (1 - value / 90.0) * (magnitude / 2)
+                end
+  magnitude - scaled_time
 end
 
 def update_moon_window
@@ -100,21 +88,16 @@ def update_moon_window
   _respond("<pushStream id=\"moonWindow\"/> #{new_message}<popStream/>\r\n")
 end
 
-def moon_change(moon, is_up)
+def moon_change(moon, is_up, offset = nil)
   snapshot = Time.now
+  snapshot = snapshot - offset if !offset.nil?
   snapshot = (snapshot - snapshot.sec).utc.to_s
+  echo "Moon Change for #{moon} with offset? #{offset}" if $debug_mode_mm
   update_moon_data(moon, 'time' => snapshot, 'event' => is_up ? 'rise' : 'set')
 end
 
 def minutes_apart(first, second)
-  ((first - second) / 60).ceil
-end
-
-def get_latest_moon
-  UserVars.moons = { 'katamba' => {}, 'yavash' => {}, 'xibar' => {}, 'visible' => [] }
-  UserVars.sun = {}
-  update_moon_info(get_all_moon_data)
-  update_sun_info(get_all_moon_data)
+  ((first - second) / 60).to_i
 end
 
 def minutes_to_next_sun_event(past, current)
@@ -127,6 +110,8 @@ def update_sun_info(latest_data)
   sun_data = latest_data['sun']
   set_time = Time.parse(sun_data['set']).localtime
   rise_time = Time.parse(sun_data['rise']).localtime
+  Settings['set']['sun'] = sun_data['set']
+  Settings['rise']['sun'] = sun_data['rise']
   if set_time > rise_time
     UserVars.sun['day'] = false
     UserVars.sun['night'] = true
@@ -140,7 +125,6 @@ end
 
 def update_moon_info(latest_data)
   return if latest_data.nil? || latest_data.empty?
-  echo "#{latest_data}"
   %w[katamba yavash xibar].each do |moon|
     data = latest_data[moon]
     event = data['event']
@@ -161,101 +145,113 @@ def update_moon_info(latest_data)
       UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
     end
   end
+  update_moon_window if CharSettings['moon_window']
 end
 
-def handle_moon_timers(line)
-  case line
-  when /that (Katamba|Xibar|Yavash) is (\w+\-?\w+?) degrees above the (eastern|western)/
-    moon = Regexp.last_match(1).downcase
-    minutes = string_to_number(Regexp.last_match(2))
-    timer = Regexp.last_match(3) == 'eastern' ? (Settings['set'][moon] / 60 - minutes).to_i : minutes.to_i
-    offline_update_moon_info(moon, 'timer' => timer, 'event' => 'rise')
-  when /that (Katamba|Xibar|Yavash) is exactly at zenith/
-    moon = Regexp.last_match(1).downcase
-    timer = (Settings['set'][moon] / (60 * 2)).to_i
-    offline_update_moon_info(moon, 'timer' => timer, 'event' => 'rise')
-  when /^(Katamba|Xibar|Yavash) is a .* should rise in about (\d+)/
-    moon = Regexp.last_match(1).downcase
-    timer = (Regexp.last_match(2).to_i * 30).to_i
-    offline_update_moon_info(moon, 'timer' => timer, 'event' => 'set')
-  when /^(Katamba|Xibar|Yavash) sets/
-    moon = Regexp.last_match(1).downcase
-    offline_update_moon_info(moon, 'timer' => Settings['rise'][moon] / 60, 'event' => 'set')
-  when /^(Katamba|Xibar|Yavash) slowly rises/
-    moon = Regexp.last_match(1).downcase
-    offline_update_moon_info(moon, 'timer' => Settings['set'][moon] / 60, 'event' => 'rise')
-  when /heralding another fine day|rises to create the new day|as the sun rises, hidden|as the sun rises behind it|faintest hint of the rising sun|The rising sun slowly/
-    old = UserVars.sun
-    UserVars.sun['set'] = old['set']
-    UserVars.sun['rise'] = Time.now.utc.to_s
-  when /The sun sinks below the horizon|night slowly drapes its starry banner|sun slowly sinks behind the scattered clouds and vanishes|grey light fades into a heavy mantle of black/
-    old = UserVars.sun
-    UserVars.sun['rise'] = old['rise']
-    UserVars.sun['set'] = Time.now.utc.to_s
+def process_sun_message(message)
+  latest_data = {'sun'=> {}}
+  if message =~ /heralding another fine day|rises to create the new day|as the sun rises, hidden|as the sun rises behind it|faintest hint of the rising sun|The rising sun slowly/
+    latest_data['sun']['set'] = Time.parse(Settings['set']['sun']).utc.to_s
+    latest_data['sun']['rise'] = Time.now.utc.to_s
+    update_moon_data('sun', latest_data['sun']) if !$online
   else
-    time_now = Time.now
-    time_now = time_now - time_now.sec
-    %w[katamba yavash xibar].each do |moon|
-      old = UserVars.moons[moon]
-      event = old.key?('set') ? 'set' : 'rise'
-      timer = minutes_apart(old[event], time_now)
-      offline_update_moon_info(moon, 'event' => (%w[rise set] - [event]).first, 'time' => time_now) if (old['timer'] - timer) > 5
+    latest_data['sun']['set'] = Time.now.utc.to_s
+    latest_data['sun']['rise'] = Time.parse(Settings['rise']['sun']).utc.to_s
+    update_moon_data('sun', latest_data['sun']) if !$online
+  end
+  update_sun_info(latest_data)
+  Flags.reset("mw-sun")
+end
+
+def process_moon_message(moon, message)
+  timer = nil
+  is_up = false
+  snapshot = Time.now
+  snapshot = (snapshot - snapshot.sec)
+  if message =~ /should rise in about (\d+) (anlaen|anlas)|less than an anlas/
+    echo("should rise #{moon}:#{Regexp.last_match(1)}") if $debug_mode_mm
+    offset = Regexp.last_match(1) ? Regexp.last_match(1).to_i : 1
+    timer = (Settings['rise'][moon] - (offset * 30 * 60))
+  elsif message =~ /sets/
+    timer = (Settings['rise'][moon] / 60)
+  else
+    if message =~ /is (.*) degree.* (western|eastern)/
+      echo("degrees above #{moon}:#{Regexp.last_match(1)}:#{Regexp.last_match(2)}") if $debug_mode_mm
+      timer = text_to_time(Regexp.last_match(1), Regexp.last_match(2), Settings['set'][moon])
+      echo("offset: #{timer}") if $debug_mode_mm
+    elsif message =~ /dipping below the horizon/
+      timer = Settings['set'][moon] - 60
+    elsif message =~ /exactly at zenith/
+      timer = Settings['set'][moon] / 2
+    elsif message =~ /slowly rises/
+      timer = Settings['set'][moon] / 60
+    end
+    is_up = true
+  end
+  event = is_up ? 'rise' : 'set'
+  if $offline
+    fluff_str = event == 'set' ? 'will rise in' : 'is up for';
+    UserVars.moons[moon].delete(event)
+    UserVars.moons[moon][event] = snapshot + timer
+    UserVars.moons[moon]['timer'] = minutes_apart(UserVars.moons[moon]['rise'], snapshot)
+    UserVars.moons[moon]['pretty'] = "#{moon} #{fluff_str} #{UserVars.moons[moon]['timer']} minutes"
+    UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
+    if event == 'rise'
+      UserVars.moons['visible'].push(moon) unless UserVars.moons['visible'].include?(moon)
+    else
+      UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
     end
   end
-  pause 0.1 unless line
+  echo("settings for #{moon}:#{minutes_apart(UserVars.moons[moon][event], Time.now)}:#{UserVars.moons['visible'].include?(moon)}") if $debug_mode_mm
+  moon_change(moon, is_up, timer) if !$offline
+  Setting[moon] = Time.now
+  update_moon_window if CharSettings['moon_window']
 end
 
-def offline_update_moon_info(moon, data)
-  return if data.nil? || data.empty?
-  event = data['event']
-  coming_event = (%w[rise set] - [event]).first
-  time_now = data['time']
-  if !time_now.nil?
-    data['timer'] = minutes_apart(UserVars.moons[moon][coming_event], time_now)
-  else
-    time_now = Time.now
-    time_now = time_now - time_now.sec
-  end
-  UserVars.moons[moon].delete(coming_event)
-  UserVars.moons[moon][coming_event] = time_now + (data['timer'] * 60)
-  UserVars.moons[moon]['timer'] = data['timer']
-  if event == 'rise'
-    UserVars.moons[moon]['pretty'] = "#{moon} is up for #{UserVars.moons[moon]['timer']} minutes"
-    UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
-    UserVars.moons['visible'].push(moon) unless UserVars.moons['visible'].include?(moon)
-  else
-    UserVars.moons[moon]['pretty'] = "#{moon} will rise in #{UserVars.moons[moon]['timer']} minutes"
-    UserVars.moons[moon]['short'] = "[#{moon[0]}]-(#{UserVars.moons[moon]['timer']})"
-    UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
+def advance_moon_time
+  %w(katamba yavash xibar).each do |moon|
+    while Time.now > (Settings[moon] + 60)
+      event = UserVars.moons[moon].key?('set') ? 'set' : 'rise'
+      echo("minutes since #{moon}:#{minutes_apart(Time.now, Settings[moon])}") if $debug_mode_mm
+      fluff_str = event == 'set' ? 'will rise in' : 'is up for';
+      UserVars.moons[moon]['timer'] = UserVars.moons[moon]['timer'] - minutes_apart(Time.now, Settings[moon])
+      UserVars.moons[moon]['pretty'] = "#{moon} #{fluff_str} #{UserVars.moons[moon]['timer']} minutes"
+      UserVars.moons[moon]['short'] = "[#{moon[0]}]-(#{UserVars.moons[moon]['timer']})"
+      if event == 'rise'
+        UserVars.moons['visible'].push(moon) unless UserVars.moons['visible'].include?(moon)
+      else
+        UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
+      end
+      Setting[moon] = Time.now
+    end
+    update_moon_window if CharSettings['moon_window']
   end
 end
 
+update_moon_info(get_all_moon_data)
+update_sun_info(get_all_moon_data)
 
-if args.offline
-  get_latest_moon
-end
+Flags.add('mw-katamba', 'Katamba .* it should rise in .*', 'Katamba is .* degree.* above the (western|eastern) horizon', 'Katamba .* dipping below the horizon', 'Katamba .* exactly at zenith', 'Katamba sets', 'Katamba slowly rises')
+
+Flags.add('mw-yavash', 'Yavash .* it should rise in .*', 'Yavash is .* degree.* above the (western|eastern) horizon', 'Yavash .* dipping below the horizon', 'Yavash .* exactly at zenith', 'Yavash sets', 'Yavash slowly rises')
+
+Flags.add('mw-xibar', 'Xibar .* it should rise in .*', 'Xibar is .* degree.* above the (western|eastern) horizon', 'Xibar .* dipping below the horizon', 'Xibar .* exactly at zenith', 'Xibar sets', 'Xibar')
+
+Flags.add('mw-sun', 'heralding another fine day', 'rises to create the new day', 'as the sun rises, hidden', 'as the sun rises behind it', 'faintest hint of the rising sun', 'The rising sun slowly', 'The sun sinks below the horizon', 'night slowly drapes its starry banner', 'sun slowly sinks behind the scattered clouds and vanishes', 'grey light fades into a heavy mantle of black')
 
 loop do
   line = script.gets?
-  if args.offline
-    handle_moon_timers(line)
-  else
-    case line
-    when /^(Katamba|Xibar|Yavash) sets/
-      moon_change(Regexp.last_match(1).downcase, false)
-    when /^(Katamba|Xibar|Yavash) slowly rises/
-      moon_change(Regexp.last_match(1).downcase, true)
-    when /heralding another fine day|rises to create the new day|as the sun rises, hidden|as the sun rises behind it|faintest hint of the rising sun|The rising sun slowly/
-      old = get_all_moon_data['sun']
-      update_moon_data('sun', 'set' => old['set'], 'rise' => Time.now.utc.to_s)
-    when /The sun sinks below the horizon|night slowly drapes its starry banner|sun slowly sinks behind the scattered clouds and vanishes|grey light fades into a heavy mantle of black/
-      old = get_all_moon_data['sun']
-      update_moon_data('sun', 'rise' => old['rise'], 'set' => Time.now.utc.to_s)
-    end
-    update_moon_info(get_all_moon_data)
-    update_sun_info(get_all_moon_data)
-    pause 0.1 unless line
+  %w(katamba yavash xibar).each do |moon|
+    next unless Flags["mw-#{moon}"]
+    process_moon_message(moon, Flags["mw-#{moon}"].first)
+    Flags.reset("mw-#{moon}")
   end
+  update_moon_info(get_all_moon_data) if !$offline
+  update_sun_info(get_all_moon_data) if !$offline
+  advance_moon_time if $offline
   check_for_new_moons if args.correct
   update_moon_window if CharSettings['moon_window']
+  process_sun_message(Flags["mw-sun"].first) if Flags['mw-sun']
+  pause 0.1 unless line
+
 end

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -200,10 +200,11 @@ def process_moon_message(moon, message)
       UserVars.moons[moon][event] = snapshot + timer
       UserVars.moons[moon]['timer'] = minutes_apart(UserVars.moons[moon][event], snapshot)
       UserVars.moons[moon]['pretty'] = "#{moon} #{fluff_str} #{UserVars.moons[moon]['timer']} minutes"
-      UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
       if event == 'rise'
+        UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
         UserVars.moons['visible'].push(moon) unless UserVars.moons['visible'].include?(moon)
       else
+        UserVars.moons[moon]['short'] = "[#{moon[0]}]-(#{UserVars.moons[moon]['timer']})"
         UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
       end
     end

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -77,6 +77,7 @@ def text_to_time(degrees, bearing, magnitude)
                 else
                   magnitude / 2 - (1 - value / 90.0) * (magnitude / 2)
                 end
+  echo("Scaled time: #{scaled_time}") if $debug_mode_mm
   magnitude - scaled_time
 end
 
@@ -242,7 +243,7 @@ Flags.add('mw-katamba', 'Katamba .* it should rise in .*', 'Katamba is .* degree
 
 Flags.add('mw-yavash', 'Yavash .* it should rise in .*', 'Yavash is .* degree.* above the (western|eastern) horizon', 'Yavash .* dipping below the horizon', 'Yavash .* exactly at zenith', 'Yavash sets', 'Yavash slowly rises')
 
-Flags.add('mw-xibar', 'Xibar .* it should rise in .*', 'Xibar is .* degree.* above the (western|eastern) horizon', 'Xibar .* dipping below the horizon', 'Xibar .* exactly at zenith', 'Xibar sets', 'Xibar')
+Flags.add('mw-xibar', 'Xibar .* it should rise in .*', 'Xibar is .* degree.* above the (western|eastern) horizon', 'Xibar .* dipping below the horizon', 'Xibar .* exactly at zenith', 'Xibar sets', 'Xibar slowly rises')
 
 Flags.add('mw-sun', 'heralding another fine day', 'rises to create the new day', 'as the sun rises, hidden', 'as the sun rises behind it', 'faintest hint of the rising sun', 'The rising sun slowly', 'The sun sinks below the horizon', 'night slowly drapes its starry banner', 'sun slowly sinks behind the scattered clouds and vanishes', 'grey light fades into a heavy mantle of black')
 

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -39,9 +39,9 @@ Settings['katamba'] ||= Time.now
 Settings['rise'] = {}
 
 Settings['rise']['yavash'] = 175 * 60
-Settings['rise']['xibar'] = 172 * 60
+Settings['rise']['xibar'] = 172 * 60 #(10320)
 Settings['rise']['katamba'] = 174 * 60
-Settings['rise']['sun'] = Time.now.utc.to_s
+Settings['rise']['sun'] ||=Time.now.utc.to_s
 
 # Time until moon sets after rising
 
@@ -50,7 +50,7 @@ Settings['set'] = {}
 Settings['set']['yavash'] = 177 * 60
 Settings['set']['xibar'] = 174 * 60
 Settings['set']['katamba'] = 177 * 60
-Settings['set']['sun'] = Time.now.utc.to_s
+Settings['set']['sun'] ||=Time.now.utc.to_s
 
 if CharSettings['moon_window']
   _respond("<streamWindow id='moonWindow' title='Moons' location='center' save='true' />")
@@ -171,29 +171,32 @@ def process_moon_message(moon, message)
   if message =~ /should rise in about (\d+) (anlaen|anlas)|less than an anlas/
     echo("should rise #{moon}:#{Regexp.last_match(1)}") if $debug_mode_mm
     offset = Regexp.last_match(1) ? Regexp.last_match(1).to_i : 1
-    timer = (Settings['rise'][moon] - (offset * 30 * 60))
+    echo("offset: #{offset}") if $debug_mode_mm
+    timer = (Settings['set'][moon] - (offset * 30 * 60))
+    echo("timer: #{moon}:#{timer / 60}") if $debug_mode_mm
   elsif message =~ /sets/
-    timer = (Settings['rise'][moon] / 60)
+    timer = (Settings['rise'][moon])
+  elsif message =~ /dipping below the horizon/
+    timer = Settings['rise'][moon]
   else
     if message =~ /is (.*) degree.* (western|eastern)/
       echo("degrees above #{moon}:#{Regexp.last_match(1)}:#{Regexp.last_match(2)}") if $debug_mode_mm
-      timer = text_to_time(Regexp.last_match(1), Regexp.last_match(2), Settings['set'][moon])
+      timer = Settings['set'][moon] - text_to_time(Regexp.last_match(1), Regexp.last_match(2), Settings['set'][moon])
       echo("offset: #{timer}") if $debug_mode_mm
-    elsif message =~ /dipping below the horizon/
-      timer = Settings['set'][moon] - 60
     elsif message =~ /exactly at zenith/
       timer = Settings['set'][moon] / 2
     elsif message =~ /slowly rises/
-      timer = Settings['set'][moon] / 60
+      timer = Settings['set'][moon]
     end
     is_up = true
   end
-  event = is_up ? 'rise' : 'set'
+  event = is_up ? 'set' : 'rise'
+  echo("timer: #{moon}:#{timer / 60}") if $debug_mode_mm
   if $offline
-    fluff_str = event == 'set' ? 'will rise in' : 'is up for';
+    fluff_str = event == 'set' ? 'is up for' : 'will rise in';
     UserVars.moons[moon].delete(event)
     UserVars.moons[moon][event] = snapshot + timer
-    UserVars.moons[moon]['timer'] = minutes_apart(UserVars.moons[moon]['rise'], snapshot)
+    UserVars.moons[moon]['timer'] = minutes_apart(UserVars.moons[moon][event], snapshot)
     UserVars.moons[moon]['pretty'] = "#{moon} #{fluff_str} #{UserVars.moons[moon]['timer']} minutes"
     UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
     if event == 'rise'
@@ -202,7 +205,7 @@ def process_moon_message(moon, message)
       UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
     end
   end
-  echo("settings for #{moon}:#{minutes_apart(UserVars.moons[moon][event], Time.now)}:#{UserVars.moons['visible'].include?(moon)}") if $debug_mode_mm
+  echo("settings for #{moon}:#{minutes_apart(UserVars.moons[moon][event], snapshot)} <> #{UserVars.moons[moon]['timer']}:#{UserVars.moons['visible'].include?(moon)}") if $debug_mode_mm
   moon_change(moon, is_up, timer) if !$offline
   Setting[moon] = Time.now
   update_moon_window if CharSettings['moon_window']

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -9,25 +9,30 @@ arg_definitions = [
     { name: 'debug', regex: /debug/i, optional: true },
     { name: 'alias', regex: /alias/i, optional: true, description: 'Add an alias for the command moon that will display moon status.' },
     { name: 'window', regex: /window/i, optional: true, description: 'Toggle a window for the moon status.' },
-    { name: 'correct', regex: /correct/i, optional: true, description: 'Set up a moonbot to deal with new moons' }
+    { name: 'correct', regex: /correct/i, optional: true, description: 'Set up a moonbot to deal with new moons.' },
+    { name: 'offline', regex: /offline/i, optional: true, description: 'Downloads latest data from firebase and then runs without autoupdating.' }
+
   ]
 ]
 
 args = parse_args(arg_definitions)
-
 $debug_mode_mm = UserVars.moon_debug || args.debug
 
 enable_moon_connection
 pause 3
 
+ENGLISH_VALUE = {}
+ENGLISH_VALUE['hundred'] = 100
+%w[zero one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen].each_with_index{ |word,i| ENGLISH_VALUE[word] = i }
+
+%w[zero ten twenty thirty forty fifty sixty seventy eighty ninety].each_with_index{ |word,i| ENGLISH_VALUE[word] = i*10 }
+
+%w[one thousand million billion trillion].each_with_index{ |word,i| ENGLISH_VALUE[word] = 10**(i*3) }
+
 if args.alias
-  UpstreamHook.run("<c>#{$clean_lich_char}alias add --global moon = #{$clean_lich_char}eq respond(\"#{UserVars.moons['katamba']['pretty']} : #{UserVars.moons['yavash']['pretty']} : #{UserVars.moons['xibar']['pretty']}\")")
+  UpstreamHook.run("<c>#{$clean_lich_char}alias add --global moon = #{$clean_lich_char}eq self.print_moon_status")
 end
-
 CharSettings['moon_window'] = !CharSettings['moon_window'] if args.window
-
-UserVars.moons = { 'katamba' => {}, 'yavash' => {}, 'xibar' => {}, 'visible' => [] }
-UserVars.sun = {}
 
 Settings['xibar'] ||= Time.now
 Settings['yavash'] ||= Time.now
@@ -53,6 +58,12 @@ if CharSettings['moon_window']
   CharSettings['moon_window_cache'] = nil
 end
 
+def print_moon_status
+  respond("#{UserVars.moons['katamba']['pretty']}")
+  respond("#{UserVars.moons['yavash']['pretty']}")
+  respond("#{UserVars.moons['xibar']['pretty']}")
+end
+
 def check_for_new_moons
   UserVars.moons.each do |moon, data|
     next if moon == 'visible' || data['timer'] >= 0
@@ -60,6 +71,25 @@ def check_for_new_moons
     moon_change(moon, !set) if data[(set ? 'set' : 'rise')]
     waitrt?
   end
+end
+
+
+def string_to_number(string)
+  values = string.downcase.split( /\W+/ ).map{ |word|
+    ENGLISH_VALUE[word]
+  }
+  time = 0
+  values.each_with_index {|num, idx|
+    next_idx = idx + 1
+    if (values[next_idx] > 99)
+      next_num = values.slice(next_idx)
+      values.delete_at(next_idx)
+      time = time + (num * next_num)
+    else
+      time = time + num
+    end
+  }
+  return time
 end
 
 def update_moon_window
@@ -71,14 +101,20 @@ def update_moon_window
 end
 
 def moon_change(moon, is_up)
-  echo("moon_change #{moon}:#{is_up}") if $debug_mode_mm
   snapshot = Time.now
   snapshot = (snapshot - snapshot.sec).utc.to_s
   update_moon_data(moon, 'time' => snapshot, 'event' => is_up ? 'rise' : 'set')
 end
 
 def minutes_apart(first, second)
-  ((first - second) / 60).to_i
+  ((first - second) / 60).ceil
+end
+
+def get_latest_moon
+  UserVars.moons = { 'katamba' => {}, 'yavash' => {}, 'xibar' => {}, 'visible' => [] }
+  UserVars.sun = {}
+  update_moon_info(get_all_moon_data)
+  update_sun_info(get_all_moon_data)
 end
 
 def minutes_to_next_sun_event(past, current)
@@ -104,6 +140,7 @@ end
 
 def update_moon_info(latest_data)
   return if latest_data.nil? || latest_data.empty?
+  echo "#{latest_data}"
   %w[katamba yavash xibar].each do |moon|
     data = latest_data[moon]
     event = data['event']
@@ -126,24 +163,99 @@ def update_moon_info(latest_data)
   end
 end
 
+def handle_moon_timers(line)
+  case line
+  when /that (Katamba|Xibar|Yavash) is (\w+\-?\w+?) degrees above the (eastern|western)/
+    moon = Regexp.last_match(1).downcase
+    minutes = string_to_number(Regexp.last_match(2))
+    timer = Regexp.last_match(3) == 'eastern' ? (Settings['set'][moon] / 60 - minutes).to_i : minutes.to_i
+    offline_update_moon_info(moon, 'timer' => timer, 'event' => 'rise')
+  when /that (Katamba|Xibar|Yavash) is exactly at zenith/
+    moon = Regexp.last_match(1).downcase
+    timer = (Settings['set'][moon] / (60 * 2)).to_i
+    offline_update_moon_info(moon, 'timer' => timer, 'event' => 'rise')
+  when /^(Katamba|Xibar|Yavash) is a .* should rise in about (\d+)/
+    moon = Regexp.last_match(1).downcase
+    timer = (Regexp.last_match(2).to_i * 30).to_i
+    offline_update_moon_info(moon, 'timer' => timer, 'event' => 'set')
+  when /^(Katamba|Xibar|Yavash) sets/
+    moon = Regexp.last_match(1).downcase
+    offline_update_moon_info(moon, 'timer' => Settings['rise'][moon] / 60, 'event' => 'set')
+  when /^(Katamba|Xibar|Yavash) slowly rises/
+    moon = Regexp.last_match(1).downcase
+    offline_update_moon_info(moon, 'timer' => Settings['set'][moon] / 60, 'event' => 'rise')
+  when /heralding another fine day|rises to create the new day|as the sun rises, hidden|as the sun rises behind it|faintest hint of the rising sun|The rising sun slowly/
+    old = UserVars.sun
+    UserVars.sun['set'] = old['set']
+    UserVars.sun['rise'] = Time.now.utc.to_s
+  when /The sun sinks below the horizon|night slowly drapes its starry banner|sun slowly sinks behind the scattered clouds and vanishes|grey light fades into a heavy mantle of black/
+    old = UserVars.sun
+    UserVars.sun['rise'] = old['rise']
+    UserVars.sun['set'] = Time.now.utc.to_s
+  else
+    time_now = Time.now
+    time_now = time_now - time_now.sec
+    %w[katamba yavash xibar].each do |moon|
+      old = UserVars.moons[moon]
+      event = old.key?('set') ? 'set' : 'rise'
+      timer = minutes_apart(old[event], time_now)
+      offline_update_moon_info(moon, 'event' => (%w[rise set] - [event]).first, 'time' => time_now) if (old['timer'] - timer) > 5
+    end
+  end
+  pause 0.1 unless line
+end
+
+def offline_update_moon_info(moon, data)
+  return if data.nil? || data.empty?
+  event = data['event']
+  coming_event = (%w[rise set] - [event]).first
+  time_now = data['time']
+  if !time_now.nil?
+    data['timer'] = minutes_apart(UserVars.moons[moon][coming_event], time_now)
+  else
+    time_now = Time.now
+    time_now = time_now - time_now.sec
+  end
+  UserVars.moons[moon].delete(coming_event)
+  UserVars.moons[moon][coming_event] = time_now + (data['timer'] * 60)
+  UserVars.moons[moon]['timer'] = data['timer']
+  if event == 'rise'
+    UserVars.moons[moon]['pretty'] = "#{moon} is up for #{UserVars.moons[moon]['timer']} minutes"
+    UserVars.moons[moon]['short'] = "[#{moon[0]}]+(#{UserVars.moons[moon]['timer']})"
+    UserVars.moons['visible'].push(moon) unless UserVars.moons['visible'].include?(moon)
+  else
+    UserVars.moons[moon]['pretty'] = "#{moon} will rise in #{UserVars.moons[moon]['timer']} minutes"
+    UserVars.moons[moon]['short'] = "[#{moon[0]}]-(#{UserVars.moons[moon]['timer']})"
+    UserVars.moons['visible'].delete(moon) if UserVars.moons['visible'].include?(moon)
+  end
+end
+
+
+if args.offline
+  get_latest_moon
+end
+
 loop do
   line = script.gets?
-  case line
-  when /^(Katamba|Xibar|Yavash) sets/
-    moon_change(Regexp.last_match(1).downcase, false)
-  when /^(Katamba|Xibar|Yavash) slowly rises/
-    moon_change(Regexp.last_match(1).downcase, true)
-  when /heralding another fine day|rises to create the new day|as the sun rises, hidden|as the sun rises behind it|faintest hint of the rising sun|The rising sun slowly/
-    old = get_all_moon_data['sun']
-    update_moon_data('sun', 'set' => old['set'], 'rise' => Time.now.utc.to_s)
-  when /The sun sinks below the horizon|night slowly drapes its starry banner|sun slowly sinks behind the scattered clouds and vanishes|grey light fades into a heavy mantle of black/
-    old = get_all_moon_data['sun']
-    update_moon_data('sun', 'rise' => old['rise'], 'set' => Time.now.utc.to_s)
+  if args.offline
+    handle_moon_timers(line)
+  else
+    case line
+    when /^(Katamba|Xibar|Yavash) sets/
+      moon_change(Regexp.last_match(1).downcase, false)
+    when /^(Katamba|Xibar|Yavash) slowly rises/
+      moon_change(Regexp.last_match(1).downcase, true)
+    when /heralding another fine day|rises to create the new day|as the sun rises, hidden|as the sun rises behind it|faintest hint of the rising sun|The rising sun slowly/
+      old = get_all_moon_data['sun']
+      update_moon_data('sun', 'set' => old['set'], 'rise' => Time.now.utc.to_s)
+    when /The sun sinks below the horizon|night slowly drapes its starry banner|sun slowly sinks behind the scattered clouds and vanishes|grey light fades into a heavy mantle of black/
+      old = get_all_moon_data['sun']
+      update_moon_data('sun', 'rise' => old['rise'], 'set' => Time.now.utc.to_s)
+    end
+    update_moon_info(get_all_moon_data)
+    update_sun_info(get_all_moon_data)
+    pause 0.1 unless line
   end
-
-  update_moon_info(get_all_moon_data)
-  update_sun_info(get_all_moon_data)
-  update_moon_window if CharSettings['moon_window']
   check_for_new_moons if args.correct
-  pause 0.1 unless line
+  update_moon_window if CharSettings['moon_window']
 end


### PR DESCRIPTION
Quite a few changes.

Gives an offline mode option that pulls the json data down to get the object setup, then reads the perc moon|moons output and builds times based off of their degrees or anlas/anlaen remaining.

Also fixes the issue Myself and Krystorm experienced yesterday with the alias returning stale times.

I tried to leave as much of the original functions alone, only changing the minute_apart to use .ceil in an attempt to fix the timer jumping ahead 2 minutes instead of 1.

Timer auto updates ever 5 minutes.

The string matches aren't set to promise accuracy. My moonie is only 11, so he isn't able to get "You feel certain that moon is # degrees above the (eastern|western) horizon." messages on anything but when the moon first rises and just before it sets.