### PR TITLE
base-theurgy.yaml: Various changes to accomidate favor altars

### DIFF
--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -43,6 +43,47 @@ immortal_to_aspect:
   Berengaria: cow
   Divyaush: welkin
 
+aspect_to_primer:
+  raven: 101
+  unicorn: 102
+  wolf: 103
+  panther: 104
+  boar: 105
+  ox: 106
+  cobra: 107
+  dolphin: 108
+  ram: 109
+  cat: 110
+  wren: 111
+  lion: 112
+  scorpion: 113
+  welkin: 201
+  cow: 202
+  owl: 203
+  nightingale: 204
+  wolverine: 205
+  magpie: 206
+  kingsnake: 207
+  albatross: 208
+  donkey: 209
+  dove: 210
+  phoenix: 211
+  mongoose: 212
+  jackal: 213
+  raccoon: 301
+  adder: 302
+  shrew: 303
+  shrike: 304
+  centaur: 305
+  weasel: 306
+  viper: 307
+  shark: 308
+  coyote: 309
+  spider: 310
+  heron: 311
+  goshawk: 312
+  vulture: 313
+
 Crossing:
   herbs:
     - sage
@@ -208,6 +249,10 @@ Crossing:
     Urrem'tier:
       id: 5846
       adjective: onyx
+  holy_water:
+    id: 5779
+    noun: basin
+  primer_npc: shaman
 
 Ratha:
   # TODO: limb foraging here and below


### PR DESCRIPTION
Add aspect_to_primer to map the npc order numbers, and add the primer npc name and start tracking free holy water rooms.

I have an updated favor.lic to use the altars, but would like to get the data in first so more people can test it easily.