### PR TITLE
sanowret: Stop multiple gazes due to laggy DRStats.concentration updates

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -23,7 +23,7 @@ class SanowretCrystal
     return if hiding?
 
     if DRSkill.getxp('Arcana') <= 10
-      response = DRC.bput('gaze sanowret crystal', /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.')
+      response = DRC.bput('gaze sanowret crystal', /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.')
     elsif DRSkill.getxp('Arcana') <= 25
       response = DRC.bput('exhale sanowret crystal', 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.')
     end
@@ -62,7 +62,7 @@ class SanowretCrystal
     loop do
       next if @invalid_rooms.include?(Room.current.id)
       check_crystal
-      pause 1
+      pause 10
     end
   end
 end


### PR DESCRIPTION
the concentration hit from using the sanowret is taking upwards of 5 seconds to register and the script was trying to loop gaze every 1 second until it did update. The 10 seconds is arbitrary but I wanted to be on the safe side, it is a passive script so an extra few seconds will not hurt. Also, it wasn't handling the already gazed message before so it was giving an error splat on the second gaze.