### PR TITLE
YAML setting to skip Crossing-Repair

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -81,6 +81,7 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
+high_social_outrage: false
 weapon_training:
 combat_trainer_target_increment: 3
 combat_trainer_action_count: 10

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -81,7 +81,6 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
-high_social_outrage: false
 weapon_training:
 combat_trainer_target_increment: 3
 combat_trainer_action_count: 10

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -130,6 +130,7 @@ hunting_room_strict_mana: false
 # Repair settings
 repair_withdrawal_amount: 10_000
 repair_timer: 600
+skip_repair: false
 
 
 

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -20,6 +20,7 @@ class TrainingManager
     @skip_repair = @settings.skip_repair
     @repair_timer = @settings.repair_timer
     @repair_timer_snap = Time.now
+    @high_social_outrage = @settings.high_social_outrage
 
     if @settings.training_manager_hunting_priority
       combat_loop(args.skip)
@@ -79,6 +80,7 @@ class TrainingManager
 
   def check_repair
     return false if @skip_repair
+    return false if @high_social_outrage
     return false if Time.now - @repair_timer_snap < @repair_timer
 
     @repair_timer_snap = Time.now

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -17,6 +17,7 @@ class TrainingManager
     args = parse_args(arg_definitions)
 
     @settings = get_settings
+    @skip_repair = @settings.skip_repair
     @repair_timer = @settings.repair_timer
     @repair_timer_snap = Time.now
 
@@ -77,6 +78,7 @@ class TrainingManager
   end
 
   def check_repair
+    return false if @skip_repair
     return false if Time.now - @repair_timer_snap < @repair_timer
 
     @repair_timer_snap = Time.now

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -20,8 +20,7 @@ class TrainingManager
     @skip_repair = @settings.skip_repair
     @repair_timer = @settings.repair_timer
     @repair_timer_snap = Time.now
-    @high_social_outrage = @settings.high_social_outrage
-
+    
     if @settings.training_manager_hunting_priority
       combat_loop(args.skip)
     else
@@ -80,7 +79,6 @@ class TrainingManager
 
   def check_repair
     return false if @skip_repair
-    return false if @high_social_outrage
     return false if Time.now - @repair_timer_snap < @repair_timer
 
     @repair_timer_snap = Time.now

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -20,7 +20,7 @@ class TrainingManager
     @skip_repair = @settings.skip_repair
     @repair_timer = @settings.repair_timer
     @repair_timer_snap = Time.now
-    
+
     if @settings.training_manager_hunting_priority
       combat_loop(args.skip)
     else


### PR DESCRIPTION
Added YAML setting to completely skip crossing-repair. Useful for people who don't want to repair, (and necromancers who blow their SO!)

I also figured this was a good time to plug in a setting for necromancers to avoid functions that could cause a social outrage spiral.

Setting is:
high_social_outrage: true/false
Default is set to false.