### PR TITLE
Astrology: Remove predictions from check_heavens

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -240,12 +240,6 @@ class Astrology
 
     pause 2
     waitrt?
-
-    observed['pools']
-      .reject { |_skill, value| value.nil? }
-      .reject { |_skill, value| value < @prediction_pool_target }
-      .each_key { |skill| align(skill) }
-    waitrt?
   end
 
   def observe(body)


### PR DESCRIPTION
Removing this lets the predict_all handle all predictions done in this script