### PR TITLE
sew.lic: Add magic training support while crafting.

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -877,9 +877,9 @@ class SetupFiles
                                        end
     end
 
-    s.crafting_spell_training
+    s.crafting_training_spells
      .each do |skill, data|
-      s.crafting_spell_training[skill] = if spells[data['name']]
+      s.crafting_training_spells[skill] = if spells[data['name']]
                                          spells[data['name']].merge(data)
                                        elsif spells[data['abbrev']]
                                          spells[data['abbrev']].merge(data)

--- a/dependency.lic
+++ b/dependency.lic
@@ -880,12 +880,12 @@ class SetupFiles
     s.crafting_training_spells
      .each do |skill, data|
       s.crafting_training_spells[skill] = if spells[data['name']]
-                                         spells[data['name']].merge(data)
-                                       elsif spells[data['abbrev']]
-                                         spells[data['abbrev']].merge(data)
-                                       else
-                                         data
-                                       end
+                                            spells[data['name']].merge(data)
+                                          elsif spells[data['abbrev']]
+                                            spells[data['abbrev']].merge(data)
+                                          else
+                                            data
+                                          end
     end
 
     s.lockpick_buffs['spells']

--- a/dependency.lic
+++ b/dependency.lic
@@ -877,6 +877,17 @@ class SetupFiles
                                        end
     end
 
+    s.crafting_spell_training
+     .each do |skill, data|
+      s.crafting_spell_training[skill] = if spells[data['name']]
+                                         spells[data['name']].merge(data)
+                                       elsif spells[data['abbrev']]
+                                         spells[data['abbrev']].merge(data)
+                                       else
+                                         data
+                                       end
+    end
+
     s.lockpick_buffs['spells']
      .each_with_index
      .select do |spell, i|

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -57,3 +57,4 @@ empty_values:
   combat_spell_training: {}
   stealing_towns: []
   safe_room_empaths: []
+  crafting_training_spells: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -329,7 +329,7 @@ outfitting_room:
 alchemy_room:
 use_own_ingot_type:
 deed_own_ingot: false
-
+crafting_training_spells:
 
 
 

--- a/sew.lic
+++ b/sew.lic
@@ -310,9 +310,9 @@ class Sew
   end
 
   def cast_spell?
-    return if !@training_spells
-    return if !Flags['magic-ready']
-    return if mana < 40
+    return false if !@training_spells
+    return false if !Flags['magic-ready']
+    return false if mana < 40
 
     unless @settings.cambrinth_items[0]['name']
       @settings.cambrinth_items = [{
@@ -336,6 +336,7 @@ class Sew
 
     cast?(@data['cast'], @data['symbiosis'], @data['before'], @data['after'])
     Flags.reset('magic-ready')
+    true
   end
 
   def prepare_spell
@@ -439,6 +440,11 @@ class Sew
       stow_item(@noun)
     when /trash/
       dispose_trash(@noun)
+    end
+    if @training_spells
+      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      bput('release mana', 'You release all', "You aren't harnessing any mana")
+      bput('release symbiosis', 'You release', 'But you haven\'t prepared')
     end
     exit
   end

--- a/sew.lic
+++ b/sew.lic
@@ -330,6 +330,23 @@ class Sew
 
     @data = @training_spells[needs_training]
     check_discern(@data, @settings) if @data['use_auto_mana']
+
+    if @data['moon']
+      check_moonwatch
+      moon = UserVars.moons['visible'].first
+      unless moon
+        weather ||= bput('weather', 'inside', 'You glance up at the sky.')
+        if weather =~ /inside/
+          echo "*** You're inside and there are no available moons. You're going to have a hard time casting #{@data['abbrev']}"
+        end
+
+        unless moon = UserVars.moons['visible'].first
+          return
+        end
+        data['cast'] = "cast #{moon}"
+      end
+    end
+
     command = 'prep'
     command = @data['prep'] if @data['prep']
     command = @data['prep_type'] if @data['prep_type']

--- a/sew.lic
+++ b/sew.lic
@@ -331,6 +331,7 @@ class Sew
         when Fixnum, Integer
           find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, @data['cambrinth'], @settings.cambrinth_invoke_exact_amount)
         end
+      end
     end
 
     cast?(@data['cast'], @data['symbiosis'], @data['before'], @data['after'])
@@ -362,7 +363,7 @@ class Sew
         unless moon = UserVars.moons['visible'].first
           return
         end
-        data['cast'] = "cast #{moon}"
+        @data['cast'] = "cast #{moon}"
       end
     end
 

--- a/sew.lic
+++ b/sew.lic
@@ -59,7 +59,7 @@ class Sew
     Flags.add('sew-assembly', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)', 'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)', 'another finished (long|short) wooden (pole)')
     Flags.add('sew-pins', 'The pins is all used up, so you toss it away.')
     Flags.add('magic-ready', 'You feel fully prepared to cast your spell.')
