### PR TITLE
Handle holy weapons

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -38,8 +38,8 @@ class CrossingRepair
       command = "give my #{item.short_name} to #{repairer}"
     end
 
-    case bput(command, "There isn't a scratch on that", "I don't work on those here", "I don't repair those here", 'Just give it to me again', "You don't need to specify the object", "I will not repair something that isn't broken", "Please don't lose this ticket!", "You hand.*#{repairer}", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!')
-    when "There isn't a scratch on that", "I will not repair something that isn't broken", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!', "I don't repair those here"
+    case bput(command, "There isn't a scratch on that", "I don't work on those here", "I don't repair those here", 'Just give it to me again', "You don't need to specify the object", "I will not repair something that isn't broken", "Please don't lose this ticket!", "You hand.*#{repairer}", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!', "You can't hand this weapon to another person!")
+    when "There isn't a scratch on that", "I will not repair something that isn't broken", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!', "I don't repair those here", "You can't hand this weapon to another person!"
       @equipment_manager.empty_hands
     when "I don't work on those here"
       echo "*** ITEM HAS IMPROPER is_leather FLAG: #{item.short_name} ***"


### PR DESCRIPTION
Holy weapons cannot be given to the repairer.

---
Issue: [#2291](https://github.com/rpherbig/dr-scripts/issues/2291)