### PR TITLE
combat-trainer.lic: set wound_level_threshold to 1 if the subkey does not exist in a yaml.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -259,7 +259,7 @@ class LootProcess
     @make_zombie = settings.zombie['make']
     echo("  @make_zombie: #{@make_zombie}") if $debug_mode_ct
 
-    @wound_level_threshold = settings.necromancer_healing["wound_level_threshold"]
+    @wound_level_threshold = settings.necromancer_healing["wound_level_threshold"] || 1
     echo("  @wound_level_threshold: #{@wound_level_threshold}") if $debug_mode_ct
 
 


### PR DESCRIPTION
the subkey is not inherited from base.yaml if the necromancer_healing: section already exists in a users yaml, and necromancer_healing: was a common one for people to have. Healing would be skipped unless would_level_threshold exists without this.