### PR TITLE
base-athletics.lic: Add Arthelun rocks outside of cinderbeasts as a practice target

### DIFF
--- a/data/base-athletics.yaml
+++ b/data/base-athletics.yaml
@@ -102,6 +102,11 @@ practice_options:
       id: 6119
       target: ladder
       hide: true
+  #Rocks in Arthelun near cinderbeasts (minimum unknown, its at least 450) 450-1000+
+  arthelun_rocks:
+      id: 10991
+      target: rocks
+      hide: false
 
 swimming_options:
   #Arthe Dale Swimming hole

--- a/data/base-athletics.yaml
+++ b/data/base-athletics.yaml
@@ -102,7 +102,7 @@ practice_options:
       id: 6119
       target: ladder
       hide: true
-  #Rocks in Arthelun near cinderbeasts (minimum unknown, its at least 450) 450-1000+
+  #Rocks in Arthelun near cinderbeasts 475-1000+
   arthelun_rocks:
       id: 10991
       target: rocks


### PR DESCRIPTION
teaches at least 450-1000+ Exacts are unknown.