### PR TITLE
Use prep_time setting in common-arcana spell casting

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -282,10 +282,15 @@ module DRCA
     end
 
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
+    prepare_time = Time.now
 
     find_charge_invoke_stow(settings.cambrinth, settings.stored_cambrinth, settings.cambrinth_cap, settings.dedicated_camb_use, data['cambrinth'])
 
-    waitcastrt?
+    if data['prep_time']
+      pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
+    else
+      waitcastrt?
+    end
 
     cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
   end

--- a/profiles/Jonas-zombie.yaml
+++ b/profiles/Jonas-zombie.yaml
@@ -1,0 +1,17 @@
+---
+hunting_info:
+- :zone: shard_kobolds
+  :duration: 3
+  args:
+  - zombie
+zombie:
+  make: true
+  summon: true
+  stance: offense
+  behavior: aggressive
+use_stealth_attacks: false
+offensive_spells:
+buff_spells:
+training_abilities:
+
+...


### PR DESCRIPTION
Combat-trainer makes use of a prep_time setting. I added this functionality to common-arcana. The difference is that combat-trainer is non-blocking while common-arcana is blocking.