### PR TITLE
Adding support for articulated tongs

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -295,26 +295,27 @@ class Forge
 
   def add_fuel
     if @articulated
-	  case bput('adjust my tongs', 'lock the tongs into a fully extended', 'You have no idea how you')
-	  when 'You have no idea how you'
-	    echo '*** YOU DO NOT HAVE ARTICULATED TONGS ***'
-		exit
+      case bput('adjust my tongs', 'lock the tongs into a fully extended', 'You have no idea how you')
+      when 'You have no idea how you'
+        echo '*** YOU DO NOT HAVE ARTICULATED TONGS ***'
+        exit
       else
-	    case bput('push fuel with my tongs', 'Roundtime', 'That tool does not seem')
+        case bput('push fuel with my tongs', 'Roundtime', 'That tool does not seem')
         when 'That tool does not seem'
           analyze_item
         else
           waitrt?
-	      case bput('adjust my tongs', 'yank you fold the shovel head back', 'You have no idea how you')
-		    when 'You have no idea how you'
-			  echo '*** YOU DO NOT HAVE ARTICULATED TONGS ***'
-		      exit
-			else
-              pound
-	      end
+          case bput('adjust my tongs', 'yank you fold the shovel head back', 'You have no idea how you')
+          when 'You have no idea how you'
+            echo '*** YOU DO NOT HAVE ARTICULATED TONGS ***'
+            exit
+          else
+            pound
+
+          end
         end
-	  end
-	else
+      end
+    else
       stow_item('tongs')
       get_item('shovel')
       case bput('push fuel with my shovel', 'Roundtime', 'That tool does not seem')
@@ -326,9 +327,9 @@ class Forge
         get_item('tongs')
         pound
       end
-	end
+    end
   end
-
+  
   def bellows
     stow_item(@hammer)
     get_item('bellows')

--- a/forge.lic
+++ b/forge.lic
@@ -56,7 +56,7 @@ class Forge
     @bag_items = settings.crafting_items_in_container
     @belt = settings.forging_belt
     @hammer = settings.forging_tools.find { |item| /hammer/ =~ item }
-	  @articulated = settings.use_tongs_as_shovel
+    @articulated = settings.use_tongs_as_shovel
 
     @item = args.noun
 

--- a/forge.lic
+++ b/forge.lic
@@ -56,6 +56,7 @@ class Forge
     @bag_items = settings.crafting_items_in_container
     @belt = settings.forging_belt
     @hammer = settings.forging_tools.find { |item| /hammer/ =~ item }
+	  @articulated = settings.use_tongs_as_shovel
 
     @item = args.noun
 
@@ -293,17 +294,39 @@ class Forge
   end
 
   def add_fuel
-    stow_item('tongs')
-    get_item('shovel')
-    case bput('push fuel with my shovel', 'Roundtime', 'That tool does not seem')
-    when 'That tool does not seem'
-      analyze_item
-    else
-      waitrt?
-      stow_item('shovel')
-      get_item('tongs')
-      pound
-    end
+    if @articulated
+	  case bput('adjust my tongs', 'lock the tongs into a fully extended', 'You have no idea how you')
+	  when 'You have no idea how you'
+	    echo '*** YOU DO NOT HAVE ARTICULATED TONGS ***'
+		exit
+      else
+	    case bput('push fuel with my tongs', 'Roundtime', 'That tool does not seem')
+        when 'That tool does not seem'
+          analyze_item
+        else
+          waitrt?
+	      case bput('adjust my tongs', 'yank you fold the shovel head back', 'You have no idea how you')
+		    when 'You have no idea how you'
+			  echo '*** YOU DO NOT HAVE ARTICULATED TONGS ***'
+		      exit
+			else
+              pound
+	      end
+        end
+	  end
+	else
+      stow_item('tongs')
+      get_item('shovel')
+      case bput('push fuel with my shovel', 'Roundtime', 'That tool does not seem')
+      when 'That tool does not seem'
+        analyze_item
+      else
+        waitrt?
+        stow_item('shovel')
+        get_item('tongs')
+        pound
+      end
+	end
   end
 
   def bellows

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -298,6 +298,7 @@ outfitting_room:
 alchemy_room:
 use_own_ingot_type:
 deed_own_ingot: false
+use_tongs_as_shovel: false
 
 
 


### PR DESCRIPTION
Adding support in forge.lic for articulated/clockwork tongs.  Put use_tongs_as_shovel: false in base.yaml