### PR TITLE
Restock supports custom hometowns for buying items.

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -134,8 +134,8 @@ module DRCM
     get_data('town')[town]['currency']
   end
 
-  def get_money_from_specific_bank(amount_as_string, hometown)
-    DRCT.walk_to(get_data('town')[hometown]['deposit']['id'])
+  def get_money_from_specific_bank(amount_as_string, town)
+    DRCT.walk_to(get_data('town')[town]['deposit']['id'])
     DRC.release_invisibility
     loop do
       case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money")

--- a/common-money.lic
+++ b/common-money.lic
@@ -129,4 +129,23 @@ module DRCM
     minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, settings) }
     DRC.bput('check balance', 'your current balance is')
   end
+
+  def town_currency(town)
+    get_data('town')[town]['currency']
+  end
+
+  def get_money_from_specific_bank(amount_as_string, hometown)
+    DRCT.walk_to(get_data('town')[hometown]['deposit']['id'])
+    DRC.release_invisibility
+    loop do
+      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money")
+      when 'The clerk counts', 'You count out'
+        break true
+      when 'The clerk glares at you.', 'Hey!  Slow down!'
+        pause 15
+      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'You do not have an account'
+        break false
+      end
+    end
+  end
 end

--- a/common-money.lic
+++ b/common-money.lic
@@ -129,23 +129,4 @@ module DRCM
     minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, settings) }
     DRC.bput('check balance', 'your current balance is')
   end
-
-  def town_currency(town)
-    get_data('town')[town]['currency']
-  end
-
-  def get_money_from_specific_bank(amount_as_string, town)
-    DRCT.walk_to(get_data('town')[town]['deposit']['id'])
-    DRC.release_invisibility
-    loop do
-      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money")
-      when 'The clerk counts', 'You count out'
-        break true
-      when 'The clerk glares at you.', 'Hey!  Slow down!'
-        pause 15
-      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'You do not have an account'
-        break false
-      end
-    end
-  end
 end

--- a/data/base-consumables.yaml
+++ b/data/base-consumables.yaml
@@ -76,14 +76,14 @@ Hibarnhvidar:
   tk_ammo:
     name: big-fist katar
     room: 12172
-    cost: 2706
+    price: 2706
     size: 1
     stackable: false
     quantity: 3
   rock:
     name: smooth rocks
     room: 12172
-    cost: 45
+    price: 45
     size: 30
     stackable: true
     quantity: 30

--- a/profiles/Chuno-setup.yaml
+++ b/profiles/Chuno-setup.yaml
@@ -115,6 +115,20 @@ hunting_info:
   - d0
   :duration: 60
 
+restock:
+  arrow:
+    quantity: 50
+  bolt:
+    quantity: 50    
+  rock:
+    hometown: Hibarnhvidar
+    name: smooth rocks
+    room: 12172
+    price: 45
+    size: 30
+    stackable: true
+    quantity: 50
+
 ###############
 # Combat Trainer
 ###############

--- a/restock.lic
+++ b/restock.lic
@@ -36,8 +36,7 @@ class Restock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-    money_string = coin_needed.to_s + ' copper ' + town_currency(town)
-    get_money_from_specific_bank(money_string, town) if coin_needed > 0
+    get_money_from_specific_bank("#{coin_needed.to_s} copper #{town_currency(town)}", town) if coin_needed > 0
     items_to_restock.each do |item|
       item['buy_num'].times do
         buy_item(item['room'], item['name'])

--- a/restock.lic
+++ b/restock.lic
@@ -1,26 +1,35 @@
 #   Documentation: https://elanthipedia.play.net/Lich_script_repository#restock
-
 custom_require.call(%w[common common-items common-money])
-
 class Restock
   include DRC
   include DRCM
   include DRCI
-
   def initialize
     setup
-
     items = parse_restockable_items
+
+    custom_loc_items = items.select{ |k| k['hometown'] }
+
+    items -= custom_loc_items
+    restock_items(items)
+
+    unique_hometowns = custom_loc_items.map{ |k| "#{k['hometown']}" }.uniq
+    unique_hometowns.each do |hometown|
+      custom_list = custom_loc_items.select{ |k| k['hometown'].eql?(hometown) }
+      custom_loc_items -= custom_list
+      restock_items(custom_list)
+    end
+  end
+  def restock_items(item_list)
     items_to_restock = []
     coin_needed = 0
 
-    items.each do |item|
+    item_list.each do |item|
       remaining = if item['stackable']
                     count_stackable_item(item['name'])
                   else
                     count_nonstackable_item(item['name'])
                   end
-
       next unless remaining < item['quantity']
       num_needed = item['quantity'] - remaining
       buy_num = (num_needed / item['size'].to_f).ceil
