### PR TITLE
[combat-trainer.lic] Fix variable undefined error in AttackProcess

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -20,7 +20,7 @@ class SetupProcess
     @cycle_armors = settings.cycle_armors
     echo("  @cycle_armors: #{@cycle_armors}") if $debug_mode_ct
     @last_cycle_time = Time.now - 125
-    
+
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
     @last_warhorn = Time.now - 305
@@ -82,7 +82,7 @@ class SetupProcess
   def blow_warhorn(game_state)
     return unless @warhorn
     return if Time.now - @last_warhorn < 600
-    
+
     game_state.sheath_whirlwind_offhand
 
     case bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
@@ -1764,7 +1764,7 @@ class AttackProcess
     @fatigue_regen_action = settings.fatigue_regen_action
     echo("  @fatigue_regen_action: #{@fatigue_regen_action}") if $debug_mode_ct
 
-    @is_empath = DRStats.empath? && !game_state.construct_mode?
+    @is_empath = DRStats.empath?
     echo("  @is_empath: #{@is_empath}") if $debug_mode_ct
 
     @undead = DRStats.empath? && settings.undead
@@ -1787,6 +1787,11 @@ class AttackProcess
   end
 
   def execute(game_state)
+    if @is_empath && game_state.construct_mode?
+      @is_empath = false
+      echo '  setting @is_empath to false due to construct_mode override' if $debug_mode_ct
+    end
+
     check_face(game_state)
     if game_state.npcs.uniq.length == 1 && !game_state.stabbable?(game_state.npcs.uniq.first)
       game_state.no_stab_current_mob = true


### PR DESCRIPTION
Fixes the issue described in #2094:

```
--- Lich: error: undefined local variable or method `game_state' for #<Scripting::AttackProcess:0x007fb369b17d48>
	combat-trainer:1767:in `initialize'
	combat-trainer:2101:in `new'
--- Lich: combat-trainer has exited.
```