### PR TITLE
truffenyi-commune-quest.lic: Simplify the matches, use anchors.

### DIFF
--- a/truffenyi-commune-quest.lic
+++ b/truffenyi-commune-quest.lic
@@ -9,61 +9,61 @@ EquipmentManager.new.empty_hands
 
 while line = get
   waitrt?
-  if line =~ /Your vision fades and you suddenly see yourself working in front of a glowing forge/
+  if line =~ /^Your vision fades and you suddenly see yourself working in front of a glowing forge/
     fput('pray Divyaush')
   end
-  if line =~ /Your vision fades and you see yourself toiling in a dusty field. Each withered crop/
+  if line =~ /^Your vision fades and you see yourself toiling in a dusty field/
     fput('pray Berengaria')
   end
-  if line =~ /Your vision fades and you see yourself huddled in front of a fire in an icy cavern/
+  if line =~ /^Your vision fades and you see yourself huddled in front of a fire in an icy cavern/
     fput('pray Kuniyo')
   end
-  if line =~ /Your vision fades and you see yourself surrounded by occupied cots. The air is still/
+  if line =~ /^Your vision fades and you see yourself surrounded by occupied cots/
     fput("pray Peri'el")
   end
-  if line =~ /Your vision fades and you see yourself alone on a raft, calm seas in all directions./
+  if line =~ /^Your vision fades and you see yourself alone on a raft/
     fput('pray Lemicus')
   end
-  if line =~ /Your vision fades and you see yourself as a young child sitting in the corner. You watch your parents/
+  if line =~ /^Your vision fades and you see yourself as a young child sitting in the corner/
     fput('pray Albreda')
   end
-  if line =~ /Your vision fades and you find yourself travelling the desert/
+  if line =~ /^Your vision fades and you find yourself travelling the desert/
     fput('pray Murrula')
   end
-  if line =~ /Your vision fades and you see yourself tired and sore after a long day of harvesting crops/
+  if line =~ /^Your vision fades and you see yourself tired and sore after a long day of harvesting crops/
     fput('pray Rutilor')
   end
-  if line =~ /Your vision fades and you see yourself sitting on a bar stool/
+  if line =~ /^Your vision fades and you see yourself sitting on a bar stool/
     fput('pray Saemaus')
   end
-  if line =~ /Your vision fades and you see yourself walking through one of your grain fields/
+  if line =~ /^Your vision fades and you see yourself walking through one of your grain fields/
     fput('pray Asketi')
   end
-  if line =~ /Your vision fades and you see yourself sitting amongst a group gathered at an outdoor wedding/
+  if line =~ /^Your vision fades and you see yourself sitting amongst a group gathered at an outdoor wedding/
     fput("pray Be'ort")
   end
-  if line =~ /Your vision fades and you see yourself sitting on a grassy hilltop/
+  if line =~ /^Your vision fades and you see yourself sitting on a grassy hilltop/
     fput('pray Dergati')
   end
-  if line =~ /In your vision the waters pull away from the shore, gathering upward in a massive wall/
+  if line =~ /^In your vision the waters pull away from the shore/
     fput('pray Drogor')
   end
-  if line =~ /Your vision fades and you see yourself facing a crackling fire next to the shore/
+  if line =~ /^Your vision fades and you see yourself facing a crackling fire next to the shore/
     fput('pray Drogor')
   end
-  if line =~ /Your vision fades and you see yourself seated in the front row of a concert hall/
+  if line =~ /^Your vision fades and you see yourself seated in the front row of a concert hall/
     fput('pray Idon')
   end
-  if line =~ /Your vision fades and you see yourself entertaining a neighboring farmer at your house/
+  if line =~ /^Your vision fades and you see yourself entertaining a neighboring farmer at your house/
     fput('pray Kerenhappuch')
   end
-  if line =~ /Your vision fades and you see yourself battling a small peccary/
+  if line =~ /^Your vision fades and you see yourself battling a small peccary/
     fput('pray Trothfang')
   end
-  if line =~ /Your vision fades and you see yourself standing in the snow peering into the window of a rival/
+  if line =~ /^Your vision fades and you see yourself standing in the snow peering into the window of a rival/
     fput('pray Zachriedek')
   end
-  if line =~ /Your stomach grumbles and you realize that you're holding a/
+  if line =~ /^Your stomach grumbles and you realize that you're holding a/
     fput("drop #{checkright || checkleft}") if DRC.left_hand || DRC.right_hand
   end
   if line =~ /you have my attention, though really you are never far from my sight/


### PR DESCRIPTION
Some clients are double spacing after the .'s