### PR TITLE
Changed up the failing to aim logic a bit.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2285,7 +2285,11 @@ class AttackProcess
     game_state.selected_maneuver = charged_maneuver unless game_state.loaded
     game_state.loaded = false if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
     game_state.clear_aim_queue if Flags['ct-ranged-ready']
-    game_state.loaded = false if Flags['ct-aim-failed']
+
+    if Flags['ct-aim-failed']
+      game_state.loaded = false
+      Flags.reset('ct-aim-failed')
+    end
 
     if game_state.loaded && game_state.done_aiming?
       if game_state.selected_maneuver
@@ -2351,7 +2355,6 @@ class AttackProcess
         game_state.set_aim_queue
         aim(game_state)
         Flags.reset('ct-ranged-ready')
-        Flags.reset('ct-aim-failed')
       end
     end
   end


### PR DESCRIPTION
So, you could get stuck in a continuous loop if you failed to aim, reloaded, and then powershot. This is why everyone isn't hitting this bug often. It's coming from the `if game_state.selected_maneuver` being true, then never resetting the failed to aim flag. This is the better way to do it. Set the need to load, and then reset the flag so we don't continuously loop. This would be a very random issue, that's why we didn't see it often.