### PR TITLE
Add skip_repair attribute to Item class

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -223,9 +223,9 @@ module DRC
   # Items class. Name is the noun of the object. Leather/metal boolean. Is the item worn (defaults to true). Does it hinder lockpicking? (false)
   # Item.new(name:'gloves', leather:true, worn:true, hinders_locks:true, adjective:'ring', bound:true)
   class Item
-    attr_accessor :name, :leather, :worn, :hinders_lockpicking, :container, :swappable, :tie_to, :adjective, :bound, :wield, :transforms_to, :transform_verb, :transform_text, :lodges
+    attr_accessor :name, :leather, :worn, :hinders_lockpicking, :container, :swappable, :tie_to, :adjective, :bound, :wield, :transforms_to, :transform_verb, :transform_text, :lodges, :skip_repair
 
-    def initialize(name: nil, leather: nil, worn: false, hinders_locks: nil, container: nil, swappable: false, tie_to: nil, adjective: nil, bound: false, wield: false, transforms_to: nil, transform_text: nil, transform_verb: nil, lodges: true)
+    def initialize(name: nil, leather: nil, worn: false, hinders_locks: nil, container: nil, swappable: false, tie_to: nil, adjective: nil, bound: false, wield: false, transforms_to: nil, transform_text: nil, transform_verb: nil, lodges: true, skip_repair: false)
       @name = name
       @leather = leather
       @worn = worn
@@ -240,6 +240,7 @@ module DRC
       @transform_verb = transform_verb
       @transform_text = transform_text
       @lodges = lodges.nil? ? true : lodges
+      @skip_repair = skip_repair
     end
 
     def short_name


### PR DESCRIPTION
Some items do not need to be or cannot be repaired.
This attribute will inform a repair script to skip this item.

---
Issue: [#2598](https://github.com/rpherbig/dr-scripts/issues/2598)
Issue: [#2118](https://github.com/rpherbig/dr-scripts/issues/2118)