### PR TITLE
fix oil purchase in hib

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -353,7 +353,8 @@ class TheurgyActions
   def purchase_method_whitelist
     %w[buy_taffelberries
        buy_parchment
-       buy_wine_shard]
+       buy_wine_shard
+       buy_oil_hib]
   end
 
   def buy_taffelberries
@@ -378,6 +379,10 @@ class TheurgyActions
     bput('get wine on bar', 'You get a flute', 'What were you referring')
   end
 
+  def buy_oil_hib
+    bput('buy oil in chest', 'You decide to purchase', 'You realize you don\'t have enough')
+  end
+  
   def perform_next_action
     perform_next_ritual unless perform_next_commune
   end


### PR DESCRIPTION
#2641 
relates to issue 2641
"buy oil" does not work in hib shop. it needs to be "buy oil in chest"