### PR TITLE
pick.lic: Make args optional

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -111,8 +111,8 @@ class LockPicker
   def setup
     arg_definitions = [
       [
-        { name: 'pets', regex: /pets/, description: 'Disarm boxes and place them in the pet box container' },
-        { name: 'count', regex: /\d+/, description: 'How many pet boxes to make' }
+        { name: 'pets', regex: /pets/, optional: true, description: 'Disarm boxes and place them in the pet box container' },
+        { name: 'count', regex: /\d+/, optional: true, description: 'How many pet boxes to make' }
       ]
     ]
 


### PR DESCRIPTION
Without this fix ;pick would not run on its own unless you supplied the args.

>;pick
>
--- Lich: pick active.
[pick: ***INVALID ARGUMENTS DON'T MATCH ANY PATTERN***]
Provided Arguments: ''

  ;pick [pets] count
   pets         Disarm boxes and place them in the pet box container 
   count        How many pet boxes to make 
--- Lich: pick has exited.