### PR TITLE
base.yaml: Clean up validation errors.

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -358,7 +358,7 @@ lumber_buddy_tree_list:
 - Copperwood # longbows
 - Crabwood # martial
 - Darkspine	# martial
-- Diamondwood	# martial
+- Diamondwood # martial
 - Dragonwood # alterations
 - E'erdream # ???
 - Felwood # martial, shortbows, composite
@@ -377,15 +377,15 @@ lumber_buddy_tree_list:
 - Mistwood # longbow, shortbow
 - Osage	# longbows
 - Ramin # longbows
-- Redwood	# alterations
+- Redwood # alterations
 - Rockwood # martial
 - Rosewood # longbows
 - Shadowbark # ???
 - Silverwood # shortbows, composite bows
 - Smokewood	# alterations
-- Tamarak	# alterations
-- Tamboti	# ???
-- Yew	# Longbows
+- Tamarak # alterations
+- Tamboti # ???
+- Yew # Longbows
 lumber_implement: axe
 lumber_use_packet: true
 lumber_while_training: false


### PR DESCRIPTION
while scanning for the next token
found character '\t' that cannot start any token