### PR TITLE
Update check_health so tests pass

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -184,7 +184,9 @@ module DRCH
       when /^You have (?!no significant injuries)(?!.* lodged into your)(?!.* infection)(?!.* poison(?:ed)?)(?!.* #{all_parasites_re})/
         wounds_line = line
         break
-      when /^You have a dormant infection/, /^Your wounds are infected/
+      when /^You have no significant injuries/
+        break
+      when /^You have a dormant infection/, /^Your wounds are infected/, /^Your body is covered in open oozing sores/
         diseased = true
       when /^You have .* poison(?:ed)?/
         poisoned = true
@@ -192,25 +194,30 @@ module DRCH
         parasites_line = line
       end
     end
-    wounds_line.gsub!($comma_detector, '') # Remove commas from individual wounds
+
     wounds = Hash.new { |h, k| h[k] = [] }
-    part = nil
-    wounds_line.split(',').each do |wound|
-      $severity_to_text.each do |severity_level, match_text|
-        next unless wound =~ Regexp.union(match_text)
-        part = Regexp.last_match.names.find { |x| Regexp.last_match[x.to_sym] }
-        part = Regexp.last_match[:part] if part == 'part'
-        wounds[severity_level] << part
+    if wounds_line
+      wounds_line.gsub!($comma_detector, '') # Remove commas from individual wounds
+      part = nil
+      wounds_line.split(',').each do |wound|
+        $severity_to_text.each do |severity_level, match_text|
+          next unless wound =~ Regexp.union(match_text)
+          part = Regexp.last_match.names.find { |x| Regexp.last_match[x.to_sym] }
+          part = Regexp.last_match[:part] if part == 'part'
+          wounds[severity_level] << part
+        end
       end
     end
 
     parasites = Hash.new { |h, k| h[k] = [] }
-    parasites_line.split(',').each do |parasite|
-      parasite =~ all_parasites_re
-      parasite_name = Regexp.last_match.to_s
-      parasite =~ /on your (?<part>(?:left|right)?\s?(?:\w+))/
-      location = Regexp.last_match[:part].to_s
-      parasites[parasite_name] << location
+    if parasites_line
+      parasites_line.split(',').each do |parasite|
+        parasite =~ all_parasites_re
+        parasite_name = Regexp.last_match.to_s
+        parasite =~ /on your (?<part>(?:left|right)?\s?(?:\w+))/
+        location = Regexp.last_match[:part].to_s
+        parasites[parasite_name] << location
+      end
     end
 
     { 'wounds' => wounds, 'poisoned' => poisoned, 'diseased' => diseased, 'parasites' => parasites }

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -183,8 +183,7 @@ module DRCH
       case line
       when /^You have (?!no significant injuries)(?!.* lodged into your)(?!.* infection)(?!.* poison(?:ed)?)(?!.* #{all_parasites_re})/
         wounds_line = line
-        break
-      when /^You have no significant injuries/
+      when /^Your body feels\b.*(?:strength|battered|beat up|bad shape|death's door|dead)/
         break
       when /^You have a dormant infection/, /^Your wounds are infected/, /^Your body is covered in open oozing sores/
         diseased = true


### PR DESCRIPTION
* gsub! doesn't work on nil (unless it was overloaded >.>)
* Moved wound_line and parasite_line logic inside an if block to prevent
operating on nil
* New disease line to check for
* ~An issue with checking health and being completely wound free but
but having wounds earlier in the message buffer. Added an explicit check
for 'You have no wounds'~
* The vitality is the last line in the reversed message history. Check_health will break on that instead.