### PR TITLE
crossing-training.lic: add a return to train_engineering if using workorders

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -859,11 +859,13 @@ class CrossingTraining
       wait_for_script_to_complete('workorders', ['Shaping'])
       wait_for_script_to_complete('sell-loot')
       walk_to(@training_room)
+      return
     elsif @settings.train_workorders.include?('Carving')
       return unless money_for_training?(5000, 'Engineering')
       wait_for_script_to_complete('workorders', ['Carving'])
       wait_for_script_to_complete('sell-loot')
       walk_to(@training_room)
+      return
     end
 
     rank = DRSkill.getrank('Engineering')


### PR DESCRIPTION
to not make an extra item after workorders are done.