### PR TITLE
crosssing-training.lic: Switch engineering to check for Shaping to do…

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -867,7 +867,7 @@ class CrossingTraining
   end
 
   def train_engineering
-    if @settings.train_workorders.include?('Engineering')
+    if @settings.train_workorders.include?('Shaping')
       return unless money_for_training?(5000, 'Engineering')
       wait_for_script_to_complete('workorders', ['Shaping'])
       wait_for_script_to_complete('sell-loot')


### PR DESCRIPTION
… work orders.

In https://github.com/rpherbig/dr-scripts/commit/f8ea74fa8cdacc890dc198d49843323f9828189a a check for Engineering in train_workorders: was added instead of the discipline, so change it to follow all of the other professions where you call the discipline instead of the skill name.