### PR TITLE
Train attunement while waiting for RtR pulses

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -156,10 +156,14 @@ class Astrology
 
     @equipment_manager.empty_hands
     cast_spell(@rtr_data, settings)
-
+    perc_time = Time.now - 61
     Flags.add('rtr-expire', get_data('spells').spell_data['Read the Ripples']['expire']) if rtr_active?
     while rtr_active?
       line = get?
+      if perc_time + 60 < Time.now
+        perc_mana
+        perc_time = Time.now
+      end
       res = @constellations.find { |body| /As your consciousness drifts amongst the currents of Fate, .* #{body['name']}/i =~ line }
       observe(res['name']) unless res.nil?
     end


### PR DESCRIPTION
During RTR you are idle, waiting for a pulsed message
telling you what constellation to look at. This is a
good opportunity to learn attunement via perc mana.