### PR TITLE
Add combat_spell_training_max_threshold setting to combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -832,7 +832,10 @@ class SpellProcess
 
     @training_spells = settings.combat_spell_training
     echo("  @training_spells: #{@training_spells}") if $debug_mode_ct
-
+    
+    @training_spells_max_threshold = settings.combat_spell_training_max_threshold
+    echo("  @training_spells_max_threshold: #{@training_spells_max_threshold}") if $debug_mode_ct
+    
     @offensive_spell_cycle = settings.offensive_spell_cycle
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
@@ -1158,6 +1161,7 @@ class SpellProcess
   def check_training(game_state)
     return if game_state.casting
     return unless @training_spells
+    return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
     return if mana < @training_spell_mana_threshold
 
     needs_training = %w[Warding Utility Augmentation]

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -115,6 +115,7 @@ dump_junk: false
 dump_item_count: 9
 use_barb_combos: false
 whirlwind_trainables:
+combat_spell_training_max_threshold:
 offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50
 buff_spell_mana_threshold: 40


### PR DESCRIPTION
Added in a `combat_spell_training_max_threshold` setting. 

The idea behind this flag is it will only try to cast spells from your `combat_spell_training` list if the number of mobs in the room is less than or equal to your `combat_spell_training_max_threshold`

I had a few convos with the folks over in #scripting about this, and while we agreed it might only be useful in some more specific situations, I am still coming back to wanting this feature due to hunting in earlier zone where skill ranges are tight and I like having this as a control mechanism. That said, this is an opt-in flag so it will only kick in if a user wants it to.

I think this is a nice option to have because without it, it seems like the script will always try to juggle between casting a tm/debil spell, and a spell from your combat spell list. I am using this to basically set a preference to always use my tm/debil in order to kill faster (and train more tm/debil) when hunting at or close to level.