### PR TITLE
fixing warhorn timer error

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -81,7 +81,7 @@ class SetupProcess
 
   def blow_warhorn(game_state)
     return unless @warhorn
-    return if Time.now - @last_warhorn < 600
+    return if Time.now - @last_warhorn < 300
 
     game_state.sheath_whirlwind_offhand
 


### PR DESCRIPTION
for some reason the timer was checking for 600 seconds. moving it back to 300.