### PR TITLE
Update check_health for nerve poison

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -181,12 +181,12 @@ module DRCH
     data = reget(300).reverse
     data.each do |line|
       case line
-      when /^You have (?!no significant injuries)(?!.* lodged into your)(?!.* infection)(?!.* poisoned)(?!.* #{all_parasites_re})/
+      when /^You have (?!no significant injuries)(?!.* lodged into your)(?!.* infection)(?!.* poison(?:ed)?)(?!.* #{all_parasites_re})/
         wounds_line = line
         break
       when /^You have a dormant infection/, /^Your wounds are infected/
         diseased = true
-      when /^You have .* poisoned/
+      when /^You have .* poison(?:ed)?/
         poisoned = true
       when /^You have a .* on your/, all_parasites_re
         parasites_line = line


### PR DESCRIPTION
Nerve poison has slightly different messaging than the regular variant ('poisoned' rather than 'poison').