### PR TITLE
base-stealing.yaml: remove pierced metal pomander from the stealing l…

### DIFF
--- a/data/base-stealing.yaml
+++ b/data/base-stealing.yaml
@@ -4710,11 +4710,3 @@
   room: 6213
 - acceptable_max: 353
   acceptable_min: 249
-  id: 439
-  item: pomander
-  item_in: catalog
-  pawnable: false
-  province: zoluren
-  room: 12048
-  vpoorly_max: 482
-  vpoorly_min: 481


### PR DESCRIPTION
…ist.

It's in haven, not zoluren.