### PR TITLE
equipmanager.lic: Add support for audrualm katanas.

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -302,9 +302,9 @@ class EquipmentManager
       return
     end
     proper_skill = case skill
-                   when /^he$|heavy edge|large edge/i
+                   when /^he$|heavy edge|large edge|one-handed/i
                      'heavy edged'
-                   when /2he|^the$|twohanded edge/i
+                   when /2he|^the$|twohanded edge|two-handed/i
                      'two-handed edged'
                    when /2hb|^thb$|twohanded blunt/i
                      'two-handed blunt'


### PR DESCRIPTION
You shift the audrualm katana so you can use it two-handed
You shift your audrualm katana so you can use it one-handed

Fixes #2525