### PR TITLE
workorders.lic: Allow crafting shaping recipes with volumes > 10, and add furniture support.

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -5320,3 +5320,146 @@ crafting_recipes:
   part:
   - shield handle
   - long cord
+- name: a rough wood table
+  noun: table
+  volume: 15
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a low wood table
+  noun: table
+  volume: 18
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - short pole
+  - short pole
+  - short pole
+  - short pole
+- name: a high wood table
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a round wood table
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a square wood table
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a long wood table
+  noun: table
+  volume: 25
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: an oval wood table
+  noun: table
+  volume: 25
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a long wood table
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood dining table
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood buffet table
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood refectory table
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood parquet table
+  noun: table
+  volume: 32
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood meditation table
+  noun: table
+  volume: 32
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole

--- a/workorders.lic
+++ b/workorders.lic
@@ -260,8 +260,6 @@ class WorkOrders
   def shape_items(info, item, quantity)
     ensure_copper_on_hand(5000, @hometown)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
-    stock_name = 'stock-name'
-    stock_number = 'stock-number'
 
     quantity.times do |count|
       if items_per_stock.zero? || (count % items_per_stock).zero?
@@ -270,9 +268,9 @@ class WorkOrders
           go_door
           pause 0.5 until Room.current.id
         end
-        bput("get my #{info[stock_name]} lumber", 'What were', 'You get')
-        while bput("count my #{info[stock_name]} lumber", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
-          order_item(info['stock-room'], info[stock_number])
+        bput("get my #{info['stock-name']} lumber", 'What were', 'You get')
+        while bput("count my #{info['stock-name']} lumber", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
+          order_item(info['stock-room'], info['stock-number'])
           bput('combine', 'combine')
         end
 
@@ -280,7 +278,7 @@ class WorkOrders
         buy_parts(recipe['part'], info['part-room'])
         find_shaping_room(@hometown, @engineering_room)
       end
-
+	  echo('shape', ['log', recipe['chapter'], recipe['name'], info['stock-name'], recipe['noun']])
       wait_for_script_to_complete('shape', ['log', recipe['chapter'], recipe['name'], info['stock-name'], recipe['noun']])
     end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -263,9 +263,9 @@ class WorkOrders
     stock_name = 'stock-name'
     stock_number = 'stock-number'
 
-	quantity.times do |count|
+    quantity.times do |count|
       if items_per_stock.zero? || (count % items_per_stock).zero?
-	    dispose("#{info['stock-name']} lumber") if count > 0 && spare_stock
+        dispose("#{info['stock-name']} lumber") if count > 0 && spare_stock
         if count > 0
           go_door
           pause 0.5 until Room.current.id

--- a/workorders.lic
+++ b/workorders.lic
@@ -278,7 +278,7 @@ class WorkOrders
         buy_parts(recipe['part'], info['part-room'])
         find_shaping_room(@hometown, @engineering_room)
       end
-	  echo('shape', ['log', recipe['chapter'], recipe['name'], info['stock-name'], recipe['noun']])
+
       wait_for_script_to_complete('shape', ['log', recipe['chapter'], recipe['name'], info['stock-name'], recipe['noun']])
     end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -260,15 +260,22 @@ class WorkOrders
   def shape_items(info, item, quantity)
     ensure_copper_on_hand(5000, @hometown)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
+    stock_name = 'stock-name'
+    stock_number = 'stock-number'
 
-    quantity.times do |count|
-      if (count % items_per_stock).zero?
-        dispose("#{info['stock-name']} lumber") if count > 0 && spare_stock
+	quantity.times do |count|
+      if items_per_stock.zero? || (count % items_per_stock).zero?
+	    dispose("#{info['stock-name']} lumber") if count > 0 && spare_stock
         if count > 0
           go_door
           pause 0.5 until Room.current.id
         end
-        order_item(info['stock-room'], info['stock-number'])
+        fput("get my #{info[stock_name]} lumber")
+        while bput("count my #{info[stock_name]} lumber", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
+          order_item(info['stock-room'], info[stock_number])
+          bput('combine', 'combine')
+        end
+
         stow_hands
         buy_parts(recipe['part'], info['part-room'])
         find_shaping_room(@hometown, @engineering_room)

--- a/workorders.lic
+++ b/workorders.lic
@@ -270,7 +270,7 @@ class WorkOrders
           go_door
           pause 0.5 until Room.current.id
         end
-        fput("get my #{info[stock_name]} lumber")
+        bput("get my #{info[stock_name]} lumber", 'What were', 'You get')
         while bput("count my #{info[stock_name]} lumber", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
           order_item(info['stock-room'], info[stock_number])
           bput('combine', 'combine')


### PR DESCRIPTION
This adds support for crafting items > 10 volumes, and adds furniture recipes. It was assumed nothing would be bigger than an order of balsa lumber before.