### PR TITLE
Common-Arcana: Add locate prereq check

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -364,7 +364,7 @@ module DRCA
     return unless data # update_astral_data returns nil on failure
 
     if (data['abbrev'] =~ /locat/i) && !DRSpells.active_spells['Clear Vision']
-      cast_spell({ 'abbrev'=> 'cv', 'mana' => 1 , 'prep_time' => 5 }, settings)
+      cast_spell({ 'abbrev' => 'cv', 'mana' => 1, 'prep_time' => 5 }, settings)
     end
 
     release_cyclics if data['cyclic']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -363,6 +363,10 @@ module DRCA
     data = update_astral_data(data)
     return unless data # update_astral_data returns nil on failure
 
+    if (data['abbrev'] =~ /locat/i) && !DRSpells.active_spells['Clear Vision']
+      cast_spell({ 'abbrev'=> 'cv', 'mana' => 1 , 'prep_time' => 5 }, settings)
+    end
+
     release_cyclics if data['cyclic']
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
     DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")


### PR DESCRIPTION
Locate requires clear vision active before casting. This logic is ported
from crossing-training::cast_spell.