### PR TITLE
forestry-buddy.lic: Updates to get rid of mining references.

### DIFF
--- a/forestry-buddy.lic
+++ b/forestry-buddy.lic
@@ -1,5 +1,5 @@
 =begin
-  Documentation: https://elanthipedia.play.net/Lich_script_repository#mining-buddy
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#forestry-buddy
 =end
 
 custom_require.call(%w[common common-items common-money common-travel drinfomon])
@@ -46,7 +46,7 @@ class ForestryBuddy
     @area_list = get_data('lumber').lumber_buddy_rooms
     @areas = settings.forests_to_chop
     @skip_populated = settings.lumber_skip_populated
-    @chop_every_room = settings.mining_buddy_chop_every_room
+    @chop_every_room = settings.lumber_buddy_chop_every_room
     @tree_list = settings.lumber_buddy_tree_list
     @lumber_implement = settings.lumber_implement
     @use_packet = settings.lumber_use_packet


### PR DESCRIPTION
change script name in the header
switch to using lumber_buddy_chop_every_room instead of mining_buddy_chop_every_room