### PR TITLE
Use Dump Junk in Crossing-Training

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -61,13 +61,12 @@ class CrossingTraining
   end
 
   def dump_junk
-    return unless settings.@dump_junk
+    return unless @settings.dump_junk
     return unless Time.now - @junk_timer < 300
     return unless DRRoom.room_objs.size > 13
 
     fput('dump junk')
     @junk_timer = Time.now
-    end
   end
 
   def main

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -62,7 +62,7 @@ class CrossingTraining
 
   def dump_junk
     return unless @settings.dump_junk
-    return unless Time.now - @junk_timer < 300
+    return unless Time.now - @junk_timer > 300
     return unless DRRoom.room_objs.size > 13
 
     fput('dump junk')

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -35,7 +35,7 @@ class CrossingTraining
     @climbing_target = get_data('athletics').practice_options[@settings.climbing_target]
     @swimming_target = get_data('athletics').swimming_options[@settings.swimming_target]
     @song_list = get_data('perform').perform_options
-
+    @junk_timer = Time.now
     @use_research = @settings.use_research
     @settings.storage_containers.each { |container| fput("open my #{container}") }
     @disciplines_to_skill = {
@@ -58,6 +58,13 @@ class CrossingTraining
     Flags.add('ct-song', 'you finish playing')
     Flags.add('research-partial', 'there is still more to learn before you arrive at a breakthrough', 'distracted by combat', 'distracted by your spellcasting', 'You lose your focus on your research project', 'you forget what you were')
     Flags.add('research-complete', '^Breakthrough!')
+  end
+
+  def dump_junk
+    if Time.now - @junk_timer > 300
+      fput('dump junk')
+      @junk_timer = Time.now
+    end
   end
 
   def main
@@ -89,6 +96,7 @@ class CrossingTraining
     if trash_nouns.any? { |noun| /\b#{noun}/i =~ GameObj.left_hand.noun } && !@equipment_manager.is_listed_item?(left_hand)
       dispose_trash(left_hand)
     end
+    dump_junk if DRRoom.room_objs.size > 9 && @settings.dump_junk
   end
 
   def event_loop

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -61,9 +61,12 @@ class CrossingTraining
   end
 
   def dump_junk
-    if Time.now - @junk_timer > 300
-      fput('dump junk')
-      @junk_timer = Time.now
+    return unless settings.@dump_junk
+    return unless Time.now - @junk_timer < 300
+    return unless DRRoom.room_objs.size > 13
+
+    fput('dump junk')
+    @junk_timer = Time.now
     end
   end
 
@@ -96,7 +99,7 @@ class CrossingTraining
     if trash_nouns.any? { |noun| /\b#{noun}/i =~ GameObj.left_hand.noun } && !@equipment_manager.is_listed_item?(left_hand)
       dispose_trash(left_hand)
     end
-    dump_junk if DRRoom.room_objs.size > 9 && @settings.dump_junk
+    dump_junk
   end
 
   def event_loop


### PR DESCRIPTION
This goes off the setting used by combat-trainer, `dump_junk` and issues a call for the janitor if there are 10 or more items on the ground.