### PR TITLE
base.yaml: Default to the safer slow_bin_speed option.

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -200,7 +200,7 @@ listen_observe: false
 safe_room: 851
 hide_to_steal: true
 bin_stolen: false
-slow_bin_speed: false
+slow_bin_speed: true
 hand_armor: gloves
 footwear:
 exit_on_skills_capped: false


### PR DESCRIPTION
No reason to default to the unsafe puts which can miss items instead of bputs, this shouldn't add much more time and people can opt in to the unsafe faster way.

https://github.com/rpherbig/dr-scripts/blob/master/steal.lic#L122