### PR TITLE
Trade: Add script for caravan trading

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -772,3 +772,5 @@ theurgy_exp_threshold: 33
 theurgy_bead_carving_tool:
 theurgy_use_prayer_mat: false
 theurgy_prayer_mat_room:
+
+trade_contract_container: backpack

--- a/trade.lic
+++ b/trade.lic
@@ -136,8 +136,7 @@ class Trade
     previous, _shortest_paths = Map.dijkstra(Room.current.id, destination)
     path = [destination]
     path.push(previous[path[-1]]) until previous[path[-1]].nil?
-    path.reverse!
-    return path
+    return path.reverse!
   end
 
   def step(dir)

--- a/trade.lic
+++ b/trade.lic
@@ -1,7 +1,7 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#trade
 =end
-custom_require.call(%w(common common-items common-money common-travel drinfomon equipmanager))
+custom_require.call(%w[common common-items common-money common-travel drinfomon equipmanager])
 
 class Trade
   include DRC
@@ -28,13 +28,13 @@ class Trade
     end
     contract = parse_contract
     unless contract.presented
-      load_caravan(contract.origin_clerk) 
+      load_caravan(contract.origin_clerk)
       recall_caravan
       walk_to(contract.origin_outpost)
     end
     feed_caravan
     take_caravan_to(contract.destination_outpost)
-    bput("get my contract", 'You get')
+    bput('get my contract', 'You get')
     deliver_contract(contract.destination_clerk)
     pay_dues(contract.destination_clerk)
     deposit_coins(500, Room.current.id) if contract.destination_town == @hometown
@@ -46,7 +46,7 @@ class Trade
 
   def deposit_coins(withdraw_amt, return_to_id)
     return if wealth(@hometown) < withdraw_amt
-    
+
     walk_to(@town_data[@hometown]['deposit']['id'])
     case bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit')
     when 'There is no teller here'
@@ -58,9 +58,9 @@ class Trade
 
   def find_closest_id(entity)
     rooms = @town_data.to_h.values.select { |data| data[entity] }
-                             .map{ |data| data[entity]['id'] }
+                      .map { |data| data[entity]['id'] }
     echo "rooms: #{rooms}" if debugging?
-    return sort_destinations(rooms).first
+    sort_destinations(rooms).first
   end
 
   def parse_contract
@@ -70,7 +70,7 @@ class Trade
     contract = OpenStruct.new
     contract.presented = true
     contract.expired = false
-    fput("read my contract")
+    fput('read my contract')
     while line = get
       echo line if debugging?
       if line =~ destination_re
@@ -101,21 +101,21 @@ class Trade
       echo "Contract destination town: #{contract.destination_town}"
       echo "Contracted presented to clerk? #{contract.presented}"
     end
-    return contract
+    contract
   end
 
   def recall_caravan
     recall_messages = [
-        /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/,
-        /You recall that your (?<description>.*) (?<name>.*) should be located in/,
-        /You don't recall where you left your caravan\./,
-        /You don't recall having a caravan\./
+      /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/,
+      /You recall that your (?<description>.*) (?<name>.*) should be located in/,
+      /You don't recall where you left your caravan\./,
+      /You don't recall having a caravan\./
     ]
-    response = bput("recall caravan", recall_messages)
+    response = bput('recall caravan', recall_messages)
     echo("Response: #{response}") if debugging?
     case response
     when /You don't recall where you left your caravan/, /You don't recall having a caravan/
-      echo("No caravan found") if debugging?
+      echo('No caravan found') if debugging?
     when /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/
       /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
       @caravan.noun = name
@@ -135,7 +135,7 @@ class Trade
     previous, _shortest_paths = Map.dijkstra(Room.current.id, destination)
     path = [destination]
     path.push(previous[path[-1]]) until previous[path[-1]].nil?
-    return path.reverse
+    path.reverse
   end
 
   def step(dir)
@@ -149,7 +149,7 @@ class Trade
   end
 
   def get_next_dir(path)
-    return Room.current.wayto[path[path.index(Room.current.id)+1].to_s]
+    Room.current.wayto[path[path.index(Room.current.id) + 1].to_s]
   end
 
   def take_caravan_to(outpost_id)
@@ -161,22 +161,22 @@ class Trade
       dir = get_next_dir(path)
       step(dir) if caravan_present?
       waitfor 'following you'
