### PR TITLE
Fix dancing

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1742,7 +1742,7 @@ class AttackProcess
       pause 1
     else
       game_state.set_dance_queue
-      fput(game_state.next_dance_action) unless game_state.next_dance_action.nil?
+      fput(game_state.next_dance_action)
       pause 0.5
       waitrt?
     end


### PR DESCRIPTION
Dancing currently skips your first action (and third action and subsequent odd numbered actions. The current version calls next_dance_action twice at line 1745 so the first action is removed in the "unless" statement and the second dance action immediately runs.

This change fixes the problem. The "unless" at line 1745 is not necessary because line 1744 already checks if the @dance_queue is empty and, if so, creates a new queue.