### PR TITLE
Update rezz.lic - rezz not cleared from active spell

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -145,6 +145,7 @@ class Rezz
       return
     end
     echo "*** It took #{@infuse_attempts * @rezz['mana']} infused mana to find #{player}'s soul. ***"
+    pause 0.1 while DRSpells.active_spells['Resurrection']
   end
 end
 


### PR DESCRIPTION
I ran into an issue while rezzing multiple deaders in 1 room and another cleric rejuving.  After the first rezz, it checked the second one and since they were silver it went straight to rezzing.  Rezz was still listed in active spells though, so it tried to infuse with rezz not actually up.
I added in a pause loop at the end of the rezz section to wait for it to clear out of the active spells.
Another option is to add in a match on line 89 where it infuses the mana and handling it from there.