### PR TITLE
Add weapon priority settings to combat trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -16,6 +16,8 @@ class SetupProcess
     echo("  @stance_override: #{@stance_override}") if $debug_mode_ct
     @priority_defense = settings.priority_defense
     echo("  @priority_defense: #{@priority_defense}") if $debug_mode_ct
+    @priority_weapons = settings.priority_weapons
+    echo("  @priority_weapons: #{@priority_weapons}") if $debug_mode_ct
     @cycle_armors = settings.cycle_armors
     echo("  @cycle_armors: #{@cycle_armors}") if $debug_mode_ct
     @cycle_armors_time = settings.cycle_armors_time
@@ -137,7 +139,7 @@ class SetupProcess
       echo('skipping summoned weapons because no moonblade available') if $debug_mode_ct
       weapon_training = weapon_training.reject { |skill, _| game_state.summoned_info(skill) }
     end
-    new_weapon_skill = weapon_training.min_by { |skill, _| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }.first
+    new_weapon_skill = weapon_training.min_by { |skill, _| [DRSkill.getxp(skill), @priority_weapons.include?(skill) ? -1 : 0, DRSkill.getrank(skill)] }.first
     game_state.update_weapon_info(new_weapon_skill)
 
     game_state.update_target_weapon_skill

--- a/profiles/SampleBarbarian-setup.yaml
+++ b/profiles/SampleBarbarian-setup.yaml
@@ -103,6 +103,10 @@ weapon_training:
   Polearms: spear
   Large Edged: bastard sword
   Twohanded Edged: bastard sword
+priority_weapons:
+  - Large Edged
+  - Polearms
+  - Heavy Thrown
 use_stealth_attacks: true
 skinning:
   skin: true

--- a/profiles/SampleBard-setup.yaml
+++ b/profiles/SampleBard-setup.yaml
@@ -99,7 +99,8 @@ weapon_training:
   Brawling: ''
   Heavy Thrown: pine-handled sledgehammer
   Large Blunt: pine-handled sledgehammer
-
+priority_weapons:
+  - Brawling
 # Non-combat settings
 crossing_training:
 - Appraisal

--- a/profiles/SampleCleric-setup.yaml
+++ b/profiles/SampleCleric-setup.yaml
@@ -102,7 +102,9 @@ weapon_training:
   Brawling: ''
   Heavy Thrown: pine-handled sledgehammer
   Large Blunt: pine-handled sledgehammer
-
+priority_weapons:
+  - Large Blunt
+  - Heavy Thrown
 # Non-combat settings
 crossing_training:
 - Theurgy

--- a/profiles/SampleMoonMage-setup.yaml
+++ b/profiles/SampleMoonMage-setup.yaml
@@ -116,6 +116,9 @@ weapon_training:
   Brawling: ''
   Heavy Thrown: pine-handled sledgehammer
   Large Blunt: pine-handled sledgehammer
+priority_weapons:
+  - Brawling
+  - Heavy Thrown
 use_stealth_attacks: true
 
 skinning:

--- a/profiles/SampleNecromancer-setup.yaml
+++ b/profiles/SampleNecromancer-setup.yaml
@@ -128,6 +128,8 @@ weapon_training:
   Crossbow: light crossbow
   Light Thrown: triple-weighted bola
   Small Blunt: triple-weighted bola
+priority_weapons:
+  - Small Edged
 dance_skill: Small Edged
 skinning:
   skin: true

--- a/profiles/SamplePaladin-setup.yaml
+++ b/profiles/SamplePaladin-setup.yaml
@@ -100,6 +100,9 @@ weapon_training:
   Heavy Thrown: spear
   Polearms: spear
   Twohanded Edged: claymore
+priority_weapons:
+  - Brawling
+  - Heavy Thrown
 skinning:
   skin: true
   arrange_all: false

--- a/profiles/SampleRanger-setup.yaml
+++ b/profiles/SampleRanger-setup.yaml
@@ -123,6 +123,8 @@ weapon_training:
   Heavy Thrown: pine-handled sledgehammer
   Light Thrown: triple-weighted bola
   Polearms: oak-hafted halberd
+priority_weapons:
+  - Bow
 dance_skill: Polearms
 skinning:
   skin: true

--- a/profiles/SampleThief-setup.yaml
+++ b/profiles/SampleThief-setup.yaml
@@ -101,6 +101,9 @@ weapon_training:
   Small Edged: throwing spike
   Small Blunt: throwing spike
   Light Thrown: throwing spike
+priority_weapons:
+  - Small Edged
+  - Light Thrown
 kneel_khri: true
 buff_nonspells:
   khri:

--- a/profiles/SampleWarriorMage-setup.yaml
+++ b/profiles/SampleWarriorMage-setup.yaml
@@ -110,6 +110,9 @@ weapon_training:
   Polearms: spear
   Large Edged: bastard sword
   Twohanded Edged: bastard sword
+priority_weapons:
+  - Heavy Thrown
+  - Large Edged
 skinning:
   skin: true
   arrange_all: false

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -35,6 +35,7 @@ empty_values:
   buff_nonspells: {}
   training_abilities: {}
   weapon_training: {}
+  priority_weapons: []
   charged_maneuvers: {}
   training_nonspells: {}
   training_spells: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -123,6 +123,7 @@ stun_weapon_skill:
 stun_skill: Debilitation
 dont_stalk: false
 cast_only_to_train: false
+priority_weapons:
 priority_defense:
 tk_ammo:
 custom_loot_type:

--- a/validate.lic
+++ b/validate.lic
@@ -91,7 +91,6 @@ class DRYamlValidator
     return unless settings.priority_weapons
 
     settings.priority_weapons
-            .keys
             .reject { |skill_name| @valid_weapon_skills.include?(skill_name) }
             .each { |skill_name| error("Invalid priority_weapons: skill name '#{skill_name}'. Valid skills are '#{@valid_weapon_skills}'") }
   end

--- a/validate.lic
+++ b/validate.lic
@@ -86,6 +86,15 @@ class DRYamlValidator
             .reject { |skill_name| @valid_weapon_skills.include?(skill_name) }
             .each { |skill_name| error("Invalid weapon_training: skill name '#{skill_name}'. Valid skills are '#{@valid_weapon_skills}'") }
   end
+
+  def assert_that_priority_weapons_are_skills(settings)
+    return unless settings.priority_weapons
+
+    settings.priority_weapons
+            .keys
+            .reject { |skill_name| @valid_weapon_skills.include?(skill_name) }
+            .each { |skill_name| error("Invalid priority_weapons: skill name '#{skill_name}'. Valid skills are '#{@valid_weapon_skills}'") }
+  end
   
   def assert_that_combat_spell_training_spells_are_skills(settings)
     return unless settings.combat_spell_training


### PR DESCRIPTION
This is an attempt to implement #2240 - the ability to specify weapon priorities. There was lots of great feedback there and I tried to incorporate it all here. 

The use of the array `min_by` to figure out the weapon skill is very clever. I built on that by adding a simple flag for priority weapons and inserting it into the middle of the `min_by` calculation.

The full weapon skill selection logic should now work as follows:
- Always pick the weapon with the lowest field experience, priority weapon or not [**unchanged**]
- If a priority weapon is specified, use that [**added**]
- If a priority weapon is not specified, pick the weapon skill with the lowest rank [**unchanged**]

I think this gets us what we want. If no priority weapon is selected, everything is unchanged. If one is selected, we will still always train the lowest exp weapon, and when they are all equal, we will train a priority weapon. The one downside is we will never train the lowest ranked weapon if a priority weapon is set, but if we set a priority weapon I assume that is the behavior we want. 