### PR TITLE
Added the ability for spells/spell sets to override the new harness. 

### DIFF
--- a/buff.lic
+++ b/buff.lic
@@ -25,7 +25,7 @@ class Waggle
 
     return unless spells
 
-    cast_spells(spells, settings, true)
+    cast_spells(spells, settings, settings.waggle_force_cambrinth)
   end
 end
 

--- a/buff.lic
+++ b/buff.lic
@@ -25,7 +25,7 @@ class Waggle
 
     return unless spells
 
-    cast_spells(spells, settings)
+    cast_spells(spells, settings, true)
   end
 end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1151,10 +1151,10 @@ class SpellProcess
         data = { 'abbrev' => 'heal', 'mana' => @empath_spells['HEAL'].first, 'cambrinth' => @empath_spells['HEAL'][1..-1] }
       end
       @wounds = {}
-      prepare_spell(data, game_state) if data
+      prepare_spell(data, game_state, true) if data
     elsif @empath_spells['VH']
       data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1] }
-      prepare_spell(data, game_state)
+      prepare_spell(data, game_state, true)
     end
   end
 
@@ -1167,7 +1167,7 @@ class SpellProcess
     game_state.casting_cfb = true
     game_state.prepare_cfb = false
     data = @necromancer_zombie['Call from Beyond']
-    prepare_spell(data, game_state)
+    prepare_spell(data, game_state, true)
   end
 
   def check_consume(game_state)
@@ -1181,7 +1181,7 @@ class SpellProcess
     data = @necromancer_healing['Devour'] || @necromancer_healing['Consume Flesh']
     game_state.casting_consume = true
     game_state.prepare_consume = false
-    prepare_spell(data, game_state)
+    prepare_spell(data, game_state, true)
   end
 
   def check_offensive(game_state)
@@ -1233,7 +1233,7 @@ class SpellProcess
     game_state.reset_stance = true
   end
 
-  def prepare_spell(data, game_state)
+  def prepare_spell(data, game_state, force_cambrinth = false)
     return unless data
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
@@ -1290,8 +1290,8 @@ class SpellProcess
     game_state.casting = true
     game_state.cambrinth_charges(data['cambrinth'])
     if data['cambrinth']
-      @should_harness = check_to_harness(@harness_for_attunement)
-      @should_invoke = data['cambrinth'] unless @should_harness
+      @should_harness = check_to_harness(@harness_for_attunement) && force_cambrinth
+      @should_invoke = data['cambrinth'] unless @should_harness 
     end
     @custom_cast = data['cast']
     @symbiosis = data['symbiosis']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -839,7 +839,7 @@ class SpellProcess
     @hide_type = settings.hide_type
     echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
 
-    @buff_force_cambrinth = settings.crossing_training_force_cambrinth
+    @buff_force_cambrinth = settings.combat_trainer_buffs_force_cambrinth
     echo("  @buff_force_cambrinth: #{@buff_force_cambrinth}") if $debug_mode_ct
 
     @perc_health_timer = Time.now

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1294,7 +1294,7 @@ class SpellProcess
     game_state.cambrinth_charges(data['cambrinth'])
     if data['cambrinth']
       @should_harness = check_to_harness(@harness_for_attunement) && !force_cambrinth
-      @should_invoke = data['cambrinth'] unless @should_harness 
+      @should_invoke = data['cambrinth'] unless @should_harness
     end
     @custom_cast = data['cast']
     @symbiosis = data['symbiosis']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1290,7 +1290,7 @@ class SpellProcess
     game_state.casting = true
     game_state.cambrinth_charges(data['cambrinth'])
     if data['cambrinth']
-      @should_harness = check_to_harness(@harness_for_attunement) && force_cambrinth
+      @should_harness = check_to_harness(@harness_for_attunement) && !force_cambrinth
       @should_invoke = data['cambrinth'] unless @should_harness 
     end
     @custom_cast = data['cast']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -839,6 +839,9 @@ class SpellProcess
     @hide_type = settings.hide_type
     echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
 
+    @buff_force_cambrinth = settings.buff_spells_force_cambrinth
+    echo("  @buff_force_cambrinth: #{@buff_force_cambrinth}") if $debug_mode_ct
+
     @perc_health_timer = Time.now
 
     Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
@@ -1121,7 +1124,7 @@ class SpellProcess
     if data['ritual']
       cast_ritual(data, game_state)
     else
-      prepare_spell(data, game_state)
+      prepare_spell(data, game_state, @buff_force_cambrinth)
     end
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -839,7 +839,7 @@ class SpellProcess
     @hide_type = settings.hide_type
     echo("  @hide_type: #{@hide_type}") if $debug_mode_ct
 
-    @buff_force_cambrinth = settings.buff_spells_force_cambrinth
+    @buff_force_cambrinth = settings.crossing_training_force_cambrinth
     echo("  @buff_force_cambrinth: #{@buff_force_cambrinth}") if $debug_mode_ct
 
     @perc_health_timer = Time.now

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -235,7 +235,7 @@ module DRCA
     end
   end
 
-  def cast_spells(spells, settings)
+  def cast_spells(spells, settings, force_cambrinth = false)
     infuse_om(!settings.osrel_no_harness, settings.osrel_amount)
     spells.each do |name, data|
       next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
@@ -316,7 +316,7 @@ module DRCA
     cast_spell(spell, settings)
   end
 
