### PR TITLE
Added two lines: 1) to ensure it picks up your mining implement and 2…

### DIFF
--- a/data/base-mining.yaml
+++ b/data/base-mining.yaml
@@ -12,6 +12,11 @@ mining_buddy_rooms:
   - 19124
   - 19088
   - 19089
+  - 19087
+  - 19085
+  - 19090
+  # Gated by athletics check
+  wicked_burrow_climbing: 
   - 19193
   - 19194
   - 19195
@@ -57,6 +62,28 @@ mining_buddy_rooms:
   - 7237
   - 7238
   # Therengia
+  # Populated by wolf spiders
+  breech_tunnels:
+  - 7009
+  - 7010
+  - 7011
+  - 7014
+  - 7015
+  - 7016
+  - 7013
+  - 7017
+  - 7018
+  - 7019
+  - 7020
+  - 7021
+  - 7040
+  - 7039
+  - 7038
+  - 7037
+  - 7035
+  - 7036
+  - 10008
+  - 10009
   dark_tunnels:
   - 8560
   - 8563

--- a/mine.lic
+++ b/mine.lic
@@ -52,6 +52,8 @@ class Mine
 
     if bleeding?
       snapshot = Room.current.id
+      bput("get #{@mining_implement}", 'You get', 'You are already')
+      store_mining_tool
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)
       bput("get my #{@mining_implement}", 'You get')
@@ -110,7 +112,7 @@ class Mine
       bput("get my #{@mining_implement}", 'You get', 'You are already')
     end
   end
-
+  
   def store_mining_tool
     waitrt?
     if @forging_belt['items'].grep(/shovel/i).any?


### PR DESCRIPTION
…) to stow it before leaving when bleeding for those (extremely) rare cases where a collapse causes you to lose your mining implement (never seen this before today actually).