### PR TITLE
Adding Butchery for Necros to combat-trainer.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -276,8 +276,8 @@ class LootProcess
     @cycle_rituals = @ritual_type == 'cycle'
     echo("  @cycle_rituals: #{@cycle_rituals}") if $debug_mode_ct
 
-    @butcher_by_default = settings.butcher_by_default
-    echo("  @butcher_by_default: #{@butcher_by_default}") if $debug_mode_ct
+    @butcher_and_dissect = settings.butcher_and_dissect
+    echo("  @butcher_by_default: #{@butcher_and_dissect}") if $debug_mode_ct
 
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -581,7 +581,7 @@ class LootProcess
   def butcher_corpse(mob_noun, ritual, game_state)
     return unless ritual.eql?('butcher')
     echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
-    echo " Only butchering it once!" if $debug_mode_ct && butcher_once
+    echo " Only butchering it once!" if $debug_mode_ct && @ritual_type.eql?('cycle')
 
     do_necro_ritual(mob_noun, 'preserve', game_state)
     @equipment_manager.stow_weapon(game_state.weapon_name)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -276,7 +276,7 @@ class LootProcess
     @cycle_rituals = @ritual_type == 'cycle'
     echo("  @cycle_rituals: #{@cycle_rituals}") if $debug_mode_ct
 
-    @dissect_and_butcher = settings.butcher_and_dissect
+    @dissect_and_butcher = settings.dissect_and_butcher
     echo("  @dissect_and_butcher: #{@dissect_and_butcher}") if $debug_mode_ct
 
     @rituals = get_data('spells').rituals

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -584,14 +584,12 @@ class LootProcess
 
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
-    only_once = true if @ritual_type.eql?('cycle')
-
     loop do
       perform_message = "perform #{ritual} on #{mob_noun}"
       result = bput(perform_message, @rituals['butcher'], @rituals['failures'])
       break if result =~ /too battered and beat up/i
       bput("drop my #{right_hand}", 'You drop', 'You discard', 'Please rephrase')
-      break if only_once
+      break if @ritual_type.eql?('cycle')
     end
 
     @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -277,7 +277,7 @@ class LootProcess
     echo("  @cycle_rituals: #{@cycle_rituals}") if $debug_mode_ct
 
     @butcher_and_dissect = settings.butcher_and_dissect
-    echo("  @butcher_by_default: #{@butcher_and_dissect}") if $debug_mode_ct
+    echo("  @butcher_and_dissect: #{@butcher_and_dissect}") if $debug_mode_ct
 
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
@@ -583,7 +583,7 @@ class LootProcess
     echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
     echo " Only butchering it once!" if $debug_mode_ct && butcher_once
 
-    bput("perform preserve on #{mob_noun}", @rituals['preserve'], @rituals['failures'])
+    do_necro_ritual(mob_noun, 'preserve', game_state)
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     loop do
@@ -594,7 +594,7 @@ class LootProcess
       break if @ritual_type.eql?('cycle')
     end
 
-    bput("perform dissect on #{mob_noun}", @rituals['dissect'], @rituals['failures']) if @ritual_type.eql?('cycle')
+    do_necro_ritual(mob_noun, 'dissect', game_state) if @ritual_type.eql?('cycle')
     @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -276,6 +276,9 @@ class LootProcess
     @cycle_rituals = @ritual_type == 'cycle'
     echo("  @cycle_rituals: #{@cycle_rituals}") if $debug_mode_ct
 
+    @butcher_by_default = settings.butcher_by_default
+    echo("  @butcher_by_default: #{@butcher_by_default}") if $debug_mode_ct
+
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
 
@@ -293,7 +296,7 @@ class LootProcess
 
     @current_harvest_count = rummage('C material', @necro_container).size if DRStats.necromancer?
     echo("  @current_harvest_count: #{@current_harvest_count}") if $debug_mode_ct
-    
+
     @necro_count = thanatology['harvest_count']
     echo("  @necro_count: #{@necro_count}") if $debug_mode_ct
 
