### PR TITLE
Add glyph-of-mana.lic, to keep glyph of mana up always.

### DIFF
--- a/glyph-of-mana.lic
+++ b/glyph-of-mana.lic
@@ -15,7 +15,7 @@ class GlyphMana
   def do_glyphy_stuff
     case bput("glyph mana", 'You trace a glyph into the air in', 'Paladin now', 'but you sense that this glyph is already in effect here', 'You trace a glyph into the air managing only to look foolish')
     when 'Paladin now', 'You trace a glyph into the air managing only to look foolish'
-	  echo('You do not know how to use this glyph.')
+      echo('You do not know how to use this glyph.')
       exit
     end
     while line = get
@@ -25,7 +25,7 @@ class GlyphMana
         bput("glyph mana", 'You trace a glyph into the air in', 'Paladin now', 'but you sense that this glyph is already in effect here', 'You trace a glyph into the air managing only to look foolish')
         Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
       end
-	end
+    end
   end
 end
 

--- a/glyph-of-mana.lic
+++ b/glyph-of-mana.lic
@@ -1,0 +1,32 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#glyph-of-mana
+=end
+
+custom_require.call(%w[common])
+
+no_pause_all
+
+class GlyphMana
+  include DRC
+  def initialize
+    do_glyphy_stuff
+  end
+  
+  def do_glyphy_stuff
+    case bput("glyph mana", 'You trace a glyph into the air in', 'Paladin now', 'but you sense that this glyph is already in effect here', 'You trace a glyph into the air managing only to look foolish')
+    when 'Paladin now', 'You trace a glyph into the air managing only to look foolish'
+	  echo('You do not know how to use this glyph.')
+      exit
+	end
+    while line = get
+      waitrt?
+	  if line =~ /^You sense the holy power return to normal/
+        Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
+        bput("glyph mana", 'You trace a glyph into the air in', 'Paladin now', 'but you sense that this glyph is already in effect here', 'You trace a glyph into the air managing only to look foolish')
+        Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
+      end
+	end
+  end
+end
+
+GlyphMana.new

--- a/glyph-of-mana.lic
+++ b/glyph-of-mana.lic
@@ -20,7 +20,7 @@ class GlyphMana
     end
     while line = get
       waitrt?
-	  if line =~ /^You sense the holy power return to normal/
+      if line =~ /^You sense the holy power return to normal/
         Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
         bput("glyph mana", 'You trace a glyph into the air in', 'Paladin now', 'but you sense that this glyph is already in effect here', 'You trace a glyph into the air managing only to look foolish')
         Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)

--- a/glyph-of-mana.lic
+++ b/glyph-of-mana.lic
@@ -17,7 +17,7 @@ class GlyphMana
     when 'Paladin now', 'You trace a glyph into the air managing only to look foolish'
 	  echo('You do not know how to use this glyph.')
       exit
-	end
+    end
     while line = get
       waitrt?
 	  if line =~ /^You sense the holy power return to normal/


### PR DESCRIPTION
This is meant to be used as a during: in hunting_info so it stays up in combat, like

```hunting_info:
- :zone: cinder_beasts
  args:
  - d1
  stop_on:
  - Small Edged
  :duration: 55
  before:
  - go2 12345
  - mech-lore
  - athletics
  during:
  - glyph-of-mana
  