### PR TITLE
Fix bug where pet box portion of pick.lic didn't get a lockpick.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1794,11 +1794,7 @@ class AttackProcess
 
       if (game_state.backstab? || game_state.ambush?) && hiding?
         if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
-          if @ambush_location
-            command += " #{@ambush_location}"
-          else
-            command += ' back'
-          end
+          command += " #{@ambush_location}"
         else
           command.sub!(verb, 'backstab')
         end

--- a/pick.lic
+++ b/pick.lic
@@ -79,6 +79,8 @@ class LockPicker
         next
       end
 
+      find_lockpick unless @settings.use_lockpick_ring
+
       loop do
         if DRSkill.getxp('Locksmithing') >= 30
           bput("put my #{box} in my #{source}", 'You put your .* in your ') if right_hand


### PR DESCRIPTION
Previously this portion of the script failed unless use_lockpick_ring was set.