### PR TITLE
crossing-training.lic: Don't call outdoorsmanship.lic 4 times, you on…

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -683,9 +683,6 @@ class CrossingTraining
           check_research
           break if DRSkill.getxp('Athletics') >= 29
           train_outdoorsmanship
-          train_outdoorsmanship
-          train_outdoorsmanship
-          train_outdoorsmanship
         end
       end
     end


### PR DESCRIPTION
…ly want 4 collects for undergondola which is the default for calling outdoorsmanship.lic with no args now. train_outdoors in ct just calls that script. in athletics.lic it uses collect() directly 4 times instead of calling out to another script.