### PR TITLE
bescort.lic: Use equipman to clear hands for iceskates

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1,6 +1,6 @@
 #   Documentation: https://elanthipedia.play.net/Lich_script_repository#bescort
 
-custom_require.call(%w[common common-arcana common-items common-travel common-money drinfomon events skill-recorder])
+custom_require.call(%w[common common-arcana common-items common-travel common-money drinfomon equipmanager events skill-recorder])
 
 $turns_since_bad = 0
 
@@ -509,7 +509,7 @@ class Bescort
     path = mode == 'shard' ? $ICE_PATH_SHARD : $ICE_PATH_HIB
 
     if exists?('skates')
-      stow_hands
+      EquipmentManager.new.empty_hands
       footwear = get_settings.footwear
       fput("remove #{footwear}") if footwear
       bput("stow my #{footwear}", 'You put') if footwear


### PR DESCRIPTION
Lets us unload loaded bows, etc instead of giving errors.
Fixes https://github.com/rpherbig/dr-scripts/issues/1967

```
[Himineldar Shel, Rope Bridge]
The path slants along the rock face at a sharp angle and ends suddenly at a makeshift wooden bridge, reaching across the gaping maw of a chasm at a nearly vertical angle.  Numerous trickles of crystal clear water sweep downward along the massive formations of ice, slipping quietly off the side of the chasm with a gentle gurgle.  An opaque mist swirls around the swaying, ice-slick bridge, giving an oddly unreal quality to the rushing gurgle of unseen water in the chasm below.  
Obvious paths: northwest.
Room Number: 4430
>
--- Lich: bescort active.
>
[bescort]>tap my skates
You tap some grey ice skates with black laces inside your tapestry carpetbag.
>
[bescort]>wear my nisha.shortbow
You need to unload the Nisha shortbow first.
>
[bescort]>unload my nisha.shortbow
You unload the shortbow.
Roundtime: 1 seconds.
R>
[bescort]>stow left
You put your arrow in your thigh quiver.
>
[bescort]>wear my nisha.shortbow
You sling a goldwood Nisha shortbow with laminated limbs over your shoulder.
>
[bescort]>remove boots
You take a pair of dark azure-scaled boots with aganylosh'a bark buckles off your feet.
>
[bescort]>stow my boots
>
You put your boots in your tapestry carpetbag.
>
[bescort]>get skates
You get some grey ice skates with black laces from inside your tapestry carpetbag.
>
[bescort]>wear skates
You slide your ice skates on your feet and tightly tie the laces.
>
[bescort]>nw
Your ice skates help you traverse the frozen terrain.
You go northwest.
```