### PR TITLE
Updated workorders to read volume from deeds

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -598,6 +598,11 @@ class WorkOrders
     res.scan(/\d+/).first.to_i
   end
 
+  def deed_ingot_volume
+    res = bput('read my deed', 'Volume:\s*\d+')
+    res.scan(/\d+/).first.to_i
+  end
+
   def forge_items_with_own_ingot(info, item, quantity)
     recipe, = find_recipe(info, item, quantity)
 
@@ -606,13 +611,15 @@ class WorkOrders
         echo('out of material/deeds')
         exit
       else
+        volume = deed_ingot_volume
         fput('tap deed')
         pause
         fput("get #{@use_own_ingot_type} ingot") unless checkleft || checkright
       end
     end
-
-    volume = ingot_volume
+    if(!volume)
+      volume = ingot_volume
+    end
     stow_hands
     smelt = false
 
@@ -623,11 +630,11 @@ class WorkOrders
         stow_hands
         exit
       else
+		volume = deed_ingot_volume
         fput('tap deed')
         pause
         fput("get #{@use_own_ingot_type} ingot") unless checkleft || checkright
       end
-      volume = ingot_volume
     end
 
     stow_hands

--- a/workorders.lic
+++ b/workorders.lic
@@ -617,9 +617,9 @@ class WorkOrders
         fput("get #{@use_own_ingot_type} ingot") unless checkleft || checkright
       end
     end
-    if(!volume)
-      volume = ingot_volume
-    end
+
+    volume = ingot_volume unless volume
+ 
     stow_hands
     smelt = false
 


### PR DESCRIPTION
workorders will pull the volume from a deed where appropriate instead of using analyze, this removes the minimum appraisal required to use your own ingots and gives a slight optimization in removing analyze RT