### PR TITLE
Restock-Shop: Support YAML Configuration of script

### DIFF
--- a/profiles/Cidemon-setup.yaml
+++ b/profiles/Cidemon-setup.yaml
@@ -262,3 +262,129 @@ lumber_buddy_tree_list:
 - Goldwood
 - Azurelle
 - Silverwood
+
+restock_shop:
+  inside_room: 9099
+  outside_room: 7943
+  entrance_noun: entrance
+  items:
+  - noun: sword
+    full_name: bastard sword
+    recipe: bastard sword
+    price: 140000
+    surface: on rack
+    material: steel
+  - noun: mace
+    recipe: bar mace
+    full_name: bar mace
+    price: 140000
+    surface: on rack
+    material: steel
+  - noun: hammer
+    full_name: throwing hammer
+    price: 120000
+    surface: on rack
+    recipe: throwing hammer
+    material: steel
+  - noun: spike
+    full_name: throwing spike
+    price: 100000
+    surface: on rack
+    recipe: throwing spike
+    material: steel
+  - noun: spear
+    full_name: steel light spear
+    price: 120000
+    surface: on rack
+    recipe: light metal spear
+    material: steel
+  - noun: nightstick
+    full_name: steel nightstick
+    price: 120000
+    surface: on rack
+    recipe: nightstick
+    material: steel
+  - noun: akabo
+    full_name: akabo
+    price: 120000
+    surface: on rack
+    recipe: akabo
+    material: steel
+  - noun: cutlass
+    full_name: steel cutlass
+    price: 120000
+    surface: on rack
+    recipe: cutlass
+    material: steel
+  - noun: bola
+    full_name: steel bola
+    price: 120000
+    surface: on rack
+    recipe: bola
+    material: steel
+  - noun: mask
+    full_name: quilted heavy burlap mask
+    price: 60000
+    recipe: quilted cloth mask
+    material: heavy burlap
+    surface: in cabinet
+  - noun: hood
+    full_name: quilted heavy burlap hood
+    price: 100000
+    recipe: quilted cloth hood
+    material: heavy burlap
+    surface: in cabinet
+  - noun: gloves
+    price: 60000
+    surface: in cabinet
+    recipe: quilted cloth gloves
+    full_name: quilted heavy burlap gloves
+    material: heavy burlap
+  - noun: pants
+    full_name: quilted heavy burlap pants
+    price: 120000
+    surface: in cabinet
+    recipe: quilted cloth pants
+    material: heavy burlap
+  - noun: shirt
+    full_name: quilted heavy burlap shirt
+    price: 220000
+    recipe: quilted cloth shirt
+    material: heavy burlap
+    surface: in cabinet
+  - noun: shield
+    price: 220000
+    surface: in cabinet
+    material: gryphon
+    full_name: small gryphon-pelt shield
+    recipe: small leather shield
+  - noun: carryall
+    recipe: carryall
+    full_name: carryall
+    price: 200000
+    surface: on table
+    material: heavy silk
+  - noun: bag
+    recipe: duffel bag
+    full_name: duffel bag
+    price: 100000
+    surface: on table
+    material: heavy linen
+  - noun: haversack
+    recipe: haversack
+    full_name: haversack
+    price: 200000
+    material: heavy silk
+    surface: on table
+  - noun: backpack
+    price: 100000 
+    recipe: backpack
+    full_name: backpack
+    surface: on table
+    material: heavy linen
+  - noun: greataxe
+    price: 120000
+    surface: on rack
+    recipe: greataxe
+    material: steel
+    full_name: greataxe

--- a/profiles/Dijkstra-setup.yaml
+++ b/profiles/Dijkstra-setup.yaml
@@ -277,16 +277,16 @@ gear:
   :is_leather: true
   :is_worn: true
 - :name: gloves
-  :adjective: rugged
+  :adjective: quilted
   :is_leather: true
-- :name: cowl
-  :adjective: rugged
+- :name: hood
+  :adjective: quilted
   :is_leather: true
-- :name: vambraces
-  :adjective: rugged
+- :name: shirt
+  :adjective: quilted
   :is_leather: true
-- :name: jerkin
-  :adjective: rugged
+- :name: mask
+  :adjective: quilted
   :is_leather: true
 - :name: greaves
   :adjective: scale
@@ -623,6 +623,13 @@ restock_shop_items:
   recipe: quilted cloth shirt
   material: heavy burlap
   surface: in cabinet
+- noun: shield
+  price: 220000
+  surface: in cabinet
+  material: gryphon
+  full_name: small gryphon-pelt shield
+  recipe: small leather shield
+
 
 
 # Coordinator is a training-manager alternative, you can ignore the below settings!

--- a/profiles/Dijkstra-setup.yaml
+++ b/profiles/Dijkstra-setup.yaml
@@ -390,12 +390,13 @@ crossing_training:
 - Augmentation
 - Warding
 - Mechanical Lore
+- Appraisal
 
 appraisal_training:
 - pouches
 - gear
 
-full_pouch_container: backpack
+full_pouch_container: sturdy backpack
 
 crafting_training_spells:
   Augmentation:
@@ -419,7 +420,7 @@ sell_loot_pouch: false
 spare_gem_pouch_container: duffel bag
 gem_pouch_adjective: purple
 sell_pouches_for_trading: true
-sale_pouches_container: backpack
+sale_pouches_container: sturdy backpack
 
 repair_timer: 86400 # Repair once every 24 hours
 repair_every: .inf # Infinity - Dont use repair counter
@@ -438,6 +439,7 @@ loot_specials:
 - name: kyanite stones
   bag: duffel bag
 
+safe_room: 
 restock_shop:
   inside_room: 14024
   outside_room: 7913
@@ -530,67 +532,67 @@ restock_shop:
   - noun: hammer
     full_name: throwing hammer
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: throwing hammer
     material: steel
   - noun: spike
     full_name: throwing spike
     price: 100000
-    surface: on table
+    surface: on rack
     recipe: throwing spike
     material: steel
   - noun: spear
     full_name: steel light spear
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: light metal spear
     material: steel
   - noun: nightstick
     full_name: steel nightstick
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: nightstick
     material: steel
   - noun: axe
     full_name: throwing axe
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: a light throwing axe
     material: steel
   - noun: axe
     full_name: hurling axe
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: hurling axe
     material: steel
   - noun: akabo
     full_name: akabo
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: akabo
     material: steel
   - noun: blade
     full_name: marauder blade
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: marauder blade
     material: steel
   - noun: cutlass
     full_name: steel cutlass
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: cutlass
     material: steel
   - noun: bola
     full_name: steel bola
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: bola
     material: steel
   - noun: fork
     full_name: military fork
     price: 120000
-    surface: on table
+    surface: on rack
     recipe: military fork
     material: steel
   - noun: mask
@@ -649,9 +651,10 @@ outfitting_tools:
 
 
 # Coordinator is a training-manager alternative, you can ignore the below settings!
-
+# CUSTOM SETTING (NOT PART OF DEPENDENCY/DR-SCRIPTS)
 coordinator_hunting_tasks:
 
+# CUSTOM SETTING (NOT PART OF DEPENDENCY/DR-SCRIPTS)
 coordinator_hunting_cleanup:
   - :script: safe-room
   - :script: sell-loot
@@ -664,6 +667,7 @@ coordinator_hunting_cleanup:
         time: 43200 
         key: 'repair'
 
+# CUSTOM SETTING (NOT PART OF DEPENDENCY/DR-SCRIPTS)
 coordinator_town_tasks:
   - :action: train_forging 
     :start_on:

--- a/profiles/Dijkstra-setup.yaml
+++ b/profiles/Dijkstra-setup.yaml
@@ -438,197 +438,197 @@ loot_specials:
 - name: kyanite stones
   bag: duffel bag
 
