### PR TITLE
Drca update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,6 @@ Metrics/PerceivedComplexity:
 
 Metrics/ParameterLists:
   Enabled: false
+
+Lint/UnifiedInteger:
+  Enabled: false

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -348,7 +348,7 @@ module DRCA
         case data['cambrinth'].first
         when Array
           find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'][index])
-        when Integer
+        when Fixnum, Integer
           find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'])
         end
       end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -345,7 +345,7 @@ module DRCA
       harness_mana(data['cambrinth'].flatten)
     else
       settings.cambrinth_items.each_with_index do |item, index|
-        case data['cambrinth'][index][0]
+        case data['cambrinth'].first
         when Array
           find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'][index])
         when Integer


### PR DESCRIPTION
The cambrinth data was being indexed incorrectly. The previous style was looking up the first bit of the first element in the array in some cases. This doesn't throw an error, so it wasn't noticed. Since we're interested in knowing if the cambrinth data is an array of arrays or an array of integers, we can look at the first element each time.

Current versions of ruby use a unified integer format for Fixnum
and Bignum. Ruby 2.0.0 is using Fixnum and Bignum. We should check both for
compatability.