### PR TITLE
Add support for waggle_sets and heal spell

### DIFF
--- a/healme.lic
+++ b/healme.lic
@@ -39,7 +39,7 @@ class HealMe
     until Flags['hm-heal-done']
       pause 1 while mana < 25
       prepare?('heal', base)
-      charge_and_invoke(@settings.cambrinth, @settings.dedicated_camb_use, camb) unless camb.empty?
+      charge_and_invoke(@settings.cambrinth, @settings.dedicated_camb_use, camb) unless camb.empty? || camb.nil?
       waitcastrt?
       cast?
       pause 0.5
@@ -91,7 +91,9 @@ class HealMe
 
     find_cambrinth(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap)
 
-    if @settings.empath_healing['HEAL'] && skip_parts.nil?
+    if @settings.waggle_sets['healing']['Heal'] && skip_parts.nil?
+      spam_heal(@settings.waggle_sets['healing']['Heal']['mana'], @settings.empath_healing['healing']['Heal']['cambrinth'])
+    elsif @settings.empath_healing['HEAL'] && skip_parts.nil?
       spam_heal(@settings.empath_healing['HEAL'].first, @settings.empath_healing['HEAL'][1..-1])
     else
       wounds = check_perc_health


### PR DESCRIPTION
If the user has defined a waggle_set named 'healing' then use that to
cast the heal spell.