### PR TITLE
Added Segoltha climbing bank in Crossing

### DIFF
--- a/data/base-athletics.yaml
+++ b/data/base-athletics.yaml
@@ -76,7 +76,7 @@ practice_options:
       id:  2245
       target: branch
       hide: true
-  #Segoltha Riverbank in Crossing (350 - 900+)
+  #Segoltha Riverbank in Crossing (280 - 700+)
   segoltha_bank:
       id: 922
       target: bank

--- a/data/base-athletics.yaml
+++ b/data/base-athletics.yaml
@@ -76,6 +76,10 @@ practice_options:
       id:  2245
       target: branch
       hide: true
+  #Segoltha Riverbank in Crossing
+      id: 922
+      target: bank
+      hide: false
 ####################################
 ##########                ##########
 ##########    ILITHI      ##########

--- a/data/base-athletics.yaml
+++ b/data/base-athletics.yaml
@@ -76,7 +76,7 @@ practice_options:
       id:  2245
       target: branch
       hide: true
-  #Segoltha Riverbank in Crossing
+  #Segoltha Riverbank in Crossing (350 - 900+)
       id: 922
       target: bank
       hide: false

--- a/data/base-athletics.yaml
+++ b/data/base-athletics.yaml
@@ -77,6 +77,7 @@ practice_options:
       target: branch
       hide: true
   #Segoltha Riverbank in Crossing (350 - 900+)
+  segoltha_bank:
       id: 922
       target: bank
       hide: false


### PR DESCRIPTION
Added this as an alternative to the default climbing of the branch by the gondola because characters without stealth skill cannot do that spot.  