### PR TITLE
Add Support for Invocation of the Spheres

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1134,9 +1134,12 @@ class SpellProcess
     else
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
-
-    check_invoke
-    ritual(data)
+    
+    data = update_astral_data(data)
+    if data # update_astral_data returns nil on failure
+      check_invoke
+      ritual(data)
+    end
 
     if summoned
       game_state.prepare_summoned_weapon(false)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1135,11 +1135,8 @@ class SpellProcess
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
 
-    data = update_astral_data(data)
-    if data # update_astral_data returns nil on failure
-      check_invoke
-      ritual(data)
-    end
+    check_invoke
+    ritual(data)
 
     if summoned
       game_state.prepare_summoned_weapon(false)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1134,7 +1134,7 @@ class SpellProcess
     else
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
-    
+
     data = update_astral_data(data)
     if data # update_astral_data returns nil on failure
       check_invoke

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -263,7 +263,7 @@ module DRCA
     end
 
     Flags.delete('planet-not-visible')
-    bput('stow telescope', 'You put')
+    DRC.bput('stow telescope', 'You put')
     observed_planets
   end
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -241,6 +241,48 @@ module DRCA
     end
   end
 
+  def update_astral_data(data)
+    if data['moon']
+      data = set_moon_data(data)
+    elsif data['stats']
+      data = set_planet_data(data)
+    end
+    data
+  end
+
+  def find_visible_planets(planets)
+    return if DRC.bput('get my telescope', 'You get', 'What were you', 'You are already') == 'What were you'
+
+    Flags.add('planet-not-visible', 'turns up fruitless')
+    observed_planets = []
+    
+    planets.each do |planet|
+      DRC.bput("center telescope on #{planet}", 'You put your eye')
+      observed_planets << planet unless Flags['planet-not-visible'] 
+      Flags.reset('planet-not-visible')
+    end
+
+    Flags.delete('planet-not-visible')
+    bput('stow telescope', 'You put')
+    observed_planets
+  end
+
+  def set_planet_data(data)
+    return data unless data['stats']
+   
+    planets = get_data('constellations')[:constellations].select{ |planet| planet['stats'] }
+    planet_names = planets.map{ |planet| planet['name'] }
+    visible_planets = find_visible_planets(planet_names)
+    data['stats'].each do |stat|
+      cast_on = planets.map { |planet| planet['name'] if planet['stats'].include?(stat) && visible_planets.include?(planet['name'])}.compact.first
+      next unless cast_on
+      data['cast'] = "cast #{cast_on}"
+      return data
+    end
+    echo "Could not find any planets to cast on"
+    nil
+  end
+
   def set_moon_data(data)
     return data unless data['moon']
 
@@ -271,8 +313,8 @@ module DRCA
     return unless data
     return unless settings
 
-    data = set_moon_data(data)
-    return unless data # set_moon_data returns nil on failure
+    data = update_astral_data(data)
+    return unless data # update_astral_data returns nil on failure
 
     release_cyclics if data['cyclic']
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -255,10 +255,10 @@ module DRCA
 
     Flags.add('planet-not-visible', 'turns up fruitless')
     observed_planets = []
-    
+
     planets.each do |planet|
       DRC.bput("center telescope on #{planet}", 'You put your eye')
-      observed_planets << planet unless Flags['planet-not-visible'] 
+      observed_planets << planet unless Flags['planet-not-visible']
       Flags.reset('planet-not-visible')
     end
 
@@ -269,17 +269,17 @@ module DRCA
 
   def set_planet_data(data)
     return data unless data['stats']
-   
-    planets = get_data('constellations')[:constellations].select{ |planet| planet['stats'] }
-    planet_names = planets.map{ |planet| planet['name'] }
+
+    planets = get_data('constellations')[:constellations].select { |planet| planet['stats'] }
+    planet_names = planets.map { |planet| planet['name'] }
     visible_planets = find_visible_planets(planet_names)
     data['stats'].each do |stat|
-      cast_on = planets.map { |planet| planet['name'] if planet['stats'].include?(stat) && visible_planets.include?(planet['name'])}.compact.first
+      cast_on = planets.map { |planet| planet['name'] if planet['stats'].include?(stat) && visible_planets.include?(planet['name']) }.compact.first
       next unless cast_on
       data['cast'] = "cast #{cast_on}"
       return data
     end
-    echo "Could not find any planets to cast on"
+    echo 'Could not find any planets to cast on'
     nil
   end
 

--- a/data/base-constellations.yaml
+++ b/data/base-constellations.yaml
@@ -478,6 +478,9 @@ constellations:
       Survival:
       Magic:
       Lore: 3
+    stats:
+    - Reflex
+    - Agility
   - name: Toad
     telescope: false
     circle: 44
@@ -508,6 +511,12 @@ constellations:
       Survival:
       Magic:
       Lore:
+    stats:
+    - Discipline
+    - Intelligence
+    stats:
+    - Discipline
+    - Intelligence
   - name: Brigantine
     telescope: false
     circle: 47
@@ -538,6 +547,9 @@ constellations:
       Survival:
       Magic: 3
       Lore:
+    stats:
+    - Charisma
+    - Wisdom
   - name: Triquetra
     telescope: false
     circle: 50
@@ -558,6 +570,9 @@ constellations:
       Survival: 3
       Magic:
       Lore:
