### PR TITLE
base-recipes.yaml: Disable wood crook workorders.

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -819,7 +819,7 @@ crafting_recipes:
   noun: crook
   volume: 5
   type: shaping
-  work_order: true
+  work_order: false
   chapter: 9
 - name: a wood earcuff
   noun: earcuff


### PR DESCRIPTION
2 people reported them as being broken today so just disable them for now.