### PR TITLE
Crossing-Repair: Deposit coins after repairing

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -21,6 +21,8 @@ class CrossingRepair
       while tickets_left?(repairer)
       end
     end
+
+    deposit_coins(@keep_copper, @skip_bank, @hometown)
   end
 
   def repair(repairer, item, repeat = false)
@@ -90,14 +92,18 @@ class CrossingRepair
     @equipment_manager.empty_hands
 
     settings = get_settings
+    @hometown = settings.hometown
+    @skip_bank = settings.skip_bank
+    amount, denom = settings.sell_loot_money_on_hand.split(' ')
+    @keep_copper = convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
-    hometown = get_data('town')[settings.hometown]
+    hometown_data = get_data('town')[settings.hometown]
 
     ensure_copper_on_hand(@repair_withdrawal_amount, settings)
 
     # Merge, do not overwrite
-    @repair_info = { hometown['leather_repair'] => @equipment_manager.items.select(&:leather) }
-                   .merge(hometown['metal_repair'] => @equipment_manager.items.reject(&:leather)) { |_key, old, new| old + new }
+    @repair_info = { hometown_data['leather_repair'] => @equipment_manager.items.select(&:leather) }
+                   .merge(hometown_data['metal_repair'] => @equipment_manager.items.reject(&:leather)) { |_key, old, new| old + new }
   end
 end
 

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -93,7 +93,7 @@ class CrossingRepair
 
     settings = get_settings
     @hometown = settings.hometown
-    @skip_bank = settings.skip_bank
+    @skip_bank = settings.sell_loot_skip_bank
     amount, denom = settings.sell_loot_money_on_hand.split(' ')
     @keep_copper = convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount


### PR DESCRIPTION
When done repairing, deposit all coins that were withdrawn to pay for
the repairs. If the user has a high withdraw amount set, there could be
a good deal left over coin.