### PR TITLE
Updating Base-items for coin pickup to prevent abuse

### DIFF
--- a/data/base-items.yaml
+++ b/data/base-items.yaml
@@ -10,8 +10,16 @@ lootables:
 - arrows
 - rock
 # valuable loot
-- coin
-- coins
+- copper coin
+- bronze coin
+- silver coin
+- gold coin
+- platinum coin
+- copper coins
+- bronze coins
+- silver coins
+- gold coins
+- platinum coins
 - map
 - pass
 - note


### PR DESCRIPTION
Updated base-items to longer coin names such as "copper coin" to avoid interactions with "imperial coin piles".  Certain individuals were using this loop hole to bog down players inventories with imperial coins.