@@ -468,6 +471,7 @@ class LootProcess
     return false unless @ritual_type
     return false if game_state.necro_casting?
     return true if @ritual_type == 'cycle'
+    return true if @ritual_type == 'butcher'
     return true if @ritual_type == 'dissect' && DRSkill.getxp('First Aid') < 32
     return true if @ritual_type == 'harvest' && DRSkill.getxp('Skinning') < 32
     return true if DRSkill.getxp('Thanatology') < 32
@@ -481,6 +485,8 @@ class LootProcess
                     'preserve'
                   elsif DRSkill.getxp('Skinning') < DRSkill.getxp('First Aid')
                     'harvest'
+                  elsif @butcher_by_default
+                    'butcher'
                   else
                     'dissect'
                   end
@@ -527,6 +533,15 @@ class LootProcess
     return if game_state.construct?(mob_noun)
 
     echo "Attempting necromancer ritual #{ritual} on #{mob_noun}" if $debug_mode_ct
+    
+    if ritual.eql?('butcher')
+      butcher_corpse(mob_noun, ritual, game_state)
+
+      @last_ritual = ritual
+      echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct
+      return
+    end
+
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w[consume harvest arise].include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
     result = bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
@@ -555,6 +570,29 @@ class LootProcess
       echo 'Failure detected' if $debug_mode_ct
     end
     echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct
+  end
+
+  def butcher_corpse(mob_noun, ritual, game_state)
+    return unless ritual.eql?('butcher')
+    echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
+    echo " Only butchering it once!" if $debug_mode_ct && butcher_once
+
+    perform_message = "perform preserve on #{mob_noun}"
+    result = bput(perform_message, @rituals['preserve'], @rituals['failures'])
+
+    @equipment_manager.stow_weapon(game_state.weapon_name)
+
+    only_once = true if @ritual_type.eql?('cycle')
+
+    loop do
+      perform_message = "perform #{ritual} on #{mob_noun}"
+      result = bput(perform_message, @rituals['butcher'], @rituals['failures'])
+      break if result =~ /too battered and beat up/i
+      bput("drop my #{right_hand}", 'You drop', 'You discard', 'Please rephrase')
+      break if only_once
+    end
+
+    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end
 
   def necro_harvest_check
@@ -951,7 +989,7 @@ class SpellProcess
     return if DRSpells.slivers
     return if UserVars.moons['visible'].empty?
 
-    fput('pre moonblade')
+    fput('prep moonblade')
     if DRSkill.getrank('Lunar Magic') < 300
       pause 3
     elsif DRSkill.getrank('Lunar Magic') < 400
@@ -1284,7 +1322,7 @@ class SpellProcess
       fput("face #{data['target_enemy']}")
     end
     release_cyclics if data['cyclic']
-    command = 'pre'
+    command = 'prep'
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -276,8 +276,8 @@ class LootProcess
     @cycle_rituals = @ritual_type == 'cycle'
     echo("  @cycle_rituals: #{@cycle_rituals}") if $debug_mode_ct
 
-    @butcher_and_dissect = settings.butcher_and_dissect
-    echo("  @butcher_and_dissect: #{@butcher_and_dissect}") if $debug_mode_ct
+    @dissect_and_butcher = settings.butcher_and_dissect
+    echo("  @dissect_and_butcher: #{@dissect_and_butcher}") if $debug_mode_ct
 
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
@@ -482,7 +482,7 @@ class LootProcess
     return unless @cycle_rituals
 
     next_ritual = if DRSkill.getxp('Skinning') > 31 && DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Thanatology') > 31
-                    if @butcher_and_dissect
+                    if @dissect_and_butcher
                       'butcher'
                     else
                       'dissect'
@@ -490,7 +490,7 @@ class LootProcess
                   elsif DRSkill.getxp('Skinning') < DRSkill.getxp('First Aid')
                     'harvest'
                   else
-                    if @butcher_and_dissect
+                    if @dissect_and_butcher
                       'butcher'
                     else
                       'dissect'
