### PR TITLE
Don't pause on each line received from the game

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -162,7 +162,6 @@ class Astrology
       line = get?
       res = @constellations.find { |body| /As your consciousness drifts amongst the currents of Fate, .* #{body['name']}/i =~ line }
       observe(res['name']) unless res.nil?
-      pause 1
     end
     nil
   end


### PR DESCRIPTION
The pause was causing people to observe
much later after receiving a prompt from the RtR spell.

Fixes #2606 after having the user test out the change.