### PR TITLE
Untie shovel if returning  after danger

### DIFF
--- a/mine.lic
+++ b/mine.lic
@@ -56,7 +56,7 @@ class Mine
       store_mining_tool
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)
-      bput("get my #{@mining_implement}", 'You get')
+      get_mining_tool
     end
 
     return unless Flags['mine-danger']


### PR DESCRIPTION
Fix script to properly get shovel after returning from danger. It will now get shovel if needed or untie shovel if needed using already implemented get_mining_tool function.