### PR TITLE
spinner.lic: Fix an issue when you finish and get a item at the same …

### DIFF
--- a/spinner.lic
+++ b/spinner.lic
@@ -21,6 +21,7 @@ class Spinnerette
     @device = nil
     case bput('push button', 'You count out', 'I don\'t think pushing that would')
     when 'I don\'t think pushing that would'
+      echo('This script must be started at the spinneret.')
       exit
     end
     pause 1
@@ -37,10 +38,10 @@ class Spinnerette
     when /You think you can (.+) the (.+) to increase your chances of spinning a good fabric/i
       @action = Regexp.last_match(1)
       @device = Regexp.last_match(2)
-    when /^You are pretty sure you can PUSH the BUTTON/i, /^You should probably push the button first./i
-      start_game
     when /^You're pretty sure you've improved your odds as much as you possibly can./i
       end_game
+    else
+      start_game
     end
 
     echo "Action is: #{@action}. Device is: #{@device}" if @spinner_debug


### PR DESCRIPTION
…time.

Turns out you can't match regex like that and the latter was ignored.
Also, add a message when it bails because you are not in the spinner room.