### PR TITLE
Add full container item to unlootable list.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -375,7 +375,10 @@ class LootProcess
       end
     end
     pause 0.25
-    bput("drop #{item}", 'You drop') if Flags['container-full']
+    if Flags['container-full']
+      bput("drop #{item}", 'You drop')
+      game_state.unlootable(item)
+    end
 
     return unless Flags['pouch-full']
     bput("drop my #{item}", 'You drop', 'What were')


### PR DESCRIPTION
When the container is full, the item that gets dropped now is added to the unlootable list. This stops the spamming of getting and failing to stow boxes and any other item. 