### PR TITLE
Don't repair items with skip_repair set

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -102,8 +102,8 @@ class CrossingRepair
     ensure_copper_on_hand(@repair_withdrawal_amount, settings)
 
     # Merge, do not overwrite
-    @repair_info = { hometown_data['leather_repair'] => @equipment_manager.items.select(&:leather) }
-                   .merge(hometown_data['metal_repair'] => @equipment_manager.items.reject(&:leather)) { |_key, old, new| old + new }
+    @repair_info = { hometown_data['leather_repair'] => @equipment_manager.items.select(&:leather).reject(&:skip_repair) }
+                   .merge(hometown_data['metal_repair'] => @equipment_manager.items.reject(&:leather).reject(&:skip_repair)) { |_key, old, new| old + new }
     settings
   end
 end

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -18,7 +18,7 @@ class EquipmentManager
     settings ||= get_settings
     @gear_sets = settings.gear_sets
     @sort_head = settings.sort_auto_head
-    @items = settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound], wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text], lodges: item[:lodges]) }
+    @items = settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound], wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text], lodges: item[:lodges], skip_repair: item[:skip_repair]) }
   end
 
   def remove_gear_by(&_block)


### PR DESCRIPTION
PR #2629 should be merged before this and wait a day or two so users can refresh common.lic

Some items cant be repaired. Crossing-repair
should avoid getting and stowing these items.
---
Issue: [#2598](https://github.com/rpherbig/dr-scripts/issues/2598)
Issue: [#2118](https://github.com/rpherbig/dr-scripts/issues/2118)