### PR TITLE
Corrected: Added Crossing Abbey, Muspar'i, additional Leth and Crossing areas!

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1354,3 +1354,175 @@ hunting_zones:
   - 11907
   - 13026
   - 13027
+
+  
+#################################################################
+# Added as of 3AUG2017 2335 EST; to be organized on next commit #
+#################################################################
+
+  ##Muspar'i ##the mobs not listed need some TLC from a mapdb guru
+  #
+  # 300-450
+  gam_chaga:
+  - 209
+  - 227
+  - 226
+  - 223
+  - 224
+  - 208
+  #
+  # 500-700 # needs a quick remap, nothing crazy.
+  ashu_shinvi:
+  - 166
+  - 162
+  #
+  # 80-100
+  sand_spider:
+  - 259
+  - 260
+  - 261
+  - 262
+  - 263
+  - 264
+  - 265
+  - 266
+  #
+  # 
+  #mottled_westanuryn 180-290
+  
+  #Leth Deriel
+  #DS leth 1200-250
+  #
+  # 175-220
+  twisted_dryad:
+  - 9766
+  - 9772
+  - 9773
+  - 9767
+  - 9774
+  - 9772
+  #
+  # 175-220-- epedia has the same values for these two, but they are in 
+  # two separate hunting areas, so this is likely not correct. These are the
+  # more difficult of the two, as well. Please test and update.
+  dryad_priestess:
+  - 9768
+  - 9771
+  - 9770
+  - 9769
+  #
+  # 330-520
+  germish_din:
+  - 2327
+  - 2323
+  - 2332
+  - 2331
+  - 2324
+  - 2325
+  - 2326
+  - 2328
+  - 2321
+  #
+  # 90-135
+  moss_meys_leth:
+  - 12985
+  - 12988
+  - 12999
+  - 12991
+  - 12992
+  - 12996
+  #
+  #
+  ###########################
+  # New Crossing Addditions #
+  ###########################
+  #
+  # 55-70
+  copperheads:
+  - 19222
+  - 19231
+  - 19225
+  #
+  # 550-800
+  resuscitant:
+  - 11280
+  - 11287
+  - 13035
+  - 11284 
+  - 11281
+  #
+  # 100-145  #drop jade apples, set to loot additions
+  crypt_fiend:
+  - 13041
+  - 13038
+  - 13040
+  #
+  # 350-500
+  snaer_hafwa_crossing:
+  - 13043
+  - 13042
+  - 13044
+  - 13045
+  - 13046
+  - 13047
+  - 13039
+  - 13037
+  - 13036
+
+  # f2p in arthe dale
+  # 10-35
+  pale_grey_death_squirrels:
+  - 1117
+  - 1118
+  - 1119
+  - 1120
+  - 1121
+  - 1122
+  - 1116
+  - 1115
+  - 1114
+  - 1113
+  #
+  # 20-50
+  goblin_shaman_crossing:
+  - 8980
+  - 8978
+  - 13048
+  - 10038
+  - 13049
+  - 8976
+  - 8992
+  - 8982
+  #
+  #
+  ##########################
+  # New Near Hib Additions #
+  ##########################
+  #
+  # 120-195
+  bloodvines_hib:
+  - 13058
+  - 4214
+  - 4215
+  - 4212
+  - 4213
+  #
+  # 80-215
+  writhing_maidens:
+  - 4231
+  - 4219
+  - 4220
+  #
+  # 160-245
+  blightwater_nyad:
+  - 4242
+  - 4243
+  - 4247
+  - 4253
+  #
+  # 180-270
+  blight_ogre_giant:
+  - 4304
+  - 4340
+  - 4303
+  - 4294  


### PR DESCRIPTION
List of areas: Gam chaga, ashu'shinvi, sand spiders, twisted dryad, dryad priestesses, germish'din, moss meys in leth, additional buccas in crossing, copperheads in crossing, resuscitant, crypt fiends, snaer hafwa, pale grey death squirrels, goblin shamans, blood vines in hib/boar clan, writing maidens, blightwater nyads, and giant blight ogres!

Forgot to add new rooms for buccas, will double tap that on next commit.