### PR TITLE
Add Shard Gates to Bescort

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -167,8 +167,8 @@ class Bescort
         { name: 'ferry1', regex: /ferry1/i, description: 'Ferry between Hibarnhvidar and the Ain Ghazal' },
         { name: 'mode', options: %w[hibarnhvidar ainghazal], description: 'Which town are you going to?' }
       ],
-      [ 
-				{ name: 'shard_gates', regex: /shard/i, description: 'Use the Shard gates' } 
+      [
+        { name: 'shard_gates', regex: /shard/i, description: 'Use the Shard gates' } 
       ]
     ]
 

--- a/bescort.lic
+++ b/bescort.lic
@@ -166,6 +166,9 @@ class Bescort
       [
         { name: 'ferry1', regex: /ferry1/i, description: 'Ferry between Hibarnhvidar and the Ain Ghazal' },
         { name: 'mode', options: %w[hibarnhvidar ainghazal], description: 'Which town are you going to?' }
+      ],
+      [ 
+				{ name: 'shard_gates', regex: /shard/i, description: 'Use the Shard gates' } 
       ]
     ]
 
@@ -207,6 +210,8 @@ class Bescort
       take_xing_ferry(args.mode)
     elsif args.ferry1
       take_ain_ghazal_ferry(args.mode)
+    elsif args.shard_gates
+      use_shard_gates
     end
   end
 
@@ -1001,6 +1006,19 @@ class Bescort
     when 'Come back when you can afford the fare'
       echo('Your fare has mysteriously disappeared!')
       return
+    end
+  end
+  
+  def use_shard_gates
+    unless [2640, 2658, 2807, 2525, 6452, 2516].include?(Room.current.id)
+      echo "You are not at the Shard gates"
+      return
+    end
+
+    case bput('go gate', 'You pass', 'KNOCK', 'errant shadow')
+    when 'KNOCK'
+      release_invisibility
+      bput('knock gate', 'You knock')
     end
   end
 end


### PR DESCRIPTION
This update will let us use the Shard gates for citizens of Ilithi. You need to be a citizen of Ilithi to use the gates at night. If you are a citizen and the gates are closed, you can knock on them to pass through. You can't be invisible when you do this. 

The west, south, and north gates will get updates to use the following stringprocs: 
```
timeto = StringProc.new("if Script.exists?('bescort') && UserVars.citizenship == 'Ilithi' then 0.2 else nil end")    
wayto = StringProc.new("start_script('bescort', ['shard_gate']); wait_while{ running?('bescort') }")             
```
We'll use the `citizenship` UserVar to let people set their citizenship, since this is readable by go2.

In the future it would be nice if users could set citizenship via their YAML settings and have that translated into a UserVar. I would be interested in hearing about solutions for doing this. For now it will be a manual setting.