### PR TITLE
setupaliases.lic: Add ez alias, to list all escort hunting zones.

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -37,6 +37,8 @@
   ['map', "#{$clean_lich_char}narost"],
   # List all hunting zones from base-hunting alphabetically by name
   ['hz', "#{$clean_lich_char}en get_data('hunting').hunting_zones.sort.each{ |x| echo x }"],
+  # List all escort zones from base-hunting alphabetically by name.
+  ['ez', "#{$clean_lich_char}en get_data('hunting').escort_zones.sort.each{ |x| echo x }"],
   # Search for a hunting zone, e.g. 'fz wark' will return warklin hunting zone rooms
   ['fz', "#{$clean_lich_char}en echo get_data('hunting').hunting_zones.find{|k,v| k =~ /\\?/i}"]
 ].each do |trigger, target|


### PR DESCRIPTION

--- Lich: exec1 active.
[exec1: ["adult_armadillos", {"base"=>6760, "area"=>"desert", "enter"=>"adult"}]]
[exec1: ["blue_crocs", {"base"=>1358, "area"=>"crocs", "enter"=>"enter"}]]
[exec1: ["desert_juvenile_armadillos", {"base"=>6760, "area"=>"desert", "enter"=>"juvenile"}]]
[exec1: ["elder_armadillos", {"base"=>6760, "area"=>"desert", "enter"=>"elder"}]]
[exec1: ["geni", {"base"=>7958, "area"=>"wilds", "enter"=>"geni"}]]
[exec1: ["grave_worms", {"base"=>2317, "area"=>"oshu_manor", "enter"=>"worms"}]]
[exec1: ["kartais", {"base"=>2317, "area"=>"oshu_manor", "enter"=>"kartais"}]]
[exec1: ["leucro1", {"base"=>7958, "area"=>"wilds", "enter"=>"leucro1"}]]
[exec1: ["leucro2", {"base"=>7958, "area"=>"wilds", "enter"=>"leucro2"}]]
--- Lich: exec1 has exited.