-restock_shop_inside_room: 14024
-restock_shop_outside_room: 7913
-restock_shop_entrance_noun: entrance
-restock_shop_town: Crossing
-restock_shop_items:
-- noun: mask  # Noun of the item
-  price: 60000 # Cost in coppers
-  surface: in cabinet # Where are you selling it in your shop, also include if its 'in' or 'on'
-  recipe: a light plate mask  # Whats the recipe name in the crafting book
-  material: steel # What are you making it out of
-  full_name: plate mask # What does the item look like in your shop, this helps distinguish similar items being sold on the same surface (This is not always 'adjective + noun' so be careful)
-- noun: gauntlets
-  full_name: light steel plate gauntlets
-  price: 60000
-  surface: in cabinet
-  recipe: some light plate gauntlets
-  material: steel
-- noun: greaves
-  full_name: light plate greaves
-  price: 120000
-  surface: in cabinet
-  recipe: light plate greaves
-  material: steel
-- noun: mask
-  full_name: scale mask
-  price: 60000
-  surface: in cabinet
-  recipe: scale mask
-  material: steel
-- noun: gloves
-  full_name: scale gloves
-  price: 60000
-  surface: in cabinet
-  recipe: scale gloves
-  material: steel
-- noun: greaves
-  full_name: scale greaves
-  price: 120000
-  surface: in cabinet
-  recipe: scale greaves
-  material: steel
-- noun: balaclava
-  full_name: ring balaclava
-  price: 110000
-  surface: in cabinet
-  recipe: ring balaclava
-  material: steel
-- noun: mask
-  full_name: ring mask
-  price: 60000
-  surface: in cabinet
-  recipe: ring mask
-  material: steel
-- noun: helm
-  full_name: ring helm
-  price: 100000
-  surface: in cabinet
-  recipe: ring helm
-  material: steel
-- noun: gloves
-  full_name: some steel ring gloves
-  price: 60000
-  surface: in cabinet
-  recipe: ring gloves
-  material: steel
-- noun: shirt
-  full_name: a steel ring shirt
-  price: 220000
-  surface: in cabinet
-  recipe: ring shirt
-  material: steel
-- noun: greaves
-  full_name: some steel ring greaves
-  price: 120000
-  surface: in cabinet
-  recipe: ring greaves
-  material: steel
-- noun: sipar
-  full_name: a steel round sipar
-  price: 200000
-  surface: in cabinet
-  recipe: round sipar
-  material: steel
-- noun: stick
-  full_name: parry stick
-  price: 120000
-  surface: on table
-  recipe: parry stick
-  material: steel
-- noun: hammer
-  full_name: throwing hammer
-  price: 120000
-  surface: on table
-  recipe: throwing hammer
-  material: steel
-- noun: spike
-  full_name: throwing spike
-  price: 100000
-  surface: on table
-  recipe: throwing spike
-  material: steel
-- noun: spear
-  full_name: steel light spear
-  price: 120000
-  surface: on table
-  recipe: light metal spear
-  material: steel
-- noun: nightstick
-  full_name: steel nightstick
-  price: 120000
-  surface: on table
-  recipe: nightstick
-  material: steel
-- noun: axe
-  full_name: throwing axe
-  price: 120000
-  surface: on table
-  recipe: a light throwing axe
-  material: steel
-- noun: axe
-  full_name: hurling axe
-  price: 120000
-  surface: on table
-  recipe: hurling axe
-  material: steel
-- noun: akabo
-  full_name: akabo
-  price: 120000
-  surface: on table
-  recipe: akabo
-  material: steel
-- noun: blade
-  full_name: marauder blade
-  price: 120000
-  surface: on table
-  recipe: marauder blade
-  material: steel
-- noun: cutlass
-  full_name: steel cutlass
-  price: 120000
-  surface: on table
-  recipe: cutlass
-  material: steel
-- noun: bola
-  full_name: steel bola
-  price: 120000
-  surface: on table
-  recipe: bola
-  material: steel
-- noun: fork
-  full_name: military fork
-  price: 120000
-  surface: on table
-  recipe: military fork
-  material: steel
-- noun: mask
-  full_name: quilted heavy burlap mask
-  price: 60000
-  recipe: quilted cloth mask
-  material: heavy burlap
-  surface: in cabinet
-- noun: hood
-  full_name: quilted heavy burlap hood
-  price: 100000
-  recipe: quilted cloth hood
-  material: heavy burlap
-  surface: in cabinet
-- noun: gloves
-  price: 60000
-  surface: in cabinet
-  recipe: quilted cloth gloves
-  full_name: quilted heavy burlap gloves
-  material: heavy burlap
-- noun: pants
-  full_name: quilted heavy burlap pants
-  price: 120000
-  surface: in cabinet
-  recipe: quilted cloth pants
-  material: heavy burlap
-- noun: shirt
-  full_name: quilted heavy burlap shirt
-  price: 220000
-  recipe: quilted cloth shirt
-  material: heavy burlap
-  surface: in cabinet
-- noun: shield
-  price: 220000
-  surface: in cabinet
-  material: gryphon
-  full_name: small gryphon-pelt shield
-  recipe: small leather shield
+restock_shop:
+  inside_room: 14024
+  outside_room: 7913
+  entrance_noun: entrance
+  items:
+  - noun: mask  # Noun of the item
+    price: 60000 # Cost in coppers
+    surface: in cabinet # Where are you selling it in your shop, also include if its 'in' or 'on'
+    recipe: a light plate mask  # Whats the recipe name in the crafting book
+    material: steel # What are you making it out of
+    full_name: plate mask # What does the item look like in your shop, this helps distinguish similar items being sold on the same surface (This is not always 'adjective + noun' so be careful)
+  - noun: gauntlets
+    full_name: light steel plate gauntlets
+    price: 60000
+    surface: in cabinet
+    recipe: some light plate gauntlets
+    material: steel
+  - noun: greaves
+    full_name: light plate greaves
+    price: 120000
+    surface: in cabinet
+    recipe: light plate greaves
+    material: steel
+  - noun: mask
+    full_name: scale mask
+    price: 60000
+    surface: in cabinet
+    recipe: scale mask
+    material: steel
+  - noun: gloves
+    full_name: scale gloves
+    price: 60000
+    surface: in cabinet
+    recipe: scale gloves
+    material: steel
+  - noun: greaves
+    full_name: scale greaves
+    price: 120000
+    surface: in cabinet
+    recipe: scale greaves
+    material: steel
+  - noun: balaclava
+    full_name: ring balaclava
+    price: 110000
+    surface: in cabinet
+    recipe: ring balaclava
+    material: steel
+  - noun: mask
+    full_name: ring mask
+    price: 60000
+    surface: in cabinet
+    recipe: ring mask
+    material: steel
+  - noun: helm
+    full_name: ring helm
+    price: 100000
+    surface: in cabinet
+    recipe: ring helm
+    material: steel
+  - noun: gloves
+    full_name: some steel ring gloves
+    price: 60000
+    surface: in cabinet
+    recipe: ring gloves
+    material: steel
+  - noun: shirt
+    full_name: a steel ring shirt
+    price: 220000
+    surface: in cabinet
+    recipe: ring shirt
+    material: steel
+  - noun: greaves
+    full_name: some steel ring greaves
+    price: 120000
+    surface: in cabinet
+    recipe: ring greaves
+    material: steel
+  - noun: sipar
+    full_name: a steel round sipar
+    price: 200000
+    surface: in cabinet
+    recipe: round sipar
+    material: steel
+  - noun: stick
+    full_name: parry stick
+    price: 120000
+    surface: on table
+    recipe: parry stick
+    material: steel
+  - noun: hammer
+    full_name: throwing hammer
+    price: 120000
+    surface: on table
+    recipe: throwing hammer
+    material: steel
+  - noun: spike
+    full_name: throwing spike
+    price: 100000
+    surface: on table
+    recipe: throwing spike
+    material: steel
+  - noun: spear
+    full_name: steel light spear
+    price: 120000
+    surface: on table
+    recipe: light metal spear
+    material: steel
+  - noun: nightstick
+    full_name: steel nightstick
+    price: 120000
+    surface: on table
+    recipe: nightstick
+    material: steel
+  - noun: axe
+    full_name: throwing axe
+    price: 120000
+    surface: on table
+    recipe: a light throwing axe
+    material: steel
+  - noun: axe
+    full_name: hurling axe
+    price: 120000
+    surface: on table
+    recipe: hurling axe
+    material: steel
+  - noun: akabo
+    full_name: akabo
+    price: 120000
+    surface: on table
+    recipe: akabo
+    material: steel
+  - noun: blade
+    full_name: marauder blade
+    price: 120000
+    surface: on table
+    recipe: marauder blade
+    material: steel
+  - noun: cutlass
+    full_name: steel cutlass
+    price: 120000
+    surface: on table
+    recipe: cutlass
+    material: steel
+  - noun: bola
+    full_name: steel bola
+    price: 120000
+    surface: on table
+    recipe: bola
+    material: steel
+  - noun: fork
+    full_name: military fork
+    price: 120000
+    surface: on table
+    recipe: military fork
+    material: steel
+  - noun: mask
+    full_name: quilted heavy burlap mask
+    price: 60000
+    recipe: quilted cloth mask
+    material: heavy burlap
+    surface: in cabinet
+  - noun: hood
+    full_name: quilted heavy burlap hood
+    price: 100000
+    recipe: quilted cloth hood
+    material: heavy burlap
+    surface: in cabinet
+  - noun: gloves
+    price: 60000
+    surface: in cabinet
+    recipe: quilted cloth gloves
+    full_name: quilted heavy burlap gloves
+    material: heavy burlap
+  - noun: pants
+    full_name: quilted heavy burlap pants
+    price: 120000
+    surface: in cabinet
+    recipe: quilted cloth pants
+    material: heavy burlap
+  - noun: shirt
+    full_name: quilted heavy burlap shirt
+    price: 220000
+    recipe: quilted cloth shirt
+    material: heavy burlap
+    surface: in cabinet
+  - noun: shield
+    price: 220000
+    surface: in cabinet
+    material: gryphon
+    full_name: small gryphon-pelt shield
+    recipe: small leather shield
 
 
 

