### PR TITLE
Add gondola to bescort

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -140,6 +140,10 @@ class Bescort
       [
         { name: 'therenropebridge', regex: /therenropebridge/i, description: 'The rope bridge between Theren and Rossman\'s Landing' },
         { name: 'mode', options: %w[totheren torossman], description: 'Where do you need to get to?' }
+      ],
+      [
+        {name: 'gondola', regex: /gondola/i, description: 'Gondola between Shard and Leth Deriel'},
+        {name: 'mode', options: %w[north south], description: 'Which direction are you going?'}
       ]
     ]
 
@@ -169,6 +173,8 @@ class Bescort
       take_crawling_plague(args.mode)
     elsif args.therenropebridge
       take_theren_rope_bridge(args.mode)
+    elsif args.gondola
+      ride_gondola(args.mode)
     end
   end
 
@@ -769,6 +775,19 @@ class Bescort
     end
     open_gate(destination_shard, false)
     fput('rel mana')
+  end
+
+  def ride_gondola(mode)
+    res = bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
+    case res
+    when /no wooden gondola here/i
+      waitfor 'The gonolda stops on the platform and the door silently swings open'
+      ride_gondola(mode)
+    when /Gondola, Cab/
+      move mode
+      waitfor 'With a soft bump, the gondola comes to a stop at its destination'
+      move 'out'
+    end
   end
 end
 

--- a/bescort.lic
+++ b/bescort.lic
@@ -778,8 +778,7 @@ class Bescort
   end
 
   def ride_gondola(mode)
-    res = bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
-    case res
+    case bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
     when /no wooden gondola here/i
       waitfor 'The gondola stops on the platform and the door silently swings open'
       ride_gondola(mode)

--- a/bescort.lic
+++ b/bescort.lic
@@ -781,7 +781,7 @@ class Bescort
     res = bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
     case res
     when /no wooden gondola here/i
-      waitfor 'The gonolda stops on the platform and the door silently swings open'
+      waitfor 'The gondola stops on the platform and the door silently swings open'
       ride_gondola(mode)
     when /Gondola, Cab/
       move mode


### PR DESCRIPTION
Add Shard gondola to bescort. Addresses #1636

I'll add these two lines to the mapdb if merged. Note that I'm keeping the existing logic in the StringProc, but deferring to bescort if the user has it. 
```
Room[2249].wayto["2904"] = StringProc.new("if Script.exists?('bescort'); start_script('bescort', ['gondola', 'south']); else; result = dothistimeout 'go gondola', 10, /^There is no wooden gondola here.| Gondola, Cab North/; unless result =~ /Gondola, Cab North/; echo 'waiting for the gondola...'; waitfor 'The gondola stops on the platform and the door silently swings open.'; move 'go gondola'; end;  move 'south'; waitfor 'With a soft bump, the gondola comes to a stop at its destination.'; move out; end")

Room[2904].wayto["2249"] = StringProc.new("if Script.exists?('bescort'); start_script('bescort', ['gondola', 'north']); else;result = dothistimeout 'go gondola', 10, /^There is no wooden gondola here.|Gondola, Cab South/; unless result =~ /Gondola, Cab South/; echo 'waiting for the gondola...'; waitfor 'The gondola stops on the platform and the door silently swings open.'; move 'go gondola'; end; move 'north'; waitfor 'With a soft bump, the gondola comes to a stop at its destination.'; move out; end")
```