### PR TITLE
Harness when Arcana full. 

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -837,7 +837,7 @@ class Bescort
     end
     if entering_ap
       focus_shard(shard) if DRStats.circle < 100
-      3.times { harness_mana(['20']) }
+      harness_mana(['20', '20', '20'])
       waitcastrt?
       if DRStats.circle > 99
         unless cast?('cast grazhir')

--- a/bescort.lic
+++ b/bescort.lic
@@ -801,7 +801,7 @@ class Bescort
   def power_walk(pattern)
     fput 'exit' if dead? || Flags['ap-danger']
     if Flags['harness-check']
-      harness_mana(['20']) unless Flags['harness-check'].include?('effortlessly')
+      harness_mana([20]) unless Flags['harness-check'].include?('effortlessly')
       Flags.reset('harness-check')
     end
     result = bput('pow', pattern)
@@ -837,7 +837,7 @@ class Bescort
     end
     if entering_ap
       focus_shard(shard) if DRStats.circle < 100
-      harness_mana(['20', '20', '20'])
+      harness_mana([20, 20, 20])
       waitcastrt?
       if DRStats.circle > 99
         unless cast?('cast grazhir')

--- a/bescort.lic
+++ b/bescort.lic
@@ -801,7 +801,7 @@ class Bescort
   def power_walk(pattern)
     fput 'exit' if dead? || Flags['ap-danger']
     if Flags['harness-check']
-      harness_mana(20) unless Flags['harness-check'].include?('effortlessly')
+      harness_mana(['20']) unless Flags['harness-check'].include?('effortlessly')
       Flags.reset('harness-check')
     end
     result = bput('pow', pattern)
@@ -837,7 +837,7 @@ class Bescort
     end
     if entering_ap
       focus_shard(shard) if DRStats.circle < 100
-      3.times { harness_mana(20) }
+      3.times { harness_mana(['20']) }
       waitcastrt?
       if DRStats.circle > 99
         unless cast?('cast grazhir')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -810,9 +810,6 @@ class SpellProcess
     @stored_cambrinth = settings.stored_cambrinth
     echo(" @stored_cambrinth: #{@stored_cambrinth}") if $debug_mode_ct
 
