### PR TITLE
Change method signature to take player settings

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -87,17 +87,17 @@ module DRCM
     DRC.bput('wealth', /\(\d+ copper #{currency}\)/i, /Wealth:/i).scan(/\d+/).first.to_i
   end
 
-  def deposit_coins(keep_copper, skip_bank, town)
-    return if skip_bank
+  def deposit_coins(keep_copper, settings)
+    return if settings.skip_bank
 
-    DRCT.walk_to(get_data('town')[town]['deposit']['id'])
+    DRCT.walk_to(get_data('town')[settings.hometown]['deposit']['id'])
     DRC.release_invisibility
     DRC.bput('wealth', 'Wealth:')
     case DRC.bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit')
     when 'There is no teller here'
       return
     end
-    minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, town) }
+    minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, settings) }
     DRC.bput('check balance', 'your current balance is')
   end
 end


### PR DESCRIPTION
withdraw_exact_amount? requires settings be passed to it. The other
settings like skip_bank can be accessed via the settings.

This line will need to be updated in crossing-repair 
https://github.com/rpherbig/dr-scripts/blob/a4eb6dcd696dceb4b01b94b95cf273724125790a/crossing-repair.lic#L25

