### PR TITLE
skill-recorder.lic: Various fixes.

### DIFF
--- a/skill-recorder.lic
+++ b/skill-recorder.lic
@@ -8,13 +8,6 @@ UserVars.thief_tunnels = {}
 if DRStats.guild == 'Cleric' && DRC.bput('spells', '\[rezz\]', 'You can use SPELL STANCE') == '[rezz]'
   UserVars.know_rezz = true
 end
-if DRStats.guild == 'Thief' && DRStats.circle > 5 && UserVars.athletics >= 25
-  UserVars.thief_tunnels['crossing_leth'] = true
-end
-if DRStats.guild == 'Thief' && DRStats.circle > 5
-  UserVars.thief_tunnels['shard_passages'] = true
-  UserVars.thief_tunnels['crossing_passages'] = true
-end
 
 loop do
   pause 30
@@ -25,5 +18,12 @@ loop do
   end
   if DRStats.guild == 'Ranger'
     UserVars.scouting = DRSkill.getrank('Scouting')
+  end
+  if DRStats.guild == 'Thief' && DRStats.circle > 5 && UserVars.athletics >= 25
+    UserVars.thief_tunnels['crossing_leth'] = true
+  end
+  if DRStats.guild == 'Thief' && DRStats.circle > 5
+    UserVars.thief_tunnels['shard_passages'] = true
+    UserVars.thief_tunnels['crossing_passages'] = true
   end
 end

--- a/skill-recorder.lic
+++ b/skill-recorder.lic
@@ -8,19 +8,22 @@ UserVars.thief_tunnels = {}
 if DRStats.guild == 'Cleric' && DRC.bput('spells', '\[rezz\]', 'You can use SPELL STANCE') == '[rezz]'
   UserVars.know_rezz = true
 end
+if DRStats.guild == 'Thief' && DRStats.circle > 5 && UserVars.athletics >= 25
+  UserVars.thief_tunnels['crossing_leth'] = true
+end
+if DRStats.guild == 'Thief' && DRStats.circle > 5
+  UserVars.thief_tunnels['shard_passages'] = true
+  UserVars.thief_tunnels['crossing_passages'] = true
+end
+
 loop do
-  pause 2
+  pause 30
   clear
   UserVars.athletics = DRSkill.getrank('Athletics')
   if DRSpells.active_spells['Athleticism'] || DRSpells.active_spells['Khri Flight'] || DRSpells.active_spells['Unyielding']
     UserVars.athletics = UserVars.athletics * 1.1
   end
-  UserVars.scouting = DRSkill.getrank('Scouting')
-  if DRStats.guild == 'Thief' && DRStats.circle > 5 && UserVars.athletics >= 25
-    UserVars.thief_tunnels['crossing_leth'] = true
-  end
-  if DRStats.guild == 'Thief' && DRStats.circle > 5
-    UserVars.thief_tunnels['shard_passages'] = true
-    UserVars.thief_tunnels['crossing_passages'] = true
+  if DRStats.guild == 'Ranger'
+    UserVars.scouting = DRSkill.getrank('Scouting')
   end
 end


### PR DESCRIPTION
Move the thief tunnel checks to script startup and outside of the loop.
Only record the scouting uservar if you are a ranger.
up the time of the loop, checking the skills to update the db every 2 seconds is excessive.