### PR TITLE
add script tutorials to links

### DIFF
--- a/links.lic
+++ b/links.lic
@@ -12,6 +12,7 @@ class Links
       'What is Dependency?' => 'https://elanthipedia.play.net/Dependency',
       'Dependency First Time Setup' => 'https://github.com/rpherbig/dr-scripts/wiki/First-Time-Setup',
       'Dependency Script Documentation' => 'https://elanthipedia.play.net/Lich_script_repository',
+      'DR-Scripts Tutorials' => 'https://github.com/rpherbig/dr-scripts/wiki/DR-Scripts-Tutorials',
       'YAML Validator' => 'http://www.yamllint.com/',
       'Lich mapping guide' => 'https://elanthipedia.play.net/Lich_mapping_reference',
       'Player Shops' => 'https://dr-scripts.firebaseapp.com/',


### PR DESCRIPTION
Addresses #1848 

Ive added links around the wiki to it. Feel free to add more. I think the tutorials fill a niche between 'what are all the settings?' and 'what does player xyz have in their YAML?' The tutorials would answer more specific but frequently asked questions like 'how do i cast invocation of the spheres?' and 'how do I use necromancer healing?'