### PR TITLE
fix sprinkle

### DIFF
--- a/commune.lic
+++ b/commune.lic
@@ -109,7 +109,7 @@ class Commune
   end
 
   def sprinkle?(item, target = @self)
-    case bput("sprinkle my #{item} on #{target}", 'You sprinkle', 'Sprinkle what', 'What were you referring to')
+    case bput("sprinkle #{item} on #{target}", 'You sprinkle', 'Sprinkle what', 'What were you referring to')
     when 'You sprinkle'
       true
     else


### PR DESCRIPTION
I'm not sure what changed in DR but I'm now getting errors when I "sprinkle MY" item on myself:

[commune]>sprinkle my oil on Gratio
>
Sprinkle ON what?
USAGE: SPRINKLE (item) on (person|creature|item|ROOM)

[commune]>sprinkle my chalice on Gratio
Sprinkle ON what?
USAGE: SPRINKLE (item) on (person|creature|item|ROOM)

If I do just "sprinkle item" rather than "sprinkle my item" it works...

>sprinkle oil on Gratio
You sprinkle yourself with some holy oil.
That was the last of your holy oil.

>sprinkle chalice on Gratio
You sprinkle yourself with some holy water.

This fix eliminates the "my" from sprinkle.