### PR TITLE
base-lumber.yaml: s/adaf/adanf/ typo fix.

### DIFF
--- a/data/base-lumber.yaml
+++ b/data/base-lumber.yaml
@@ -161,7 +161,7 @@ lumber_buddy_rooms:
   - 9524
   - 9525
   - 9526
-  adaf_woods:
+  adanf_woods:
   - 9458
   - 9459
   - 9460


### PR DESCRIPTION
Not sure if this is worth pushing but sending it anyway.