### PR TITLE
test_afk: Update test_harness and test_afk

### DIFF
--- a/test/test_afk.rb
+++ b/test/test_afk.rb
@@ -54,11 +54,15 @@ class TestAfk < Minitest::Test
   end
 
   def test_exits_if_low_health
-    skip "Afk has changed and this test needs to be updated to modify health while its running"
     setup_settings({})
+    $history = ['You continue to braid your vines.', 'You are attacked by a Grue! Your injuries are severe.']
     expected_messages = ['health', 'avoid all', 'exit']
-    self.health = 20
+    self.health = 100
+
     run_script('afk')
+
+    next until $history.empty?
+    self.health = 20
 
     Timecop.return
 

--- a/test/test_afk.rb
+++ b/test/test_afk.rb
@@ -20,8 +20,10 @@ end
 
 class TestAfk < Minitest::Test
   def setup
+    $history.clear
     self.dead = false
     self.health = 100
+    self.spirit = 100
     sent_messages.clear
   end
 
@@ -57,12 +59,27 @@ class TestAfk < Minitest::Test
     setup_settings({})
     $history = ['You continue to braid your vines.', 'You are attacked by a Grue! Your injuries are severe.']
     expected_messages = ['health', 'avoid all', 'exit']
-    self.health = 100
 
     run_script('afk')
 
     next until $history.empty?
     self.health = 20
+
+    Timecop.return
+
+    assert_sends_messages expected_messages
+  end
+
+  def test_exits_if_low_spirit
+    setup_settings({})
+    $history = ['You continue to braid your vines.', 'You are attacked by a Grue! Your injuries are severe.']
+    expected_messages = ['health', 'avoid all', 'exit']
+    self.spirit = 100
+
+    run_script('afk')
+
+    next until $history.empty?
+    self.spirit = 20
 
     Timecop.return
 

--- a/test/test_afk.rb
+++ b/test/test_afk.rb
@@ -54,12 +54,12 @@ class TestAfk < Minitest::Test
   end
 
   def test_exits_if_low_health
+    skip "Afk has changed and this test needs to be updated to modify health while its running"
     setup_settings({})
     expected_messages = ['health', 'avoid all', 'exit']
-
+    self.health = 20
     run_script('afk')
-    sleep 0.4
-    self.health = 15
+
     Timecop.return
 
     assert_sends_messages expected_messages

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -1,7 +1,7 @@
 module Harness
   class Script
     def gets?
-      ''
+      get?
     end
   end
 
@@ -76,6 +76,10 @@ module Harness
 
   def health=(health)
     $health = health
+  end
+
+  def spirit=(spirit)
+    $spirit = spirit
   end
 
   def dead=(dead)

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -21,7 +21,7 @@ module Harness
     args
   end
 
-  def get_settings(dummy)
+  def get_settings(dummy=nil)
     $settings_called_with = dummy
     $test_settings
   end
@@ -58,6 +58,10 @@ module Harness
     $health || 100
   end
 
+  def spirit
+    $spirit || 100
+  end
+
   def fput(message)
     sent_messages << message
   end
@@ -85,6 +89,12 @@ module Harness
   end
 
   def no_pause_all; end
+
+  def no_kill_all; end
+
+  def register_slackbot(username); end
+
+  def send_slackbot_message(message); end
 
   def get
     get?


### PR DESCRIPTION
Tests were failing due to missing methods in the Script class.
The get_settings method is often called without an argument, i.e.
`settings = get_settings` which wasn't matching the signature in
Script::get_settings.

Copied the setup_settings method from another test file to test_afk
so that the script is ran with base.yaml loaded.

Added a new test to check for exiting with default settings enabled and
modified current tests to use updated settings such as depart_on_death.