--- a/profiles/Dijkstra-setup.yaml
+++ b/profiles/Dijkstra-setup.yaml
@@ -1,17 +1,9 @@
-# Spell Wish List (23 slots to spend)
-# Noumena (1), Finesse(2), Last Gift V(1), TURI(2), Platinum Hands of Kertigen(3)
-# Trabe Chalice(1), Crystal Dart(1), Arbiter's Stylus(1)
-# Gauge Flow(2), Manifest Force(1)
-# Feat Wish List
-# Sorcerous Patterns(1), Improved Memory(1), Raw Channeling(1), Efficient Harnessing(1)
+# Spell Wish List (1 slots to spend)
+# TURI(2)
+
 hometown: Crossing
 
 buff_spells:
-  Trabe Chalice:
-    sun: false
-    cambrinth:
-    - 29
-    recast: -1
   Manifest Force:
     cambrinth:
     - 32
@@ -27,6 +19,12 @@ buff_spells:
   Noumena:
     cambrinth:
     - 28
+  Trabe Chalice:
+    day: false
+    mana: 20
+    cambrinth:
+    - 32
+    recast: -1
 
 # offensive_spell_cycle:
 # - Arbiter's Stylus
@@ -53,6 +51,12 @@ offensive_spells:
 
 waggle_sets:
   ## Individual Spells
+  ava:
+    # Room objs: "ball of red luminescence", 
+    Avren Aevareae:
+      cambrinth:
+      - 10
+      skill: Augmentation
   blur:
     Blur:
       cambrinth:
@@ -63,9 +67,18 @@ waggle_sets:
       recast: 7
       cambrinth:
       - 32
+  gaf:
+    Gauge Flow:
+      cambrinth:
+      - 25
   maf:
     Manifest Force:
       mana: 9
+      cambrinth:
+      - 32
+  meg:
+    Membrach's Greed:
+      mana: 10
       cambrinth:
       - 32
   nou:
@@ -83,14 +96,29 @@ waggle_sets:
     Platinum Hands of Kertigen:
       recast: 7
       cambrinth:
-      - 10
+      - 20
     << : *finesse
   smith:
     Platinum Hands of Kertigen:
       recast: 7
       cambrinth:
-      - 10
+      - 20
     << : *finesse
+  mining:
+    Membrach's Greed:
+      recast: 10
+      mana: 10
+      cambrinth:
+      - 32
+  forestry:
+    Membrach's Greed:
+      recast: 10
+      mana: 10
+      cambrinth:
+      - 32
+
+hunting_buddies:
+- Ssarek
 
 prep_scaling_factor: 0.95
 
@@ -109,22 +137,26 @@ dedicated_camb_use: spell
 training_spells:
   Augmentation:
     abbrev: FIN
+    symbiosis: true
   Utility:
     abbrev: NOU
   Warding:
     abbrev: NON
+    symbiosis: true # Need more than 204
 
 training_manager_hunting_priority: yes
 training_manager_town_duration: 60
 training_manager_priority_skills:
 - Targeted Magic
+
 hunting_file_list:
+- stealth
 - setup
 
 combat_trainer_target_increment: 10
 combat_trainer_action_count: 50
 
-skip_last_kill: true
+skip_last_kill: true  # Stops hunting as soon as possible, otherwise combat-trainer lingers and tries to kill the last mob to recover ammo, etc..., this just says "my hunting skills are locked, im out"
 
 trade_contract_container: backpack
 
@@ -141,25 +173,37 @@ workorder_diff:
   remedies: Challenging
   shaping: Challenging
   tailoring: Hard
-  weaponsmithing: Challenging
+  weaponsmithing: Hard
 
 work_order_disciplines:
 - Blacksmithing
 - Tailoring
 
-workorder_min_items: 1
-workorder_max_items: 10
+workorder_min_items: 1 # accept any work order above or at this amount
+workorder_max_items: 4 # accept any work order below or at this amount
 
-use_own_ingot_type: 
-deed_own_ingot: false
+mark_crafted_goods: true # Stamp your goods when doing workorders. You still have to tell ;smith to stamp if you run it manually
+
+use_own_ingot_type: # Use a specific ingot for workorders
+deed_own_ingot: false # Deed whatevers in use_own_ingot_type
 
 forging_tools:
 - diagonal-peen mallet
 - tong
 - bellow
 - curved shovel
+- stamp
+- stirring rod
 
 mining_buddy_vein_list:
+#- Oravir
+- Zinc
+- Silver
+- Tin
+- Nickel
+- Platinum
+- Covellite # Heat resistant, makes good tongs
+# Rare Metals
 - Lumium
 - Damite
 - Kertig
@@ -168,17 +212,22 @@ mining_buddy_vein_list:
 - Animite
 
 mines_to_mine:
+- dark_tunnels
 - waterfall
 - wicked_burrow
+- wicked_burrow_premie
+- wicked_burrow_climbing
 - stone_clan
 - abandoned_mine
 
 
 hunting_info: 
-- :zone: dire_bears
+- :zone:
+  - rock_guardians
   :duration: 30
   stop_on:
-  - Polearms
+  - Targeted Magic
+  - Debilitation
 
 restock:
   bolt:
@@ -193,20 +242,21 @@ favor_god: Kertigen
 favor_goal: 30
 
 picking_box_source: bag 
-picking_box_storage: backpack
+picking_box_storage:
 lockpick_dismantle: salvage
 use_lockpick_ring: true
 
 use_weak_attacks: true
 use_stealth_attacks: false
 
-safe_room:
-slack_username:
-status_monitor_no_window: false
+status_monitor_no_window: true
 dump_junk: true
 
 gear:
 ### Weapons
+- :name: sword
+  :adjective: bastard
+  :swappable: true
 - :name: spear
   :adjective: light
 - :name: spike
@@ -224,6 +274,19 @@ gear:
 ### Armor
 - :name: pants
   :adjective: insulated
+  :is_leather: true
+  :is_worn: true
+- :name: gloves
+  :adjective: rugged
+  :is_leather: true
+- :name: cowl
+  :adjective: rugged
+  :is_leather: true
+- :name: vambraces
+  :adjective: rugged
+  :is_leather: true
+- :name: jerkin
+  :adjective: rugged
   :is_leather: true
 - :name: greaves
   :adjective: scale
@@ -262,6 +325,8 @@ gear:
   :adjective: diagonal-peen
 - :name: shovel
   :adjective: curved
+- :name: rod
+  :adjective: stirring
 
 gear_sets:
   standard:
@@ -269,11 +334,15 @@ gear_sets:
   - round sipar
   - ring lorica
   - ring vambraces
-  - ring greaves
+  - insulated pants
+    #- ring greaves
   - ring mask
   - ring helm
   - Nisha shortbow
   - ring gloves 
+
+performance_monitor_weapons:
+- bastard sword
 
 weapon_training:
   Brawling: ''
@@ -287,18 +356,21 @@ weapon_training:
   Heavy Thrown: light spear
   Large Blunt: bar mace
   Twohanded Blunt: bar mace
+  Large Edged: bastard sword
+  Twohanded Edged: bastard sword
 
 training_abilities:
   Hunt: 80
   PercMana: 60
   Analyze: 70
   Recall: 1205
+  App: 60
 
 cycle_armors:
   Light Armor:
   - insulated pants
-  Chain Armor:
-  - ring greaves
+    #  Chain Armor:
+    #- ring greaves
   Plate Armor:
   - light greaves
   Brigandine:
@@ -308,20 +380,37 @@ hand_armor: *hand_armor # check the gear list to see whats going on here
 
 crossing_training:
 - Locksmithing
+- Trading
 - Athletics
 - Outdoorsmanship
-# - Forging
-# - Outfitting
+- Forging
+- Outfitting
 - Attunement
 - Utility
 - Augmentation
 - Warding
-- Trading
 - Mechanical Lore
 
 appraisal_training:
 - pouches
 - gear
+
+full_pouch_container: backpack
+
+crafting_training_spells:
+  Augmentation:
+    abbrev: FIN
+    name: Finesse
+    mana: 5
+    symbiosis: true
+  Utility:
+    abbrev: NOU
+    mana: 5
+    symbiosis: true
+  Warding:
+    abbrev: NON
+    mana: 5
+    symbiosis: true
 
 listen: true
 listen_observe: true
@@ -329,22 +418,238 @@ listen_observe: true
 sell_loot_pouch: false
 spare_gem_pouch_container: duffel bag
 gem_pouch_adjective: purple
