### PR TITLE
adjustable cambrinth charges

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -458,8 +458,8 @@ module DRCA
       }]
     end
     total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+)
-    charges_count_floor = settings.cambrinth_num_charges if (remaining >= settings.cambrinth_charges)
-    charges_count_floor = 1 if (remaining < settings.cambrinth_num_charges || settings.cambrinth_num_charges.nil?)
+    charges_count_floor = settings.cambrinth_num_charges if (remaining >= settings.cambrinth_num_charges)
+    charges_count_floor = 1 if (remaining < settings.cambrinth_num_charges)
     settings.cambrinth_items.each do |item|
       item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
     end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -458,8 +458,7 @@ module DRCA
       }]
     end
     total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+)
-    charges_count_floor = settings.cambrinth_num_charges if (remaining >= settings.cambrinth_num_charges)
-    charges_count_floor = 1 if (remaining < settings.cambrinth_num_charges)
+    charges_count_floor = remaining >= settings.cambrinth_num_charges ? settings.cambrinth_num_charges : 1
     settings.cambrinth_items.each do |item|
       item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
     end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -458,8 +458,8 @@ module DRCA
       }]
     end
     total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+)
-    charges_count_floor = settings.cambrinth_charges if (remaining >= settings.cambrinth_charges)
-    charges_count_floor = 1 if (remaining < settings.cambrinth_charges || settings.cambrinth_charges.nil?)
+    charges_count_floor = settings.cambrinth_num_charges if (remaining >= settings.cambrinth_charges)
+    charges_count_floor = 1 if (remaining < settings.cambrinth_num_charges || settings.cambrinth_num_charges.nil?)
     settings.cambrinth_items.each do |item|
       item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
     end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -458,8 +458,8 @@ module DRCA
       }]
     end
     total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+)
-    charges_count_floor = 4 if (remaining >=4)
-    charges_count_floor = 1 if (remaining <4)
+    charges_count_floor = settings.cambrinth_charges if (remaining >= settings.cambrinth_charges)
+    charges_count_floor = 1 if (remaining < settings.cambrinth_charges || settings.cambrinth_charges.nil?)
     settings.cambrinth_items.each do |item|
       item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
     end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -435,7 +435,7 @@ module DRCA
       else
         discern =~ /minimum (\d+) mana streams and you think you can reinforce it with (\d+) more/i
         calculate_mana(Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, discern_data, data['cyclic'], settings)
-      end
+      end     
     end
     pause 1
     waitrt?
@@ -458,7 +458,8 @@ module DRCA
       }]
     end
     total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+)
-    charges_count_floor = 4
+    charges_count_floor = 4 if (remaining >=4)
+    charges_count_floor = 1 if (remaining <4)
     settings.cambrinth_items.each do |item|
       item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
     end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -183,7 +183,7 @@ cambrinth_items:
 - name:
   cap:
   stored:
-cambrinth_charges: 4  #Number of times to charge a cambrinth item with use_auto_mana
+cambrinth_num_charges: 4  #Number of times to charge a cambrinth item with use_auto_mana
 
 
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -183,7 +183,7 @@ cambrinth_items:
 - name:
   cap:
   stored:
-
+cambrinth_charges: 4  #Number of times to charge a cambrinth item with use_auto_mana
 
 
 


### PR DESCRIPTION
adds a setting to base.yaml and common-arcana to allow auto_mana to use variable number of cambrinth charges. Defaults to 4