### PR TITLE
base-town.yaml: start tracking guildleader room numbers.

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -81,6 +81,28 @@ Crossing:
     inner_room: structure
   almsbox:
     id: 741
+  barbarian_guild:
+    id: 7892
+  cleric_guild:
+    id: 7901
+  moonmage_guild:
+    id: 656
+  ranger_guild:
+    id: 7900
+  paladin_guild:
+    id: 7891
+  warmage_guild:
+    id: 7887
+  necromancer_guild:
+    id: 8944
+  thief_guild:
+    id: 9080
+  trader_guild:
+    id: 8918
+  bard_guild:
+    id: 7879
+  empath_guild:
+    id: 5994
 Leth Deriel:
   currency: kronars
   leather_repair:
@@ -185,8 +207,23 @@ Shard:
   stamina:
     outer_room: 8190
     inner_room: 
+  ranger_guild:
+    id: 12701
+  paladin_guild:
+    id: 8222
+  necromancer_guild:
+    id: 9659
+  moonmage_guild:
+    id: 2491
+  bard_guild:
+    id: 8211
+  empath_guild:
+    id: 8187
+  warmage_guild:
+    id: 11197
   almsbox:
     id: 13143
+# TODO: cleric guild mapping
 Riverhaven:
   currency: lirums
   deposit:
@@ -253,7 +290,26 @@ Riverhaven:
   stamina:
     outer_room: 578
     inner_room: 
-  # repairs: 8737
+  ranger_guild:
+    id: 506
+  necromancer_guild:
+    id: 11463
+  empath_guild:
+    id: 7861
+  cleric_guild:
+    id: 7883
+  warmage_guild:
+    id: 427
+  bard_guild:
+    id: 7881
+  trader_guild:
+    id: 7875
+  paladin_guild:
+    id: 7951
+  barbarian_guild:
+    id: 7885
+  moon_mage:
+    id: 308
   # athletics (jant river): 7651, 7650, 7649, 7648, 7647, 7633
 Rossman's Landing:
   # safe room: 7695
@@ -333,6 +389,8 @@ Langenfirth:
     - 12269
     - 12215
     - 12209
+  ranger_guild:
+    id: 13417
 Therenborough:
   currency: lirums
   leather_repair:
@@ -411,6 +469,14 @@ Ratha:
     - 4638
     - 4637
     - 4636
+  trader_guild:
+    id: 12686
+  barbarian_guild:
+    id: 7892
+  cleric_guild:
+    id: 12698
+  paladin_guild:
+    id: 12961
 Aesry:
   currency: lirums
   leather_repair:
@@ -439,6 +505,8 @@ Aesry:
     id: 107
   guard_house:
     id: 129
+  cleric_guild:
+    id: 12868
   attunement_rooms:
     - 5377
     - 5372
@@ -504,6 +572,12 @@ Mer'Kresh:
     id: 11922
   guard_house:
     id: 11816
+  barbarian_guild: #M'riss
+    id: 6592
+  cleric_guild:
+    id: 11811
+  warmage_guild:
+    id: 6580
   attunement_rooms:
     - 6578
     - 6576
@@ -625,6 +699,16 @@ Hibarnhvidar:
     - 3831
     - 3832
     - 3833
+  moonmage_guild:
+    id: 3784
+  cleric_guild:
+    id: 4211
+  barbarian_guild:
+    id: 7399
+  trader_guild:
+    id: 7417
+  warmage_guild:
+    id: 11498
 Fang Cove:
   currency: dokoras
   exchange:
@@ -671,6 +755,8 @@ Muspar'i:
     id: 54
   guard_house:
     id: 11212
+  cleric_guild:
+    id: 7611
     #Needs theurgy_supplies, attunement_rooms, and perceive_health_rooms
 Ain Ghazal:
   currency: dokoras


### PR DESCRIPTION
complete for crossing and riverhaven (except for thieves guild in haven), the other places have what is available and need more mapping to fix but the mapdb has been locked. Help is needed finding the room numbers for the thief guilds outside of crossing.