### PR TITLE
workorders: pass cloth type to sew, define cloth name in base

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -299,6 +299,7 @@ tailoring:
     stock-room: 16667
     tool-room: 16668
     sew-stock-number: 8
+    sew-stock-name: burlap
     knit-stock-number: 13
     pattern-book: tailoring
     idle-room:
@@ -326,6 +327,7 @@ tailoring:
     stock-room: 9716
     tool-room: 
     sew-stock-number: 8
+    sew-stock-name: burlap
     knit-stock-number: 13
     pattern-book: tailoring
     idle-room: 9720
@@ -354,6 +356,7 @@ tailoring:
     stock-room: 10939
     tool-room: 10938
     sew-stock-number: 8
+    sew-stock-name: burlap
     knit-stock-number: 13
     pattern-book: tailoring
     idle-room: 19333
@@ -378,6 +381,7 @@ tailoring:
     repair-npc: clerk
     stock-room: 10746
     sew-stock-number: 8
+    sew-stock-name: burlap
     knit-stock-number: 13
     pattern-book: tailoring
     idle-room: 10744
@@ -400,6 +404,7 @@ tailoring:
     repair-npc: Osmandikar # Fang Cove metal-repairer
     stock-room: 9125
     sew-stock-number: 8
+    sew-stock-name: burlap
     knit-stock-number: 13
     pattern-book: tailoring
     idle-room: 9127

--- a/workorders.lic
+++ b/workorders.lic
@@ -85,7 +85,7 @@ class WorkOrders
       tools = settings.knitting_tools
       @belt = settings.outfitting_belt
       case item['chapter']
-      when 4, 2
+      when 4, 2, 3
         craft_method = :sew_items
       when 5
         craft_method = :knit_items
@@ -327,10 +327,10 @@ class WorkOrders
     find_sewing_room(@hometown, @outfitting_room)
 
     quantity.times do
-      wait_for_script_to_complete('sew', ['log', 'sewing', recipe['chapter'], recipe['name'], recipe['noun']])
+      wait_for_script_to_complete('sew', ['log', 'sewing', recipe['chapter'], recipe['name'], recipe['noun'], info['sew-stock-name']])
     end
     leftover = (quantity * recipe['volume']) % 10 != 0
-    dispose("#{info['stock-name']} cloth") if leftover
+    dispose("#{info['sew-stock-name']} cloth") if leftover
   end
 
   def knit_items(info, recipe, quantity)


### PR DESCRIPTION
Also allow sewing workorders from chapter 3 (bags and accessories), and discard the proper cloth. info['stock-name'] was not defined.