### PR TITLE
Add a duration setting for crossing trainer when using training manager

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1,8 +1,8 @@
 ---
 # See https://github.com/rpherbig/dr-scripts/wiki/YAML-Settings for documentation
 
-
 hometown: Crossing
+training_manager_town_duration:
 
 # Combat settings
 aim_fillers:

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -45,13 +45,20 @@ class TrainingManager
       skip = false
 
       start_script('crossing-training')
+      start_time = Time.now
       pause 5
-      pause 1 until priority_skills_low?
+      pause 1 until priority_skills_low? || timer_expired?(start_time)
       $CROSSING_TRAINER.stop
       pause 1 while $CROSSING_TRAINER.running
 
       hunting_combo
     end
+  end
+
+  def timer_expired?(start_time)
+    return unless @settings.training_manager_town_duration
+
+    return Time.now - start_time >= @settings.training_manager_town_duration * 60
   end
 
   def priority_skills_low?
@@ -65,14 +72,15 @@ class TrainingManager
 
       check_favors
 
-      wait_for_script_to_complete('sell-loot')
+      wait_for_script_to_complete('sell-loot') 
 
       wait_for_script_to_complete('mining-buddy') if @settings.mine_while_training
 
       $CROSSING_TRAINER = nil
       start_script('crossing-training')
+      start_time = Time.now
       pause 5
-      pause 1 until $CROSSING_TRAINER.idling
+      pause 1 until $CROSSING_TRAINER.idling || timer_expired?(start_time)
       $CROSSING_TRAINER.stop
       pause 1 while $CROSSING_TRAINER.running
 


### PR DESCRIPTION
This adds a setting for limiting the amount of time spent training in town. It's similar to the duration setting for hunting-buddy. If the duration timer is expired OR a priority skill is below threshold (and the priority skills setting is true), hunting buddy is called.