### PR TITLE
Update Healme to use waggle sets, more spells, and current check_health method

### DIFF
--- a/healme.lic
+++ b/healme.lic
@@ -155,6 +155,9 @@ class HealMe
       wounds.sort_by { |_, val| severity(val) }.reverse_each { |_, wound| heal_wounds(wound, skip_parts) }
     end
 
+    cure_disease(spells, health)
+    flush_poisons(spells, health)
+
     stow_cambrinth(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap)
   end
 end

--- a/healme.lic
+++ b/healme.lic
@@ -105,6 +105,8 @@ class HealMe
   end
 
   def heal_self(skip_parts)
+    return unless DRStats.empath?
+
     Flags.delete('hm-partial-heal')
     Flags.add('hm-partial-heal',
               'appear very slightly improved\.',

--- a/healme.lic
+++ b/healme.lic
@@ -150,6 +150,7 @@ class HealMe
       wounds.sort_by { |_, val| severity(val) }.reverse_each { |_, wound| heal_wounds(wound, skip_parts) }
     end
 
+    health = check_health
     cure_disease(spells, health)
     flush_poisons(spells, health)
 

--- a/healme.lic
+++ b/healme.lic
@@ -129,7 +129,11 @@ class HealMe
              end
     find_cambrinth(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap)
 
-    if @settings.empath_healing['HEAL'] && skip_parts.nil?
+    DRCA.cast_spell(spells['Regenerate'], @settings) if spells['Regenerate'] && !DRSpells.active_spells.include?('Regenerate')
+
+    if spells['Heal'] && using_waggle && skip_parts.nil?
+      spam_heal(@settings.waggle_sets['healing']['Heal']['mana'], @settings.waggle_sets['healing']['Heal']['cambrinth'])
+    elsif @settings.empath_healing['HEAL'] && skip_parts.nil?
       spam_heal(@settings.empath_healing['HEAL'].first, @settings.empath_healing['HEAL'][1..-1])
     else
       wounds = check_perc_health

--- a/healme.lic
+++ b/healme.lic
@@ -118,6 +118,15 @@ class HealMe
               'appear somewhat better\.',
               'appear considerably better\.')
 
+    health = check_health
+ 
+    using_waggle = false
+    spells = if @settings.waggle_sets['healing']
+               using_waggle = true
+               @settings.waggle_sets['healing']
+             else
+               @settings.empath_healing
+             end
     find_cambrinth(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap)
 
     if @settings.empath_healing['HEAL'] && skip_parts.nil?

--- a/healme.lic
+++ b/healme.lic
@@ -77,6 +77,33 @@ class HealMe
     heal_scar(wounds.first['part'])
   end
 
+  def need_healing?(health=nil)
+    health = check_health unless health
+    !health['wounds'].empty? || health['diseased'] || health['poisoned']
+  end
+  
+  def cure_disease(spells, health)
+    return unless health['diseased']
+    return unless spells['Cure Disease']
+
+    Flags.add('hm-disease', 'You feel completely cured of all disease', 'you don.t seem to be so afflicted')
+    until Flags['hm-disease']
+      DRCA.cast_spell(spells['Cure Disease'], @settings)
+    end
+    Flags.delete('hm-disease')
+  end
+
+  def flush_poisons(spells, health)
+    return unless health['poisoned']
+    return unless spells['Flush Poisons']
+
+    Flags.add('hm-poison', '^A sudden wave of heat washes over you as your spell attempts to flush poison from your body but finds no toxins', '^A sudden wave of heat washes over you as your spell flushes all poison from your body')
+    until Flags['hm-poison']
+      DRCA.cast_spell(spells['Flush Poisons'], @settings)
+    end
+    Flags.delete('hm-poison')
+  end
+
   def heal_self(skip_parts)
     Flags.delete('hm-partial-heal')
     Flags.add('hm-partial-heal',

--- a/healme.lic
+++ b/healme.lic
@@ -77,11 +77,6 @@ class HealMe
     heal_scar(wounds.first['part'])
   end
 
-  def need_healing?(health=nil)
-    health = check_health unless health
-    !health['wounds'].empty? || health['diseased'] || health['poisoned']
-  end
-  
   def cure_disease(spells, health)
     return unless health['diseased']
     return unless spells['Cure Disease']
@@ -118,8 +113,9 @@ class HealMe
               'appear somewhat better\.',
               'appear considerably better\.')
 
-    health = check_health
- 
+    wounds = check_perc_health
+    return if wounds.empty?
+
     using_waggle = false
     spells = if @settings.waggle_sets['healing']
                using_waggle = true
@@ -136,7 +132,6 @@ class HealMe
     elsif @settings.empath_healing['HEAL'] && skip_parts.nil?
       spam_heal(@settings.empath_healing['HEAL'].first, @settings.empath_healing['HEAL'][1..-1])
     else
-      wounds = check_perc_health
 
       skip_parts = skip_parts.split(',').map(&:upcase).map(&:strip)
 


### PR DESCRIPTION
1. Add waggle_set support for
    * Regenerate
    * Heal
    * Flush Poisons
    * Cure Disease
2. Use `common-healing::check_health` to look for poison, disease, and wounds
3. Use a waggle_set called 'healing' to handle new spell data. The old `empath_healing` still works.
