### PR TITLE
Add Crossing Ferry to Bescort

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -158,7 +158,11 @@ class Bescort
       [
         { name: 'desert', regex: /desert/i, description: 'Hidasharon Desert on Mriss for hunting armadillos' },
         { name: 'mode', options: %w[adult juvenile elder oasis exit], description: 'Where to?' }
-      ]
+      ],
+      [
+        { name: 'ferry', regex: /ferry/i, description: 'Ferry between Leth Deriel and the Crossing' },
+        { name: 'mode', options: %w[leth crossing], description: 'Which town are you going to?' } 
+      ],
     ]
 
     args = parse_args(arg_definitions)
@@ -195,6 +199,8 @@ class Bescort
       take_sandbarge(args.start_location, args.end_location)
     elsif args.desert
       desert(args.mode)
+    elsif args.ferry
+      take_xing_ferry(args.mode)
     end
   end
 
@@ -932,6 +938,32 @@ class Bescort
       move mode
       waitfor 'With a soft bump, the gondola comes to a stop at its destination'
       move 'out'
+    end
+  end
+
+  def take_xing_ferry(mode)
+    unless [1904, 957].include?(Room.current.id)
+      echo "You are not at the ferry docks"
+      return
+    end
+
+    if wealth('Crossing') < 35
+      echo('Get money you slob!')
+      return
+    end
+
+    pause 1 until DRRoom.room_objs.find{ |x| x =~ /the ferry/ }
+
+    case bput('go ferry', 'You hand him', 'The ferry has just pulled away from the dock', 'There is no ferry here to go aboard', 'Come back when you can afford the fare')
+    when 'You hand him'
+      waitfor 'reaches the dock and its crew ties the ferry off'
+      move 'go dock'
+    when 'The ferry has just pulled away from the dock', 'There is no ferry here to go aboard'
+      pause 1 while DRRoom.room_objs.find{ |x| x =~ /the ferry/ }
+      take_xing_ferry(mode)
+    when 'Come back when you can afford the fare'
+      echo('Your fare has mysteriously disappeared!')
+      return
     end
   end
 end


### PR DESCRIPTION
This adds the ferry between leth deriel and crossing to bescort. Moving the logic to bescort will make it easier to make future modifications, like handling the presence of invasion mobs, running a script while idling, or fetching the correct fare.

Stringprocs to add after merge:
```
;e Room[957].wayto["1904"]=StringProc.new("if Script.exists?('bescort'); start_script('bescort', ['ferry', 'leth']); wait_while{ running?('bescort') }; else; echo 'ESCORT REQUIRED DOWNLOAD IT FROM THE REPO'; start_script ('escort'); wait_while{ running?('escort') }; end")
;e Room[1904].wayto["957"]=StringProc.new("if Script.exists?('bescort'); start_script('bescort', ['ferry', 'crossing']); wait_while{ running?('bescort') }; else; echo 'ESCORT REQUIRED DOWNLOAD IT FROM THE REPO'; start_script ('escort'); wait_while{ running?('escort') }; end")                                                               
```