### PR TITLE
textsubs.lic: Fix extra comma if an item is badly damaged.

### DIFF
--- a/textsubs.lic
+++ b/textsubs.lic
@@ -322,7 +322,7 @@ TextSubs.add('(it is|is|they are|are) unusually resilient to damage', '\1 unusua
 TextSubs.add('(it is|is|they are|are) nearly impervious to damage', '\1 nearly impervious to damage (17/18)')
 TextSubs.add('(it is|is|they are|are) practically invulnerable to damage', '\1 practically invulnerable to damage (18/18)')
 TextSubs.add(' and (it is|is|they are|are|it has|has|have|contains?) battered and practically destroyed\.', ' and \1 battered and practically destroyed (0-19%).')
-TextSubs.add(' and (it is|is|they are|are|it has|has|have|contains?) badly damaged\.', ', and \1 badly damaged (20-29%).')
+TextSubs.add(' and (it is|is|they are|are|it has|has|have|contains?) badly damaged\.', ' and \1 badly damaged (20-29%).')
 TextSubs.add(' and (it is|is|they are|are|it has|has|have|contains?) heavily scratched and notched\.', ' and \1 heavily scratched and notched (30-39%).')
 TextSubs.add(' and (it is|is|they are|are|it has|has|have|contains?) several unsightly notches\.', ' and \1 several unsightly notches (40-49%).')
 TextSubs.add(' and (it is|is|they are|are|it has|has|have|contains?) a few dents and dings\.', ' and \1 a few dents and dings (50-59%).')


### PR DESCRIPTION
Without this you get:

You are certain that the targe is nearly impervious to damage (17/18),, and is badly damaged (20-29%).