### PR TITLE
base.yaml: switch cycle_armors_hysteresis to be enabled by default. There…

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -38,7 +38,7 @@ default_stance: 100 0 80
 stance_override:
 cycle_armors:
 cycle_armors_time: 125
-cycle_armors_hysteresis: false
+cycle_armors_hysteresis: true
 skinning:
   skin: true
   arrange_all: false


### PR DESCRIPTION
… is no reason not to be smarter about cycling armors instead of using a dumb timer.