### PR TITLE
Add unloading while hidden matcher

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -338,7 +338,7 @@ class EquipmentManager
   end
 
   def unload_weapon(name)
-    result = bput("unload my #{name}", 'You unload', 'Your .* fall.* from', 'As you release the string')
+    result = bput("unload my #{name}", 'You unload', 'Your .* fall.* from', 'As you release the string', 'You .* unloading')
     waitrt?
     bput('stow left', 'You put') if result == 'You unload'
   end


### PR DESCRIPTION
Noticed this hung my script earlier. Seems like it shouldn't break anything, the main use case is probably the call to this method from the combat-trainer (which is where mine hung).

Full string:
`You remain concealed by your surroundings, convinced that your unloading of the yew shortbow went unobserved.`

I wasn't able to test some of the other cases if you were noticed unloading, let me know if you would like me to add those as well.