### PR TITLE
base-crafting updates for Muspar'i Societies

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -56,6 +56,40 @@ blacksmithing:
     idle-room: 8775
   Leth Deriel:
     << : *zoluren_blacksmithing
+  Muspar'i:
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+     - 11260
+     - 11261
+     - 11263
+     - 11264
+     - 11262
+     - 11265
+     - 11266
+     - 11267
+     - 14348
+    anvils:
+      - 14349
+    crucibles:
+      - 14350
+    grindstones:
+      - 14349
+    logbook: forging
+    pattern-book: blacksmithing
+    finisher: oil
+    finisher-full: flask of oil
+    finisher-room: 11263
+    finisher-number: 6
+    repair-room: 11267
+    repair-npc: Rokumru
+    stock-volume: 5
+    stock-room: 11264
+    stock-number: 11
+    stock-name: bronze ingot
+    trash-room: 14350
+    idle-room: 11260
+    part-room: 11263
   Riverhaven:
     npc: Fereldrin
     npc_last_name: Fereldrin
@@ -415,6 +449,34 @@ tailoring:
     knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 9127
+  Muspar'i: 
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+    - 11255
+    - 11254
+    - 11256
+    - 11251
+    - 11252
+    - 11253
+    - 11249
+    - 11250
+    - 11259
+    sewing-rooms:
+    - 11257 #Only one due to the other rooms having identical descriptions.
+    spinning-rooms:
+    - 11258
+    logbook: outfitting
+    repair-room: 11254
+    repair-npc: Mhhrval
+    stock-room: 11252
+    tool-room: 11253
+    sew-stock-number: 8
+    sew-stock-name: burlap
+    knit-stock-number: 13
+    knit-stock-name: wool
+    pattern-book: tailoring
+    idle-room: 11251
 shaping:
   Crossing: &zoluren_shaping
     npc: Talia
@@ -526,6 +588,34 @@ shaping:
     - 9578
     - 9579
     - 9580
+  Muspar'i:
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+    - 11269
+    - 11268
+    - 11270
+    - 11271
+    - 11272
+    - 11276
+    - 12414
+    - 11273
+    - 11274
+    - 11275
+    shaping-rooms:
+    - 11273
+    - 11274
+    - 11275
+    logbook: engineering
+    repair-room: 11269
+    repair-npc: Sizlldan
+    stock-room: 11272
+    stock-number: 10
+    stock-name: maple
+    stock-volume: 5
+    pattern-book: shaping
+    part-room: 11272
+    idle-room: 11268
 carving:
   Crossing: &zoluren_carving
     npc: Talia
@@ -601,6 +691,35 @@ carving:
     - 9578
     - 9579
     - 9580
+  Muspar'i:
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+    - 11269
+    - 11268
+    - 11270
+    - 11271
+    - 11272
+    - 11276
+    - 12414
+    - 11273
+    - 11274
+    - 11275
+    logbook: engineering
+    repair-room: 11269
+    repair-npc: Sizlldan
+    polish: polish
+    polish-room: 11276
+    polish-number: 4
+    stock-room: 11272
+    stock-number: 1
+    stock-name: alabaster
+    stock-volume: 1
+    stock-bone-number: 8
+    stock-bone-name: wolf
+    stock-bone-volume: 10
+    pattern-book: carving
+    part-room: 11272
 
 remedies:
   Crossing: &zoluren_remedies
@@ -679,6 +798,31 @@ remedies:
     catalyst-room: 4434 # Forging Society
     catalyst_number: 2
     catalyst_volume: 10
+  Muspar'i:
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+    - 12653
+    - 12656
+    - 12658
+    - 12654
+    - 12655
+    - 14347
+    logbook: alchemy
+    repair-room: 12653
+    repair-npc: clerk
+    stock-room: 12654
+    stock-number: 1
+    stock-name: water
+    stock-volume: 10
+    stock-number-a: 2
+    stock-name-a: alcohol
+    stock-volume-a: 10
+    pattern-book: remed
+    catalyst: coal nugget
+    catalyst-room: 11264
+    catalyst_number: 2
+    catalyst_volume: 10 
 deeds:
   Crossing:
     room: 8775
