### PR TITLE
Update to lodged ammo messages

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -568,7 +568,7 @@ class SafetyProcess
   def initialize
     echo('New SafetyProcess') if $debug_mode_ct
     Flags.add('ct-engaged', 'closes to pole weapon range on you', 'closes to melee range on you')
-    Flags.add('ct-lodged', 'You feel an agonizing pain from the .* lodged in your (.*)\.')
+    Flags.add('ct-lodged', 'from the .* lodged in your (.*)\.')
   end
 
   def execute(game_state)


### PR DESCRIPTION
Removing "You feel a sharp pain" should allow the combat-trainer to catch all lodged messages ("slight twinge" or "you wince" etc)

I'm assuming the logic is such that it tends the area the item is lodged in, and then drops the item?