### PR TITLE
add match text for unrepairable item

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -36,8 +36,8 @@ class CrossingRepair
       command = "give my #{item.short_name} to #{repairer}"
     end
 
-    case bput(command, "There isn't a scratch on that", "I don't work on those here", 'Just give it to me again', "You don't need to specify the object", "I will not repair something that isn't broken", "Please don't lose this ticket!", "You hand.*#{repairer}", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!')
-    when "There isn't a scratch on that", "I will not repair something that isn't broken", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!'
+    case bput(command, "There isn't a scratch on that", "I don't work on those here", "I don't repair those here",'Just give it to me again', "You don't need to specify the object", "I will not repair something that isn't broken", "Please don't lose this ticket!", "You hand.*#{repairer}", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!')
+    when "There isn't a scratch on that", "I will not repair something that isn't broken", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!', "I don't repair those here"
       @equipment_manager.empty_hands
     when "I don't work on those here"
       echo "*** ITEM HAS IMPROPER is_leather FLAG: #{item.short_name} ***"


### PR DESCRIPTION
Some items can't be repaired but are nice to have in a gear list. An example is a TM focus or gear used for appraisal. This is also needed to prevent the script from hanging