### PR TITLE
Add climbing rope training to athletics

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -152,24 +152,25 @@ class Athletics
     bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
     until done_training?
       fix_standing
+      Flags.reset('climbing-finished')
       break unless play_climbing_song?
-      case bput("climb practice climbing rope", 'You begin to practice ', 'you mime a convincing climb while pulling the rope hand over hand', 'Directing your attention toward your rope', 'Allows you to climb various things like a tree', 'But you aren\'t holding')
+      case bput("climb practice climbing rope", 'You begin to practice ', 'you mime a convincing climb while pulling the rope hand over hand', 'Directing your attention toward your rope', 'Allows you to climb various things like a tree', 'But you aren\'t holding', 'You should stop practicing')
       when /you mime/
         break unless play_climbing_song?
-      when /Directing your/
+      when /Directing your/, /You should stop practicing/
         loop do
           pause 1
           break if Flags['climbing-finished']
           if Flags['climbing-too-hard']
             Flags.reset('climbing-too-hard')
-            stop_play
             UserVars.climbing_song_offset = true
+            stop_play
             offset_climbing_song(-1)
             break
           elsif Flags['climbing-too-easy']
-            stop_play
             Flags.reset('climbing-too-easy')
             UserVars.climbing_song_offset = true
+            stop_play
             offset_climbing_song(1)
             break
           end
@@ -181,9 +182,10 @@ class Athletics
         bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
       end
     end
-    Flags.delete('finished-climbing')
+    Flags.delete('climbing-finished')
     Flags.delete('climbing-too-easy')
     Flags.delete('climbing-too-hard')
+    bput('stop climb', 'You stop practicing your climbing skills.', "You weren't practicing your climbing skills anyway.")
     fix_standing
     stow_hands
   end

--- a/athletics.lic
+++ b/athletics.lic
@@ -114,10 +114,8 @@ class Athletics
     return unless exists?('climbing rope')
     return unless exists?('zills')
 
-    # TODO: Move setup logic to its own method
-    Flags.add('climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away')
-    stow_hands
     @song_list = get_data('perform').perform_options
+    stow_hands
     walk_to @settings.safe_room
     bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
     until done_training?
@@ -135,7 +133,6 @@ class Athletics
         bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
       end
     end
-    # TODO: Move cleanup logic to its own method
     fix_standing
     stow_hands
   end

--- a/athletics.lic
+++ b/athletics.lic
@@ -77,7 +77,7 @@ class Athletics
     bput("stow my #{cloth}", 'You put')
   end
 
