### PR TITLE
 Add perc_aura method

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -274,8 +274,7 @@ module DRCA
 
   def perc_aura
     return unless DRStats.trader?
-
-    # Local conditions prohibit your aura from growing.
+    
     starlight_messages = [
       'The smallest hint of starlight flickers within your aura',
       'A bare flicker of starlight plays within your aura',

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -272,6 +272,31 @@ module DRCA
     end
   end
 
+  def perc_aura
+    return unless DRStats.trader?
+
+    # Local conditions prohibit your aura from growing.
+    starlight_messages = [
+      'The smallest hint of starlight flickers within your aura',
+      'A bare flicker of starlight plays within your aura',
+      'A faint amount of starlight illuminates your aura'
+    ]
+    Flags.add('aura-level', Regexp.union(starlight_messages))
+    Flags.add('aura-capped?', 'Your aura contains as much starlight as you can safely handle')
+    Flags.add('aura-growing?', 'Local conditions permit optimal growth of your aura')
+    aura = {}
+    DRC.bput('perceive aura', 'You close your eyes and take a measure of your aura')
+    waitfor 'Roundtime' # Make sure we receive all the messages from the game before proceeding
+    aura['level'] = Flags['aura-level'] ? starlight_messages.index(Flags['aura-level'].first) : 0
+    aura['capped'] = Flags['aura-capped?'] ? true : false
+    aura['growing'] = Flags['aura-growing?'] ? true : false
+    echo Flags['aura-env'].find {}
+    Flags.delete('aura-level')
+    Flags.delete('aura-capped?')
+    Flags.delete('aura-growing?')
+    aura
+  end
+
   def cast_spells(spells, settings, force_cambrinth = false)
     infuse_om(!settings.osrel_no_harness, settings.osrel_amount)
     spells.each do |name, data|

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -285,12 +285,10 @@ module DRCA
     Flags.add('aura-capped?', 'Your aura contains as much starlight as you can safely handle')
     Flags.add('aura-growing?', 'Local conditions permit optimal growth of your aura')
     aura = {}
-    DRC.bput('perceive aura', 'You close your eyes and take a measure of your aura')
-    waitfor 'Roundtime' # Make sure we receive all the messages from the game before proceeding
+    DRC.bput('perceive aura', 'Roundtime')
     aura['level'] = Flags['aura-level'] ? starlight_messages.index(Flags['aura-level'].first) : 0
     aura['capped'] = Flags['aura-capped?'] ? true : false
     aura['growing'] = Flags['aura-growing?'] ? true : false
-    echo Flags['aura-env'].find {}
     Flags.delete('aura-level')
     Flags.delete('aura-capped?')
     Flags.delete('aura-growing?')


### PR DESCRIPTION
Traders use starlight aura as a battery
for some of their spells. It will be necessary
to track the users level of starlight aura
in order to reliably cast these spells.