### PR TITLE
Fix for attacks starting with vowels

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3038,7 +3038,7 @@ class GameState
     return false if combo_type != 'flame' && !Flags["ct-#{combo_type}-ready"]
     return false if DRSkill.getrank('Expertise') < expertise_requirement
 
-    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing a .*', 'You need to hold')
+    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold')
     waitrt?
 
     case result
@@ -3050,7 +3050,7 @@ class GameState
       return true
     end
 
-    text = result.match(/by landing a (.*)\.$/).to_a[1]
+    text = result.match(/by landing an? (.*)\.$/).to_a[1]
     @analyze_combo_array = list_to_nouns(text)
 
     true


### PR DESCRIPTION
Changed "by landing a .*" to "by landing an? .*" to account for maneuvers that start with a vowel. (E.G. 'an elbow' was stalling the script)