### PR TITLE
add arrow and bolt to Hib/Boar Clan

### DIFF
--- a/data/base-consumables.yaml
+++ b/data/base-consumables.yaml
@@ -73,6 +73,20 @@ Riverhaven:
     stackable: true
     quantity: 30
 Hibarnhvidar:
+  arrow:
+    name: long arrows
+    room: 12172
+    price: 649
+    size: 10
+    stackable: true
+    quantity: 30
+  bolt:
+    name: crossbow bolts
+    room: 12172
+    price: 405
+    size: 15
+    stackable: true
+    quantity: 30
   tk_ammo:
     name: big-fist katar
     room: 12172


### PR DESCRIPTION
just moved someone to Hib and realized this wasn't added. tested the change and it worked. technically the purchase is in Boar Clan but I don't know of a shop in Hib itself.