-sell_pouches_for_trading: yes # same as true
-
-# safe_room_empath:
-# safe_room_id:
+sell_pouches_for_trading: true
+sale_pouches_container: backpack
 
 repair_timer: 86400 # Repair once every 24 hours
 repair_every: .inf # Infinity - Dont use repair counter
 
+# To correctly stow special types of 'stones' you need to subtract the general 'stones' from your lootables list. Keep in mind that you now need to list all types of stones to loot in loot additions, e.g. 'shmurgle stones' wont be looted anymore with the settings below
 loot_subtractions:
 - stones
 loot_additions:
 - kyanite stones
 - jadeite stones
 - waermodi stones
+- lantholite stones
 loot_specials:
 - name: jadeite stones
   bag: duffel bag
 - name: kyanite stones
   bag: duffel bag
+
+restock_shop_inside_room: 14024
+restock_shop_outside_room: 7913
+restock_shop_entrance_noun: entrance
+restock_shop_town: Crossing
+restock_shop_items:
+- noun: mask  # Noun of the item
+  price: 60000 # Cost in coppers
+  surface: in cabinet # Where are you selling it in your shop, also include if its 'in' or 'on'
+  recipe: a light plate mask  # Whats the recipe name in the crafting book
+  material: steel # What are you making it out of
+  full_name: plate mask # What does the item look like in your shop, this helps distinguish similar items being sold on the same surface (This is not always 'adjective + noun' so be careful)
+- noun: gauntlets
+  full_name: light steel plate gauntlets
+  price: 60000
+  surface: in cabinet
+  recipe: some light plate gauntlets
+  material: steel
+- noun: greaves
+  full_name: light plate greaves
+  price: 120000
+  surface: in cabinet
+  recipe: light plate greaves
+  material: steel
+- noun: mask
+  full_name: scale mask
+  price: 60000
+  surface: in cabinet
+  recipe: scale mask
+  material: steel
+- noun: gloves
+  full_name: scale gloves
+  price: 60000
+  surface: in cabinet
+  recipe: scale gloves
+  material: steel
+- noun: greaves
+  full_name: scale greaves
+  price: 120000
+  surface: in cabinet
+  recipe: scale greaves
+  material: steel
+- noun: balaclava
+  full_name: ring balaclava
+  price: 110000
+  surface: in cabinet
+  recipe: ring balaclava
+  material: steel
+- noun: mask
+  full_name: ring mask
+  price: 60000
+  surface: in cabinet
+  recipe: ring mask
+  material: steel
+- noun: helm
+  full_name: ring helm
+  price: 100000
+  surface: in cabinet
+  recipe: ring helm
+  material: steel
+- noun: gloves
+  full_name: some steel ring gloves
+  price: 60000
+  surface: in cabinet
+  recipe: ring gloves
+  material: steel
+- noun: shirt
+  full_name: a steel ring shirt
+  price: 220000
+  surface: in cabinet
+  recipe: ring shirt
+  material: steel
+- noun: greaves
+  full_name: some steel ring greaves
+  price: 120000
+  surface: in cabinet
+  recipe: ring greaves
+  material: steel
+- noun: sipar
+  full_name: a steel round sipar
+  price: 200000
+  surface: in cabinet
+  recipe: round sipar
+  material: steel
+- noun: stick
+  full_name: parry stick
+  price: 120000
+  surface: on table
+  recipe: parry stick
+  material: steel
+- noun: hammer
+  full_name: throwing hammer
+  price: 120000
+  surface: on table
+  recipe: throwing hammer
+  material: steel
+- noun: spike
+  full_name: throwing spike
+  price: 100000
+  surface: on table
+  recipe: throwing spike
+  material: steel
+- noun: spear
+  full_name: steel light spear
+  price: 120000
+  surface: on table
+  recipe: light metal spear
+  material: steel
+- noun: nightstick
+  full_name: steel nightstick
+  price: 120000
+  surface: on table
+  recipe: nightstick
+  material: steel
+- noun: axe
+  full_name: throwing axe
+  price: 120000
+  surface: on table
+  recipe: a light throwing axe
+  material: steel
+- noun: axe
+  full_name: hurling axe
+  price: 120000
+  surface: on table
+  recipe: hurling axe
+  material: steel
+- noun: akabo
+  full_name: akabo
+  price: 120000
+  surface: on table
+  recipe: akabo
+  material: steel
+- noun: blade
+  full_name: marauder blade
+  price: 120000
+  surface: on table
+  recipe: marauder blade
+  material: steel
+- noun: cutlass
+  full_name: steel cutlass
+  price: 120000
+  surface: on table
+  recipe: cutlass
+  material: steel
+- noun: bola
+  full_name: steel bola
+  price: 120000
+  surface: on table
+  recipe: bola
+  material: steel
+- noun: fork
+  full_name: military fork
+  price: 120000
+  surface: on table
+  recipe: military fork
+  material: steel
+- noun: mask
+  full_name: quilted heavy burlap mask
+  price: 60000
+  recipe: quilted cloth mask
+  material: heavy burlap
+  surface: in cabinet
+- noun: hood
+  full_name: quilted heavy burlap hood
+  price: 100000
+  recipe: quilted cloth hood
+  material: heavy burlap
+  surface: in cabinet
+- noun: gloves
+  price: 60000
+  surface: in cabinet
+  recipe: quilted cloth gloves
+  full_name: quilted heavy burlap gloves
+  material: heavy burlap
+- noun: pants
+  full_name: quilted heavy burlap pants
+  price: 120000
+  surface: in cabinet
+  recipe: quilted cloth pants
+  material: heavy burlap
+- noun: shirt
+  full_name: quilted heavy burlap shirt
+  price: 220000
+  recipe: quilted cloth shirt
+  material: heavy burlap
+  surface: in cabinet
+
+
+# Coordinator is a training-manager alternative, you can ignore the below settings!
+
+coordinator_hunting_tasks:
+
+coordinator_hunting_cleanup:
+  - :script: safe-room
+  - :script: sell-loot
+    :skip_first_run: true
+  - :script: crossing-repair
+    :skip_first_run: true
+    :start_on:
+      timer:
+        global: true
+        time: 43200 
+        key: 'repair'
+
+coordinator_town_tasks:
+  - :action: train_forging 
+    :start_on:
+      skill_under:
+        skill: Forging
+        target: 5
+  - :script: athletics
+    :args:
+    :start_on:
+      skill_under:
+        skill: Athletics
+        target: 10

--- a/profiles/Dijkstra-setup.yaml
+++ b/profiles/Dijkstra-setup.yaml
@@ -158,9 +158,9 @@ combat_trainer_action_count: 50
 
 skip_last_kill: true  # Stops hunting as soon as possible, otherwise combat-trainer lingers and tries to kill the last mob to recover ammo, etc..., this just says "my hunting skills are locked, im out"
 
-trade_contract_container: backpack
+trade_contract_container: sturdy backpack
 
-crafting_container: backpack
+crafting_container: sturdy backpack # Add an adjective, this helps if you craft backpacks
 
 train_workorders:
 - Blacksmithing
@@ -629,7 +629,23 @@ restock_shop:
     material: gryphon
     full_name: small gryphon-pelt shield
     recipe: small leather shield
+  - noun: backpack
+    price: 100000 
+    recipe: backpack
+    full_name: backpack
+    surface: on table
+    material: heavy linen
 
+
+outfitting_tools:
+- knitting needles
+- sewing needles
+- awl
+- scissors
+- stamp
+- hide scraper
+- slickstone
+- yardstick
 
 
 # Coordinator is a training-manager alternative, you can ignore the below settings!

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -58,4 +58,4 @@ empty_values:
   stealing_towns: []
   safe_room_empaths: []
   crafting_training_spells: {}
-  restock_shop_items: []
+  restock_shop: {}

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -58,3 +58,4 @@ empty_values:
   stealing_towns: []
   safe_room_empaths: []
   crafting_training_spells: {}
+  restock_shop_items: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -848,6 +848,6 @@ spell_cycle:
 
 restock_shop_inside_room:
 restock_shop_outside_room:
-restock_shop_entrance_noun: entrance
+restock_shop_entrance_noun:
 restock_shop_town: Crossing
 restock_shop_items:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -849,5 +849,4 @@ spell_cycle:
 restock_shop_inside_room:
 restock_shop_outside_room:
 restock_shop_entrance_noun:
-restock_shop_town: Crossing
 restock_shop_items:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -845,3 +845,9 @@ force_healer_town:
 shard_thief_password:
 forge_container:
 spell_cycle:
+
+restock_shop_inside_room:
+restock_shop_outside_room:
+restock_shop_entrance_noun: entrance
+restock_shop_town: Crossing
+restock_shop_items:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -846,7 +846,4 @@ shard_thief_password:
 forge_container:
 spell_cycle:
 
