### PR TITLE
fix exiting Junk Room

### DIFF
--- a/steal.lic
+++ b/steal.lic
@@ -274,10 +274,6 @@ class Steal
     waitrt?
   end
 
-      end
-    waitrt?
-  end
-
   def put_item?(item)
     case bput("put my #{item} in my #{@stealing_bag}", 'You put', 'no matter how you arrange it', 'The .* is too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again')
     when 'perhaps try doing that again'

--- a/steal.lic
+++ b/steal.lic
@@ -256,7 +256,18 @@ class Steal
 
         drop_item(item) unless keep_item
 
-        move('go portal') if XMLData.room_title == '[[A Junk Yard]]'
+        if XMLData.room_title == '[[A Junk Yard]]'
+		      case bput('look portal', 'You are now able to go through', 'You must get below', 'Please get rid of')
+		      when 'You are now able to go through'
+		        move('go portal')
+		      else
+		        bin_item
+		      end
+		    end
+      end
+    waitrt?
+  end
+
       end
     waitrt?
   end

--- a/steal.lic
+++ b/steal.lic
@@ -239,7 +239,13 @@ class Steal
           # Stop binning future items and drop this item
           @bin_stolen = false
           # Dispose of one extra item to stay under the item limit
-          last_stolen = @bin_items.pop
+	  if @bin_item.any?
+            last_stolen = @bin_items.pop
+	  else
+	    echo('*** All stolen items have been dropped. ***')
+	    echo('*** Please manually reduce your item count and restart steal.lic. ***')
+	    exit
+	  end
           bput("get my #{last_stolen} from my #{@stealing_bag}", 'You get', 'What were you') if last_stolen
           dispose_trash(last_stolen)
         end
@@ -257,13 +263,13 @@ class Steal
         drop_item(item) unless keep_item
 
         if XMLData.room_title == '[[A Junk Yard]]'
-		      case bput('look portal', 'You are now able to go through', 'You must get below', 'Please get rid of')
-		      when 'You are now able to go through'
-		        move('go portal')
-		      else
-		        bin_item
-		      end
-		    end
+          case bput('look portal', 'You are now able to go through', 'You must get below', 'Please get rid of')
+          when 'You are now able to go through'
+            move('go portal')
+          else
+            bin_item
+          end
+        end
       end
     waitrt?
   end

--- a/steal.lic
+++ b/steal.lic
@@ -239,7 +239,7 @@ class Steal
           # Stop binning future items and drop this item
           @bin_stolen = false
           # Dispose of one extra item to stay under the item limit
-	  if @bin_item.any?
+	  if @bin_items.any?
             last_stolen = @bin_items.pop
 	  else
 	    echo('*** All stolen items have been dropped. ***')


### PR DESCRIPTION
It appears there was a recent change where dropping 1 item doesn't always let you exit the Junk Room. This caused the ;steal script to stall in the Junk Room when dropping 1 item didn't allow an exit.

The proposed change looks at the portal after each dropped item until the portal indicates it is safe to exit.