### PR TITLE
craft.lic: remove forging workorder support.

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -101,15 +101,6 @@ class Craft
   end
 
   def train_forging
-    eligible = @settings.train_workorders & %w[Blacksmithing Weaponsmithing]
-    unless eligible.empty?
-      return unless money_for_training?(5000, 'Forging')
-      wait_for_script_to_complete('workorders', [eligible.first])
-      wait_for_script_to_complete('sell-loot')
-      walk_to(@training_room)
-      return
-    end
-
     rank = DRSkill.getrank('Forging')
     if rank <= 25 # Tier 1 - Extremely Easy
       smith('a shallow metal cup')


### PR DESCRIPTION
This is handled by crossing-training instead. Missed this craft when removing workorder support from all the others.