### PR TITLE
Fix buying multiple oils in Theurgy

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -100,7 +100,7 @@ class Theurgy
     buy_theurgy_supply('sage')
     buy_theurgy_supply('lavender')
     buy_theurgy_supply('wine')
-    buy_oil unless inside?('holy oil', @theurgy_supply_container)
+    buy_oil unless (inside?('holy oil', @theurgy_supply_container) or inside?('some oil', @theurgy_supply_container))
     buy_flint unless inside?('flint', @theurgy_supply_container)
     buy_parchment unless inside?('golden parchment', @theurgy_supply_container)
   end


### PR DESCRIPTION
Fixed Theurgy to check not only for holy oil, but also 'some oil' before buying more.  Should fix the issue of buying more oil when you already have some.