### PR TITLE
setupaliases: add nexus alias

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -43,7 +43,9 @@
   # List all escort zones from base-hunting alphabetically by name.
   ['ez', "#{$clean_lich_char}e get_data('hunting').escort_zones.sort.each{ |x| echo x }"],
   # Search for a hunting zone, e.g. 'fz wark' will return warklin hunting zone rooms
-  ['fz', "#{$clean_lich_char}e echo get_data('hunting').hunting_zones.find{|k,v| k =~ /\\?/i}"]
+  ['fz', "#{$clean_lich_char}e echo get_data('hunting').hunting_zones.find{|k,v| k =~ /\\?/i}"],
+  # List all the rooms tagged with nexus
+  ['nexus', "#{$clean_lich_char}e respond(\"--------------------\\nNexus List\\n--------------------\");Map.list.find_all{ |room| room.tags.include?('nexus') }.collect(&:id).each{ |id| respond(\"\#\{Map.list[id].title.first.sub(/^\\[/, '').sub(/\\]$/, '').ljust(45)\}  \#\{id\}\")}"]
 ].each do |trigger, target|
   UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
 end


### PR DESCRIPTION
Prints a list of the nexuses tagged in the mapdb.

```
 >nexus                                                     
 --- Lich: exec1 active.                                    
 --------------------                                       
 Nexus List                                                 
 --------------------                                       
 [Riverhaven, Theren Way]                       365         
 [Riverhaven Road, South Road]                  475         
 [The Crossing, Town Green Southeast]           793         
 [Wilds, Pine Needle Path]                      851         
 [Northeast Wilds, Grimsage Way]                984         
 [Northeast Wilds, Outside Northeast Gate]      992         
 [Therenborough, Quadrangle]                    3158        
 [Langenfirth, Blufe Path]                      3353        
 [Truffenyi's Green]                            4947        
 [Empaths' Guild, Courtyard Garden]             5713        
 [Clerics' Guild, Gathering Hall]               5987        
 [Market Plaza, Foyer]                          7906        
 [Whistling Wood, Path]                         9459        
 [Middens, Crossbow Bend]                       19162       
 [Triage Building]                              19330       
```