### PR TITLE
bescort.lic: Add support for the mriss/lang balloon.

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -139,6 +139,10 @@ class Bescort
         { name: 'mode', options: %w[island ratha], description: 'Where do you need to get to?' }
       ],
       [
+        { name: 'baloon', regex: /baloon/i, description: 'The air ship between Langenfirth and Mriss' },
+        { name: 'mode', options: %w[langenfirth mriss], description: 'Where do you need to get to?' }
+      ],
+      [
         { name: 'dirigible', regex: /dirigible/i, description: 'The air ship between Shard and Aesry' },
         { name: 'mode', options: %w[shard aesry], description: 'Where do you need to get to?' }
       ],
@@ -205,6 +209,8 @@ class Bescort
       iceroad(args.mode)
     elsif args.basalt
       take_crawling_plague(args.mode)
+    elsif args.baloon
+      take_baloon(args.mode)
     elsif args.dirigible
       take_dirigible(args.mode)
     elsif args.therenropebridge
@@ -654,6 +660,36 @@ class Bescort
       end
     when /What were you referring to/
       waitfor 'JOIN CHARCOAL DIRIGIBLE'
+      take_dirigible(mode)
+    end
+  end
+
+  def take_baloon(mode)
+    case mode
+    when 'mriss'
+      manual_go2(8793)
+      if wealth('Therenborough') < 10_000
+        echo('Get money you slob!')
+        return
+      end
+    when 'langenfirth'
+      if wealth('Mer'Kresh') < 10_000
+        echo('Get money you slob!')
+        return
+      end
+      manual_go2(8794)
+    end
+    case bput('join balloon', 'The Gnomish operator says, "Woah there', 'What were you referring to?')
+    when /Gnomish operator /
+      case bput('join balloon', 'You hand over your funds and step closer', 'You reach your funds, but')
+      when /closer/
+        pause 5
+        pause until XMLData.room_title != '[[Aboard the Balloon, Gondola]]'
+      else
+        return
+      end
+    when /What were you referring to/
+      waitfor 'JOIN GNOMISH BALLOON'
       take_dirigible(mode)
     end
   end

--- a/bescort.lic
+++ b/bescort.lic
@@ -139,7 +139,7 @@ class Bescort
         { name: 'mode', options: %w[island ratha], description: 'Where do you need to get to?' }
       ],
       [
-        { name: 'baloon', regex: /baloon/i, description: 'The air ship between Langenfirth and Mriss' },
+        { name: 'balloon', regex: /balloon/i, description: 'The air ship between Langenfirth and Mriss' },
         { name: 'mode', options: %w[langenfirth mriss], description: 'Where do you need to get to?' }
       ],
       [
@@ -209,8 +209,8 @@ class Bescort
       iceroad(args.mode)
     elsif args.basalt
       take_crawling_plague(args.mode)
-    elsif args.baloon
-      take_baloon(args.mode)
+    elsif args.balloon
+      take_balloon(args.mode)
     elsif args.dirigible
       take_dirigible(args.mode)
     elsif args.therenropebridge
@@ -664,7 +664,7 @@ class Bescort
     end
   end
 
-  def take_baloon(mode)
+  def take_balloon(mode)
     case mode
     when 'mriss'
       manual_go2(8793)


### PR DESCRIPTION
Yes baloon is misspelled on purpose internally, keeping in tradition with escort.lic. :)

Closes: #2554