### PR TITLE
shape.lic: Fix cord assembly.

### DIFF
--- a/shape.lic
+++ b/shape.lic
@@ -40,7 +40,7 @@ class Shape
     @training_spells = @settings.crafting_training_spells
 
     wait_for_script_to_complete('buff', ['shape'])
-    Flags.add('shaping-assembly', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* leather (strip)')
+    Flags.add('shaping-assembly', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* leather (strip|cord)')
     Flags.add('shape-magic-ready', 'You feel fully prepared to cast your spell.')
     if args.continue
       shape("analyze my #{@noun}")


### PR DESCRIPTION
You need another finished short leather cord to continue crafting an unfinished maple mask.  You believe you can assemble the two ingredients together once you acquire them.