-restock_shop_inside_room:
-restock_shop_outside_room:
-restock_shop_entrance_noun:
-restock_shop_items:
+restock_shop:

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -31,7 +31,6 @@ class ShopRestock
     #   ['sealed', 220_000, 8, 'in cabinet', 'gryphon'],
     #   ['sword', 140_000, 9, 'on rack', 'bastard sword', 'steel'],
     #   ['mace', 140_000, 12, 'on rack', 'bar mace', 'steel'],
-    #   ['hammer', 120_000, 10, 'on rack', 'throwing hammer', 'steel'],
     #   ['greataxe', 120_000, 12, 'on rack', 'greataxe', 'steel'],
     #   ['carryall', 200_000, 5, 'on table', 3, 'carryall', 'heavy silk'],
     #   ['haversack', 200_000, 6, 'on table', 3, 'haversack', 'heavy silk']
@@ -66,6 +65,7 @@ class ShopRestock
     @recipes = all_recipes.select { |recipe| missing_recipes_re.match(recipe['name']) }
 
     ensure_copper_on_hand(40_000, @settings)
+    go_to_shop
     restock_surfaces(missing_items)
   end
 
@@ -137,7 +137,7 @@ class ShopRestock
       wait_for_script_to_complete('sew', ['reinforce'])
       fput("stow #{item['noun']}")
       go_to_shop
-      get_item(item['noun'])
+      fput("get my #{item['noun']} from my #{@bag}")
       sell(item)
     end
     wait_for_script_to_complete('workorders', %w[tailoring repair])
@@ -173,7 +173,8 @@ class ShopRestock
 
     missing_items.each do |item|
       move('out') if Room.current.id == @inner_id
-      wait_for_script_to_complete('sew', ['stow', 'sewing', item['chapter'], item['recipe'], item['noun'], 'linen'])
+      recipe_data = recipe_lookup(@recipes, item['recipe'])
+      wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun'], 'linen'])
       go_to_shop
       stamp(item)
       sell(item)
@@ -208,8 +209,9 @@ class ShopRestock
     stow_hands
 
     missing_items.each do |item|
+      recipe_data = recipe_lookup(@recipes, item['recipe'])
       move('out') if Room.current.id == @inner_id
-      wait_for_script_to_complete('sew', ['stow', 'sewing', item['chapter'], item['recipe'], item['noun']])
+      wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun']])
       go_to_shop
       stamp(item)
       sell(item)
@@ -231,8 +233,8 @@ class ShopRestock
 
     missing_items.each do |item|
       recipe_data = recipe_lookup(@recipes, item['recipe'])
-    e recipe_data['part'].each { |part| buy_part(part) }
-      wait_for_script_to_complete('sew', ['stow', 'leather', recipe_data['chapter'], item['recipe'], item['noun'], item['material']])
+      recipe_data['part'].each { |part| buy_part(part) }
+      wait_for_script_to_complete('sew', ['stow', 'leather', recipe_data['chapter'], item['recipe'], item['noun'], item['material'], 'silk'])
       fput('stow leather')
       get_item('shield')
       wait_for_script_to_complete('sew', ['seal'])
@@ -272,7 +274,7 @@ class ShopRestock
   end
 
   def stamp(item)
-    get_item(item['noun'])
+    fput("get my #{item['noun']} from my #{@bag}")
     get_item('stamp')
     fput("mark my #{item['noun']} with my stamp")
     waitrt?

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -23,15 +23,14 @@ class ShopRestock
     @inner_id = settings.restock_shop_inside_room
     @entrance = settings.restock_shop_entrance_noun
     @item_list = settings.restock_shop_items
-    town = settings.restock_shop_town
-    @town_data = get_data('town').town
+    @town = settings.restock_shop_town
+    @part_data = get_data('crafting')[:recipe_parts]
     @bag = settings.crafting_container
     # TODO: Validate users item list against recipe data. Ensure that there is only one match per user specified recipe.
-    # TODO: Validate users town
+    # TODO: Validate users town. Allow only towns with plazas for simplicity
 
     # @item_list = [
     #   ['shirt', 220_000, 34, 'in cabinet', 4, 'quilted cloth shirt', 0, 2, 'heavy burlap'],
-    #   ['pants', 120_000, 10, 'in cabinet', 4, 'quilted cloth pants', 1, 1, 'heavy burlap'],
     #   ['backpack', 100_000, 5, 'on table', 3, 'backpack', 'heavy linen'],
     #   ['bag', 100_000, 6, 'on table', 3, 'duffel bag', 'heavy linen'],
     #   ['sealed', 220_000, 8, 'in cabinet', 'gryphon'],
@@ -45,7 +44,6 @@ class ShopRestock
     go_to_shop
     check_surfaces
 
-    return if Room.current.id == @inner_id
     go_to_shop
   end
 
@@ -133,20 +131,19 @@ class ShopRestock
 
     missing_items.each do |item|
       move('out') if Room.current.id == @inner_id
-
-      # Reinforcing requires one large padding
-      large_padding_qty = 1
-      small_padding_qty = 0
-
-      # TODO: Read Padding data from recipe data instead of making the user supply padding data. Assume they are going to reinforce and buy the right amount of padding for that too
-      item['small_padding_qty'].times do
-        # TODO: Convert to town data (restricted to towns with plazas)
-        order_item(16_667, 11)
+      echo "item: #{item}"
+      item['part'] = recipe_lookup(@recipes, item['recipe'])['part']
+      item['part'].map { |part| part == 'small padding' ? 1 : 0 }
+                  .reduce(0, :+)
+                  .times do
+        order_item(part_data['small padding'][@town]['part-room'], part_data['small padding'][@town]['part-number'])
         fput('stow padding')
       end
-      item['large_padding_qty'].times do
-        # TODO: Convert to town data (restricted to towns with plazas)
-        order_item(16_667, 12)
+      # Include one large padding for reinforcing
+      item['part'].map { |part| part == 'large padding' ? 1 : 0 }
+                  .reduce(1, :+)
+                  .times do
+        order_item(part_data['large padding'][@town]['part-room'], part_data['large padding'][@town]['part-number'])
         fput('stow padding')
       end
 

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -12,21 +12,19 @@ class ShopRestock
   include DRCT
 
   def initialize
-    settings = get_settings
-    ensure_copper_on_hand(40_000, settings)
+    @settings = get_settings
 
-    @shop_id = settings.restock_shop_outside_room
-    @inner_id = settings.restock_shop_inside_room
-    @entrance = settings.restock_shop_entrance_noun
-    @item_list = settings.restock_shop_items
-    @town = settings.restock_shop_town
+    @shop_id = @settings.restock_shop_outside_room
+    @inner_id = @settings.restock_shop_inside_room
+    @entrance = @settings.restock_shop_entrance_noun
+    @item_list = @settings.restock_shop_items
+    @town = @settings.restock_shop_town
     @part_data = get_data('crafting')[:recipe_parts]
-    @bag = settings.crafting_container
+    @bag = @settings.crafting_container
     # TODO: Validate users item list against recipe data. Ensure that there is only one match per user specified recipe.
     # TODO: Validate users town. Allow only towns with plazas for simplicity
 
     # @item_list = [
-    #   ['shirt', 220_000, 34, 'in cabinet', 4, 'quilted cloth shirt', 0, 2, 'heavy burlap'],
     #   ['backpack', 100_000, 5, 'on table', 3, 'backpack', 'heavy linen'],
     #   ['bag', 100_000, 6, 'on table', 3, 'duffel bag', 'heavy linen'],
     #   ['sealed', 220_000, 8, 'in cabinet', 'gryphon'],
@@ -66,6 +64,7 @@ class ShopRestock
     missing_recipes_re = Regexp.union(missing_items.map { |item| item['recipe'] })
     @recipes = all_recipes.select { |recipe| missing_recipes_re.match(recipe['name']) }
 
+    ensure_copper_on_hand(40_000, @settings)
     restock_surfaces(missing_items)
   end
 

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -92,8 +92,7 @@ class ShopRestock
     end
 
     wait_for_script_to_complete('workorders', %w[blacksmithing repair])
-    # TODO: Convert to town data (restricted to towns with plazas)
-    walk_to(8774)
+    walk_to(get_data('crafting')[:blacksmithing][@town]['trash-room'])
     fput('get my steel ingot')
     dispose_trash('steel ingot')
   end
@@ -127,23 +126,13 @@ class ShopRestock
 
     missing_items.each do |item|
       move('out') if Room.current.id == @inner_id
