### PR TITLE
base-empty.yaml: Add lockpick_buffs as a hash.

### DIFF
--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -54,3 +54,4 @@ empty_values:
   athletics_outdoorsmanship_rooms: []
   paladin: {}
   combat_spell_training: {}
+  lockpick_buffs: {}


### PR DESCRIPTION
return if settings.lockpick_buffs.empty? in validate is not working otherwise.