-  def play_climbing_song?(blocking = false)
+  def play_climbing_song?
     UserVars.song = @song_list.first.first unless UserVars.song
     case bput("play #{UserVars.song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play')
     when 'Play on what instrument'
@@ -107,10 +107,6 @@ class Athletics
       end
     end
 
-    return true unless blocking
-
-    Flags.reset('ct-song')
-    pause 1 until Flags['ct-song']
     true
   end
 
@@ -122,7 +118,6 @@ class Athletics
     Flags.add('climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away')
     stow_hands
     @song_list = get_data('perform').perform_options
-    climbing_song = UserVars.song
     walk_to @settings.safe_room
     bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
     until done_training?
@@ -132,7 +127,7 @@ class Athletics
       when /you mime/
         break unless play_climbing_song?
       when /Directing your/
-        res = waitfor 'You finish practicing your climbing', 'The rope\'s will quickly fades away', 'Your focus diverts away from the rope'
+        waitfor 'You finish practicing your climbing', 'The rope\'s will quickly fades away', 'Your focus diverts away from the rope'
       when /Allows you to climb various things like a tree/
         echo "Waiting for rope to become climbable again"
         pause 10

--- a/athletics.lic
+++ b/athletics.lic
@@ -78,8 +78,8 @@ class Athletics
   end
 
   def play_climbing_song?
-    UserVars.song = @song_list.first.first unless UserVars.song
-    case bput("play #{UserVars.song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play')
+    UserVars.climbing_song = @song_list.first.first unless UserVars.climbing_song
+    case bput("play #{UserVars.climbing_song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play')
     when 'Play on what instrument'
       return false
     when 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play'
@@ -96,25 +96,57 @@ class Athletics
       clean_zills
       return play_climbing_song?
     when 'You begin a', 'You effortlessly begin', 'You begin some'
-      stop_play
-      UserVars.song = @song_list[UserVars.song] || @song_list.first.first
-      return play_climbing_song?
-    when 'You struggle to begin'
-      if UserVars.song != @song_list.first.first
+      # Ignore difficulty messages if we have an offset
+      unless UserVars.climbing_song_offset
         stop_play
-        UserVars.song = @song_list.first.first
+        UserVars.climbing_song = @song_list[UserVars.climbing_song] || @song_list.first.first
         return play_climbing_song?
+      else
+        return true
+      end
+    when 'You struggle to begin'
+      # Ignore difficulty message if we have an offset
+      unless UserVars.climbing_song_offset
+        if UserVars.climbing_song != @song_list.first.first
+          stop_play
+          UserVars.climbing_song = @song_list.first.first
+          return play_climbing_song?
+        end
+      else
+        return true
       end
     end
 
     true
   end
 
+  def offset_climbing_song(direction)
+    return unless UserVars.climbing_song_offset
+    return unless @song_list
+
+    if direction.eql?(1)
+      UserVars.climbing_song = @song_list[UserVars.climbing_song]
+    elsif direction.eql?(-1)
+      UserVars.climbing_song = @song_list.key(UserVars.climbing_song)
+    else
+      echo "Invalid offset direction"
+    end 
+  end
+
   def train_with_rope
     return unless exists?('climbing rope')
     return unless exists?('zills')
 
+    UserVars.climbing_song ||= UserVars.song
+    echo "UserVars.climbing_song: #{UserVars.climbing_song}" if UserVars.athletics_debug
+
     @song_list = get_data('perform').perform_options
+    echo "@song_list: #{@song_list}" if UserVars.athletics_debug
+
+    Flags.add('climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away', 'Your focus diverts away from the rope')
+    Flags.add('climbing-too-hard', 'This climb is too difficult')
+    Flags.add('climbing-too-easy', 'This climb is no challenge at all, so you stop practicing') 
+
     stow_hands
     walk_to @settings.safe_room
     bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
@@ -125,14 +157,33 @@ class Athletics
       when /you mime/
         break unless play_climbing_song?
       when /Directing your/
-        waitfor 'You finish practicing your climbing', 'The rope\'s will quickly fades away', 'Your focus diverts away from the rope'
+        loop do
+          pause 1
+          break if Flags['climbing-finished']
+          if Flags['climbing-too-hard']
+            Flags.reset('climbing-too-hard')
+            stop_play
+            UserVars.climbing_song_offset = true
+            offset_climbing_song(-1)
+            break
+          elsif Flags['climbing-too-easy']
+            stop_play
+            Flags.reset('climbing-too-easy')
+            UserVars.climbing_song_offset = true
+            offset_climbing_song(1)
+            break
+          end
+        end
       when /Allows you to climb various things like a tree/
         echo "Waiting for rope to become climbable again"
-        pause 10
+        pause 20
       when /But you aren't holding/
         bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
       end
     end
+    Flags.delete('finished-climbing')
+    Flags.delete('climbing-too-easy')
+    Flags.delete('climbing-too-hard')
     fix_standing
     stow_hands
   end
@@ -222,13 +273,14 @@ class Athletics
         end
         return if remaining_attempts.zero?
       end
-      Flags.add('ct-climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away')
+      Flags.add('ct-climbing-finished', 'You finish practicing your climbing')
       Flags.add('ct-climbing-combat', 'You are engaged in combat')
       bput("climb practice #{target}", 'You begin to practice ')
       loop do
         pause
+        break if Flags['ct-climbing-finished']
         return if Flags['ct-climbing-combat']
-        break if done_training? || Flags['ct-climbing-finished']
+        break if done_training?
       end
       bput('stop climb', 'You stop practicing your climbing skills.', "You weren't practicing your climbing skills anyway.")
     end

--- a/athletics.lic
+++ b/athletics.lic
@@ -42,7 +42,6 @@ class Athletics
   
   def stop_play
     bput('stop play', 'You stop playing your song', 'In the name of', "But you're not performing")
-    Flags['ct-song'] = true
   end
 
   def clean_zills

--- a/athletics.lic
+++ b/athletics.lic
@@ -2,22 +2,26 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#athletics
 =end
 
-custom_require.call(%w[common common-travel events drinfomon])
+custom_require.call(%w[common common-items common-travel events drinfomon])
 
 class Athletics
   include DRC
   include DRCT
+  include DRCI
 
   def initialize
     @settings = get_settings
     @athletics_options = get_data('athletics').athletics_options
 
     @climbing_target = get_data('athletics').practice_options[@settings.climbing_target]
+    have_climbing_rope = get_settings.have_climbing_rope
 
     start_exp = DRSkill.getxp('Athletics')
     @end_exp = [start_exp + 15, 29].min
 
-    if @climbing_target
+    if have_climbing_rope
+      climb_practice(get_settings.safe_room, 'climbing rope', false)
+    elsif @climbing_target
       climb_practice(@climbing_target['id'], @climbing_target['target'], @climbing_target['hide'])
     elsif @settings.hometown == 'Crossing'
       crossing_athletics
@@ -111,6 +115,7 @@ class Athletics
   def climb_practice(room, target, to_hide = false)
     return unless target
     walk_to(room)
+    bput('get climbing rope', 'You are already holding that', 'You get') if target.eql?('climbing rope')
     until done_training?
       retreat
       if to_hide
@@ -121,19 +126,21 @@ class Athletics
         end
         return if remaining_attempts.zero?
       end
-      Flags.add('ct-climbing-finished', 'You finish practicing your climbing')
+      Flags.add('ct-climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away')
       Flags.add('ct-climbing-combat', 'You are engaged in combat')
-      bput("climb practice #{target}", 'You begin to practice ')
+      fix_standing
+      bput("play #{UserVars.song} on zills", 'You begin', 'You\'re already playing a song') if target.eql?('climbing rope') 
+      bput("climb practice #{target}", 'You begin to practice ', 'you mime a convincing climb while pulling the rope hand over hand', 'Directing your attention toward your rope')
       loop do
         pause
-        break if Flags['ct-climbing-finished']
         return if Flags['ct-climbing-combat']
-        break if done_training?
+        break if done_training? || Flags['ct-climbing-finished']
       end
       bput('stop climb', 'You stop practicing your climbing skills.', "You weren't practicing your climbing skills anyway.")
     end
 
     bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not') if to_hide
+    stow_hands if target.eql?('climbing rope')
   end
 
   def climb?(room, targets)

--- a/athletics.lic
+++ b/athletics.lic
@@ -20,7 +20,7 @@ class Athletics
     @end_exp = [start_exp + 15, 29].min
 
     if have_climbing_rope
-      climb_practice(get_settings.safe_room, 'climbing rope', false)
+      train_with_rope
     elsif @climbing_target
       climb_practice(@climbing_target['id'], @climbing_target['target'], @climbing_target['hide'])
     elsif @settings.hometown == 'Crossing'
@@ -38,6 +38,111 @@ class Athletics
 
   def done_training?
     DRSkill.getxp('Athletics') >= @end_exp
+  end
+  
+  def stop_play
+    bput('stop play', 'You stop playing your song', 'In the name of', "But you're not performing")
+    Flags['ct-song'] = true
+  end
+
+  def clean_zills
+    cloth = @settings.cleaning_cloth
+    stow_hands
+    bput('remove my zills', 'You slide')
+    bput("get my #{cloth}", 'You get')
+
+    loop do
+      case bput("wipe my zills with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
+      when 'not in need of drying'
+        break
+      when 'You should be sitting up'
+        fix_standing
+        next
+      end
+      pause 1
+      waitrt?
+
+      until /you wring a dry/i =~ bput("wring my #{cloth}", 'You wring a dry', 'You wring out')
+        pause 1
+        waitrt?
+      end
+    end
+
+    until /not in need of cleaning/i =~ bput("clean my zills with my #{cloth}", 'Roundtime', 'not in need of cleaning')
+      pause 1
+      waitrt?
+    end
+
+    bput('wear my zills', 'You slide')
+    bput("stow my #{cloth}", 'You put')
+  end
+
+  def play_climbing_song?(blocking = false)
+    UserVars.song = @song_list.first.first unless UserVars.song
+    case bput("play #{UserVars.song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play')
+    when 'Play on what instrument'
+      return false
+    when 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play'
+      return false
+    when 'You cannot play'
+      wait_for_script_to_complete('safe-room')
+      return false
+    when 'dirtiness may affect your performance'
+      if DRSkill.getrank('Performance') < 20
+        echo "Skipping cleaning of zills due to low rank of Performance: #{DRSkill.getrank('Performance')}" if UserVars.athletics_debug
+        return true
+      end
+      stop_play
+      clean_zills
+      return play_climbing_song?
+    when 'You begin a', 'You effortlessly begin', 'You begin some'
+      stop_play
+      UserVars.song = @song_list[UserVars.song] || @song_list.first.first
+      return play_climbing_song?
+    when 'You struggle to begin'
+      if UserVars.song != @song_list.first.first
+        stop_play
+        UserVars.song = @song_list.first.first
+        return play_climbing_song?
+      end
+    end
+
+    return true unless blocking
+
+    Flags.reset('ct-song')
+    pause 1 until Flags['ct-song']
+    true
+  end
+
+  def train_with_rope
+    return unless exists?('climbing rope')
+    return unless exists?('zills')
+
+    # TODO: Move setup logic to its own method
+    Flags.add('climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away')
+    stow_hands
+    @song_list = get_data('perform').perform_options
+    climbing_song = UserVars.song
+    walk_to @settings.safe_room
+    bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
+    until done_training?
+      fix_standing
+      break unless play_climbing_song?
+      case bput("climb practice climbing rope", 'You begin to practice ', 'you mime a convincing climb while pulling the rope hand over hand', 'Directing your attention toward your rope', 'Allows you to climb various things like a tree', 'But you aren\'t holding')
+      when /you mime/
+        break unless play_climbing_song?
+      when /Directing your/
+        res = waitfor 'You finish practicing your climbing', 'The rope\'s will quickly fades away', 'Your focus diverts away from the rope'
+      when /Allows you to climb various things like a tree/
+        echo "Waiting for rope to become climbable again"
+        pause 10
+      when /But you aren't holding/
+        bput('get climbing rope', 'You are already holding that', 'You get', 'What were you')
+      end
+    end
+    # TODO: Move cleanup logic to its own method
+    fix_standing
+    stow_hands
   end
 
   def crossing_athletics
@@ -115,7 +220,6 @@ class Athletics
   def climb_practice(room, target, to_hide = false)
     return unless target
     walk_to(room)
-    bput('get climbing rope', 'You are already holding that', 'You get') if target.eql?('climbing rope')
     until done_training?
       retreat
       if to_hide
@@ -128,9 +232,7 @@ class Athletics
       end
       Flags.add('ct-climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away')
       Flags.add('ct-climbing-combat', 'You are engaged in combat')
-      fix_standing
-      bput("play #{UserVars.song} on zills", 'You begin', 'You\'re already playing a song') if target.eql?('climbing rope') 
-      bput("climb practice #{target}", 'You begin to practice ', 'you mime a convincing climb while pulling the rope hand over hand', 'Directing your attention toward your rope')
+      bput("climb practice #{target}", 'You begin to practice ')
       loop do
         pause
         return if Flags['ct-climbing-combat']
@@ -140,7 +242,6 @@ class Athletics
     end
 
     bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not') if to_hide
-    stow_hands if target.eql?('climbing rope')
   end
 
   def climb?(room, targets)

--- a/common-items.lic
+++ b/common-items.lic
@@ -82,8 +82,8 @@ module DRCI
   end
 
   def exists?(description)
-    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder')
-    result =~ /You tap/
+    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You thump your fingers')
+    result =~ /You tap|You thump/
   end
 
   def count_lockpick_container(container)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -548,7 +548,7 @@ pumpkin_junk:
 - platinum ring
 
 climbing_target:
-have_climbing_rope: true
+have_climbing_rope: false 
 # Astrology settings
 astrology_buffs:
 have_telescope: false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -564,16 +564,4 @@ predict_event: false
 
 learned_column_count: 2
 sort_auto_head: true
-
-scroll_stackers:
-- tome
-discard_scrolls:
-- Burden
-- Dispel
-- Ease Burden
-- Gauge Flow
-- Imbue
-- Lay Ward
-- Manifest Force
-- Seal Cambrinth
-- Strange Arrow
+have_climbing_rope: false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -548,7 +548,7 @@ pumpkin_junk:
 - platinum ring
 
 climbing_target:
-
+have_climbing_rope: true
 # Astrology settings
 astrology_buffs:
 have_telescope: false
@@ -564,4 +564,16 @@ predict_event: false
 
 learned_column_count: 2
 sort_auto_head: true
-have_climbing_rope: false
+
+scroll_stackers:
+- tome
+discard_scrolls:
+- Burden
+- Dispel
+- Ease Burden
+- Gauge Flow
+- Imbue
+- Lay Ward
+- Manifest Force
+- Seal Cambrinth
+- Strange Arrow


### PR DESCRIPTION
This implements support for the climbing ropes that allow for stationary training of athletics. The script makes the assumption that you have zills.

If you set `have_climbing_rope` to true, then the script will go to your safe room, play a song on your zills, and begin climb practice on the rope. Playing a song is necessary to make the rope climbable, I guess its like a snake-charmer type of deal.

The script attempts to maximize performance training while still training athletics. It starts by determining the best performance training song (either by copying `UserVars.song` or starting from scratch). While climbing, if the song is too hard/easy, the song difficulty is stepped down/up.

Item details and usage are documented here:
* item: https://elanthipedia.play.net/Item:Dark_climbing_rope_woven_with_strangely_glowing_threads
* usage: https://elanthipedia.play.net/Dancing_rope