### PR TITLE
crossing-training.lic: Gut non-workorder training and just use craft.…

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -783,24 +783,7 @@ class CrossingTraining
       return
     end
 
-    rank = DRSkill.getrank('Outfitting')
-    if rank <= 25 # Tier 1  Extremely Easy
-      sew(5, 'knitted socks', 'socks')
-    elsif rank <= 50 # Tier 2 Very Easy
-      sew(5, 'knitted mittens', 'mittens')
-    elsif rank <= 100 # Tier 3  Easy
-      sew(5, 'knitted hat', 'hat')
-    elsif rank <= 175 # Tier 4  Simple
-      sew(5, 'knitted gloves', 'gloves')
-    elsif rank <= 300 # Tier 5  Basic
-      sew(5, 'knitted hose', 'hose')
-    elsif rank <= 425 # Tier 6  Somewhat Challenging
-      sew(5, 'knitted cloak', 'cloak')
-    elsif rank <= 650 # Tier 7  Challenging
-      sew(5, 'knitted blanket', 'blanket')
-    else # Tier 12  Extremely Difficult
-      echo('*** NOT YET IMPLEMENTED ***')
-    end
+    wait_for_script_to_complete('craft', ['outfitting'])
   end
 
   def train_engineering
@@ -818,32 +801,7 @@ class CrossingTraining
       return
     end
 
-    rank = DRSkill.getrank('Engineering')
-
-    if rank <= 25 # Tier 1  Extremely Easy
-      shape(7, 'wood band', 'band')
-    elsif rank <= 50 # Tier 2 Very Easy
-      shape(7, 'wood bracelet', 'bracelet')
-    elsif rank <= 100 # Tier 3  Easy
-      shape(7, 'wood cloak pin', 'cloak pin')
-    elsif rank <= 175 # Tier 4  Simple
-      shape(7, 'pair of wood earrings', 'earrings')
-    elsif rank <= 300 # Tier 5  Basic
-      shape(7, 'wood brooch', 'brooch')
-    elsif rank <= 425 # Tier 6  Somewhat Challenging
-      shape(7, 'wood armband', 'armband')
-    elsif rank <= 600 # Tier 7  Challenging
-      shape(7, 'wood choker', 'choker')
-    elsif rank <= 700 # Tier 8 - Complicated
-      shape(7, 'articulated wood necklace', 'necklace')
-    elsif rank <= 850 # Tier 9 - Intricate
-      shape(7, 'wood crown', 'crown')
-    elsif rank <= 1175 # Tier 10 - Difficult
-      shape(7, 'wood comb', 'comb')
-    elsif rank <= 1400 # Tier 11 - Very Difficult
-      shape(7, 'wood haircomb', 'haircomb')
-    else # Tier 12  Extremely Difficult
-      echo('*** NOT YET IMPLEMENTED ***')
+    wait_for_script_to_complete('craft', ['engineering'])
     end
   end
 
@@ -892,37 +850,7 @@ class CrossingTraining
       return
     end
 
-    rank = DRSkill.getrank('Forging')
-    if rank <= 25 # Tier 1 - Extremely Easy
-      smith('a shallow metal cup')
-    elsif rank <= 50 # Tier 2 - Very Easy
-      smith('a short metal mug')
-    elsif rank <= 100 # Tier 3 - Easy
-      smith('a back scratcher')
-    elsif rank <= 175 # Tier 4 - Simple
-      smith('a metal ankle band')
-    elsif rank <= 300 # Tier 5 - Basic
-      smith('a metal lockpick ring')
-    elsif rank <= 425 # Tier 6 - Somewhat Challenging
-      smith('a metal armband')
-    elsif rank <= 550 # Tier 7 - Challenging
-      smith('some metal clippers')
-    elsif rank <= 700 # Tier 8 - Complicated
-      smith('some squat knitting needles')
-      # Journeyman book: triangular wire sieve, bent <metal> scissors, knobby sewing needles, squat knitting needles, narrow <metal> awl
-    elsif rank <= 850 # Tier 9 - Intricate
-      smith('serrated hide scraper')
-      # Master book: beveled wood shaper, serrated hide scraper, compact <metal> awl, compact <metal> awl, round pestle
-    elsif rank <= 1175 # Tier 10 - Difficult
-      smith('serrated scissors')
-      # Master book: slender <metal> awl, serrated scissors, grooved pestle, oblong wire sieve
-    elsif rank <= 1400 # Tier 11 - Very Difficult
-      smith('thin sewing needles')
-      # Master book: jagged wood shaper, thin sewing needles
-    else # Tier 12 - Extremely Difficult
-      smith('trapezoidal wire sieve')
-      # Master book: trapezoidal wire sieve
-    end
+    wait_for_script_to_complete('craft', ['forging'])
   end
 
   # https://elanthipedia.play.net/Remedies_products
@@ -949,52 +877,6 @@ class CrossingTraining
       @settings.crossing_training.delete(skill)
       false
     end
-  end
-
-  def shape(chapter, unique_name, item)
-    return unless buy_wood
-
-    find_shaping_room(@hometown, @training_room)
-    check_listening
-    check_teaching
-
-    wait_for_script_to_complete('shape', ['trash', chapter, unique_name, 'maple', item])
-
-    bput('get my lumber', 'You get some', 'You pick up')
-    dispose_trash('lumber')
-  end
-
-  def sew(chapter, unique_name, item)
-    return unless buy_yarn
-
-    walk_to(@training_room)
-    check_listening
-    check_teaching
-
-    wait_for_script_to_complete('sew', ['trash', 'knitting', chapter, unique_name, item, 'wool'])
-
-    fput('get my wool yarn')
-    dispose_trash('yarn')
-  end
-
-  def smith(full_name)
-    wait_for_script_to_complete('smith', ['bronze', full_name, 'buy'])
-    dispose_trash(right_hand)
-    dispose_trash(left_hand)
-  end
-
-  def buy_wood
-    crafting_data = get_data('crafting')
-    return unless money_for_training?(1000, 'Engineering')
-    order_item(crafting_data['shaping'][@hometown]['stock-room'], 10)
-    bput('stow my lumber', 'You put your')
-  end
-
-  def buy_yarn
-    crafting_data = get_data('crafting')
-    return unless money_for_training?(700, 'Outfitting')
-    order_item(crafting_data['tailoring'][@hometown]['stock-room'], 13)
-    bput('stow my yarn', 'You put your')
   end
 
   def stop_play


### PR DESCRIPTION
…lic.

workorders stay in, and alchemy stays in to remove it from the crossing-training list if you do not do workorders since it's unsupported.