### PR TITLE
Alleviate issue of backfire due to inaccurate checkcastrt from server lag

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -930,7 +930,7 @@ class Bescort
     if entering_ap
       focus_shard(shard) if DRStats.circle < 100
       harness_mana([20, 20, 20])
-      waitcastrt?
+      waitcastrt_and_pause?
       if DRStats.circle > 99
         unless cast?('cast grazhir')
           echo 'You may need to move to another room'
@@ -942,7 +942,7 @@ class Bescort
       end
     else
       focus_shard(shard)
-      waitcastrt?
+      waitcastrt_and_pause?
       cast?("cast #{shard}")
     end
     pause 0.25

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -113,7 +113,7 @@ module DRCA
     stow_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'])
     DRCT.retreat(ignored_npcs) unless spell['skip_retreat']
 
-    waitcastrt?
+    waitcastrt_and_pause?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
     DRCT.retreat(ignored_npcs) unless spell['skip_retreat']
   end
@@ -426,7 +426,7 @@ module DRCA
     if data['prep_time']
       pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
     else
-      waitcastrt?
+      waitcastrt_and_pause?
     end
 
     cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
@@ -568,5 +568,11 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
     prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
+  end
+
+  def waitcastrt_and_pause?
+    result = waitcastrt?
+    pause UserVars.cast_pause || 2
+    result
   end
 end

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -523,7 +523,7 @@ class CrossingTraining
         find_charge_invoke_stow(item['name'], item['stored'], item['cap'], @settings.dedicated_camb_use, data['cambrinth'][index], @settings.cambrinth_invoke_exact_amount)
       end
     end
-    waitcastrt?
+    waitcastrt_and_pause?
 
     snapshot = DRSkill.getxp(skill) if data['symbiosis']
 

--- a/gate.lic
+++ b/gate.lic
@@ -130,7 +130,7 @@ class Moongate
 
   def cast_spell(spell, mana, target, snap = false)
     prepare?(spell, mana, false)
-    snap ? pause(5) : waitcastrt?
+    snap ? pause(5) : waitcastrt_and_pause?
     cast?("cast #{target}")
   end
 end

--- a/healme.lic
+++ b/healme.lic
@@ -40,7 +40,7 @@ class HealMe
       pause 1 while mana < 25
       prepare?('heal', base)
       charge_and_invoke(@settings.cambrinth, @settings.dedicated_camb_use, camb, @settings.cambrinth_invoke_exact_amount) unless camb.empty?
-      waitcastrt?
+      waitcastrt_and_pause?
       cast?
       pause 0.5
     end
@@ -50,7 +50,7 @@ class HealMe
     pause 1 while mana < 25
     prepare?(spell, preps.first)
     charge_and_invoke(@settings.cambrinth, @settings.dedicated_camb_use, preps[1..-1], @settings.cambrinth_invoke_exact_amount) unless preps[1..-1].empty?
-    waitcastrt?
+    waitcastrt_and_pause?
     Flags.reset('hm-partial-heal')
     cast?("cast #{part} #{internal ? 'internal' : ''}")
     pause 0.5

--- a/sorcery.lic
+++ b/sorcery.lic
@@ -32,7 +32,7 @@ class Sorcery
       else
         fput "prep #{sorcery_spell}"
         pause 3
-        waitcastrt?
+        waitcastrt_and_pause?
         cast?
       end
       pause 0.5 while stunned?


### PR DESCRIPTION
Related conversation:

[13:40] [DRPrime]-DR:Samyl: "waitcastrt? doesn't seem to be working quite right.  It's registering 0 time left, but the spell isn't yet fully prepared.  What'm I doing wrong?"
[13:41] [DRPrime]-DR:Atanamir: "waitcastrt? is inherently unreliable"
[13:41] [DRPrime]-DR:Sarvatt: "its lag to the server"
[13:41] [DRPrime]-DR:Atanamir: "due to lag to the server, yeah"
[13:41] [DRPrime]-DR:Atanamir: "it should include a sleep after it in nearly every case"
[13:42] [DRPrime]-DR:Samyl: "Okay... It's peppered throughout common-arcana (without a pause) eg with Buff.  What is the SOP to deal with that?"
[13:42] [DRPrime]-DR:Atanamir: "yes....I know... /teethgrit"
[13:42] [DRPrime]-DR:Samyl: "Just reduce my mana target? Add a prep time?"
[13:44] [DRPrime]-DR:Atanamir: "at some point I'm going to get fed up and actually submit a pr to include a sleep after every waitcastrt?...eventually"
[13:44] [DRPrime]-DR:Atanamir: "annoyance has not yet tipped over the wall of laziness just yet"
[13:44] [DRPrime]-DR:Samyl: "Might it be better to add a method to common_arcana called waitcastrt_pause? that does waitcastrt and adds a configurable pause?"
[13:45] [DRPrime]-DR:Yggrald: "pauses aren't robust tho"
[13:45] [DRPrime]-DR:Atanamir: "I see a project in your future, good sir or madame"
[13:46] [DRPrime]-DR:Samyl: "I will do this if it's the approach the community would prefer.. I just need a vague consensus.  eg Yggrald thinks adding a pause won't work.  A Fully Prepared flag also seems fragile."
[13:46] [DRPrime]-DR:Atanamir: "waitcastrt? does most of the work, but given latency, it always falls just short.  A pause coupled with waitcastrt is robust enough"
[13:46] [DRPrime]-DR:Yggrald: "if you have a handle on your max latency yes it'd be fine"
[13:47] [DRPrime]-DR:Atanamir: "I wonder if anyone suffers from more than a 2 second latency these days"
[13:47] [DRPrime]-DR:Yggrald: "I do sometimes"
[13:47] [DRPrime]-DR:Atanamir: "yeesh"
[13:47] [DRPrime]-DR:Yggrald: "but i don't use that function either way so my opinion doens't matter"
[13:48] [DRPrime]-DR:Atanamir: "do you have a better idea how to address the existing shortcomings of waitcastrt?"
[13:48] [DRPrime]-DR:Yggrald: "no i'm just shitting on your dreams :-/"
[13:48] [DRPrime]-DR:Atanamir: "Ahh, ok.  Carry on! :D"
[13:48] [DRPrime]-DR:Sarvatt: "waitcastrt is hardcoded to add a 60ms delay so if your ping is over that RIP"
[13:49] [DRPrime]-DR:Ashalf: "that's what 60000ms?"
[13:49] [DRPrime]-DR:Yggrald: "no it's 60 ms"
[13:49] [DRPrime]-DR:Atanamir: "Um"
[13:49] [DRPrime]-DR:Ashalf: "oshit, I read that as 60s delay"
[13:49] [DRPrime]-DR:Ashalf: "I'm a horrible person."
[13:49] [DRPrime]-DR:Yggrald: "hahaha"
[13:50] [DRPrime]-DR:Sarvatt: "https://github.com/rcuhljr/dr-lich/blob/master/lich.rbw#L4471"
[13:50] [DRPrime]-DR:Atanamir: "1s is 1000 ms"
[13:50] [DRPrime]-DR:Atanamir: "I deal with them all day long"
[13:50] [DRPrime]-DR:Atanamir: "I promise"
[13:51] [DRPrime]-DR:Barder: "but do you pinkie swear?"
[13:51] [DRPrime]-DR:Atanamir: "only for you Barder"
[13:51] [DRPrime]-DR:Atanamir: "oh, I missed the 60ms mention, my bad"
