### PR TITLE
setupaliases.lic: add lfr alias to look at raw data of remote rooms.

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -22,6 +22,9 @@
   # echos the full data of the room you're standing in
   ['lr', "#{$clean_lich_char}e echo Room[Room.current.id].inspect"],
 
+  # echos the full data of a specified remote room
+  ['lfr', "#{$clean_lich_char}e echo Room[\\?].inspect"],
+
   # these work as a pair, for recording room numbers (like setting up a hunting area); run cb, then rec in each room you want to record
   ['cb', "#{$clean_lich_char}e $temp = []"],
   ['rec', "#{$clean_lich_char}e echo $temp << Room.current.id"],


### PR DESCRIPTION
usage: lfr <roomnumber>. 

Happy to change the name, in my head its look far room instead of just look room like the lr alias.