### PR TITLE
Combat-Trainer: Add setting for allowing spell mana/cambrinth/harness data to be calculated dynamically

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -842,6 +842,15 @@ class SpellProcess
 
     @perc_health_timer = Time.now
 
+    @check_discern_settings = OpenStruct.new(
+      'prep_scaling_factor' => settings.prep_scaling_factor,
+      'cambrinth_items' => settings.cambrinth_items,
+      'cambrinth' => settings.cambrinth,
+      'cambrinth_cap' => settings.cambrinth_cap,
+      'stored_cambrinth' => settings.stored_cambrinth,
+    )
+    echo(" @check_discern_settings: #{@check_discern_settings}")
+
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}")
 
@@ -1257,7 +1266,7 @@ class SpellProcess
   def prepare_spell(data, game_state, force_cambrinth = false)
     return unless data
 
-    data = check_discern if data['use_auto_mana']
+    data = check_discern(data, @check_discern_settings) if data['use_auto_mana']
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
     echo("prepare spell: #{data}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1,7 +1,7 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 =end
-
+require 'ostruct'
 custom_require.call(%w[common common-arcana common-healing common-items common-summoning common-travel drinfomon equipmanager events spellmonitor])
 
 class SetupProcess

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -847,7 +847,7 @@ class SpellProcess
       'cambrinth_items' => settings.cambrinth_items,
       'cambrinth' => settings.cambrinth,
       'cambrinth_cap' => settings.cambrinth_cap,
-      'stored_cambrinth' => settings.stored_cambrinth,
+      'stored_cambrinth' => settings.stored_cambrinth
     )
     echo(" @check_discern_settings: #{@check_discern_settings}")
 
@@ -2724,12 +2724,12 @@ class GameState
   end
 
   def cambrinth_charges(charges)
-    case charges.first
-    when Array
-      cambrinth = charges.first
-    else
-      cambrinth = charges
-    end
+    cambrinth = case charges.first
+                when Array
+                  charges.first
+                else
+                  charges
+                end
     @charges = cambrinth.nil? || cambrinth.empty? ? nil : cambrinth.dup
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -842,6 +842,9 @@ class SpellProcess
 
     @perc_health_timer = Time.now
 
+    @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
+    echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}")
+
     Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
 
@@ -1040,11 +1043,22 @@ class SpellProcess
 
     hide?(@hide_type) if XMLData.prepared_spell == 'Vivisection' && game_state.use_stealth_attack?
 
-    cast?(@custom_cast, @symbiosis, @before, @after)
+    snapshot = DRSkill.get_xp(@skill)
+    success = cast?(@custom_cast, @symbiosis, @before, @after)
+    if @symbiosis && @use_auto_mana
+      if !success
+        UserVars.discerns[@abbrev]['more'] = [UserVars.discerns[@abbrev]['more'] - 1, 0].max
+      elsif DRSkill.getxp(@skill) - snapshot < @symbiosis_learning_threshold
+        UserVars.discerns[@abbrev]['more'] = UserVars.discerns[@abbrev]['more'] + 1
+      end
+    end
     @custom_cast = nil
     @symbiosis = nil
     @before = nil
     @after = nil
+    @skill = nil
+    @abbrev = nil
+    @use_auto_mana = nil
 
     game_state.casting = false
     game_state.cast_timer = nil
@@ -1242,6 +1256,8 @@ class SpellProcess
 
   def prepare_spell(data, game_state, force_cambrinth = false)
     return unless data
+
+    data = check_discern if data['use_auto_mana']
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
     echo("prepare spell: #{data}") if $debug_mode_ct
@@ -1309,6 +1325,8 @@ class SpellProcess
     @reset_expire = data['expire'] ? data['abbrev'] : nil
     Flags.reset('ct-spellcast')
     @before = data['before']
+    @abbrev = data['abbrev']
+    @use_auto_mana = data['use_auto_mana']
     game_state.action_taken if (@skill == 'Targeted Magic' || @prep == 'target') && game_state.weapon_skill == 'Targeted Magic'
   end
 end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -773,7 +773,7 @@ class SpellProcess
     @equipment_manager = equipment_manager
     echo('New SpellProcess') if $debug_mode_ct
 
