### PR TITLE
combat-trainer.lic: Change combat_training_spells_max_threshold to a more telling name

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -857,8 +857,8 @@ class SpellProcess
     @training_spells = settings.combat_spell_training
     echo("  @training_spells: #{@training_spells}") if $debug_mode_ct
 
-    @training_spells_max_threshold = settings.combat_spell_training_max_threshold
-    echo("  @training_spells_max_threshold: #{@training_spells_max_threshold}") if $debug_mode_ct
+    @training_spells_max_npcs = settings.combat_spell_training_max_npcs
+    echo("  @training_spells_max_npcs: #{@training_spells_max_npc}") if $debug_mode_ct
 
     @magic_exp_training_max_threshold = settings.magic_exp_training_max_threshold
     echo("  @magic_exp_training_max_threshold: #{@magic_exp_training_max_threshold}") if $debug_mode_ct
@@ -1196,7 +1196,7 @@ class SpellProcess
   def check_training(game_state)
     return if game_state.casting
     return unless @training_spells
-    return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
+    return if @training_spells_max_npcs && game_state.npcs.length > @training_spells_max_npcs
     return if mana < @training_spell_mana_threshold
 
     needs_training = %w[Warding Utility Augmentation Sorcery]

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -127,6 +127,7 @@ aiming_trainables:
 # allow melee offhand weapon training while aiming crossbow in aiming_trainables
 using_light_crossbow: false
 magic_exp_training_max_threshold: 32
+# Limits combat_spell_training in combat-trainer to only train when x number of npcs are in the room
 combat_spell_training_max_npcs:
 offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -127,7 +127,7 @@ aiming_trainables:
 # allow melee offhand weapon training while aiming crossbow in aiming_trainables
 using_light_crossbow: false
 magic_exp_training_max_threshold: 32
-combat_spell_training_max_threshold:
+combat_spell_training_max_npcs:
 offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50
 buff_spell_mana_threshold: 40

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -127,7 +127,7 @@ aiming_trainables:
 # allow melee offhand weapon training while aiming crossbow in aiming_trainables
 using_light_crossbow: false
 magic_exp_training_max_threshold: 32
-# Limits combat_spell_training in combat-trainer to only train when x number of npcs are in the room
+# Limits combat_spell_training in combat-trainer to only train when x number or under npcs are in the room
 combat_spell_training_max_npcs:
 offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50


### PR DESCRIPTION
This setting limits casting combat_training_spells to only when there are a certain amount of npcs in the room. I want to add an actual combat_training_spells_max_threshold that limits only combat_spell_training mindstates the same way magic_training_spells_max_threshold does because the magic version limits offensive casting too.