### PR TITLE
Revert "sanowret-crystal.lic: skip the loop if you are in any scripts…

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -60,7 +60,7 @@ class SanowretCrystal
 
   def passive
     loop do
-      next if @invalid_rooms.include?(Room.current.id) || Script.running?('sew') || Script.running?('carve') || Script.running?('forge') || Script.running?('remedy')  || Script.running?('shape') || Script.running?('outdoorsmanship') || Script.running?('combat-trainer')
+      next if @invalid_rooms.include?(Room.current.id)
       check_crystal
       pause 10
     end


### PR DESCRIPTION
… where you need concentration. (#2946)"

This reverts commit bf3c9c944f24ef8ea199c4063b8158389fdfd7e1.
It was making it constantly loop using too much cpu when any of those scripts were running. I'll fix it properly another way but this is needed now.