### PR TITLE
base-hunting.yaml: Get rid of now removed orc_raiders2 hunting area

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1148,7 +1148,6 @@ hunting_zones:
   - 8713
   - 8714
   - 8715
-  orc_raiders2:
   # https://elanthipedia.play.net/Orc_clan-chief                         400-500
   # further upstairs, raiders with high spawn of clan chiefs
   # Barb warhorn = tons of chiefs


### PR DESCRIPTION
[exec1: ["orc_raiders", [8704, 8705, 8706, 8707, 8708, 8709]]]
[exec1: ["orc_raiders2", nil]]
[exec1: ["orc_raiders_upstairs", [8710, 8711, 8712, 8713, 8714, 8715]]]