### PR TITLE
Pet buffing support added to buff_spells.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1219,7 +1219,7 @@ class SpellProcess
       if data['pet_type']
         check_spell_timer?(data) && pet_active?(data['pet_type'])
       elsif data['recast_every']
-        check_spell_timer(data)
+        check_spell_timer?(data)
       elsif data['expire']
         true
       else
@@ -1310,7 +1310,7 @@ class SpellProcess
                    .select { |spell| spell['max_threshold'] ? game_state.npcs.length <= spell['max_threshold'] : true }
                    .select { |spell| spell['expire'] ? Flags["ct-#{spell['abbrev']}"] : true }
                    .select { |spell| game_state.dancing? ? spell['harmless'] : true }
-                   .select { |spell| spell['recast_every'] ? check_spell_timer(spell) : true }
+                   .select { |spell| spell['recast_every'] ? check_spell_timer?(spell) : true }
                    .select { |spell| @cast_only_to_train ? DRSkill.getxp(spell['skill']) <= 32 : true }
                    .select { |spell| spell['cast_only_to_train'] ? DRSkill.getxp(spell['skill']) <= 32 : true }
                    .select { |spell| spell['cyclic'] ? !DRSpells.active_spells[spell['name']] : true }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1159,10 +1159,6 @@ class SpellProcess
     Time.now - (@spell_timers[data['pet_type']] || @spell_timers[data['abbrev']] || Time.at(0)) >= data['recast_every']
   end
 
-  def pet_active?(type)
-    DRRoom.npcs.include?(type)
-  end
-
   def check_buff_conditions?(name, game_state)
     return false if $weapon_buffs.include?(name) && (game_state.aimed_skill? || game_state.brawling?)
     # Resonance does not show up in Active Spells, so we need to track the last weapon on which it was cast to avoid recasting it continuously
@@ -1213,7 +1209,7 @@ class SpellProcess
 
     name, data = recastable_buffs.find do |name, data|
       if data['pet_type']
-        check_spell_timer?(data) && pet_active?(data['pet_type'])
+        check_spell_timer?(data) && DRRoom.npcs.include?(data['pet_type'])
       elsif data['recast_every']
         check_spell_timer?(data)
       elsif data['expire']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -906,9 +906,6 @@ class SpellProcess
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
 
-    @pet_buffs = settings.pet_buffs
-    echo(" @pet_buffs: #{@pet_buffs}") if $debug_mode_ct
-
     Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
 
@@ -1152,15 +1149,22 @@ class SpellProcess
 
     Flags.reset("ct-#{@reset_expire}") if @reset_expire
 
-    prepare_spell(@pet_buffs, game_state, true) if @pet_buffs
     return unless @command
     pause 0.5 until DRRoom.npcs.include?('warrior')
     fput("command #{@command}")
     @command = nil
   end
 
-  def check_spell_timer(data)
-    Time.now - (@spell_timers[data['abbrev']] || Time.at(0)) >= data['recast_every']
+  def check_spell_timer?(data)
+    Time.now - (@spell_timers[data['pet_type']] || @spell_timers[data['abbrev']] || Time.at(0)) >= data['recast_every']
+  end
+
+  def pet_active?(type)
+    if DRStats.moon_mage?
+      DRRoom.room_objs.include?(type)
+    else
+      DRRoom.npcs.include?(type)
+    end
   end
 
   def check_buff_conditions?(name, game_state)
@@ -1212,7 +1216,9 @@ class SpellProcess
                        .select { |name, _data| check_buff_conditions?(name, game_state) }
 
     name, data = recastable_buffs.find do |name, data|
-      if data['recast_every']
+      if data['pet_type']
+        check_spell_timer?(data) && pet_active?(data['pet_type'])
+      elsif data['recast_every']
         check_spell_timer(data)
       elsif data['expire']
         true
@@ -1358,7 +1364,13 @@ class SpellProcess
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    @spell_timers[data['abbrev']] = Time.now if data['recast_every']
+    if data['recast_every'] 
+      if data['pet_type']
+        @spell_timers[data['pet_type']] = Time.now
+      else
+        @spell_timers[data['abbrev']] = Time.now 
+      end
+    end
 
     if data['moon']
       check_moonwatch

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -906,6 +906,9 @@ class SpellProcess
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
 
+    @pet_buffs = settings.pet_buffs
+    echo(" @pet_buffs: #{@pet_buffs}") if $debug_mode_ct
+
     Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
 
@@ -1149,6 +1152,7 @@ class SpellProcess
 
     Flags.reset("ct-#{@reset_expire}") if @reset_expire
 
