### PR TITLE
Common-Arcana: Invoke exact amount from cambrinth items

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -151,11 +151,11 @@ module DRCA
     !Flags['spell-fail']
   end
 
-  def find_charge_invoke_stow(cambrinth, stored_cambrinth, cambrinth_cap, dedicated_camb_use, charges)
+  def find_charge_invoke_stow(cambrinth, stored_cambrinth, cambrinth_cap, dedicated_camb_use, charges, invoke_exact_amount)
     return unless charges
 
     find_cambrinth(cambrinth, stored_cambrinth, cambrinth_cap)
-    charge_and_invoke(cambrinth, dedicated_camb_use, charges)
+    charge_and_invoke(cambrinth, dedicated_camb_use, charges, invoke_exact_amount)
     stow_cambrinth(cambrinth, stored_cambrinth, cambrinth_cap)
   end
 
@@ -203,18 +203,20 @@ module DRCA
     end
   end
 
-  def charge_and_invoke(cambrinth, dedicated_camb_use, charges)
+  def charge_and_invoke(cambrinth, dedicated_camb_use, charges, invoke_exact_amount)
     charges.each do |mana|
       break unless charge?(cambrinth, mana)
     end
 
-    invoke(cambrinth, dedicated_camb_use)
+    invoke_amount = invoke_exact_amount ? charges.inject(:+) : nil
+
+    invoke(cambrinth, dedicated_camb_use, invoke_amount)
   end
 
-  def invoke(cambrinth, dedicated_camb_use)
+  def invoke(cambrinth, dedicated_camb_use, invoke_amount)
     return unless cambrinth
 
-    DRC.bput("invoke my #{cambrinth} #{dedicated_camb_use}", get_data('spells').invoke_messages)
+    DRC.bput("invoke my #{cambrinth} #{dedicated_camb_use} #{invoke_amount}", get_data('spells').invoke_messages)
     pause
     waitrt?
   end
@@ -396,9 +398,9 @@ module DRCA
       settings.cambrinth_items.each_with_index do |item, index|
         case data['cambrinth'].first
         when Array
-          find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'][index])
+          find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'][index], settings.cambrinth_invoke_exact_amount)
         when Fixnum, Integer
-          find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'])
+          find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'], settings.cambrinth_invoke_exact_amount)
         end
       end
     end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -151,7 +151,8 @@ module DRCA
     !Flags['spell-fail']
   end
 
-  def find_charge_invoke_stow(cambrinth, stored_cambrinth, cambrinth_cap, dedicated_camb_use, charges, invoke_exact_amount)
+  def find_charge_invoke_stow(cambrinth, stored_cambrinth, cambrinth_cap, dedicated_camb_use, charges, invoke_exact_amount = nil)
+    # TODO: Remove default nil argument once all users are up to date with common-arcana
     return unless charges
 
     find_cambrinth(cambrinth, stored_cambrinth, cambrinth_cap)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -213,7 +213,8 @@ module DRCA
     invoke(cambrinth, dedicated_camb_use, invoke_amount)
   end
 
-  def invoke(cambrinth, dedicated_camb_use, invoke_amount)
+  def invoke(cambrinth, dedicated_camb_use, invoke_amount = nil)
+    # TODO: Remove default argument for invoke_amount after users have had time to reload changes in common-arcana. (A couple of days)
     return unless cambrinth
 
     DRC.bput("invoke my #{cambrinth} #{dedicated_camb_use} #{invoke_amount}", get_data('spells').invoke_messages)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -188,6 +188,7 @@ cambrinth_items:
   cap:
   stored:
 cambrinth_num_charges: 4  #Number of times to charge a cambrinth item with use_auto_mana
+cambrinth_invoke_exact_amount: false
 
 
 


### PR DESCRIPTION
The setting lets a magic user invoke the exact amount
of mana from their cambrinth items. This is useful for
Traders in particular where their cambrinth items
are charged passively and can lead to backfiring.

Only common-arcana and the base setting is included in this update to give users time to get drca updated.