### PR TITLE
common-arcana.lic: Use DRCT.retreat for activate_barb_buff.

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -73,7 +73,7 @@ module DRCA
     ability_data = get_data('spells').barb_abilities[name]
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting')
     when 'You must be sitting'
-      retreat
+      DRCT.retreat
       DRC.bput('sit', 'You sit', 'You are already', 'You rise')
       activate_barb_buff(name)
     when 'You should stand'


### PR DESCRIPTION
--- Lich: error: undefined local variable or method `retreat' for #<Scripting::AbilityProcess:0xaf46730>
    common-arcana:76:in `activate_barb_buff'
    combat-trainer:1466:in `block in check_nonspell_buffs'
--- Lich: combat-trainer has exited.