### PR TITLE
Based on community feedback, this is an issue I needed to fix. 

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -914,7 +914,10 @@ class SpellProcess
       echo('SpellProcess::clean_up') if $debug_mode_ct
       game_state.next_clean_up_step
       release_cyclics
-      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") if checkprep != 'None'
+      if checkprep != 'None'
+        bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") 
+        bput('release mana', 'You release all', "You aren't harnessing any mana")
+      end
       if @tk_ammo
         waitrt?
         pause
@@ -958,7 +961,10 @@ class SpellProcess
     return if game_state.cast_timer.nil? || (Time.now - game_state.cast_timer) <= 70
 
     game_state.cast_timer = nil
-    fput('release spell') if game_state.casting
+    if game_state.casting
+      fput('release spell')
+      bput('release mana', 'You release all', "You aren't harnessing any mana")
+    end
     game_state.casting = false
   end
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -95,6 +95,7 @@ module DRCA
     case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
     when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/
       fput('release spell')
+      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     end
     waitrt?
 
@@ -325,6 +326,7 @@ module DRCA
 
     release_cyclics if data['cyclic']
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
 
     if data['ritual']
       ritual(data, settings.ignored_npcs)


### PR DESCRIPTION
Harnessing mana didn't release it on spell failure, so the next spell would definitely fail.

This occurs when **harness mana** is set to be used for attunement training! Just pointing out the issue's starting point.
  