### PR TITLE
Temporarily modify crossing bank id's to use Dirge due to bank closure

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -7,10 +7,12 @@ Crossing:
   metal_repair:
     id: 19093
     name: Catrox
-  deposit:
-    id: 1900
-  exchange:
-    id: 1902
+   deposit:        
+     id: 16655 # Dirge  
+     #id: 1900     
+   exchange:  
+     id: 16655 # Dirge    
+     #id: 1902     
   gemshop:
     id: 4652
     name: appraiser


### PR DESCRIPTION
The bank in Crossing is closed due to an invasion.