### PR TITLE
Minor change, added 'You can't do that' to the failure for put_item.

### DIFF
--- a/steal.lic
+++ b/steal.lic
@@ -287,7 +287,7 @@ class Steal
   end
 
   def put_item?(item)
-    case bput("put my #{item} in my #{@stealing_bag}", 'You put', 'no matter how you arrange it', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again')
+    case bput("put my #{item} in my #{@stealing_bag}", 'You put', "You can't do that", 'no matter how you arrange it', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again')
     when 'perhaps try doing that again'
       return put_item?(item)
     when 'You put'


### PR DESCRIPTION
```[steal]>hide
You melt into the background, convinced that your attempt to hide went unobserved.
Roundtime: 2 sec.
[steal]>steal backpack in catalog
>
Moving stealthily, you manage to grab a rugged backpack right from underneath the merchant Berolt's very nose.
You learned acceptably from this theft.
Roundtime: 5 sec.
[steal]>put my backpack in my backpack
You come out of hiding.
You can't do that!
>
[steal: *** No match was found after 15 seconds, dumping info]
[steal: messages seen length: 2]
[steal: message: You can't do that!]
[steal: message: You come out of hiding.]
[steal: checked against [/You put/i, /no matter how you arrange it/i, /The .* is *.* too \w+ to fit in/i, /There
  isn't any more room/i, /perhaps try doing that again/i]]
[steal: for command put my backpack in my backpack]
[steal]>drop my backpack
You drop a rugged backpack.