### PR TITLE
Copy deposit coins method to DRCM

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -86,4 +86,18 @@ module DRCM
     currency = hometown_currency(hometown)
     DRC.bput('wealth', /\(\d+ copper #{currency}\)/i, /Wealth:/i).scan(/\d+/).first.to_i
   end
+
+  def deposit_coins(keep_copper, skip_bank, town)
+    return if skip_bank
+
+    DRCT.walk_to(get_data('town')[town]['deposit']['id'])
+    DRC.release_invisibility
+    DRC.bput('wealth', 'Wealth:')
+    case DRC.bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit')
+    when 'There is no teller here'
+      return
+    end
+    minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, town) }
+    DRC.bput('check balance', 'your current balance is')
+  end
 end


### PR DESCRIPTION
This is copied from sell-loot. Having it in common-money will allow
other scripts to use it.