### PR TITLE
Fixed bug in 'careful' disarming

### DIFF
--- a/data/base-picking.yaml
+++ b/data/base-picking.yaml
@@ -73,9 +73,6 @@ picking:
   - A pitiful snowball encased in the Flames
 
   disarm_careful:
-  - covered black scarab of some unidentifiable substance clings to the
-  - are covered with a thin metal circle that has been lacquered with
-  - you see a tiny metal tube just poking out of a small
   - with only minor troubles
   - should not take long with your skills
   - trap has the edge on you, but you've got a good shot at disarming


### PR DESCRIPTION
Eliminated messages which cause a 'disarm careful' even if the trap is too difficult