@@ -525,7 +525,11 @@ class LootProcess
       ritual = if @cycle_rituals
                  determine_next_ritual
                else
-                 @ritual_type
+                 if @ritual_type.eql?('dissect') && @dissect_and_butcher
+                   'butcher'
+                 else 
+                   @ritual_type
+                 end
                end
       do_necro_ritual(mob_noun, ritual, game_state) if should_perform_ritual?(game_state)
     end
@@ -581,7 +585,7 @@ class LootProcess
   def butcher_corpse(mob_noun, ritual, game_state)
     return unless ritual.eql?('butcher')
     echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
-    echo " Only butchering it once!" if $debug_mode_ct && @ritual_type.eql?('cycle')
+    echo " Only butchering it once!" if $debug_mode_ct && @dissect_and_butcher
 
     do_necro_ritual(mob_noun, 'preserve', game_state)
     @equipment_manager.stow_weapon(game_state.weapon_name)
@@ -591,10 +595,10 @@ class LootProcess
       result = bput(perform_message, @rituals['butcher'], @rituals['failures'])
       break if result =~ /too battered and beat up/i
       bput("drop my #{right_hand}", 'You drop', 'You discard', 'Please rephrase')
-      break if @ritual_type.eql?('cycle')
+      break if @dissect_and_butcher
     end
 
-    do_necro_ritual(mob_noun, 'dissect', game_state) if @ritual_type.eql?('cycle')
+    do_necro_ritual(mob_noun, 'dissect', game_state) if @dissect_and_butcher
     @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -482,7 +482,7 @@ class LootProcess
     return unless @cycle_rituals
 
     next_ritual = if DRSkill.getxp('Skinning') > 31 && DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Thanatology') > 31
-                    if @butcher_by_default
+                    if @butcher_and_dissect
                       'butcher'
                     else
                       'dissect'
@@ -490,7 +490,11 @@ class LootProcess
                   elsif DRSkill.getxp('Skinning') < DRSkill.getxp('First Aid')
                     'harvest'
                   else
-                    'dissect'
+                    if @butcher_and_dissect
+                      'butcher'
+                    else
+                      'dissect'
+                    end
                   end
     next_ritual
   end
@@ -579,9 +583,7 @@ class LootProcess
     echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
     echo " Only butchering it once!" if $debug_mode_ct && butcher_once
 
-    perform_message = "perform preserve on #{mob_noun}"
-    result = bput(perform_message, @rituals['preserve'], @rituals['failures'])
-
+    bput("perform preserve on #{mob_noun}", @rituals['preserve'], @rituals['failures'])
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     loop do
@@ -592,6 +594,7 @@ class LootProcess
       break if @ritual_type.eql?('cycle')
     end
 
+    bput("perform dissect on #{mob_noun}", @rituals['dissect'], @rituals['failures']) if @ritual_type.eql?('cycle')
     @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -482,11 +482,13 @@ class LootProcess
     return unless @cycle_rituals
 
     next_ritual = if DRSkill.getxp('Skinning') > 31 && DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Thanatology') > 31
-                    'preserve'
+                    if @butcher_by_default
+                      'butcher'
+                    else
+                      'dissect'
+                    end
                   elsif DRSkill.getxp('Skinning') < DRSkill.getxp('First Aid')
                     'harvest'
-                  elsif @butcher_by_default
-                    'butcher'
                   else
                     'dissect'
                   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -585,7 +585,7 @@ class LootProcess
   def butcher_corpse(mob_noun, ritual, game_state)
     return unless ritual.eql?('butcher')
     echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
-    echo " Only butchering it once!" if $debug_mode_ct && @dissect_and_butcher
+    echo " Only butchering it once!" if $debug_mode_ct && @dissect_and_butcher && !@ritual_type.eql?('butcher')
 
     do_necro_ritual(mob_noun, 'preserve', game_state)
     @equipment_manager.stow_weapon(game_state.weapon_name)
