### PR TITLE
fix small error

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -103,7 +103,7 @@ module DRCA
     after.each { |action| DRC.bput(action['message'], action['matches']) }
 
     if symbiosis && Flags['spell-fail']
-      bput('release symbiosis', 'You release', 'But you haven\'t prepared')
+      DRC.bput('release symbiosis', 'You release', 'But you haven\'t prepared')
     end
 
     !Flags['spell-fail']


### PR DESCRIPTION
without the "DRC." before bput it gives the following error:

[test]>cast
>
You gesture.
Your spell barely backfires.
>
--- Lich: error: undefined method `bput' for Scripting::DRCA:Module
	common-arcana:106:in `cast?'
	test:59:in `favor_magic'

This fixes the only bput in common-arcana without the DRC prefix.