### PR TITLE
mech-lore.lic: Remove timer usage, this is a short lived script.

### DIFF
--- a/mech-lore.lic
+++ b/mech-lore.lic
@@ -29,15 +29,6 @@ class MechLore
     fput "wear my #{@settings.hand_armor}"
   end
 
-  def dump_junk
-    return unless @settings.dump_junk
-    return unless Time.now - @junk_timer > 300
-    return unless DRRoom.room_objs.size > @settings.dump_item_count
-
-    bput('dump junk', 'You should just kick', 'You have marked this room', 'You cannot summon')
-    @junk_timer = Time.now
-  end
-
   def braid_to_fail(item)
     return if left_hand || right_hand
     return unless forage?(item)
@@ -82,7 +73,6 @@ class MechLore
     if trash_nouns.any? { |noun| /\b#{noun}/i =~ GameObj.left_hand.noun } && !@equipment_manager.is_listed_item?(left_hand)
       dispose_trash(left_hand)
     end
-    dump_junk
   end
 end
 


### PR DESCRIPTION
This script would never run 300 seconds anyway, just try to dump junk if the setting exists and there is enough trash on the ground.