### PR TITLE
Update sanowret-crystal.lic

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -23,9 +23,9 @@ class SanowretCrystal
     return if hiding?
 
     if DRSkill.getxp('Arcana') <= 10
-      response = DRC.bput('gaze sanowret crystal', /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.')
+      response = DRC.bput('gaze my sanowret crystal', /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.')
     elsif DRSkill.getxp('Arcana') <= 25
-      response = DRC.bput('exhale sanowret crystal', 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.')
+      response = DRC.bput('exhale my sanowret crystal', 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.')
     end
 
     return if response !~ /This is not a good place for that\./


### PR DESCRIPTION
If there is another sanowret crystal in the room with you (i.e. on a table in a player house), "gaze sanowret crystal" will fail.  Adding "my" qualifier fixes the issue.