### PR TITLE
validate.lic: Fix up after 7ca2f0746a3

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -597,6 +597,7 @@ class DRYamlValidator
     settings.buff_spells.select { |_name, data| data['pet_type'] }
             .reject { |_name, data| data.include? 'cast' }
             .each_key { |name| error("Pet buffs require a custom cast message. Please include a \"cast:\" setting for #{name}.") }
+  end
 
   def assert_that_restock_shop_items_recipes_are_valid(settings)
     return if settings.restock_shop.empty?


### PR DESCRIPTION
--- Lich: validate active.
--- Lich: error: validate:649: syntax error, unexpected end-of-input, expecting keyword_end
DRYamlValidator.new
                   ^
        lich.rbw:2560:in `eval'
        lich.rbw:2560:in `block (3 levels) in <class:Script>'
--- Lich: validate has exited.