### PR TITLE
Added support to astrology for full prediction pools

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -158,13 +158,9 @@ class Astrology
       'future events' => 'future events'
     }
 
-	if @full_pools
-		pools.reject { |_skill, size| (size < 10) }
-			.each { |skill, _size| align(skillset_to_pool[skill]) }
-	else
-		pools.reject { |_skill, size| size.zero? }
-			.each { |skill, _size| align(skillset_to_pool[skill]) }
-	end
+	target = @full_pools ? 10 : 1
+	pools.reject { |_skill, size| (size < target) }
+		.each { |skill, _size| align(skillset_to_pool[skill]) }
   end
 
   def check_heavens
@@ -221,17 +217,12 @@ class Astrology
     pause 2
     waitrt?
 
-	if @full_pools
-		observed['pools']
-		.reject { |_skill, value| (value < 10 || value.nil?) }
-		.each { |skill, _value| align(skill) }
-		waitrt?	
-	else
-		observed['pools']
-		.reject { |_skill, value| value.nil? }
-		.each { |skill, _value| align(skill) }
-		waitrt?
-	end
+	target = @full_pools ? 10 : 1
+	observed['pools']
+	.reject { |_skill, value| value.nil? }
+	.reject { |_skill, value| value < target }
+	.each { |skill, _value| align(skill) }
+	waitrt?
   end
 
   def observe(body)

--- a/astrology.lic
+++ b/astrology.lic
@@ -28,6 +28,7 @@ class Astrology
     @ap_source = settings.astral_plane_training['train_source']
     @ap_destination = settings.astral_plane_training['train_destination']
     @predict_event = settings.predict_event
+	@full_pools = settings.astrology_use_full_pools
     do_buffs(settings)
     if args.rtr
       check_ripples
@@ -157,8 +158,13 @@ class Astrology
       'future events' => 'future events'
     }
 
-    pools.reject { |_skill, size| size.zero? }
-         .each { |skill, _size| align(skillset_to_pool[skill]) }
+	if @full_pools
+		pools.reject { |_skill, size| (size < 10) }
+			.each { |skill, _size| align(skillset_to_pool[skill]) }
+	else
+		pools.reject { |_skill, size| size.zero? }
+			.each { |skill, _size| align(skillset_to_pool[skill]) }
+	end
   end
 
   def check_heavens
@@ -215,10 +221,17 @@ class Astrology
     pause 2
     waitrt?
 
-    observed['pools']
-      .reject { |_skill, value| value.nil? }
-      .each { |skill, _value| align(skill) }
-    waitrt?
+	if @full_pools
+		observed['pools']
+		.reject { |_skill, value| (value < 10 || value.nil?) }
+		.each { |skill, _value| align(skill) }
+		waitrt?	
+	else
+		observed['pools']
+		.reject { |_skill, value| value.nil? }
+		.each { |skill, _value| align(skill) }
+		waitrt?
+	end
   end
 
   def observe(body)


### PR DESCRIPTION
Updated astrology to look for a new yaml setting to only use full pools.  If set to true, the script will still make observations, but will only predict skillsets if the prediction pool is full.  Default setting is still the old functionality (make predictions on any pool >0).