@@ -595,10 +595,10 @@ class LootProcess
       result = bput(perform_message, @rituals['butcher'], @rituals['failures'])
       break if result =~ /too battered and beat up/i
       bput("drop my #{right_hand}", 'You drop', 'You discard', 'Please rephrase')
-      break if @dissect_and_butcher
+      break if @dissect_and_butcher && !@ritual_type.eql?('butcher')
     end
 
-    do_necro_ritual(mob_noun, 'dissect', game_state) if @dissect_and_butcher
+    do_necro_ritual(mob_noun, 'dissect', game_state) if @dissect_and_butcher && !@ritual_type.eql?('butcher')
     @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end
 

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1886,6 +1886,7 @@ rituals:
   consume: a few quick, precise cuts with your ritual knife
   arise: carefully carve a ritual design across a handspan of its body
   construct: Rituals do not work upon constructs
+  butcher: Making several deep cuts with your knife
   failures:
   - don't have enough thanatological
   - You cannot harvest
@@ -1898,3 +1899,4 @@ rituals:
   - You realize the unfortunate butchery ruins the body for any further attempts at rituals
   - A skinned creature is worthless for your purposes
   - The consumption ritual performed on this corpse prevents its harvesting
+  - much too battered and beat up to extract any body parts from

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1900,3 +1900,4 @@ rituals:
   - A skinned creature is worthless for your purposes
   - The consumption ritual performed on this corpse prevents its harvesting
   - much too battered and beat up to extract any body parts from
+  - renders it useless for butchering

--- a/profiles/Melborne-back.yaml
+++ b/profiles/Melborne-back.yaml
@@ -1,40 +1,24 @@
 ---
 hunting_info:
-- :zone: 
-  - orc_bandits
-  - orc_bandits
+- :zone:
+  - shard_gryphons
+  - elder_blue_dappled_prereni
+  - adanf_warriors_and_mages
   args:
   - d0
   - back
-  :duration: 30
+  :duration: 25
   before:
   - buff eotb
-  after:
-  - athletics
-  - go2 ####
-  - rem eotb
-  #- deposit riverhaven
-  #- go2 ####
-  #- buff eotb
 
 offensive_spells:
 - skill: Sorcery
-  name: Stun Foe
-  abbrev: lethargy
+  name: Sleep
   cast_only_to_train: true
   harmless: true
-  mana: 8
+  mana: 15
 buff_spells:
-  # Obfuscation:
-  #   abbrev: obf
-  #   recast: 2
-  #   mana: 5
-  #   cambrinth:
-  #   - 20
-  #   - 15
 
-use_weak_attacks: true
-use_stealth_attacks: false
 weapon_training:
   Brawling: ''
   Light Thrown: bola
@@ -50,11 +34,10 @@ weapon_training:
 offhand_thrown: true
 dance_skill: Brawling
 
+skip_last_kill: true
+use_weak_attacks: true
+use_stealth_attacks: false
 training_abilities:
-  Hunt: 120
-  Perc: 120
-  #Collect: 120
-
 thanatology:
 skinning:
   skin: true
@@ -77,4 +60,4 @@ loot_subtractions:
 - arrow
 - arrows
 - bolt
-- boltsexp
+- bolts

--- a/profiles/Melborne-butcher.yaml
+++ b/profiles/Melborne-butcher.yaml
@@ -1,0 +1,47 @@
+---
+hunting_info:
+- :zone: black_apes
+  args:
+  - d0
+  - butcher
+  :duration: 10
+
+combat_spell_training:
+training_abilities:
+cycle_armors:
+buff_spells:
+use_stealth_attacks: false
+use_weak_attacks: true
+
+skinning:
+  skin: false
+  arrange_all: false
+  arrange_count: 0
+  tie_bundle: true
+
+thanatology:
+  ritual_type: butcher
+  heal: false
+
+weapon_training:
+  #Brawling: ''
+  #Offhand Weapon: throwing dagger
+  Small Edged: rapier
+dance_skill: Small Edged
+
+loot_subtractions:
+- coffer
+- strongbox
+- chest
+- caddy
+- trunk
+- casket
+- skippet
+- crate
+- box
+- rock
+- rocks
+- arrow
+- arrows
+- bolt
+- bolts

