### PR TITLE
Added message for wrong type of material.

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -150,8 +150,8 @@ module DRCC
 
   def logbook_item(logbook, noun, container)
     DRC.bput("get my #{logbook} logbook", 'You get')
-    case bput("bundle my #{noun} with my logbook", 'You notate the', 'This work order has expired', 'The work order requires items of a higher quality')
-    when 'This work order has expired', 'The work order requires items of a higher quality'
+    case bput("bundle my #{noun} with my logbook", 'You notate the', 'This work order has expired', 'The work order requires items of a higher quality', 'That isn\'t the correct type of item for this work order.')
+    when 'This work order has expired', 'The work order requires items of a higher quality', 'That isn\'t the correct type of item for this work order.'
       dispose_trash(noun)
     end
     DRC.bput("put my #{logbook} logbook in my #{container}", 'You put')


### PR DESCRIPTION
This catch is required if you make a cloth item and the work order wanted leather of the item.