### PR TITLE
common-arcana: Move moonwatch logic from crossing-training

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -341,8 +341,10 @@ module DRCA
     return if Script.running? 'moonwatch'
 
     echo 'moonwatch is not running. Starting it now'
+    UserVars.moons = {}
     custom_require.call('moonwatch')
     echo "Run `#{$clean_lich_char}e autostart('moonwatch')` to avoid this in the future"
+    pause 0.5 while UserVars.moons.empty?
   end
 
   def buff(spell, settings, force_cambrinth = false)


### PR DESCRIPTION
These lines existed in the duplicate logic in crossing-training but not
in common-arcana.