### PR TITLE
common-items.lic: add another potential trash message to the dispose_…

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -72,7 +72,7 @@ module DRCI
         trashcan = 'hollow' if DRRoom.room_objs.include?('dead tree with a darkened hollow near its base')
       end
 
-      if /^You (drop|put)/ =~ DRC.bput("put my #{item} in #{trashcan}", '^You drop', '^You put', "You're kidding, right", 'What were you referring to')
+      if /^You (drop|put)/ =~ DRC.bput("put my #{item} in #{trashcan}", '^You drop', '^You put', "You're kidding, right", 'What were you referring to', "You can't do that")
         return
       end
     end


### PR DESCRIPTION
…trash bput

[pick: *** No match was found after 15 seconds, dumping info]
[pick: messages seen length: 5]
[pick: message: Obvious paths: east.]
[pick: message: The ground's scent of rich loam coupled with the ferns' herbal fragrance transforms the plain grassland into a pristine natural para$
[pick: message: [Prairie Grove, Brushwood Trail]]
[pick: message: Whispers of the Muse  (22 roisaen)]
[pick: message: You can't do that.]
[pick: checked against [/^You drop/i, /^You put/i, /You're kidding, right/i, /What were you referring to/i]]
[pick: for command put my nugget in tree]