### PR TITLE
crossing-training.lic: Don't train stealth above 30 ranks.

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -738,11 +738,17 @@ class CrossingTraining
   end
 
   def train_stealth
-    hide_in 851
-    hide_in 850
-    hide_in 764
-    hide_in 5992
-    hide_in 992
+    if DRSkill.getrank('Stealth') >= 25
+      echo('Skill too high to learn this way, removing Stealth from training')
+      @settings.crossing_training.delete('Stealth')
+      nil
+    else
+      hide_in 851
+      hide_in 850
+      hide_in 764
+      hide_in 5992
+      hide_in 992
+    end
   end
 
   def train_thievery

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -738,10 +738,9 @@ class CrossingTraining
   end
 
   def train_stealth
-    if DRSkill.getrank('Stealth') >= 25
+    if DRSkill.getrank('Stealth') >= 30
       echo('Skill too high to learn this way, removing Stealth from training')
       @settings.crossing_training.delete('Stealth')
-      nil
     else
       hide_in 851
       hide_in 850

--- a/workorders.lic
+++ b/workorders.lic
@@ -284,7 +284,7 @@ class WorkOrders
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
         break if log_num == quantity
-      end  
+      end
     end
 
     dispose("#{info['stock-name']} lumber") if scrap
@@ -337,7 +337,7 @@ class WorkOrders
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
         break if log_num == quantity
-      end 
+      end
     end
     leftover = (quantity * recipe['volume']) % 10 != 0
     dispose("#{info['sew-stock-name']} cloth") if leftover


### PR DESCRIPTION
It is just a waste of time to train this higher, and is really obvious behavior. People think it actually trains when they first join lich without reading the scripting reference saying its low ranks only leading to spam at the empaths guild.