### PR TITLE
Reverting BPUT timeout timer to 15 seconds.

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -66,7 +66,7 @@ module DRC
     clear
     put message
     timer = Time.now
-    while (response = get?) || (Time.now - timer < 5)
+    while (response = get?) || (Time.now - timer < 15)
 
       if response.nil?
         pause 0.1


### PR DESCRIPTION
Some lag issues may be causing people to lose items in relation to bput timing out too fast. Safer to revert.