### PR TITLE
Add empty_hands to crossing-repair setup

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -87,6 +87,7 @@ class CrossingRepair
   def setup
     @equipment_manager = EquipmentManager.new
     @equipment_manager.wear_equipment_set?('standard')
+    @equipment_manager.empty_hands
 
     settings = get_settings
     @repair_withdrawal_amount = settings.repair_withdrawal_amount


### PR DESCRIPTION
Based on certain factors (blindness, RT, etc) armor was in hand when calling crossing-repair. If that armor is not part of the standard gear set, it breaks crossing-repair when trying to retrieve the item for repair. Easy fix is by calling empty_hands after the standard gear set is equipped. This will make sure any other armor items are appropriately stowed.