### PR TITLE
Update trader TM cast message

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -144,7 +144,7 @@ cast_messages:
 - You point a crooked finger at
 - Mentally steeling yourself in preparation for the unnatural action
 - Currently lacking the skill
-- ^You mold an? .* of (?:the available (?:starlight|moonlight)|your starlight aura)
+- ^You mold
 - You gaze towards the sky above seeking the strongest flows of Air
 - Having located a suitably abundant flow of Air, you inhale sharply filling yourself with the tranquil element
 - You gaze upward seeking the strongest flows of Air


### PR DESCRIPTION
Instead of updating the capture group with another match, shortening it
will save future headaches.