### PR TITLE
Update rezz.lic to allow different messaging

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -41,7 +41,7 @@ class Rezz
     rejuv(person)
 
     # gesture
-    bput("gest #{person}", 'As you intone a quiet prayer')
+    bput("gest #{person}", 'Roundtime')
   end
 
   def find_soul(person, infuse_amt)


### PR DESCRIPTION
Successful rezz message varies. Roundtime seems to exist regardless of message when gesturing.