+    prepare_spell(@pet_buffs, game_state, true) if @pet_buffs
     return unless @command
     pause 0.5 until DRRoom.npcs.include?('warrior')
     fput("command #{@command}")

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1160,11 +1160,7 @@ class SpellProcess
   end
 
   def pet_active?(type)
-    if DRStats.moon_mage?
-      DRRoom.room_objs.include?(type)
-    else
-      DRRoom.npcs.include?(type)
-    end
+    DRRoom.npcs.include?(type)
   end
 
   def check_buff_conditions?(name, game_state)

--- a/profiles/Melborne-setup.yaml
+++ b/profiles/Melborne-setup.yaml
@@ -58,14 +58,6 @@ quicken_earth: &qe
     - message: perform cut
       matches: You draw  
 buffs: &buffs
-  Reverse Putrefaction:
-    recast_every: 1800 # 30 minutes
-    pet_type: zombie
-    cast: cast zombie
-    mana: 20
-    cambrinth:
-    - 20
-    - 20
   Kura-Silma:
     abbrev: ks
     recast: 4
@@ -141,6 +133,14 @@ magic_training:
 
 buff_spells:
   #<< : *qe
+  Reverse Putrefaction:
+    pet_type: zombie
+    recast_every: 2100 # 35 minutes
+    cast: cast zombie
+    mana: 20
+    cambrinth:
+    - 20
+    - 20
   << : *buffs
 
 use_weak_attacks: true

--- a/profiles/Melborne-setup.yaml
+++ b/profiles/Melborne-setup.yaml
@@ -58,6 +58,14 @@ quicken_earth: &qe
     - message: perform cut
       matches: You draw  
 buffs: &buffs
+  Reverse Putrefaction:
+    recast_every: 1800 # 30 minutes
+    pet_type: zombie
+    cast: cast zombie
+    mana: 20
+    cambrinth:
+    - 20
+    - 20
   Kura-Silma:
     abbrev: ks
     recast: 4
@@ -202,14 +210,6 @@ thanatology:
   store: true
   harvest_container: haversack
   harvest_count: 10
-pet_buffs:
-  abbrev: rpu
-  recast: 99
-  mana: 15
-  cambrinth:
-  - 15
-  - 15
-  - 10
 # Necromancer -->
 
 buff_nonspells:

--- a/profiles/Melborne-setup.yaml
+++ b/profiles/Melborne-setup.yaml
@@ -136,7 +136,7 @@ buff_spells:
   Reverse Putrefaction:
     pet_type: zombie
     recast_every: 2100 # 35 minutes
-    cast: cast zombie
+    cast: cast offense
     mana: 20
     cambrinth:
     - 20

--- a/profiles/Melborne-setup.yaml
+++ b/profiles/Melborne-setup.yaml
@@ -202,6 +202,14 @@ thanatology:
   store: true
   harvest_container: haversack
   harvest_count: 10
+pet_buffs:
+  abbrev: rpu
+  recast: 99
+  mana: 15
+  cambrinth:
+  - 15
+  - 15
+  - 10
 # Necromancer -->
 
 buff_nonspells:

--- a/profiles/Ssarek-setup.yaml
+++ b/profiles/Ssarek-setup.yaml
@@ -94,8 +94,8 @@ vig: &vig
     - 20
 vigpet: &vigpet
   Vigor:
-    recast_every: 1800 #in seconds
     pet_type: warrior
+    recast_every: 2100 # 35 minutes
     cast: cast warrior
     mana: 20
     cambrinth:

--- a/profiles/Ssarek-setup.yaml
+++ b/profiles/Ssarek-setup.yaml
@@ -251,7 +251,6 @@ waggle_sets:
     << : *maf
     << : *lw
 
-
 combat_spell_training: &cst
   Warding:
     abbrev: maf
@@ -312,14 +311,13 @@ empath_healing:
   - 10
   - 20
   - 20
-pet_buffs: # private script
-  Vigor:
-    abbrev: vigor
-    mana: 20
-    cambrinth:
-    - 20
-    - 20
-    cast: cast warrior
+pet_buffs:
+  abbrev: vigor
+  mana: 20
+  cambrinth:
+  - 20
+  - 20
+  cast: cast warrior
 
 ###############
 # Weapons

--- a/profiles/Ssarek-setup.yaml
+++ b/profiles/Ssarek-setup.yaml
@@ -92,6 +92,15 @@ vig: &vig
     cambrinth:
     - 20
     - 20
+vigpet: &vigpet
+  Vigor:
+    recast_every: 1800 #in seconds
+    pet_type: warrior
+    cast: cast warrior
+    mana: 20
+    cambrinth:
+    - 20
+    - 20
 tranq: &tranq
   Tranquility:
     mana: 20
