### PR TITLE
common.lic: Bump bput timeout up to 10 seconds

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -66,7 +66,7 @@ module DRC
     clear
     put message
     timer = Time.now
-    while (response = get?) || (Time.now - timer < 5)
+    while (response = get?) || (Time.now - timer < 10)
 
       if response.nil?
         pause 0.1

--- a/test/test_bput.rb
+++ b/test/test_bput.rb
@@ -50,7 +50,7 @@ class TestCommon < Minitest::Test
     Timecop.scale(30)
     sleep 0.1 until @test.thread_variable_get('runtime')
     Timecop.return
-    assert_in_delta 5, @test.thread_variable_get('runtime'), 1.0
+    assert_in_delta 10, @test.thread_variable_get('runtime'), 1.0
   end
 
   def test_bput_delays_timeout_for_wait


### PR DESCRIPTION
5 seconds is proving to be too little in some lag situations, but 15 seconds is too much. Lets try 10.