### PR TITLE
Bput will handle pauses

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -66,7 +66,7 @@ module DRC
     clear
     put message
     timer = Time.now
-    while (Time.now - timer < 15) || !(response = get?).nil?
+    while response = get? || (Time.now - timer < 15) 
 
       if response.nil?
         pause 0.1

--- a/common.lic
+++ b/common.lic
@@ -66,8 +66,7 @@ module DRC
     matches.map! { |item| item.is_a?(Regexp) ? item : /#{item}/i }
     clear
     put message
-    while Time.now - timer < 15
-      response = get?
+    while (Time.now - timer < 15) || !(response = get?).nil?
 
       if response.nil?
         pause 0.1

--- a/common.lic
+++ b/common.lic
@@ -59,13 +59,13 @@ module DRC
   module_function
 
   def bput(message, *matches)
-    waitrt?
-    timer = Time.now
+    waitrt?    
     log = []
     matches.flatten!
     matches.map! { |item| item.is_a?(Regexp) ? item : /#{item}/i }
     clear
     put message
+    timer = Time.now
     while (Time.now - timer < 15) || !(response = get?).nil?
 
       if response.nil?

--- a/common.lic
+++ b/common.lic
@@ -66,7 +66,7 @@ module DRC
     clear
     put message
     timer = Time.now
-    while response = get? || (Time.now - timer < 15) 
+    while (response = get?) || (Time.now - timer < 15) 
 
       if response.nil?
         pause 0.1


### PR DESCRIPTION
This should allow bput to handle pauses and resumes by ignoring the timer expiry until it has consumed all incoming messages.