+    stats:
+    - Charisma
+    - Wisdom
   - name: Penhetia
     telescope: false
     circle: 55
@@ -568,6 +583,9 @@ constellations:
       Survival:
       Magic:
       Lore:
+    stats:
+    - Discipline
+    - Intelligence
   - name: Szeldia
     telescope: false
     circle: 60
@@ -578,6 +596,9 @@ constellations:
       Survival: 1
       Magic:
       Lore:
+    stats:
+    - Reflex
+    - Agility
   - name: Merewalda
     telescope: true
     circle: 65
@@ -588,6 +609,9 @@ constellations:
       Survival:
       Magic:
       Lore:
+    stats:
+    - Reflex
+    - Agility
   - name: Ismenia
     telescope: true
     circle: 70
@@ -598,6 +622,9 @@ constellations:
       Survival:
       Magic: 3
       Lore: 1
+    stats:
+    - Charisma
+    - Wisdom
   - name: Morleena
     telescope: true
     circle: 75
@@ -608,6 +635,9 @@ constellations:
       Survival: 3
       Magic:
       Lore:
+    stats:
+    - Discipline
+    - Intelligence
   - name: Amlothi
     telescope: true
     circle: 80
@@ -618,6 +648,9 @@ constellations:
       Survival:
       Magic: 1
       Lore: 3
+    stats:
+    - Discipline
+    - Intelligence
   - name: Dawgolesh
     telescope: false
     circle: 85
@@ -628,6 +661,9 @@ constellations:
       Survival:
       Magic: 2
       Lore:
+    stats:
+    - Reflex
+    - Agility
   - name: Er'qutra
     telescope: true
     circle: 90
@@ -638,6 +674,9 @@ constellations:
       Survival: 2
       Magic:
       Lore:
+    stats:
+    - Charisma
+    - Wisdom
   - name: Forge
     telescope: true
     circle: 100

--- a/data/base-constellations.yaml
+++ b/data/base-constellations.yaml
@@ -514,9 +514,6 @@ constellations:
     stats:
     - Discipline
     - Intelligence
-    stats:
-    - Discipline
-    - Intelligence
   - name: Brigantine
     telescope: false
     circle: 47

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -865,6 +865,16 @@ spell_data:
     abbrev: IOTS
     mana: 300
     ritual: true
+    recast: 0
+    stats:
+    - Discipline
+    - Agility
+    - Wisdom
+    after:
+      - message: invoke circle
+        matches:
+        - You step inside
+        - Invoke what
   Ivory Mask:
     skill: Augmentation
     abbrev: IVM

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -874,6 +874,7 @@ spell_data:
       - message: invoke circle
         matches:
         - You step inside
+        - You draw your hand
         - Invoke what
   Ivory Mask:
     skill: Augmentation

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -270,15 +270,11 @@ waggle_sets:
     Invocation of the Spheres:
       mana: 700
       focus: staff
-      recast: 0  # Don't risk killing self
       worn_focus: true
       stats:
-      - Discipline
       - Agility
-      - Intelligence
-      after:
-        - message: invoke circle
-          matches: You
+      - Discipline
+      - Wisdom
   shadowling: &shadowling
     Shadowling:
       abbrev: shadowling

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -20,7 +20,6 @@ training_manager_hunting_priority: false
 training_manager_priority_skills:
 - Targeted Magic
 repair_timer: 86400 # Repair once every 24 hours
-braid_item: grass
 repair_every: .inf # Infinity
 favor_god: Meraud
 favor_goal: 30
@@ -32,6 +31,7 @@ hunting_buddies:
 - Fuss
 - Chuno
 - Qetu
+- Ugsy
 - Ssarek
 - Paeriluno
 - Sheltim
@@ -63,6 +63,7 @@ hunting_info:
     - zombie_stompers
     :duration: 30
     stop_on:
+    - Skinning
     - Large Edged
     - Stealth
 training_abilities:
@@ -219,10 +220,8 @@ cambrinth_cap: 48
 prep_scaling_factor: 0.85
 
 offensive_spells:
-- name: Stun Foe
-  mana: 1
-  cambrinth:
-  - 32
+- name: Curse of Zachriedek
+  mana: 20
   skill: Sorcery
   cast_only_to_train: true
 - name: Starlight Sphere
@@ -271,8 +270,12 @@ waggle_sets:
     Invocation of the Spheres:
       mana: 700
       focus: staff
+      recast: 0  # Don't risk killing self
       worn_focus: true
-      cast: cast Verena
+      stats:
+      - Discipline
+      - Agility
+      - Intelligence
       after:
         - message: invoke circle
           matches: You
@@ -359,6 +362,7 @@ buff_spells: &buff_spells
     cambrinth:
     - 48
     recast: 2
+  << : *iots
 ####################
 ### LOCKSMITHING ###
 ####################


### PR DESCRIPTION
* Modified common-arcana to branch when updating moon data to include updating planet data. The new method is `update_astral_data`. This still returns nil on failure to update or set data.
* Observable planets are found by attempting to center a telescope on them
* IOTS spell data takes a list called `stats` which corresponds to the desired stat buff from casting on a planet which provides a bonus to those stats.
* Updated planet data in `base-constellations` to include which stats they buff
* Added `updated_astral_data` to combat-trainer, inside the `cast_ritual` method. Using a telescope requires both hands, and `cast_ritual` already handles the storing and retrieving of the weapon.