### PR TITLE
Updated for support for Trader's Trabe magic.

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -150,6 +150,12 @@ else
       when %r{([^<>]+)\s\s\((\d+) roisan\)}
         DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
         DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{([^<>]+)\s\s\(.+(\d+) roisaen\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
+      when %r{([^<>]+)\s\s\(.+(\d+) roisan\)}
+        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+        DRSpells.refresh_data[Regexp.last_match(1)] = true
       when %r{([^<>]+)\s\s\(Fading\)}
         DRSpells.active_spells[Regexp.last_match(1)] = 0
         DRSpells.refresh_data[Regexp.last_match(1)] = true


### PR DESCRIPTION
Trader magic uses a weird new system, this is probably why they pushed it through.

`Trabe Chalice  (cracked, 9 roisaen)`



