### PR TITLE
Astrology: Stop predicting when nearly mindlocked

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -183,7 +183,7 @@ class Astrology
     }
 
     pools.reject { |_skill, size| (size < @prediction_pool_target) }
-         .each_key { |skill| align(skillset_to_pool[skill]) }
+      .each_key { |skill| break if DRSkill.getxp('Astrology') > 30; align(skillset_to_pool[skill]) }
   end
 
   def check_heavens

--- a/astrology.lic
+++ b/astrology.lic
@@ -183,10 +183,10 @@ class Astrology
     }
 
     pools.reject { |_skill, size| (size < @prediction_pool_target) }
-      .each_key do |skill| 
-        break if DRSkill.getxp('Astrology') > 30
-        align(skillset_to_pool[skill]) 
-      end
+         .each_key do |skill|
+      break if DRSkill.getxp('Astrology') > 30
+      align(skillset_to_pool[skill])
+    end
   end
 
   def check_heavens

--- a/astrology.lic
+++ b/astrology.lic
@@ -183,7 +183,10 @@ class Astrology
     }
 
     pools.reject { |_skill, size| (size < @prediction_pool_target) }
-      .each_key { |skill| break if DRSkill.getxp('Astrology') > 30; align(skillset_to_pool[skill]) }
+      .each_key do |skill| 
+        break if DRSkill.getxp('Astrology') > 30
+        align(skillset_to_pool[skill]) 
+      end
   end
 
   def check_heavens


### PR DESCRIPTION
This change makes the `predict_all` method return early if Astrology experience is over 30 mindstate. Continuing to predict would be a waste of prediction pools.