### PR TITLE
Add support for light crossbows to aiming trainables

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3184,7 +3184,7 @@ class GameState
   def determine_aiming_skill
     held_types = ['Small Edged', 'Large Edged', 'Small Blunt', 'Large Blunt', 'Staves', 'Polearms']
     options = @aiming_trainables
-    options -= held_types if weapon_skill.eql?('Bow') || weapon_skill.eql?('Crossbow')
+    options -= held_types if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !weapon_name.include?('light'))
     options.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2719,6 +2719,9 @@ class GameState
     @aiming_trainables = settings.aiming_trainables & settings.weapon_training.keys # Intersection of the arrays to make sure weapons are available in the hunt
     echo("  @aiming_trainables: #{@aiming_trainables}") if $debug_mode_ct
 
+    @using_light_crossbow = settings.using_light_crossbow
+    echo("  @using_light_crossbow: #{@using_light_crossbow}") if $debug_mode_ct
+
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
 
@@ -3184,7 +3187,7 @@ class GameState
   def determine_aiming_skill
     held_types = ['Small Edged', 'Large Edged', 'Small Blunt', 'Large Blunt', 'Staves', 'Polearms']
     options = @aiming_trainables
-    options -= held_types if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !weapon_name.include?('light'))
+    options -= held_types if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow)
     options.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -116,6 +116,7 @@ dump_item_count: 9
 use_barb_combos: false
 whirlwind_trainables:
 aiming_trainables:
+using_light_crossbow: false
 magic_exp_training_max_threshold: 32
 combat_spell_training_max_threshold:
 offensive_spell_mana_threshold: 40


### PR DESCRIPTION
Added in a new setting for letting the user say whether they're crossbow is light or not. There are too many different types of crossbows to keep a list of all possible versions. To be safe we default to false, but the user can adjust it. The `determine_aiming_skill` now checks that the new **game_state** setting is true, if so, it allows the use of attacking with the offhand instead of just thrown, tactics, and brawling. One of the benefits of lighter crossbows.