### PR TITLE
drinfomon: Check exp all after death

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -859,6 +859,8 @@ while line = script.gets
       end
     end
     if DRStats.guild.nil? && !dead? && Time.now - info_check_time > 30
+      put('exp all')
+      pause 1
       put('info')
       info_check_time = Time.now
       pause 1


### PR DESCRIPTION
Fixes an error with running circlecheck immediately after dying