### PR TITLE
Add travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+- 2.0.0


### PR DESCRIPTION
This is a simple config file that would let us use travis-ci for this repository. With that we can run tests against all pull requests, potentially run rubocop on them. I think this might help mitigate future breakages. I was able to run this successfully on my fork.