### PR TITLE
Added Slip Stalk to combat_trainer & common

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -703,6 +703,9 @@ class SpellProcess
     @stored_cambrinth = settings.stored_cambrinth
     echo(" @stored_cambrinth: #{@stored_cambrinth}") if $debug_mode_ct
 
+    @hide_type = settings.hide_type
+    echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
+
     @perc_health_timer = Time.now
 
     Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
@@ -877,7 +880,7 @@ class SpellProcess
       end
     end
 
-    hide? if XMLData.prepared_spell == 'Vivisection' && game_state.use_stealth_attack?
+    hide?(@hide_type) if XMLData.prepared_spell == 'Vivisection' && game_state.use_stealth_attack?
 
     cast?(@custom_cast, @symbiosis, @before, @after)
     @custom_cast = nil
@@ -1246,6 +1249,9 @@ class TrainerProcess
     @dont_stalk = settings.dont_stalk
     echo("  @dont_stalk: #{@dont_stalk}") if $debug_mode_ct
 
+    @hide_type = settings.hide_type
+    echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
+
     @stun_weapon = settings.stun_weapon
     echo("  @stun_weapon: #{@stun_weapon}") if $debug_mode_ct
 
@@ -1310,7 +1316,7 @@ class TrainerProcess
         fput('stand')
       end
     when 'Stealth'
-      bput('stalk', 'Try being out of sight', 'You move into position', 'already stalking', 'discovers you, ruining your hiding place') if hide? && !@dont_stalk && !game_state.npcs.empty?
+      bput('stalk', 'Try being out of sight', 'You move into position', 'already stalking', 'discovers you, ruining your hiding place') if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
       bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not') if game_state.npcs.empty?
     when 'Ambush Stun'
       return ambush_stun(game_state)
@@ -1497,6 +1503,9 @@ class AttackProcess
     @stealth_attack_aimed_action = settings.stealth_attack_aimed_action
     echo("  @stealth_attack_aimed_action: #{@stealth_attack_aimed_action}") if $debug_mode_ct
 
+    @hide_type = settings.hide_type
+    echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
+
     @offhand_thrown = settings.offhand_thrown
     echo("  @offhand_thrown: #{@offhand_thrown}") if $debug_mode_ct
 
@@ -1554,7 +1563,7 @@ class AttackProcess
     waitrt?
     if charged_maneuver.empty?
       if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush?
-        hide?
+        hide?(@hide_type)
       end
 
       verb = game_state.melee_attack_verb
@@ -1640,7 +1649,7 @@ class AttackProcess
 
     if game_state.loaded && game_state.done_aiming?
       if game_state.selected_maneuver.empty?
-        command = if game_state.use_stealth_attack? && hide?
+        command = if game_state.use_stealth_attack? && hide?(@hide_type)
                     @stealth_attack_aimed_action
                   else
                     'shoot'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1252,6 +1252,9 @@ class TrainerProcess
     @hide_type = settings.hide_type
     echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
 
+    @force_unhide = settings.force_unhide
+    echo("  @force_unhide: #{@force_unhide}") if $debug_mode_ct
+
     @stun_weapon = settings.stun_weapon
     echo("  @stun_weapon: #{@stun_weapon}") if $debug_mode_ct
 
@@ -1317,7 +1320,7 @@ class TrainerProcess
       end
     when 'Stealth'
       bput('stalk', 'Try being out of sight', 'You move into position', 'already stalking', 'discovers you, ruining your hiding place') if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
-      bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not') if game_state.npcs.empty?
+      bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not') if (game_state.npcs.empty? || @force_unhide) && hidden
     when 'Ambush Stun'
       return ambush_stun(game_state)
     when 'Favor Orb'
@@ -1706,7 +1709,7 @@ class AttackProcess
       pause 1
     else
       game_state.set_dance_queue
-      fput(game_state.next_dance_action)
+      fput(game_state.next_dance_action) if !game_state.next_dance_action.nil?
       pause 0.5
       waitrt?
     end

--- a/common.lic
+++ b/common.lic
@@ -268,13 +268,15 @@ module DRC
     end
   end
 
-  def hide?(*hide_type)
-    hide_type.any? ? hide_type = hide_type[0] : hide_type = 'hide' 
+  def hide?(hide_type = 'hide')
     unless hiding?