-    Flags.reset('magic-ready')
+
     if args.type == 'knitting'
       knit
     elsif args.type == 'sewing'

--- a/sew.lic
+++ b/sew.lic
@@ -314,7 +314,7 @@ class Sew
     return if !Flags['magic-ready']
     return if mana < 40
 
-    cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
+    cast?(@data['cast'], @data['symbiosis'], @data['before'], @data['after'])
     Flags.reset('magic-ready')
   end
 

--- a/sew.lic
+++ b/sew.lic
@@ -334,7 +334,6 @@ class Sew
     command = @data['prep'] if @data['prep']
     command = @data['prep_type'] if @data['prep_type']
     prepare?(@data['abbrev'], @data['mana'], @data['symbiosis'], command)
-    Flags.reset('magic-prepping')
     unless @settings.cambrinth_items[0]['name']
       @settings.cambrinth_items = [{
         'name' => @settings.cambrinth,

--- a/sew.lic
+++ b/sew.lic
@@ -329,7 +329,7 @@ class Sew
     return unless needs_training
 
     @data = @training_spells[needs_training]
-    check_discern(@data, @settings) if data['use_auto_mana']
+    check_discern(@data, @settings) if @data['use_auto_mana']
     command = 'prep'
     command = @data['prep'] if @data['prep']
     command = @data['prep_type'] if @data['prep_type']

--- a/sew.lic
+++ b/sew.lic
@@ -59,7 +59,7 @@ class Sew
     Flags.add('sew-assembly', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)', 'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)', 'another finished (long|short) wooden (pole)')
     Flags.add('sew-pins', 'The pins is all used up, so you toss it away.')
     Flags.add('magic-ready', 'You feel fully prepared to cast your spell.')
-
+    Flags.reset('magic-ready')
     if args.type == 'knitting'
       knit
     elsif args.type == 'sewing'
@@ -114,6 +114,7 @@ class Sew
 
   def leather
     check_thread
+    magic_routine
     study_tailoring(@chapter, @recipe_name)
     get_item("#{@mat_type} leather")
     do_sew("cut my #{@mat_type} leather with my scissors", 'scissors')
@@ -121,12 +122,14 @@ class Sew
 
   def sew
     check_thread
+    magic_routine
     study_tailoring(@chapter, @recipe_name)
     get_item("#{@mat_type} cloth")
     do_sew("cut my #{@mat_type} cloth with my scissors", 'scissors')
   end
 
   def knit
+    magic_routine
     study_tailoring(@chapter, @recipe_name)
     get_item('knitting needle')
     pause 1
@@ -306,13 +309,19 @@ class Sew
   end
 
   def magic_routine
-    prepare_spell unless cast_spell?
+    return if !@training_spells
+
+    if !@preparing
+      prepare_spell
+    end
+    if Flags['magic-ready']
+      cast_spell
+    end
   end
 
-  def cast_spell?
-    return false if !@training_spells
-    return false if !Flags['magic-ready']
-    return false if mana < 40
+  def cast_spell
+    return unless Flags['magic-ready']
+    return if mana < 40
 
     unless @settings.cambrinth_items[0]['name']
       @settings.cambrinth_items = [{
@@ -336,13 +345,13 @@ class Sew
 
     cast?(@data['cast'], @data['symbiosis'], @data['before'], @data['after'])
     Flags.reset('magic-ready')
-    true
+    @preparing = false
   end
 
   def prepare_spell
-    return if !@training_spells
     return if Flags['magic-ready']
 
+    @preparing = true
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| DRSkill.getxp(skill) < 31 }
@@ -353,8 +362,7 @@ class Sew
     check_discern(@data, @settings) if @data['use_auto_mana']
 
     release_cyclics if @data['cyclic']
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
-    bput('release mana', 'You release all', "You aren't harnessing any mana")
+    magic_cleanup
 
     if @data['moon']
       check_moonwatch
@@ -376,6 +384,12 @@ class Sew
     command = @data['prep'] if @data['prep']
     command = @data['prep_type'] if @data['prep_type']
     prepare?(@data['abbrev'], @data['mana'], @data['symbiosis'], command)
+  end
+
+  def magic_cleanup
+      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      bput('release mana', 'You release all', "You aren't harnessing any mana")
+      bput('release symbiosis', 'You release', 'But you haven\'t prepared')
   end
 
   def do_knit(command)
@@ -446,9 +460,7 @@ class Sew
       dispose_trash(@noun)
     end
     if @training_spells
-      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      bput('release mana', 'You release all', "You aren't harnessing any mana")
-      bput('release symbiosis', 'You release', 'But you haven\'t prepared')
+      magic_cleanup
     end
     exit
   end

--- a/sew.lic
+++ b/sew.lic
@@ -326,7 +326,7 @@ class Sew
         'stored' => @settings.stored_cambrinth
       }]
     end
