### PR TITLE
Move core functions from restock.lic into common items.

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -121,7 +121,9 @@ module DRCI
 
   def count_items_in_container(item, container)
     contents = DRC.bput("rummage /C #{item} IN MY #{container}", '^You rummage .*', 'That would accomplish nothing')
-    contents.scan(/#{item}/).size
+    # This regexp avoids counting the quoted item name in the message, as
+    # well as avoiding finding the item as a substring of other items.
+    contents.scan(/ #{item}\W/).size
   end
 
   def count_lockpick_container(container)

--- a/common-items.lic
+++ b/common-items.lic
@@ -91,6 +91,39 @@ module DRCI
     result =~ /You tap|You thump/
   end
 
+  def count_item_parts(item)
+    match_messages = [
+      /and see there (?:is|are) (.+) left\./,
+      /There (?:is|are) (.+) parts? left/
+    ]
+    count = case DRC.bput("count my #{item}",
+                          'I could not find what you were referring to.',
+                          'tell you much of anything.',
+                          *match_messages)
+            when 'I could not find what you were referring to.'
+              0
+            when 'tell you much of anything.'
+              echo "ERROR: count_item_parts called on non-stackable item: #{item}"
+              count_items(item)
+            when *match_messages
+              DRC.text2num(Regexp.last_match(1).tr('-', ' '))
+            end
+    waitrt?
+    count
+  end
+
+  def count_items(item)
+    /inside your (.*).|I could not find/ =~ DRC.bput("tap my #{item}", 'inside your (.*).', 'I could not find')
+    container = Regexp.last_match(1)
+    return 0 if container.nil?
+    count_items_in_container(item, container)
+  end
+
+  def count_items_in_container(item, container)
+    contents = DRC.bput("rummage /C #{item} IN MY #{container}", '^You rummage .*', 'That would accomplish nothing')
+    contents.scan(/#{item}/).size
+  end
+
   def count_lockpick_container(container)
     count = DRC.bput("app my lockpick #{container}", 'and it appears to be full', 'and it might hold an additional \d+', '\d+ lockpicks would probably fit').scan(/\d+/).first.to_i
     waitrt?


### PR DESCRIPTION
Split into its own commit so people have time to pick this up before scripts start using it.