--- a/profiles/Melborne-evasion.yaml
+++ b/profiles/Melborne-evasion.yaml
@@ -1,5 +1,5 @@
 ---
-stance_override: 100 84 0 
+stance_override: 100 85 0 
 offensive_spells:
 - skill: Targeted Magic
   name: Acid Splash

--- a/profiles/Melborne-main.yaml
+++ b/profiles/Melborne-main.yaml
@@ -1,49 +1,63 @@
 ---
 hunting_info:
 - :zone:
-  - mountain_giants
-  - mountain_giants
+  - black_apes
+  - black_apes
   args:
-  - d1
+  - d0
   - main
-  :duration: 30
+  :duration: 25
   stop_on:
   - Debilitation
   - Sorcery
+  after:
+  - buff stealth
+- :zone:
+  - black_apes
+  - black_apes
+  args:
+  - d0
+  - stealth
+  :duration: 5
+  stop_on:
   - Stealth
 - :zone:
-  - mountain_giants
-  - mountain_giants
+  - black_apes
+  - black_apes
   args:
   - d4
   - evasion
-  :duration: 10
+  :duration: 8
   stop_on:
   - Evasion
+  after:
+  - safe-room
 
 cycle_armors:
 combat_spell_training:
 offensive_spells:
-# - skill: Targeted Magic
-#   name: Vivisection
-#   mana: 20
-#   cambrinth:
-#   - 5
-#   cast_only_to_train: true
 - skill: Targeted Magic
-  name: Blood Burst
-  mana: 15
+  name: Vivisection
+  mana: 20
   cambrinth:
   - 10
   cast_only_to_train: true
-  # before:
-  # - message: perform cut
-  #   matches: 
-  #   - You draw a slight
-  #   - You've already performed
+# - skill: Targeted Magic
+#   name: Blood Burst
+#   mana: 15
+#   cambrinth:
+#   - 15
+#   cast_only_to_train: true
+#   before:
+#   - message: perform cut
+#     matches: 
+#     - You draw a slight
+#     - You've already performed
 - skill: Debilitation
   name: Petrifying Visions
   mana: 10
+  cambrinth:
+  - 10
   max_threshold: 1
   expire: no longer seems petrified
   cast_only_to_train: true
@@ -60,8 +74,10 @@ offensive_spells:
   harmless: true
   mana: 15
 
+buff_spells:
 skip_last_kill: true
-use_weak_attacks: false
+use_stealth_attacks: true
+use_weak_attacks: true
 weapon_training:
   Small Edged: rapier
 dance_skill: Small Edged

--- a/profiles/Melborne-setup.yaml
+++ b/profiles/Melborne-setup.yaml
@@ -13,11 +13,17 @@ repair_withdrawal_amount: 30000
 repair_timer: 86400 # Repair once every 24 hours
 repair_every: .inf # Infinity
 dump_junk: true
-default_stance: 100 0 84
+
+default_stance: 100 0 85
 
 training_manager_hunting_priority: false
 training_manager_priority_skills:
+- Targeted Magic
+- Evasion
 hunting_file_list:
+- usol
+- main
+- back
 
 gear_sets:
   standard:
@@ -81,11 +87,13 @@ buffs: &buffs
     - 20
     - 15
     - 15
-  # Researcher's Insight:
-  #   recast: 2
-  #   mana: 15
-  #   cambrinth: 
-  #   - 3
+  Researcher's Insight:
+    recast: 2
+    mana: 30
+    cambrinth:
+    - 20
+    - 20
+    - 10
   Calcified Hide:
     abbrev: ch
     recast: -1
@@ -102,23 +110,23 @@ buffs: &buffs
     - 10
   # Worm's Mist:
   #   recast: -1
-  #   mana: 15
+  #   mana: 20
   #   cambrinth:
   #   - 20
-  #   - 15
+  #   - 20
 combat_spell_training: &cst
   Warding: 
     abbrev: maf
     symbiosis: true