-      echo "Caravan arrival detected" if debugging?
+      echo 'Caravan arrival detected' if debugging?
     end
     command_caravan('wait')
   end
 
-  def command_caravan(command, destination = nil)
+  def command_caravan(command, _destination = nil)
     case command
     when 'follow'
       follow_messages = [
-        "You grab hold of your .* harness and make it follow.",
-        "You pass on the order to follow to your driver, who makes sure your .* does your bidding."
+        'You grab hold of your .* harness and make it follow.',
+        'You pass on the order to follow to your driver, who makes sure your .* does your bidding.'
       ]
       bput("tell #{@caravan.noun} to follow", follow_messages)
     when 'wait'
       wait_messages = [
-        "You pass on the order to wait to your driver, who makes sure your .* does your bidding"
+        'You pass on the order to wait to your driver, who makes sure your .* does your bidding'
       ]
       bput("tell #{@caravan.noun} to wait", wait_messages)
     end
@@ -185,28 +185,28 @@ class Trade
   def deliver_contract(clerk_id)
     walk_to(clerk_id)
     clerk_messages = [
-      '^The \w+ clerk finds everything in order with your merchandise',
+      '^The \w+ clerk finds everything in order with your merchandise'
     ]
-    bput("give my contract to clerk", clerk_messages)
+    bput('give my contract to clerk', clerk_messages)
   end
 
   def pay_dues(clerk_id)
     echo "Paying dues at clerk_room: #{clerk_id}" if debugging?
     clerk_messages = [
-        /^You don't have any coins on you to pay dues\./,
-        /^You count out some coins, and the clerk notes that your dues are settled\./,
-        /^You count out some coins, and the clerk notes that your dues are now (.*)\./,
-        /^The clerk says, "You do not owe dues, .*!"/
+      /^You don't have any coins on you to pay dues\./,
+      /^You count out some coins, and the clerk notes that your dues are settled\./,
+      /^You count out some coins, and the clerk notes that your dues are now (.*)\./,
+      /^The clerk says, "You do not owe dues, .*!"/
     ]
     walk_to(clerk_id)
-    bput("pay clerk", clerk_messages)
+    bput('pay clerk', clerk_messages)
   end
 
   def feed_caravan
     feed_messages = [
-      "The driver takes the feedbag from you",
-      "You offer the .* feedbag to the caravan driver",
-      "The .* sniffs disinterestedly at your .* feedbag",
+      'The driver takes the feedbag from you',
+      'You offer the .* feedbag to the caravan driver',
+      'The .* sniffs disinterestedly at your .* feedbag',
       'The .* sticks its nose into your feedbag and munches away happily'
     ]
     @equipment_manager.empty_hands
@@ -225,11 +225,11 @@ class Trade
     echo "Getting a new contract from room #{minister_id}" if debugging?
     walk_to(minister_id)
     minister_messages = [
-      "The minister plucks a contract from the hands",
-      "The minister reminds you that you still owe .*" 
+      'The minister plucks a contract from the hands',
+      'The minister reminds you that you still owe .*'
     ]
-    response = bput("ask minister for contract", minister_messages)
-    case response  
+    response = bput('ask minister for contract', minister_messages)
+    case response
     when /The minister reminds you/
       /The minister reminds you that you still owe (?<dues_amt>.*) (?<dues_currency>Kronars|Lirums|Dokoras) in dues to (?:The )?(?<outpost>.*) and asks that you pay the clerk before s?he issues you a new contract\./ =~ response
       echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if debugging?
@@ -242,14 +242,14 @@ class Trade
   def caravan_present?
     return unless @caravan.adjective
     return unless @caravan.noun
