### PR TITLE
Added necromancer EOTB support to attunement script

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#attunement
 =end
 
-custom_require.call(%w[common common-travel drinfomon])
+custom_require.call(%w(common common-travel drinfomon))
 
 class Attunement
   include DRC
@@ -12,6 +12,7 @@ class Attunement
     settings = get_settings
     @stationary_skills_only = settings.crossing_training_stationary_skills_only
     @hometown = settings.hometown
+    @force_power_walk = settings.force_power_walk
 
     train_attunement
   end
@@ -24,9 +25,13 @@ class Attunement
       return
     end
 
-    room_list = if @stationary_skills_only || DRStats.necromancer?
+    room_list = if @stationary_skills_only || (DRStats.necromancer? and !@force_power_walk)
                   [Room.current.id]
                 else
+                  if DRStats.necromancer? and @force_power_walk
+                    put "prep eotb"
+                    bput "cast", "You whisper"
+                  end
                   get_data('town')[@hometown]['attunement_rooms']
                 end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -81,6 +81,7 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
+force_power_walk: false
 weapon_training:
 combat_trainer_target_increment: 3
 combat_trainer_action_count: 10


### PR DESCRIPTION
Updated attunement script to allow necromancers to use power walk feature of attunement.

Uses EOTB.

yaml variable:  
force_power_walk: true
default: false