### PR TITLE
validate.lic: Add validation that dance_skill is correct

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -88,6 +88,13 @@ class DRYamlValidator
             .each { |skill_name| error("Invalid weapon_training: skill name '#{skill_name}'. Valid skills are '#{@valid_weapon_skills}'") }
   end
 
+  def assert_that_dance_skill_is_skill(settings)
+    return unless settings.dance_skill
+    return if settings.dance_skill.include?('#{@valid_melee_skill}')
+
+    error("Dance skill '#{settings.dance_skill}' is not valid. Valid skills are  '#{@valid_melee_skills}'")
+  end
+
   def assert_that_priority_weapons_are_skills(settings)
     return unless settings.priority_weapons
 

--- a/validate.lic
+++ b/validate.lic
@@ -90,9 +90,8 @@ class DRYamlValidator
 
   def assert_that_dance_skill_is_skill(settings)
     return unless settings.dance_skill
-    return if settings.dance_skill.include?('#{@valid_melee_skill}')
 
-    error("Dance skill '#{settings.dance_skill}' is not valid. Valid skills are  '#{@valid_melee_skills}'")
+    error("dance_skill: skill name '#{settings.dance_skill}' is not valid. Valid skills are '#{@valid_melee_skills}'") unless @valid_melee_skills.include?(settings.dance_skill)
   end
 
   def assert_that_priority_weapons_are_skills(settings)


### PR DESCRIPTION
This came up on lnet yesterday.

[validate: ERROR:< Dance skill 'greatsword' is not valid. Valid skills are  '["Offhand Weapon", "Brawling", "Polearms", "Large Blunt", "Twohanded Blunt", "Staves", "Small Blunt", "Small Edged", "Large Edged", "Twohanded Edged"]'  >]