### PR TITLE
combat-trainer.lic: Add yet another message the the dismantle bput.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2017,7 +2017,7 @@ class TrainerProcess
       # Dump the box so that combat-trainer lootprocess can take over
       bput("open my #{box}", 'You open', 'That is already open')
       2.times do
-        bput("dismantle my #{box}", 'You can not dismantle', 'You dump the contents', 'You move your hands', 'You must be holding the object')
+        bput("dismantle my #{box}", 'You can not dismantle', 'You dump the contents', 'You move your hands', 'You must be holding the object', 'Unable to locate')
       end
       waitrt?
     else


### PR DESCRIPTION
[combat-trainer: message: [Unable to locate the object you specified.]]
[combat-trainer: checked against [/You can not dismantle/i, /You dump the contents/i, /You move your hands/i, /You must be holding the object/i]]
[combat-trainer: for command dismantle my coffer]