-      echo "item: #{item}"
-      item['part'] = recipe_lookup(@recipes, item['recipe'])['part']
-      item['part'].map { |part| part == 'small padding' ? 1 : 0 }
-                  .reduce(0, :+)
-                  .times do
-        order_item(@part_data['small padding'][@town]['part-room'], @part_data['small padding'][@town]['part-number'])
-        fput('stow padding')
-      end
-      # Include one large padding for reinforcing
-      item['part'].map { |part| part == 'large padding' ? 1 : 0 }
-                  .reduce(1, :+)
-                  .times do
-        order_item(@part_data['large padding'][@town]['part-room'], @part_data['large padding'][@town]['part-number'])
-        fput('stow padding')
+      recipe_data = recipe_lookup(@recipes, item['recipe'])
+      recipe_data['part'] << 'large padding' # HACK: Reinforcing should be user specified
+      recipe_data['part'].uniq.each do |part_name|
+        recipe_data['part'].map { |part| part == part_name ? 1 : 0 }.reduce(0, :+).times { buy_part(part_name) }
       end
 
-      wait_for_script_to_complete('sew', ['stow', 'sewing', item['chapter'], item['recipe'], item['noun'], 'burlap'])
+      wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun'], 'burlap'])
       stamp(item)
       wait_for_script_to_complete('sew', ['reinforce'])
       fput("stow #{item['noun']}")
@@ -227,22 +216,30 @@ class ShopRestock
     end
   end
 
+  def buy_part(name)
+    part_data = @part_data[name][@town]
+    if part_data['part-number']
+      order_item(part_data['part-room'], part_data['part-number'])
+    else
+      buy_item(part_data['part-room'], name)
+    end
+    stow_hands
+  end
+
   def restock_gryphon(missing_items)
     return if missing_items.empty?
 
-    # TODO: Convert to town data (restricted to towns with plazas)
-    order_item(16_667, 16)
-    order_item(16_667, 17)
-    stow_hands
-    # TODO: Convert to YAML setting once tested
-    item = { 'noun'=>'shield', 'volume'=>10, 'recipe'=>'small leather shield', 'material'=>'leather', 'chapter'=>10, 'price'=>220_000, 'surface'=>'in cabinet' }
-    wait_for_script_to_complete('sew', ['stow', item['material'], item['chapter'], item['recipe'], item['noun'], 'gryphon'])
-    fput('stow leather')
-    fput('get shield from my back')
-    wait_for_script_to_complete('sew', ['seal'])
-    go_to_shop
-    stamp(item)
-    sell(item)
+    missing_items.each do |item|
+      recipe_data = recipe_lookup(@recipes, item['recipe'])
+      recipe_data['part'].each { |part| buy_part(part) }
+      wait_for_script_to_complete('sew', ['stow', item['material'], recipe_data['chapter'], item['recipe'], item['noun'], 'gryphon'])
+      fput('stow leather')
+      fput("get shield from my #{@bag}")
+      wait_for_script_to_complete('sew', ['seal'])
+      go_to_shop
+      stamp(item)
+      sell(item)
+    end
   end
 
   def go_to_shop

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -4,10 +4,6 @@
 
 custom_require.call(%w[common common-crafting common-items common-money common-travel])
 
-class ShopItem
-  def initialize; end
-end
-
 class ShopRestock
   include DRC
   include DRCC
@@ -136,14 +132,14 @@ class ShopRestock
       item['part'].map { |part| part == 'small padding' ? 1 : 0 }
                   .reduce(0, :+)
                   .times do
-        order_item(part_data['small padding'][@town]['part-room'], part_data['small padding'][@town]['part-number'])
+        order_item(@part_data['small padding'][@town]['part-room'], @part_data['small padding'][@town]['part-number'])
         fput('stow padding')
       end
       # Include one large padding for reinforcing
       item['part'].map { |part| part == 'large padding' ? 1 : 0 }
                   .reduce(1, :+)
                   .times do
-        order_item(part_data['large padding'][@town]['part-room'], part_data['large padding'][@town]['part-number'])
+        order_item(@part_data['large padding'][@town]['part-room'], @part_data['large padding'][@town]['part-number'])
         fput('stow padding')
       end
 

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -4,6 +4,10 @@
 
 custom_require.call(%w[common common-crafting common-items common-money common-travel])
 
+class ShopItem
+  def initialize; end
+end
+
 class ShopRestock
   include DRC
   include DRCC
@@ -15,95 +19,96 @@ class ShopRestock
     settings = get_settings
     ensure_copper_on_hand(40_000, settings)
 
-    @shop_id = 7943
-    @inner_id = 9099
+    @shop_id = settings.restock_shop_outside_room
+    @inner_id = settings.restock_shop_inside_room
+    @entrance = settings.restock_shop_entrance_noun
+    @item_list = settings.restock_shop_items
+    town = settings.restock_shop_town
+    @town_data = get_data('town').town
+    @bag = settings.crafting_container
+    # TODO: Validate users item list against recipe data. Ensure that there is only one match per user specified recipe.
+    # TODO: Validate users town
 
-    @item_list = [
-      ['mask', 60_000, 2, 'in cabinet', 4, 'quilted cloth mask', 1, 1, 'heavy burlap'],
-      ['hood', 100_000, 9, 'in cabinet',  4, 'quilted cloth hood', 1, 1, 'heavy burlap'],
-      ['gloves', 60_000, 4, 'in cabinet', 4, 'quilted cloth gloves', 1, 1, 'heavy burlap'],
-      ['shirt', 220_000, 34, 'in cabinet', 4, 'quilted cloth shirt', 0, 2, 'heavy burlap'],
-      ['pants', 120_000, 10, 'in cabinet', 4, 'quilted cloth pants', 1, 1, 'heavy burlap'],
-      ['backpack', 100_000, 5, 'on table', 3, 'backpack', 'heavy linen'],
-      ['bag', 100_000, 6, 'on table', 3, 'duffel bag', 'heavy linen'],
-      ['sealed', 220_000, 8, 'in cabinet', 'gryphon'],
-      ['sword', 140_000, 9, 'on rack', 'bastard sword', 'steel'],
-      ['spear', 120_000, 7, 'on rack', 'light metal spear', 'steel'],
-      ['mace', 140_000, 12, 'on rack', 'bar mace', 'steel'],
-      ['cutlass', 120_000, 7, 'on rack', 'cutlass', 'steel'],
-      ['bola', 120_000, 5, 'on rack', 'bola', 'steel'],
-      ['hammer', 120_000, 10, 'on rack', 'throwing hammer', 'steel'],
-      ['akabo', 120_000, 13, 'on rack', 'akabo', 'steel'],
-      ['spike', 100_000, 4, 'on rack', 'throwing spike', 'steel'],
-      ['nightstick', 120_000, 7, 'on rack', 'nightstick', 'steel'],
-      ['greataxe', 120_000, 12, 'on rack', 'greataxe', 'steel'],
-      ['carryall', 200_000, 5, 'on table', 3, 'carryall', 'heavy silk'],
-      ['haversack', 200_000, 6, 'on table', 3, 'haversack', 'heavy silk']
-    ]
-
-    walk_to(@shop_id)
-    fput('open entrance')
-    pause 0.5
-    fput('go entrance')
-
+    # @item_list = [
+    #   ['shirt', 220_000, 34, 'in cabinet', 4, 'quilted cloth shirt', 0, 2, 'heavy burlap'],
+    #   ['pants', 120_000, 10, 'in cabinet', 4, 'quilted cloth pants', 1, 1, 'heavy burlap'],
+    #   ['backpack', 100_000, 5, 'on table', 3, 'backpack', 'heavy linen'],
+    #   ['bag', 100_000, 6, 'on table', 3, 'duffel bag', 'heavy linen'],
+    #   ['sealed', 220_000, 8, 'in cabinet', 'gryphon'],
+    #   ['sword', 140_000, 9, 'on rack', 'bastard sword', 'steel'],
+    #   ['mace', 140_000, 12, 'on rack', 'bar mace', 'steel'],
+    #   ['hammer', 120_000, 10, 'on rack', 'throwing hammer', 'steel'],
+    #   ['greataxe', 120_000, 12, 'on rack', 'greataxe', 'steel'],
+    #   ['carryall', 200_000, 5, 'on table', 3, 'carryall', 'heavy silk'],
+    #   ['haversack', 200_000, 6, 'on table', 3, 'haversack', 'heavy silk']
+    # ]
+    go_to_shop
     check_surfaces
 
     return if Room.current.id == @inner_id
-    walk_to(@shop_id)
-    fput('open entrance')
-    pause 0.5
-    fput('go entrance')
+    go_to_shop
   end
 
   def check_surfaces
     missing_items = []
-    @item_list.map { |x| x[3] }.uniq.each do |surface|
+    @item_list.map { |data| data['surface'] }.uniq.each do |surface|
       raw_list = bput("look #{surface}", "There's nothing", 'you see [^\.]*')
       raw_list = if raw_list == "There's nothing"
                    []
                  else
-                   list_to_nouns(raw_list)
+                   list_to_array(raw_list)
                  end
