### PR TITLE
Updating Crossing-training for multiple cambrinth

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -382,15 +382,36 @@ class CrossingTraining
   def calculate_mana(min, more, discern_data, cyclic)
     total = min + more
     total = (total * @settings.prep_scaling_factor).floor
-    discern_data['mana'] = [(total / 4.0).ceil, min].max
+    discern_data['mana'] = [(total / 5.0).ceil, min].max
     remaining = total - discern_data['mana']
-    if remaining > @settings.cambrinth_cap
+    total_cambrinth_mana = 0
+    @settings.cambrinth_items.each do |item|
+      total_cambrinth_mana += item[:cap]
+    end
+    if remaining > total_cambrinth_mana && !!@settings.cambrinth_items
+      discern_data['mana'] = discern_data['mana'] + (remaining - @settings.cambrinth_cap)
+      remaining = total - discern_data['mana']
+    elsif remaining > @settings.cambrinth_cap && !@settings.cambrinth_items
       discern_data['mana'] = discern_data['mana'] + (remaining - @settings.cambrinth_cap)
       remaining = total - discern_data['mana']
     end
     if cyclic
       discern_data['cambrinth'] = nil
       discern_data['mana'] = discern_data['mana'] + remaining
+    elsif remaining > 0 && !!@settings.cambrinth_items
+      discern_data['cambrinth'] = []
+      @settings.cambrinth_items.each do |item|
+        step_size = (item[:cap]/2).floor
+        if remaining > step_size
+          discern_data['cambrinth'] << [remaining, step_size].min
+          remaining -= step_size
+          discern_data['cambrinth'] << [remaining, step_size].min
+          remaining -= step_size
+        elsif remaining > 0
+          discern_data['cambrinth'] << [remaining, step_size].min
+          remaining -= step_size
+        end
+      end
     elsif remaining > 0
       discern_data['cambrinth'] = []
       step_size = (remaining / 3.0).ceil
@@ -527,12 +548,23 @@ class CrossingTraining
       data['cast'] = "cast #{moon}"
     end
 
-    release_cyclics if data['cyclic']
+    release_cyclics if data['cyclic']    
 
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
 
-    find_charge_invoke_stow(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap, @settings.dedicated_camb_use, data['cambrinth'])
-
+    if !!@settings.cambrinth_items
+      charges_array = []
+      data['cambrinth'].each_with_index do |mana, index|
+        charges_array[(index/2.0).floor] ||= []
+        charges_array[(index/2.0).floor] << mana
+        end
+      charges_array.each_with_index do |charges, index|
+        current_item = @settings.cambrinth_items[index]
+        find_charge_invoke_stow(current_item[:name], current_item[:stored], current_item[:cap], @settings.dedicated_camb_use, charges)
+        end
+    else
+      find_charge_invoke_stow(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap, @settings.dedicated_camb_use, data['cambrinth'])
+    end
     waitcastrt?
 
     snapshot = DRSkill.getxp(skill) if data['symbiosis']

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -384,49 +384,47 @@ class CrossingTraining
     total = (total * @settings.prep_scaling_factor).floor
     discern_data['mana'] = [(total / 5.0).ceil, min].max
     remaining = total - discern_data['mana']
-    total_cambrinth_mana = 0
-    @settings.cambrinth_items.each do |item|
-      total_cambrinth_mana += item['cap']
+    if @settings.cambrinth_items
+      cambrinth_items = @settings.cambrinth_items
+    else
+      cambrinth_items = []
+      cambrinth_items[0] = {}
+      cambrinth_items[0]['name'], cambrinth_items[0]['cap'], cambrinth_items[0]['stored'] = map_cambrinth(@settings)
     end
