### PR TITLE
Convert pouch selling for trading to a script

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -809,6 +809,7 @@ class CrossingTraining
 
     if @settings.sell_pouches_for_trading && DRSkill.getxp('Trading') < 5 
       wait_for_script_to_complete('sell-pouches')
+      return if DRSkill.getxp('Trading') > 5
     end
 
     unless disciplines

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -807,19 +807,8 @@ class CrossingTraining
   def train_trading
     disciplines = @settings.work_order_disciplines
 
-    if @settings.sell_pouches_for_trading && DRSkill.getxp('Trading') < 5 && bput("get pouch from my #{@settings.sale_pouches_container}", 'You get a', 'What were you') == 'You get a'
-      gemshop = get_data('town')[@hometown]['gemshop']['id']
-      unless gemshop
-        echo('NO GEMSHOP DATA FOUND?')
-        fput('stow pouch')
-        return
-      end
-      walk_to gemshop
-      fput('spec finesse')
-      fput('sell pouch')
-      fput('put pouch in bucket')
-      wait_for_script_to_complete('sell-loot')
-      return
+    if @settings.sell_pouches_for_trading && DRSkill.getxp('Trading') < 5 
+      wait_for_script_to_complete('sell-pouches')
     end
 
     unless disciplines

--- a/sell-pouches.lic
+++ b/sell-pouches.lic
@@ -1,0 +1,43 @@
+custom_require.call(%w[common common-items common-travel])
+
+class PouchSeller
+  include DRC
+  include DRCI
+  include DRCT
+
+  def initialize
+    settings = get_settings
+    pouch_container = settings.sale_pouches_container
+    hometown = settings.hometown
+
+    exit unless have_pouch?(pouch_container)
+
+    gemshop = get_data('town')[hometown]['gemshop']['id']
+    unless gemshop
+      echo('NO GEMSHOP DATA FOUND?')
+      fput('stow pouch')
+      exit
+    end
+
+    sell_pouch(gemshop)
+  end
+
+  def have_pouch?(container)
+    return false unless container
+
+    bput("get pouch from my #{container}", 'You get a', 'What were you') == 'You get a'  
+  end
+
+  def sell_pouch(shop_id)
+    return unless shop_id
+
+    walk_to(shop_id)
+    wait_for_script_to_complete('buff', [Script.current.name])
+    fput('sell pouch')
+    fput('put pouch in bucket')
+    wait_for_script_to_complete('sell-loot')
+  end
+
+end
+
+PouchSeller.new


### PR DESCRIPTION
Essentially a copy and paste of the logic from crossing-training to a separate script.

This also updates the use of speculate finesse to a modern use of
trader magic spell finesse via a waggle set (the scripts name).

Another note is that this has potential to expand into running accept-sell multiple times as a counterpart to the new give pouches script.