@@ -28,9 +37,10 @@ class Restock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-
-    ensure_copper_on_hand(coin_needed, @settings) if coin_needed > 0
-
+    town = @settings.hometown
+    town = items_to_restock.first['hometown'] if items_to_restock.first.key?('hometown')
+    coin_string = coin_needed.to_s + ' copper ' + town_currency(town)
+    get_money_from_specific_bank(coin_string, town) if coin_needed > 0
     items_to_restock.each do |item|
       item['buy_num'].times do
         buy_item(item['room'], item['name'])
@@ -38,21 +48,18 @@ class Restock
       end
     end
   end
-
   def setup
     @settings = get_settings
     @restock = @settings.restock
     @hometown = @settings.hometown
     get_settings.storage_containers.each { |container| fput("open my #{container}") }
   end
-
   def parse_restockable_items
     item_list = @restock
     hometown_data = get_data('consumables')[@hometown]
     items = []
-
     item_list.each do |key, value|
-      if hometown_data.key?(key)
+      if hometown_data.key?(key) && !value.key?('hometown')
         ht_data = hometown_data[key]
         data = ht_data.each_key { |k| ht_data[k] = value[k] if value.key?(k) }
         items.push(data)
@@ -62,10 +69,8 @@ class Restock
         echo "No hometown of explicit data for '#{key}'"
       end
     end
-
     items
   end
-
   def count_stackable_item(item)
     count = 0
     $ORDINALS.each do |ordinal|
@@ -85,25 +90,21 @@ class Restock
     end
     count
   end
-
   def count_nonstackable_item(item)
     /inside your (.*).|I could not find/ =~ bput("tap my #{item}", 'inside your (.*).', 'I could not find')
     tap_result = Regexp.last_match(1)
     return 0 if tap_result.nil?
-
     container = tap_result
     count_items_in_container(item, container)
   end
-
   def valid_item_data?(item_data)
-    return false unless item_data.key?('name')
-    return false unless item_data.key?('size')
-    return false unless item_data.key?('room')
-    return false unless item_data.key?('price')
-    return false unless item_data.key?('stackable')
-    return false unless item_data.key?('quantity')
+    return false unless item_data.key?('name')     &&\
+                        item_data.key?('size')     &&\
+                        item_data.key?('room')     &&\
+                        item_data.key?('price')    &&\
+                        item_data.key?('stackable')&&\
+                        item_data.key?('quantity')
     true
   end
 end
-
 Restock.new

--- a/restock.lic
+++ b/restock.lic
@@ -11,16 +11,15 @@ class Restock
     custom_loc_items = items.select{ |k| k['hometown'] }
 
     items -= custom_loc_items
-    restock_items(items)
+    restock_items(items, @settings.hometown)
 
-    unique_hometowns = custom_loc_items.map{ |k| "#{k['hometown']}" }.uniq
-    unique_hometowns.each do |hometown|
-      custom_list = custom_loc_items.select{ |k| k['hometown'].eql?(hometown) }
-      custom_loc_items -= custom_list
-      restock_items(custom_list)
-    end
+    custom_loc_items.map{ |k| k['hometown'] }.uniq
+                                             .each do |hometown|
+                                                custom_loc_items.group_by { |v| v['hometown'] }
+                                                                .each { |hometown, items| restock_items(items, hometown) }
+                                              end
   end
-  def restock_items(item_list)
+  def restock_items(item_list, town)
     items_to_restock = []
     coin_needed = 0
 
@@ -37,10 +36,8 @@ class Restock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-    town = @settings.hometown
-    town = items_to_restock.first['hometown'] if items_to_restock.first.key?('hometown')
-    coin_string = coin_needed.to_s + ' copper ' + town_currency(town)
-    get_money_from_specific_bank(coin_string, town) if coin_needed > 0
+    money_string = coin_needed.to_s + ' copper ' + town_currency(town)
+    get_money_from_specific_bank(money_string, town) if coin_needed > 0
     items_to_restock.each do |item|
       item['buy_num'].times do
         buy_item(item['room'], item['name'])
@@ -98,13 +95,13 @@ class Restock
     count_items_in_container(item, container)
   end
   def valid_item_data?(item_data)
-    return false unless item_data.key?('name')     &&\
-                        item_data.key?('size')     &&\
-                        item_data.key?('room')     &&\
-                        item_data.key?('price')    &&\
-                        item_data.key?('stackable')&&\
-                        item_data.key?('quantity')
-    true
+    return true if  item_data.key?('name')     &&\
+                    item_data.key?('size')     &&\
+                    item_data.key?('room')     &&\
+                    item_data.key?('price')    &&\
+                    item_data.key?('stackable')&&\
+                    item_data.key?('quantity')
+    false
   end
 end
 Restock.new


### PR DESCRIPTION
Initial commit for adding custom hometowns to restock. If a hometown is found, it will then go to that hometown instead. I added two new money methods to handle things. Also fixed a bug in the base consumables for hib's items needing price and not cost.