### PR TITLE
Set healing thresholds for necro healing

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -428,8 +428,8 @@ class LootProcess
       if @necro_heal && !game_state.necro_casting?
         game_state.wounds = check_health
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
-        if @heal_threshold <= game_state.wounds.keys.max
-          unless game_state.wounds.empty?
+        unless game_state.wounds.empty?
+		  if @heal_threshold <= game_state.wounds.keys.max
             do_necro_ritual(mob_noun, 'consume', game_state)
             return false
           end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -432,11 +432,11 @@ class LootProcess
       if @necro_heal && !game_state.necro_casting?
         game_state.wounds = check_health
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
-        echo "wound_level_threshold: #{@wound_level_threshold}"
+        echo "wound_level_threshold: #{@wound_level_threshold}" if $debug_mode_ct
         unless game_state.wounds.empty?
 		      if @wound_level_threshold <= game_state.wounds.keys.max
-                do_necro_ritual(mob_noun, 'consume', game_state)
-                return false
+            do_necro_ritual(mob_noun, 'consume', game_state)
+            return false
           end
         end
       end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -428,10 +428,12 @@ class LootProcess
       if @necro_heal && !game_state.necro_casting?
         game_state.wounds = check_health
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
-        unless game_state.wounds.empty?
-          do_necro_ritual(mob_noun, 'consume', game_state)
-          return false
-        end
+		if @heal_threshold <= game_state.wounds.keys.max
+			unless game_state.wounds.empty?
+			  do_necro_ritual(mob_noun, 'consume', game_state)
+			  return false
+			end
+		end
       end
       if @make_zombie && !game_state.necro_casting? && !game_state.cfb_active?
         echo 'Making zombie' if $debug_mode_ct
@@ -723,6 +725,9 @@ class SpellProcess
 
     @necromancer_zombie = settings.waggle_sets['zombie']
     echo("  @necromancer_zombie: #{@necromancer_zombie}") if $debug_mode_ct
+
+    @heal_threshold = settings.heal_threshold
+    echo("  @heal_threshold: #{@heal_threshold}") if $debug_mode_ct
 
     @empath_spells = settings.empath_healing
     echo("  @empath_spells: #{@empath_spells}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -259,6 +259,10 @@ class LootProcess
     @make_zombie = settings.zombie['make']
     echo("  @make_zombie: #{@make_zombie}") if $debug_mode_ct
 
+    @wound_level_threshold = settings.necromancer_healing["wound_level_threshold"]
+    echo("  @wound_level_threshold: #{@wound_level_threshold}") if $debug_mode_ct
+
+
     @gem_nouns = get_data('items').gem_nouns
     echo("  @gem_nouns: #{@gem_nouns}") if $debug_mode_ct
 
@@ -428,10 +432,11 @@ class LootProcess
       if @necro_heal && !game_state.necro_casting?
         game_state.wounds = check_health
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
+        echo "wound_level_threshold: #{@wound_level_threshold}"
         unless game_state.wounds.empty?
-		  if @heal_threshold <= game_state.wounds.keys.max
-            do_necro_ritual(mob_noun, 'consume', game_state)
-            return false
+		      if @wound_level_threshold <= game_state.wounds.keys.max
+                do_necro_ritual(mob_noun, 'consume', game_state)
+                return false
           end
         end
       end
@@ -725,9 +730,6 @@ class SpellProcess
 
     @necromancer_zombie = settings.waggle_sets['zombie']
     echo("  @necromancer_zombie: #{@necromancer_zombie}") if $debug_mode_ct
-
-    @heal_threshold = settings.heal_threshold
-    echo("  @heal_threshold: #{@heal_threshold}") if $debug_mode_ct
 
     @empath_spells = settings.empath_healing
     echo("  @empath_spells: #{@empath_spells}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -434,7 +434,7 @@ class LootProcess
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         echo "wound_level_threshold: #{@wound_level_threshold}" if $debug_mode_ct
         unless game_state.wounds.empty?
-		      if @wound_level_threshold <= game_state.wounds.keys.max
+          if @wound_level_threshold <= game_state.wounds.keys.max
             do_necro_ritual(mob_noun, 'consume', game_state)
             return false
           end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -428,12 +428,12 @@ class LootProcess
       if @necro_heal && !game_state.necro_casting?
         game_state.wounds = check_health
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
-		if @heal_threshold <= game_state.wounds.keys.max
-			unless game_state.wounds.empty?
-			  do_necro_ritual(mob_noun, 'consume', game_state)
-			  return false
-			end
-		end
+        if @heal_threshold <= game_state.wounds.keys.max
+          unless game_state.wounds.empty?
+            do_necro_ritual(mob_noun, 'consume', game_state)
+            return false
+          end
+        end
       end
       if @make_zombie && !game_state.necro_casting? && !game_state.cfb_active?
         echo 'Making zombie' if $debug_mode_ct

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -82,6 +82,7 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
+heal_threashold: 1
 zombie:
   make: false
   summon: false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -82,7 +82,7 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
-heal_threshold: 1 # 1 - 8
+  wound_level_threshold: 1 # 1 - 8
 zombie:
   make: false
   summon: false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -82,7 +82,7 @@ buff_nonspells:
 dance_actions_stealth:
 thanatology:
 necromancer_healing:
-heal_threashold: 1
+heal_threshold: 1 # 1 - 8
 zombie:
   make: false
   summon: false


### PR DESCRIPTION
update combat trainer to allow user to set a healing threshold to avoid healing scratches if you so choose. Updated base yaml with the setting defaulting to heal everything.