### PR TITLE
Ignore listed NPC's when trying to retreat during rituals

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -760,6 +760,9 @@ class SpellProcess
     @stored_cambrinth = settings.stored_cambrinth
     echo(" @stored_cambrinth: #{@stored_cambrinth}") if $debug_mode_ct
 
+    @ignored_npcs = settings.ignored_npcs
+    echo(" @ignored_npcs: #{@ignored_npcs}") if $debug_mode_ct
+
     @hide_type = settings.hide_type
     echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
 
@@ -1140,7 +1143,7 @@ class SpellProcess
     data = update_astral_data(data)
     if data # update_astral_data returns nil on failure
       check_invoke
-      ritual(data)
+      ritual(data, @ignored_npcs)
     end
 
     if summoned

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -77,7 +77,7 @@ module DRCA
     DRCT.retreat(ignored_npcs)
     waitcastrt?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
-    DRCT.retreat(ignored_npc)
+    DRCT.retreat(ignored_npcs)
   end
 
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -65,7 +65,7 @@ module DRCA
     true
   end
   def ritual(spell, ignored_npcs)
-    DRCT.retreat(ignored_npcs)
+    DRCT.retreat(ignored_npcs) unless spell['skip_retreat']
     DRC.release_invisibility
     DRC.bput('stance set 100 0 80', 'Setting your')
 
@@ -74,10 +74,11 @@ module DRCA
 
     invoke(spell['focus'], nil)
     stow_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'])
-    DRCT.retreat(ignored_npcs)
+    DRCT.retreat(ignored_npcs) unless spell['skip_retreat']
+
     waitcastrt?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
-    DRCT.retreat(ignored_npcs)
+    DRCT.retreat(ignored_npcs) unless spell['skip_retreat']
   end
 
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -65,8 +65,8 @@ module DRCA
     true
   end
 
-  def ritual(spell)
-    DRCT.retreat
+  def ritual(spell, settings = nil)
+    DRCT.retreat(settings.ignored_npcs)
     DRC.release_invisibility
     DRC.bput('stance set 100 0 80', 'Setting your')
 
@@ -75,10 +75,10 @@ module DRCA
 
     invoke(spell['focus'], nil)
     stow_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'])
-    DRCT.retreat
+    DRCT.retreat(settings.ignored_npcs)
     waitcastrt?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
-    DRCT.retreat
+    DRCT.retreat(settings.ignored_npcs)
   end
 
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])
@@ -324,7 +324,7 @@ module DRCA
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
 
     if data['ritual']
-      ritual(data)
+      ritual(data, settings)
       return
     end
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -64,9 +64,8 @@ module DRCA
 
     true
   end
-
-  def ritual(spell, settings = nil)
-    DRCT.retreat(settings.ignored_npcs)
+  def ritual(spell, ignored_npcs)
+    DRCT.retreat(ignored_npcs)
     DRC.release_invisibility
     DRC.bput('stance set 100 0 80', 'Setting your')
 
@@ -75,10 +74,10 @@ module DRCA
 
     invoke(spell['focus'], nil)
     stow_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'])
-    DRCT.retreat(settings.ignored_npcs)
+    DRCT.retreat(ignored_npcs)
     waitcastrt?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
-    DRCT.retreat(settings.ignored_npcs)
+    DRCT.retreat(ignored_npc)
   end
 
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])
@@ -324,7 +323,7 @@ module DRCA
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
 
     if data['ritual']
-      ritual(data, settings)
+      ritual(data, settings.ignored_npcs)
       return
     end
 

--- a/common-travel.lic
+++ b/common-travel.lic
@@ -73,7 +73,6 @@ module DRCT
   end
 
   def retreat(ignored_npcs=Array.new)
-    return if DRRoom.npcs.empty?
     return if (DRRoom.npcs - ignored_npcs).empty?
 
     escape_messages = ['You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat']

--- a/common-travel.lic
+++ b/common-travel.lic
@@ -74,7 +74,7 @@ module DRCT
 
   def retreat(ignored_npcs=Array.new)
     return if DRRoom.npcs.empty?
-    return if DRRoom.npcs.to_set.subtract(ignored_npcs).empty?
+    return if (DRRoom.npcs - ignored_npcs).empty?
 
     escape_messages = ['You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat']
     until escape_messages.include?(DRC.bput('retreat', *(escape_messages + ['retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing'])))

--- a/common-travel.lic
+++ b/common-travel.lic
@@ -72,8 +72,9 @@ module DRCT
     room_num == Room.current.id
   end
 
-  def retreat
+  def retreat(ignored_npcs=Array.new)
     return if DRRoom.npcs.empty?
+    return if DRRoom.npcs.to_set.subtract(ignored_npcs).empty?
 
     escape_messages = ['You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat']
     until escape_messages.include?(DRC.bput('retreat', *(escape_messages + ['retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing'])))

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1175,6 +1175,7 @@ spell_data:
     skill: Utility
     abbrev: RtR
     mana: 300
+    skip_retreat: true
     ritual: true
     before:
     - message: sit


### PR DESCRIPTION
When doing rituals, the retreat command is ignored if all npc's in the room match the list of ignored npc's