### PR TITLE
Change untying failure in get_crafting_tem

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -106,28 +106,18 @@ module DRCC
   def get_crafting_item(name, bag, bag_items, belt)
     waitrt?
     if belt && belt['items'].find { |item| /\b#{name}/i =~ item || /\b#{item}/i =~ name }
-      case DRC.bput("untie my #{name} from my #{belt['name']}", "You remove", "Untie what")
-	    when "You remove"
-		    return
-      when "Untie what"
-		    case DRC.bput("get my #{name}", '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
-        when 'What do you', 'What were you'
-           echo("You seem to be missing: #{name}")
-           exit
-		    end
-		  else
-        return
+      if "You remove" == DRC.bput("untie my #{name} from my #{belt['name']}", "You remove", "Untie what")
+          return
       end
-    else
-      command = "get my #{name}"
-      command += " from my #{bag}" if bag_items && bag_items.include?(name)
-      case DRC.bput(command, '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
-      when 'What do you', 'What were you'
-        echo("You seem to be missing: #{name}")
-        exit
-      when "can't quite lift it"
-        get_crafting_item(name, bag, bag_items, belt)
-      end
+    end
+    command = "get my #{name}"
+    command += " from my #{bag}" if bag_items && bag_items.include?(name)
+    case DRC.bput(command, '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
+    when 'What do you', 'What were you'
+      echo("You seem to be missing: #{name}")
+      exit
+    when "can't quite lift it"
+      get_crafting_item(name, bag, bag_items, belt)
     end
   end
 

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -106,9 +106,17 @@ module DRCC
   def get_crafting_item(name, bag, bag_items, belt)
     waitrt?
     if belt && belt['items'].find { |item| /\b#{name}/i =~ item || /\b#{item}/i =~ name }
-      if 'untie what' == DRC.bput("untie my #{name} from my #{belt['name']}", 'you remove', 'untie what')
-        echo("You seem to be missing: #{name} from your #{belt['name']}")
-        exit
+      case DRC.bput("untie my #{name} from my #{belt['name']}", "You remove", "Untie what")
+	    when "You remove"
+		    return
+      when "Untie what"
+		    case DRC.bput("get my #{name}", '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
+        when 'What do you', 'What were you'
+           echo("You seem to be missing: #{name}")
+           exit
+		    end
+		  else
+        return
       end
     else
       command = "get my #{name}"


### PR DESCRIPTION
At least once per week I end up in an infinite loop when a crafting item that should be tied to my belt ends up stowed in a bag. The current get_crafting_item method doesn't match the failed attempted to untie. When running ;forge with a belt-worn crafting item in a bag the current result is:

[forge]>untie my ball-peen hammer from my forger belt
Untie what?
>
[forge]>untie my tongs from my forger belt
You remove some articulated covellite tongs with a tempered finish from your forger's belt.
>
[forge]>pound ingot on anvil with my hammer
You must be holding the ball-peen hammer to do that.
>
[forge]>untie my ball-peen hammer from my forger belt
Untie what?
>
[forge]>pound ingot on anvil with my hammer
You must be holding the ball-peen hammer to do that.
>
[forge]>untie my ball-peen hammer from my forger belt
Untie what?
>
[forge]>pound ingot on anvil with my hammer
You must be holding the ball-peen hammer to do that.
.
.
.

The adjusted script SHOULD correct this issue but I had some trouble testing. Despite changing the script it kept running the old version. I created an entirely new script and tested and it all seemed to work. The new script should notice the error, attempt to correct it, and if it can't find the crafting item in a bag it should exit the script without looping. The messaging from my test script was:

[forge2]>untie my ball-peen hammer from my forger belt
Untie what?
>
[forge2]>get my ball-peen hammer
You get a steel ball-peen hammer with a tempered finish from inside your duffel bag.
>
Garendel came through an arch.
>
[forge2]>untie my tongs from my forger belt
You remove some articulated covellite tongs with a tempered finish from your forger's belt.