### PR TITLE
Lower the default prep_scaling_factor in the sample yamls.

### DIFF
--- a/profiles/SampleBard-setup.yaml
+++ b/profiles/SampleBard-setup.yaml
@@ -120,6 +120,7 @@ training_spells:
     cyclic: true
   Augmentation:
     abbrev: ECRY
+prep_scaling_factor: 0.85
 safe_room: 984
 cambrinth: cambrinth ring
 cambrinth_cap: 5

--- a/profiles/SampleCleric-setup.yaml
+++ b/profiles/SampleCleric-setup.yaml
@@ -117,6 +117,7 @@ crossing_training:
 training_spells:
   Augmentation:
     abbrev: Centering
+prep_scaling_factor: 0.85
 safe_room: 984
 cambrinth: cambrinth ring
 cambrinth_cap: 5

--- a/profiles/SampleMoonMage-setup.yaml
+++ b/profiles/SampleMoonMage-setup.yaml
@@ -145,6 +145,7 @@ safe_room: 19162
 training_spells:
   Augmentation:
     abbrev: shadows
+prep_scaling_factor: 0.85
 cambrinth: cambrinth ring
 cambrinth_cap: 5
 favor_god: Meraud

--- a/profiles/SampleNecromancer-setup.yaml
+++ b/profiles/SampleNecromancer-setup.yaml
@@ -150,6 +150,7 @@ crossing_training:
 - Athletics
 - Scholarship
 - Appraisal
+prep_scaling_factor: 0.85
 safe_room: 1645
 cambrinth: cambrinth ring
 cambrinth_cap: 5

--- a/profiles/SamplePaladin-setup.yaml
+++ b/profiles/SamplePaladin-setup.yaml
@@ -120,6 +120,7 @@ crossing_training:
 training_spells:
   Augmentation:
     abbrev: HES
+prep_scaling_factor: 0.85
 safe_room: 984
 cambrinth: cambrinth ring
 cambrinth_cap: 5

--- a/profiles/SampleRanger-setup.yaml
+++ b/profiles/SampleRanger-setup.yaml
@@ -150,6 +150,7 @@ crossing_training:
 - Scholarship
 - Augmentation
 - Utility
+prep_scaling_factor: 0.85
 safe_room: 851
 cambrinth: cambrinth ring
 cambrinth_cap: 5

--- a/profiles/SampleWarriorMage-setup.yaml
+++ b/profiles/SampleWarriorMage-setup.yaml
@@ -125,6 +125,7 @@ crossing_training:
 - Attunement
 - Scholarship
 - Outdoorsmanship
+prep_scaling_factor: 0.85
 safe_room: 984
 cambrinth: cambrinth ring
 cambrinth_cap: 5


### PR DESCRIPTION
Backfiring when starting out with the default 98% discerns is a very common issue on lnet.