### PR TITLE
sorcery.lic: Don't walk to a sorcery room if you are using runestones.

### DIFF
--- a/sorcery.lic
+++ b/sorcery.lic
@@ -11,7 +11,6 @@ class Sorcery
 
   def initialize
     @settings = get_settings
-    walk_to(@settings.crossing_training_sorcery_room)
 
     return if cast_sorcery_spell?
 


### PR DESCRIPTION
The walk_to was already in cast_sorcery_spell? anyway.