-    @settings = get_settings
+    @settings = settings
 
     @buff_spells = settings.buff_spells
     echo("  @buff_spells: #{@buff_spells}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2723,8 +2723,18 @@ class GameState
     @dance_queue.shift
   end
 
+  def charges_to_array
+    # TODO: Support multiple cambrinth
+    case @charges.first
+    when Array
+      echo "*** Multiple cambrinth items are not supported in combat trainer yet!"
+      @charges = @charges.first
+    end
+  end
+
   def cambrinth_charges(cambrinth)
     @charges = cambrinth.nil? || cambrinth.empty? ? nil : cambrinth.dup
+    charges_to_array
   end
 
   def check_charging?
@@ -2757,7 +2767,7 @@ class GameState
       return
     end
 
-    harness_mana(@charges)
+    harness_mana(@charges.flatten)
 
     @charges = []
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1,7 +1,6 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 =end
-require 'ostruct'
 custom_require.call(%w[common common-arcana common-healing common-items common-summoning common-travel drinfomon equipmanager events spellmonitor])
 
 class SetupProcess
@@ -774,6 +773,8 @@ class SpellProcess
     @equipment_manager = equipment_manager
     echo('New SpellProcess') if $debug_mode_ct
 
+    @settings = get_settings
+
     @buff_spells = settings.buff_spells
     echo("  @buff_spells: #{@buff_spells}") if $debug_mode_ct
 
@@ -841,15 +842,6 @@ class SpellProcess
     echo("  @buff_force_cambrinth: #{@buff_force_cambrinth}") if $debug_mode_ct
 
     @perc_health_timer = Time.now
-
-    @check_discern_settings = OpenStruct.new(
-      'prep_scaling_factor' => settings.prep_scaling_factor,
-      'cambrinth_items' => settings.cambrinth_items,
-      'cambrinth' => settings.cambrinth,
-      'cambrinth_cap' => settings.cambrinth_cap,
-      'stored_cambrinth' => settings.stored_cambrinth
-    )
-    echo(" @check_discern_settings: #{@check_discern_settings}")
 
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}")
@@ -1265,8 +1257,7 @@ class SpellProcess
 
   def prepare_spell(data, game_state, force_cambrinth = false)
     return unless data
-
-    data = check_discern(data, @check_discern_settings) if data['use_auto_mana']
+    data = check_discern(data, @settings) if data['use_auto_mana']
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
     echo("prepare spell: #{data}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1043,7 +1043,7 @@ class SpellProcess
 
     hide?(@hide_type) if XMLData.prepared_spell == 'Vivisection' && game_state.use_stealth_attack?
 
-    snapshot = DRSkill.get_xp(@skill)
+    snapshot = DRSkill.getxp(@skill)
     success = cast?(@custom_cast, @symbiosis, @before, @after)
     if @symbiosis && @use_auto_mana
       if !success

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2723,18 +2723,14 @@ class GameState
     @dance_queue.shift
   end
 
-  def charges_to_array
-    # TODO: Support multiple cambrinth
-    case @charges.first
+  def cambrinth_charges(charges)
+    case charges.first
     when Array
-      echo "*** Multiple cambrinth items are not supported in combat trainer yet!"
-      @charges = @charges.first
+      cambrinth = charges.first
+    else
+      cambrinth = charges
     end
-  end
-
-  def cambrinth_charges(cambrinth)
     @charges = cambrinth.nil? || cambrinth.empty? ? nil : cambrinth.dup
-    charges_to_array
   end
 
   def check_charging?


### PR DESCRIPTION
This works almost the same as with the logic in crossing-trainer. 

Add the attribute `use_auto_mana: true` to spell data and it will update the mana/cambrinth data based on info from `discern spellname` and the `calculate_mana` method from DRCA. If symbiosis is true then it will step up the mana/cambrinth data one mana at a time until a cast teaches at least as much as defined in `symbiosis_learning_threshold` (default is 2).

If the setting name is terrible (`use_auto_mana`) let me know, I dont care one way or the other what its called :P