### PR TITLE
Combat Trainer: Dont train mm attunement if nearly locked

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1776,6 +1776,7 @@ class TrainerProcess
 
   def moon_mage_perc(game_state)
     return if game_state.retreating?
+    return if DRSkill.getxp('Attunement') > 32
 
     retreat
     bput('perc mana', 'You reach out')


### PR DESCRIPTION
At 1200 attunement ranks this gives 2 mindstates, so stopping at 32 mindstate
seems appropriate