-  def cast_spell(data, settings)
+  def cast_spell(data, settings, force_cambrinth = false)
     return unless data
     return unless settings
 
@@ -341,7 +341,7 @@ module DRCA
         'stored' => settings.stored_cambrinth
       }]
     end
-    if check_to_harness(settings.use_harness_when_arcana_locked)
+    if check_to_harness(settings.use_harness_when_arcana_locked)  && !force_cambrinth
       harness_mana(data['cambrinth'].flatten)
     else
       settings.cambrinth_items.each_with_index do |item, index|

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -312,8 +312,8 @@ module DRCA
     echo "Run `#{$clean_lich_char}e autostart('moonwatch')` to avoid this in the future"
   end
 
-  def buff(spell, settings)
-    cast_spell(spell, settings)
+  def buff(spell, settings, force_cambrinth = false)
+    cast_spell(spell, settings, force_cambrinth)
   end
 
   def cast_spell(data, settings, force_cambrinth = false)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -341,7 +341,7 @@ module DRCA
         'stored' => settings.stored_cambrinth
       }]
     end
-    if check_to_harness(settings.use_harness_when_arcana_locked)  && !force_cambrinth
+    if check_to_harness(settings.use_harness_when_arcana_locked) && !force_cambrinth
       harness_mana(data['cambrinth'].flatten)
     else
       settings.cambrinth_items.each_with_index do |item, index|

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -244,7 +244,7 @@ module DRCA
         pause 15
       end
 
-      cast_spell(data, settings)
+      cast_spell(data, settings, force_cambrinth)
     end
   end
 

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -337,7 +337,7 @@ class CrossingTraining
         do_research(skill)
       else
         handle_cyclic_timers(skill)
-        cast_spell(@settings.training_spells[skill], skill)
+        cast_spell(@settings.training_spells[skill], skill, true)
       end
     else
       cast_nonspell(skill)

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -49,6 +49,7 @@ class CrossingTraining
       'Remedies' => 'Alchemy'
     }
     @skills_requiring_movement = @settings.crossing_training_requires_movement
+    @force_cambrinth = @settings.crossing_training_force_cambrinth
 
     @equipment_manager = EquipmentManager.new(@settings)
 
@@ -337,7 +338,7 @@ class CrossingTraining
         do_research(skill)
       else
         handle_cyclic_timers(skill)
-        cast_spell(@settings.training_spells[skill], skill, true)
+        cast_spell(@settings.training_spells[skill], skill, @force_cambrinth)
       end
     else
       cast_nonspell(skill)

--- a/healme.lic
+++ b/healme.lic
@@ -82,7 +82,7 @@ class HealMe
     return unless spells['Cure Disease']
 
     Flags.add('hm-disease', 'You feel completely cured of all disease', 'you don.t seem to be so afflicted')
-    DRCA.cast_spell(spells['Cure Disease'], @settings) until Flags['hm-disease']
+    DRCA.cast_spell(spells['Cure Disease'], @settings, true) until Flags['hm-disease']
     Flags.delete('hm-disease')
   end
 
@@ -91,7 +91,7 @@ class HealMe
     return unless spells['Flush Poisons']
 
     Flags.add('hm-poison', '^A sudden wave of heat washes over you as your spell attempts to flush poison from your body but finds no toxins', '^A sudden wave of heat washes over you as your spell flushes all poison from your body')
-    DRCA.cast_spell(spells['Flush Poisons'], @settings) until Flags['hm-poison']
+    DRCA.cast_spell(spells['Flush Poisons'], @settings, true) until Flags['hm-poison']
     Flags.delete('hm-poison')
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -168,7 +168,7 @@ safe_room_empath:
 # Spellcasting (and Khri) settings
 use_harness_when_arcana_locked: false
 crossing_training_force_cambrinth: true
-buff_spells_force_cambrinth: true
+combat_trainer_buffs_force_cambrinth: true
 waggle_force_cambrinth: true
 cambrinth: armband
 cambrinth_cap: 32

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -167,6 +167,9 @@ safe_room_empath:
 
 # Spellcasting (and Khri) settings
 use_harness_when_arcana_locked: false
+crossing_training_force_cambrinth: true
+buff_spells_force_cambrinth: true
+waggle_force_cambrinth: true
 cambrinth: armband
 cambrinth_cap: 32
 stored_cambrinth: false

--- a/sorcery.lic
+++ b/sorcery.lic
@@ -29,7 +29,7 @@ class Sorcery
       walk_to(@settings.crossing_training_sorcery_room)
 
       if sorcery_spell.is_a?(Hash)
-        buff(sorcery_spell, @settings)
+        buff(sorcery_spell, @settings, true)
       else
         fput "prep #{sorcery_spell}"
         pause 3

--- a/sorcery.lic
+++ b/sorcery.lic
@@ -29,7 +29,7 @@ class Sorcery
       walk_to(@settings.crossing_training_sorcery_room)
 
       if sorcery_spell.is_a?(Hash)
-        buff(sorcery_spell, @settings, true)
+        buff(sorcery_spell, @settings, @settings.crossing_training_force_cambrinth)
       else
         fput "prep #{sorcery_spell}"
         pause 3


### PR DESCRIPTION
This will make it better for crossing-training and buff as people can't use it due to nerve damage and leakage, and also want forced max cast buffing. Should also be spread tout to force buffing spells in combat-trainer as well. Currently have it set to force cambrinth use with buff.lic and crossing-training.lic.
  