-      case bput(hide_type, 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself', 'Stalk what')
+      case bput(hide_type, 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself', 'Stalk what', 'You\'re already stalking')
       when 'too busy performing'
         bput('stop play', 'You stop playing', 'In the name of')
-        return hide?
+        return hide?(hide_type)
+      when "You're already stalking"
+        put 'stop stalk'
+        return hide?(hide_type)
       end
       pause
       waitrt?

--- a/common.lic
+++ b/common.lic
@@ -20,7 +20,7 @@ $ENC_MAP = {
   'It\'s amazing you aren\'t squashed!' => 11
 }
 
-custom_require.call(%w(spellmonitor drinfomon))
+custom_require.call(%w[spellmonitor drinfomon])
 
 module DRC
   module_function
@@ -174,7 +174,7 @@ module DRC
     list_to_array(list)
       .map { |long_name| get_noun(long_name) }
       .compact
-      .select { |noun| noun != '' }
+      .reject { |noun| noun == '' }
   end
 
   def get_noun(long_name)
@@ -224,17 +224,17 @@ module DRC
     end
   end
 
-  def listen?(teacher,observe_flag=false)
+  def listen?(teacher, observe_flag = false)
     return false if teacher.nil?
     return false if teacher.empty?
 
-    bad_classes = %w(Thievery Sorcery)
+    bad_classes = %w[Thievery Sorcery]
     bad_classes += ['Life Magic', 'Holy Magic', 'Lunar Magic', 'Elemental Magic', 'Arcane Magic', 'Targeted Magic', 'Arcana', 'Attunement'] if DRStats.barbarian? || DRStats.thief?
     bad_classes += ['Warding'] if DRStats.thief?
     bad_classes += ['Utility'] if DRStats.barbarian?
 
-    observe = observe_flag ? "observe" : ""
-    
+    observe = observe_flag ? 'observe' : ''
+
     case bput("listen to #{teacher} #{observe}", 'begin to listen to \w+ teach the .* skill', 'already listening', 'could not find who', 'You have no idea', 'isn\'t teaching a class', 'don\'t have the appropriate training', 'Your teacher appears to have left', 'isn\'t teaching you anymore', 'experience differs too much from your own', 'but you don\'t see any harm in listening', 'invitation if you wish to join this class')
     when /begin to listen to \w+ teach the (.*) skill/
       return true if bad_classes.grep(/#{Regexp.last_match(1)}/i).empty?

--- a/common.lic
+++ b/common.lic
@@ -20,7 +20,7 @@ $ENC_MAP = {
   'It\'s amazing you aren\'t squashed!' => 11
 }
 
-custom_require.call(%w[spellmonitor drinfomon])
+custom_require.call(%w(spellmonitor drinfomon))
 
 module DRC
   module_function
@@ -174,7 +174,7 @@ module DRC
     list_to_array(list)
       .map { |long_name| get_noun(long_name) }
       .compact
-      .reject { |noun| noun == '' }
+      .select { |noun| noun != '' }
   end
 
   def get_noun(long_name)
@@ -224,17 +224,17 @@ module DRC
     end
   end
 
-  def listen?(teacher, observe_flag = false)
+  def listen?(teacher,observe_flag=false)
     return false if teacher.nil?
     return false if teacher.empty?
 
-    bad_classes = %w[Thievery Sorcery]
+    bad_classes = %w(Thievery Sorcery)
     bad_classes += ['Life Magic', 'Holy Magic', 'Lunar Magic', 'Elemental Magic', 'Arcane Magic', 'Targeted Magic', 'Arcana', 'Attunement'] if DRStats.barbarian? || DRStats.thief?
     bad_classes += ['Warding'] if DRStats.thief?
     bad_classes += ['Utility'] if DRStats.barbarian?
 
-    observe = observe_flag ? 'observe' : ''
-
+    observe = observe_flag ? "observe" : ""
+    
     case bput("listen to #{teacher} #{observe}", 'begin to listen to \w+ teach the .* skill', 'already listening', 'could not find who', 'You have no idea', 'isn\'t teaching a class', 'don\'t have the appropriate training', 'Your teacher appears to have left', 'isn\'t teaching you anymore', 'experience differs too much from your own', 'but you don\'t see any harm in listening', 'invitation if you wish to join this class')
     when /begin to listen to \w+ teach the (.*) skill/
       return true if bad_classes.grep(/#{Regexp.last_match(1)}/i).empty?
@@ -268,9 +268,10 @@ module DRC
     end
   end
 
-  def hide?
+  def hide?(*hide_type)
+    hide_type.any? ? hide_type = hide_type[0] : hide_type = 'hide' 
     unless hiding?
-      case bput('hide', 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself')
+      case bput(hide_type, 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself', 'Stalk what')
       when 'too busy performing'
         bput('stop play', 'You stop playing', 'In the name of')
         return hide?

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -46,3 +46,4 @@ empty_values:
   empty_hunting_room_messages: []
   classes_to_teach: []
   whirlwind_trainables: []
+  hide_type: hide

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -46,4 +46,3 @@ empty_values:
   empty_hunting_room_messages: []
   classes_to_teach: []
   whirlwind_trainables: []
-  hide_type: hide

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -87,6 +87,7 @@ combat_trainer_action_count: 10
 dual_load: false
 use_stealth_attacks: false
 stealth_attack_aimed_action: poach
+hide_type: hide
 backstab:
 ambush: false
 performance_monitor_weapons:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -88,6 +88,7 @@ dual_load: false
 use_stealth_attacks: false
 stealth_attack_aimed_action: poach
 hide_type: hide
+force_unhide: false
 backstab:
 ambush: false
 performance_monitor_weapons:


### PR DESCRIPTION
You can now supply a YAML setting of "hide_type" to change what command is performed.  For example "hide_type: stalk" will perform slip stalk.

Also updated hide? method to use optional paramaters. Since hide? is in common, i wanted to retain its functionality for other scripts that may use it.

I tested the exp unofficially and it seemed to be better, but at the very least it has 25% reduced RT. Hide is 2 sec, stalk is 2 sec. Slip stalk is 3 sec total.

Yaml Settings:
hide_type: stalk     - will perform slip stalk instead of hide
force_unhide:  true  (default false) - will always unhide after hiding via Stealth timer.  (this will not affect attacks)