-    if check_to_harness(@settings.use_harness_when_arcana_locked) && !force_cambrinth
+    if check_to_harness(@settings.use_harness_when_arcana_locked)
       harness_mana(@data['cambrinth'].flatten)
     else
       @settings.cambrinth_items.each_with_index do |item, index|

--- a/sew.lic
+++ b/sew.lic
@@ -383,6 +383,8 @@ class Sew
   end
 
   def magic_cleanup
+    return unless @training_spells
+
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")
     bput('release symbiosis', 'You release', 'But you haven\'t prepared')
@@ -455,7 +457,7 @@ class Sew
     when /trash/
       dispose_trash(@noun)
     end
-    magic_cleanup if @training_spells
+    magic_cleanup
     exit
   end
 end

--- a/sew.lic
+++ b/sew.lic
@@ -309,14 +309,10 @@ class Sew
   end
 
   def magic_routine
-    return if !@training_spells
+    return unless @training_spells
 
-    if !@preparing
-      prepare_spell
-    end
-    if Flags['magic-ready']
-      cast_spell
-    end
+    prepare_spell unless @preparing
+    cast_spell if Flags['magic-ready']
   end
 
   def cast_spell
@@ -387,9 +383,9 @@ class Sew
   end
 
   def magic_cleanup
-      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      bput('release mana', 'You release all', "You aren't harnessing any mana")
-      bput('release symbiosis', 'You release', 'But you haven\'t prepared')
+    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    bput('release mana', 'You release all', "You aren't harnessing any mana")
+    bput('release symbiosis', 'You release', 'But you haven\'t prepared')
   end
 
   def do_knit(command)
@@ -459,9 +455,7 @@ class Sew
     when /trash/
       dispose_trash(@noun)
     end
-    if @training_spells
-      magic_cleanup
-    end
+    magic_cleanup if @training_spells
     exit
   end
 end

--- a/sew.lic
+++ b/sew.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#sew
 =end
 
-custom_require.call(%w[common common-crafting common-items common-money common-travel])
+custom_require.call(%w[common common-arcana common-crafting common-items common-money common-travel])
 
 class Sew
   include DRC
@@ -10,6 +10,7 @@ class Sew
   include DRCI
   include DRCM
   include DRCT
+  include DRCA
 
   def initialize
     @settings = get_settings
@@ -51,11 +52,13 @@ class Sew
     @noun = args.noun
     @mat_type = args.material
     @stamp = @settings.mark_crafted_goods
+    @training_spells = @settings.crafting_training_spells
 
     wait_for_script_to_complete('buff', ['sew'])
 
     Flags.add('sew-assembly', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)', 'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)', 'another finished (long|short) wooden (pole)')
     Flags.add('sew-pins', 'The pins is all used up, so you toss it away.')
+	Flags.add('magic-ready', 'You feel fully prepared to cast your spell.')
 
     if args.type == 'knitting'
       knit
@@ -298,7 +301,52 @@ class Sew
         tool = 'sewing needles'
       end
     end
+    magic_routine
     do_sew(next_command, tool, lighten)
