### PR TITLE
Made some changes to parse the new text block of spell data.

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -20,6 +20,8 @@ class DRSpells
   @@refresh_data = {}
   @@slivers = false
 
+  @@grabbing_spell_data = false
+
   def self.active_spells
     @@active_spells
   end
@@ -35,67 +37,141 @@ class DRSpells
   def self.slivers=(val)
     @@slivers = val
   end
+  
+  def self.grabbing_spell_data
+    @@grabbing_spell_data
+  end
+  
+  def self.grabbing_spell_data=(val)
+    @@grabbing_spell_data = val
+  end
 end
 
-spell_action = proc do |server_string|
-  if server_string =~ %r{<clearStream id="percWindow"/>}
-    DRSpells.slivers = false
-    DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
-    begin
-      Thread.new do
-        sleep 0.5
-        DRSpells.refresh_data.each do |key, state|
-          unless state
-            DRSpells.active_spells.delete(key)
-            DRSpells.refresh_data.delete(key)
+if DRStats.barbarian? || DRStats.thief?
+  spell_action = proc do |server_string|
+    if server_string =~ %r{<clearStream id="percWindow"/>}
+      DRSpells.slivers = false
+      DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
+      begin
+        Thread.new do
+          sleep 0.5
+          DRSpells.refresh_data.each do |key, state|
+            unless state
+              DRSpells.active_spells.delete(key)
+              DRSpells.refresh_data.delete(key)
+            end
           end
         end
+      rescue => e
+        echo(e)
+        echo('Error in spell monitor')
       end
-    rescue => e
-      echo(e)
-      echo('Error in spell monitor')
+    elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisaen\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisan\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\(Fading\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = 0
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisaen\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisan\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Indefinite\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = $CYCLICAL # is there a better solution?
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(OM\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{<pushStream id="percWindow"/>.*orbiting sliver.*}
+      DRSpells.slivers = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s*$}
+      DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s+\((\d+)%\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Fading\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = 0
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{<pushStream id="percWindow"/> (.*) \((\d+) roisaen\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    elsif server_string =~ %r{<popStream/><pushStream id="percWindow"/> (.+) \((\d+) roisaen\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
     end
-  elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisaen\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisan\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\(Fading\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = 0
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisaen\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisan\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Indefinite\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = $CYCLICAL # is there a better solution?
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(OM\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{<pushStream id="percWindow"/>.*orbiting sliver.*}
-    DRSpells.slivers = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s*$}
-    DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s+\((\d+)%\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Fading\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = 0
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{<pushStream id="percWindow"/> (.*) \((\d+) roisaen\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  elsif server_string =~ %r{<popStream/><pushStream id="percWindow"/> (.+) \((\d+) roisaen\)}
-    DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-    DRSpells.refresh_data[Regexp.last_match(1)] = true
-  end
 
-  server_string
+    server_string
+  end
+else
+  spell_action = proc do |server_string|
+    if server_string =~ %r{<clearStream id="percWindow"/>}
+      DRSpells.slivers = false
+      DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
+      begin
+        Thread.new do
+          sleep 0.5
+          DRSpells.refresh_data.each do |key, state|
+            unless state
+              DRSpells.active_spells.delete(key)
+              DRSpells.refresh_data.delete(key)
+            end
+          end
+        end
+      rescue => e
+        echo(e)
+        echo('Error in spell monitor')
+      end
+
+      next server_string
+    end 
+
+    data = server_string.dup
+    if server_string =~ %r{pushStream id="percWindow"/>}
+      DRSpells.grabbing_spell_data = true
+      data.slice!(0,29)
+    end
+
+    if DRSpells.grabbing_spell_data
+      if server_string =~ %r{popStream/}
+        DRSpells.grabbing_spell_data = false
+        next server_string
+      end
+
+    case data
+      when %r{([^<>]+)\s\s\((\d+) roisaen\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{([^<>]+)\s\s\((\d+) roisan\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{([^<>]+)\s\s\(Fading\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = 0
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{(.+)  \(Indefinite\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = $CYCLICAL # is there a better solution?
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{(.+)  \(OM\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{.*orbiting sliver.*}
+        DRSpells.slivers = true
+      when %r{(.+)  \((\d+)%\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{^*$}
+        DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      end
+    end
+
+    server_string
+  end
 end
 
 DownstreamHook.remove('spell_action')


### PR DESCRIPTION
DR pushed a changed that all spell data went from coming through a single tag at a time, to one large tag. Note that this only affects MU's, not NMU (FOR NOW). So, for now this is an easily reversable workaround.

**OLD**
```
<clearStream id="percWindow"/>
<pushStream id="percWindow"/>Obfuscation<popStream/><pushStream id="percWindow"/>  (1 roisan)
<popStream/><pushStream id="percWindow"/>Gauge Flow<popStream/><pushStream id="percWindow"/>  (1 roisan)
<popStream/><prompt time="1495722924">&gt;</prompt>
```

NEW
```
<clearStream id="percWindow"/>
<pushStream id="percWindow"/>Skein of Shadows  (9 roisaen)
Manifest Force  (11 roisaen)
Ease Burden  (8 roisaen)
<popStream/>
```