### PR TITLE
bescort: Disable gate access for criminals

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1147,7 +1147,7 @@ class Bescort
     end
     Flags.add('bescort-ur-a-criminal', 'a wanted criminal')
     case bput('go gate', 'You pass', 'KNOCK', 'errant shadow')
-    when 'You pass'
+    when 'KNOCK'
       if Flags['bescort-ur-a-criminal']
         # HACK: This turns off gate access until you log out. A better solution is desired
         Room.current.timeto[Room.current.timeto.keys.find { |room| gate_rooms.to_s.include?(room) }] = nil

--- a/bescort.lic
+++ b/bescort.lic
@@ -1140,17 +1140,27 @@ class Bescort
   end
 
   def use_shard_gates
-    unless [2640, 2658, 2807, 2525, 6452, 2516].include?(Room.current.id)
+    gate_rooms = [2640, 2658, 2807, 2525, 6452, 2516]
+    unless gate_rooms.include?(Room.current.id)
       echo 'You are not at the Shard gates'
       return
     end
-
+    Flags.add('bescort-ur-a-criminal', 'a wanted criminal')
     case bput('go gate', 'You pass', 'KNOCK', 'errant shadow')
-    when 'KNOCK'
+    when 'You pass'
+      if Flags['bescort-ur-a-criminal']
+        # HACK: This turns off gate access until you log out. A better solution is desired
+        Room.current.timeto[Room.current.timeto.keys.find { |room| gate_rooms.to_s.include?(room) }] = nil
+        return
+      end
       release_invisibility
       bput('knock gate', 'You knock')
     end
   end
+end
+
+before_dying do
+  Flags.delete('bescort-ur-a-criminal')
 end
 
 Bescort.new


### PR DESCRIPTION
A hardened criminal has reported that the guards do not support
citizens usage of the town gates when they are wanted, so a check
has been added to disable access when they are denied access for being
up to no good.