-    return DRRoom.room_objs.find{ |obj| obj =~ /#{@caravan.adjective} #{@caravan.noun}/}
+    DRRoom.room_objs.find { |obj| obj =~ /#{@caravan.adjective} #{@caravan.noun}/ }
   end
 
   def give_clerk(clerk_id)
     walk_to(clerk_id)
-    bput("get my contract", 'You get')
+    bput('get my contract', 'You get')
     Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
-    bput("give my contract to clerk", /The .* clerk accepts your contract and peruses it\./)
+    bput('give my contract to clerk', /The .* clerk accepts your contract and peruses it\./)
     recall_caravan if Flags['caravan-upgrade']
     bput("put my contract in my #{@contract_container}", 'You put')
     Flags.delete('caravan-upgrade')

--- a/trade.lic
+++ b/trade.lic
@@ -1,0 +1,258 @@
+custom_require.call(%w(common common-items common-money common-travel drinfomon equipmanager))
+$debug = UserVars.trade_debug
+
+class Trade
+  include DRC
+  include DRCT
+  include DRCI
+  include DRCM
+
+  def initialize
+    @town_data = get_data('town')
+    @caravan_noun = nil
+    @caravan_adjective = nil
+    @equipment_manager = EquipmentManager.new
+    settings = get_settings
+    @contract_container = settings.trade_contract_container
+    @hometown = settings.hometown
+    bput("open my #{@contract_container}", 'You open', 'That is already')
+    @equipment_manager.empty_hands
+    recall_caravan
+  end
+
+  def run
+    unless exists?('contract')
+      nearest_minister = find_closest_id('trade_minister')
+      get_new_contract(nearest_minister)
+    end
+    contract = parse_contract
+    unless contract.presented
+      load_caravan(contract.origin_clerk) 
+      recall_caravan
+      walk_to(contract.origin_outpost)
+    end
+    feed_caravan
+    take_caravan_to(contract.destination_outpost)
+    fput("get my contract")
+    deliver_contract(contract.destination_clerk)
+    pay_dues(contract.destination_clerk)
+    deposit_coins(500, Room.current.id) if contract.destination_town == @hometown
+  end
+
+  def deposit_coins(withdraw_amt, return_to_id)
+    return if wealth(@hometown) < withdraw_amt
+    
+    walk_to(@town_data[@hometown]['deposit']['id'])
+    case bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit')
+    when 'There is no teller here'
+      return
+    end
+    minimize_coins(withdraw_amt).each { |amount| withdraw_exact_amount?(amount, @hometown) }
+    walk_to(return_to_id)
+  end
+
+  def find_closest_id(entity)
+    rooms = @town_data.to_h.values.select { |data| data[entity] }
+                             .map{ |data| data[entity]['id'] }
+    echo "rooms: #{rooms}" if $debug
+    return sort_destinations(rooms).first
+  end
+
+  def parse_contract(name=nil)
+    destination_re = /The guild office at (?:The )?(?<destination>.*) requires .*/
+    payment_re = /You estimate these goods are currently worth (.*) (Kronars|Dokoras|Lirums) on delivery\./
+    origin_re = /Trading Contract Issued by:  (?:The )?(?<origin>.*)/
+    contract = OpenStruct.new
+    contract.presented = true
+    contract.expired = false
+    fput("read my #{name} contract")
+    while line = get
+      echo line if $debug
+      if line =~ destination_re
+        contract.destination_town = line.match(destination_re).captures.first
+        contract.destination_outpost = @town_data[contract.destination_town]['trader_outpost']['id']
+        contract.destination_clerk = @town_data[contract.destination_town]['shipment_clerk']['id']
+        contract.destination_minister = @town_data[contract.destination_town]['trade_minister']['id']
+      elsif line =~ payment_re
+        # This is the last line of the contract so break when finished
+        contract.payment, contract.currency = line.match(payment_re).captures
+        break
+      elsif line =~ origin_re
+        contract.origin_town = line.match(origin_re).captures.first
+        contract.origin_clerk = @town_data[contract.origin_town]['shipment_clerk']['id']
+        contract.origin_minister = @town_data[contract.origin_town]['trade_minister']['id']
+        contract.origin_outpost = @town_data[contract.origin_town]['trader_outpost']['id']
+      elsif line =~ /This contract has yet to be/
+        contract.presented = false
+      elsif line =~ /The contract is now useless since it has expired\./
+        contract.expired = true
+        break
+      end
+    end
+    if $debug
+      echo "Contract origin: #{contract.origin_town}"
+      echo "Contract origin clerk room: #{contract.origin_clerk}"
+      echo "Contract origin minister room: #{contract.origin_minister}"
+      echo "Contract destination town: #{contract.destination_town}"
+      echo "Contracted presented to clerk? #{contract.presented}"
+    end
+    return contract
+  end
+
+  def recall_caravan
+    recall_messages = [
+        /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/,
+        /You recall that your (?<description>.*) (?<name>.*) should be located in/,
+        /You don't recall where you left your caravan\./,
+        /You don't recall having a caravan\./
+    ]
+    response = bput("recall caravan", recall_messages)
+    echo("Response: #{response}") if $debug
+    case response
+    when /You don't recall where you left your caravan/, /You don't recall having a caravan/
+      echo("No caravan found") if $debug
+    when /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/
+      /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
+      @caravan_noun = name
+      echo "@caravan_noun: #{@caravan_noun}" if $debug
+      @caravan_adjective = description
+      echo "@caravan_description: #{@caravan_adjective}" if $debug
+    when /You recall that your (?<description>.*) (?<name>.*) should be located in/
+      /You recall that your (?<description>.*) (?<name>.*) should be located in/ =~ response
+      @caravan_noun = name
+      echo "@caravan_noun: #{@caravan_noun}" if $debug
+      @caravan_adjective = description
+      echo "@caravan_description: #{@caravan_adjective}" if $debug
+    end
+  end
+
+  def compute_path(destination)
+    previous, _shortest_paths = Map.dijkstra(Room.current.id, destination)
+    path = [destination]
+    path.push(previous[path[-1]]) until previous[path[-1]].nil?
+    path.reverse!
+    return path
+  end
+
+  def step(dir)
+    echo "step dir: #{dir}" if $debug
+    case dir
+    when String
+      move(dir)
+    when Proc, StringProc
+      dir.call
+    end
+  end
+
+  def get_next_dir(path)
+    return Room.current.wayto[path[path.index(Room.current.id)+1].to_s]
+  end
+
+  def take_caravan_to(outpost_id)
+    command_caravan('follow')
+    path = compute_path(outpost_id)
+    until Room.current.id == outpost_id
+      dir = get_next_dir(path)
+      step(dir) if caravan_present?
+      waitfor 'following you'
+      echo "Caravan arrival detected" if $debug
+    end
+    command_caravan('wait')
+  end
+
+  def command_caravan(command, destination = nil)
+    case command
+    when 'follow'
+      follow_messages = [
+        "You grab hold of your .* harness and make it follow.",
+        "You pass on the order to follow to your driver, who makes sure your .* does your bidding."
+      ]
+      bput("tell #{@caravan_noun} to follow", follow_messages)
+    when 'wait'
+      wait_messages = [
+        "You pass on the order to wait to your driver, who makes sure your .* does your bidding"
+      ]
+      bput("tell #{@caravan_noun} to wait", wait_messages)
+    when 'lead'
+      # TODO: Switch to bput
+      # TODO: Implement leading logic
+      fput("tell caravan to lead to #{destination}")
+    end
+  end
+
+  def deliver_contract(clerk_id)
+    walk_to(clerk_id)
+    clerk_messages = [
+      '^The \w+ clerk finds everything in order with your merchandise',
+    ]
+    bput("give my contract to clerk", clerk_messages)
+  end
+
+  def pay_dues(clerk_id)
+    echo "Paying dues at clerk_room: #{clerk_id}" if $debug
+    clerk_messages = [
+        /^You don't have any coins on you to pay dues\./,
+        /^You count out some coins, and the clerk notes that your dues are settled\./,
+        /^You count out some coins, and the clerk notes that your dues are now (.*)\./,
+        /^The clerk says, "You do not owe dues, .*!"/
+    ]
+    walk_to(clerk_id)
+    bput("pay clerk", clerk_messages)
+  end
+
+  def feed_caravan
+    feed_messages = [
+      "The driver takes the feedbag from you",
+      "You offer the .* feedbag to the caravan driver",
+      "The .* sniffs disinterestedly at your .* feedbag",
+      'The .* sticks its nose into your feedbag and munches away happily'
+    ]
+    @equipment_manager.empty_hands
+    bput('remove feedbag', 'You remove')
+    bput("give #{@caravan_noun}", feed_messages)
+    bput('wear feedbag', 'You attach')
+  end
+
+  def load_caravan(clerk_id)
+    echo "Presenting contract to clerk in room: #{clerk_id}" if $debug
+    walk_to(clerk_id)
+    give_clerk(clerk_id)
+  end
+
+  def get_new_contract(minister_id)
+    echo "Getting a new contract from room #{minister_id}" if $debug
+    walk_to(minister_id)
+    minister_messages = [
+      "The minister plucks a contract from the hands",
+      "The minister reminds you that you still owe .*" 
+    ]
+    response = bput("ask minister for contract", minister_messages)
+    case response  
+    when /The minister reminds you/
+      /The minister reminds you that you still owe (?<dues_amt>.*) (?<dues_currency>Kronars|Lirums|Dokoras) in dues to (?:The )?(?<outpost>.*) and asks that you pay the clerk before s?he issues you a new contract\./ =~ response
+      echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if $debug
+      ensure_copper_on_hand(dues_amt.to_i, @hometown)
+      pay_dues(@town_data[outpost]['shipment_clerk']['id'])
+      get_new_contract(minister_id)
+    end
+  end
+
+  def caravan_present?
+    return unless @caravan_adjective
+    return unless @caravan_noun
+    return DRRoom.room_objs.find{ |obj| obj =~ /#{@caravan_adjective} #{@caravan_noun}/}
+  end
+
+  def give_clerk(clerk_id)
+    walk_to(clerk_id)
+    fput("get my contract")
+    Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
+    bput("give my contract to clerk", /The .* clerk accepts your contract and peruses it\./)
+    recall_caravan if Flags['caravan-upgrade']
+    fput("put my contract in my #{@contract_container}")
+    Flags.delete('caravan-upgrade')
+  end
+end
+
+trade = Trade.new
+loop { trade.run }

--- a/trade.lic
+++ b/trade.lic
@@ -37,6 +37,7 @@ class Trade
     bput('get my contract', 'You get')
     deliver_contract(contract.destination_clerk)
     pay_dues(contract.destination_clerk)
+    walk_to(contract.destination_outpost)
     deposit_coins(500, Room.current.id) if contract.destination_town == @hometown
   end
 

--- a/trade.lic
+++ b/trade.lic
@@ -1,3 +1,6 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#trade
+=end
 custom_require.call(%w(common common-items common-money common-travel drinfomon equipmanager))
 
 class Trade

--- a/trade.lic
+++ b/trade.lic
@@ -11,14 +11,13 @@ class Trade
 
   def initialize
     @town_data = get_data('town')
-    @caravan_noun = nil
-    @caravan_adjective = nil
     @equipment_manager = EquipmentManager.new
     settings = get_settings
     @contract_container = settings.trade_contract_container
     @hometown = settings.hometown
     bput("open my #{@contract_container}", 'You open', 'That is already')
     @equipment_manager.empty_hands
+    @caravan = OpenStruct.new
     recall_caravan
   end
 
@@ -33,7 +32,7 @@ class Trade
       recall_caravan
       walk_to(contract.origin_outpost)
     end
-    feed_caravan
+    feed_caravan(caravan)
     take_caravan_to(contract.destination_outpost)
     fput("get my contract")
     deliver_contract(contract.destination_clerk)
@@ -119,16 +118,16 @@ class Trade
       echo("No caravan found") if debugging?
     when /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/
       /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
-      @caravan_noun = name
-      echo "@caravan_noun: #{@caravan_noun}" if debugging?
-      @caravan_adjective = description
-      echo "@caravan_description: #{@caravan_adjective}" if debugging?
+      @caravan.noun = name
+      echo "@caravan.noun: #{@caravan.noun}" if debugging?
+      @caravan.description = description
+      echo "@caravan.description: #{@caravan.adjective}" if debugging?
     when /You recall that your (?<description>.*) (?<name>.*) should be located in/
       /You recall that your (?<description>.*) (?<name>.*) should be located in/ =~ response
-      @caravan_noun = name
-      echo "@caravan_noun: #{@caravan_noun}" if debugging?
-      @caravan_adjective = description
-      echo "@caravan_description: #{@caravan_adjective}" if debugging?
+      @caravan.noun = name
+      echo "@caravan.noun: #{@caravan.noun}" if debugging?
+      @caravan.adjective = description
+      echo "@caravan.description: #{@caravan.adjective}" if debugging?
     end
   end
 
@@ -136,7 +135,7 @@ class Trade
     previous, _shortest_paths = Map.dijkstra(Room.current.id, destination)
     path = [destination]
     path.push(previous[path[-1]]) until previous[path[-1]].nil?
-    return path.reverse!
+    return path.reverse
   end
 
   def step(dir)
@@ -172,12 +171,12 @@ class Trade
         "You grab hold of your .* harness and make it follow.",
         "You pass on the order to follow to your driver, who makes sure your .* does your bidding."
       ]
-      bput("tell #{@caravan_noun} to follow", follow_messages)
+      bput("tell #{@caravan.noun} to follow", follow_messages)
     when 'wait'
       wait_messages = [
         "You pass on the order to wait to your driver, who makes sure your .* does your bidding"
       ]
-      bput("tell #{@caravan_noun} to wait", wait_messages)
+      bput("tell #{@caravan.noun} to wait", wait_messages)
     when 'lead'
       # TODO: Switch to bput
       # TODO: Implement leading logic
@@ -214,7 +213,7 @@ class Trade
     ]
     @equipment_manager.empty_hands
     bput('remove feedbag', 'You remove')
-    bput("give #{@caravan_noun}", feed_messages)
+    bput("give #{@caravan.noun}", feed_messages)
     bput('wear feedbag', 'You attach')
   end
 
@@ -243,9 +242,9 @@ class Trade
   end
 
   def caravan_present?
-    return unless @caravan_adjective
-    return unless @caravan_noun
-    return DRRoom.room_objs.find{ |obj| obj =~ /#{@caravan_adjective} #{@caravan_noun}/}
+    return unless @caravan.adjective
+    return unless @caravan.noun
+    return DRRoom.room_objs.find{ |obj| obj =~ /#{@caravan.adjective} #{@caravan.noun}/}
   end
 
   def give_clerk(clerk_id)

--- a/trade.lic
+++ b/trade.lic
@@ -1,5 +1,4 @@
 custom_require.call(%w(common common-items common-money common-travel drinfomon equipmanager))
-$debug = UserVars.trade_debug
 
 class Trade
   include DRC
@@ -39,6 +38,10 @@ class Trade
     deposit_coins(500, Room.current.id) if contract.destination_town == @hometown
   end
 
+  def debugging?
+    UserVars.trade_debug
+  end
+
   def deposit_coins(withdraw_amt, return_to_id)
     return if wealth(@hometown) < withdraw_amt
     
@@ -54,7 +57,7 @@ class Trade
   def find_closest_id(entity)
     rooms = @town_data.to_h.values.select { |data| data[entity] }
                              .map{ |data| data[entity]['id'] }
-    echo "rooms: #{rooms}" if $debug
+    echo "rooms: #{rooms}" if debugging?
     return sort_destinations(rooms).first
   end
 
@@ -67,7 +70,7 @@ class Trade
     contract.expired = false
     fput("read my #{name} contract")
     while line = get
-      echo line if $debug
+      echo line if debugging?
       if line =~ destination_re
         contract.destination_town = line.match(destination_re).captures.first
         contract.destination_outpost = @town_data[contract.destination_town]['trader_outpost']['id']
@@ -89,7 +92,7 @@ class Trade
         break
       end
     end
-    if $debug
+    if debugging?
       echo "Contract origin: #{contract.origin_town}"
       echo "Contract origin clerk room: #{contract.origin_clerk}"
       echo "Contract origin minister room: #{contract.origin_minister}"
@@ -107,22 +110,22 @@ class Trade
         /You don't recall having a caravan\./
     ]
     response = bput("recall caravan", recall_messages)
-    echo("Response: #{response}") if $debug
+    echo("Response: #{response}") if debugging?
     case response
     when /You don't recall where you left your caravan/, /You don't recall having a caravan/
-      echo("No caravan found") if $debug
+      echo("No caravan found") if debugging?
     when /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/
       /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
       @caravan_noun = name
-      echo "@caravan_noun: #{@caravan_noun}" if $debug
+      echo "@caravan_noun: #{@caravan_noun}" if debugging?
       @caravan_adjective = description
-      echo "@caravan_description: #{@caravan_adjective}" if $debug
+      echo "@caravan_description: #{@caravan_adjective}" if debugging?
     when /You recall that your (?<description>.*) (?<name>.*) should be located in/
       /You recall that your (?<description>.*) (?<name>.*) should be located in/ =~ response
       @caravan_noun = name
-      echo "@caravan_noun: #{@caravan_noun}" if $debug
+      echo "@caravan_noun: #{@caravan_noun}" if debugging?
       @caravan_adjective = description
-      echo "@caravan_description: #{@caravan_adjective}" if $debug
+      echo "@caravan_description: #{@caravan_adjective}" if debugging?
     end
   end
 
@@ -135,7 +138,7 @@ class Trade
   end
 
   def step(dir)
-    echo "step dir: #{dir}" if $debug
+    echo "step dir: #{dir}" if debugging?
     case dir
     when String
       move(dir)
@@ -155,7 +158,7 @@ class Trade
       dir = get_next_dir(path)
       step(dir) if caravan_present?
       waitfor 'following you'
-      echo "Caravan arrival detected" if $debug
+      echo "Caravan arrival detected" if debugging?
     end
     command_caravan('wait')
   end
@@ -189,7 +192,7 @@ class Trade
   end
 
   def pay_dues(clerk_id)
-    echo "Paying dues at clerk_room: #{clerk_id}" if $debug
+    echo "Paying dues at clerk_room: #{clerk_id}" if debugging?
     clerk_messages = [
         /^You don't have any coins on you to pay dues\./,
         /^You count out some coins, and the clerk notes that your dues are settled\./,
@@ -214,13 +217,13 @@ class Trade
   end
 
   def load_caravan(clerk_id)
-    echo "Presenting contract to clerk in room: #{clerk_id}" if $debug
+    echo "Presenting contract to clerk in room: #{clerk_id}" if debugging?
     walk_to(clerk_id)
     give_clerk(clerk_id)
   end
 
   def get_new_contract(minister_id)
-    echo "Getting a new contract from room #{minister_id}" if $debug
+    echo "Getting a new contract from room #{minister_id}" if debugging?
     walk_to(minister_id)
     minister_messages = [
       "The minister plucks a contract from the hands",
@@ -230,7 +233,7 @@ class Trade
     case response  
     when /The minister reminds you/
       /The minister reminds you that you still owe (?<dues_amt>.*) (?<dues_currency>Kronars|Lirums|Dokoras) in dues to (?:The )?(?<outpost>.*) and asks that you pay the clerk before s?he issues you a new contract\./ =~ response
-      echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if $debug
+      echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if debugging?
       ensure_copper_on_hand(dues_amt.to_i, @hometown)
       pay_dues(@town_data[outpost]['shipment_clerk']['id'])
       get_new_contract(minister_id)

--- a/trade.lic
+++ b/trade.lic
@@ -166,7 +166,7 @@ class Trade
     command_caravan('wait')
   end
 
-  def command_caravan(command, _destination = nil)
+  def command_caravan(command)
     case command
     when 'follow'
       follow_messages = [

--- a/trade.lic
+++ b/trade.lic
@@ -66,9 +66,9 @@ class Trade
   end
 
   def parse_contract
-    destination_re = /The guild office at (?:The )?(?<destination>.*) requires .*/
-    payment_re = /You estimate these goods are currently worth (.*) (Kronars|Dokoras|Lirums) on delivery\./
-    origin_re = /Trading Contract Issued by:  (?:The )?(?<origin>.*)/
+    destination_re = /^ The guild office at (?:The )?(?<destination>.*) requires .*/
+    payment_re = /^You estimate these goods are currently worth (.*) (Kronars|Dokoras|Lirums) on delivery\./
+    origin_re = /^ Trading Contract Issued by:  (?:The )?(?<origin>.*)/
     contract = OpenStruct.new
     contract.presented = true
     contract.expired = false
@@ -108,10 +108,11 @@ class Trade
 
   def recall_caravan
     recall_messages = [
-      /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/,
-      /You recall that your (?<description>.*) (?<name>.*) should be located in/,
-      /You don't recall where you left your caravan\./,
-      /You don't recall having a caravan\./
+      /^You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/,
+      /^You recall that your (?<description>.*) (?<name>.*) should be located in/,
+      /^You don't recall where you left your caravan\./,
+      /^You don't recall having a caravan\./,
+      /^You seem to recall your (?<description>.*) (?<name>.*) should be somewhere to the/
     ]
     response = bput('recall caravan', recall_messages)
     echo("Response: #{response}") if debugging?
@@ -249,7 +250,7 @@ class Trade
 
   def give_clerk(clerk_id)
     walk_to(clerk_id)
-    bput('get my contract', 'You get')
+    bput('get my contract', 'You get', 'You are already holding that')
     Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
     bput('give my contract to clerk', /The .* clerk accepts your contract and peruses it\./)
     recall_caravan if Flags['caravan-upgrade']

--- a/trade.lic
+++ b/trade.lic
@@ -34,7 +34,7 @@ class Trade
     end
     feed_caravan(caravan)
     take_caravan_to(contract.destination_outpost)
-    fput("get my contract")
+    bput("get my contract", 'You get')
     deliver_contract(contract.destination_clerk)
     pay_dues(contract.destination_clerk)
     deposit_coins(500, Room.current.id) if contract.destination_town == @hometown
@@ -249,11 +249,11 @@ class Trade
 
   def give_clerk(clerk_id)
     walk_to(clerk_id)
-    fput("get my contract")
+    bput("get my contract", 'You get')
     Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
     bput("give my contract to clerk", /The .* clerk accepts your contract and peruses it\./)
     recall_caravan if Flags['caravan-upgrade']
-    fput("put my contract in my #{@contract_container}")
+    bput("put my contract in my #{@contract_container}", 'You put')
     Flags.delete('caravan-upgrade')
   end
 end

--- a/trade.lic
+++ b/trade.lic
@@ -32,7 +32,7 @@ class Trade
       recall_caravan
       walk_to(contract.origin_outpost)
     end
-    feed_caravan(caravan)
+    feed_caravan
     take_caravan_to(contract.destination_outpost)
     bput("get my contract", 'You get')
     deliver_contract(contract.destination_clerk)
@@ -120,14 +120,14 @@ class Trade
       /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
       @caravan.noun = name
       echo "@caravan.noun: #{@caravan.noun}" if debugging?
-      @caravan.description = description
-      echo "@caravan.description: #{@caravan.adjective}" if debugging?
+      @caravan.adjective = description
+      echo "@caravan.adjective: #{@caravan.adjective}" if debugging?
     when /You recall that your (?<description>.*) (?<name>.*) should be located in/
       /You recall that your (?<description>.*) (?<name>.*) should be located in/ =~ response
       @caravan.noun = name
       echo "@caravan.noun: #{@caravan.noun}" if debugging?
       @caravan.adjective = description
-      echo "@caravan.description: #{@caravan.adjective}" if debugging?
+      echo "@caravan.adjective #{@caravan.adjective}" if debugging?
     end
   end
 
@@ -155,6 +155,8 @@ class Trade
   def take_caravan_to(outpost_id)
     command_caravan('follow')
     path = compute_path(outpost_id)
+    echo "path: #{path}" if debugging?
+    echo "caravan_present?: #{caravan_present?}" if debugging?
     until Room.current.id == outpost_id
       dir = get_next_dir(path)
       step(dir) if caravan_present?
@@ -177,10 +179,6 @@ class Trade
         "You pass on the order to wait to your driver, who makes sure your .* does your bidding"
       ]
       bput("tell #{@caravan.noun} to wait", wait_messages)
-    when 'lead'
-      # TODO: Switch to bput
-      # TODO: Implement leading logic
-      fput("tell caravan to lead to #{destination}")
     end
   end
 
@@ -258,5 +256,4 @@ class Trade
   end
 end
 
-trade = Trade.new
-loop { trade.run }
+Trade.new.run

--- a/trade.lic
+++ b/trade.lic
@@ -51,6 +51,7 @@ class Trade
     walk_to(@town_data[@hometown]['deposit']['id'])
     case bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit')
     when 'There is no teller here'
+      walk_to(return_to_id)
       return
     end
     minimize_coins(withdraw_amt).each { |amount| withdraw_exact_amount?(amount, @hometown) }

--- a/trade.lic
+++ b/trade.lic
@@ -63,14 +63,14 @@ class Trade
     return sort_destinations(rooms).first
   end
 
-  def parse_contract(name=nil)
+  def parse_contract
     destination_re = /The guild office at (?:The )?(?<destination>.*) requires .*/
     payment_re = /You estimate these goods are currently worth (.*) (Kronars|Dokoras|Lirums) on delivery\./
     origin_re = /Trading Contract Issued by:  (?:The )?(?<origin>.*)/
     contract = OpenStruct.new
     contract.presented = true
     contract.expired = false
-    fput("read my #{name} contract")
+    fput("read my contract")
     while line = get
       echo line if debugging?
       if line =~ destination_re


### PR DESCRIPTION
This script handles running a caravan route in Zoluren. It will trade one contract at a time, but has the potential to be updated to run fancier routes with several contracts at a time. The script assumes you have a worn feedbag for feeding the animals.