### PR TITLE
Adding the sheath_offhand to the cleanup process for combat-trainer.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -35,6 +35,7 @@ class SetupProcess
         end
       else
         @equipment_manager.stow_weapon(game_state.weapon_name)
+        game_state.sheath_whirlwind_offhand
       end
       game_state.next_clean_up_step
       return true


### PR DESCRIPTION
This sheaths when combat is ending. Haven't had an issue with it yet. 