### PR TITLE
Change whirlwind gouge to jab.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2350,7 +2350,7 @@ class GameState
     elsif (npcs.length > 2) && !balance_low?
       return 'whirlwind'
     else
-      'jab'
+      return 'jab'
     end
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2350,7 +2350,7 @@ class GameState
     elsif (npcs.length > 2) && !balance_low?
       return 'whirlwind'
     elsif balance_low?
-      return 'gouge'
+      return 'jab'
     end
     'jab'
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2349,10 +2349,9 @@ class GameState
       return @analyze_combo_array.shift
     elsif (npcs.length > 2) && !balance_low?
       return 'whirlwind'
-    elsif balance_low?
-      return 'jab'
+    else
+      'jab'
     end
-    'jab'
   end
 
   def weapon_skill


### PR DESCRIPTION
This is important because jab also gains balance, but at the same time trains the weapon in hand. Due to how we use:

```
combat_trainer_target_increment: 3
combat_trainer_action_count: 10
```

It will change weapons without actually training them. 