### PR TITLE
common.lic: Add messaging when slip stalk fails to the bput

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -302,7 +302,7 @@ module DRC
 
   def hide?(hide_type = 'hide')
     unless hiding?
-      case bput(hide_type, 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself', 'Stalk what', 'You\'re already stalking')
+      case bput(hide_type, 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself', 'Stalk what', 'You\'re already stalking', 'Stalking is an inherently stealthy')
       when 'too busy performing'
         bput('stop play', 'You stop playing', 'In the name of')
         return hide?(hide_type)


### PR DESCRIPTION
[combat-trainer]>stalk
The cinder beast moves into a position to parry.
>
You quickly slip into hiding to prepare to stalk.
The cinder beast notices your attempt to hide!
The cinder beast discovers you, ruining your hiding place!
Stalking is an inherently stealthy endeavor, try being out of sight.

[combat-trainer: message: Stalking is an inherently stealthy endeavor, try being out of sight.]
[combat-trainer: message: The cinder beast discovers you, ruining your hiding place!]
[combat-trainer: message: The cinder beast notices your attempt to hide!]
[combat-trainer: message: You quickly slip into hiding to prepare to stalk.]
[combat-trainer: message: The cinder beast moves into a position to parry.]
[combat-trainer: checked against [/Roundtime/i, /too busy performing/i, /can't see any place to hide yourself/i, /Stalk what/i, /You're already stalking/i]]
[combat-trainer: for command stalk]