### PR TITLE
base-town.lic: Add generic favor altars for each town.

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -40,6 +40,8 @@ Crossing:
     id: 19125
   theurgy_supplies:
     id: 19073
+  favor_altar: &zoluren_favor_altar
+    id: 5865
   debt_office:
     id: 8282
   guard_house:
@@ -170,6 +172,8 @@ Leth Deriel:
   npc_empath:
     id: 9691
     action: lie
+  favor_altar:
+    << : *zoluren_favor_altar
   # safe room: 2189
   guild_leaders:
     << : *zoluren_guild_leaders
@@ -206,6 +210,8 @@ Shard:
     id: 12835
   theurgy_supplies:
     id: 13161
+  favor_altar: &southern_favor_altar
+    id: 14320
   attunement_rooms:
     - 2780
     - 2779
@@ -347,6 +353,8 @@ Riverhaven:
     id: 13403
   theurgy_supplies:
     id: 12048
+  favor_altar: &northern_favor_altar
+    id: 513
   attunement_rooms:
     - 352
     - 353
@@ -474,6 +482,8 @@ Therenborough:
     id: 10079
   theurgy_supplies:
     id: 11606
+  favor_altar:
+    << : *northern_favor_altar
   locksmithing:
     id:
   guard_house:
@@ -523,6 +533,8 @@ Langenfirth:
     id: 10079
   theurgy_supplies:
     id: 11606
+  favor_altar:
+    << : *northern_favor_altar
   locksmithing:
     id:
   guard_house:
@@ -808,6 +820,8 @@ Hibarnhvidar:
     id:
   theurgy_supplies:
     id:
+  favor_altar:
+    << : *southern_favor_altar
   debt_office:
     id: 11696
   guard_house:
@@ -895,6 +909,8 @@ Boar Clan:
     id:
   theurgy_supplies:
     id:
+  favor_altar:
+    << : *southern_favor_altar
   debt_office:
     id: 11696
   guard_house:
@@ -954,6 +970,8 @@ Muspar'i:
     name: Ushikhh
   npc_empath:
     id: 10063
+  favor_altar:
+    << : *northern_favor_altar
   locksmithing:
     id: 7613
   debt_office:

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -211,7 +211,7 @@ Shard:
   theurgy_supplies:
     id: 13161
   favor_altar: &southern_favor_altar
-    id: 14320
+    id: 11381
   attunement_rooms:
     - 2780
     - 2779

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -17,6 +17,8 @@ class TrainingManager
     args = parse_args(arg_definitions)
 
     @settings = get_settings
+    town_data = get_data('town')
+    @hometown = town_data[@settings.hometown]
     @skip_repair = @settings.skip_repair
     @repair_timer = @settings.repair_timer
     UserVars.repair_timer_snap ||= Time.now
@@ -126,7 +128,7 @@ class TrainingManager
       run_favors
       fput('stow my orb')
     elsif rub_orb?
-      walk_to(5865)
+      walk_to(@hometown['favor_altar']['id'])
       fput("get my #{@settings.favor_god} orb")
       fput('put my orb on altar')
       if favor_count + 1 < @settings.favor_goal


### PR DESCRIPTION
And use them in training-manager to return orbs. It's hardcoded to crossing right now.