### PR TITLE
spellmonitor.lic: Rip out legacy thief/barb handling.

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -7,7 +7,7 @@ unless XMLData.game =~ /^(?:DRF|DR|DRT||DRPlat|DRX)$/
   echo "This script is meant for DragonRealms Prime, Platinum, or Fallen.  It will likely cause problems on whatever game you're trying to run it on..."
   exit
 end
-custom_require.call %w[drinfomon]
+
 no_kill_all
 no_pause_all
 # hide_me
@@ -47,137 +47,74 @@ class DRSpells
   end
 end
 
-if DRStats.barbarian? || DRStats.thief?
-  spell_action = proc do |server_string|
-    if server_string =~ %r{<clearStream id="percWindow"/>}
-      DRSpells.slivers = false
-      DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
-      begin
-        Thread.new do
-          sleep 0.5
-          DRSpells.refresh_data.each do |key, state|
-            unless state
-              DRSpells.active_spells.delete(key)
-              DRSpells.refresh_data.delete(key)
-            end
+spell_action = proc do |server_string|
+  if server_string =~ %r{<clearStream id="percWindow"/>}
+    DRSpells.slivers = false
+    DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
+    begin
+      Thread.new do
+        sleep 0.5
+        DRSpells.refresh_data.each do |key, state|
+          unless state
+            DRSpells.active_spells.delete(key)
+            DRSpells.refresh_data.delete(key)
           end
         end
-      rescue => e
-        echo(e)
-        echo('Error in spell monitor')
       end
-    elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisaen\)}
+    rescue => e
+      echo(e)
+      echo('Error in spell monitor')
+    end
+
+    next server_string
+  end 
+
+  data = server_string.dup
+  if server_string =~ %r{pushStream id="percWindow"/>}
+    DRSpells.grabbing_spell_data = true
+    data.slice!(0,29)
+  end
+
+  if DRSpells.grabbing_spell_data
+    if server_string =~ %r{popStream/}
+      DRSpells.grabbing_spell_data = false
+      next server_string
+    end
+
+  case data
+    when %r{([^<>]+)\s\s\((\d+) roisaen\)}
       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisan\)}
+    when %r{([^<>]+)\s\s\((\d+) roisan\)}
       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\(Fading\)}
+    when %r{([^<>]+)\s\s\(.+(\d+) roisaen\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    when %r{([^<>]+)\s\s\(.+(\d+) roisan\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    when %r{([^<>]+)\s\s\(Fading\)}
       DRSpells.active_spells[Regexp.last_match(1)] = 0
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisaen\)}
-      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-      DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisan\)}
-      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-      DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Indefinite\)}
+    when %r{(.+)  \(Indefinite\)}
       DRSpells.active_spells[Regexp.last_match(1)] = $CYCLICAL # is there a better solution?
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(OM\)}
+    when %r{(.+)  \(OM\)}
       DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{<pushStream id="percWindow"/>.*orbiting sliver.*}
+    when %r{.*orbiting sliver.*}
       DRSpells.slivers = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s*$}
+    when %r{(.+)  \((\d+)%\)}
+      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
+      DRSpells.refresh_data[Regexp.last_match(1)] = true
+    when %r{^*$}
       DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s+\((\d+)%\)}
-      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-      DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Fading\)}
-      DRSpells.active_spells[Regexp.last_match(1)] = 0
-      DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{<pushStream id="percWindow"/> (.*) \((\d+) roisaen\)}
-      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-      DRSpells.refresh_data[Regexp.last_match(1)] = true
-    elsif server_string =~ %r{<popStream/><pushStream id="percWindow"/> (.+) \((\d+) roisaen\)}
-      DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-      DRSpells.refresh_data[Regexp.last_match(1)] = true
     end
-
-    server_string
   end
-else
-  spell_action = proc do |server_string|
-    if server_string =~ %r{<clearStream id="percWindow"/>}
-      DRSpells.slivers = false
-      DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
-      begin
-        Thread.new do
-          sleep 0.5
-          DRSpells.refresh_data.each do |key, state|
-            unless state
-              DRSpells.active_spells.delete(key)
-              DRSpells.refresh_data.delete(key)
-            end
-          end
-        end
-      rescue => e
-        echo(e)
-        echo('Error in spell monitor')
-      end
 
-      next server_string
-    end 
-
-    data = server_string.dup
-    if server_string =~ %r{pushStream id="percWindow"/>}
-      DRSpells.grabbing_spell_data = true
-      data.slice!(0,29)
-    end
-
-    if DRSpells.grabbing_spell_data
-      if server_string =~ %r{popStream/}
-        DRSpells.grabbing_spell_data = false
-        next server_string
-      end
-
-    case data
-      when %r{([^<>]+)\s\s\((\d+) roisaen\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{([^<>]+)\s\s\((\d+) roisan\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{([^<>]+)\s\s\(.+(\d+) roisaen\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{([^<>]+)\s\s\(.+(\d+) roisan\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{([^<>]+)\s\s\(Fading\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = 0
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{(.+)  \(Indefinite\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = $CYCLICAL # is there a better solution?
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{(.+)  \(OM\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{.*orbiting sliver.*}
-        DRSpells.slivers = true
-      when %r{(.+)  \((\d+)%\)}
-        DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      when %r{^*$}
-        DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-        DRSpells.refresh_data[Regexp.last_match(1)] = true
-      end
-    end
-
-    server_string
-  end
+  server_string
 end
 
 DownstreamHook.remove('spell_action')

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -88,10 +88,10 @@ spell_action = proc do |server_string|
     when %r{([^<>]+)\s\s\((\d+) roisan\)}
       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    when %r{([^<>]+)\s\s\(.+(\d+) roisaen\)}
+    when %r{([^<>]+)\s\s\(.+\s(\d+) roisaen\)}
       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
       DRSpells.refresh_data[Regexp.last_match(1)] = true
-    when %r{([^<>]+)\s\s\(.+(\d+) roisan\)}
+    when %r{([^<>]+)\s\s\(.+\s(\d+) roisan\)}
       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
       DRSpells.refresh_data[Regexp.last_match(1)] = true
     when %r{([^<>]+)\s\s\(Fading\)}


### PR DESCRIPTION
Note: Please don't pull this until thieves/barbs are switched over to the new spell tracking by simu. Just submitting this so it's ready to pull as soon as it goes live.