### PR TITLE
Added Crossing Abbey, Muspar'i, additional Leth and Crossing areas!

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -198,6 +198,9 @@ hunting_zones:
   - 19215
   - 19219
   - 19220
+  - 12944
+  - 19214
+  - 12943
   # https://elanthipedia.play.net/Dusk_Ogre 60-75
   dusk_ogres:
   - 8580
@@ -1354,3 +1357,1551 @@ hunting_zones:
   - 11907
   - 13026
   - 13027
+
+
+
+
+  ---
+escort_zones:
+  # https://elanthipedia.play.net/Grave_worm 90-130
+  grave_worms:
+    base: 2317
+    area: oshu_manor
+    enter: worms
+  # https://elanthipedia.play.net/Blue-belly_crocodile 100-140
+  blue_crocs:
+    base: 1358
+    area: crocs
+    enter: enter
+  # https://elanthipedia.play.net/Giant_black_leucro 160-215
+  leucro1:
+    base: 7958
+    area: wilds
+    enter: leucro1
+  leucro2:
+    base: 7958
+    area: wilds
+    enter: leucro2
+  # https://elanthipedia.play.net/Seordhevor_kartais 180-250
+  kartais:
+    base: 2317
+    area: oshu_manor
+    enter: kartais
+  # https://elanthipedia.play.net/Forest_geni 250-350
+  geni:
+    base: 7958
+    area: wilds
+    enter: geni
+  # https://elanthipedia.play.net/Adult_desert_armadillo 725-1000
+  adult_armadillos:
+    base: 6760
+    area: desert
+    enter: adult
+  # https://elanthipedia.play.net/Juvenile_desert_armadillo 600-740
+  desert_juvenile_armadillos:
+    base: 6760
+    area: desert
+    enter: juvenile
+
+hunting_zones:
+  # https://elanthipedia.play.net/Rat 0-30
+  rats:
+  - 6049
+  - 6048
+  - 6047
+  - 6046
+  - 6050
+  - 6053
+  - 6054
+  # https://elanthipedia.play.net/Sleazy_Lout 0-35
+  louts:
+  - 686
+  - 687
+  - 688
+  - 19199
+  - 690
+  # https://elanthipedia.play.net/Musk_Hog 10-35
+  hogs:
+  - 1438
+  - 1439
+  - 1440
+  - 1441
+  - 1442
+  - 1443
+  - 1444
+  - 1445
+  - 1446
+  - 1447
+  - 1448
+  # https://elanthipedia.play.net/Forager_goblin 12-34
+  # https://elanthipedia.play.net/Field_Goblin 17-42
+  # https://elanthipedia.play.net/Scavenger_goblin 18-36
+  goblins:
+  - 1473
+  - 1479
+  - 1483
+  - 1480
+  - 1481
+  - 1486
+  - 1482
+  # https://elanthipedia.play.net/bobcat 45-65
+  # https://elanthipedia.play.net/Blood_wolf_(2) 75-90
+  Blood_wolf2:
+  - 5643
+  - 5649
+  - 5651
+  - 5644
+  - 5645
+  - 5650
+  - 5652
+  # https://elanthipedia.play.net/Grass_eel 25-50
+  grass_eels:
+  - 1492
+  - 1495
+  - 1491
+  - 1490
+  - 1493
+  - 1494
+  # https://elanthipedia.play.net/Origami_Creature 20-55
+  origami:
+  - 8433
+  - 8434
+  - 8430
+  - 8431
+  - 8429
+  - 8428
+  - 8427
+  - 8426
+  # https://elanthipedia.play.net/Cougar 30-49
+  cougars:
+  - 1518
+  - 1519
+  - 1512
+  - 1515
+  - 1513
+  # https://elanthipedia.play.net/S%27lai_Scout 36-49
+  scouts:
+  - 7292
+  - 7293
+  - 7294
+  - 7295
+  - 7296
+  - 7297
+  - 7298
+  - 7299
+  # https://elanthipedia.play.net/Kobold 35-50
+  shard_kobolds:
+  - 2739
+  - 2744
+  - 2742
+  - 2763
+  - 2764
+  - 2740
+  # https://elanthipedia.play.net/Faenrae_reaver 35-55
+  # https://elanthipedia.play.net/Wind_Hound 45-73
+  reavers:
+  - 1850
+  - 1851
+  - 1852
+  - 1856
+  - 1848
+  - 1849
+  # https://elanthipedia.play.net/Wood_Troll_(1) 36-53
+  wood_trolls1:
+  - 1047
+  - 1049
+  - 1052
+  - 1053
+  - 1055
+  - 1056
+  - 1057
+  - 1058
+  - 1059
+  - 1060
+  - 1061
+  # https://elanthipedia.play.net/Wood_Troll_(1) 36-53
+  # https://elanthipedia.play.net/Kelpie
+  # https://elanthipedia.play.net/Cougar
+  # https://elanthipedia.play.net/Wild_boar
+  wood_trolls1_theren:
+  - 3316
+  - 3317
+  - 3318
+  - 3319
+  - 3320
+  - 3321
+  - 3322
+  - 3323
+  - 3324
+  - 3325
+  # https://elanthipedia.play.net/Bone_wolf 45-73
+  # https://elanthipedia.play.net/Revenant_zombie 45-59
+  bone_wolves:
+  - 2109
+  - 2108
+  - 2107
+  - 2106
+  - 2105
+  - 2104
+  # https://elanthipedia.play.net/Cave_bear 45-65
+  cave_bears:
+  - 7235
+  - 7236
+  - 7237
+  - 7238
+  # https://elanthipedia.play.net/Beisswurm 50-63
+  beisswurms:
+  - 7263
+  - 7264
+  - 7265
+  - 7266
+  - 7267
+  # https://elanthipedia.play.net/Dusk_Ogre 60-75
+  dusk_ogres:
+  - 8580
+  - 8582
+  - 8583
+  - 8584
+  - 8577
+  - 8576
+  # https://elanthipedia.play.net/Rock_Troll_(1) 60-73
+  rock_trolls:
+  - 8946
+  - 8947
+  - 8954
+  - 8955
+  - 8948
+  - 8949
+  # trolls past the rockslide
+  rock_trolls2:
+  - 9059
+  - 9060
+  - 9061
+  - 9062
+  # https://elanthipedia.play.net/Endrus_serpent 50-90
+  endrus_serpents:
+  - 9527
+  - 9528
+  - 9529
+  - 9530
+  - 9531
+  - 9532
+  - 9533
+  - 9534
+  - 9535
+  # https://elanthipedia.play.net/Blood_wolf_(2) 75-90 skinning
+  blood_wolves:
+  - 8675
+  - 8671
+  - 8678
+  - 8672
+  - 8676
+  - 8679
+  - 8669
+  - 8667
+  - 8673
+  - 8677
+  - 8678
+  # https://elanthipedia.play.net/Fire_Sprite 80-100
+  # 80-100 Locksmithing/Skinning
+  fire_sprites1:
+  - 1770
+  - 1771
+  - 1772
+  - 1773
+  - 1774
+  - 1775
+  - 1776
+  - 1777
+  - 1778
+  # https://elanthipedia.play.net/Snowbeast 80-105
+  # 2264 causes a loop, do not use
+  # 2256 frequently has issues with day/night descriptions
+  snowbeasts:
+  - 2255
+  - 2268
+  - 2263
+  - 2265
+  - 2266
+  - 2272
+  - 2259
+  - 2260
+  - 2262
+  - 2267
+  - 2269
+  - 2270
+  - 2261
+  # https://elanthipedia.play.net/Skeletal_kobold_savage 85-110
+  # https://elanthipedia.play.net/Skeletal_Kobold_Headhunter 85-110
+  # https://elanthipedia.play.net/Zombie_Kobold_Savage 85-110
+  # https://elanthipedia.play.net/Zombie_Kobold_Headhunter 85-110
+  undead_kobolds:
+  - 8109
+  - 8112
+  - 8116
+  - 8114
+  - 8113
+  - 8108
+  - 8110
+  # https://elanthipedia.play.net/Young_Ogre 80-120
+  young_ogres:
+  - 1588
+  - 1591
+  - 1592
+  - 1593
+  - 1590
+  - 1589
+  - 1587
+  #Aesry moss meys
+  # https://elanthipedia.play.net/Moss_mey 90-135
+  moss_meys:
+  - 5581
+  - 5583
+  - 5582
+  - 5584
+  - 5585
+  # https://elanthipedia.play.net/Eidolon_steed 100-160
+  eidolon_steeds:
+  - 2691
+  - 2692
+  - 2690
+  - 2689
+  # https://elanthipedia.play.net/Gypsy_marauder 100-125
+  marauders:
+  - 3648
+  - 3649
+  - 3650
+  - 3651
+  - 3652
+  - 3653
+  - 3654
+  # https://elanthipedia.play.net/Blue-belly_crocodile 100-140
+  # Near Shard (Ilithi Province), NOT Zoluren Province
+  blue_belly_crocs_shard:
+  - 9692
+  - 9693
+  - 9694
+  # https://elanthipedia.play.net/snow_goblin_(1) 110-140
+  snow_goblins_1:
+  - 5684
+  - 5685
+  - 5686
+  - 5687
+  snow_goblins_2:
+  - 5688
+  - 5689
+  - 5690
+  - 5693
+  - 5694
+  - 5695
+  - 5696
+  - 4848
+  snow_goblins_3:
+  - 5698
+  - 5699
+  - 5700
+  - 5701
+  - 5702
+  # https://elanthipedia.play.net/Dire_Bear 120-170
+  # 1555 is bugged, do not use
+  dire_bears:
+  - 1563
+  - 1565
+  - 1582
+  - 1581
+  - 1578
+  - 1566
+  # https://elanthipedia.play.net/Writhing_maiden%27s_tress 80-215
+  # Hibarnhvidar
+  maidens_tress:
+  - 4232
+  - 4231
+  - 4230
+  - 4229
+  - 4228
+  # https://elanthipedia.play.net/Giant_thicket_viper 125-165
+  thicket_vipers:
+  - 6837
+  - 6846
+  - 6845
+  - 6850
+  - 6843
+  - 6849
+  # https://elanthipedia.play.net/nipoh_oshu 240-350 Aesry
+  # 3 different areas here, didn't realize initially needs to be broken up:
+  nipoh_oshu:
+  - 12482
+  - 12493
+  - 12497
+  - 12498
+  - 12499
+  - 12494
+  - 12496
+  - 12495
+  - 12483
+  - 12487
+  - 12937
+  - 12936
+  - 12484
+  - 12937
+  - 12936
+  - 12488
+  - 12489
+  - 12490
+  # https://elanthipedia.play.net/nightweaver_unyun 100-188 Aesry
+  nightweaver_unyun:
+  - 5642
+  - 12472
+  - 12473
+  - 12474
+  - 12475
+  - 12476
+  - 12477
+  - 12478
+  - 12475
+  - 12507
+  - 12508
+  - 12509
+  - 12480
+  - 12481
+  - 12501
+  - 12507
+  - 12506
+  - 12500
+  # https://elanthipedia.play.net/nightreaver_unyn 180-225 Aesry
+  nightreaver_unyn:
+  - 12491  
+  - 12503
+  - 12504
+  - 12505
+  - 12536
+  - 12522
+  - 12517
+  - 12514
+  - 12513
+  - 12512
+  - 12515
+  - 12516
+  # https://elanthipedia.play.net/Dryad_priestess 175-220
+  # https://elanthipedia.play.net/Twisted_Dryad 175-220
+  dryads:
+  - 9766
+  - 9774
+  - 9773
+  - 9772
+  - 9767
+  - 9768
+  - 9769
+  - 9770
+  - 9771
+  # https://elanthipedia.play.net/Thug_(creature) 110-150
+  # 110-150 Locksmithing
+  thugs:
+  - 6091
+  - 6092
+  - 6097
+  - 6097
+  # https://elanthipedia.play.net/Granite_gargoyle 95-125, Shard
+  granite_gargoyles:
+  - 2908
+  - 2909
+  - 2910
+  - 2911
+  - 2915
+  - 2919
+  - 2916
+  - 2917
+  - 2918
+  - 2926
+  - 2927
+  - 2928
+  # https://elanthipedia.play.net/River_Sprite 120-175
+  river_sprites:
+  - 19754
+  - 19799
+  - 19847
+  - 19778
+  - 9055
+  # https://elanthipedia.play.net/Bawdy_swain 120-150
+  # Ratha
+  bawdy_swain:
+  #- 4850
+  - 4851
+  - 4852
+  - 4853
+  - 4854
+  # https://elanthipedia.play.net/Kra%27hei_hatchling 130-210
+  # Ratha
+  krahei_hatchling:
+  - 4890
+  - 4883
+  - 4896
+  # https://elanthipedia.play.net/Young_blue-dappled_prereni 120-180
+  young_blue_dappled_prereni:
+  - 9676
+  - 9677
+  - 9678
+  - 9679
+  # https://elanthipedia.play.net/ghoul_crow 130-175
+  ghoul_crow:
+  - 5519
+  - 5520
+  - 5521
+  - 5522
+  # https://elanthipedia.play.net/Sickly_blightwater_nyad 160-245
+  sickly_blightwater_nyads:
+  - 4240
+  - 4241
+  - 4242
+  - 4243
+  - 4244
+  - 4245
+  - 4246
+  - 4247
+  - 4248
+  - 4249
+  - 4250
+  - 4251
+  - 4252
+  - 4253
+  - 4254
+  # https://elanthipedia.play.net/Yvhh_la%27tami 160-2317 #yvhh for short!
+  yvhh:
+  - 12457
+  - 12458
+  - 12459
+  - 12460
+  - 12461
+  - 12462
+  - 12463
+  - 12464
+  - 12465
+  - 12466
+  - 12467
+  - 12468
+  - 12469
+  - 12470
+  # https://elanthipedia.play.net/frostweaver 180-260
+  frostweaver:
+  - 5664
+  - 5665
+  - 5667
+  - 5668
+  - 5669
+  - 5661
+  - 5666
+  - 5662
+  - 5660
+  # https://elanthipedia.play.net/Blue-dappled_prereni 180-225
+  blue_dappled_prereni:
+  - 10148
+  - 10149
+  - 10151
+  # https://elanthipedia.play.net/Elder_blue-dappled_prereni 250-300
+  elder_blue_dappled_prereni:
+  - 10150
+  - 11229
+  - 11230
+  # https://elanthipedia.play.net/Quartz_gargoyle 135-190
+  quartz_gargs:
+  - 8290
+  - 8291
+  - 8289
+  # https://elanthipedia.play.net/Orc_Bandit 180-317
+  orc_bandits:
+  - 8634
+  - 8641
+  - 8638
+  - 8640
+  # https://elanthipedia.play.net/Scavenger_Troll 170-220
+  # STEAL WEAPONS
+  scavenger_trolls:
+  - 1275
+  - 1273
+  - 1274
+  - 1279
+  - 1280
+  - 1276
+  - 1277
+  - 1278
+  # https://elanthipedia.play.net/Small_Peccary 175-250
+  # https://elanthipedia.play.net/Swamp_Troll_(2) 140-235
+  small_peccary_and_swamp_trolls:
+  - 3565
+  - 3566
+  - 3567
+  - 3568
+  - 3569
+  - 3570
+  - 3571
+  - 3572
+  - 3573
+  - 3574
+  - 3575
+  - 3576
+  - 3577
+  - 3578
+  # https://elanthipedia.play.net/Frostweyr_bear 175-225
+  frostweyr_bears:
+  - 6981
+  - 6983
+  - 6984
+  - 6985
+  - 6986
+  - 6987
+  - 6990
+  - 6989
+  - 6988
+  # https://elanthipedia.play.net/Pale_Grey_Death_Spirit 200-250
+  pale_gray_spirits:
+  - 19384
+  - 19387
+  - 19390
+  - 19393
+  # https://elanthipedia.play.net/Rock_guardian 200-323
+  rock_guardians:
+  - 19413
+  - 19412
+  - 19410
+  - 19409
+  - 19407
+  - 1386
+  # https://elanthipedia.play.net/Sinuous_ice_adder 200-300
+  # Hibarnhvidar
+  ice_adders:
+  - 50227
+  - 50225
+  - 50215
+  - 50213
+  - 50212
+  - 50221
+  # https://elanthipedia.play.net/Adan%27f_blood_warrior 250-325
+  # https://elanthipedia.play.net/Adan%27f_shadow_mage 250-370
+  adanf_warriors_and_mages:
+  - 9471
+  - 9472
+  - 9473
+  - 9474
+  - 9475
+  - 9476
+  - 9477
+  - 9478
+  - 9479
+  - 9480
+  - 9481
+  # https://elanthipedia.play.net/Caracal 225-345
+  caracals:
+  - 8872
+  - 8875
+  - 8876
+  - 8873
+  - 8874
+  # https://elanthipedia.play.net/graverobber_(2) 270-380
+  # https://elanthipedia.play.net/ghoul_raven 260-400
+  graverobbers_and_ghoul_ravens:
+  - 5531
+  - 5532
+  - 5525
+  - 5527
+  - 5528
+  - 5529
+  - 5530
+  # https://elanthipedia.play.net/Wir_dinego 300-400
+  wir_dinego:
+  - 5543
+  - 5537
+  - 5540
+  - 5541
+  - 5542
+  - 5544
+  - 5545
+  # https://elanthipedia.play.net/Robed_Dragon_Priest(ess) 350-500
+  dragon_priests:
+  - 6379
+  - 6380
+  - 6381
+  - 6382
+  - 6383
+  - 6384
+  - 6385
+  # https://elanthipedia.play.net/Armored_shalswar 300-400
+  # https://elanthipedia.play.net/Dragon_Priest_zealot 400-520
+  # https://elanthipedia.play.net/Dragon_Priest_sentinel
+  shalswar:
+  - 6226
+  - 6222
+  - 6220
+  - 6227
+  - 6229
+  - 6224
+  - 6223
+  # https://elanthipedia.play.net/snaer_hafwa 350-500 (Aesry)
+  snaer_hafwa:
+  - 12927
+  - 12928
+  - 12929
+  - 12926
+  - 12930
+  # https://elanthipedia.play.net/Adan%27f_spirit_dancer  380-600
+  adanf_spirit_dancers:
+  - 10771
+  - 10102
+  - 10103
+  - 10104
+  - 10105
+  - 10119
+  - 10113
+  - 10111
+  - 10112
+  # https://elanthipedia.play.net/Orc_reiver 280-350
+  orc_reivers:
+  - 8694
+  - 8695
+  - 8696
+  - 8697
+  - 8699
+  - 8700
+  - 8701
+  - 8702
+  - 8703
+  # https://elanthipedia.play.net/Orc_raider 365-450
+  orc_raiders:
+  - 8704
+  - 8705
+  - 8706
+  - 8707
+  - 8708
+  - 8709
+  orc_raiders2:
+  - 8710
+  - 8711
+  - 8712
+  - 8713
+  - 8714
+  - 8715
+  - 8716
+  - 8717
+  - 8718
+  # https://elanthipedia.play.net/Cave_troll 220-375
+  cave_trolls:
+  - 19194
+  - 19195
+  - 19203
+  - 19204
+  - 19193
+  # https://elanthipedia.play.net/Baby_forest_gryphon 250-350
+  gryphons0:
+  - 8628
+  - 8629
+  - 8630
+  # first two tier gryphons in Rossman's Landing.  250-350 skill range
+  gryphons1:
+  - 8627
+  - 8626
+  - 8624
+  - 8625
+  - 8628
+  - 8629
+  - 8630
+  gryphons3:
+  - 8632
+  - 8631
+  - 8682
+  - 8684
+  - 8685
+  - 8687
+  - 8689
+  - 8683
+  - 8686
+  - 8690
+  - 8688
+  - 8691
+  gryphons4:
+  - 8728
+  - 8727
+  - 8729
+  - 8730
+  - 8731
+  - 8732
+  - 8723
+  - 8726
+  - 8725
+  - 8724
+  shard_gryphons:
+  - 6236
+  - 6235
+  - 6237
+  - 6238
+  # https://elanthipedia.play.net/Bristle-backed_peccary 280-405
+  bristle_peccs:
+  - 7707
+  - 7716
+  - 7713
+  - 7706
+  - 7719
+  # Blade Spiders 300ish
+  blade_spiders:
+  - 11508
+  - 11507
+  - 11503
+  # https://elanthipedia.play.net/Yellow_bristled_gremlin 280-410
+  yellow_gremlins:
+  - 8410
+  - 8408
+  - 8409
+  # https://elanthipedia.play.net/Red-bristled_gremlin 280-410
+  red_gremlins:
+  - 11445
+  - 11449
+  - 11450
+  - 11451
+  - 11452
+  - 11453
+  # https://elanthipedia.play.net/Lesser_Dusky-Scaled_Basilisk 270-460
+  dusky_basilisk:
+  - 19435
+  - 19436
+  - 19437
+  - 19438
+  # https://elanthipedia.play.net/Treehopper_Toad 300-370
+  toads:
+  - 50266
+  - 50267
+  #https://elanthipedia.play.net/Orc_scout
+  #https://elanthipedia.play.net/Vicious_Warcat
+  orc_warcats:
+  - 19188
+  - 19101
+  - 19099
+  - 19100
+  - 19097
+  - 19191
+  - 19192
+  # https://elanthipedia.play.net/Black_marble_gargoyle 300 to 440
+  black_marble_gargoyles:
+  - 31500
+  - 31502
+  - 31504
+  #- 31506          #31506 has bug where attempts to grab arrows try to grab rock formations
+  - 31508
+  - 31512
+  - 31514
+  - 31519
+  - 31521
+  - 31523
+  - 31524
+  # https://elanthipedia.play.net/Misshapen_Germish%27din 330-520
+  germishdin:
+  - 2321
+  - 2323
+  - 2329
+  - 2324
+  - 2325
+  - 2326
+  - 2320
+  - 2319
+  - 2322
+  - 2331
+  - 2332
+  - 2327
+  - 2328
+  - 2334
+  - 2333
+  - 2335
+  # https://elanthipedia.play.net/Mountain_Giant 375-550
+  mountain_giants:
+  - 4393
+  - 4391
+  - 4389
+  - 4381
+  - 4378
+  - 4379
+  - 4380
+  - 4382
+  - 4383
+  - 4384
+  - 4385
+  - 4386
+  - 4387
+  # https://elanthipedia.play.net/Armored_warklin 400-600
+  # https://elanthipedia.play.net/Warklin_mauler 400-600
+  warklin:
+  - 7272
+  - 7273
+  - 7274
+  - 7275
+  - 7276
+  - 7277
+  - 7278
+  - 7279
+  - 7271
+  # https://elanthipedia.play.net/Maelshyvean_cinder_beast 450-600
+  cinder_beasts:
+  - 19455
+  - 10792
+  - 10793
+  - 10794
+  - 10795
+  - 10796
+  - 10797
+  - 10798
+  - 10799
+  - 10800
+  - 10801
+  - 10802
+  - 10803
+  - 10804
+  - 10805
+  - 10806
+  - 10807
+  - 10808
+  - 10809
+  - 10810
+  - 10811
+  - 10812
+  # https://elanthipedia.play.net/Vile_plague_wraith 450-630
+  plague_wraiths:
+  - 11349
+  - 11350
+  - 11351
+  - 11352
+  - 11356
+  - 11357
+  - 11359
+  - 11360
+  - 11361
+  - 11364
+  - 11365
+  - 11366
+  - 11369
+  - 11370
+  - 11371
+  - 11372
+  - 11373
+  - 11374
+  - 11376
+  - 11377
+  - 11378
+  - 11379
+  - 11380
+  # https://elanthipedia.play.net/Zombie_stomper 460-625
+  zombie_stompers:
+  - 7124
+  - 7123
+  - 7125
+  - 7122
+  - 9536
+  - 7121
+  # https://elanthipedia.play.net/Zombie_mauler 500-670
+  zombie_maulers:
+  - 9537
+  - 9538
+  - 9539
+  - 9540
+  - 9542
+  - 9541
+  # https://elanthipedia.play.net/Dragon_Priest_zealot
+  dragon_priest_zealots:
+  - 4556
+  - 4555
+  - 4554
+  - 4553
+  # https://elanthipedia.play.net/Black_goblin 460-720
+  black_goblins:
+  - 4167
+  - 4168
+  - 4170
+  - 4169
+  # https://elanthipedia.play.net/S%27sugi_malchata 500-700
+  ssgui_malchata:
+  - 11017
+  - 12176
+  - 11018
+  - 10998
+  - 11001
+  - 11006
+  # https://elanthipedia.play.net/Sky_giant 500-700
+  sky_giants:
+  - 10072
+  - 10067
+  - 10071
+  - 10075
+  - 10074
+  - 10070
+  - 10067
+  - 10066
+  - 10065
+  - 10064
+  # https://elanthipedia.play.net/Black_ape 490-750
+  black_apes:
+  - 8756
+  - 8750
+  - 8749
+  - 8756
+  - 8740
+  - 8759
+  - 8739
+  - 8741
+  - 8747
+  - 8745
+  # https://elanthipedia.play.net/Storm_bull 550-750
+  storm_bulls:
+  - 2451
+  - 2452
+  - 2453
+  - 2454
+  - 2455
+  - 2456
+  - 2457
+  - 2458
+  - 2461
+  - 2462
+  - 2463
+  - 2464
+  - 2465
+  - 2450
+  # https://elanthipedia.play.net/Zombie_head-splitter 600-725
+  zombie_headsplitters:
+  - 9543
+  - 9544
+  - 9545
+  - 9546
+  - 9547
+  - 9548
+  - 9549
+  - 9550
+  - 9551
+  # https://elanthipedia.play.net/Juvenile_desert_armadillo 600-740
+  juvenile_armadillos:
+  - 19142
+  - 12800
+  - 12579
+  - 12580
+  - 12581
+  # https://elanthipedia.play.net/Young_wyvern 600-900
+  young_wyverns:
+  - 9029
+  - 9028
+  - 9030
+  - 9033
+  - 9032
+  - 9031
+  - 9034
+  - 9035
+  - 19181
+  - 9036
+  # https://elanthipedia.play.net/Juvenile_wyvern 700-1100
+  juvenile_wyverns:
+  - 19168
+  - 19170
+  - 19169
+  - 19184
+  - 19186
+  - 19167
+  - 19165
+  # https://elanthipedia.play.net/Xala%27shar_magus https://elanthipedia.play.net/Xala%27shar_thrall 750-1000
+  thrall_magus:
+  - 11470
+  - 11471
+  - 11472
+  - 11473
+  - 11468
+  - 11469
+  - 11474
+  # https://elanthipedia.play.net/Dragon_Priest_assassin 750-1100
+  assassins:
+  - 4580
+  - 4578
+  - 4580
+  - 4549
+  - 4581
+  # https://elanthipedia.play.net/Dragon_Priest_intercessor 750-1100
+  intercessor:
+  - 12146
+  - 12142
+  - 12143
+  - 12144
+  - 12145
+  # https://elanthipedia.play.net/Lava_drake 900-1300
+  lava_drakes:
+  - 11487
+  - 11486
+  - 11488
+  - 11489
+  - 11489
+  - 11491
+  - 11490
+  - 10990
+  # https://elanthipedia.play.net/Umbral_moth 950-1400
+  umbral_moths:
+  - 12041
+  - 12171
+  - 12036
+  - 12037
+  - 12038
+  - 12039
+  - 12040
+  - 12042
+  - 12165
+  - 12166
+  - 12167
+  - 12168
+  - 12169
+  - 12170
+  # https://elanthipedia.play.net/Adult_wyvern 1000-1300
+  adult_wyverns:
+  - 19175
+  - 9038
+  - 9039
+  - 9040
+  - 9674
+  - 9675
+  - 19182
+  - 19179
+  # https://elanthipedia.play.net/Arthelun_cabalist 1100-1600
+  cabalist:
+  - 12708
+  - 12704
+  - 12709
+  - 12707
+  - 12706
+  - 12703
+  - 12705
+#################
+## THRONE CITY ##
+#################
+  # https://elanthipedia.play.net/Angiswaerd_hatchling
+  # 180-250 
+  angiswaerd_hatchling:
+  - 3036
+  - 3037
+  - 3038
+  - 3040
+  - 3044
+  - 3046
+  - 3043
+  # https://elanthipedia.play.net/Marbled_angiswaerd
+  # 300-400 
+  marbled_angiswaerd:
+  - 3057
+  - 3059
+  - 3058
+  - 3057
+  - 3061
+  - 3064
+  # https://elanthipedia.play.net/River_boa
+  # 275-350 
+  river_boa:
+  - 12121
+  - 12122
+  # https://elanthipedia.play.net/Alley_thug
+  # 140-230 
+  alley_thug:
+  - 3067
+  - 3067
+  - 3074
+  - 3073
+  - 3072
+  - 3070
+  # https://elanthipedia.play.net/River_caiman
+  #  75-125 
+  river_caiman:
+  - 3090
+  - 3091
+  - 3092
+  - 3094
+  - 3095
+  - 3096
+  - 3097
+  - 3098
+  # https://elanthipedia.play.net/Blue-belly_crocodile
+  # 100-140 
+  blue_belly_crocs_TC:
+  - 12917
+  - 12919
+  - 12918
+  - 12920
+  # https://elanthipedia.play.net/Heggarangi_boar
+  # 150-200 
+  heggarangi_boar:
+  - 12124
+  - 12126
+  - 12125
+  - 3086
+  - 3087
+##################
+##    Ratha     ##
+##################
+  # https://elanthipedia.play.net/Sand_sprite
+  # 50-73 
+  sandsprites:
+  - 5220
+  - 5521
+  - 5515
+  - 5517
+  - 5514
+  - 5516
+  - 5522
+  - 5523
+  - 5524
+  - 5525
+  - 5526
+  - 5527
+  - 5528
+  # https://elanthipedia.play.net/Silver_leucro
+  # 95-110 
+  silver_leucros_ratha: 
+  - 5182
+  - 5183
+  - 5179
+  - 5174
+  - 5175
+  - 5176
+  # https://elanthipedia.play.net/Ochre_la%27heke
+  # 150-240 
+  ochre_la_heke:
+  - 12952
+  - 12956
+  - 11119
+  - 12945
+  - 12946
+  - 12947
+  - 12953
+  - 12954
+  - 12955
+  # https://elanthipedia.play.net/Kra%27hei
+  # 130-210 
+  kra_hei_hatchlings:
+  - 4890
+  - 4892
+  - 4898
+  - 4899
+  - 4900
+  - 4912
+  - 4902
+  - 4903
+  - 4905
+  - 4908
+  - 4907
+  - 4906
+  - 4919
+  - 4920
+  - 4922
+  - 4921
+  # https://elanthipedia.play.net/Retan_dolomar
+  # 260-410 
+  retan_dolomar:
+  - 12667
+  - 12664
+  - 12665
+  - 5309
+  - 5310
+  - 5311
+  - 5312
+  - 12662
+  # https://elanthipedia.play.net/Spectral_pirate
+  # 250-325 
+  spectral_pirate:
+  - 12958
+  - 7447
+  - 7448
+  - 7449
+  # https://elanthipedia.play.net/Bawdy_swain
+  # 120-150
+  bawdy_swain:
+  - 4850
+  - 4854
+  - 4667
+  - 4666
+  - 4853
+  # https://elanthipedia.play.net/Merrows
+  crimson_merrows:
+  - 12345
+  - 12344
+  - 12342
+  - 12350
+  # https://elanthipedia.play.net/Asaren_Celpeze
+  #asaren celpeze ARE IN A JUSTICE AREA BE CAREFUL!
+  asaren_celpeze_1:
+  - 4871
+  - 4872
+  - 4870
+  - 4873
+  - 4874
+  - 4875
+  - 4878
+  - 4877
+  - 4876
+  - 4880
+  - 4881
+  # not on e-pedia
+  #250-340
+  umbramagus:
+  - 9989
+  - 9978
+  - 9977
+  - 9979
+  - 9980
+  - 9981
+  - 9985
+  # https://elanthipedia.play.net/Gaunt_shadow_master
+  #? ranks?  safe room: 9994
+  shadow_master:
+  - 9991
+  - 9992
+  - 9993
+  # https://elanthipedia.play.net/Asaren_celpeze_(2)
+  # southern is 400-620 ranks
+  asaren_celpeze_southern:
+  - 6633
+  - 6632
+  - 6634
+  - 6635
+  - 6636
+  - 6637
+  - 6638
+  #https://elanthipedia.play.net/Asaren_celpeze_(3)
+  #northern is 550-800 ranks
+  asaren_celpeze_northern:
+  - 6609
+  - 6610
+  - 6611
+  - 6612
+  - 6613
+  # https://elanthipedia.play.net/Spiny_bloodfish_(1)
+  # epedia states the current skill cap is unknown!
+  # if you are reading this, please test it!
+  spiny_bloodfish:
+  - 11844
+  - 11855
+  - 13014
+  - 13015
+  - 13016
+  - 13020
+
+##########
+# M'Riss #
+##########
+
+  # https://elanthipedia.play.net/Lun%27Shele_trekhalo
+  #370-530
+  lun_shele:
+  - 6805
+  - 6803
+  - 6814
+  - 6815
+  - 6813
+  - 6811
+  - 6810
+  # https://elanthipedia.play.net/Bristle-backed_peccary
+  #280-405
+  bristle_back_peccary_mriss:
+  - 6819
+  - 6829
+  - 6824
+  - 6818
+  - 6825
+  - 6826
+  - 6827
+  - 6828
+  # https://elanthipedia.play.net/Peccary
+  #225-300
+  peccary:
+  - 11900
+  - 11911
+  - 11907
+  - 13026
+  - 13027
+
+#################################################################
+# Added as of 3AUG2017 2335 EST; to be organized on next commit #
+#################################################################
+
+  ##Muspar'i ##the mobs not listed need some TLC from a mapdb guru
+  #
+  # 300-450
+  gam_chaga:
+  - 209
+  - 227
+  - 226
+  - 223
+  - 224
+  - 208
+  #
+  # 500-700 # needs a quick remap, nothing crazy.
+  ashu_shinvi:
+  - 166
+  - 162
+  #
+  # 80-100
+  sand_spider:
+  - 259
+  - 260
+  - 261
+  - 262
+  - 263
+  - 264
+  - 265
+  - 266
+  #
+  # 
+  #mottled_westanuryn 180-290
+  
+  #Leth Deriel
+  #DS leth 1200-250
+  #
+  # 175-220
+  twisted_dryad:
+  - 9766
+  - 9772
+  - 9773
+  - 9767
+  - 9774
+  - 9772
+  #
+  # 175-220-- epedia has the same values for these two, but they are in 
+  # two separate hunting areas, so this is likely not correct. These are the
+  # more difficult of the two, as well. Please test and update.
+  dryad_priestess:
+  - 9768
+  - 9771
+  - 9770
+  - 9769
+  #
+  # 330-520
+  germish_din:
+  - 2327
+  - 2323
+  - 2332
+  - 2331
+  - 2324
+  - 2325
+  - 2326
+  - 2328
+  - 2321
+  #
+  # 90-135
+  moss_meys_leth:
+  - 12985
+  - 12988
+  - 12999
+  - 12991
+  - 12992
+  - 12996
+  #
+  #
+  ###########################
+  # New Crossing Addditions #
+  ###########################
+  #
+  # 55-70
+  copperheads:
+  - 19222
+  - 19231
+  - 19225
+  #
+  # 550-800
+  resuscitant:
+  - 11280
+  - 11287
+  - 13035
+  - 11284 
+  - 11281
+  #
+  # 100-145  #drop jade apples, set to loot additions
+  crypt_fiend:
+  - 13041
+  - 13038
+  - 13040
+  #
+  # 350-500
+  snaer_hafwa_crossing:
+  - 13043
+  - 13042
+  - 13044
+  - 13045
+  - 13046
+  - 13047
+  - 13039
+  - 13037
+  - 13036
+
+  # f2p in arthe dale
+  # 10-35
+  pale_grey_death_squirrels:
+  - 1117
+  - 1118
+  - 1119
+  - 1120
+  - 1121
+  - 1122
+  - 1116
+  - 1115
+  - 1114
+  - 1113
+  #
+  # 20-50
+  goblin_shaman_crossing:
+  - 8980
+  - 8978
+  - 13048
+  - 10038
+  - 13049
+  - 8976
+  - 8992
+  - 8982
+  #
+  #
+  ##########################
+  # New Near Hib Additions #
+  ##########################
+  #
+  # 120-195
+  bloodvines_hib:
+  - 13058
+  - 4214
+  - 4215
+  - 4212
+  - 4213
+  #
+  # 80-215
+  writhing_maidens:
+  - 4231
+  - 4219
+  - 4220
+  #
+  # 160-245
+  blightwater_nyad:
+  - 4242
+  - 4243
+  - 4247
+  - 4253
+  #
+  # 180-270
+  blight_ogre_giant:
+  - 4304
+  - 4340
+  - 4303
+  - 4294  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
List of areas: Gam chaga, ashu'shinvi, sand spiders, twisted dryad, dryad priestesses, germish'din, moss meys in leth, additional buccas in crossing, copperheads in crossing, resuscitant, crypt fiends, snaer hafwa, pale grey death squirrels, goblin shamans, blood vines in hib/boar clan, writing maidens, blightwater nyards, and giant blight ogres!

Deleted 2nd occurence of buccas.

Enjoy!