### PR TITLE
validate.lic: add test for cycle_armor names being correct.

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -88,6 +88,14 @@ class DRYamlValidator
     echo("Valid skills are #{@valid_weapon_skills}")
   end
 
+  def assert_that_cycle_skills_named_properly(settings)
+    return unless settings.cycle_armors
+
+    settings.cycle_armors
+            .reject { |skill| ['Light Armor', 'Chain Armor', 'Brigandine', 'Plate Armor'].include?(skill) }
+            .each_key { |skill| error("Skill name in cycle_armors is not valid: #{skill}") }
+  end
+
   def assert_that_summoned_weapons_are_skills(settings)
     return unless settings.summoned_weapons
 

--- a/validate.lic
+++ b/validate.lic
@@ -88,7 +88,7 @@ class DRYamlValidator
     echo("Valid skills are #{@valid_weapon_skills}")
   end
 
-  def assert_that_cycle_skills_named_properly(settings)
+  def assert_that_cycle_armors_are_skills(settings)
     return unless settings.cycle_armors
 
     settings.cycle_armors


### PR DESCRIPTION
--- Lich: validate active.
  Validating settings for 1 settings files
  Checking 50 different potential errors in file Sarvatt-setup.yaml
[validate: ERROR:< Skill name in cycle_armors is not valid: Chain  >]
  WARNINGS:0 ERRORS:1
  All done!
--- Lich: validate has exited.