### PR TITLE
drinfomon.lic: Fix DRRoom.pcs for celestial compact members

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -458,7 +458,7 @@ end
 def find_pcs(room_players)
   room_players.sub(/ and (.*)$/) { ", #{Regexp.last_match(1)}" }
               .split(', ')
-              .map { |obj| obj.sub(/ who (has|is) .+/, '').sub(/ \(.+\)/, '') }
+              .map { |obj| obj.sub(/ who (has|is|appears) .+/, '').sub(/ \(.+\)/, '') }
               .map { |obj| obj.strip.scan(/\w+$/).first }
 end
 


### PR DESCRIPTION
--- Lich: exec1 active.
[exec1: ["Serature", "Sentoki", "inhuman", "Viansome"]]
--- Lich: exec1 has exited.

Also here: Serature who is shrouded in ghostly flames, Sentoki, Celestian Treylis who appears sublimely inhuman and Viansome.

Fixes #2347