### PR TITLE
Add shadowling to base spells

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1239,6 +1239,16 @@ spell_data:
     abbrev: SR
     mana: 5
     recast: 1
+  Shadowling:
+    skill: Utility
+    abbrev: shadowling
+    mana: 15
+    recast: 1
+    after:
+    - message: invoke shadowling
+      matches:
+      - Invoke what
+      - You gesture, adjusting the pattern that binds the shadowling to this plane
   Shadows:
     skill: Augmentation
     abbrev: shadows

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1244,11 +1244,18 @@ spell_data:
     abbrev: shadowling
     mana: 15
     recast: 1
+    before:
+    - message: release shadowling
+      matches:
+      - You gesture
+      - A faint growl
+      - That would be a neat trick
     after:
     - message: invoke shadowling
       matches:
       - Invoke what
       - You gesture, adjusting the pattern that binds the shadowling to this plane
+      - You're not sure what would happen
   Shadows:
     skill: Augmentation
     abbrev: shadows

--- a/profiles/Crannach-setup.yaml
+++ b/profiles/Crannach-setup.yaml
@@ -277,17 +277,13 @@ waggle_sets:
       - Wisdom
   shadowling: &shadowling
     Shadowling:
-      abbrev: shadowling
       mana: 52
       cambrinth:
       - 48
-      after:
-      - message: invoke shadowling
-        matches: You
   sls: &sls
     Starlight Sphere:
       abbrev: sls
-      mana:   15
+      mana:   10
       cast:   cast spider
       night:  true
   astrology:
@@ -359,6 +355,7 @@ buff_spells: &buff_spells
     - 48
     recast: 2
   << : *iots
+  << : *shadowling
 ####################
 ### LOCKSMITHING ###
 ####################


### PR DESCRIPTION
Makes casting shadowling a little bit easier. Invoke it by default. Release it before casting to allow for refreshing it via making a new shadowling (or possibly the same one). 