-      missing_items += @item_list.select { |data| surface == data[3] }.reject { |data| raw_list.include?(data.first) }
+      missing_items += @item_list.select { |item| surface == item['surface'] }
+                                 .reject { |item| raw_list.find { |raw_item| raw_item.match(item['full_name']) } }
     end
+
+    return if missing_items.empty?
+
+    respond 'Restocking'
+    respond '------------'
+    missing_items.each { |item| respond "- #{item['full_name']}" }
+
+    all_recipes = get_data('recipes').crafting_recipes
+    missing_recipes_re = Regexp.union(missing_items.map { |item| item['recipe'] })
+    @recipes = all_recipes.select { |recipe| missing_recipes_re.match(recipe['name']) }
+
     restock_surfaces(missing_items)
   end
 
   def restock_surfaces(missing_items)
-    echo missing_items
-    restock_steel(missing_items.select { |x| x.last == 'steel' })
-    restock_burlap(missing_items.select { |x| x.last == 'heavy burlap' })
-    restock_silk(missing_items.select { |x| x.last == 'heavy silk' })
-    restock_linen(missing_items.select { |x| x.last == 'heavy linen' })
-    restock_gryphon(missing_items.select { |x| x.last == 'gryphon' })
+    restock_steel(missing_items.select { |item| item['material'] == 'steel' })
+    restock_burlap(missing_items.select { |item| item['material'] == 'heavy burlap' })
+    restock_silk(missing_items.select { |item| item['material'] == 'heavy silk' })
+    restock_linen(missing_items.select { |item| item['material'] == 'heavy linen' })
+    restock_gryphon(missing_items.select { |item| item['material'] == 'gryphon' })
   end
 
   def restock_steel(missing_items)
     return if missing_items.empty?
-    echo missing_items
-    volume = ((missing_items.map { |x| x[2] }.inject(&:+) * 1.25) / 10.0).ceil
+
+    volume = ((total_volume_of(missing_items) * 1.25) / 10.0).ceil
+    return if volume == 0
+
     wait_for_script_to_complete('makesteel', [volume, 'refine'])
 
     missing_items.each do |item|
-      wait_for_script_to_complete('smith', ['steel', item[4], 'stamp', 'temper'])
-      walk_to(@shop_id)
-      fput('open entrance')
-      pause 0.5
-      fput('go entrance')
-      fput("sell my #{item.first} #{item[3]} for #{item[1]}")
+      wait_for_script_to_complete('smith', ['steel', item['recipe'], 'stamp', 'temper'])
+      go_to_shop
+      sell(item)
     end
 
     wait_for_script_to_complete('workorders', %w[blacksmithing repair])
+    # TODO: Convert to town data (restricted to towns with plazas)
     walk_to(8774)
     fput('get my steel ingot')
-    fput('put ingot in bucket')
+    dispose_trash('steel ingot')
   end
 
   def restock_burlap(missing_items)
     return if missing_items.empty?
-    echo missing_items
 
-    volume = missing_items.map { |x| x[2] }.inject(&:+)
+    volume = total_volume_of(missing_items)
+    return if volume == 0
 
     have = 0
     if bput('get burlap cloth', 'You get', 'What were') == 'You get'
@@ -121,7 +126,7 @@ class ShopRestock
       end
     end
 
-    while bput('get burlap cloth from back', 'You get', 'What were') == 'You get'
+    while bput("get burlap cloth from #{@bag}", 'You get', 'What were') == 'You get'
       fput('combine cloth')
     end
     stow_hands
@@ -129,31 +134,29 @@ class ShopRestock
     missing_items.each do |item|
       move('out') if Room.current.id == @inner_id
 
-      item[6].times do
+      # Reinforcing requires one large padding
+      large_padding_qty = 1
+      small_padding_qty = 0
+
+      # TODO: Read Padding data from recipe data instead of making the user supply padding data. Assume they are going to reinforce and buy the right amount of padding for that too
+      item['small_padding_qty'].times do
+        # TODO: Convert to town data (restricted to towns with plazas)
         order_item(16_667, 11)
         fput('stow padding')
       end
-      item[7].times do
+      item['large_padding_qty'].times do
+        # TODO: Convert to town data (restricted to towns with plazas)
         order_item(16_667, 12)
         fput('stow padding')
       end
 
-      wait_for_script_to_complete('sew', ['stow', 'sewing', item[4], item[5], item[0], 'burlap'])
-
-      fput("get #{item[0]} from back")
-      fput('get my stamp')
-      fput("mark my #{item[0]} with my stamp")
-      waitrt?
-      pause
-      fput('stow stamp')
+      wait_for_script_to_complete('sew', ['stow', 'sewing', item['chapter'], item['recipe'], item['noun'], 'burlap'])
+      stamp(item)
       wait_for_script_to_complete('sew', ['reinforce'])
-      fput("stow #{item[0]}")
-      walk_to(@shop_id)
-      fput('open entrance')
-      pause 0.5
-      fput('go entrance')
-      fput("get #{item[0]} from back")
-      fput("sell my #{item.first} #{item[3]} for #{item[1]}")
+      fput("stow #{item['noun']}")
+      go_to_shop
+      fput("get #{item['noun']} from #{@bag}")
+      sell(item)
     end
     wait_for_script_to_complete('workorders', %w[tailoring repair])
   end
@@ -162,7 +165,8 @@ class ShopRestock
     return if missing_items.empty?
     echo missing_items
 
-    volume = missing_items.map { |x| x[2] }.inject(&:+)
+    volume = total_volume_of(missing_items)
+    return if volume == 0
 
     have = 0
     if bput('get linen cloth', 'You get', 'What were') == 'You get'
@@ -180,36 +184,28 @@ class ShopRestock
       end
     end
 
-    while bput('get linen cloth from back', 'You get', 'What were') == 'You get'
+    while bput("get linen cloth from #{@bag}", 'You get', 'What were') == 'You get'
       fput('combine cloth')
     end
     stow_hands
 
     missing_items.each do |item|
       move('out') if Room.current.id == @inner_id
-      wait_for_script_to_complete('sew', ['stow', 'sewing', item[4], item[5], item[0], 'linen'])
-      walk_to(@shop_id)
-      fput('open entrance')
-      pause 0.5
-      fput('go entrance')
-      fput("get #{item[0]} from back")
-      fput('get my stamp')
-      fput("mark my #{item[0]} with my stamp")
-      waitrt?
-      pause
-      fput('stow stamp')
-      fput("sell my #{item.first} #{item[3]} for #{item[1]}")
+      wait_for_script_to_complete('sew', ['stow', 'sewing', item['chapter'], item['recipe'], item['noun'], 'linen'])
+      go_to_shop
+      stamp(item)
+      sell(item)
     end
   end
 
   def restock_silk(missing_items)
     return if missing_items.empty?
-    echo missing_items
 
-    volume = missing_items.map { |x| x[2] }.inject(&:+)
+    volume = total_volume_of(missing_items)
+    return if volume == 0
 
     have = 0
-    if bput('get silk cloth from my back', 'You get', 'What were') == 'You get'
+    if bput("get silk cloth from my #{@bag}", 'You get', 'What were') == 'You get'
       res = bput('count my cloth', 'You count out .*')
       have = res.scan(/\d+/).first.to_i
       stow_hands
@@ -224,50 +220,74 @@ class ShopRestock
       end
     end
 
-    while bput('get silk cloth from my back', 'You get', 'What were') == 'You get'
+    while bput("get silk cloth from my #{@bag}", 'You get', 'What were') == 'You get'
       fput('combine cloth')
     end
     stow_hands
 
     missing_items.each do |item|
       move('out') if Room.current.id == @inner_id
-      wait_for_script_to_complete('sew', ['stow', 'sewing', item[4], item[5], item[0]])
-      walk_to(@shop_id)
-      fput('open entrance')
-      pause 0.5
-      fput('go entrance')
-      fput("get #{item[0]} from back")
-      fput('get my stamp')
-      fput("mark my #{item[0]} with my stamp")
-      waitrt?
-      pause
-      fput('stow stamp')
-      fput("sell my #{item.first} #{item[3]} for #{item[1]}")
+      wait_for_script_to_complete('sew', ['stow', 'sewing', item['chapter'], item['recipe'], item['noun']])
+      go_to_shop
+      stamp(item)
+      sell(item)
     end
   end
 
   def restock_gryphon(missing_items)
     return if missing_items.empty?
-    echo missing_items
 
+    # TODO: Convert to town data (restricted to towns with plazas)
     order_item(16_667, 16)
     order_item(16_667, 17)
     stow_hands
