### PR TITLE
Update ;pick to allow storing harvested trap components

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -137,6 +137,7 @@ class LockPicker
     end
 
     @harvest_traps = !@make_pets && @settings.harvest_traps
+    @component_container = @settings.component_container
     @stop_pick_on_mindlock = !@make_pets && @settings.stop_pick_on_mindlock
     @loot_nouns = @settings.lootables
     echo "Loot nouns: #{@loot_nouns}" if UserVars.lockpick_debug
@@ -221,8 +222,11 @@ class LockPicker
     bput("get my #{box} from my #{@settings.picking_box_source}", 'You get a .* from inside ')
 
     unless disarm?(box)
-      if @settings.picking_box_storage
-        bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in ') if right_hand
+      if @settings.picking_box_storage && right_hand
+		case bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in ', "You just can\'t get", "There isn\'t any more")
+		when "You just can\'t get", "There isn\'t any more"
+			dispose_trash(box)
+		end
       elsif right_hand
         dispose_trash(box)
       end
@@ -452,6 +456,11 @@ class LockPicker
   end
 
   def harvest(box)
+  	patterns = /glass reservoir|steel striker|black cube|chitinous leg|
+				spring|brown clay|animal bladder|sharp blade|tiny hammer|sealed vial|
+				stoppered vial|iron disc|spring|lever|striker|needle|curved blade|silver studs|
+				striker|metal circle|steel pin|broken rune|green runestone|bronze seal|
+				glass sphere|bronze face|black crystal|capillary tube/  
     waitrt?
     case bput("disarm my #{box} harvest",
               /You fumble around with the trap apparatus/,
@@ -463,7 +472,8 @@ class LockPicker
       harvest(box)
     when 'Roundtime'
       waitrt?
-      dispose_trash(left_hand) # only dispose https://elanthipedia.play.net/Locksmithing_skill#Box_Traps items.
+	  fput("put my #{left_hand} in my #{@component_container}") if (@component_container != nil && left_hand =~ patterns)
+      dispose_trash(left_hand)
       while left_hand
       end
     end

--- a/pick.lic
+++ b/pick.lic
@@ -168,6 +168,7 @@ class LockPicker
     open_container(@settings.picking_box_source)
     open_container(@settings.picking_box_storage)
     open_container(@settings.picking_pet_box_source)
+    open_container(@settings.component_container)
   end
 
   def open_container(name)
@@ -223,10 +224,10 @@ class LockPicker
 
     unless disarm?(box)
       if @settings.picking_box_storage && right_hand
-		case bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in ', "You just can\'t get", "There isn\'t any more")
-		when "You just can\'t get", "There isn\'t any more"
-			dispose_trash(box)
-		end
+        case bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in ', "You just can\'t get", "There isn\'t any more")
+          when "You just can\'t get", "There isn\'t any more"
+          dispose_trash(box)
+        end
       elsif right_hand
         dispose_trash(box)
       end
@@ -456,11 +457,11 @@ class LockPicker
   end
 
   def harvest(box)
-  	patterns = /glass reservoir|steel striker|black cube|chitinous leg|
-				spring|brown clay|animal bladder|sharp blade|tiny hammer|sealed vial|
-				stoppered vial|iron disc|spring|lever|striker|needle|curved blade|silver studs|
-				striker|metal circle|steel pin|broken rune|green runestone|bronze seal|
-				glass sphere|bronze face|black crystal|capillary tube/  
+    patterns = /glass reservoir|steel striker|black cube|chitinous leg|
+               spring|brown clay|animal bladder|sharp blade|tiny hammer|sealed vial|
+               stoppered vial|iron disc|spring|lever|striker|needle|curved blade|silver studs|
+               striker|metal circle|steel pin|broken rune|green runestone|bronze seal|
+               glass sphere|bronze face|black crystal|capillary tube/  
     waitrt?
     case bput("disarm my #{box} harvest",
               /You fumble around with the trap apparatus/,
@@ -472,7 +473,7 @@ class LockPicker
       harvest(box)
     when 'Roundtime'
       waitrt?
-	  bput("put my #{left_hand} in my #{@component_container}", 'You put your', "You just can\'t get", "There isn\'t any more") if (@component_container != nil && left_hand =~ patterns)
+      bput("put my #{left_hand} in my #{@component_container}", 'You put your', "You just can\'t get", "There isn\'t any more") if @component_container && left_hand =~ patterns
       dispose_trash(left_hand)
       while left_hand
       end

--- a/pick.lic
+++ b/pick.lic
@@ -472,7 +472,7 @@ class LockPicker
       harvest(box)
     when 'Roundtime'
       waitrt?
-	  fput("put my #{left_hand} in my #{@component_container}") if (@component_container != nil && left_hand =~ patterns)
+	  bput("put my #{left_hand} in my #{@component_container}", 'You put your', "You just can\'t get", "There isn\'t any more") if (@component_container != nil && left_hand =~ patterns)
       dispose_trash(left_hand)
       while left_hand
       end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -505,6 +505,7 @@ skip_lockpick_ring_refill: false
 lockpick_container: ring
 lockpick_type: ordinary
 harvest_traps: true
+component_container:
 picking_box_source: duffel bag
 # Keep this empty to drop too-hard boxes on the ground
 picking_box_storage:


### PR DESCRIPTION
If component_container: is defined in the yaml, then when a picker is harvesting components it will attempt to place them inside the container.  If it can't, it will drop/dispose of them as normal.

Also a fix that prevents a rare problem I've run into.  There is a situation where stowing pliable equipment (eg. removing and stowing all the hindering equipment before beginning picking) can fill picking_box_source to the point that it can't stow a box it pulled out of it.  It would happen like:

  - Thief removes box from backpack
  - Thief fails to disarm box.
  - Thief tries to stow box but can't fit it inside the backpack anymore.
  - Thief grabs the next box and has two in his/her hands.

In rarer situations this can cause a picker to try and pick an un-disarmed box.  

With this change if it fails to stow the box it will drop it and continue picking.