### PR TITLE
Combat-Trainer: Support for zombie creation recast timer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2475,6 +2475,9 @@ class GameState
     @use_stealth_attacks = settings.use_stealth_attacks
     echo("  @use_stealth_attacks: #{@use_stealth_attacks}") if $debug_mode_ct
 
+    @zombie_recast = settings.waggle_sets['zombie']['Call from Beyond']['recast']
+    echo("  @zombie_recast: #{@settings.waggle_sets['zombie']['Call from Beyond']['recast']}") if $debug_mode_ct
+
     @ambush = settings.ambush
     echo("  @ambush: #{@ambush}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -502,7 +502,7 @@ class LootProcess
           end
         end
       end
-      if @make_zombie && !game_state.necro_casting? && !game_state.cfb_active?
+      if @make_zombie && !game_state.necro_casting? && (!game_state.cfb_active? || game_state.cfb_recast?)
         echo 'Making zombie' if $debug_mode_ct
         do_necro_ritual(mob_noun, 'arise', game_state)
         return false
@@ -1416,7 +1416,7 @@ class PetProcess
     when 'zombie shambles off with a groan'
       echo('  Zombie is no longer present') if $debug_mode_ct
       @is_present = false
-    when /shift into a \w+ stance/
+    when /shift into a(?:n)? \w+ stance/
       echo("  Zombie stance set to #{@zombie['stance']}") if $debug_mode_ct
       @current_stance = @zombie['stance']
     when /you sense your .+ behavior shift/
@@ -2968,6 +2968,10 @@ class GameState
 
   def cfb_active?
     DRSpells.active_spells.include?('Call from Beyond')
+  end
+
+  def cfb_recast?
+    DRSpells.active_spells['Call from Beyond'] && DRSpells.active_spells['Call from Beyond'].to_i < @zombie_recast
   end
 
   def construct_mode?


### PR DESCRIPTION
Adds support for recasting zombie before it has worn off. Also added a regex match for a message that was missing it.