### PR TITLE
Added a loaded=true to aim method for case statement.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2432,6 +2432,8 @@ class AttackProcess
 
   def aim(game_state)
     case bput('aim', 'You begin to target', 'You are already', 'There is nothing else', 'Face what\?', 'You shift your target', 'Your repeating crossbow', 'Your assassin\'s crossbow', 'Your repeating arbalest', 'Strangely, you don\'t feel like fighting right now', 'Your riot crossbow')
+    when 'You are already'
+      game_state.loaded = true
     when 'Your repeating crossbow', 'Your assassin\'s crossbow', 'Your riot crossbow'
       case bput('push my cross', 'A rapid series of clicks', 'You attempt to ready your repeating crossbow', 'You attempt to ready your assassin\'s crossbow', 'You attempt to ready your riot crossbow')
       when 'A rapid series of clicks'


### PR DESCRIPTION
This will fix the issue with load/aim. 

```
[combat-trainer]>aim
You begin to target a void-black umbral moth.
[combat-trainer]>wield my throwing.hammer
You draw out your throwing hammer from the multi-strapped carryall, gripping it firmly in your left hand.
[combat-trainer]>throw left
< Attacking gracefully, you throw a haralun throwing hammer at a void-black umbral moth.  A void-black umbral
  moth barely fails to block with uncanny wings.  The hammer lands a hard hit (5/23) that explodes the heart and
  lungs with a bone-shattering blow to the chest.
The throwing hammer falls to the ground!
A void-black umbral moth's wings spasm one last time, drifting away from its body like a cloud of acrid smoke.
  The creature goes still, now nothing more than an ungainly mound of disintegrating shadow.
[You're nimbly balanced]
[Roundtime 4 sec.]
>
In a weak and directionless display of aggression, a void-black umbral moth swings at Brahmer.  Brahmer dodges,
  twisting to one side.
>
The moth stretches its dark wings wide, their substance seeming to shift and whirl like smoke tattered by a brisk
  wind.
>
Brahmer completes arranging the moth's corpse to increase the chance of a high quality prize.
[combat-trainer]>get my throwing hammer
You pick up the hammer lying at your feet.
[combat-trainer]>throw left
You turn to face a void-black umbral moth.
< Moving skillfully, you throw a haralun throwing hammer at a void-black umbral moth.  A void-black umbral moth
  barely fails to block with uncanny wings.  The hammer lands a hard hit (5/23) that breaks the right femur with
  a sickening crunch of splintered bone, stunning it.
The throwing hammer falls to the ground!
A void-black umbral moth crashes to the ground amid its massive wings, moaning in a soundless timbre.
[You're winded, nimbly balanced and overwhelming opponent.]
[Roundtime 3 sec.]
>
The void-black moth begins to advance on Brahmer.
>
* Looking as if this were a bad idea, a void-black umbral moth stabs at you.  You evade, twisting to one side.
[You're winded, nimbly balanced and opponent has slight advantage.]
[You're winded, nimbly balanced and opponent has slight advantage.]
[combat-trainer]>get my throwing hammer
You think you have your best shot possible now.
>
The void-black moth begins to advance on you!
The void-black moth advances from nearby and is closing steadily.
>
A void-black umbral moth staggers about drunkenly, its massive wings losing coherence.
>
You pick up the hammer lying at your feet.
[combat-trainer]>throw left
< Driving in with exacting precision, you throw a haralun throwing hammer at a void-black umbral moth.  A
  void-black umbral moth attempts to evade, avoiding most of the blow.  The hammer lands a strong hit (6/23) that
  breaks the right arm.
The throwing hammer falls to the ground!
A void-black umbral moth's wings spasm one last time, drifting away from its body like a cloud of acrid smoke.
  The creature goes still, now nothing more than an ungainly mound of disintegrating shadow.
[You're nimbly balanced]
[Roundtime 3 sec.]
>

Working deftly, Brahmer skillfully removes a moth antenna from the remains of a void-black umbral moth.
Brahmer carefully fits a void-black moth antenna into his bundle.
[combat-trainer]>get my throwing hammer
You pick up the hammer lying at your feet.
[combat-trainer]>sheath my throwing.hammer
You sheathe the throwing hammer in your multi-strapped carryall.
[combat-trainer]>roar quiet wail
The technique of the Banshee's Wail flows fluidly through your mind an instant before you unleash its power
  through a roar of fatal intent.
A void-black umbral moth appears to be frozen with fear!
A void-black umbral moth appears to be frozen with fear!
A void-black umbral moth appears to be frozen with fear!
Roundtime: 2 sec.
>
Blood pumping loudly, you whip about in a tumultuous fury.
>
The void-black moth's massive proboscis licks the air lasciviously as it stands motionless.
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You turn to face a void-black umbral moth.
You turn to face a void-black umbral moth.
You shift your target to a void-black umbral moth.
>
Brahmer bends over the moth's corpse briefly.
[combat-trainer]>stow carnelian
You pick up a small chestnut carnelian.
You open your pouch and put the chestnut carnelian inside, closing it once more.
>
The void-black moth closes to pole weapon range on Brahmer.
>
You feel fully rested.
>
A void-black umbral moth glides in, shadows seeming to warp as it passes.
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
Brahmer scans the area briefly.
>
You are already targetting that!
[combat-trainer]>load
>
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>bob
You bob suddenly, lowering yourself into a smaller target.
[You're winded, adeptly balanced and in dominating position.]
Roundtime: 3 sec.
>
The void-black moth closes to melee range on Brahmer.
>
The void-black moth's massive proboscis licks the air lasciviously as it stands motionless.
[combat-trainer]>load
You think you have your best shot possible now.
>
Moving well, a void-black umbral moth lunges at Brahmer.  Brahmer badly fails to parry with a tyrium scimitar.
  The proboscis lands a brushing (0/23) hit to his chest!
>
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
>
The void-black moth's massive proboscis licks the air lasciviously as it stands motionless.
>
A void-black umbral moth's shadowy form roils and churns, slowly sifting away to nothing.
>
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
>
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
You are already targetting that!
[combat-trainer]>load
Your forester's crossbow is already loaded with a crossbow bolt.
[combat-trainer]>aim
A void-black umbral moth growls and shakes off the fear that was holding it frozen.
```