-    mana: 9
+    mana: 15
   Utility:
     abbrev: gaf
     symbiosis: true
-    mana: 14
+    mana: 20
   Augmentation:
     abbrev: obf
     symbiosis: true
-    mana: 13
+    mana: 20
 
 magic_training:
   << : *cst
@@ -128,7 +136,6 @@ buff_spells:
   << : *buffs
 
 use_weak_attacks: true
-ambush: false
 dont_stalk: true
 hide_type: stalk
 use_stealth_attacks: true
@@ -187,13 +194,14 @@ necromancer_healing:
     abbrev: sv
     mana: 15
     cambrinth:
-    - 15
+    - 20
+dissect_and_butcher: true
 thanatology:
   ritual_type: cycle
   heal: true
   store: true
   harvest_container: haversack
-  harvest_count: 8
+  harvest_count: 10
 # Necromancer -->
 
 buff_nonspells:
@@ -218,6 +226,12 @@ training_spells:
     symbiosis: false
 
 avoid_athletics_in_justice: false
+athletics_outdoorsmanship_rooms: 
+- ####
+- ####
+- ####
+- ####
+- ####
 crossing_training:
 
 textbook: true
@@ -227,7 +241,7 @@ footwear: boots
 hand_armor: gloves
 listen: true
 listern_observe: true
-safe_room: ####
+safe_room: ###
 braid_item: grass
 
 use_harness_when_arcana_locked: true
@@ -239,6 +253,7 @@ cambrinth_cap: 50
 prep_scaling_factor: 0.85
 
 box_loot_limit: 10
+box_hunt_minimum: 5
 picking_pet_boxes_on_hand: 5
 picking_box_source: rucksack
 picking_box_storage: rucksack
@@ -261,28 +276,73 @@ waggle_sets:
     << : *buffs
   prebuff:
     << : *buffs
-  eotb: &eotb
-    Eyes of the Blind:
-      recast: 25
-      mana: 20
+  stealth:
+    Philosopher's Preservation:
+      recast: 1
+      mana: 99
+      cambrinth:
+      - 20
+      - 15
+      - 15 
+    Calcified Hide:
+      abbrev: ch
+      recast: 1
+      mana: 99
+      cambrinth:
+      - 20
+      - 15
+    Obfuscation:
+      recast: 2
+      mana: 99
       cambrinth:
       - 20
       - 20
+      - 10  
+  qeotb: &eotb
+    Eyes of the Blind:
+      recast: 25
+      prep_time: 0
+      mana: 5
+  eotb: &eotb
+    Eyes of the Blind:
+      recast: 20
+      mana: 20
+      cambrinth:
       - 20
+      - 15
+      - 15
   devour:
     Devour:
       mana: 30
       cambrinth:
       - 10
+  nr:
+    Necrotic Reconstruction:
+      recast: 99
+      mana: 15
+      cambrinth:
+      - 15
+      - 15
+      - 15
+      cast: cast zombie
+  rpu:
+    Reverse Putrefaction:
+      abbrev: rpu
+      recast: 99
+      mana: 15
+      cambrinth:
+      - 15
+      - 15
+      - 10
 ignored_npcs:
-- Brokk
 - zombie
+- Brokk
 - construct
 
 loot_specials:
-- name: jadeite stones
+- name: stones
   bag: bag
-- name: kyanite stones
+- name: stones
   bag: bag
 - name: cigar
   bag: bag
@@ -341,7 +401,7 @@ aim_fillers:
   - bob
 
 empty_hunting_room_messages:
-- hello?
+  - hello?
 
 gear:
 # ARMOR
@@ -365,8 +425,7 @@ gear:
   :is_leather: true
   :hinders_lockpicking: true
   :is_worn: true
-- :adjective:
-  :name: sallet
+- :name: sallet
   :is_leather: false
   :hinders_lockpicking: true
   :is_worn: true
@@ -392,6 +451,12 @@ gear:
   :hinders_lockpicking: true
   :is_worn: true
 #WEAPONS
