### PR TITLE
common-items.lic: Make count_items_in_container work for multi word i…

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -129,7 +129,7 @@ module DRCI
   end
 
   def count_items_in_container(item, container)
-    contents = DRC.bput("rummage /C #{item} IN MY #{container}", '^You rummage .*', 'That would accomplish nothing')
+    contents = DRC.bput("rummage /C #{item.split.last} IN MY #{container}", '^You rummage .*', 'That would accomplish nothing')
     # This regexp avoids counting the quoted item name in the message, as
     # well as avoiding finding the item as a substring of other items.
     contents.scan(/ #{item}\W/).size


### PR DESCRIPTION
…tems.

Fixes carving in theurgy so it works, it was skipping it because of the multi word rummage.
Closes #2725