### PR TITLE
base-crafting.yaml: dedupe the leth settings with anchors.

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -1,6 +1,6 @@
 ---
 blacksmithing:
-  Crossing:
+  Crossing: &zoluren_blacksmithing
     npc: Yalda
     npc_last_name: Yalda
     npc-rooms:
@@ -55,59 +55,7 @@ blacksmithing:
     trash-room: 8773
     idle-room: 8775
   Leth Deriel:
-    npc: Yalda
-    npc_last_name: Yalda
-    npc-rooms:
-      - 8771
-      - 8772
-      - 8775
-      - 8776
-      - 8777
-      - 8778
-      - 8773
-      - 8779
-      - 8774
-      - 19030
-    anvils:
-      - 8909
-      - 8910
-      - 8911
-#     - 8777 TODO: Reenable when the room is working
-      - 8778
-      - 760
-      - 19_252
-      - 19_211
-      - 50_270
-      - 19_267
-    crucibles:
-      - 8774
-      - 19_030
-      - 8773
-      - 8777
-      - 8779
-    grindstones:
-      - 8909
-      - 8910
-      - 8911
-      - 50_270
-      - 19_267
-      - 19_261
-      - 19_252
-      - 19_255
-    logbook: forging
-    pattern-book: blacksmithing
-    finisher: oil
-    finisher-full: flask of oil
-    finisher-room: 8776
-    finisher-number: 6
-    repair-room: 8776
-    repair-npc: clerk
-    stock-volume: 5
-    stock-room: 8775
-    stock-number: 11
-    stock-name: bronze ingot
-    trash-room: 8773
-    idle-room: 8775
+    << : *zoluren_blacksmithing
   Riverhaven:
     npc: Fereldrin
     npc_last_name: Fereldrin
@@ -322,7 +270,7 @@ blacksmithing:
     idle-room: 8808
 
 tailoring:
-  Crossing:
+  Crossing: &zoluren_tailoring
     npc: Milline
     npc_last_name: Milline
     npc-rooms:
@@ -355,37 +303,7 @@ tailoring:
     pattern-book: tailoring
     idle-room:
   Leth Deriel:
-    npc: Milline
-    npc_last_name: Milline
-    npc-rooms:
-    - 16657
-    - 16656
-    - 16659
-    - 16665
-    - 16668
-    - 16667
-    - 16661
-    - 16663
-    sewing-rooms:
-    - 19_037
-    - 19_036
-    - 16_670
-    # - 19_063
-    - 19_064
-    - 19_065
-    spinning-rooms:
-    - 16670
-    - 19036
-    - 19037
-    logbook: outfitting
-    repair-room: 16659
-    repair-npc: clerk
-    stock-room: 16667
-    tool-room: 16668
-    sew-stock-number: 8
-    knit-stock-number: 13
-    pattern-book: tailoring
-    idle-room:
+    << : *zoluren_tailoring
   Riverhaven:
     npc: Hagim
     npc_last_name: Hagim
@@ -486,7 +404,7 @@ tailoring:
     pattern-book: tailoring
     idle-room: 9127
 shaping:
-  Crossing:
+  Crossing: &zoluren_shaping
     npc: Talia
     npc_last_name: Volmogen
     npc-rooms:
@@ -532,28 +450,7 @@ shaping:
     part-room: 9119
     idle-room: 9119
   Leth Deriel:
-    npc: Talia
-    npc_last_name: Volmogen
-    npc-rooms:
-    - 8867
-    - 8864
-    - 8865
-    - 8868
-    - 19209
-    shaping-rooms:
-    - 9056
-    - 9057
-    - 9058
-    logbook: engineering
-    repair-room: 19209
-    repair-npc: Rangu
-    stock-room: 8864
-    stock-number: 11
-    stock-name: balsa
-    stock-volume: 10
-    pattern-book: shaping
-    part-room: 8864
-    idle-room: 8867 
+    << : *zoluren_shaping
   Riverhaven:
     npc: Paarupensteen
     npc_last_name: Paarupensteen
@@ -618,7 +515,7 @@ shaping:
     - 9579
     - 9580
 carving:
-  Crossing:
+  Crossing: &zoluren_carving
     npc: Talia
     npc_last_name: Volmogen
     npc-rooms:
@@ -643,29 +540,7 @@ carving:
     stock-bone-volume: 10
     pattern-book: carving
   Leth Deriel:
-    npc: Talia
-    npc_last_name: Volmogen
-    npc-rooms:
-    - 8867
-    - 8864
-    - 8865
-    - 8868
-    - 19209
-    logbook: engineering
-    polish: polish
-    polish-full: jar of surface polish
-    polish-room: 8865
-    polish-number: 4
-    repair-room: 19209
-    repair-npc: Rangu
-    stock-room: 8864
-    stock-number: 1
-    stock-name: alabaster
-    stock-volume: 1
-    stock-bone-number: 8
-    stock-bone-name: wolf
-    stock-bone-volume: 10
-    pattern-book: carving
+    << : *zoluren_carving
   Riverhaven:
     npc: Paarupensteen
     npc_last_name: Paarupensteen
@@ -719,7 +594,7 @@ carving:
     - 9580
 
 remedies:
-  Crossing:
+  Crossing: &zoluren_remedies
     npc: Lanshado
     npc_last_name: Lanshado
     npc-rooms:
@@ -744,29 +619,7 @@ remedies:
     catalyst_number: 2
     catalyst_volume: 10
   Leth Deriel:
-    npc: Lanshado
-    npc_last_name: Lanshado
-    npc-rooms:
-    - 8859
-    - 8860
-    - 8861
-    - 8862
-    - 8863
-    logbook: alchemy
-    repair-room: 8860
-    repair-npc: clerk
-    stock-room: 8862
-    stock-number: 1
-    stock-name: water
-    stock-volume: 10
-    stock-number-a: 2
-    stock-name-a: alcohol
-    stock-volume-a: 10
-    pattern-book: remed
-    catalyst: coal nugget
-    catalyst-room: 8775
-    catalyst_number: 2
-    catalyst_volume: 10
+    << : *zoluren_remedies
   Riverhaven:
     npc: Carmifex
     npc_last_name: Carmifex


### PR DESCRIPTION
I made hometown: leth go to crossing for crafting by duplicating the crossing settings, this lets us only have to update crossing for changes