### PR TITLE
Trash only the item forged

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -979,8 +979,8 @@ class CrossingTraining
 
   def smith(full_name)
     wait_for_script_to_complete('smith', ['bronze', full_name, 'buy'])
-    dispose_trash(right_hand)
-    dispose_trash(left_hand)
+    noun = get_data('recipes')['crafting_recipes'].select { |item| item['name'] == full_name }.first['noun']
+    dispose_trash(noun)
   end
 
   def buy_wood


### PR DESCRIPTION
This helps prevents throwing out items that may have ended up stuck
in hands such as valuable crafting tools. The smith script already
disposes the ingot.