### PR TITLE
[chop, mine] Prevent partial room item matches

### DIFF
--- a/chop-wood.lic
+++ b/chop-wood.lic
@@ -57,7 +57,7 @@ class ChopWood
     waitrt?
 
     @loot_list.each do |item|
-      matches = DRRoom.room_objs.grep(/\b#{item}/i)
+      matches = DRRoom.room_objs.grep(/(?:\b|^)#{item}(?:\b|$)/i)
       matches.each do |match|
         if @use_packet && packet?
           bput("push #{item} #{match.scan(/\w+/).last} with my packet", 'You push')

--- a/mine.lic
+++ b/mine.lic
@@ -85,7 +85,7 @@ class Mine
     waitrt?
 
     @loot_list.each do |item|
-      matches = DRRoom.room_objs.grep(/\b#{item}/i)
+      matches = DRRoom.room_objs.grep(/(?:\b|^)#{item}(?:\b|$)/i)
       matches.each do |match|
         next if @ignored_rock_sizes.any? { |x| match =~ /#{x}/i }
         noun = match.scan(/\w+/).last


### PR DESCRIPTION
Fixes a bug where lich attempts to stow room objects that are partial
matches to your loot list. For example, if you add `Lead` to your
`mining_buddy_vein_list` array, you'll experience this in Dirge's Wicked
Barrow Mines:

```
> l
... You also see an opening leading outside.
> ;mine
...
> mine
...
> stow outside
```