### PR TITLE
Added Timer to Crossing Repair

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -126,7 +126,7 @@ hunting_room_strict_mana: false
 
 # Repair settings
 repair_withdrawal_amount: 10_000
-
+repair_timer: 600
 
 
 

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -16,7 +16,11 @@ class TrainingManager
     ]
     args = parse_args(arg_definitions)
 
+    
     @settings = get_settings
+    @repair_timer = @settings.repair_timer
+    @repair_timer_snap = Time.now
+
     if @settings.training_manager_hunting_priority
       combat_loop(args.skip)
     else
@@ -73,10 +77,17 @@ class TrainingManager
     end
   end
 
+  def check_repair
+    if Time.now - @repair_timer_snap > @repair_timer
+      @repair_timer_snap = Time.now
+      true
+    end
+  end
+
   def hunting_combo
     wait_for_script_to_complete('hunting-buddy')
     wait_for_script_to_complete('safe-room')
-    wait_for_script_to_complete('crossing-repair')
+    wait_for_script_to_complete('crossing-repair') if check_repair
   end
 
   def check_favors


### PR DESCRIPTION
Added Timer to Crossing Repair.  Timer can be set using YAML setting "repair_timer: 100". (or any number)

Updated base.yaml to have a default timer of 10 minutes (600 seconds) between repair attempts.