### PR TITLE
hunting-buddy.lic: Add during: option.

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -60,6 +60,7 @@ class HuntingBuddy
       args = info['args']
       before_actions = info['before']
       after_actions = info['after']
+      during_actions = info['during']
       duration = info[:duration]
       stop_on_skills = info['stop_on']
 
@@ -67,6 +68,7 @@ class HuntingBuddy
       execute_actions(before_actions)
 
       if all_skills_at_cap?(stop_on_skills)
+        stop_actions(during_actions)
         # Execute scripts to run after the hunt
         execute_actions(after_actions)
         next
@@ -82,8 +84,11 @@ class HuntingBuddy
           stop_script('tendme') if Script.running?('tendme')
           break
         end
+        execute_nonblocking_actions(during_actions)
         hunt(arg, duration ? duration[index] : nil, stop_on_skills ? stop_on_skills[index] : nil)
       end
+
+      stop_actions(during_actions)
 
       wait_for_script_to_complete('bescort', @exit) if @exit
       release_cyclics
@@ -101,6 +106,21 @@ class HuntingBuddy
       action_parts = action.split(' ')
       script_name = action_parts.shift
       wait_for_script_to_complete(script_name, action_parts)
+    end
+  end
+
+  def execute_nonblocking_actions(actions)
+    actions.each do |action|
+      echo "***STATUS*** EXECUTE #{action}"
+      action_parts = action.split(' ')
+      script_name = action_parts.shift
+      start_script(script_name, action_parts)
+    end
+  end
+
+  def stop_actions(actions)
+    actions.each do |script_name|
+      stop_script(script_name) if Script.running?(script_name)
     end
   end
 
@@ -229,6 +249,7 @@ class HuntingBuddy
           info['stop_on'] = [info['stop_on']]
           info['before'] = info['before']
           info['after'] = info['after']
+          info['during'] = info['during']
         end
         hunting_info << info
       else
@@ -237,6 +258,7 @@ class HuntingBuddy
         hunting_info.last['stop_on'] << info['stop_on']
         hunting_info.last['before'] ||= info['before']
         hunting_info.last['after'] ||= info['after']
+        hunting_info.last['during'] ||= info['during']
       end
     end
     hunting_info


### PR DESCRIPTION
This is to run arbitrary scripts only while in combat. For instance, I have one that summons a wolf companion, and watches for triggers to react to so you can automate the process of getting them older and dismisses it when the script is killed. Baby wolves can't deliver items to other people, and it takes around 80 hours for them to get older so this seems like the most fitting place to add it. I'm sure it could be used for other things too.

Usage:
```hunting_info:
- :zone: black_goblins
  args:
  - d1
  stop_on:
  - Small Edged
  - Stealth
  :duration: 50
  before:
  - mech-lore
  - athletics
  during:
  - combat-ranger-companion
  after:
  - athletics