### PR TITLE
Check if RTR is active 100 times in 1 second

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -128,6 +128,15 @@ class Astrology
     waitrt?
   end
 
+  def rtr_active?
+    # DRSpells.active_spells sometimes shows RtR as inactive even though it is active
+    100.times do
+      pause 0.01
+      return true if DRSpells.active_spells.include?('Read the Ripples')
+    end
+    false
+  end
+
   def check_ripples(settings)
     return unless @rtr_data
     return unless settings
@@ -135,7 +144,7 @@ class Astrology
 
     @equipment_manager.empty_hands
     cast_spell(@rtr_data, settings)
-    while DRSpells.active_spells.include?('Read the Ripples')
+    while rtr_active?
       line = get?
       res = @constellations.find { |body| /As your consciousness drifts amongst the currents of Fate, .* #{body['name']}/i =~ line }
       observe(res['name']) unless res.nil?


### PR DESCRIPTION
Some users have experienced RTR not showing up as an active spell and
pre-emptively exiting the RTR training portion of astrology. This patch
will poll active spells at most 100 times before moving on from RTR
training.

Personally, Ive been sitting on this for a couple months because I thought it was just an issue with my machine, but some other users have reported similar behaviour. This has already been tested.

