### PR TITLE
data/*.yaml: Clean up yamllint errors.

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -815,16 +815,6 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
-  small padding:
-    Crossing:
-      part-room: 8776
-      part-number:
-    Leth Deriel:
-      part-room: 8776
-      part-number:
-    Mer'Kresh:
-      part-room: 8810
-      part-number:
   hilt:
     Crossing:
       part-room: 8776

--- a/data/base-picking.yaml
+++ b/data/base-picking.yaml
@@ -113,7 +113,6 @@ picking:
     earth-toned slim: 400
     # Ain Ghazal
     ordinary metal: 157
-    quality copper: 3,608
     stout azure: 248
     shimmering diamondique: 13,530
     night-black: 157


### PR DESCRIPTION
base-crafting.yaml
  The same key is defined more than once: recipe_parts.small padding
  The same key is defined more than once: recipe_parts.small padding.Crossing
  The same key is defined more than once: recipe_parts.small padding.Crossing.part-room
  The same key is defined more than once: recipe_parts.small padding.Crossing.part-number
  The same key is defined more than once: recipe_parts.small padding.Leth Deriel
  The same key is defined more than once: recipe_parts.small padding.Leth Deriel.part-room
  The same key is defined more than once: recipe_parts.small padding.Leth Deriel.part-number
  The same key is defined more than once: recipe_parts.small padding.Mer'Kresh
  The same key is defined more than once: recipe_parts.small padding.Mer'Kresh.part-room
  The same key is defined more than once: recipe_parts.small padding.Mer'Kresh.part-number

base-picking.yaml
  The same key is defined more than once: picking.lockpick_costs.quality copper