### PR TITLE
combat-trainer.lic: Remove conditional, people should have updated.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1787,11 +1787,7 @@ class AttackProcess
 
       if (game_state.backstab? || game_state.ambush?) && hiding?
         if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
-          if @ambush_location
-            command += " #{@ambush_location}"
-          else
-            command += ' back'
-          end
+          command += " #{@ambush_location}"
         else
           command.sub!(verb, 'backstab')
         end


### PR DESCRIPTION
This conditional was left in to not break people who haven't restarted
dependency after ambush_location was added to base.yaml.

Please don't pull this until a reasonable amount of time has passed since 10/17/2017.