### PR TITLE
Add validation for combat_spell_training

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -88,6 +88,19 @@ class DRYamlValidator
     bad_names.each { |skill_name| error("Invalid weapon_training: skill name '#{skill_name}'") }
     echo("Valid skills are #{@valid_weapon_skills}")
   end
+  
+  def assert_that_combat_spell_training_spells_are_skills(settings)
+    return unless settings.combat_spell_training
+    
+    valid_combat_spell_training_skills = %w[Augmentation Warding Utility]
+
+    bad_names = settings.combat_spell_training.keys
+                        .reject { |skill_name| valid_combat_spell_training_skills.include?(skill_name) }
+    return if bad_names.empty?
+
+    bad_names.each { |skill_name| error("Invalid combat_spell_training: skill name '#{skill_name}'") }
+    echo("Valid skill names are #{valid_combat_spell_training_skills}")
+  end
 
   def assert_that_cycle_armors_are_skills(settings)
     return unless settings.cycle_armors

--- a/validate.lic
+++ b/validate.lic
@@ -81,12 +81,10 @@ class DRYamlValidator
   def assert_that_weapon_training_are_skills(settings)
     return unless settings.weapon_training
 
-    bad_names = settings.weapon_training.keys
-                        .reject { |skill_name| @valid_weapon_skills.include?(skill_name) }
-    return if bad_names.empty?
-
-    bad_names.each { |skill_name| error("Invalid weapon_training: skill name '#{skill_name}'") }
-    echo("Valid skills are #{@valid_weapon_skills}")
+    settings.weapon_training
+            .keys
+            .reject { |skill_name| @valid_weapon_skills.include?(skill_name) }
+            .each { |skill_name| error("Invalid weapon_training: skill name '#{skill_name}'. Valid skills are '#{@valid_weapon_skills}'") }
   end
   
   def assert_that_combat_spell_training_spells_are_skills(settings)
@@ -94,12 +92,10 @@ class DRYamlValidator
     
     valid_combat_spell_training_skills = %w[Augmentation Warding Utility]
 
-    bad_names = settings.combat_spell_training.keys
-                        .reject { |skill_name| valid_combat_spell_training_skills.include?(skill_name) }
-    return if bad_names.empty?
-
-    bad_names.each { |skill_name| error("Invalid combat_spell_training: skill name '#{skill_name}'") }
-    echo("Valid skill names are #{valid_combat_spell_training_skills}")
+    settings.combat_spell_training
+            .keys
+            .reject { |skill_name| valid_combat_spell_training_skills.include?(skill_name) }
+            .each { |skill_name| error("Invalid combat_spell_training: skill name '#{skill_name}'. Valid skill names are '#{valid_combat_spell_training_skills}'") }
   end
 
   def assert_that_cycle_armors_are_skills(settings)


### PR DESCRIPTION
This got me pretty good. For my `combat_spell_training` I was following the pattern set with `buff_spells` in naming the key as a spell name, so for a few days none of my magics were training in combat and I couldn't figure out why. Finally did, and decided to add in a validation to clue in others.

One question - do these abbreviations also need to appear anywhere else like they do for `training_spells` used in the `crossing-training` script? I saw a validation for that, but I haven't yet dug into the specifics of how combat-training works with spells yet.