### PR TITLE
Train sorcery in combat spell training

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1101,6 +1101,10 @@ class SpellProcess
 
     hide?(@hide_type) if XMLData.prepared_spell == 'Vivisection' && game_state.use_stealth_attack?
 
+    if game_state.casting_sorcery
+      @equipment_manager.stow_weapon(game_state.weapon_name)
+    end
+
     snapshot = DRSkill.getxp(@skill)
     success = cast?(@custom_cast, @symbiosis, @before, @after)
     if @symbiosis && @use_auto_mana
@@ -1124,6 +1128,10 @@ class SpellProcess
     game_state.casting_weapon_buff = false
     game_state.casting_consume = false
     game_state.casting_cfb = false
+    if game_state.casting_sorcery
+      game_state.casting_sorcery = false
+      @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+    end
 
     if game_state.casting_moonblade
       if left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?
@@ -1160,10 +1168,12 @@ class SpellProcess
     return unless @training_spells
     return if mana < @training_spell_mana_threshold
 
-    needs_training = %w[Warding Utility Augmentation]
+    needs_training = %w[Warding Utility Augmentation Sorcery]
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| DRSkill.getxp(skill) < 31 }
                      .select { |skill| Time.now > (@training_spells[skill]['cyclic'] ? @training_cyclic_timer : @training_cast_timer) }
+                     .select { |skill| @training_spells[skill]['night'] ? UserVars.sun['night'] : true }
+                     .select { |skill| @training_spells[skill]['day'] ? UserVars.sun['day'] : true }
                      .sort_by { |skill| DRSkill.getxp(skill) }.first
     return unless needs_training
 
@@ -1173,6 +1183,11 @@ class SpellProcess
       @training_cyclic_timer = Time.now + 325
     elsif @training_cyclic_timer < @training_cast_timer
       @training_cyclic_timer = @training_cast_timer
+    end
+
+    if needs_training == 'Sorcery'
+      echo 'Preparing a sorcery spell, held items will be stowed to prevent item loss' if $debug_mode_ct
+      game_state.casting_sorcery = true
     end
     prepare_spell(data, game_state)
   end
@@ -2426,7 +2441,7 @@ class GameState
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
 
-  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total
+  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -2444,6 +2459,7 @@ class GameState
     @selected_maneuver = nil
     @cast_timer = nil
     @casting_moonblade = false
+    @casting_sorcery = false
     @casting_weapon_buff = false
     @casting_consume = false
     @prepare_consume = false

--- a/validate.lic
+++ b/validate.lic
@@ -86,11 +86,11 @@ class DRYamlValidator
             .reject { |skill_name| @valid_weapon_skills.include?(skill_name) }
             .each { |skill_name| error("Invalid weapon_training: skill name '#{skill_name}'. Valid skills are '#{@valid_weapon_skills}'") }
   end
-  
+
   def assert_that_combat_spell_training_spells_are_skills(settings)
     return unless settings.combat_spell_training
-    
-    valid_combat_spell_training_skills = %w[Augmentation Warding Utility]
+
+    valid_combat_spell_training_skills = %w[Augmentation Sorcery Utility Warding]
 
     settings.combat_spell_training
             .keys


### PR DESCRIPTION
Sheath and wield items before and after casting via
a flag in gamestate, `casting_sorcery`

Example settings
---
```yaml
combat_spell_training:
  Sorcery:
    name: Ghost Shroud
    mana: 21
    cyclic: true
    day: true # Keeps from conflicting with SLS, another cyclic
```