### PR TITLE
drinfomon.lic: Make DRRooms.pcs work for heritage house cantrip users.

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -458,7 +458,7 @@ end
 def find_pcs(room_players)
   room_players.sub(/ and (.*)$/) { ", #{Regexp.last_match(1)}" }
               .split(', ')
-              .map { |obj| obj.sub(/ who (has|is|appears) .+/, '').sub(/ \(.+\)/, '') }
+              .map { |obj| obj.sub(/ (who|whose body) (has|is|appears) .+/, '').sub(/ \(.+\)/, '') }
               .map { |obj| obj.strip.scan(/\w+$/).first }
 end
 

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -458,7 +458,7 @@ end
 def find_pcs(room_players)
   room_players.sub(/ and (.*)$/) { ", #{Regexp.last_match(1)}" }
               .split(', ')
-              .map { |obj| obj.sub(/ (who|whose body) (has|is|appears) .+/, '').sub(/ \(.+\)/, '') }
+              .map { |obj| obj.sub(/ (who|whose body) (has|is|appears|glows) .+/, '').sub(/ \(.+\)/, '') }
               .map { |obj| obj.strip.scan(/\w+$/).first }
 end
 


### PR DESCRIPTION
This should cover all of the ones on https://elanthipedia.play.net/Veiled_Identity now.

Crannach whose body glows with starlight

;en echo DRRoom.pcs
--- Lich: exec1 active.
[exec1: ["starlight", "Yndass"]]
--- Lich: exec1 has exited.