### PR TITLE
Be extra careful about starting/stopping performance.

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -212,6 +212,7 @@ class Athletics
     if DRSkill.getrank('Athletics') >= 400
       climb_branch
     else
+      pause 2 if Script.running?('performance')
       start_script('performance') unless Script.running?('performance')
       until done_training?
         @athletics_options

--- a/athletics.lic
+++ b/athletics.lic
@@ -214,7 +214,6 @@ class Athletics
     else
       pause 2 # to give performance time to complete before_dying if stopped from the previous script
       start_script('performance') unless Script.running?('performance')
-      pause 1 # make sure you are playing before starting climb practice
       until done_training?
         @athletics_options
           .reject { |data| @settings.avoid_athletics_in_justice && data['justice'] }

--- a/athletics.lic
+++ b/athletics.lic
@@ -212,7 +212,7 @@ class Athletics
     if DRSkill.getrank('Athletics') >= 400
       climb_branch
     else
-      pause 2 if Script.running?('performance')
+      pause 2 # to give performance time to complete before_dying if stopped from the previous script
       start_script('performance') unless Script.running?('performance')
       until done_training?
         @athletics_options

--- a/athletics.lic
+++ b/athletics.lic
@@ -214,6 +214,7 @@ class Athletics
     else
       pause 2 # to give performance time to complete before_dying if stopped from the previous script
       start_script('performance') unless Script.running?('performance')
+      pause 1 # make sure you are playing before starting climb practice
       until done_training?
         @athletics_options
           .reject { |data| @settings.avoid_athletics_in_justice && data['justice'] }
@@ -294,6 +295,7 @@ class Athletics
         return if remaining_attempts.zero?
       else
         start_script('performance') unless Script.running?('performance')
+        pause 1 # make sure you are playing before starting climb practice
       end
       Flags.add('ct-climbing-finished', 'You finish practicing your climbing')
       Flags.add('ct-climbing-combat', 'You are engaged in combat')

--- a/athletics.lic
+++ b/athletics.lic
@@ -294,7 +294,7 @@ class Athletics
         return if remaining_attempts.zero?
       else
         start_script('performance') unless Script.running?('performance')
-        pause 1 # make sure you are playing before starting climb practice
+        pause 2 # make sure you are playing before starting climb practice
       end
       Flags.add('ct-climbing-finished', 'You finish practicing your climbing')
       Flags.add('ct-climbing-combat', 'You are engaged in combat')

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -30,9 +30,9 @@ class FirstAid
   end
 
   def compendium_charts
-    pause 2 if Script.running?('performance')
+    pause 2 # to give performance time to complete before_dying if stopped from the previous script
     start_script('performance') unless Script.running?('performance')
-    pause 4
+    pause 4 # to catch the dirty zill message from performance.lic
     bput('get my compendium', 'You get', 'You are already holding')
     bput('look my compendium', '^The compendium lies open to the section on .* physiology')
     pause
@@ -42,9 +42,9 @@ class FirstAid
   end
 
   def textbook_charts
-    pause 2 if Script.running?('performance')
+    pause 2 # to give performance time to complete before_dying if stopped from the previous script
     start_script('performance') unless Script.running?('performance')
-    pause 4
+    pause 4 # to catch the dirty zill message from performance.lic
     bput("get my #{@booktype}", 'You get', 'You are already holding')
     bput("open my #{@booktype}", 'You open your', 'That is already open')
     study_charts(@chart_data)

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -30,8 +30,9 @@ class FirstAid
   end
 
   def compendium_charts
+    pause 2 if Script.running?('performance')
     start_script('performance') unless Script.running?('performance')
-    pause 2
+    pause 4
     bput('get my compendium', 'You get', 'You are already holding')
     bput('look my compendium', '^The compendium lies open to the section on .* physiology')
     pause
@@ -41,8 +42,9 @@ class FirstAid
   end
 
   def textbook_charts
+    pause 2 if Script.running?('performance')
     start_script('performance') unless Script.running?('performance')
-    pause 2
+    pause 4
     bput("get my #{@booktype}", 'You get', 'You are already holding')
     bput("open my #{@booktype}", 'You open your', 'That is already open')
     study_charts(@chart_data)

--- a/study-art.lic
+++ b/study-art.lic
@@ -21,7 +21,7 @@ class StudyArt
     @stop_skill = args.skill || 'scholarship'
 
     art_options = get_data('art').art_options
-    pause 2 if Script.running?('performance')
+    pause 2 unless Script.running?('crossing-training') # to give performance time to complete before_dying if stopped from the previous script
     start_script('performance') unless Script.running?('performance') || Script.running?('crossing-training')
     study_art(art_options)
   end

--- a/study-art.lic
+++ b/study-art.lic
@@ -21,6 +21,7 @@ class StudyArt
     @stop_skill = args.skill || 'scholarship'
 
     art_options = get_data('art').art_options
+    pause 2 if Script.running?('performance')
     start_script('performance') unless Script.running?('performance') || Script.running?('crossing-training')
     study_art(art_options)
   end


### PR DESCRIPTION
On slow systems 2 seconds is not enough to catch the dirty message in performance for first-aid so increase that to 4.
Also add a 2 second pause if performance is still running, performance handles stopping playing in before_dying, which happens after the script is stopped but before it's actually in exited status, causing problems when handing off to another script that runs performance.

Fixes #2908