### PR TITLE
Zombie Support

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -536,6 +536,7 @@ class LootProcess
     return true if game_state.casting_consume
     return true if game_state.prepare_cfb
     return true if game_state.casting_cfb
+    false
   end
 
   def arrange_mob(mob_noun, game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -422,7 +422,7 @@ class LootProcess
       end
       if @make_zombie && can_perform_priority_ritual?(game_state)
         echo "Making zombie" if $debug_mode_ct
-        do_necro_ritual(mob_noun, 'arise', game_state) unless DRSpells.active_spells.include?('Call from Beyond')
+        do_necro_ritual(mob_noun, 'arise', game_state) unless game_state.cfb_active? 
       end
       do_necro_ritual(mob_noun, @ritual_type, game_state) if can_perform_training_ritual?(game_state)
     end
@@ -1229,12 +1229,9 @@ class PetProcess
     false
   end
  
-  def cfb_active?
-    DRSpells.active_spells.include?('Call from Beyond')
-  end
 
   def summon_zombie
-    return unless cfb_active?
+    return unless game_state.cfb_active?
     return unless @zombie['summon']
     return if @is_present
 
@@ -1243,13 +1240,13 @@ class PetProcess
 
   def dismiss_zombie
     return unless @is_present
-    return unless cfb_active?
+    return unless game_state.cfb_active?
 
     command_zombie('leave')
   end
 
   def update_behavior
-    return unless cfb_active?
+    return unless game_state.cfb_active?
     return unless @zombie['behavior']
     return if @zombie['behavior'].eql?(@current_behavior)
 
@@ -1257,7 +1254,7 @@ class PetProcess
   end
 
   def update_stance
-    return unless cfb_active?
+    return unless game_state.cfb_active?
     return unless @zombie['stance']
     return if @zombie['stance'].eql?(@current_stance)
 
@@ -1266,7 +1263,7 @@ class PetProcess
 
   def check_zombie
     return unless DRStats.necromancer?
-    return unless cfb_active?
+    return unless game_state.cfb_active?
 
     summon_zombie
     update_behavior
@@ -1274,7 +1271,7 @@ class PetProcess
   end
 
   def command_zombie(command)
-    return unless cfb_active?
+    return unless game_state.cfb_active?
 
     case bput("command zombie #{command}", 'willing it to come back to you', 'You have already shifted', 'That is not a valid stance', 'is already right beside you', 'zombie shambles off with a groan', 'You sense a flicker of acknowledgement through the link', 'you sense your .+ shift into a \w+ stance', 'you sense your .+ behavior shift')
     when 'is already right beside you'
@@ -2568,6 +2565,10 @@ class GameState
     else
       "get my #{weapon_name}"
     end
+  end
+
+  def cfb_active?
+    DRSpells.active_spells.include?('Call from Beyond')
   end
 
   private

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -948,8 +948,8 @@ class SpellProcess
     game_state.cast_timer = nil
 
     game_state.casting_weapon_buff = false
-    game_state.casting_consume = false if game_state.casting_consume
-    game_state.casting_cfb = false if game_state.casting_cfb
+    game_state.casting_consume = false
+    game_state.casting_cfb = false
 
     if game_state.casting_moonblade
       if left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -402,6 +402,7 @@ class LootProcess
   end
 
   def can_perform_priority_ritual?(game_state)
+    return false unless DRStats.necromancer?
     return false if game_state.prepare_cfb
     return false if game_state.casting_cfb
     return false if game_state.prepare_consume
@@ -520,7 +521,7 @@ class LootProcess
 
     game_state.wield_whirlwind_offhand
 
-    unless necro_casting?(game_state)
+    if can_perform_priority_ritual?(game_state)
       while bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
         pause
         waitrt?
@@ -528,15 +529,6 @@ class LootProcess
       @last_ritual = nil
     end
     @loot_timer = Time.now
-  end
-
-  def necro_casting?(game_state)
-    return false unless DRStats.necromancer?
-    return true if game_state.prepare_consume
-    return true if game_state.casting_consume
-    return true if game_state.prepare_cfb
-    return true if game_state.casting_cfb
-    false
   end
 
   def arrange_mob(mob_noun, game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1213,57 +1213,56 @@ class PetProcess
   end
 
   def execute(game_state)
-    check_zombie
+    check_zombie(game_state)
     if game_state.dismiss_pet?
-      dismiss_zombie
+      dismiss_zombie(game_state)
       game_state.next_clean_up_step
       return true
     end
     false
   end
  
-
-  def summon_zombie
+  def summon_zombie(game_state)
     return unless game_state.cfb_active?
     return unless @zombie['summon']
     return if @is_present
 
-    command_zombie('come')
+    command_zombie('come', game_state)
   end
 
-  def dismiss_zombie
+  def dismiss_zombie(game_state)
     return unless @is_present
     return unless game_state.cfb_active?
 
-    command_zombie('leave')
+    command_zombie('leave', game_state)
   end
 
-  def update_behavior
+  def update_behavior(game_state)
     return unless game_state.cfb_active?
     return unless @zombie['behavior']
     return if @zombie['behavior'].eql?(@current_behavior)
 
-    command_zombie("behavior #{@zombie['behavior']}")
+    command_zombie("behavior #{@zombie['behavior']}", game_state)
   end
 
-  def update_stance
+  def update_stance(game_state)
     return unless game_state.cfb_active?
     return unless @zombie['stance']
     return if @zombie['stance'].eql?(@current_stance)
 
-    command_zombie("stance #{@zombie['stance']}")
+    command_zombie("stance #{@zombie['stance']}", game_state)
   end
 
-  def check_zombie
+  def check_zombie(game_state)
     return unless DRStats.necromancer?
     return unless game_state.cfb_active?
 
-    summon_zombie
-    update_behavior
-    update_stance
+    summon_zombie(game_state)
+    update_behavior(game_state)
+    update_stance(game_state)
   end
 
-  def command_zombie(command)
+  def command_zombie(command, game_state)
     return unless game_state.cfb_active?
 
     case bput("command zombie #{command}", 'willing it to come back to you', 'You have already shifted', 'That is not a valid stance', 'is already right beside you', 'zombie shambles off with a groan', 'You sense a flicker of acknowledgement through the link', 'you sense your .+ shift into a \w+ stance', 'you sense your .+ behavior shift')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -256,6 +256,9 @@ class LootProcess
     @necro_count = thanatology['harvest_count']
     echo("  @necro_count: #{@necro_count}") if $debug_mode_ct
 
+    @make_zombie = settings.zombie['make']
+    echo("  @make_zombie: #{@make_zombie}") if $debug_mode_ct
+
     @gem_nouns = get_data('items').gem_nouns
     echo("  @gem_nouns: #{@gem_nouns}") if $debug_mode_ct
 
@@ -391,9 +394,19 @@ class LootProcess
     end
   end
 
-  def should_perform_ritual(prepare_consume)
-    !prepare_consume &&
-      ((@necro_train_first_aid && DRSkill.getxp('First Aid') < 32) || DRSkill.getxp('Thanatology') < 32)
+  def can_perform_training_ritual?(game_state)
+    return false unless can_perform_priority_ritual?(game_state)
+    return false if @necro_train_first_aid && DRSkill.getxp('First Aid') < 32
+    return false if DRSkill.getxp('Thanatology') < 32
+    true
+  end
+
+  def can_perform_priority_ritual?(game_state)
+    return false if game_state.prepare_cfb
+    return false if game_state.casting_cfb
+    return false if game_state.prepare_consume
+    return false if game_state.casting_consume
+    true
   end
 
   def check_rituals?(game_state)
@@ -402,12 +415,16 @@ class LootProcess
     return true if game_state.construct?(mob_noun)
 
     if @last_ritual.nil?
-      if @necro_heal
+      if @necro_heal && can_perform_priority_ritual?(game_state)
         game_state.wounds = check_health
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         do_necro_ritual(mob_noun, 'consume', game_state) unless game_state.wounds.empty?
       end
-      do_necro_ritual(mob_noun, @ritual_type, game_state) if should_perform_ritual(game_state.prepare_consume)
+      if @make_zombie && can_perform_priority_ritual?(game_state)
+        echo "Making zombie" if $debug_mode_ct
+        do_necro_ritual(mob_noun, 'arise', game_state) unless DRSpells.active_spells.include?('Call from Beyond')
+      end
+      do_necro_ritual(mob_noun, @ritual_type, game_state) if can_perform_training_ritual?(game_state)
     end
     return false if %w[consume harvest dissect].include?(@last_ritual)
     true
@@ -417,12 +434,17 @@ class LootProcess
     return unless DRStats.necromancer?
     return unless ritual
     return if game_state.construct?(mob_noun)
+
     echo "Attempting necromancer ritual #{ritual} on #{mob_noun}" if $debug_mode_ct
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w[consume harvest arise].include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
-    result = bput(perform_message, @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
+    result = bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
     echo result if $debug_mode_ct
     case result
+    when @rituals['arise']
+      echo 'Detected arise messaging' if $debug_mode_ct
+      game_state.prepare_cfb = true
+      @last_ritual = ritual
     when @rituals['preserve'], @rituals['dissect']
       echo 'Detected preserve or dissect messaging' if $debug_mode_ct
       @last_ritual = ritual
@@ -498,7 +520,7 @@ class LootProcess
 
     game_state.wield_whirlwind_offhand
 
-    unless game_state.casting_consume || game_state.prepare_consume
+    unless necro_casting?(game_state)
       while bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
         pause
         waitrt?
@@ -508,11 +530,19 @@ class LootProcess
     @loot_timer = Time.now
   end
 
+  def necro_casting?(game_state)
+    return false unless DRStats.necromancer?
+    return true if game_state.prepare_consume
+    return true if game_state.casting_consume
+    return true if game_state.prepare_cfb
+    return true if game_state.casting_cfb
+  end
+
   def arrange_mob(mob_noun, game_state)
     return unless @skin
     return unless @arrange_count > 0
     return unless game_state.skinnable?(mob_noun)
-    return if game_state.casting_consume || game_state.prepare_consume
+    return if necro_casting?(game_state)
 
     arranges = 0
     type = @arrange_types[mob_noun] || 'skin'
@@ -680,6 +710,9 @@ class SpellProcess
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 
+    @necromancer_zombie = settings.waggle_sets['zombie']
+    echo("  @necromancer_zombie: #{@necromancer_zombie}") if $debug_mode_ct
+
     @empath_spells = settings.empath_healing
     echo("  @empath_spells: #{@empath_spells}") if $debug_mode_ct
 
@@ -777,6 +810,7 @@ class SpellProcess
     end
     check_slivers(game_state)
     check_consume(game_state)
+    check_cfb(game_state)
     check_bless(game_state)
     check_ignite(game_state)
     check_rutilors_edge(game_state)
@@ -915,6 +949,7 @@ class SpellProcess
 
     game_state.casting_weapon_buff = false
     game_state.casting_consume = false if game_state.casting_consume
+    game_state.casting_cfb = false if game_state.casting_cfb
 
     if game_state.casting_moonblade
       if left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?
@@ -1026,6 +1061,18 @@ class SpellProcess
       data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1] }
       prepare_spell(data, game_state)
     end
+  end
+
+  def check_cfb(game_state)
+    return unless DRStats.necromancer?
+    return unless @necromancer_zombie['Call from Beyond']
+    return if game_state.casting
+    return unless game_state.prepare_cfb
+
+    game_state.casting_cfb = true
+    game_state.prepare_cfb = false
+    data = @necromancer_zombie['Call from Beyond']
+    prepare_spell(data, game_state)
   end
 
   def check_consume(game_state)
@@ -1155,6 +1202,94 @@ class SpellProcess
     Flags.reset('ct-spellcast')
     @before = data['before']
     game_state.action_taken if (@skill == 'Targeted Magic' || @prep == 'target') && game_state.weapon_skill == 'Targeted Magic'
+  end
+end
+
+class PetProcess
+  include DRC
+
+  def initialize(settings)
+    echo('New Pet Process') if $debug_mode_ct
+
+    @zombie = settings.zombie
+    echo("  @zombie: #{@zombie}") if $debug_mode_ct
+    
+    @is_present = false
+    @current_stance = nil
+    @current_behavior = nil
+  end
+
+  def execute(game_state)
+    check_zombie
+    if game_state.dismiss_pet?
+      game_state.next_clean_up_step
+      dismiss_zombie
+      return true
+    end
+    false
+  end
+ 
+  def cfb_active?
+    DRSpells.active_spells.include?('Call from Beyond')
+  end
+
+  def summon_zombie
+    return unless cfb_active?
+    return unless @zombie['summon']
+    return if @is_present
+
+    command_zombie('come')
+  end
+
+  def dismiss_zombie
+    return unless @is_present
+    return unless cfb_active?
+
+    command_zombie('leave')
+  end
+
+  def update_behavior
+    return unless cfb_active?
+    return unless @zombie['behavior']
+    return if @zombie['behavior'].eql?(@current_behavior)
+
+    command_zombie("behavior #{@zombie['behavior']}")
+  end
+
+  def update_stance
+    return unless cfb_active?
+    return unless @zombie['stance']
+    return if @zombie['stance'].eql?(@current_stance)
+
+    command_zombie("stance #{@zombie['stance']}")
+  end
+
+  def check_zombie
+    return unless DRStats.necromancer?
+    return unless cfb_active?
+
+    summon_zombie
+    update_behavior
+    update_stance
+  end
+
+  def command_zombie(command)
+    return unless cfb_active?
+
+    case bput("command zombie #{command}", 'willing it to come back to you', 'You have already shifted', 'That is not a valid stance', 'is already right beside you', 'zombie shambles off with a groan', 'You sense a flicker of acknowledgement through the link', 'you sense your .+ shift into a \w+ stance', 'you sense your .+ behavior shift')
+    when 'is already right beside you'
+      echo("  Zombie is present") if $debug_mode_ct
+      @is_present = true
+    when 'zombie shambles off with a groan'
+      echo("  Zombie is no longer present") if $debug_mode_ct
+      @is_present = false
+    when /shift into a \w+ stance/
+      echo("  Zombie stance set to #{@zombie['stance']}") if $debug_mode_ct
+      @current_stance = @zombie['stance']
+    when /you sense your .+ behavior shift/
+      echo("  Zombie behavior set to #{@zombie['behavior']}") if $debug_mode_ct
+      @current_behavior = @zombie['behavior']
+    end
   end
 end
 
@@ -1874,6 +2009,7 @@ class CombatTrainer
     [
       SetupProcess.new(settings, @equipment_manager),
       SpellProcess.new(settings, @equipment_manager),
+      PetProcess.new(settings),
       AbilityProcess.new(settings),
       LootProcess.new(settings, @equipment_manager),
       ManipulateProcess.new(settings),
@@ -1913,7 +2049,7 @@ class GameState
   $aim_skills = %w[Bow Slings Crossbow]
   $ranged_skills = $thrown_skills + $aim_skills
 
-  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance
+  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -1934,6 +2070,8 @@ class GameState
     @casting_weapon_buff = false
     @casting_consume = false
     @prepare_consume = false
+    @prepare_cfb = false
+    @casting_cfb = false
     @use_charged_maneuvers = false
     @wounds = {}
     @blessed_room = false
@@ -2080,6 +2218,8 @@ class GameState
     when 'kill'
       @clean_up_step = 'clear_magic'
     when 'clear_magic'
+      @clean_up_step = 'dismiss_pet'
+    when 'dismiss_pet'
       @clean_up_step = 'stow'
     when 'stow'
       @clean_up_step = 'done'
@@ -2096,6 +2236,10 @@ class GameState
 
   def finish_spell_casting?
     @clean_up_step == 'clear_magic'
+  end
+
+  def dismiss_pet?
+    @clean_up_step == 'dismiss_pet'
   end
 
   def stowing?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1215,8 +1215,8 @@ class PetProcess
   def execute(game_state)
     check_zombie
     if game_state.dismiss_pet?
-      game_state.next_clean_up_step
       dismiss_zombie
+      game_state.next_clean_up_step
       return true
     end
     false

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -9,6 +9,7 @@ empty_values:
   buff_spells: {}
   offensive_spells: []
   necromancer_healing: {}
+  zombie: {}
   empath_healing: {}
   storage_containers: []
   summoned_weapons: []

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -9,7 +9,6 @@ empty_values:
   buff_spells: {}
   offensive_spells: []
   necromancer_healing: {}
-  zombie: {}
   empath_healing: {}
   storage_containers: []
   summoned_weapons: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -81,6 +81,11 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
+zombie:
+  make: false
+  summon: false
+  stance: offense
+  behavior: defensive
 weapon_training:
 combat_trainer_target_increment: 3
 combat_trainer_action_count: 10
@@ -282,8 +287,6 @@ mark_crafted_goods: false
 engineering_room:
 outfitting_room:
 alchemy_room:
-use_own_ingot_type:
-deed_own_ingot: false
 
 
 
@@ -591,3 +594,4 @@ discard_scrolls:
 - Manifest Force
 - Seal Cambrinth
 - Strange Arrow
+

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -81,11 +81,6 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
-zombie:
-  make: false
-  summon: false
-  stance: offense
-  behavior: defensive
 weapon_training:
 combat_trainer_target_increment: 3
 combat_trainer_action_count: 10
@@ -287,6 +282,8 @@ mark_crafted_goods: false
 engineering_room:
 outfitting_room:
 alchemy_room:
+use_own_ingot_type:
+deed_own_ingot: false
 
 
 
@@ -594,4 +591,3 @@ discard_scrolls:
 - Manifest Force
 - Seal Cambrinth
 - Strange Arrow
-

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -81,6 +81,11 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
+zombie:
+  make: false
+  summon: false
+  stance: offense
+  behavior: defensive
 weapon_training:
 combat_trainer_target_increment: 3
 combat_trainer_action_count: 10
@@ -591,3 +596,4 @@ discard_scrolls:
 - Manifest Force
 - Seal Cambrinth
 - Strange Arrow
+


### PR DESCRIPTION
This PR adds support for zombie creation and usage in combat. 

Settings for a zombie look like this:
```yaml
zombie:               
  make: false  # Create a zombie during LootProcess if you do not already have one. You have a zombie if the spell Call from Beyond is active
  summon: true  # Command your zombie to come to your current room (if CFB is active)
  behavior: defensive # tells the zombie what mobs to attack
  stance: balanced # sets the offensive/defensive stance of the zombie
waggle_sets:
  zombie:       # Store zombie related spell data here... we can add the zombie buff spell RPU and healing spell NR in a future update
    Call from Beyond:   
      mana: 30         
      cambrinth:       
      - 32     
```

To make a zombie, a mob is killed then the 'arise' ritual is performed on it. Once that is completed, the spell 'Call from Beyond' is cast. The zombie can be dismissed into the ether with the 'leave' command and recalled to your room with the 'come' command.