-    if remaining > total_cambrinth_mana && @settings.cambrinth_items
-      discern_data['mana'] = discern_data['mana'] + (remaining - @settings.cambrinth_cap)
-      remaining = total - discern_data['mana']
-    elsif remaining > @settings.cambrinth_cap && !@settings.cambrinth_items
-      discern_data['mana'] = discern_data['mana'] + (remaining - @settings.cambrinth_cap)
+    total_cambrinth_cap = 0
+    cambrinth_items.each do |item|
+      total_cambrinth_cap += item['cap']
+    end
+    total_cambrinth_charges = 0
+    charges_count_floor = 4
+    cambrinth_items.each do |item|
+      item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
+      total_cambrinth_charges += item['charges']
+    end
+    if remaining > total_cambrinth_cap
+      discern_data['mana'] = discern_data['mana'] + (remaining - total_cambrinth_cap)
       remaining = total - discern_data['mana']
     end
     if cyclic
       discern_data['cambrinth'] = nil
       discern_data['mana'] = discern_data['mana'] + remaining
-    elsif remaining > 0 && @settings.cambrinth_items
-      discern_data['cambrinth'] = []
-      @settings.cambrinth_items.each do |item|
-        step_size = (item['cap']/2).floor
-        if remaining > item['cap']
-          2.times do
-            discern_data['cambrinth'] << step_size
-            remaining -= step_size
-          end
-        elsif remaining > step_size
-          2.times do
-            discern_data['cambrinth'] << (remaining/2).floor
-          end
-          remaining = 0
-        elsif remaining > 0
-          discern_data['cambrinth'] << remaining
-          remaining = 0
-        end
-      end
     elsif remaining > 0
-      discern_data['cambrinth'] = []
-      step_size = (remaining / 3.0).ceil
-      while remaining > 0
-        discern_data['cambrinth'] << [remaining, step_size].min
-        remaining -= step_size
+      total_cambrinth_mana = [remaining, total_cambrinth_cap].min
+      cambrinth_items.each_with_index do |item, index|
+        discern_data['cambrinth'] ||= []
+        charge_amount = (total_cambrinth_mana / total_cambrinth_charges) * item['charges']
+        discern_data['cambrinth'][index] = []
+        charge_amount.times do |i|
+          discern_data['cambrinth'][index][i%item['charges']] += 1
+        end
       end
     else
       discern_data['cambrinth'] = nil
     end
+  end
+
+  def map_cambrinth(settings)
+      return settings.cambrinth, settings.cambrinth_cap, settings.stored_cambrinth
   end
 
   def check_discern(data)
@@ -557,18 +555,13 @@ class CrossingTraining
 
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
 
-    if @settings.cambrinth_items
-      charges_array = []
-      data['cambrinth'].each_with_index do |mana, index|
-        charges_array[(index/2.0).floor] ||= []
-        charges_array[(index/2.0).floor] << mana
-        end
-      charges_array.each_with_index do |charges, index|
-        current_item = @settings.cambrinth_items[index]
-        find_charge_invoke_stow(current_item['name'], current_item['stored'], current_item['cap'], @settings.dedicated_camb_use, charges)
-        end
-    else
-      find_charge_invoke_stow(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap, @settings.dedicated_camb_use, data['cambrinth'])
+    if !@settings.cambrinth_items
+      @settings.cambrinth_items = []
+      @settings.cambrinth_items[0] = {}
+      @settings.cambrinth_items[0]['name'], @settings.cambrinth_items[0]['cap'], @settings.cambrinth_items[0]['stored'] = map_cambrinth(@settings)
+    end
+    @settings.cambrinth_items.each_with_index do |item, index|
+      find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, data['cambrinth'][index])
     end
     waitcastrt?
 

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -386,9 +386,9 @@ class CrossingTraining
     remaining = total - discern_data['mana']
     total_cambrinth_mana = 0
     @settings.cambrinth_items.each do |item|
-      total_cambrinth_mana += item[:cap]
+      total_cambrinth_mana += item['cap']
     end