+- :adjective: dragon
+  :name: amulet
+  :is_leather: true
+- :adjective: steel
+  :name: scythe
+  :is_worn: true
 - :name: bola
   :wield: true
   :lodges: false
@@ -405,19 +470,14 @@ gear:
   :name: mace
   :swappable: true
   :wield: true
-- :adjective:
-  :name: nightstick
+- :name: nightstick
   :wield: true
 - :adjective: bastard
   :name: sword
   :swappable: true
   :wield: true
-- :adjective:
-  :name: rapier
+- :name: rapier
   :wield: true
-# - :adjective: steel
-#   :name: scythe
-#   :is_worn: true
 - :adjective: light
   :name: spear
   :wield: true
@@ -437,8 +497,6 @@ gear:
 
 scroll_stackers:
 - booklet
-- wizard.tome
-- folio
 
 hunting_buddies:
 
@@ -452,12 +510,15 @@ training_list:
   scripts:
   - athletics
   - go2 ####
-  - rem eotb
-  - magic-training
+  - rem qeotb
+  #- magic-training
   #- outdoorsmanship
   - bitchin-pick
   #- go2 ####
   #- fill-dirt
-  - buff eotb
-  - hunting-buddy usol main back
+  - go2 ####
+  - buff prebuff
+  - buff qeotb
+  - hunting-buddy main usol back
   - sloot shard
+  - salt-circle2

--- a/profiles/Melborne-usol.yaml
+++ b/profiles/Melborne-usol.yaml
@@ -1,12 +1,24 @@
 ---
 hunting_info:
 - :zone:
-  - mountain_giants
-  - mountain_giants
+  - black_apes
+  - black_apes
   args:
-  - d4
+  - d0
+  - r0
+  - usol
+  :duration: 20
+  stop_on:
+  - Thanatology
+  - Skinning
+- :zone:
+  - black_goblins
+  - black_goblins
+  args:
+  - d0
   - usol
   :duration: 15
+  boxes: true
   stop_on:
   - Thanatology
   - Skinning
@@ -23,15 +35,18 @@ offensive_spells:
   cast: cast creature
   expire: The greenish hues
 
+buff_spells:
 skip_last_kill: true
-use_weak_attacks: false
-use_stealth_attacks: false
+use_weak_attacks: true
+use_stealth_attacks: true
 weapon_training:
-  Small Edged: rapier
-dance_skill: Small Edged
+  Targeted Magic: dragon amulet
+dance_skill: Targeted Magic
 
 skinning:
   skin: true
   arrange_all: false
   arrange_count: 2
   tie_bundle: true
+
+

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -84,7 +84,7 @@ aim_fillers_stealth:
 buff_nonspells:
 dance_actions_stealth:
 thanatology:
-butcher_by_default: false 
+butcher_and_dissect: false 
 necro_force_safe_room: false
 necro_siphon_vit_threshold: 85
 necro_safe_room_use_devour: false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -84,6 +84,7 @@ aim_fillers_stealth:
 buff_nonspells:
 dance_actions_stealth:
 thanatology:
+butcher_by_default: false 
 necro_force_safe_room: false
 necro_siphon_vit_threshold: 85
 necro_safe_room_use_devour: false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -84,7 +84,7 @@ aim_fillers_stealth:
 buff_nonspells:
 dance_actions_stealth:
 thanatology:
-butcher_and_dissect: false 
+dissect_and_butcher: false 
 necro_force_safe_room: false
 necro_siphon_vit_threshold: 85
 necro_safe_room_use_devour: false


### PR DESCRIPTION
The butchery addition for necromancers to combat-trainer.

1) You can set the `ritual_type` as butcher and it will butcher the entire corpse until done. 
2) You can set the `ritual_type` as cycle, and then override the default dissect to butcher for when locked with FA and Skinning. This could be further expanded to let butcher be the total default, and replace dissect which would only occur `if skinning > 0 and FA >= skinning`. Just need feedback on peoples thoughts about it.