### PR TITLE
Added #{info[stock_name]} and changed quotes from single to double on…

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -224,7 +224,7 @@ class WorkOrders
         end
         if bone_carving
           fput("get my #{info[stock_name]} stack")
-          while bput('count my stack', 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
+          while bput("count my #{info[stock_name]} stack", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
             order_item(info['stock-room'], info[stock_number])
             bput('combine', 'combine')
           end


### PR DESCRIPTION
… line 227. It was not counting the proper stack causing bone carving to fail.