### PR TITLE
Shard gryphon room adjustment

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -705,9 +705,9 @@ hunting_zones:
   # Good swarm, few rooms usually full
   shard_gryphons:
   - 6236
-  - 6235
   - 6237
   - 6238
+  - 6239
   # https://elanthipedia.play.net/Adan%27f_shadow_mage                   250-370
   # https://elanthipedia.play.net/Adan%27f_blood_warrior                 250-325
   # Spawn is hit or miss


### PR DESCRIPTION
Remove 6235 - nothing ever spawns in here. Add 6239  - do spawn, and can use hunt.