### PR TITLE
base-recipes.yaml: turn off workorders for shaping recipes that need …

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -1361,7 +1361,7 @@ crafting_recipes:
   noun: locket
   volume: 2
   type: shaping
-  work_order: true
+  work_order: false
   chapter: 7
   part:
   - short cord
@@ -1369,7 +1369,7 @@ crafting_recipes:
   noun: circlet
   volume: 3
   type: shaping
-  work_order: true
+  work_order: false
   chapter: 7
   part:
   - short cord
@@ -1407,7 +1407,7 @@ crafting_recipes:
   noun: mask
   volume: 3
   type: shaping
-  work_order: true
+  work_order: false
   chapter: 7
   part:
   - short cord


### PR DESCRIPTION
…a short cord.

Closes #3054