### PR TITLE
hunting-buddy.lic: Skip restock if sell_loot_skip_bank is enabled.

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -52,7 +52,7 @@ class HuntingBuddy
 
   def main
     check_bundling_rope
-    wait_for_script_to_complete('restock')
+    wait_for_script_to_complete('restock') unless @settings.sell_loot_skip_bank
 
     @hunting_info.each do |info|
       if @stop_hunting


### PR DESCRIPTION
Closes #3043