### PR TITLE
Added carving to validate (+2 bucca rooms)

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -198,6 +198,8 @@ hunting_zones:
   - 19215
   - 19219
   - 19220
+  - 12943
+  - 12944
   # https://elanthipedia.play.net/Dusk_Ogre 60-75
   dusk_ogres:
   - 8580

--- a/data/base-mining.yaml
+++ b/data/base-mining.yaml
@@ -62,28 +62,8 @@ mining_buddy_rooms:
   - 7237
   - 7238
   # Therengia
-  # Populated by wolf spiders
-  breech_tunnels:
-  - 7009
-  - 7010
-  - 7011
-  - 7014
-  - 7015
-  - 7016
-  - 7013
-  - 7017
-  - 7018
-  - 7019
-  - 7020
-  - 7021
-  - 7040
-  - 7039
-  - 7038
-  - 7037
-  - 7035
-  - 7036
-  - 10008
-  - 10009
+  # Removed Breeach Tunnels from Theren Keep because
+  # inability to retreat from wolf spiders breaks mining_buddy
   dark_tunnels:
   - 8560
   - 8563

--- a/data/base-mining.yaml
+++ b/data/base-mining.yaml
@@ -12,6 +12,11 @@ mining_buddy_rooms:
   - 19124
   - 19088
   - 19089
+  - 19087
+  - 19085
+  - 19090
+  # Gated by athletics check
+  wicked_burrow_climbing: 
   - 19193
   - 19194
   - 19195
@@ -57,6 +62,28 @@ mining_buddy_rooms:
   - 7237
   - 7238
   # Therengia
+  # Populated by wolf spiders
+  breech_tunnels:
+  - 7009
+  - 7010
+  - 7011
+  - 7014
+  - 7015
+  - 7016
+  - 7013
+  - 7017
+  - 7018
+  - 7019
+  - 7020
+  - 7021
+  - 7040
+  - 7039
+  - 7038
+  - 7037
+  - 7035
+  - 7036
+  - 10008
+  - 10009
   dark_tunnels:
   - 8560
   - 8563

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -313,9 +313,9 @@ Ratha:
   debt_office:
     id: 7160
   guard_house:
-    id: 13023
+    id: 13106
   theurgy_supplies:
-    id: 13003
+    id: 13108
   attunement_rooms:
     - 4690
     - 4651

--- a/mine.lic
+++ b/mine.lic
@@ -52,6 +52,8 @@ class Mine
 
     if bleeding?
       snapshot = Room.current.id
+      bput("get #{@mining_implement}", 'You get', 'You are already')
+      store_mining_tool
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)
       bput("get my #{@mining_implement}", 'You get')
@@ -110,7 +112,7 @@ class Mine
       bput("get my #{@mining_implement}", 'You get', 'You are already')
     end
   end
-
+  
   def store_mining_tool
     waitrt?
     if @forging_belt['items'].grep(/shovel/i).any?

--- a/validate.lic
+++ b/validate.lic
@@ -255,7 +255,7 @@ class DRYamlValidator
     return unless settings.train_workorders
 
     settings.train_workorders
-            .reject { |discipline| %w[Blacksmithing Tailoring Shaping Remedies].include?(discipline) }
+            .reject { |discipline| %w[Blacksmithing Tailoring Shaping Carving Remedies].include?(discipline) }
             .each { |discipline| error("Invalid train_workorders: discipline name '#{discipline}'") }
   end
 


### PR DESCRIPTION
Added carving to validate: Fixed a bug where carving was failing a validate check in workorders.lic at lines 56-58, causing it to default to shaping instead.

Crossing_Training will still default to shaping, but atleast manually calling stone from a before: , works.

I will continue investigating what else is needed to ensure calling Engineering from Crossing_Training will support carving stone.