### PR TITLE
Hotfix for the parameter in cast_spell. 

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -49,7 +49,6 @@ class CrossingTraining
       'Remedies' => 'Alchemy'
     }
     @skills_requiring_movement = @settings.crossing_training_requires_movement
-    @force_cambrinth = @settings.crossing_training_force_cambrinth
 
     @equipment_manager = EquipmentManager.new(@settings)
 
@@ -338,7 +337,7 @@ class CrossingTraining
         do_research(skill)
       else
         handle_cyclic_timers(skill)
-        cast_spell(@settings.training_spells[skill], skill, @force_cambrinth)
+        cast_spell(@settings.training_spells[skill], skill)
       end
     else
       cast_nonspell(skill)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -168,7 +168,6 @@ safe_room_empath:
 
 # Spellcasting (and Khri) settings
 use_harness_when_arcana_locked: false
-crossing_training_force_cambrinth: true
 combat_trainer_buffs_force_cambrinth: true
 waggle_force_cambrinth: true
 cambrinth: armband


### PR DESCRIPTION
It appeared to use the common-arcana one, but it had a local one. No need for a spell override as I think in this context you'll want to be using the cambrinth array anyhow. 
  