### PR TITLE
Fix bugged pilgrim's badge purchase method

### DIFF
--- a/pilgrimage.lic
+++ b/pilgrimage.lic
@@ -21,7 +21,8 @@ class Pilgrimage
   end
 
   def buy_badge(hometown)
-    return if exists?('pilgrim\'s badge')
+    description = 'pilgrim\'s badge'
+    return if exists?(description)
 
     if DRStats.cleric?
       ensure_copper_on_hand(37_500, hometown)
@@ -30,7 +31,7 @@ class Pilgrimage
       move('go storeroom')
       bput("buy #{description}", 'You decide')
       bput("kiss my #{description}", 'making it your own', 'You kiss')
-      bput('wear my badge', 'You put on')
+      bput("wear my #{description}", 'You put on')
       move('out')
     else
       echo '***YOU MUST BE A CLERIC TO BUY A PILGRIM\'S BADGE***'


### PR DESCRIPTION
Local variable `description` was lost in the creation of `pilgrimage.lic`, so this never worked.