### PR TITLE
Crossing-Trainer: Use commonized discern methods

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -382,78 +382,8 @@ class CrossingTraining
     end
   end
 
-  def calculate_mana(min, more, discern_data, cyclic)
-    total = min + more
-    total = (total * @settings.prep_scaling_factor).floor
-    discern_data['mana'] = [(total / 5.0).ceil, min].max
-    remaining = total - discern_data['mana']
-    unless @settings.cambrinth_items[0]['name']
-      @settings.cambrinth_items = [{
-        'name' => @settings.cambrinth,
-        'cap' => @settings.cambrinth_cap,
-        'stored' => @settings.stored_cambrinth
-      }]
-    end
-    total_cambrinth_cap = @settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+)
-    charges_count_floor = 4
-    @settings.cambrinth_items.each do |item|
-      item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
-    end
-    total_cambrinth_charges = @settings.cambrinth_items.map { |x| x['charges'] }.inject(&:+)
-    if remaining > total_cambrinth_cap
-      discern_data['mana'] = discern_data['mana'] + (remaining - total_cambrinth_cap)
-      remaining = total - discern_data['mana']
-    end
-    if cyclic
-      discern_data['cambrinth'] = nil
-      discern_data['mana'] = discern_data['mana'] + remaining
-    elsif remaining > 0
-      total_cambrinth_mana = [remaining, total_cambrinth_cap].min
-      @settings.cambrinth_items.each_with_index do |item, index|
-        discern_data['cambrinth'] ||= []
-        charge_amount = (total_cambrinth_mana / total_cambrinth_charges) * item['charges']
-        discern_data['cambrinth'][index] = []
-        charge_amount.times do |i|
-          discern_data['cambrinth'][index][i % item['charges']] += 1
-        end
-      end
-    else
-      discern_data['cambrinth'] = nil
-    end
-  end
-
   def map_cambrinth(settings)
     [settings.cambrinth, settings.cambrinth_cap, settings.stored_cambrinth]
-  end
-
-  def check_discern(data)
-    UserVars.discerns = {} unless UserVars.discerns
-    discern_data = UserVars.discerns[data['abbrev']] || {}
-    if data['symbiosis']
-      if discern_data.empty? || discern_data['min'].nil?
-        /requires at minimum (\d+) mana streams/ =~ bput("discern #{data['abbrev']}", 'requires at minimum \d+ mana streams')
-        discern_data['mana'] = Regexp.last_match(1).to_i
-        discern_data['cambrinth'] = nil
-        discern_data['min'] = Regexp.last_match(1).to_i
-        discern_data['more'] = 0
-      end
-      calculate_mana(discern_data['min'], discern_data['more'], discern_data, false)
-    elsif discern_data.empty? || discern_data['time_stamp'].nil? || Time.now - discern_data['time_stamp'] > 24 * 60 * 60 || !discern_data['more'].nil?
-      discern_data['time_stamp'] = Time.now
-      case discern = bput("discern #{data['abbrev']}", 'The spell requires at minimum \d+ mana streams and you think you can reinforce it with \d+ more', 'You don\'t think you are able to cast this spell', 'You have no idea how to cast that spell')
-      when /you don't think you are able/i, 'You have no idea how to cast that spell'
-        discern_data['mana'] = 1
-        discern_data['cambrinth'] = nil
-      else
-        discern =~ /minimum (\d+) mana streams and you think you can reinforce it with (\d+) more/i
-        calculate_mana(Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, discern_data, data['cyclic'])
-      end
-    end
-    pause 1
-    waitrt?
-    UserVars.discerns[data['abbrev']] = discern_data
-    data['mana'] = discern_data['mana']
-    data['cambrinth'] = discern_data['cambrinth']
   end
 
   def check_osrel
@@ -512,7 +442,7 @@ class CrossingTraining
   end
 
   def cast_spell(data, skill)
-    check_discern(data)
+    data = check_discern(data, @settings)
     if data['abbrev'] =~ /^comp/i
       walk_to @settings.compost_room
       return unless DRRoom.npcs.empty?


### PR DESCRIPTION
Removed commonized methods from ct. Updated check_discern call to pass settings and grab returned data