### PR TITLE
rezz.lic: Delete rotting flag, update rejuv method

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -69,10 +69,10 @@ class Rezz
   end
 
   def rejuv(player, quick = false)
-    @rejuv = { 'abbrev' => 'rejuv', 'prep_time' => 5, 'cast' => "cast #{player}", 'mana' => 10 } if quick
+    quick ? spell = { 'abbrev' => 'rejuv', 'prep_time' => 5, 'cast' => "cast #{player}", 'mana' => 10 } : spell = @rejuv
     until Flags['rejuv-silver'] || Flags['necro']
       pause 5 while DRStats.mana < 40
-      cast_spell(@rejuv, @settings)
+      cast_spell(spell, @settings)
     end
   end
 
@@ -157,6 +157,7 @@ before_dying do
   Flags.delete('dead')
   Flags.delete('decaying')
   Flags.delete('necro')
+  Flags.delete('rotting')
 end
 
 Rezz.new


### PR DESCRIPTION
Added a line to delete the rotting flag before dying (it's created in def find_soul?).

Edited the rejuv method.  It was overwriting the global @rejuv variable if it was called with quick = true.  This would only cause an issue if you're trying to rezz more than 1 body, ie: you called it with just ;rezz, and there are multiple bodies in the room.  It would be rejuving the second body with the quick settings.

Now it creates a variable in the method and sets it either to @rejuv or the quick rejuv settings.