### PR TITLE
forge.lic: Allow using mallets instead of hammers automatically.

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -55,7 +55,7 @@ class Forge
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container
     @belt = settings.forging_belt
-    @hammer = settings.forging_tools.find { |item| /hammer/ =~ item }
+    @hammer = settings.forging_tools.find { |item| /hammer|mallet/ =~ item }
 
     @item = args.noun
 
@@ -140,7 +140,7 @@ class Forge
     bput("put #{@item} on anvil", 'You put')
     get_item(@hammer)
     get_item('tongs')
-    bput("pound #{@item} with my hammer", 'roundtime')
+    bput("pound #{@item} with my #{@hammer}", 'roundtime')
     stow_item(@hammer)
     stow_item('tongs')
     bput("get #{@item}", 'You get')
@@ -178,7 +178,7 @@ class Forge
       bput("put #{@item} on anvil", 'You put')
       get_item(@hammer)
       get_item('tongs')
-      bput("pound #{@item} with my hammer", 'roundtime')
+      bput("pound #{@item} with my #{@hammer}", 'roundtime')
       stow_item(@hammer)
       stow_item('tongs')
       bput("get #{@item}", 'You get')
@@ -246,7 +246,7 @@ class Forge
 
   def pound(item = @item)
     waitrt?
-    case bput("pound #{item} on anvil with my hammer",
+    case bput("pound #{item} on anvil with my #{@hammer}",
               'You must be holding',
               'needs more fuel', 'need some more fuel',
               'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel',


### PR DESCRIPTION
If a mallet is listed in forging_tools: and a hammer isn't, it will be used instead.