### PR TITLE
Add "target creature/area/engaged" for area TM spells

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -47,14 +47,12 @@ module DRCA
     ['Your body is willing', 'You have not recovered'].include?(result)
   end
 
-  def targetArea(targetType, abbrev, mana)
-    put "prepare #{abbrev} #{mana}"
-    DRC.bput("target #{targetType}", "You begin to weave")
-  end
-
   def prepare?(abbrev, mana, symbiosis = false, command = 'prepare')
     return false unless abbrev
-    (targetArea($1, abbrev, mana); return true) if command =~ /target (creature|area|engaged)/
+    if command =~ /target (creature|area|engaged)/
+      mana = mana.to_s + " at #{$1}"
+      command = "target"
+    end
 
     DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -47,8 +47,14 @@ module DRCA
     ['Your body is willing', 'You have not recovered'].include?(result)
   end
 
+  def targetArea(targetType, abbrev, mana)
+    put "prepare #{abbrev} #{mana}"
+    DRC.bput("target #{targetType}", "You begin to weave")
+  end
+
   def prepare?(abbrev, mana, symbiosis = false, command = 'prepare')
     return false unless abbrev
+    (targetArea($1, abbrev, mana); return true) if command =~ /target (creature|area|engaged)/
 
     DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 


### PR DESCRIPTION
Adds YAML setting to allow target creature/area/engaged for area TM spells. The design of the code is to allow for the smallest possible time gap between "prep" and "target" because "target" command is where the actual prep timer starts for TM spells.

Builds on prep: YAML setting.  

Hard coded Options are:
prep: target area
prep: target creature
prep: target engaged

- skill: Targeted Magic
  name: Chain Lightning
  abbrev: cl
  mana: 15
  min_threshold: 2
  prep: target creature