### PR TITLE
Skip deposit coins by setting

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -22,7 +22,7 @@ class CrossingRepair
       end
     end
 
-    deposit_coins(@keep_copper, settings)
+    deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
   end
 
   def repair(repairer, item, repeat = false)


### PR DESCRIPTION
Some users might want to skip going to the bank for various reasons
such as high social outrage.

Resolves #2698