### PR TITLE
Follow-on for unloading while hidden

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -340,7 +340,7 @@ class EquipmentManager
   def unload_weapon(name)
     result = bput("unload my #{name}", 'You unload', 'Your .* fall.* from', 'As you release the string', 'You .* unloading')
     waitrt?
-    bput('stow left', 'You put') if result == 'You unload'
+    bput('stow left', 'You put') if result == 'You unload' || result =~ /You .* unloading/
   end
 
   def stow_weapon(description = nil)


### PR DESCRIPTION
Follow-on to #2678, since unloading while hidden actually puts an arrow in your left hand we should stow it as well.