### PR TITLE
Adding support for warhorn lure

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -24,6 +24,15 @@ class SetupProcess
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
     @last_warhorn = Time.now - 305
+    if @warhorn
+      if DRCI.wearing?(@warhorn)
+        @warhorn_get_verb = "remove"
+        @warhorn_store_verb = "wear"
+      else
+        @warhorn_get_verb = "get"
+        @warhorn_store_verb = "stow"
+      end
+    end
   end
 
   def execute(game_state)
@@ -72,22 +81,17 @@ class SetupProcess
 
   def blow_warhorn()
     return unless @warhorn
-    return if Time.now - @last_warhorn < 300
+    return if Time.now - @last_warhorn < 600
 
-    if DRCI.wearing?(@warhorn)
-        get_verb = "remove"
-        store_verb = "wear"
-    else
-        get_verb = "get"
-        store_verb = "stow"
-    end
-
-    case bput("#{get_verb} my #{@warhorn}", 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
+    case bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
     when 'You get', 'You remove'
       bput('exhale warhorn lure','You sound a series of bursts from the warhorn','Your lungs are tired from having sounded a warhorn so recently.')
       @last_warhorn = Time.now
       waitrt?
-      bput("#{store_verb} my #{@warhorn}",'You put','You attach')
+      bput("#{@warhorn_store_verb} my #{@warhorn}",'You put','You attach')
+    when 'What were you referring to'
+      echo "#{warhorn} NOT FOUND! Removing from hunt."
+      @warhorn = ''
     end
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -74,8 +74,7 @@ class SetupProcess
     return unless @warhorn
     return if Time.now - @last_warhorn < 600
 
-    case bput("tap my #{@warhorn}", 'inside your', 'that you are wearing', 'I could not find what you were referring to.')
-    when 'that you are wearing'
+    if DRCI.wearing?(@warhorn)
         get_verb = "remove"
         store_verb = "wear"
     else
@@ -83,11 +82,12 @@ class SetupProcess
         store_verb = "stow"
     end
 
-    if ['You remove','You get'].include? bput("#{get_verb} my #{@warhorn}", 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
+    case bput("#{get_verb} my #{@warhorn}", 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
+    when 'You get', 'You remove'
       bput('exhale warhorn lure','You sound a series of bursts from the warhorn','Your lungs are tired from having sounded a warhorn so recently.')
       @last_warhorn = Time.now
       waitrt?
-      fput("#{store_verb} my #{@warhorn}")
+      bput("#{store_verb} my #{@warhorn}",'You put','You attach')
     end
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -20,6 +20,12 @@ class SetupProcess
     @cycle_armors = settings.cycle_armors
     echo("  @cycle_armors: #{@cycle_armors}") if $debug_mode_ct
     @last_cycle_time = Time.now - 125
+    
+    @warhorn = settings.warhorn
+    echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
+    @use_warhorn = settings.use_warhorn
+    echo("  @use_warhorn: #{@use_warhorn}") if $debug_mode_ct
+    @last_warhorn = Time.now - 305
   end
 
   def execute(game_state)
@@ -44,6 +50,9 @@ class SetupProcess
     was_retreating = game_state.retreating?
     game_state.update_room_npcs
     if game_state.dancing?
+      if @use_warhorn
+        blow_warhorn
+      end
       game_state.dance
     elsif game_state.retreating?
       determine_next_to_train(game_state, game_state.retreat_weapons, false)
@@ -64,6 +73,16 @@ class SetupProcess
   end
 
   private
+
+  def blow_warhorn()
+    return if Time.now - @last_warhorn < 300
+    if bput("get #{@warhorn}", 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
+      bput('exhale warhorn lure','You sound a series of bursts from the warhorn','Your lungs are tired from having sounded a warhorn so recently.')
+      @last_warhorn = Time.now
+      waitrt?
+      fput("stow #{@warhorn}")
+    end
+  end
 
   def check_armor_swap(game_state)
     return if Time.now - @last_cycle_time < 120

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -73,11 +73,21 @@ class SetupProcess
   def blow_warhorn()
     return unless @warhorn
     return if Time.now - @last_warhorn < 600
-    if bput("get #{@warhorn}", 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
+
+    case bput("tap my #{@warhorn}", 'inside your', 'that you are wearing', 'I could not find what you were referring to.')
+    when 'that you are wearing'
+        get_verb = "remove"
+        store_verb = "wear"
+    else
+        get_verb = "get"
+        store_verb = "stow"
+    end
+
+    if ['You remove','You get'].include? bput("#{get_verb} my #{@warhorn}", 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
       bput('exhale warhorn lure','You sound a series of bursts from the warhorn','Your lungs are tired from having sounded a warhorn so recently.')
       @last_warhorn = Time.now
       waitrt?
-      fput("stow #{@warhorn}")
+      fput("#{store_verb} my #{@warhorn}")
     end
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -23,9 +23,7 @@ class SetupProcess
     
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
-    @use_warhorn = settings.use_warhorn
-    echo("  @use_warhorn: #{@use_warhorn}") if $debug_mode_ct
-    @last_warhorn = Time.now - 305
+    @last_warhorn = Time.now - 605
   end
 
   def execute(game_state)
@@ -50,9 +48,7 @@ class SetupProcess
     was_retreating = game_state.retreating?
     game_state.update_room_npcs
     if game_state.dancing?
-      if @use_warhorn
-        blow_warhorn
-      end
+      blow_warhorn
       game_state.dance
     elsif game_state.retreating?
       determine_next_to_train(game_state, game_state.retreat_weapons, false)
@@ -75,7 +71,8 @@ class SetupProcess
   private
 
   def blow_warhorn()
-    return if Time.now - @last_warhorn < 300
+    return unless @warhorn
+    return if Time.now - @last_warhorn < 600
     if bput("get #{@warhorn}", 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
       bput('exhale warhorn lure','You sound a series of bursts from the warhorn','Your lungs are tired from having sounded a warhorn so recently.')
       @last_warhorn = Time.now

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -23,7 +23,7 @@ class SetupProcess
     
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
-    @last_warhorn = Time.now - 605
+    @last_warhorn = Time.now - 305
   end
 
   def execute(game_state)
@@ -72,7 +72,7 @@ class SetupProcess
 
   def blow_warhorn()
     return unless @warhorn
-    return if Time.now - @last_warhorn < 600
+    return if Time.now - @last_warhorn < 300
 
     if DRCI.wearing?(@warhorn)
         get_verb = "remove"

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -120,7 +120,7 @@ tk_ammo:
 custom_loot_type:
 last_rites: false
 ambush_location: back
-
+warhorn:
 
 
 # Hunting settings


### PR DESCRIPTION
Adding warhorn lure on a 5 minute timer. Only executes if dancing (i.e too few creatures) and every 5 minutes.