-    if remaining > total_cambrinth_mana && !!@settings.cambrinth_items
+    if remaining > total_cambrinth_mana && @settings.cambrinth_items
       discern_data['mana'] = discern_data['mana'] + (remaining - @settings.cambrinth_cap)
       remaining = total - discern_data['mana']
     elsif remaining > @settings.cambrinth_cap && !@settings.cambrinth_items
@@ -398,18 +398,23 @@ class CrossingTraining
     if cyclic
       discern_data['cambrinth'] = nil
       discern_data['mana'] = discern_data['mana'] + remaining
-    elsif remaining > 0 && !!@settings.cambrinth_items
+    elsif remaining > 0 && @settings.cambrinth_items
       discern_data['cambrinth'] = []
       @settings.cambrinth_items.each do |item|
-        step_size = (item[:cap]/2).floor
-        if remaining > step_size
-          discern_data['cambrinth'] << [remaining, step_size].min
-          remaining -= step_size
-          discern_data['cambrinth'] << [remaining, step_size].min
-          remaining -= step_size
+        step_size = (item['cap']/2).floor
+        if remaining > item['cap']
+          2.times do
+            discern_data['cambrinth'] << step_size
+            remaining -= step_size
+          end
+        elsif remaining > step_size
+          2.times do
+            discern_data['cambrinth'] << (remaining/2).floor
+          end
+          remaining = 0
         elsif remaining > 0
-          discern_data['cambrinth'] << [remaining, step_size].min
-          remaining -= step_size
+          discern_data['cambrinth'] << remaining
+          remaining = 0
         end
       end
     elsif remaining > 0
@@ -552,7 +557,7 @@ class CrossingTraining
 
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
 
-    if !!@settings.cambrinth_items
+    if @settings.cambrinth_items
       charges_array = []
       data['cambrinth'].each_with_index do |mana, index|
         charges_array[(index/2.0).floor] ||= []
@@ -560,7 +565,7 @@ class CrossingTraining
         end
       charges_array.each_with_index do |charges, index|
         current_item = @settings.cambrinth_items[index]
-        find_charge_invoke_stow(current_item[:name], current_item[:stored], current_item[:cap], @settings.dedicated_camb_use, charges)
+        find_charge_invoke_stow(current_item['name'], current_item['stored'], current_item['cap'], @settings.dedicated_camb_use, charges)
         end
     else
       find_charge_invoke_stow(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap, @settings.dedicated_camb_use, data['cambrinth'])

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -384,23 +384,19 @@ class CrossingTraining
     total = (total * @settings.prep_scaling_factor).floor
     discern_data['mana'] = [(total / 5.0).ceil, min].max
     remaining = total - discern_data['mana']
-    if @settings.cambrinth_items[0]['name']
-      cambrinth_items = @settings.cambrinth_items
-    else
-      cambrinth_items = []
-      cambrinth_items[0] = {}
-      cambrinth_items[0]['name'], cambrinth_items[0]['cap'], cambrinth_items[0]['stored'] = map_cambrinth(@settings)
+    if !@settings.cambrinth_items[0]['name']
+      @settings.cambrinth_items = [{
+        'name' => @settings.cambrinth,
+        'cap' => @settings.cambrinth_cap,
+        'stored' => @settings.stored_cambrinth
+      }]
     end
-    total_cambrinth_cap = 0
-    cambrinth_items.each do |item|
-      total_cambrinth_cap += item['cap']
-    end
-    total_cambrinth_charges = 0
+    total_cambrinth_cap = @settings.cambrinth_items.map{|x| x['cap']}.inject(&:+)
     charges_count_floor = 4
-    cambrinth_items.each do |item|
+    @settings.cambrinth_items.each do |item|
       item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
-      total_cambrinth_charges += item['charges']
     end
