### PR TITLE
Added capability for chained aim_actions

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2246,8 +2246,11 @@ class AttackProcess
       game_state.loaded = false
       waitrt?
     elsif game_state.loaded
-      fput(game_state.next_aim_action)
-      waitrt?
+      actions = game_state.next_aim_action.split(";")
+      actions.each do | action |
+        fput(action.strip)
+        waitrt?
+      end
     else
       if game_state.dual_load?
         pause 0.5 until load_return = bput('load arrows', 'You reach into', 'already loaded', 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty')


### PR DESCRIPTION
Added capability to allow cor chained aim_actions:

```aim_fillers:
  Crossbow:
  - gouge left
  - gouge left
  Bow:
  - get bola; lob left; stow bola
  - gouge left
  - gouge left
  Slings:
  - get bola; lob left; stow bola
  - gouge left
  - gouge left```