### PR TITLE
Simple change to let thieves listen to warding

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -271,11 +271,10 @@ module DRC
 
     bad_classes = %w[Thievery Sorcery]
     bad_classes += ['Life Magic', 'Holy Magic', 'Lunar Magic', 'Elemental Magic', 'Arcane Magic', 'Targeted Magic', 'Arcana', 'Attunement'] if DRStats.barbarian? || DRStats.thief?
-    bad_classes += ['Warding'] if DRStats.thief?
     bad_classes += ['Utility'] if DRStats.barbarian?
-
+    
     observe = observe_flag ? 'observe' : ''
-
+    
     case bput("listen to #{teacher} #{observe}", 'begin to listen to \w+ teach the .* skill', 'already listening', 'could not find who', 'You have no idea', 'isn\'t teaching a class', 'don\'t have the appropriate training', 'Your teacher appears to have left', 'isn\'t teaching you anymore', 'experience differs too much from your own', 'but you don\'t see any harm in listening', 'invitation if you wish to join this class')
     when /begin to listen to \w+ teach the (.*) skill/
       return true if bad_classes.grep(/#{Regexp.last_match(1)}/i).empty?


### PR DESCRIPTION
Something should also change to allow thieves to listen observe automatically to skills they cannot actually learn-- like TM. I don't see a simple fix for this with the current setup--- where currently the class subject is matched AFTER you begin listening.