### PR TITLE
 Add astrology prediction targets.

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -32,6 +32,11 @@ class Astrology
     @ap_destination = settings.astral_plane_training['train_destination']
     @prediction_pool_target = settings.astrology_use_full_pools ? 10 : settings.astrology_pool_target
     @rtr_data = nil
+    @astrology_prediction_skills_magic = settings.astrology_prediction_skills['magic']
+    @astrology_prediction_skills_lore = settings.astrology_prediction_skills['lore']
+    @astrology_prediction_skills_offense = settings.astrology_prediction_skills['offense']
+    @astrology_prediction_skills_defense = settings.astrology_prediction_skills['defense']
+    @astrology_prediction_skills_survival = settings.astrology_prediction_skills['survival']
     echo " Flags['rtr-expire'].nil? #{Flags['rtr-expire'].nil?}" if UserVars.astrology_debug
     echo " Flags['rtr-expire'] = #{Flags['rtr-expire']}" if UserVars.astrology_debug
 
@@ -184,11 +189,11 @@ class Astrology
 
   def predict_all(pools)
     skillset_to_pool = {
-      'offensive combat' => 'offense',
-      'defensive combat' => 'defense',
-      'magic' => 'magic',
-      'survival' => 'survival',
-      'lore' => 'lore',
+      'offensive combat' => @astrology_prediction_skills_offense,
+      'defensive combat' => @astrology_prediction_skills_defense,
+      'magic' => @astrology_prediction_skills_magic,
+      'survival' => @astrology_prediction_skills_survival,
+      'lore' => @astrology_prediction_skills_lore,
       'future events' => 'future events'
     }
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -820,6 +820,12 @@ astrology_training:
 - attunement
 #- moons #Deprecated
 #- events
+astrology_prediction_skills:
+  magic: magic
+  lore: lore
+  offense: offense
+  defense: defense
+  survival: survival
 
 learned_column_count: 2
 sort_auto_head: true


### PR DESCRIPTION
 Negative predictions can sometimes ruin hunting. These changes keep the core logic in the base.yaml in case people don't want to mess with it, but allow for the overriding of the prediction targets to skills that the user determined as necessary.