### PR TITLE
bug-grabber.lic: Adjust rooms, use DRCT.walk_to

### DIFF
--- a/bug-grabber.lic
+++ b/bug-grabber.lic
@@ -1,7 +1,7 @@
 custom_require.call(%w[common-travel drinfomon])
 
-rooms = [10_506, 10_507, 10_676, 10_508, 10_509, 10_665, 10_670, 10_673, 10_482, 10_493, 10_497, 10_515, 10_675, 10_674, 10_510, 10_539, 10_668, 10_669, 10_590, 10_520,
-         10_666, 10_640, 10_557, 10_576, 10_617, 10_667, 10_620, 10_572, 10_671, 10_672, 10_677, 10_679, 10_678]
+rooms = [10_506, 10_507, 10_676, 10_508, 10_509, 10_665, 10_670, 10_673, 10_482, 10_497, 10_515, 10_675, 10_510, 10_539, 10_668, 10_669, 10_590, 10_520,
+         10_666, 10_640, 10_557, 10_576, 10_617, 10_667, 10_620, 10_572, 10_671, 10_672, 10_677, 13_231, 10_678]
 
 def bug?(obj_name)
   /\b(locust|bug|beetle|cricket|hornet|moth|scarab|firefly|dragonfly|mantis)/i =~ obj_name
@@ -9,7 +9,7 @@ end
 
 loop do
   rooms.each do |room|
-    DRC.walk_to(room)
+    DRCT.walk_to(room)
     break if DRRoom.room_objs.any? { |x| bug?(x) }
   end
   unless DRRoom.room_objs.any? { |x| bug?(x) }


### PR DESCRIPTION
Adjust rooms to account for number changes, same as find-darkbox.