### PR TITLE
Updating arcana for bard ritual & focus

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -135,8 +135,11 @@ module DRCA
     if worn
       DRC.bput("wear my #{focus}", 'You attach', 'You slide', 'You are already wearing', 'You hang', 'You sling', 'You put', 'You place')
     elsif tied
-      DRCT.retreat
-      DRC.bput("tie my #{focus} to my #{tied}", 'You attach', '[Y|y]ou tie')
+      case DRC.bput("tie my #{focus} to my #{tied}", 'You attach', '[Y|y]ou tie', 'You are a little too busy to be worrying')
+      when 'You are a little too busy to be worrying'
+        DRCT.retreat
+        stow_focus(focus, worn, tied)
+      end
     else
       DRC.bput("stow my #{focus}", 'You put', 'You easily strap your')
     end

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -125,6 +125,7 @@ cast_messages:
 - Your fingerbones phosphoresce hylomorphic blue
 - you immediately recognize the onset of an abnormal arthritis
 - You point a crooked finger at
+- Mentally steeling yourself in preparation for the unnatural action
 
 khri_preps:
 - With deep breaths


### PR DESCRIPTION
Adding a check in common-arcana to retreat if tying ritual focus doesn't work due to combat (sample log below), as well as adding re-cast messaging for Will of Winter.

```
[combat-trainer]>retreat
You retreat back to pole range.
[combat-trainer]>retreat
You retreat from combat.
[combat-trainer]>tie my steel staff to my rucksack
The river sprite closes to pole weapon range on you!
A river sprite gestures at you.
A river sprite grins triumphantly as it completes its song, revealing a set of wickedly sharp teeth.
A spout of steamy water erupts from the ground, sending bits of dirt through the air.  The blast of superheated water and steam suddenly diverts in midair, charging toward you!
You manage to get out of the way!
You are a little too busy to be worrying about doing that!
```