### PR TITLE
Fix validation check

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -512,8 +512,9 @@ class DRYamlValidator
 
   def assert_that_sell_loot_money_on_hand_is_correct(settings)
     settings.sell_loot_money_on_hand =~ /(\d+) (\w+)/
-    return if Regexp.last_match(1) && %w[copper bronze silver gold platinum].any? { |denom| denom[/^#{Regexp.last_match(2)}/] }
-
+    amount = Regexp.last_match(1)
+    denomination = Regexp.last_match(2)
+    return if amount && %w[copper bronze silver gold platinum].any? { |denom| denom[/^#{denomination}/] }
     error('sell_loot_money_on_hand is invalid. The proper format is: <amount> <denomination> e.g. 3 silv or 4 bronze')
   end
 


### PR DESCRIPTION
Reading Regexp.last_match after a regex was just evaluated will clear the previous last matches.