### PR TITLE
Common-Arcana: Pause after casting

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -128,6 +128,8 @@ module DRCA
     when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
       DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    when /You gesture/
+      pause 0.25
     end
     waitrt?
 


### PR DESCRIPTION
This will give more time for the game to return a backfire message.
Currently the method returns too quickly in some instances, reporting a
backfire as a successful cast.

Note: This commit is cherry-picking from a Jan 21 commit on my fork.