### PR TITLE
base-spells.yaml: Add message for having too low arcana to use cambri…

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -6,6 +6,7 @@ charge_messages:
 - only absorbing part of the energy
 - already holding as much power
 - lack the mental stamina to charge
+- resists your efforts to charge it
 
 invoke_messages:
 - You reach for its center


### PR DESCRIPTION
…nth to quiet the bput

[combat-trainer: message: The cambrinth ring resists your efforts to charge it, and your energy is wasted.]
[combat-trainer: message: You harness a small amount of energy and attempt to channel it into your cambrinth ring.]
[combat-trainer: checked against [/You'll have to hold it/i, /You are in no condition to do that/i, /(absorb|absorbs) all of the energy/i, /only absorbing part of the energy/i, /already holding as much power/i, /lack the mental stamina to charge/i]]
[combat-trainer: for command charge my cambrinth ring 1]