+  end
+
+  def magic_routine
+    prepare_spell unless cast_spell?
+  end
+
+  def cast_spell?
+    return if !@training_spells
+    return if !Flags['magic-ready']
+    return if mana < 40
+
+    cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
+    Flags.reset('magic-ready')
+  end
+
+  def prepare_spell
+    return if !@training_spells
+    return if Flags['magic-ready']
+
+    needs_training = %w[Warding Utility Augmentation]
+                     .select { |skill| @training_spells[skill] }
+                     .select { |skill| DRSkill.getxp(skill) < 31 }
+                     .sort_by { |skill| DRSkill.getxp(skill) }.first
+    return unless needs_training
+
+    @data = @training_spells[needs_training]
+    check_discern(@data, @settings)
+    command = 'prep'
+    command = @data['prep'] if @data['prep']
+    command = @data['prep_type'] if @data['prep_type']
+    prepare?(@data['abbrev'], @data['mana'], @data['symbiosis'], command)
+    Flags.reset('magic-prepping')
+    unless @settings.cambrinth_items[0]['name']
+      @settings.cambrinth_items = [{
+        'name' => @settings.cambrinth,
+        'cap' => @settings.cambrinth_cap,
+        'stored' => @settings.stored_cambrinth
+      }]
+     end
+    @settings.cambrinth_items.each_with_index do |item, index|
+      if @data['cambrinth'][index][0]
+        find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, @data['cambrinth'][index], @settings.cambrinth_invoke_exact_amount)
+      end
+    end
   end
 
   def do_knit(command)
@@ -340,6 +388,7 @@ class Sew
     end
     waitrt?
     stow_item('yarn') if left_hand =~ /yarn/i
+    magic_routine
     do_knit(next_command)
   end
 

--- a/sew.lic
+++ b/sew.lic
@@ -58,7 +58,7 @@ class Sew
 
     Flags.add('sew-assembly', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)', 'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)', 'another finished (long|short) wooden (pole)')
     Flags.add('sew-pins', 'The pins is all used up, so you toss it away.')
-	Flags.add('magic-ready', 'You feel fully prepared to cast your spell.')
+    Flags.add('magic-ready', 'You feel fully prepared to cast your spell.')
 
     if args.type == 'knitting'
       knit

--- a/sew.lic
+++ b/sew.lic
@@ -352,6 +352,10 @@ class Sew
     @data = @training_spells[needs_training]
     check_discern(@data, @settings) if @data['use_auto_mana']
 
+    release_cyclics if @data['cyclic']
+    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+    bput('release mana', 'You release all', "You aren't harnessing any mana")
+
     if @data['moon']
       check_moonwatch
       moon = UserVars.moons['visible'].first

--- a/sew.lic
+++ b/sew.lic
@@ -329,11 +329,12 @@ class Sew
     return unless needs_training
 
     @data = @training_spells[needs_training]
-    check_discern(@data, @settings)
+    check_discern(@data, @settings) if data['use_auto_mana']
     command = 'prep'
     command = @data['prep'] if @data['prep']
     command = @data['prep_type'] if @data['prep_type']
     prepare?(@data['abbrev'], @data['mana'], @data['symbiosis'], command)
+
     unless @settings.cambrinth_items[0]['name']
       @settings.cambrinth_items = [{
         'name' => @settings.cambrinth,

--- a/sew.lic
+++ b/sew.lic
@@ -314,6 +314,25 @@ class Sew
     return if !Flags['magic-ready']
     return if mana < 40
 
+    unless @settings.cambrinth_items[0]['name']
+      @settings.cambrinth_items = [{
+        'name' => @settings.cambrinth,
+        'cap' => @settings.cambrinth_cap,
+        'stored' => @settings.stored_cambrinth
+      }]
+    end
+    if check_to_harness(@settings.use_harness_when_arcana_locked) && !force_cambrinth
+      harness_mana(@data['cambrinth'].flatten)
+    else
+      @settings.cambrinth_items.each_with_index do |item, index|
+        case @data['cambrinth'].first
+        when Array
+          find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, @data['cambrinth'][index], @settings.cambrinth_invoke_exact_amount)
+        when Fixnum, Integer
+          find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, @data['cambrinth'], @settings.cambrinth_invoke_exact_amount)
+        end
+    end
+
     cast?(@data['cast'], @data['symbiosis'], @data['before'], @data['after'])
     Flags.reset('magic-ready')
   end
@@ -351,19 +370,6 @@ class Sew
     command = @data['prep'] if @data['prep']
     command = @data['prep_type'] if @data['prep_type']
     prepare?(@data['abbrev'], @data['mana'], @data['symbiosis'], command)
