### PR TITLE
first-aid.lic: Empty hands on script exit instead of just completion.

### DIFF
--- a/first-aid.lic
+++ b/first-aid.lic
@@ -27,7 +27,6 @@ class FirstAid
       @booktype = 'compendium'
       compendium_charts
     end
-    EquipmentManager.new.empty_hands
   end
 
   def compendium_charts
@@ -61,6 +60,10 @@ class FirstAid
         end
       end
   end
+end
+
+before_dying do
+  EquipmentManager.new.empty_hands
 end
 
 # Call this last to avoid the need for forward declarations


### PR DESCRIPTION
So you stow your book when killing the script manually also.