### PR TITLE
Change buff to cast_spell

### DIFF
--- a/lichbot.lic
+++ b/lichbot.lic
@@ -69,7 +69,7 @@ class Lichbot
     fput "whisper #{character} Preparing [#{buff_data['name']}] now"
     buff_data = buff_data.clone
     buff_data['cast'] = "cast #{character}"
-    buff(buff_data, @settings)
+    cast_spell(buff_data, @settings)
     fput "whisper #{character} Buffing complete"
   end
 
@@ -158,7 +158,7 @@ class Lichbot
                 .lichbot_buffs
                 .sort_by { |spell| DRSpells.active_spells[spell['name']] || 0 }
                 .first
-    buff(buff_data, @settings) if buff_data
+    cast_spell(buff_data, @settings) if buff_data
   end
 
   private

--- a/pick.lic
+++ b/pick.lic
@@ -172,7 +172,7 @@ class LockPicker
 
     buffs['spells'].each do |spell|
       echo "Buffing: #{spell}" if UserVars.lockpick_debug
-      buff(spell, @settings)
+      cast_spell(spell, @settings)
     end
 
     buffs['khri']

--- a/scouting.lic
+++ b/scouting.lic
@@ -21,7 +21,7 @@ class Scouting
   def do_buffs(settings)
     settings.scouting_buffs['spells'].each do |spell|
       echo "Buffing: #{spell}" if UserVars.scouting_debug
-      buff(spell, settings)
+      cast_spell(spell, settings)
     end
   end
 

--- a/sorcery.lic
+++ b/sorcery.lic
@@ -29,7 +29,7 @@ class Sorcery
       walk_to(@settings.crossing_training_sorcery_room)
 
       if sorcery_spell.is_a?(Hash)
-        buff(sorcery_spell, @settings, @settings.crossing_training_force_cambrinth)
+        cast_spell(sorcery_spell, @settings, @settings.crossing_training_force_cambrinth)
       else
         fput "prep #{sorcery_spell}"
         pause 3

--- a/steal.lic
+++ b/steal.lic
@@ -104,7 +104,7 @@ class Steal
   end
 
   def do_buff(buffs, settings)
-    buffs['spells'].each { |spell| buff(spell, settings) }
+    buffs['spells'].each { |spell| cast_spell(spell, settings) }
 
     buffs['khri']
       .map { |name| "Khri #{name}" }


### PR DESCRIPTION
Buff is being removed in favor of cast_spell. Buff calls cast_spell
acting as an alias without actually being one.

Removing buff from common-arcana submitted as a different PR #2337 