### PR TITLE
Revert "Add/Removed Xing Thug rooms (#2779)"

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -370,12 +370,9 @@ hunting_zones:
   - 6091
   - 6092
   - 6097
+  - 6097
   - 6098
   - 6099
-  - 6111
-  - 6093
-  - 6094
-  - 6095
   - 6100
   - 6101
   # https://elanthipedia.play.net/Dire_Bear                              120-170


### PR DESCRIPTION
This reverts commit af9e85f1172f453b352534037aacede5abd162f8.

It is causing people to get stuck hunting in this area sometimes because it it wacky and randomly returning the wrong info.

--- Lich: exec1 active.
[exec1: @id=6097
@image="Zoluren, 1g, Misc Xing Interiors.gif"
@climate=nil
@title=["[[Sewer]]"]
@check_location=nil
@timeto={"6098"=>0.2}
@location=nil
@tags=["thugs", "thugs"]
@wayto={"6098"=>"west"}
@paths=["Obvious exits: east, southwest, west."]
@image_coords=[146, 360, 158, 372]
@terrain=nil
@description=["Water running off from other parts of the sewer has puddled here in a slight depression in the floor.  The corpse of a skinned
  rodent bobs slowly in the lightly swirling current, playing water tag with the decomposing remains of a wooden crate."]]
--- Lich: exec1 has exited.

--- Lich: exec1 active.
[exec1: @id=6097
@image="Zoluren, 1g, Misc Xing Interiors.gif"
@climate=nil
@title=["[[Sewer]]"]
@check_location=nil
@timeto={"6098"=>0.2, "6099"=>0.2, "6092"=>0.2}
@location=nil
@tags=["thugs", "thugs"]
@wayto={"6098"=>"west", "6099"=>"east", "6092"=>"southwest"}
@paths=["Obvious exits: east, southwest, west."]
@image_coords=[146, 360, 158, 372]
@terrain=nil
@description=["Water running off from other parts of the sewer has puddled here in a slight depression in the floor.  The corpse of a skinned
  rodent bobs slowly in the lightly swirling current, playing water tag with the decomposing remains of a wooden crate."]]
--- Lich: exec1 has exited.