### PR TITLE
SmartTransfer and avoid !touch

### DIFF
--- a/smarttransfer.lic
+++ b/smarttransfer.lic
@@ -42,7 +42,10 @@ class SmartTransfer
     if target == 'self'
       bput('perc heal self', 'Roundtime')
     else
-      bput("touch #{target}", 'vitality')
+      case bput("touch #{target}", 'vitality', 'avoids your touch')
+	    when 'avoids your touch'
+		    exit
+	    end
     end
     data = reget 100
     data = data.reverse.take_while { |item| item !~ /injuries include/ }.reverse


### PR DESCRIPTION
Kills the SmartTransfer script when you attempt to heal someone who has Avoid !Touch set rather than letting the script time out.