### PR TITLE
theurgy.lic: add new failure messages if you dont have favors.

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -390,6 +390,7 @@ class TheurgyActions
     get_from_container(@water_holder)
     match = bput('commune eluned',
                  'completed this commune too recently',
+                 'You struggle to commune',
                  'you have attempted a commune too recently in the past',
                  'You grind some dirt in your fist')
     put_in_container(@water_holder)
@@ -412,6 +413,7 @@ class TheurgyActions
          'Sprinkle what?')
     match = bput('commune tamsine',
                  'completed this commune too recently',
+                 'You struggle to commune',
                  'you have attempted a commune too recently in the past',
                  'You feel warmth spread throughout your body')
     put_in_container(@water_holder)


### PR DESCRIPTION
these 2 communes are at circles 2 and 3, its highly possible someone doesn't
have favors by then thanks to the divine charm and it would get stuck.

The messaging is "You struggle to commune, but feel somehow too hollow to channel foo"