### PR TITLE
Added custom prep to waggle_sets/buffs

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -376,7 +376,11 @@ module DRCA
       return
     end
 
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'])
+    command = 'prep'
+    command = data['prep'] if data['prep']
+    command = data['prep_type'] if data['prep_type']
+
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']


### PR DESCRIPTION
```>;buff test_prep
--- Lich: buff active.
[buff]>release mana
You aren't harnessing any mana.
[buff]>target hes 5
You cannot target the Heroic Strength spell!
>;k buf
--- Lich: buff has exited.
>;buff test_prep
--- Lich: buff active.
[buff]>release mana
You aren't harnessing any mana.
[buff]>prep hes 5
You begin chanting catechisms to invoke the Heroic Strength spell.
[buff]>remove my armband
You remove an armband displaying an array of cambrinth lotus flowers from your upper arm.
[buff]>charge my armband 15
You harness a moderate amount of energy and attempt to channel it into your armband.
You are able to channel all the energy into the armband.
The armband absorbs all of the energy.
Roundtime: 4 sec.```