### PR TITLE
[base.yaml] Update lumber, ore and rocks

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -320,27 +320,55 @@ forests_to_chop:
 lumber_skip_populated: true
 lumber_buddy_chop_every_room: false
 lumber_buddy_tree_list:
-# MISC
-#- Durian
 # common
-# - Ash #shortbows
-# - Birch #composite
-# - Maple #longbows
-# - Oak #martial
-# rare
-- Cherry #shortbows
-- Ramin #longbows
-- Hickory #Composite
-- Lelori #Composite
+- Ash #shortbows
+- Bamboo # martial
+- Durian # martial
+- Mahogany # martial
+- Mangrove #martial, shortbows
+- Maple #longbows
 - Sandalwood #Composite
-#- Ironwood #martial
-# very rare
-- Bloodwood
-- Copperwood
-- Mistwood
-- Goldwood
-- Azurelle
-- Silverwood
+# rare
+- Adder # Alterations
+- Aformosia # Alterations
+- Albarco # shortbow
+- Alerce # Alterations
+- Avodire # composite
+- Azurelle # longbows
+- Bloodwood # longbows, shortbows
+- Bocote # martial
+- Cherry # longbows
+- Copperwood # longbows
+- Crabwood # martial
+- Darkspine	# martial
+- Diamondwood	# martial
+- Dragonwood # alterations
+- E'erdream # ???
+- Felwood # martial, shortbows, composite
+- Finivire # all bows
+- Glitvire # ???
+- Gloomwood # ???
+- Goldwood # longbows, shortbows
+- Greenheart # martial
+- Hickory # martial, composite
+- Ilomba # Alterations
+- Iroko # Alterations
+- Ironwood #martial
+- Kapok # alterations
+- Lelori #Composite
+- Macawood #alterations
+- Mistwood # longbow, shortbow
+- Osage	# longbows
+- Ramin # longbows
+- Redwood	# alterations
+- Rockwood # martial
+- Rosewood # longbows
+- Shadowbark # ???
+- Silverwood # shortbows, composite bows
+- Smokewood	# alterations
+- Tamarak	# alterations
+- Tamboti	# ???
+- Yew	# Longbows
 lumber_implement: axe
 lumber_use_packet: true
 lumber_while_training: false
@@ -356,22 +384,52 @@ mines_to_mine:
 mining_skip_populated: true
 mining_buddy_mine_every_room: false
 mining_buddy_vein_list:
-# uncommon
+# common
+- Covellite
+- Lead
+- Oravir
 - Silver
-# rare
-- Gold
-- Platinum
-- Lumium
-- Niniam
+# alchemy
 - Electrum
+- Kadepa
 - Muracite
-- Darkstone
-# very rare
-- Damite
-- Kertig
-- Haralun
-- Glaes
+- Niello
+- Niniam
+- Orichalcum
+# forging
+- Aldamdin
 - Animite
+- Audrualm
+- Damite
+- Darkstone
+- Glaes
+- Haledroth
+- Haralun
+- Icesteel
+- Indurium
+- Kertig
+- Kiralan
+- Lumium
+- Platinum
+- Quelium
+- Silversteel
+- Telothian
+- Tyrium
+- Vardite
+- Yellow gold
+# engineering
+# common
+# - Obsidian
+# - Quartize
+# rare
+- Anjisis
+- Belzune
+- Blackwater jet
+- Diamondique
+- Felstone
+- Fulginode
+- Senci
+- Xenomite
 mining_ignored_stone_sizes:
 - pebble
 mining_implement: shovel

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -387,7 +387,6 @@ mining_buddy_vein_list:
 # common
 - Covellite
 - Lead
-- Oravir
 - Silver
 # alchemy
 - Electrum


### PR DESCRIPTION
Adds all rare and the useful common ore types to base.yaml in order to ensure auto-harvesting does
not drop something potentially valuable. Some of these may not drop from from harvesting,
but better safe than sorry.