### PR TITLE
Add currency exchange conversion method

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -30,20 +30,20 @@ module DRCM
 
   def convert_currency(amount, from, to, fee = 0.05)
     exchange_rates = {
-        'Dokora' => {
-            'Dokora' => 1,
-            'Kronar' => 1.38580991,
-            'Lirum' => 1.108646953,
+        'dokoras' => {
+            'dokoras' => 1,
+            'kronars' => 1.38580991,
+            'lirums' => 1.108646953,
         },
-        'Kronar' => {
-            'Dokora' => 0.7216,
-            'Kronar' => 1,
-            'Lirum' => 0.8,
+        'kronars' => {
+            'dokoras' => 0.7216,
+            'kronars' => 1,
+            'lirums' => 0.8,
         },
-        'Lirum' => {
-            'Dokora' => 0.902,
-            'Kronar' => 1.25,
-            'Lirum' => 1,
+        'lirums' => {
+            'dokoras' => 0.902,
+            'kronars' => 1.25,
+            'lirums' => 1,
         },
     }
     (exchange_rates[from][to] * amount * (1 - fee)).floor

--- a/common-money.lic
+++ b/common-money.lic
@@ -28,6 +28,27 @@ module DRCM
     amount
   end
 
+  def convert_currency(amount, from, to, fee = 0.05)
+    exchange_rates = {
+        'Dokora' => {
+            'Dokora' => 1,
+            'Kronar' => 1.38580991,
+            'Lirum' => 1.108646953,
+        },
+        'Kronar' => {
+            'Dokora' => 0.7216,
+            'Kronar' => 1,
+            'Lirum' => 0.8,
+        },
+        'Lirum' => {
+            'Dokora' => 0.902,
+            'Kronar' => 1.25,
+            'Lirum' => 1,
+        },
+    }
+    (exchange_rates[from][to] * amount * (1 - fee)).floor
+  end
+
   def hometown_currency(hometown_name)
     get_data('town')[hometown_name]['currency']
   end


### PR DESCRIPTION
Converts one form of currency to another and subtracts the exchange
fee. Default exchange fee is 5% as that is the fee in most of the
commonly used banks. The bank keeps any fractional amount. Assumes the
amount is in copper.