### PR TITLE
[combat-trainer] Don't manipulate constructs

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1434,14 +1434,11 @@ class ManipulateProcess
     @threshold = settings.manipulate_threshold
     echo("  @threshold: #{@threshold}") if $debug_mode_ct
 
-    @construct_mode = settings.construct(false)
-    echo("  @construct_mode: #{@construct_mode}") if $debug_mode_ct
-     
     @last_manip = Time.now - 200
   end
 
   def execute(game_state)
-    return if game_state.danger || @threshold.nil? || @construct_mode
+    return if game_state.danger || @threshold.nil? || game_state.construct_mode?
     @filtered_npcs = game_state.npcs
     manipulate if should_manipulate?
   end
@@ -1459,15 +1456,15 @@ class ManipulateProcess
     npc_occurrences = Hash.new(0)
 
     @filtered_npcs.each do |npc|
-      next if construct?(npc)
+      next if game_state.construct?(npc)
       break if manipulate_count >= @threshold
 
       index = npc_occurrences[npc]
       ordinal_string = $ORDINALS[index]
 
       case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence')
-      when 'does not seem to have a life essence' then
-        construct(npc)
+      when 'does not seem to have a life essence'  then
+        game_state.construct(npc)
       else
         manipulate_count += 1
         npc_occurrences[npc] += 1
@@ -1760,7 +1757,7 @@ class AttackProcess
     @fatigue_regen_action = settings.fatigue_regen_action
     echo("  @fatigue_regen_action: #{@fatigue_regen_action}") if $debug_mode_ct
 
-    @is_empath = DRStats.empath? && !settings.construct(false)
+    @is_empath = DRStats.empath? && !game_state.construct_mode?
     echo("  @is_empath: #{@is_empath}") if $debug_mode_ct
 
     @undead = DRStats.empath? && settings.undead
@@ -2287,6 +2284,10 @@ class GameState
     echo(" @dedicated_camb_use: #{@dedicated_camb_use}") if $debug_mode_ct
 
     $thrown_skills << 'Offhand Weapon' if settings.offhand_thrown
+
+    @construct_mode = settings.construct(false)
+    echo("  @construct_mode: #{@construct_mode}") if $debug_mode_ct
+
   end
 
   def next_clean_up_step
@@ -2665,6 +2666,10 @@ class GameState
 
   def cfb_active?
     DRSpells.active_spells.include?('Call from Beyond')
+  end
+
+  def construct_mode?
+    @construct_mode
   end
 
   private

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1434,11 +1434,14 @@ class ManipulateProcess
     @threshold = settings.manipulate_threshold
     echo("  @threshold: #{@threshold}") if $debug_mode_ct
 
+    @construct_mode = settings.construct(false)
+    echo("  @construct_mode: #{@construct_mode}") if $debug_mode_ct
+     
     @last_manip = Time.now - 200
   end
 
   def execute(game_state)
-    return if game_state.danger || @threshold.nil?
+    return if game_state.danger || @threshold.nil? || @construct_mode
     @filtered_npcs = game_state.npcs
     manipulate if should_manipulate?
   end
@@ -1456,14 +1459,19 @@ class ManipulateProcess
     npc_occurrences = Hash.new(0)
 
     @filtered_npcs.each do |npc|
+      next if construct?(npc)
       break if manipulate_count >= @threshold
 
       index = npc_occurrences[npc]
       ordinal_string = $ORDINALS[index]
 
-      bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain')
-      manipulate_count += 1
-      npc_occurrences[npc] += 1
+      case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'no life force')
+      when 'no life force' then
+        construct(npc)
+      else
+        manipulate_count += 1
+        npc_occurrences[npc] += 1
+      end
     end
 
     @last_manip = Time.now

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1465,8 +1465,8 @@ class ManipulateProcess
       index = npc_occurrences[npc]
       ordinal_string = $ORDINALS[index]
 
-      case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'no life force')
-      when 'no life force' then
+      case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence')
+      when 'does not seem to have a life essence' then
         construct(npc)
       else
         manipulate_count += 1


### PR DESCRIPTION
Ensures if you run `;combat-trainer construct` you won't manipulate mobs, and adds a catch if you accidentally do (e.g. in mixed groups).