### PR TITLE
base-hunting.yaml: Add more rooms to juvenile wyverns

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1062,6 +1062,12 @@ hunting_zones:
   - 19186
   - 19167
   - 19165
+  - 19183
+  - 19163
+  - 19164
+  - 19171
+  - 19174
+  - 19172
   #https://elanthipedia.play.net/Adult_wyvern   1000-1350
   adult_wyvern:
   - 19178


### PR DESCRIPTION
These were gated behind a room missing a daytime description which was just fixed. 

Fixes #2173