### PR TITLE
Ignore prone players if the NPC healer is idle

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -31,6 +31,7 @@ class SafeRoom
       wait_for_script_to_complete('healme')
     elsif !DRStats.necromancer?
       ensure_copper_on_hand(4_000, settings.hometown)
+      Flags.add('npc-idle', '^Dokt glances around the room')
       Flags.add('healthy', 'Dokt waves a large hand at you', 'Dokt gives you a quick glance', 'go have yourself a birthday party', 'you are well', 'have other patients', 'you look fine and healthy', 'A little rest and exercise', 'There is nothing I can do for you', 'Up and out')
       Flags.add('moved', 'grabs you and drags you')
       Flags.add('idle', 'you have been idle too long')
@@ -120,6 +121,10 @@ class SafeRoom
         counter = 0
       end
       check_idle
+      if Flags['npc-idle'] && DRRoom.pcs_prone
+        people_in_front -= DRRoom.pcs_prone
+        Flags.reset('npc-idle')
+      end
       break if ((DRRoom.pcs - DRRoom.pcs_sitting) & people_in_front).empty?
     end
 


### PR DESCRIPTION
A player using an NPC healer can be prone due to disease and won't be forced to sit up because theyre injured. When this happens, the NPC healer becomes idle and the line does not advance. The NPC healer gives an idle message indicating that he's not busy. If we see this message, we remove the prone player from the 'line'.

This will fix some of the backups at Dokt's.