### PR TITLE
Prayer mat rituals in combat

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1667,11 +1667,23 @@ class TrainerProcess
   end
 
   def pray_mat(game_state)
+    unless @prayer_mat && @theurgy_supply_container
+      echo '*** Cannot run PrayerMat; need prayer_mat and theurgy_supply_container defined'
+      @training_abilities.delete('PrayerMat')
+      return
+    end
     waitrt?
     retreat
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
-    fput "get #{@prayer_mat} from my #{@theurgy_supply_container}"
+    unless bput(
+      "get #{@prayer_mat} from my #{@theurgy_supply_container}",
+      'You get', 'What were you referring to'
+    ) == 'You get'
+      echo '*** Cannot run PrayerMat; no prayer mat in theurgy_supply_container'
+      @training_abilities.delete('PrayerMat')
+      return
+    end
     fix_standing
     bput("unroll #{@prayer_mat}",
          'reverently lay your', 'need to be holding that first')
@@ -1679,8 +1691,9 @@ class TrainerProcess
     bput("kneel #{@prayer_mat}", 'You humbly kneel')
     bput("kiss #{@prayer_mat}", 'You bend forward to kiss')
 
-    fput "get wine from my #{@theurgy_supply_container}"
-    bput("pour wine on #{@prayer_mat || 'altar'}",
+    bput("get wine from my #{@theurgy_supply_container}",
+         'You get', 'What were you referring to')
+    bput("pour wine on #{@prayer_mat}",
          'You quietly pour', 'Pour what')
     bput("put wine in my #{@theurgy_supply_container}",
          'You put', 'What were you referring to')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1493,7 +1493,7 @@ class TrainerProcess
     echo("  @training_abilities: #{@training_abilities}") if $debug_mode_ct
 
     @skill_map = { 'Hunt' => 'Perception', 'Pray' => 'Theurgy', 'PercMana' => 'Attunement',
-                   'Perc' => 'Attunement', 'Astro' => 'Astrology', 'App' => 'Appraisal',
+                   'Perc' => 'Attunement', 'Astro' => 'Astrology', 'App' => 'Appraisal', 'PrayerMat' => 'Theurgy',
                    'App Quick' => 'Appraisal', 'App Careful' => 'Appraisal', 'Tactics' => 'Tactics', 'Analyze' => 'Tactics',
                    'Scream' => 'Bardic Lore', 'Perc Health' => 'Empathy', 'Khri Prowess' => 'Debilitation',
                    'Stealth' => 'Stealth', 'Ambush Stun' => settings.stun_skill, 'Favor Orb' => 'Anything',
@@ -1532,6 +1532,9 @@ class TrainerProcess
 
     @flint_lighter = settings.flint_lighter
     echo("  @flint_lighter: #{@flint_lighter}") if $debug_mode_ct
+
+    @prayer_mat = settings.prayer_mat
+    echo("  @prayer_mat: #{@prayer_mat}") if $debug_mode_ct
 
     @kneel_khri = settings.kneel_khri
     echo("  @kneel_khri: #{@kneel_khri}") if $debug_mode_ct
@@ -1595,6 +1598,8 @@ class TrainerProcess
       game_state.use_charged_maneuvers = true
     when 'Meraud'
       meraud_commune(game_state)
+    when 'PrayerMat'
+      pray_mat(game_state)
     when 'Recall'
       bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
     when 'Barb Research Augmentation'
@@ -1659,6 +1664,34 @@ class TrainerProcess
     waitrt?
     fix_standing
     game_state.blessed_room = true
+  end
+
+  def pray_mat(game_state)
+    waitrt?
+    retreat
+    @equipment_manager.stow_weapon(game_state.weapon_name)
+
+    fput "get #{@prayer_mat} from my #{@theurgy_supply_container}"
+    fix_standing
+    bput("unroll #{@prayer_mat}",
+         'reverently lay your', 'need to be holding that first')
+
+    bput("kneel #{@prayer_mat}", 'You humbly kneel')
+    bput("kiss #{@prayer_mat}", 'You bend forward to kiss')
+
+    fput "get wine from my #{@theurgy_supply_container}"
+    bput("pour wine on #{@prayer_mat || 'altar'}",
+         'You quietly pour', 'Pour what')
+    bput("put wine in my #{@theurgy_supply_container}",
+         'You put', 'What were you referring to')
+    fix_standing
+
+    bput("roll #{@prayer_mat}",
+         'carefully gather up',
+         'need to be holding that first', 'not on the ground')
+    bput("put #{@prayer_mat} in my #{@theurgy_supply_container}",
+         'You put', 'What were you referring to')
+    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end
 
   def ambush_stun(game_state)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -121,6 +121,7 @@ custom_loot_type:
 last_rites: false
 ambush_location: back
 warhorn:
+prayer_mat:
 
 
 # Hunting settings

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -123,7 +123,6 @@ ambush_location: back
 warhorn:
 prayer_mat:
 
-
 # Hunting settings
 training_manager_hunting_priority: false
 training_manager_priority_skills:
@@ -707,5 +706,5 @@ theurgy_blacklist:
 - embarass_myself
 theurgy_exp_threshold: 0
 theurgy_bead_carving_tool:
-theurgy_prayer_mat:
+theurgy_use_prayer_mat: false
 theurgy_prayer_mat_room:

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -29,7 +29,7 @@ class TheurgyActions
     @water_holder = @settings.water_holder
     @flint_lighter = @settings.flint_lighter
 
-    @prayer_mat = @settings.theurgy_prayer_mat
+    (@prayer_mat = @settings.prayer_mat) if @settings.theurgy_use_prayer_mat
     @prayer_mat_room = @settings.theurgy_prayer_mat_room
 
     @known_spells = check_spells


### PR DESCRIPTION
Note: I named the yaml setting `prayer_mat` rather than reusing `theurgy_prayer_mat` because the presence of `theurgy_prayer_mat` turns on prayer mat use in theurgy.lic, which shouldn't be linked to using the mat in combat.