### PR TITLE
release prepared spells in common-arcana

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -45,7 +45,6 @@ class Astrology
   def do_buffs(settings)
     return unless settings
 
-    fput('release spell') unless checkprep == 'None'
     # Pop out rtr data from buffs and save it for later
     if settings.waggle_sets['astrology']
       buffs = settings.waggle_sets['astrology']
@@ -178,7 +177,6 @@ class Astrology
   end
 
   def check_heavens
-    @equipmentmanager.empty_hands
     vis_bodies = visible_bodies
 
     night = vis_bodies.find { |body| body['constellation'] }

--- a/astrology.lic
+++ b/astrology.lic
@@ -45,6 +45,7 @@ class Astrology
   def do_buffs(settings)
     return unless settings
 
+    fput('release spell') if checkprep == 'None'
     # Pop out rtr data from buffs and save it for later
     if settings.waggle_sets['astrology']
       buffs = settings.waggle_sets['astrology']

--- a/astrology.lic
+++ b/astrology.lic
@@ -45,7 +45,7 @@ class Astrology
   def do_buffs(settings)
     return unless settings
 
-    fput('release spell') if checkprep == 'None'
+    fput('release spell') unless checkprep == 'None'
     # Pop out rtr data from buffs and save it for later
     if settings.waggle_sets['astrology']
       buffs = settings.waggle_sets['astrology']

--- a/astrology.lic
+++ b/astrology.lic
@@ -178,6 +178,7 @@ class Astrology
   end
 
   def check_heavens
+    @equipmentmanager.empty_hands
     vis_bodies = visible_bodies
 
     night = vis_bodies.find { |body| body['constellation'] }

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -317,7 +317,7 @@ module DRCA
     return unless data # update_astral_data returns nil on failure
 
     release_cyclics if data['cyclic']
-    fput('release spell') unless checkprep == 'None'
+    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
 
     if data['ritual']
       ritual(data)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -317,6 +317,7 @@ module DRCA
     return unless data # update_astral_data returns nil on failure
 
     release_cyclics if data['cyclic']
+    fput('release spell') unless checkprep == 'None'
 
     if data['ritual']
       ritual(data)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -317,7 +317,7 @@ module DRCA
     return unless data # update_astral_data returns nil on failure
 
     release_cyclics if data['cyclic']
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
 
     if data['ritual']
       ritual(data)


### PR DESCRIPTION
Partially addresses #1919 though the problem still remains in combat-trainer.

* Release prepared spells in `common-arcana::cast_spell`