-    @harness_for_attunement = settings.use_harness_when_arcana_locked
-    echo(" @harness_for_attunement: #{@harness_for_attunement}") if $debug_mode_ct
-
     @ignored_npcs = settings.ignored_npcs
     echo(" @ignored_npcs: #{@ignored_npcs}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -976,6 +976,7 @@ class SpellProcess
 
   def check_current(game_state)
     return unless game_state.casting
+
     if @should_invoke
       return if game_state.check_charging? && game_state.check_charging?
     end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -810,6 +810,9 @@ class SpellProcess
     @stored_cambrinth = settings.stored_cambrinth
     echo(" @stored_cambrinth: #{@stored_cambrinth}") if $debug_mode_ct
 
+    @harness_for_attunement = settings.use_harness_when_arcana_locked
+    echo(" @harness_for_attunement: #{@harness_for_attunement}") if $debug_mode_ct
+
     @ignored_npcs = settings.ignored_npcs
     echo(" @ignored_npcs: #{@ignored_npcs}") if $debug_mode_ct
 
@@ -976,9 +979,14 @@ class SpellProcess
 
   def check_current(game_state)
     return unless game_state.casting
-    return if game_state.check_charging? && game_state.check_charging?
+    if @should_invoke
+      return if game_state.check_charging? && game_state.check_charging?
+    end
 
-    cast_spell(game_state) if ready_to_cast?(game_state)
+    if ready_to_cast?(game_state) 
+      game_state.check_harness if @should_harness
+      cast_spell(game_state) 
+    end
   end
 
   def check_invoke
@@ -1260,7 +1268,10 @@ class SpellProcess
     prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
     game_state.casting = true
     game_state.cambrinth_charges(data['cambrinth'])
-    @should_invoke = data['cambrinth']
+    if data['cambrinth'] 
+      @should_harness = check_to_harness(@harness_for_attunement)
+      @should_invoke = data['cambrinth'] unless @should_harness
+    end
     @custom_cast = data['cast']
     @symbiosis = data['symbiosis']
     @after = data['after']
@@ -2609,6 +2620,20 @@ class GameState
     stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
 
     true
+  end
+
+  def check_harness
+    return if @charges.nil?
+
+    if @charges.empty?
+      echo('check_harness?: done') if $debug_mode_ct
+      cambrinth_charges(nil)
+      return
+    end
+
+    harness_mana(@charges)
+
+    @charges = []
   end
 
   def npcs

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -24,7 +24,7 @@ module DRCA
 
     loop do
       pause 5 while mana <= amount
-      harness_mana(amount) if harness
+      harness_mana(['amount']) if harness
       break if success.include?(DRC.bput("infuse om #{amount}", success, failure))
       pause 0.5
       waitrt?
@@ -32,9 +32,12 @@ module DRCA
   end
 
   def harness_mana(amount)
-    DRC.bput("harness #{amount}", 'You tap into', 'Strain though you may')
-    pause 0.5
-    waitrt?
+    amount.each { |mana|
+      result = DRC.bput("harness #{mana}", 'You tap into', 'Strain though you may')
+      pause 0.5
+      waitrt?
+      break if result =~ /Strain though you may/
+    }
   end
 
   def activate_khri?(kneel, ability)
@@ -331,7 +334,11 @@ module DRCA
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
     prepare_time = Time.now
 
-    find_charge_invoke_stow(settings.cambrinth, settings.stored_cambrinth, settings.cambrinth_cap, settings.dedicated_camb_use, data['cambrinth'])
+    if check_to_harness(settings.use_harness_when_arcana_locked)
+      harness_mana(data['cambrinth'])
+    else 
+      find_charge_invoke_stow(settings.cambrinth, settings.stored_cambrinth, settings.cambrinth_cap, settings.dedicated_camb_use, data['cambrinth'])
+    end
 
     if data['prep_time']
       pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
@@ -340,5 +347,13 @@ module DRCA
     end
 
     cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
+  end
+
+  def check_to_harness(should_harness)
+    return false unless should_harness.equals? 'true'
+    return false unless DRSkill.getxp('Attunement') < DRSkill.getxp('Arcana')
+    return false unless DRSkill.getxp('Attunement') < 30
+    
+    true
   end
 end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -350,7 +350,7 @@ module DRCA
   end
 
   def check_to_harness(should_harness)
-    return false unless should_harness.equals? 'true'
+    return false unless should_harness
     return false if DRSkill.getxp('Attunement') >= DRSkill.getxp('Arcana')
     return false if DRSkill.getxp('Attunement') >= 30
     

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -351,7 +351,7 @@ module DRCA
 
   def check_to_harness(should_harness)
     return false unless should_harness.equals? 'true'
-    return false unless DRSkill.getxp('Attunement') < DRSkill.getxp('Arcana')
+    return false if DRSkill.getxp('Attunement') >= DRSkill.getxp('Arcana')
     return false if DRSkill.getxp('Attunement') >= 30
     
     true

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -352,7 +352,7 @@ module DRCA
   def check_to_harness(should_harness)
     return false unless should_harness.equals? 'true'
     return false unless DRSkill.getxp('Attunement') < DRSkill.getxp('Arcana')
-    return false unless DRSkill.getxp('Attunement') < 30
+    return false if DRSkill.getxp('Attunement') >= 30
     
     true
   end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -24,7 +24,7 @@ module DRCA
 
     loop do
       pause 5 while mana <= amount
-      harness_mana(['amount']) if harness
+      harness_mana([amount]) if harness
       break if success.include?(DRC.bput("infuse om #{amount}", success, failure))
       pause 0.5
       waitrt?

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -164,6 +164,7 @@ safe_room_empath:
 
 
 # Spellcasting (and Khri) settings
+use_harness_when_arcana_locked: false
 cambrinth: armband
 cambrinth_cap: 32
 stored_cambrinth: false


### PR DESCRIPTION
Changes the use of Cambrinth to Harness when Arcana is full. Does not Harness if attunement is above 30. 

I've been running this all night, but the benefits really push themselves for someone that has a lot of attunement. Using harness over Cambrinth teaches Attunement, and this with the use of Perc/Pow during combat will lock attunement quick and require less power walking, and when at 800+ attunement, and magic secondary, and worst of all prime, can take a very long time, even for just a few mind levels. 

This needs more testing, and some feedback on implementation. 

Also, note that due to how harnessing works and the loss of mana from leakage (means less with higher and higher attunement, and with some cyclics running, it was decided to harness all the mana after the spell has been completed. Another check we can do here is wait for the spell to have, let's say, 3 RT remaining. 3 RT due to the fact that it's the RT for harnessing, minimum, that I've seen.