### PR TITLE
common-crating.lic: handle the book already being on the correct page…

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -101,7 +101,7 @@ module DRCC
   end
 
   def find_recipe(chapter, match_string)
-    case bput("turn my book to chapter #{chapter}", 'You turn', 'You are too distracted to be doing that right now')
+    case bput("turn my book to chapter #{chapter}", 'You turn', 'You are too distracted to be doing that right now', 'The book is already turned')
     when 'You are too distracted to be doing that right now'
       echo '***CANNOT TURN BOOK, ASSUMING I AM ENGAGED IN COMBAT***'
       fput('look')


### PR DESCRIPTION
… in find_recipe.

[carve: *** No match was found after 15 seconds, dumping info]
 
[carve: messages seen length: 2]
 
[carve: message: Hrin assumes a meditative stance, concentrating on something.]
 
[carve: message: The book is already turned to chapter 9, entitled "Bone Carved Accessories and Containers".]
 
[carve: checked against [/You turn/i, /You are too distracted to be doing that right now/i]]
 
[carve: for command turn my book to chapter 9]