### PR TITLE
Updating TM Cyclics to use 'prep_type: prepare'

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -244,6 +244,7 @@ spell_data:
   Abandoned Heart:
     skill: Targeted Magic
     abbrev: ABAN
+    prep_type: prepare
     cyclic: true
     mana: 7
   Acid Splash:
@@ -750,7 +751,7 @@ spell_data:
     skill: Utility
     abbrev: GS
     cyclic: true
-    prep: pre
+    prep_type: prepare
     mana: 5
   Halo:
     skill: Debilitation # Also warding
@@ -1056,7 +1057,7 @@ spell_data:
     abbrev: PYRE
     cyclic: true
     mana: 7
-    prep: prepare
+    prep_type: prepare
     triggers_justice: true
   Protection from Evil:
     skill: Warding
@@ -1155,11 +1156,13 @@ spell_data:
   Rimefang:
     skill: Targeted Magic
     abbrev: RIM
+    prep_type: prepare
     cyclic: true
     mana: 6
   Ring of Spears:
     skill: Targeted Magic
     abbrev: ROS
+    prep_type: prepare
     cyclic: true
     mana: 7
   Rising Mists:
@@ -1307,7 +1310,7 @@ spell_data:
     skill: Targeted Magic
     abbrev: SLS
     cyclic: true
-    prep: prepare
+    prep_type: prepare
     night: true
     mana: 6
   Steps of Vuan:
@@ -1396,6 +1399,7 @@ spell_data:
     abbrev: USOL
     cyclic: true
     triggers_justice: true
+    prep_type: prepare
     mana: 7
   Unleash:
     skill: Utility


### PR DESCRIPTION
Added to a few spells that didn't have it, replaced all examples of 'prep: prepare' with 'prep_type: prepare'