@@ -705,6 +849,11 @@ deeds:
     small_number: 14
     medium_number: 15
     large_number: 16
+  Muspar'i:
+    room: 11268
+    small_number: 1
+    medium_number: 2
+    large_number: 3
 
 recipe_parts:
   small backing:
@@ -717,6 +866,9 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
+    Muspar'i:
+      part-room: 11263
+      part-number:
   large backing:
     Crossing:
       part-room: 8776
@@ -726,6 +878,9 @@ recipe_parts:
       part-number:
     Mer'Kresh:
       part-room: 8810
+      part-number:
+    Muspar'i:
+      part-room: 11263
       part-number:
   small padding:
     Crossing:
@@ -742,6 +897,9 @@ recipe_parts:
       part-number: 11
     Mer'Kresh:
       part-room: 8810
+      part-number:
+    Muspar'i:
+      part-room: 11263
       part-number:
   long pole:
     Crossing:
@@ -762,6 +920,9 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
+    Muspar'i:
+      part-room: 11263
+      part-number:
   short pole:
     Crossing:
       part-room: 8776
@@ -781,6 +942,9 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
+    Muspar'i:
+      part-room: 11263
+      part-number:
   long cord:
     Crossing:
       part-room: 8776
@@ -797,6 +961,9 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
+    Muspar'i:
+      part-room: 11263
+      part-number:
   short.cord:
     Crossing:
       part-room: 8776
@@ -810,6 +977,9 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
+    Muspar'i:
+      part-room: 11263
+      part-number:
   large padding:
     Crossing:
       part-room: 8776
@@ -822,6 +992,9 @@ recipe_parts:
       part-number: 12
     Mer'Kresh:
       part-room: 8810
+      part-number:
+    Muspar'i:
+      part-room: 11263
       part-number:
   hilt:
     Crossing:
@@ -839,6 +1012,9 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
+    Muspar'i:
+      part-room: 11263
+      part-number:
   haft:
     Crossing:
       part-room: 8776
@@ -854,6 +1030,9 @@ recipe_parts:
       part-number:      
     Mer'Kresh:
       part-room: 8810
+      part-number:
+    Muspar'i:
+      part-room: 11263
       part-number:
   shield handle:
     Crossing:
@@ -871,6 +1050,9 @@ recipe_parts:
     Mer'Kresh:
       part-room: 8810
       part-number:
+    Muspar'i:
+      part-room: 11263
+      part-number:
   thread:
     Crossing:
       part-room: 16667
@@ -880,6 +1062,9 @@ recipe_parts:
       part-number: 6
     Riverhaven:
       part-room: 9716
+      part-number: 6
+    Muspar'i:
+      part-room: 11252
       part-number: 6
   pins:
     Crossing:
@@ -891,6 +1076,9 @@ recipe_parts:
     Riverhaven:
       part-room: 9717
       part-number: 5
+    Muspar'i:
+      part-room: 11253
+      part-number: 5
   bow string:
     Crossing:
       part-room: 8864
@@ -900,6 +1088,9 @@ recipe_parts:
       part-number:
     Riverhaven:
       part-room: 9110
+      part-number:
+    Muspar'i:
+      part-room: 11272
       part-number:
   bone backer:
     Crossing:
@@ -914,6 +1105,9 @@ recipe_parts:
     Shard:
       part-room: 19306
       part-number:
+    Muspar'i:
+      part-room: 11272
+      part-number:
   leather strip:
     Crossing:
       part-room: 8864
@@ -927,4 +1121,6 @@ recipe_parts:
     Shard:
       part-room: 19306
       part-number:
-
+    Muspar'i:
+      part-room: 11263
+      part-number:


### PR DESCRIPTION
All disciplines tested through multiple ;workorders after dropping all restockables to demonstrate pulling oil and yarn and whatever.  Forging and Outfitting only support 1 workroom of each type due to identical room descriptions in their sewing, weaving, anvil and crucible rooms.