### PR TITLE
Remove astrology_buffs from astrology.lic

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -44,24 +44,15 @@ class Astrology
 
   def do_buffs(settings)
     return unless settings
+    return unless settings.waggle_sets['astrology']
 
     # Pop out rtr data from buffs and save it for later
-    if settings.waggle_sets['astrology']
-      buffs = settings.waggle_sets['astrology']
-      @rtr_data = buffs.select { |spell| spell.eql?('Read the Ripples') }
-                       .values
-                       .first
-      buffs.reject! { |spell| spell.eql?('Read the Ripples') }
-      cast_spells(buffs, settings)
-    elsif settings.astrology_buffs
-      echo '******************'
-      echo "astrology_buffs has been deprecated in favor of 'astrology' waggle set and will be removed in a future version"
-      echo '******************'
-      buffs = settings.astrology_buffs['spells']
-      @rtr_data = buffs.select { |spell| spell['abbrev'].casecmp('rtr').zero? }.first
-      buffs.reject { |spell| spell['abbrev'].casecmp('rtr').zero? }
-           .each { |buff| cast_spell(buff, settings) }
-    end
+    buffs = settings.waggle_sets['astrology']
+    @rtr_data = buffs.select { |spell| spell.eql?('Read the Ripples') }
+                     .values
+                     .first
+    buffs.reject! { |spell| spell.eql?('Read the Ripples') }
+    cast_spells(buffs, settings)
   end
 
   def visible_bodies

--- a/dependency.lic
+++ b/dependency.lic
@@ -873,13 +873,6 @@ class SetupFiles
              .each { |_name, data| s.lockpick_buffs['spells'][i] = data.merge(spell) }
      end
 
-    s.astrology_buffs['spells']
-     .each_with_index
-     .select do |spell, i|
-       spells.select { |_name, data| data['abbrev'].casecmp(spell['abbrev'].downcase).zero? }
-             .each { |_name, data| s.astrology_buffs['spells'][i] = data.merge(spell) }
-     end
-
     s.waggle_sets
      .select { |set_name, set_spells| set_spells.select { |spell_name, spell_data| spells[spell_name].each { s.waggle_sets[set_name][spell_name] = spells[spell_name].merge(spell_data) } } }
 


### PR DESCRIPTION
Removes outdated `astrology_buffs`. The warning has been in place for ~2-3 months? That seems like a fair amount of time.