### PR TITLE
Ignore poison line when searching for wounds

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -165,7 +165,7 @@ module DRCH
     data = reget(300).reverse
     wounds_line = nil
     data.each do |line|
-      if line =~ /^You have/ && line !~ /^You have no significant injuries\./ && line !~ /^You have .* lodged .* into your/
+      if line =~ /^You have/ && line !~ /^You have no significant injuries\./ && line !~ /^You have .* lodged .* into your/ && line !~ /^You have .* poisoned/
         wounds_line = line
         break
       end


### PR DESCRIPTION
The line with 'You have these poisoned limbs' matches the line with 'You have these
wounds'. This caused check_health to erroneously return an empty list of
wounds. This update ignores any line that mentions poison.

Resolves #1584 