### PR TITLE
cleric-quests.lic: fix_standing in the eluned2 quest.

### DIFF
--- a/cleric-quests.lic
+++ b/cleric-quests.lic
@@ -67,6 +67,7 @@ class ClericQuests
 
     echo '***Be patient, this next part will take a while***'
     waitfor('once again your will is your own')
+    fix_standing
     bput('climb indentation', 'You begin climbing up the cliff indentations')
   end
 


### PR DESCRIPTION
[cleric-quests]>climb indentation
You must be standing to do that.
>
You feel fully rested.
>
[cleric-quests: *** No match was found after 15 seconds, dumping info]
[cleric-quests: messages seen length: 7]
[cleric-quests: message:  * Battlehardened Kja Siklings just crawled into the adventure.]
[cleric-quests: message:  * Stargazer Mistanna Redivas joins the adventure with a gleam in her eye.]
[cleric-quests: message: Bless  (12 roisaen)]
[cleric-quests: message: Major Physical Protection  (8 roisaen)]
[cleric-quests: message:  * Sorrower Lirrag joins the adventure.]
[cleric-quests: message: You feel fully rested.]
[cleric-quests: message: You must be standing to do that.]
[cleric-quests: checked against [/You begin climbing up the cliff indentations/i]]
[cleric-quests: for command climb indentation]