### PR TITLE
Base-recipes: remove duplicate entries

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -1419,6 +1419,12 @@ crafting_recipes:
   type: tailoring
   work_order: true
   chapter: 2
+- name: some flowing cloth robes
+  noun: robes
+  volume: 9
+  type: tailoring
+  work_order: true
+  chapter: 2
 - name: a cloth mage's robe
   noun: robe
   volume: 9
@@ -1853,24 +1859,6 @@ crafting_recipes:
   chapter: 2
 - name: a deeply-hooded cloak
   noun: cloak
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth shaman's robe
-  noun: robe
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some flowing cloth robes
-  noun: robes
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth mage's robe
-  noun: robe
   volume: 9
   type: tailoring
   work_order: false


### PR DESCRIPTION
Some of the robe items were listed twice. I left in the ones with workorders turned on