### PR TITLE
links.lic: Update to yaml parser to http://yaml-online-parser.appspot…

### DIFF
--- a/links.lic
+++ b/links.lic
@@ -13,7 +13,7 @@ class Links
       'Dependency First Time Setup' => 'https://github.com/rpherbig/dr-scripts/wiki/First-Time-Setup',
       'Dependency Script Documentation' => 'https://elanthipedia.play.net/Lich_script_repository',
       'DR-Scripts Tutorials' => 'https://github.com/rpherbig/dr-scripts/wiki/DR-Scripts-Tutorials',
-      'YAML Validator' => 'http://www.yamllint.com/',
+      'YAML Validator' => 'http://yaml-online-parser.appspot.com/',
       'Lich mapping guide' => 'https://elanthipedia.play.net/Lich_mapping_reference',
       'Player Shops' => 'https://dr-scripts.firebaseapp.com/',
       'Hunting Ladder Spreadsheet' => 'http://i.imgur.com/lCcb3rD.jpg',


### PR DESCRIPTION
….com/

This parser gives much more information on a block error which is the most common error.

For instance, instead of this that lich reports:
while parsing a block mapping
  in "<unicode string>", line 3, column 1:
    hunting_info:

the parser will report:
while parsing a block mapping
  in "<unicode string>", line 3, column 1:
    hunting_info:
    ^
expected <block end>, but found '<block sequence start>'
  in "<unicode string>", line 7, column 2:
     - undead
     ^

where the second hunk is the actual problem that needs fixing.