### PR TITLE
combat-trainer.lic: Remove dump_item_count safety precaution.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -290,8 +290,7 @@ class LootProcess
     @dump_junk = settings.dump_junk
     echo("  @dump_junk: #{@dump_junk}") if $debug_mode_ct
     @dump_timer = Time.now - 300
-    # remove || 9 after a few days when base.yaml migrates
-    @dump_item_count = settings.dump_item_count || 9
+    @dump_item_count = settings.dump_item_count
 
     @last_rites = settings.last_rites
     echo("  @last_rites: #{@last_rites}") if $debug_mode_ct


### PR DESCRIPTION
should be fine to remove by the 29th.