### PR TITLE
Merge combat spell training with base-spells

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -866,6 +866,17 @@ class SetupFiles
      .select { |spell| spells[spell] }
      .each_key { |name| s.buff_spells[name] = spells[name].merge(s.buff_spells[name]) }
 
+    s.combat_spell_training
+     .each do |skill, data|
+      s.combat_spell_training[skill] = if spells[data['name']]
+                                         spells[data['name']].merge(data)
+                                       elsif spells[data['abbrev']]
+                                         spells[data['abbrev']].merge(data)
+                                       else
+                                         data
+                                       end
+    end
+
     s.lockpick_buffs['spells']
      .each_with_index
      .select do |spell, i|


### PR DESCRIPTION
Much like the other spell merging, this compares the abbreviation and
the spell name with data base spells. If there is a match, then the data
is merged, keeping the users data.