### PR TITLE
Use a list of pc empaths when healing

### DIFF
--- a/common-validation.lic
+++ b/common-validation.lic
@@ -62,4 +62,8 @@ class CharacterValidator
       @lnet.unique_buffer.push("chat to #{character} #{message}")
     end
   end
+
+  def in_game?(character)
+    "  #{character}." == bput("find #{character}", 'There are no adventurers in the realms that match the names specified', "^  #{character}.$")
+  end
 end

--- a/dependency.lic
+++ b/dependency.lic
@@ -896,6 +896,7 @@ class SetupFiles
     s.safe_room ||= UserVars.safe_room
     s.safe_room_id ||= UserVars.safe_room_id
     s.safe_room_empath ||= UserVars.safe_room_empath
+    s.safe_room_empaths ||= UserVars.safe_room_empaths
     s.slack_username ||= UserVars.slack_username
     s.bankbot_name ||= UserVars.bankbot_name
     s.bankbot_room_id ||= UserVars.bankbot_room_id

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -55,3 +55,4 @@ empty_values:
   athletics_outdoorsmanship_rooms: []
   combat_spell_training: {}
   stealing_towns: []
+  safe_room_empaths: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -170,7 +170,7 @@ safe_room_give:
 safe_room_tip_threshold:
 safe_room_tip_amount:
 safe_room_empath:
-
+safe_room_empaths:
 
 
 

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -37,6 +37,7 @@ class SafeRoom
       sort_destinations(pc_empaths.map { |empath| empath['id'] })
         .map { |room| pc_empaths.find { |empath| empath['id'] == room } }
         .each do |empath|
+        next unless DRRoom.pcs.include?(empath['name'].capitalize!) || in_game?(empath['name'])
         next unless use_pc_empath?(empath['id'], empath['name'])
         ensure_copper_on_hand(settings.safe_room_tip_threshold || 0, settings)
         tip(settings.safe_room_tip_threshold, settings.safe_room_tip_amount, empath['name'])
@@ -67,6 +68,11 @@ class SafeRoom
     end
 
     give_and_take(settings.safe_room_id, settings.safe_room_give, settings.safe_room_take)
+  end
+
+  def in_game?(character)
+    # TODO: Remove and use common-validation::in_game? when all players have had a reasonable amount of time to reload common-scripts
+    "  #{character}." == bput("find #{character}", 'There are no adventurers in the realms that match the names specified', "^  #{character}.$")
   end
 
   def need_healing?

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -26,9 +26,22 @@ class SafeRoom
 
     return unless args.force || need_healing?
 
-    if use_pc_empath?(settings.safe_room_id, settings.safe_room_empath)
-      ensure_copper_on_hand(settings.safe_room_tip_threshold || 0, settings)
-      tip(settings.safe_room_tip_threshold, settings.safe_room_tip_amount, settings.safe_room_empath)
+    pc_empaths = settings.safe_room_empaths || []
+    if settings.safe_room_id && settings.safe_room_empath
+      # Add to pc_empaths list if its not in there already
+      pc_empaths << { 'name' => settings.safe_room_empath, 'id' => settings.safe_room_id } unless pc_empaths.any? { |empath| empath['name'] == settings.safe_room_empath && empath['id'] == settings.safe_room_id }
+    end
+
+    if !pc_empaths.empty?
+      # Sort pc empaths list by nearest first
+      sort_destinations(pc_empaths.map { |empath| empath['id'] })
+        .map { |room| pc_empaths.find { |empath| empath['id'] == room } }
+        .each do |empath|
+        next unless use_pc_empath?(empath['id'], empath['name'])
+        ensure_copper_on_hand(settings.safe_room_tip_threshold || 0, settings)
+        tip(settings.safe_room_tip_threshold, settings.safe_room_tip_amount, empath['name'])
+        break
+      end
     elsif DRStats.empath?
       walk_to(settings.safe_room) unless args.skip
       wait_for_script_to_complete('healme')

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -35,7 +35,8 @@ class SafeRoom
     if !pc_empaths.empty?
       # Sort pc empaths list by nearest first
       sort_destinations(pc_empaths.map { |empath| empath['id'] })
-        .map { |room| pc_empaths.find { |empath| empath['id'] == room } }
+        .map { |room| pc_empaths.select { |empath| empath['id'] == room } }
+        .flatten
         .each do |empath|
         next unless DRRoom.pcs.include?(empath['name'].capitalize!) || in_game?(empath['name'])
         next unless use_pc_empath?(empath['id'], empath['name'])


### PR DESCRIPTION
Let the user specify multiple empaths incase one goes offline.
Also sorts the list of empaths by nearest first.
If the user already has safe_room_empath and safe_room_id defined,
then these are merged into the pc_empath list.

Example setting
```yaml
---
safe_room_empaths:
- name: Dolores
  id: 1234
- name: Teddy
  id: 5678
- name: Bernard
  id: 7373
```