### PR TITLE
Move nerve check to its own method

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -217,6 +217,13 @@ class CrossingTraining
     end
   end
 
+  def check_nerves
+    wounds = check_health['wounds']
+    if wounds.any? { |_k, v| v.include?('skin') }
+      wait_for_script_to_complete('safe-room', ['force'])
+    end
+  end
+
   def refresh_cyclic
     return unless @settings.cyclic_training_spells
     return unless Time.now - @cyclic_cycle_timer > 300
@@ -230,6 +237,7 @@ class CrossingTraining
     end
 
     cast_spell(@settings.cyclic_training_spells[cyclic_skill], cyclic_skill)
+    check_nerves
     @cyclic_cycle_timer = Time.now
   end
 
@@ -366,6 +374,7 @@ class CrossingTraining
       else
         handle_cyclic_timers(skill)
         cast_spell(@settings.training_spells[skill], skill)
+        check_nerves
       end
     else
       cast_nonspell(skill)
@@ -456,6 +465,7 @@ class CrossingTraining
 
     until DRSpells.active_spells['Gauge Flow'] > 20
       cast_spell({ 'abbrev' => 'GAF' }, nil)
+      check_nerves
       pause 2
     end
     @researching = case skill
@@ -517,12 +527,6 @@ class CrossingTraining
     snapshot = DRSkill.getxp(skill) if data['symbiosis']
 
     success = cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
-
-    wounds = check_health['wounds']
-    if !success && wounds.any? { |_k, v| v.include?('skin') }
-      wait_for_script_to_complete('safe-room', ['force'])
-      walk_to(@training_room)
-    end
 
     return unless data['symbiosis']
 

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -221,6 +221,7 @@ class CrossingTraining
     wounds = check_health['wounds']
     if wounds.any? { |_k, v| v.include?('skin') }
       wait_for_script_to_complete('safe-room', ['force'])
+      walk_to(@training_room)
     end
   end
 


### PR DESCRIPTION
Part of commonizing the cast_spell method. The success check was removed
to allow for healing if any nerve damage exists.

One more item for #2243 