### PR TITLE
Removed, added, changed links. Supports a main "WIKI" for Dep.

### DIFF
--- a/links.lic
+++ b/links.lic
@@ -20,7 +20,7 @@ class Links
     }
 
     links.each do |title, url|
-      respond("  #{title}:".ljust(35) + url)
+      respond("  #{title}:".ljust(42) + url)
     end
   end
 end

--- a/links.lic
+++ b/links.lic
@@ -12,7 +12,7 @@ class Links
       'YAML, Scripts, and Guild Tutorials' => 'https://github.com/rpherbig/dr-scripts/wiki/DR-Scripts-Tutorials',
       'Hunting Ladder Spreadsheet' => 'http://i.imgur.com/lCcb3rD.jpg',
       'Add and Check Known Issues' => 'https://github.com/rpherbig/dr-scripts/issues',
-      'Recent Script Changes (Updated Weekly)' =>  'https://github.com/rpherbig/dr-scripts/wiki/dr-scripts-update-summary',
+      'Recent Script Changes (Updated Weekly)' => 'https://github.com/rpherbig/dr-scripts/wiki/dr-scripts-update-summary',
       'YAML Validator' => 'http://yaml-online-parser.appspot.com/',
       'Player Shops' => 'http://drservice.info/Plaza/',
       'Lich mapping guide' => 'https://elanthipedia.play.net/Lich_mapping_reference',

--- a/links.lic
+++ b/links.lic
@@ -12,7 +12,7 @@ class Links
       'YAML, Scripts, and Guild Tutorials' => 'https://github.com/rpherbig/dr-scripts/wiki/DR-Scripts-Tutorials',
       'Hunting Ladder Spreadsheet' => 'http://i.imgur.com/lCcb3rD.jpg',
       'Add and Check Known Issues' => 'https://github.com/rpherbig/dr-scripts/issues',
-      'Summary of recent script changes, updated weekly' =>  'https://github.com/rpherbig/dr-scripts/wiki/dr-scripts-update-summary',
+      'Recent Script Changes (Updated Weekly)' =>  'https://github.com/rpherbig/dr-scripts/wiki/dr-scripts-update-summary',
       'YAML Validator' => 'http://yaml-online-parser.appspot.com/',
       'Player Shops' => 'http://drservice.info/Plaza/',
       'Lich mapping guide' => 'https://elanthipedia.play.net/Lich_mapping_reference',

--- a/links.lic
+++ b/links.lic
@@ -7,10 +7,8 @@ class Links
 
   def initialize
     links = {
-      'What is Lich?' => 'https://elanthipedia.play.net/Lich_scripting_engine',
       'Lich New User Guide' => 'https://lichproject.org/new-user-guide.html',
-      'What is Dependency?' => 'https://elanthipedia.play.net/Dependency',
-      'Dependency First Time Setup' => 'https://github.com/rpherbig/dr-scripts/wiki/First-Time-Setup',
+      'Lich & Dependency Wiki' => 'https://elanthipedia.play.net/Lich_scripting_engine',
       'Dependency Script Documentation' => 'https://elanthipedia.play.net/Lich_script_repository',
       'DR-Scripts Tutorials' => 'https://github.com/rpherbig/dr-scripts/wiki/DR-Scripts-Tutorials',
       'YAML Validator' => 'http://yaml-online-parser.appspot.com/',

--- a/links.lic
+++ b/links.lic
@@ -7,17 +7,16 @@ class Links
 
   def initialize
     links = {
-      'Lich New User Guide' => 'https://lichproject.org/new-user-guide.html',
-      'Lich & Dependency Wiki' => 'https://elanthipedia.play.net/Lich_scripting_engine',
-      'Dependency Script Documentation' => 'https://elanthipedia.play.net/Lich_script_repository',
-      'DR-Scripts Tutorials' => 'https://github.com/rpherbig/dr-scripts/wiki/DR-Scripts-Tutorials',
-      'YAML Validator' => 'http://yaml-online-parser.appspot.com/',
-      'Lich mapping guide' => 'https://elanthipedia.play.net/Lich_mapping_reference',
-      'Player Shops' => 'https://dr-scripts.firebaseapp.com/',
+      'Lich & Dependency Wiki' => 'https://github.com/rpherbig/dr-scripts/wiki',
+      'Script Settings Documentation' => 'https://elanthipedia.play.net/Lich_script_repository',
+      'YAML, Scripts, and Guild Tutorials' => 'https://github.com/rpherbig/dr-scripts/wiki/DR-Scripts-Tutorials',
       'Hunting Ladder Spreadsheet' => 'http://i.imgur.com/lCcb3rD.jpg',
-      'Trigger to fix genie chat spam' => '#queue clear;#send 1 ,chat #queue clear',
-      'Guide to github pull requests' => 'https://gist.github.com/Chaser324/ce0505fbed06b947d962',
-      'Summary of recent script changes, updated weekly' =>  'https://github.com/rpherbig/dr-scripts/wiki/dr-scripts-update-summary'
+      'Add and Check Known Issues' => 'https://github.com/rpherbig/dr-scripts/issues',
+      'Summary of recent script changes, updated weekly' =>  'https://github.com/rpherbig/dr-scripts/wiki/dr-scripts-update-summary',
+      'YAML Validator' => 'http://yaml-online-parser.appspot.com/',
+      'Player Shops' => 'http://drservice.info/Plaza/',
+      'Lich mapping guide' => 'https://elanthipedia.play.net/Lich_mapping_reference',
+      'Trigger to fix GENIE chat spam' => '#queue clear;#send 1 ,chat #queue clear'
     }
 
     links.each do |title, url|


### PR DESCRIPTION
We can just point people at the Wiki. I've reorganized it. I think the links area was subpar at this point. Lots of double links, nothing pointing to a main area, etc. We can now point people at the wiki, which is like saying "it's on Elanthipedia". We can continue to better organize that single area as well as the "go to" for all people's questions. 