+    total_cambrinth_charges = @settings.cambrinth_items.map{|x| x['charges']}.inject(&:+)
     if remaining > total_cambrinth_cap
       discern_data['mana'] = discern_data['mana'] + (remaining - total_cambrinth_cap)
       remaining = total - discern_data['mana']
@@ -410,7 +406,7 @@ class CrossingTraining
       discern_data['mana'] = discern_data['mana'] + remaining
     elsif remaining > 0
       total_cambrinth_mana = [remaining, total_cambrinth_cap].min
-      cambrinth_items.each_with_index do |item, index|
+      @settings.cambrinth_items.each_with_index do |item, index|
         discern_data['cambrinth'] ||= []
         charge_amount = (total_cambrinth_mana / total_cambrinth_charges) * item['charges']
         discern_data['cambrinth'][index] = []
@@ -556,12 +552,16 @@ class CrossingTraining
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
 
     if !@settings.cambrinth_items[0]['name']
-      @settings.cambrinth_items = []
-      @settings.cambrinth_items[0] = {}
-      @settings.cambrinth_items[0]['name'], @settings.cambrinth_items[0]['cap'], @settings.cambrinth_items[0]['stored'] = map_cambrinth(@settings)
+      @settings.cambrinth_items = [{
+        'name' => @settings.cambrinth,
+        'cap' => @settings.cambrinth_cap,
+        'stored' => @settings.stored_cambrinth
+      }]
     end
     @settings.cambrinth_items.each_with_index do |item, index|
-      find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, data['cambrinth'][index])
+      if data['cambrinth'][index][0]
+        find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, data['cambrinth'][index])
+      end
     end
     waitcastrt?
 

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -384,7 +384,7 @@ class CrossingTraining
     total = (total * @settings.prep_scaling_factor).floor
     discern_data['mana'] = [(total / 5.0).ceil, min].max
     remaining = total - discern_data['mana']
-    if @settings.cambrinth_items
+    if @settings.cambrinth_items[0]['name']
       cambrinth_items = @settings.cambrinth_items
     else
       cambrinth_items = []
@@ -555,7 +555,7 @@ class CrossingTraining
 
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
 
-    if !@settings.cambrinth_items
+    if !@settings.cambrinth_items[0]['name']
       @settings.cambrinth_items = []
       @settings.cambrinth_items[0] = {}
       @settings.cambrinth_items[0]['name'], @settings.cambrinth_items[0]['cap'], @settings.cambrinth_items[0]['stored'] = map_cambrinth(@settings)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -160,6 +160,10 @@ cambrinth_cap: 32
 stored_cambrinth: false
 prep_scaling_factor: 0.98
 kneel_khri: false
+cambrinth_items:
+- name:
+  cap:
+  stored:
 
 
 


### PR DESCRIPTION
I added logic to crossing-training to allow using multiple cambrinth items when training magic skills.  The requires new yaml settings (example copied below) to identify an array of cambrinth items.  The logic right now is to identify how much mana to put into cambrinth,  iterate over the cambrinth items to determine how much each can hold, and charge/invoke them sequentially (2 charges per item).  I'd like to work on other scripts to utilize multiple cambrinth (notably combat-trainer and buff), but I first wanted to get other eyes on what I did here to make sure I'm not doing something way off-base.

I also kept the logic in there to support the previous methodology so as not to break the script for people who don't add the new settings.

Potential future updates: 
- As it is now, it will iterate through cambrinth items in the order listed.  It would make sense to sort them biggest to smallest, but since they can be manually listed in that order, this wasn't high priority.
- The script was set to use 1/4 of the mana as prep, and put the remainder into cambrinth (if it fit).  I changed that to 1/5, since I figured keeping less as prep makes sense if there's more room available for cambrinth.  It might make sense to have this as a user-defined option, similar to prep_scaling_factor. 

Sample yaml settings:
```cambrinth_items:
- :name: cambrinth armband
  :cap: 50
  :stored: false
- :name: cambrinth cuff
  :cap: 28
  :stored: false