### PR TITLE
Updating missing remedies item in base-recipies

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -3849,6 +3849,15 @@ crafting_recipes:
   container: bowl
   herb1: yelith
   herb1_stock:
+- name: some neck tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 4
+  container: bowl
+  herb1: riolur
+  herb1_stock: 8
 - name: some abdominal tonic
   noun: tonic
   volume: 1


### PR DESCRIPTION
Adding missing recipe "some neck tonic". It is only one of two difficulty 7 - challenging recipes where all ingredients are sold by the society. From the order of the remedies recipes, it looks like everything was just added in order from the Wiki, but this one was just skipped.

This had originally blocked having a viable workorder at any difficulty at 601 alchemy with no techniques. Stopgap is to switch to "easy" workorders for a time with this being the only option available.