### PR TITLE
base-spells.yaml: Release AEG or MOF before casting the opposite one

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -339,6 +339,11 @@ spell_data:
     abbrev: AEG
     ritual: true
     mana: 300
+    before:
+    - message: release mof
+      matches:
+      - Your body is no longer imbued with Fire.
+      - Release what?
     recast: 2
   Aesandry Darlaeth:
     skill: Augmentation
@@ -1155,6 +1160,11 @@ spell_data:
     abbrev: MOF
     mana: 300
     ritual: true
+    before:
+    - message: release aeg
+      matches:
+      - The Earth energy flows from your body, returning to its rightful place in the ground beneath your feet
+      - Release what?
     recast: 2
   Mark of Arhat:
     skill: Debilitation


### PR DESCRIPTION
Added before sections to Aegis of Granite and Mantle of Flame to release the other elemental transformation before trying to cast the specified one.