### PR TITLE
Run buff before crafting

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -50,6 +50,7 @@ class Smith
 
     buy_parts(parts)
     buy_ingot(discipline) if buy
+    wait_for_script_to_complete('buff', ['smith'])
     craft_item(recipe, discipline, material)
     stamp_item(recipe) if stamp
     temper_item(discipline, recipe) if temper


### PR DESCRIPTION
Call the buff script looking for the 'smith' waggle set.
There's an example in Dijkstra-setup.yaml which casts
a crafting skill buff