### PR TITLE
Added box loot tracking

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -431,7 +431,7 @@ class LootProcess
     items_to_loot = []
     @lootables
       .select { |item| game_state.lootable?(item) }
-      .reject { |item| @box_nounts.include?(item) && @box_loot_limit && @current_box_count >= @box_loot_limit }
+      .reject { |item| @box_nouns.include?(item) && @box_loot_limit && @current_box_count >= @box_loot_limit }
       .each do |item|
         item_reg = item.split.join('.*')
         matches = DRRoom.room_objs.grep(/\b#{item_reg}$/)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -333,6 +333,15 @@ class LootProcess
     echo("  @last_rites: #{@last_rites}") if $debug_mode_ct
     @last_rites_timer = Time.now - 600
 
+    if settings.box_loot_limit
+      @stop_hunt_on_box_limit = settings.stop_hunt_on_box_limit
+      @box_nouns = get_data('items').box_nouns
+      @box_loot_limit = settings.box_loot_limit
+      @current_box_count = get_boxes(settings.picking_box_source).size + get_boxes(settings.picking_pet_box_source).size
+      echo("  @current_box_count: #{@current_box_count}")
+      echo("  @box_loot_limit: #{@box_loot_limit}")
+    end
+
     Flags.add('using-corpse', 'begins arranging', 'completes arranging', 'kneels down briefly and draws a knife', 'cruelly into the body and carving out a chunk', 'makes additional cuts, purposeful but seemingly at random')
     Flags.add('pouch-full', 'You think the .* pouch is too full to fit another gem into', 'You\'d better tie it up before putting')
     Flags.add('container-full', 'There isn\'t any more room')
@@ -374,12 +383,18 @@ class LootProcess
       return
     end
 
-    if bput("stow #{item}", 'You pick up', 'You get', 'You need a free hand', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything') == 'already in your inventory'
+    case bput("stow #{item}", 'You pick up', 'You get', 'You need a free hand', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything') 
+    when 'already in your inventory'
       if @gem_nouns.include?(item)
         bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       else
         bput("stow other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       end
+    when 'You pick up','You get'
+      if @box_loot_limit and @box_nouns.include?(item)
+        @current_box_count += 1
+      end
+    else
     end
     pause 0.25
     if Flags['container-full']
@@ -423,6 +438,7 @@ class LootProcess
         tried_loot ||= !matches.empty?
         matches.each { |_| items_to_loot.push(item); }
       end
+    items_to_loot = items_to_loot - @box_nouns if @box_loot_limit and @current_box_count >= @box_loot_limit
     if items_to_loot.any?
       game_state.sheath_whirlwind_offhand
       items_to_loot.each { |item| stow_loot(item, game_state) }
@@ -440,6 +456,7 @@ class LootProcess
       game_state.unlootable(GameObj.right_hand.noun.downcase)
       dispose_trash(right_hand)
     end
+
   end
 
   def should_perform_ritual?(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -245,6 +245,8 @@ class LootProcess
   include DRCS
   include DRCH
 
+  attr_reader :current_box_count
+
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
     echo('New LootProcess') if $debug_mode_ct
@@ -2184,6 +2186,20 @@ class CombatTrainer
       TrainerProcess.new(settings, @equipment_manager),
       AttackProcess.new(settings)
     ]
+  end
+
+  def get_process(process)
+    case process
+    when 'setup'; @combat_processes[0]
+    when 'spell'; @combat_processes[1]
+    when 'pet'; @combat_processes[2]
+    when 'ability'; @combat_processes[3]
+    when 'loot'; @combat_processes[4]
+    when 'manipulate'; @combat_processes[5]
+    when 'trainer'; @combat_processes[6]
+    when 'attack'; @combat_processes[7]
+    else nil
+    end  
   end
 
   def start_combat

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -334,7 +334,6 @@ class LootProcess
     @last_rites_timer = Time.now - 600
 
     if settings.box_loot_limit
-      @stop_hunt_on_box_limit = settings.stop_hunt_on_box_limit
       @box_nouns = get_data('items').box_nouns
       @box_loot_limit = settings.box_loot_limit
       @current_box_count = get_boxes(settings.picking_box_source).size + get_boxes(settings.picking_pet_box_source).size
@@ -391,7 +390,7 @@ class LootProcess
         bput("stow other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       end
     when 'You pick up','You get'
-      if @box_loot_limit and @box_nouns.include?(item)
+      if @box_loot_limit && @box_nouns.include?(item)
         @current_box_count += 1
       end
     else
@@ -432,13 +431,13 @@ class LootProcess
     items_to_loot = []
     @lootables
       .select { |item| game_state.lootable?(item) }
+      .reject { |item| @box_nounts.include?(item) && @box_loot_limit && @current_box_count >= @box_loot_limit }
       .each do |item|
         item_reg = item.split.join('.*')
         matches = DRRoom.room_objs.grep(/\b#{item_reg}$/)
         tried_loot ||= !matches.empty?
         matches.each { |_| items_to_loot.push(item); }
       end
-    items_to_loot = items_to_loot - @box_nouns if @box_loot_limit and @current_box_count >= @box_loot_limit
     if items_to_loot.any?
       game_state.sheath_whirlwind_offhand
       items_to_loot.each { |item| stow_loot(item, game_state) }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -338,7 +338,10 @@ class LootProcess
     if settings.box_loot_limit
       @box_nouns = get_data('items').box_nouns
       @box_loot_limit = settings.box_loot_limit
-      @current_box_count = get_boxes(settings.picking_box_source).size + get_boxes(settings.picking_pet_box_source).size
+      @current_box_count = get_boxes(settings.picking_box_source).size
+      if settings.picking_pet_box_source != settings.picking_box_source
+        @current_box_count += get_boxes(settings.picking_pet_box_source).size
+      end
       echo("  @current_box_count: #{@current_box_count}")
       echo("  @box_loot_limit: #{@box_loot_limit}")
     end

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -63,6 +63,7 @@ class HuntingBuddy
       during_actions = info['during']
       duration = info[:duration]
       stop_on_skills = info['stop_on']
+      stop_on_boxes = info['boxes']
 
       # Execute scripts to run before the hunt
       execute_actions(before_actions)
@@ -85,7 +86,7 @@ class HuntingBuddy
           break
         end
         execute_nonblocking_actions(during_actions)
-        hunt(arg, duration ? duration[index] : nil, stop_on_skills ? stop_on_skills[index] : nil)
+        hunt(arg, duration ? duration[index] : nil, stop_on_skills ? stop_on_skills[index] : nil, stop_on_boxes ? stop_on_boxes[index] : nil)
       end
 
       stop_actions(during_actions)
@@ -193,7 +194,11 @@ class HuntingBuddy
     stop_on_skills && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= 32 }
   end
 
-  def hunt(args, duration, stop_on_skills)
+  def over_box_limit?
+    @settings.box_loot_limit <= $COMBAT_TRAINER.get_process('loot').current_box_count
+  end 
+
+  def hunt(args, duration, stop_on_skills, stop_on_boxes)
     $COMBAT_TRAINER = nil
     echo("***STATUS*** beginning hunt '#{args}' for '#{duration}' minutes")
     verify_script('combat-trainer')
@@ -207,6 +212,10 @@ class HuntingBuddy
         @stopped_for_bleeding = true
         break
       end
+      if stop_on_boxes && over_box_limit?
+        echo('***STATUS*** stopping due to boxes')
+        break
+      end 
       if all_skills_at_cap?(stop_on_skills)
         echo('***STATUS*** stopping due to skills')
         break
@@ -250,6 +259,7 @@ class HuntingBuddy
           info['before'] = info['before']
           info['after'] = info['after']
           info['during'] = info['during']
+          info['boxes'] = info['boxes']
         end
         hunting_info << info
       else
@@ -259,6 +269,7 @@ class HuntingBuddy
         hunting_info.last['before'] ||= info['before']
         hunting_info.last['after'] ||= info['after']
         hunting_info.last['during'] ||= info['during']
+        hunting_info.last['boxes'] ||= info['boxes']
       end
     end
     hunting_info

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -183,7 +183,7 @@ cambrinth_items:
 loot_additions:
 loot_subtractions:
 loot_specials:
-
+box_loot_limit:
 
 
 


### PR DESCRIPTION
will track box looting. 
- Counts pet boxes and non-pet boxes at beginning of combat-trainer.
- If box limits are defined in yaml, will track each looted box.
- Once limit is set, will stop looting boxes.