### PR TITLE
Add an optional Armor Swap Hysteresis Logic

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -116,10 +116,8 @@ class SetupProcess
         @equipment_manager.wear_items(@equipment_manager.desc_to_items(@cycle_armors[@default_armor]))
         @last_worn_type = @default_armor
       end
-      return true
-    else
-      return false
     end
+    true
   end
   
   def check_armor_swap(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -129,7 +129,6 @@ class SetupProcess
     toggle_armor_hysteresis?
     return if @armor_hysteresis
     return if Time.now - @last_cycle_time < @cycle_armors_time
-    return if Time.now - @last_cycle_time < @cycle_armors_time
     return if game_state.loaded
     armor_types = @cycle_armors.map { |skill, _| skill }
     next_armor_type = armor_types.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -22,7 +22,7 @@ class SetupProcess
     echo("  @cycle_armors: #{@cycle_armors}") if $debug_mode_ct
     @cycle_armors_time = settings.cycle_armors_time
     echo("  @cycle_armors_time: #{@cycle_armors_time}") if $debug_mode_ct
-    @armor_hysteresis = settings.armor_cycle_hysteresis || false
+    @armor_hysteresis = settings.armor_cycle_hysteresis
     echo("  @armor_hysteresis: #{@armor_hysteresis}") if $debug_mode_ct
     @last_cycle_time = Time.now - @cycle_armors_time
     @combat_training_abilities_target = settings.combat_training_abilities_target
@@ -107,27 +107,23 @@ class SetupProcess
     game_state.wield_whirlwind_offhand
   end
   
-  def toggle_ah(mode)
-    @armor_hysteresis = mode
-    echo("*** armor hysteresis: #{@armor_hysteresis} ***")
-  end
-  
-  def toggle_armor_hysteresis?
-    if @armor_hysteresis == true
-      toggle_ah(false) if @cycle_armors.keys.any? { |skill| DRSkill.getxp(skill) < 25 }
-    elsif @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
-      toggle_ah(true)
+  def armor_hysteresis?
+    return false unless @armor_hysteresis
+    return false if @cycle_armors.keys.any? { |skill| DRSkill.getxp(skill) < 25 }
+    if @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
       if @last_worn_type != @default_armor
         @equipment_manager.worn_items(@all_swap_pieces).each { |item| @equipment_manager.remove_item(item) }
         @equipment_manager.wear_items(@equipment_manager.desc_to_items(@cycle_armors[@default_armor]))
         @last_worn_type = @default_armor
       end
+      return true
+    else
+      return false
     end
   end
   
   def check_armor_swap(game_state)
-    toggle_armor_hysteresis?
-    return if @armor_hysteresis
+    return if armor_hysteresis?
     return if Time.now - @last_cycle_time < @cycle_armors_time
     return if game_state.loaded
     armor_types = @cycle_armors.map { |skill, _| skill }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -22,6 +22,8 @@ class SetupProcess
     echo("  @cycle_armors: #{@cycle_armors}") if $debug_mode_ct
     @cycle_armors_time = settings.cycle_armors_time
     echo("  @cycle_armors_time: #{@cycle_armors_time}") if $debug_mode_ct
+    @armor_hysteresis = settings.armor_cycle_hysteresis || false
+    echo("  @armor_hysteresis: #{@armor_hysteresis}") if $debug_mode_ct
     @last_cycle_time = Time.now - @cycle_armors_time
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
@@ -104,8 +106,29 @@ class SetupProcess
 
     game_state.wield_whirlwind_offhand
   end
-
+  
+  def toggle_ah(mode)
+    @armor_hysteresis = mode
+    echo("*** armor hysteresis: #{@armor_hysteresis} ***")
+  end
+  
+  def toggle_armor_hysteresis?
+    if @armor_hysteresis == true
+      toggle_ah(false) if @cycle_armors.keys.any? { |skill| DRSkill.getxp(skill) < 25 }
+    elsif @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
+      toggle_ah(true)
+      if @last_worn_type != @default_armor
+        @equipment_manager.worn_items(@all_swap_pieces).each { |item| @equipment_manager.remove_item(item) }
+        @equipment_manager.wear_items(@equipment_manager.desc_to_items(@cycle_armors[@default_armor]))
+        @last_worn_type = @default_armor
+      end
+    end
+  end
+  
   def check_armor_swap(game_state)
+    toggle_armor_hysteresis?
+    return if @armor_hysteresis
+    return if Time.now - @last_cycle_time < @cycle_armors_time
     return if Time.now - @last_cycle_time < @cycle_armors_time
     return if game_state.loaded
     armor_types = @cycle_armors.map { |skill, _| skill }


### PR DESCRIPTION
Stops swapping armors once all armors in swap cycle are above 32/34.
Equips the user's 'default' armor set once it toggles on hysteresis.
Will resume armor swapping after any of them drop below 25/34.