### PR TITLE
Update to Thanatology Training v2 (Skinning/First Aid Ritual Cycle)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -213,8 +213,7 @@ class LootProcess
     @ritual_type = thanatology['ritual_type'].downcase
     echo("  @ritual_type: #{@ritual_type}") if $debug_mode_ct
 
-    @cycle_rituals = false
-    @cycle_rituals = true if @ritual_type == "cycle"
+    @ritual_type == "cycle" ? @cycle_rituals = true : @cycle_rituals = false
 
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
@@ -361,19 +360,14 @@ class LootProcess
     DRSkill.getxp('Thanatology') < 32)
   end
 
-  def check_ritual_xp
-    DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Skinning') > 31
-  end
-
   def cycle_rituals
-    @ritual_type = "preserve"
-    @ritual_type = "dissect" if DRSkill.getxp('First Aid') < 32
+    return unless @cycle_rituals 
+    @ritual_type = "dissect"
     @ritual_type = "harvest" if DRSkill.getxp('Skinning') < DRSkill.getxp('First Aid')
-    @ritual_type = "preserve" if check_ritual_xp
+    @ritual_type = "preserve" if DRSkill.getxp('Skinning') > 31
   end
 
-  def check_rituals?(game_state)
-    cycle_rituals if @cycle_rituals && !game_state.prepare_consume
+  def check_rituals?(game_state) 
     return true unless DRStats.necromancer?
     mob_noun = DRRoom.dead_npcs.first
     return true if game_state.construct?(mob_noun)
@@ -384,6 +378,7 @@ class LootProcess
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         do_necro_ritual(mob_noun, 'consume', game_state) unless game_state.wounds.empty?
       end
+      cycle_rituals
       do_necro_ritual(mob_noun, @ritual_type, game_state) if should_perform_ritual(game_state.prepare_consume)
     end
     return false if %w[consume harvest dissect].include?(@last_ritual)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -213,6 +213,9 @@ class LootProcess
     @ritual_type = thanatology['ritual_type'].downcase
     echo("  @ritual_type: #{@ritual_type}") if $debug_mode_ct
 
+    @cycle_rituals = false
+    @cycle_rituals = true if @ritual_type == "cycle"
+
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
 
@@ -221,9 +224,6 @@ class LootProcess
 
     @necro_heal = thanatology['heal'] || false
     echo("  @necro_heal: #{@necro_heal}") if $debug_mode_ct
-
-    @necro_train_first_aid = thanatology['train_first_aid'] || false
-    echo("  @necro_train_first_aid: #{@necro_train_first_aid}") if $debug_mode_ct
 
     @necro_store = thanatology['store'] || false
     echo("  @necro_store: #{@necro_store}") if $debug_mode_ct
@@ -355,11 +355,25 @@ class LootProcess
   end
 
   def should_perform_ritual(prepare_consume)
-    !prepare_consume &&
-      ((@necro_train_first_aid && DRSkill.getxp('First Aid') < 32) || DRSkill.getxp('Thanatology') < 32)
+   !prepare_consume &&
+    (@ritual_type == "dissect" && DRSkill.getxp('First Aid') < 32) ||
+    (@ritual_type == "harvest" && DRSkill.getxp('Skinning') < 32) ||
+    DRSkill.getxp('Thanatology') < 32
+  end
+
+  def check_ritual_xp
+    DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Skinning') > 31
+  end
+
+  def cycle_rituals
+    @ritual_type = "preserve"
+    @ritual_type = "dissect" if DRSkill.getxp('First Aid') < 32
+    @ritual_type = "harvest" if DRSkill.getxp('Skinning') < DRSkill.getxp('First Aid')
+    @ritual_type = "preserve" if check_ritual_xp
   end
 
   def check_rituals?(game_state)
+    cycle_rituals if @cycle_rituals
     return true unless DRStats.necromancer?
     mob_noun = DRRoom.dead_npcs.first
     return true if game_state.construct?(mob_noun)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -373,7 +373,7 @@ class LootProcess
   end
 
   def check_rituals?(game_state)
-    cycle_rituals if @cycle_rituals
+    cycle_rituals if @cycle_rituals && !game_state.prepare_consume
     return true unless DRStats.necromancer?
     mob_noun = DRRoom.dead_npcs.first
     return true if game_state.construct?(mob_noun)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -367,7 +367,7 @@ class LootProcess
     @ritual_type = "preserve" if DRSkill.getxp('Skinning') > 31
   end
 
-  def check_rituals?(game_state) 
+  def check_rituals?(game_state)
     return true unless DRStats.necromancer?
     mob_noun = DRRoom.dead_npcs.first
     return true if game_state.construct?(mob_noun)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -213,7 +213,7 @@ class LootProcess
     @ritual_type = thanatology['ritual_type'].downcase
     echo("  @ritual_type: #{@ritual_type}") if $debug_mode_ct
 
-    @ritual_type == "cycle" ? @cycle_rituals = true : @cycle_rituals = false
+    @cycle_rituals = @ritual_type == "cycle"
 
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -356,9 +356,9 @@ class LootProcess
 
   def should_perform_ritual(prepare_consume)
    !prepare_consume &&
-    (@ritual_type == "dissect" && DRSkill.getxp('First Aid') < 32) ||
+    ((@ritual_type == "dissect" && DRSkill.getxp('First Aid') < 32) ||
     (@ritual_type == "harvest" && DRSkill.getxp('Skinning') < 32) ||
-    DRSkill.getxp('Thanatology') < 32
+    DRSkill.getxp('Thanatology') < 32)
   end
 
   def check_ritual_xp

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -213,6 +213,7 @@ class LootProcess
     @ritual_type = thanatology['ritual_type'].downcase
     echo("  @ritual_type: #{@ritual_type}") if $debug_mode_ct
 
+    @cycle_rituals = false
     @cycle_rituals = @ritual_type == "cycle"
 
     @rituals = get_data('spells').rituals
@@ -361,7 +362,7 @@ class LootProcess
   end
 
   def cycle_rituals
-    return unless @cycle_rituals 
+    return unless @cycle_rituals
     @ritual_type = "dissect"
     @ritual_type = "harvest" if DRSkill.getxp('Skinning') < DRSkill.getxp('First Aid')
     @ritual_type = "preserve" if DRSkill.getxp('Skinning') > 31


### PR DESCRIPTION
Added new "cycle" ritual which swaps between Harvest and Dissect based on Skinning/First Aid Training.
Made changes to default ritual training behavior and removed first aid exp variable.
Now checks for FA exp if using Dissect, or skinning if using harvest.

See #1563 for prior PR.  Calling it V1.