### PR TITLE
performance.lic: Don't clean zills during first-aid.

### DIFF
--- a/first-aid.lic
+++ b/first-aid.lic
@@ -31,7 +31,7 @@ class FirstAid
 
   def compendium_charts
     pause 2 # to give performance time to complete before_dying if stopped from the previous script
-    start_script('performance') unless Script.running?('performance')
+    start_script('performance', ['noclean']) unless Script.running?('performance')
     pause 4 # to catch the dirty zill message from performance.lic
     bput('get my compendium', 'You get', 'You are already holding')
     bput('look my compendium', '^The compendium lies open to the section on .* physiology')
@@ -43,7 +43,7 @@ class FirstAid
 
   def textbook_charts
     pause 2 # to give performance time to complete before_dying if stopped from the previous script
-    start_script('performance') unless Script.running?('performance')
+    start_script('performance', ['noclean']) unless Script.running?('performance')
     pause 4 # to catch the dirty zill message from performance.lic
     bput("get my #{@booktype}", 'You get', 'You are already holding')
     bput("open my #{@booktype}", 'You open your', 'That is already open')

--- a/performance.lic
+++ b/performance.lic
@@ -10,9 +10,18 @@ class Performance
   def initialize
     no_pause_all
     start_time = Time.new.to_i
+    arg_definitions = [
+      [
+        { name: 'noclean', regex: /noclean/i, optional: true, description: 'Skip cleaning your instrument' }
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
 
     @settings = get_settings
     @song_list = get_data('perform').perform_options
+    @skip_clean = args.noclean
+
     UserVars.song = @song_list.first.first unless UserVars.song
     fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
 
@@ -70,7 +79,7 @@ class Performance
     when 'You cannot play'
       wait_for_script_to_complete('safe-room')
     when 'dirtiness may affect your performance'
-      return true if DRSkill.getrank('Performance') < 20 || Script.running?('first-aid')
+      return true if DRSkill.getrank('Performance') < 20 || @skip_clean
       stop_play
       clean_zills
       return play_song

--- a/performance.lic
+++ b/performance.lic
@@ -70,12 +70,9 @@ class Performance
     when 'You cannot play'
       wait_for_script_to_complete('safe-room')
     when 'dirtiness may affect your performance'
-      return true if DRSkill.getrank('Performance') < 20
-
-      Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
+      return true if DRSkill.getrank('Performance') < 20 || Script.running?('first-aid')
       stop_play
       clean_zills
-      Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
       return play_song
     when 'slightest hint of difficulty', 'fumble slightly'
       return true


### PR DESCRIPTION
Not sure of how to get around this and people are hitting errors. I removed the script pausing also because it was only implemented for first-aid. The other users of this script (study-art and athletics) are fine wwithout pausing.