### PR TITLE
Added four rooms to base-crafting for muspar'i forging society

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -70,11 +70,17 @@ blacksmithing:
      - 11267
      - 14348
     anvils:
-      - 14349
+     - 14349
+     - 14371
+     - 14373
     crucibles:
-      - 14350
+     - 14350
+     - 14372
+     - 14374
     grindstones:
-      - 14349
+     - 14349
+     - 14371
+     - 14373
     logbook: forging
     pattern-book: blacksmithing
     finisher: oil
@@ -1124,3 +1130,4 @@ recipe_parts:
     Muspar'i:
       part-room: 11263
       part-number:
+      


### PR DESCRIPTION
Added and tested the four identical missing rooms at the Muspar'i Forging Society to base-crafting.  As per the example, each of them uses peer tags now and all six register as independent rooms.