### PR TITLE
base-crafting.yaml: Switch all shaping to use maple instead of balsa.

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -421,9 +421,9 @@ shaping:
     repair-room: 19209
     repair-npc: Rangu
     stock-room: 8864
-    stock-number: 11
-    stock-name: balsa
-    stock-volume: 10
+    stock-number: 10
+    stock-name: maple
+    stock-volume: 5
     pattern-book: shaping
     part-room: 8864
     idle-room: 8867
@@ -443,9 +443,9 @@ shaping:
     repair-room: 8392
     repair-npc: Osmandikar
     stock-room: 9118
-    stock-number: 11
-    stock-name: balsa
-    stock-volume: 10
+    stock-number: 10
+    stock-name: maple
+    stock-volume: 5
     pattern-book: shaping
     part-room: 9119
     idle-room: 9119
@@ -461,9 +461,9 @@ shaping:
     repair-room: 8856
     repair-npc: Valomenica
     stock-room: 9110
-    stock-number: 11
-    stock-name: balsa
-    stock-volume: 10
+    stock-number: 10
+    stock-name: maple
+    stock-volume: 5
     pattern-book: shaping
     part-room: 9110
     idle-room:
@@ -482,9 +482,9 @@ shaping:
     repair-room: 10734
     repair-npc: Glarstan
     stock-room: 10738
-    stock-number: 11
-    stock-name: balsa
-    stock-volume: 10
+    stock-number: 10
+    stock-name: maple
+    stock-volume: 5
     pattern-book: shaping
     part-room: 10737
     idle-room:
@@ -503,9 +503,9 @@ shaping:
     repair-room: 9575
     repair-npc: clerk
     stock-room: 19306
-    stock-number: 11
-    stock-name: balsa
-    stock-volume: 10
+    stock-number: 10
+    stock-name: maple
+    stock-volume: 5
     pattern-book: shaping
     part-room: 19306
     idle-room:


### PR DESCRIPTION
Workorders pay better for maple, and shaping is not hardcoded to use balsa because it is 10 pieces (aka the max pieces any of the previous recipes would have needed) anymore now that it supports buying enough of any wood to complete any recipe. 80 workability for maple vs 85 for balsa is insignificant. This will add a minor few silver extra cost to non workorders if they use a recipe that needs more than 5 pieces but workorder profits will more than make up for that.