### PR TITLE
Go2: Add nexus list for DR

### DIFF
--- a/go2.lic
+++ b/go2.lic
@@ -229,6 +229,13 @@ elsif script.vars[0] =~ /^targets$/i
 		}
 		output.concat "\n"
 	}
+  if XMLData.game =~ /^DR/
+    output.concat "---------------------------------------------------------------\n"
+    output.concat " - Known Nexus Rooms\n"
+    output.concat "---------------------------------------------------------------\n"
+    Map.list.find_all{ |room| room.tags.include?('nexus') }
+            .each{ |room| output.concat "#{room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(45)} - #{room.id.to_s.rjust(5)}\n" }
+  end
 	respond output
 	exit
 elsif script.vars[0] =~ /^list$/i


### PR DESCRIPTION
Adds the output, similar from #2873 to `;go2 targets`. The benefit is the user doesn't have to run `;setupaliases`