### PR TITLE
Ensure last rites matching to all gender creatures

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -470,7 +470,7 @@ class LootProcess
 
     game_state.mob_died = true
     if (Time.now - @last_rites_timer > 600) && @last_rites && game_state.blessed_room
-      bput("pray #{DRRoom.dead_npcs.first}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for its safe travels beyond this life')
+      bput("pray #{DRRoom.dead_npcs.first}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for')
       waitrt?
       fput "recite Meraud, power the holy fires that unleash my righteous vengeance;Chadatru, guide my sword to swing in justice;Everild, give me the power to conquer my enemies;Truffenyi, let me not lose sight of compassion and mercy;Else, I will become like those I despise;Urrem'tier, receive into your fetid grasp these wicked souls;May the Tamsine's realms never know their evil ways again;May all the Immortals guide your faithful soldier #{checkname}."
       waitrt?


### PR DESCRIPTION
pray (creature) currently matches to creatures defined as "its". certain creatures, such as cave trolls, always match as "his". Such as:

[combat-trainer]>pray troll
The cave troll moves into a position to dodge.
You bend over the corpse of a cave troll and murmur a brief prayer for his safe travels beyond this life.
The substance of a cave troll's body shimmers, as if covered by a veil of crystal tears.  A moment later he fades away, leaving nothing but empty air where his body had once lain.
You sense that you are as pure of spirit as you can be, and you are ready for whatever rituals might face you.
You feel that the light gods have cast their benevolent gaze favorably upon you at your attempts to please them.
[Roundtime: 8 sec.]

This waits for 15 seconds before the script continues and ultimately gives:

[combat-trainer: checked against [/You beseech your god for mercy/i, /You pray fervently/i, /You continue praying for guidance/i, /Quietly touching your lips with the tips of your fingers/i, /murmur a brief prayer for its safe travels beyond this life/i]]