### PR TITLE
Updated text2num to fix bug in parsing >=100

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -351,11 +351,11 @@ module DRC
 
     split_words.each do |word|
       x = $NUM_MAP.fetch(word, nil)
-      if x.nil?
+      if word.eql?('hundred') && (g != 0)
+        g *= 100
+      elsif x.nil?
         echo 'Unknown number'
         return nil
-      elsif word.eql?('hundred') && (g != 0)
-        g *= 100
       else
         g += x
       end


### PR DESCRIPTION
Because 'hundred' was not in the map (on purpose, for scaling) the nil condition was being met first. Switched it to be checked first. Limited testing works now. 

Before:
You count some small rocks in the quiver and see there are one hundred three left.                                                                                                                       
[restock: Unknown number]   

After:
You count some small rocks in the quiver and see there are one hundred three left.                                                                                                                       
[restock: 103]