### PR TITLE
astrology: Resolve outstanding todo

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -306,10 +306,6 @@ class Astrology
 
   def train_astrology(settings)
     return unless settings
-    if settings.astrology_training.nil? # TODO: Temporary until everyone is updated
-      echo ' Astrology training settings have been updated, please restart dependency!'
-      exit
-    end
     return unless settings.astrology_training.is_a?(Array)
     return if settings.astrology_training.none?
 


### PR DESCRIPTION
Removes the guard against astrology_training being nil. Since this
exists in base and base-empty, it cannot be nil.