### PR TITLE
Add/Removed Xing Thug rooms

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -370,9 +370,12 @@ hunting_zones:
   - 6091
   - 6092
   - 6097
-  - 6097
   - 6098
   - 6099
+  - 6111
+  - 6093
+  - 6094
+  - 6095
   - 6100
   - 6101
   # https://elanthipedia.play.net/Dire_Bear                              120-170


### PR DESCRIPTION
Removed a duplicate room number in Crossing Thugs (6097) and added a few more rooms.