-
-    unless @settings.cambrinth_items[0]['name']
-      @settings.cambrinth_items = [{
-        'name' => @settings.cambrinth,
-        'cap' => @settings.cambrinth_cap,
-        'stored' => @settings.stored_cambrinth
-      }]
-     end
-    @settings.cambrinth_items.each_with_index do |item, index|
-      if @data['cambrinth'][index][0]
-        find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, @data['cambrinth'][index], @settings.cambrinth_invoke_exact_amount)
-      end
-    end
   end
 
   def do_knit(command)

--- a/validate.lic
+++ b/validate.lic
@@ -117,6 +117,13 @@ class DRYamlValidator
             .each { |skill_name| error("Invalid crafting_training_spells: skill name '#{skill_name}'. Valid skill names are '#{valid_crafting_training_spell_skills}'") }
   end
 
+  def assert_that_crafting_training_spells_have_no_cambrinth(settings)
+    return unless settings.crafting_training_spells
+
+    settings.crafting_training_spells.select { |_spell, data| data['cambrinth'] }
+            .each { |_spell, _data| warn("#{_name} in crafting_training_spells uses cambrinth which increases crafting time, you may want to remove it.") }
+  end
+
   def assert_that_cycle_armors_are_skills(settings)
     return unless settings.cycle_armors
 

--- a/validate.lic
+++ b/validate.lic
@@ -117,13 +117,6 @@ class DRYamlValidator
             .each { |skill_name| error("Invalid crafting_training_spells: skill name '#{skill_name}'. Valid skill names are '#{valid_crafting_training_spell_skills}'") }
   end
 
-  def assert_that_crafting_training_spells_have_no_cambrinth(settings)
-    return unless settings.crafting_training_spells
-
-    settings.crafting_training_spells.select { |_spell, data| data['cambrinth'] }
-            .each { |_spell, _data| warn("#{_name} in crafting_training_spells uses cambrinth which increases crafting time, you may want to remove it.") }
-  end
-
   def assert_that_cycle_armors_are_skills(settings)
     return unless settings.cycle_armors
 

--- a/validate.lic
+++ b/validate.lic
@@ -106,6 +106,17 @@ class DRYamlValidator
             .each { |skill_name| error("Invalid combat_spell_training: skill name '#{skill_name}'. Valid skill names are '#{valid_combat_spell_training_skills}'") }
   end
 
+  def assert_that_crafting_spell_training_spells_are_skills(settings)
+    return unless settings.crafting_spell_training
+
+    valid_crafting_spell_training_skills = %w[Augmentation Utility Warding]
+
+    settings.crafting_spell_training
+            .keys
+            .reject { |skill_name| valid_crafting_spell_training_skills.include?(skill_name) }
+            .each { |skill_name| error("Invalid crafting_spell_training: skill name '#{skill_name}'. Valid skill names are '#{valid_crafting_spell_training_skills}'") }
+  end
+
   def assert_that_cycle_armors_are_skills(settings)
     return unless settings.cycle_armors
 

--- a/validate.lic
+++ b/validate.lic
@@ -106,15 +106,15 @@ class DRYamlValidator
             .each { |skill_name| error("Invalid combat_spell_training: skill name '#{skill_name}'. Valid skill names are '#{valid_combat_spell_training_skills}'") }
   end
 
-  def assert_that_crafting_spell_training_spells_are_skills(settings)
-    return unless settings.crafting_spell_training
+  def assert_that_crafting_training_spells_are_skills(settings)
+    return unless settings.crafting_training_spells
 
-    valid_crafting_spell_training_skills = %w[Augmentation Utility Warding]
+    valid_crafting_training_spell_skills = %w[Augmentation Utility Warding]
 
-    settings.crafting_spell_training
+    settings.crafting_training_spells
             .keys
-            .reject { |skill_name| valid_crafting_spell_training_skills.include?(skill_name) }
-            .each { |skill_name| error("Invalid crafting_spell_training: skill name '#{skill_name}'. Valid skill names are '#{valid_crafting_spell_training_skills}'") }
+            .reject { |skill_name| valid_crafting_training_spells_skills.include?(skill_name) }
+            .each { |skill_name| error("Invalid crafting_training_spells: skill name '#{skill_name}'. Valid skill names are '#{valid_crafting_training_spell_skills}'") }
   end
 
   def assert_that_cycle_armors_are_skills(settings)


### PR DESCRIPTION
Uses the crafting_training_spells: yaml setting, I initially made it use training-spells with discerns but charging cambrinth isn't worth the time unless you really want to.