### PR TITLE
common-healing.lic: Lower the check_health reget to 50, 300 is way to…

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -178,7 +178,7 @@ module DRCH
 
     DRC.bput('health', 'You have')
     pause 0.5
-    data = reget(300).reverse
+    data = reget(50).reverse
     data.each do |line|
       case line
       when /^You have (?!no significant injuries)(?!.* lodged into your)(?!.* infection)(?!.* poison(?:ed)?)(?!.* #{all_parasites_re})/


### PR DESCRIPTION
…o much.

It takes 6 lines at most, 44 extra lines in the reget array every time its called is maybe a bit excessive still but better than 294 :)