### PR TITLE
Remove an unmappable room with multiple locations from orc scouts hun…

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -837,7 +837,7 @@ hunting_zones:
   - 19101
   - 19099
   - 19100
-  - 19097
+  #- 19097          Unmappable room with multiple locations
   - 19191
   - 19192
   # https://elanthipedia.play.net/Black_marble_gargoyle 300 to 440


### PR DESCRIPTION
…ting area.

There are 2 possible locations to this room and go2 gets stuck in a loop if you end up in it. It is unmappable because you can't peer in the rose thicket to differentiate the rooms.