### PR TITLE
Spellmonitor: require drinfomon

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -7,7 +7,7 @@ unless XMLData.game =~ /^(?:DRF|DR|DRT||DRPlat|DRX)$/
   echo "This script is meant for DragonRealms Prime, Platinum, or Fallen.  It will likely cause problems on whatever game you're trying to run it on..."
   exit
 end
-
+custom_require.call %w[drinfomon]
 no_kill_all
 no_pause_all
 # hide_me


### PR DESCRIPTION
Require drinfomon to avoid an error if spellmonitor is started before drinfomon