### PR TITLE
[combat-trainer] Support blowguns

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2201,6 +2201,11 @@ class GameState
 
     @weapons_to_train = settings.weapon_training
     echo("  @weapons_to_train: #{@weapons_to_train}") if $debug_mode_ct
+    if is_brawling_ranged?
+      echo("  Augmenting ranged groups due to brawling with blowgun") if $debug_mode_ct
+      $aim_skills << 'Brawling'
+      $ranged_skills << 'Brawling'
+    end
 
     @use_stealth_attacks = settings.use_stealth_attacks
     echo("  @use_stealth_attacks: #{@use_stealth_attacks}") if $debug_mode_ct
@@ -2482,7 +2487,11 @@ class GameState
   end
 
   def brawling?
-    weapon_skill == 'Brawling'
+    weapon_skill == 'Brawling' && !is_brawling_ranged?
+  end
+
+  def is_brawling_ranged?
+    /(?:\b|^)blowgun(?:\b|$)/i.match(weapon_training['Brawling'])
   end
 
   def use_stealth_attack?

--- a/data/base-items.yaml
+++ b/data/base-items.yaml
@@ -9,6 +9,8 @@ lootables:
 - arrow
 - arrows
 - rock
+- blowgun dart
+- blowgun darts
 # valuable loot
 - copper coin
 - bronze coin


### PR DESCRIPTION
Blowguns turn Brawling from hand-to-hand combat into a ranged skill,
like bows. This change:

* Adds blowgun darts to the loot list
* Detects a blowgun and if present, aiming and firing as normal

Syntax in the YAML files remains the same as other weapons:

```yaml
weapons_to_train:
  Brawling: bone blowgun
gear:
- :name: blowgun
  :adjective: bone
  :is_leather: true
  :is_worn: true
  :hinders_lockpicking: false
```