### PR TITLE
Adding a setting for pouch tying.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -311,6 +311,9 @@ class LootProcess
     @gem_nouns = get_data('items').gem_nouns
     echo("  @gem_nouns: #{@gem_nouns}") if $debug_mode_ct
 
+    @tie_pouch = settings.tie_gem_pouches
+    echo("  @tie_pouch: #{@tie_pouch}") if $debug_mode_ct
+
     @spare_gem_pouch_container = settings.spare_gem_pouch_container
     echo("  @spare_gem_pouch_container: #{@spare_gem_pouch_container}") if $debug_mode_ct
 
@@ -422,10 +425,10 @@ class LootProcess
     bput("get #{@gem_pouch_adjective} pouch from my #{@spare_gem_pouch_container}", 'You get a')
     bput('wear my pouch', 'You attach')
     bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
-    if Flags['pouch-full'].first =~ /tie it up/
-      fput('close my pouch')
-    else
+    if @tie_pouch
       bput('tie my pouch', 'You tie')
+    else
+      fput('close my pouch')
     end
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -514,6 +514,7 @@ restock:
 osrel_no_harness: false
 osrel_amount:
 
+tie_gem_pouches: true
 spare_gem_pouch_container:
 gem_pouch_adjective:
 


### PR DESCRIPTION
Adding this for discussion. 

Pros:

1) A lot of new players ask about this consistently. 
2) I don't have a person to take my pouches, so sometimes I have issues where gems get stowed and I have to "start over". I do then have to go out and kill something until a gem, or pick a box, etc. I then need to manually tie up a new pouch. This would just tie always if setting is true. 

Cons:

1) Yet another YAML setting. 
2) Not as slick at the first approach.