### PR TITLE
combat-trainer.lic: Add another message for dismantling.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2017,7 +2017,7 @@ class TrainerProcess
       # Dump the box so that combat-trainer lootprocess can take over
       bput("open my #{box}", 'You open', 'That is already open')
       2.times do
-        bput("dismantle my #{box}", 'You can not dismantle', 'You dump the contents', 'You move your hands')
+        bput("dismantle my #{box}", 'You can not dismantle', 'You dump the contents', 'You move your hands', 'You must be holding the object')
       end
       waitrt?
     else


### PR DESCRIPTION
If the first dismantle succeeds the second gives you [combat-trainer: message: You must be holding the object you wish to dismantle.] if you have another of that box noun in your containers.