### PR TITLE
Unify crafting waggle sets to remove duplication

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -52,7 +52,7 @@ class Sew
     @mat_type = args.material
     @stamp = @settings.mark_crafted_goods
 
-    wait_for_script_to_complete('buff', ['sew'])
+    wait_for_script_to_complete('buff', ['crafting'])
 
     Flags.add('sew-assembly', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)', 'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)', 'another finished (long|short) wooden (pole)')
     Flags.add('sew-pins', 'The pins is all used up, so you toss it away.')

--- a/smith.lic
+++ b/smith.lic
@@ -50,7 +50,7 @@ class Smith
 
     buy_parts(parts)
     buy_ingot(discipline) if buy
-    wait_for_script_to_complete('buff', ['smith'])
+    wait_for_script_to_complete('buff', ['crafting'])
     craft_item(recipe, discipline, material)
     stamp_item(recipe) if stamp
     temper_item(discipline, recipe) if temper


### PR DESCRIPTION
I don't see any reason to have to have separate waggle sets for each craft, if you want to buff one you'd want to buff them all?