### PR TITLE
fix for charging plural cambrinth

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -177,7 +177,7 @@ module DRCA
     result = DRC.bput("charge my #{cambrinth} #{mana}", get_data('spells').charge_messages)
     pause
     waitrt?
-    result == 'absorbs all of the energy'
+    result =~ /absorbs? all of the energy/
   end
 
   def release_cyclics


### PR DESCRIPTION
Plural cambrinth apparently use "absorb" vs "absorbs"

base-spells has the message of:

- (absorb|absorbs) all of the energy

which is used on line 177 by common-arcana.

I updated the match on 180 to include the "s".

logs

> You harness a small amount of energy and attempt to channel it into your cambrinth fox.
> You are able to channel all the energy into the fox.
> The cambrinth fox absorbs all of the energy.
> Roundtime: 3 sec.

> You harness a small amount of energy and attempt to channel it into your cambrinth discs.
> You are able to channel all the energy into the discs.
> The cambrinth discs absorb all of the energy.
> Roundtime: 3 sec.