@@ -213,6 +222,7 @@ buffs: &buffs
 
 buff_spells: &buff_spells
   << : *gs
+  << : *vigpet
   << : *buffs
 
 waggle_sets:
@@ -311,13 +321,6 @@ empath_healing:
   - 10
   - 20
   - 20
-pet_buffs:
-  abbrev: vigor
-  mana: 20
-  cambrinth:
-  - 20
-  - 20
-  cast: cast warrior
 
 ###############
 # Weapons

--- a/validate.lic
+++ b/validate.lic
@@ -551,6 +551,26 @@ class DRYamlValidator
     error('sell_loot_money_on_hand is invalid. The proper format is: <amount> <denomination> e.g. 3 silv or 4 bronze')
   end
 
+  def assert_that_pet_buffs_have_recast_timers(settings)
+    return unless settings.buff_spells
+    
+    buffs_without = settings.buff_spells.select { |_name, data| data['pet_type'] }
+                                        .reject{ |_name, data| data.include? ('recast_every') }
+                                        .each{ |_name, data|
+                                          error("Pet buffs require a custom recast timer. Please include a \"recast_every:\" setting for #{_name}.")
+                                        }
+  end
+
+  def assert_that_pet_buffs_have_custom_cast(settings)
+    return unless settings.buff_spells
+
+    buffs_without = settings.buff_spells.select {|_name, data| data['pet_type']}
+                                        .reject{|_name, data| data.include? ('cast')}
+                                        .each{|_name, data|
+                                          error("Pet buffs require a custom cast message. Please include a \"cast:\" setting for #{_name}.")
+                                        }
+  end
+
   private
 
   def warn(message)

--- a/validate.lic
+++ b/validate.lic
@@ -551,16 +551,12 @@ class DRYamlValidator
     error('sell_loot_money_on_hand is invalid. The proper format is: <amount> <denomination> e.g. 3 silv or 4 bronze')
   end
 
-  def assert_that_pet_buffs_have_recast_timers(settings)
+  def assert_that_pet_buffs_have_spell_requirements(settings)
     return unless settings.buff_spells
     
     settings.buff_spells.select { |_name, data| data['pet_type'] }
                         .reject{ |_name, data| data.include? ('recast_every') }
                         .each{ |_name, data| error("Pet buffs require a custom recast timer. Please include a \"recast_every:\" setting for #{_name}.") }
-  end
-
-  def assert_that_pet_buffs_have_custom_cast(settings)
-    return unless settings.buff_spells
 
     settings.buff_spells.select { |_name, data| data['pet_type']}
                         .reject{ |_name, data| data.include? ('cast')}

--- a/validate.lic
+++ b/validate.lic
@@ -554,21 +554,17 @@ class DRYamlValidator
   def assert_that_pet_buffs_have_recast_timers(settings)
     return unless settings.buff_spells
     
-    buffs_without = settings.buff_spells.select { |_name, data| data['pet_type'] }
-                                        .reject{ |_name, data| data.include? ('recast_every') }
-                                        .each{ |_name, data|
-                                          error("Pet buffs require a custom recast timer. Please include a \"recast_every:\" setting for #{_name}.")
-                                        }
+    settings.buff_spells.select { |_name, data| data['pet_type'] }
+                        .reject{ |_name, data| data.include? ('recast_every') }
+                        .each{ |_name, data| error("Pet buffs require a custom recast timer. Please include a \"recast_every:\" setting for #{_name}.") }
   end
 
   def assert_that_pet_buffs_have_custom_cast(settings)
     return unless settings.buff_spells
 
-    buffs_without = settings.buff_spells.select {|_name, data| data['pet_type']}
-                                        .reject{|_name, data| data.include? ('cast')}
-                                        .each{|_name, data|
-                                          error("Pet buffs require a custom cast message. Please include a \"cast:\" setting for #{_name}.")
-                                        }
+    settings.buff_spells.select { |_name, data| data['pet_type']}
+                        .reject{ |_name, data| data.include? ('cast')}
+                        .each{ |_name, data| error("Pet buffs require a custom cast message. Please include a \"cast:\" setting for #{_name}.") }
   end
 
   private


### PR DESCRIPTION
This will allow you to buff your pet once right after it is up. This doesn't support maintained buffs due to the issue that Vigor's up-time on a Warrior is not perceptible. You don't see the buff fall off.

Min prep RUP lasts a very long time, not a typical buff, around 50 mana and by the time you need Vigor for your warrior, you are big enough to cast it for the full duration of 40 minutes which is longer than most people hunt.