### PR TITLE
[combat-trainer.lic] Fix inverted logic

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1839,7 +1839,7 @@ class AttackProcess
 
   def attack_melee(charged_maneuver, game_state)
     waitrt?
-    if charged_maneuver
+    unless charged_maneuver
       if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush?
         hide?(@hide_type)
       end
@@ -1926,7 +1926,7 @@ class AttackProcess
     game_state.clear_aim_queue if Flags['ct-ranged-ready']
 
     if game_state.loaded && game_state.done_aiming?
-      if game_state.selected_maneuver
+      unless game_state.selected_maneuver
         command = if game_state.use_stealth_attack? && hide?(@hide_type)
                     @stealth_attack_aimed_action
                   else
@@ -1954,7 +1954,7 @@ class AttackProcess
 
       waitrt?
       game_state.loaded = true
-      if game_state.selected_maneuver
+      unless game_state.selected_maneuver
         game_state.set_aim_queue
         aim(game_state)
         Flags.reset('ct-ranged-ready')


### PR DESCRIPTION
Switching from `if charged_maneuver.empty?` to `if charged_maneuver` inverted the logic.

```ruby
if ''.empty? # true
if nil       # false
```

Switched the affected checks from `if` to `unless` in order to restore the logic.