### PR TITLE
Update common-healing.lic

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -95,6 +95,7 @@ $severity_to_text = {
     /a severely bloated and discolored #{re_part} with strange round lumps under the skin/,
     /(?<abdomen>a definite greenish pallor and emaciated look)/,
     /(?<skin>a painful,* inflamed body rash)/,
+    /(?<skin>a painful,* enflamed body rash)/,
     /some shriveled and oddly folded (?<part>skin)/,
     /(?<skin>partial paralysis of the entire body)/,
     /(?<skin>numbness in your arms and legs)/


### PR DESCRIPTION
Not sure if 'inflamed' was actually a typo, but someone is reporting an 'enflamed' body rash. According to Genie highlights, it's enflamed, accordingly to Epedia it's inflamed, might just be best to include both to avoid any weirdness.