-
-    wait_for_script_to_complete('sew', ['stow', 'leather', 10, 'small leather shield', 'shield', 'gryphon'])
+    # TODO: Convert to YAML setting once tested
+    item = { 'noun'=>'shield', 'volume'=>10, 'recipe'=>'small leather shield', 'material'=>'leather', 'chapter'=>10, 'price'=>220_000, 'surface'=>'in cabinet' }
+    wait_for_script_to_complete('sew', ['stow', item['material'], item['chapter'], item['recipe'], item['noun'], 'gryphon'])
     fput('stow leather')
     fput('get shield from my back')
     wait_for_script_to_complete('sew', ['seal'])
+    go_to_shop
+    stamp(item)
+    sell(item)
+  end
+
+  def go_to_shop
+    return if Room.current.id == @inner_id
+
     walk_to(@shop_id)
-    fput('open entrance')
+    if bput("open #{@entrance}",
+            'You will need to contact the owner about that',
+            'But your shop is already set up and ready for you to enter',
+            'Your shop is ready') == 'You will need to contact the owner about that'
+      echo '*****************'
+      echo 'Your shop settings appear to be incorrect. Please check the script documentation and update your settings'
+      echo '*****************'
+      exit
+    end
     pause 0.5
-    fput('go entrance')
+    move("go #{@entrance}")
+  end
+
+  def sell(item)
+    fput("sell my #{item['noun']} #{item['surface']} for #{item['price']}")
+  end
+
+  def stamp(item)
+    # TODO: Convert to stow/get crafting item
+    fput("get #{item['noun']} from #{@bag}")
     fput('get my stamp')
-    fput('mark my shield with my stamp')
+    fput("mark my #{item['noun']} with my stamp")
     waitrt?
     pause
     fput('stow stamp')
-    fput('sell my shield in cabinet for 220000')
+  end
+
+  def total_volume_of(items)
+    return 0 if items.empty?
+
+    items.map { |item| recipe_lookup(@recipes.select{ |recipe| recipe['noun'] == item['noun'] }, item['recipe'])['volume'] }
+         .inject(&:+)
   end
 end
 

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -18,9 +18,10 @@ class ShopRestock
     @inner_id = @settings.restock_shop_inside_room
     @entrance = @settings.restock_shop_entrance_noun
     @item_list = @settings.restock_shop_items
-    @town = @settings.restock_shop_town
+    @town = @settings.hometown
     @part_data = get_data('crafting')[:recipe_parts]
     @bag = @settings.crafting_container
+    @belt = @settings.forging_belt || @settings.engineering_belt
     # TODO: Validate users item list against recipe data. Ensure that there is only one match per user specified recipe.
     # TODO: Validate users town. Allow only towns with plazas for simplicity
 
@@ -92,7 +93,7 @@ class ShopRestock
 
     wait_for_script_to_complete('workorders', %w[blacksmithing repair])
     walk_to(get_data('crafting')[:blacksmithing][@town]['trash-room'])
-    fput('get my steel ingot')
+    get_item('steel ingot')
     dispose_trash('steel ingot')
   end
 
@@ -136,7 +137,7 @@ class ShopRestock
       wait_for_script_to_complete('sew', ['reinforce'])
       fput("stow #{item['noun']}")
       go_to_shop
-      fput("get #{item['noun']} from #{@bag}")
+      get_item(item['noun'])
       sell(item)
     end
     wait_for_script_to_complete('workorders', %w[tailoring repair])
@@ -230,10 +231,10 @@ class ShopRestock
 
     missing_items.each do |item|
       recipe_data = recipe_lookup(@recipes, item['recipe'])
-      recipe_data['part'].each { |part| buy_part(part) }
-      wait_for_script_to_complete('sew', ['stow', item['material'], recipe_data['chapter'], item['recipe'], item['noun'], 'gryphon'])
+    e recipe_data['part'].each { |part| buy_part(part) }
+      wait_for_script_to_complete('sew', ['stow', 'leather', recipe_data['chapter'], item['recipe'], item['noun'], item['material']])
       fput('stow leather')
-      fput("get shield from my #{@bag}")
+      get_item('shield')
       wait_for_script_to_complete('sew', ['seal'])
       go_to_shop
       stamp(item)
@@ -262,14 +263,21 @@ class ShopRestock
     fput("sell my #{item['noun']} #{item['surface']} for #{item['price']}")
   end
 
+  def get_item(name)
+    get_crafting_item(name, @bag, @belt, @belt)
+  end
+
+  def stow_item(name)
+    stow_crafting_item(name, @bag, @belt)
+  end
+
   def stamp(item)
-    # TODO: Convert to stow/get crafting item
-    fput("get #{item['noun']} from #{@bag}")
-    fput('get my stamp')
+    get_item(item['noun'])
+    get_item('stamp')
     fput("mark my #{item['noun']} with my stamp")
     waitrt?
     pause
-    fput('stow stamp')
+    stow_item('stamp')
   end
 
   def total_volume_of(items)

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -22,19 +22,7 @@ class ShopRestock
     @part_data = get_data('crafting')[:recipe_parts]
     @bag = @settings.crafting_container
     @belt = @settings.forging_belt || @settings.engineering_belt
-    # TODO: Validate users item list against recipe data. Ensure that there is only one match per user specified recipe.
-    # TODO: Validate users town. Allow only towns with plazas for simplicity
 
-    # @item_list = [
-    #   ['backpack', 100_000, 5, 'on table', 3, 'backpack', 'heavy linen'],
-    #   ['bag', 100_000, 6, 'on table', 3, 'duffel bag', 'heavy linen'],
-    #   ['sealed', 220_000, 8, 'in cabinet', 'gryphon'],
-    #   ['sword', 140_000, 9, 'on rack', 'bastard sword', 'steel'],
-    #   ['mace', 140_000, 12, 'on rack', 'bar mace', 'steel'],
-    #   ['greataxe', 120_000, 12, 'on rack', 'greataxe', 'steel'],
-    #   ['carryall', 200_000, 5, 'on table', 3, 'carryall', 'heavy silk'],
-    #   ['haversack', 200_000, 6, 'on table', 3, 'haversack', 'heavy silk']
-    # ]
     go_to_shop
     check_surfaces
 
@@ -211,7 +199,7 @@ class ShopRestock
     missing_items.each do |item|
       recipe_data = recipe_lookup(@recipes, item['recipe'])
       move('out') if Room.current.id == @inner_id
-      wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun']])
+      wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun'], 'silk'])
       go_to_shop
       stamp(item)
       sell(item)
@@ -234,7 +222,7 @@ class ShopRestock
     missing_items.each do |item|
       recipe_data = recipe_lookup(@recipes, item['recipe'])
       recipe_data['part'].each { |part| buy_part(part) }
-      wait_for_script_to_complete('sew', ['stow', 'leather', recipe_data['chapter'], item['recipe'], item['noun'], item['material'], 'silk'])
+      wait_for_script_to_complete('sew', ['stow', 'leather', recipe_data['chapter'], item['recipe'], item['noun'], item['material']])
       fput('stow leather')
       get_item('shield')
       wait_for_script_to_complete('sew', ['seal'])

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -14,10 +14,10 @@ class ShopRestock
   def initialize
     @settings = get_settings
 
-    @shop_id = @settings.restock_shop_outside_room
-    @inner_id = @settings.restock_shop_inside_room
-    @entrance = @settings.restock_shop_entrance_noun
-    @item_list = @settings.restock_shop_items
+    @shop_id = @settings.restock_shop['outside_room']
+    @inner_id = @settings.restock_shop['inside_room']
+    @entrance = @settings.restock_shop['entrance_noun']
+    @item_list = @settings.restock_shop['items']
     @town = @settings.hometown
     @part_data = get_data('crafting')[:recipe_parts]
     @bag = @settings.crafting_container

--- a/validate.lic
+++ b/validate.lic
@@ -579,6 +579,15 @@ class DRYamlValidator
     settings.buff_spells.select { |_name, data| data['pet_type'] }
             .reject { |_name, data| data.include? 'cast' }
             .each_key { |name| error("Pet buffs require a custom cast message. Please include a \"cast:\" setting for #{name}.") }
+
+  def assert_that_restock_shop_items_recipes_are_valid(settings)
+    return if settings.restock_shop.empty?
+    return unless settings.restock_shop.key?('items')
+  
+    recipes = get_data('recipes').crafting_recipes
+    unknown_item_recipes = settings.restock_shop['items'].reject { |item| recipes.any? { |recipe| recipe['name'].match(item['recipe']) } }
+    return if unknown_item_recipes.empty?
+    error("The following restock shop items match no recipe data: #{unknown_item_recipes.map { |item| item['recipe'] } }")
   end
 
   private


### PR DESCRIPTION
* Add example in Dijkstra-setup.yaml
* Read recipe data from base data collection
* Read restock information from user settings file
* Made several helper methods (they can be found at the bottom of the script)
* Allow shop surface to hold multiple items of the same noun. Distinguishing items is done by the 'full_name' attribute rather than the 'noun' attribute now.