### PR TITLE
cleric-quests.lic: Fix check for eluneds and add an echo

### DIFF
--- a/cleric-quests.lic
+++ b/cleric-quests.lic
@@ -138,8 +138,9 @@ class ClericQuests
     bput('meditate', 'You close your eyes and begin to meditate')
     waitfor('once again changing and reforming into your Human form')
 
-    case bput('dive deeper water', 'You take a deep breath', 'You get a sense that you have completed this')
-    when 'You get a sense that you have completed this'
+    case bput('dive deeper water', 'You take a deep breath', 'you find that you cannot move yourself to go in')
+    when 'you find that you cannot move yourself to go in'
+      echo 'Pausing for 5 minutes until you can complete another ritual because you did tamsine's too recently.'
       pause 300
       bput('dive deeper water', 'You take a deep breath')
     end


### PR DESCRIPTION
2018-01-19 14:28:30 -0500:[cleric-quests: *** No match was found after 15 seconds, dumping info]
2018-01-19 14:28:30 -0500:[cleric-quests: messages seen length: 2]
2018-01-19 14:28:30 -0500:[cleric-quests: message: The vision fades, and you find that you cannot move yourself to go in.]
2018-01-19 14:28:30 -0500:[cleric-quests: message: You stare deep into the deeper water, focusing on your reflection.  The eyes of the man in the water stare back up at you, and the surface suddenly breaks, revealing a younger$
2018-01-19 14:28:30 -0500:[cleric-quests: checked against [/You take a deep breath/i]]
2018-01-19 14:28:30 -0500:[cleric-quests: for command dive deeper water]