### PR TITLE
Combat-trainer support for regalia+starlight

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -39,7 +39,7 @@ class SetupProcess
       echo "ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!"
       @cycle_regalia = nil
     end
-    if @cycle_regalia && settings.gear_sets['regalia'].empty?
+    if @cycle_regalia && (settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?)
       echo "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
       @cycle_regalia = nil
     end
@@ -142,9 +142,10 @@ class SetupProcess
     return if armor_hysteresis?(game_state)
     return if Time.now - @last_cycle_time < @cycle_armors_time && !Flags['ct-regalia-expired']
     return if game_state.loaded
-    
-    @cycle_regalia = nil if Flags['ct-cancel-regalia']
-    
+    if game_state.regalia_cancel
+      regalia_shutdown(game_state) if Flags['ct-regalia-expired']
+      return
+    end
     armor_types = @cycle_regalia ? @cycle_regalia.map { |skill, _| skill } : @cycle_armors.map { |skill, _| skill }
     next_armor_type = armor_types.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
     return if next_armor_type == @last_worn_type unless Flags['ct-regalia-expired']
@@ -282,6 +283,22 @@ class SetupProcess
     offhand_skill = temp_array.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
     game_state.update_whirlwind_weapon_info(offhand_skill)
     game_state.wield_whirlwind_offhand
+  end
+  
+  def regalia_shutdown(game_state)
+    bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing') if Flags['ct-engaged']
+    bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing') if Flags['ct-engaged']
+    if game_state.last_regalia_type
+      @cycle_regalia[game_state.last_regalia_type].each do |item| 
+        bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
+      end
+      game_state.last_regalia_type = nil
+      game_state.swap_regalia_type = nil
+      game_state.regalia_cancel = nil
+      @cycle_regalia = nil
+      Flags.reset('ct-regalia-expired')
+    end
+    @equipment_manager.wear_equipment_set?('standard')
   end
 end
 
@@ -965,7 +982,6 @@ class SpellProcess
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
     Flags.add('ct-starlight-depleted', 'enough starlight') if DRStats.trader?
     Flags.add('ct-regalia-expired', 'Your .* glimmers weakly') if DRStats.trader?
-    Flags.add('ct-cancel-regalia')
 
     @offensive_spells
       .select { |spell| spell['expire'] }
@@ -985,6 +1001,8 @@ class SpellProcess
     @tk_spell = @offensive_spells.find { |spell| spell['abbrev'] =~ /tkt|tks/i }
     drop_tkt_ammo
     Flags.add('need-tkt-ammo', 'There is nothing here that can be thrown')
+    
+    @regalia_spell = get_data('spells').spell_data['Regalia'] if (@regalia_array && @regalia_spell.nil?)
   end
 
   def drop_tkt_ammo
@@ -1098,10 +1116,6 @@ class SpellProcess
     game_state.swap_regalia_type = nil if game_state.swap_regalia_type == game_state.last_regalia_type
     return if game_state.casting
     return unless game_state.swap_regalia_type
-    if @regalia_spell.nil?
-      echo "Couldn't find a regalia waggle.  Using default values for the spell."
-      @regalia_spell = get_data('spells').spell_data['Regalia']
-    end
     
     case game_state.swap_regalia_type
     when 'Light Armor'
@@ -1115,13 +1129,6 @@ class SpellProcess
     end
     @regalia_spell['cast'] = "cast #{armor_word} all"
     prepare_spell(@regalia_spell, game_state)
-    if game_state.last_regalia_type.nil? 
-      @equipment_manager.wear_equipment_set?('regalia')
-    else
-      @regalia_array[game_state.last_regalia_type].each do |item| 
-        bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
-      end
-    end
   end
   
   def check_bless(game_state)
@@ -1203,7 +1210,19 @@ class SpellProcess
     if game_state.casting_sorcery
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
-
+    
+    if game_state.casting_regalia
+      bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
+      bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
+      if game_state.last_regalia_type.nil? 
+        @equipment_manager.wear_equipment_set?('regalia')
+      else
+        @regalia_array[game_state.last_regalia_type].each do |item| 
+          bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
+        end
+      end
+    end
+    
     snapshot = DRSkill.getxp(@skill)
     success = cast?(@custom_cast, @symbiosis, @before, @after)
     if @symbiosis && @use_auto_mana
@@ -1360,22 +1379,22 @@ class SpellProcess
 
   def check_trader_magic(game_state)
     return unless DRStats.trader?
-    if Flags['ct-starlight-depleted'] then
+    if Flags['ct-starlight-depleted']
       echo "----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----"
-      @buff_spells.delete_if { |spell| @buff_spells[spell]['starlight'] }
-      @offensive_spells.delete_if do |spell|
-        if spell['starlight'] then true end
-      end
-      Flags['ct-cancel-regalia'] = true
+      @buff_spells.reject! { |spell| @buff_spells[spell]['starlight'] }
+      @offensive_spells.reject! { |spell| spell['starlight'] }
+      game_state.regalia_cancel = true
     end
     if game_state.casting_regalia
       if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
+        bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
+        bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
         @regalia_array[game_state.swap_regalia_type].each do |item| 
           bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
         end
         @equipment_manager.wear_equipment_set?('standard')
       end
-      Flags['ct-starlight-depleted'] ? game_state.last_regalia_type = nil : game_state.last_regalia_type = game_state.swap_regalia_type
+      game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
       Flags.reset('ct-regalia-expired')
       game_state.swap_regalia_type = nil
       game_state.casting_regalia = false
@@ -1521,7 +1540,7 @@ class SpellProcess
       end
     end
     
-    game_state.casting_regalia = true if data['abbrev'] == 'REGAL'
+    game_state.casting_regalia = data['abbrev'] == 'REGAL'
     
     prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
     game_state.casting = true
@@ -2721,7 +2740,7 @@ class GameState
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
 
-  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_regalia, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :starlight, :last_regalia_type, :swap_regalia_type
+  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_regalia, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -2742,6 +2761,7 @@ class GameState
     @casting_sorcery = false
     @hide_on_cast = false
     @casting_regalia = false
+    @regalia_cancel = false
     @last_regalia_type = nil
     @swap_regalia_type = nil
     @casting_weapon_buff = false
@@ -3441,7 +3461,6 @@ before_dying do
   Flags.delete('last-stance')
   Flags.delete('ct-regalia-expired')
   Flags.delete('ct-starlight-depleted')
-  Flags.delete('ct-cancel-regalia')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1362,7 +1362,7 @@ class SpellProcess
       echo "----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----"
       @buff_spells.delete_if { |spell| @buff_spells[spell]['starlight'] }
       @offensive_spells.delete_if do |spell|
-        if spell['ct-starlight-depleted'] then true end
+        if spell['starlight'] then true end
       end
     end
     if game_state.casting_regalia

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -31,18 +31,13 @@ class SetupProcess
     echo("  @cycle_regalia: #{@cycle_regalia}") if $debug_mode_ct
     @default_armor = settings.default_armor_type
     echo("  @default_armor: #{@default_armor}") if $debug_mode_ct
+    
+    @gearsets = settings.gear_sets
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
     @last_warhorn = Time.now - 305
-
-    if @cycle_regalia && @cycle_armors
-      echo "ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!"
-      @cycle_regalia = nil
-    end
-    if @cycle_regalia && (settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?)
-      echo "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
-      @cycle_regalia = nil
-    end
+    
+    validate_regalia(settings)
     
     return unless @warhorn
 
@@ -285,6 +280,20 @@ class SetupProcess
     game_state.wield_whirlwind_offhand
   end
   
+  def validate_regalia(settings)
+    return unless @cycle_regalia
+   
+    if @cycle_armors
+      echo "ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!"
+      @cycle_regalia = nil
+    end
+    
+    if (settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?)
+      echo "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
+      @cycle_regalia = nil
+    end
+  end
+  
   def regalia_shutdown(game_state)
     if game_state.last_regalia_type
       game_state.shatter_regalia(@cycle_regalia[game_state.last_regalia_type])
@@ -295,6 +304,7 @@ class SetupProcess
       Flags.reset('ct-regalia-expired')
     end
     @equipment_manager.wear_equipment_set?('standard')
+    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@gear_sets['standard'].include?(game_state.weapon_name))
   end
 end
 
@@ -997,8 +1007,11 @@ class SpellProcess
     @tk_spell = @offensive_spells.find { |spell| spell['abbrev'] =~ /tkt|tks/i }
     drop_tkt_ammo
     Flags.add('need-tkt-ammo', 'There is nothing here that can be thrown')
-    
-    @regalia_spell = get_data('spells').spell_data['Regalia'] if (@regalia_array && @regalia_spell.nil?)
+    if DRStats.trader? && @regalia_array
+      @regalia_spell = get_data('spells').spell_data['Regalia'] if (@regalia_array && @regalia_spell.nil?)
+      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+      @know_bespoke = DRC.bput('pre bspk', 'Bespoke Regalia', 'You have no idea', 'fully prepared', 'already preparing') == 'Bespoke Regalia'
+    end
   end
 
   def drop_tkt_ammo
@@ -1107,6 +1120,7 @@ class SpellProcess
   def check_regalia(game_state)
     game_state.swap_regalia_type = nil if game_state.swap_regalia_type == game_state.last_regalia_type
     return if game_state.casting
+    return if game_state.loaded
     return unless game_state.swap_regalia_type
     return if mana < @buff_spell_mana_threshold
     
@@ -1120,7 +1134,8 @@ class SpellProcess
     when 'Plate Armor'
       armor_word = 'plate'
     end
-    @regalia_spell['cast'] = "cast #{armor_word} all"
+    
+    @regalia_spell['cast'] = @know_bespoke ? "cast #{armor_word} all" : "cast"
     prepare_spell(@regalia_spell, game_state)
   end
   
@@ -1208,6 +1223,7 @@ class SpellProcess
       if game_state.last_regalia_type.nil? 
         DRCT.retreat
         @equipment_manager.wear_equipment_set?('regalia')
+        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@settings.gear_sets['standard'].include?(game_state.weapon_name))
       else
         game_state.shatter_regalia(@regalia_array[game_state.last_regalia_type])
       end
@@ -1379,6 +1395,7 @@ class SpellProcess
       if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
         game_state.shatter_regalia(@regalia_array[game_state.swap_regalia_type])
         @equipment_manager.wear_equipment_set?('standard')
+        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
       end
       game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
       Flags.reset('ct-regalia-expired')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -27,11 +27,23 @@ class SetupProcess
     @last_cycle_time = Time.now - @cycle_armors_time
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
-
+    @cycle_regalia = settings.cycle_armors_regalia
+    echo("  @cycle_regalia: #{@cycle_regalia}") if $debug_mode_ct
+    @default_armor = settings.default_armor_type
+    echo("  @default_armor: #{@default_armor}") if $debug_mode_ct
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
     @last_warhorn = Time.now - 305
 
+    if @cycle_regalia && @cycle_armors
+      echo "ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!"
+      @cycle_regalia = nil
+    end
+    if @cycle_regalia && settings.gear_sets['regalia'].empty?
+      echo "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
+      @cycle_regalia = nil
+    end
+    
     return unless @warhorn
 
     if DRCI.wearing?(@warhorn)
@@ -107,10 +119,16 @@ class SetupProcess
     game_state.wield_whirlwind_offhand
   end
 
-  def armor_hysteresis?
+  def armor_hysteresis?(game_state)
     return false unless @armor_hysteresis
     return false if @cycle_armors.keys.any? { |skill| DRSkill.getxp(skill) < 25 }
-    if @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
+    return false if @cycle_regalia.keys.any? { |skill| DRSkill.getxp(skill) < 22 } || game_state.last_regalia_type.nil? || Flags['ct-regalia-expired']
+    if @cycle_regalia
+      if @cycle_regalia.keys.all? { |skill| DRSkill.getxp(skill) > 24 } && game_state.last_regalia_type != @default_armor  # Different swap threshold because Regalia costs resources, and starlight will run out if used too often.
+        return false if Time.now - @last_cycle_time < @cycle_armors_time
+        game_state.swap_regalia_type = @default_armor ? @default_armor : @cycle_regalia.max_by { |skill| DRSkill.getrank(skill) } # If no default type declared, go by the highest rank.
+      end
+    elsif @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
       if @last_worn_type != @default_armor
         @equipment_manager.worn_items(@all_swap_pieces).each { |item| @equipment_manager.remove_item(item) }
         @equipment_manager.wear_items(@equipment_manager.desc_to_items(@cycle_armors[@default_armor]))
@@ -121,19 +139,23 @@ class SetupProcess
   end
 
   def check_armor_swap(game_state)
-    return if armor_hysteresis?
-    return if Time.now - @last_cycle_time < @cycle_armors_time
+    return if armor_hysteresis?(game_state)
+    return if Time.now - @last_cycle_time < @cycle_armors_time && !Flags['ct-regalia-expired']
     return if game_state.loaded
-    armor_types = @cycle_armors.map { |skill, _| skill }
+    
+    armor_types = @cycle_regalia ? @cycle_regalia.map { |skill, _| skill } : @cycle_armors.map { |skill, _| skill }
     next_armor_type = armor_types.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
-    return if next_armor_type == @last_worn_type
+    return if next_armor_type == @last_worn_type unless Flags['ct-regalia-expired']
     return if DRSkill.getxp(next_armor_type) >= @combat_training_abilities_target
 
     @last_cycle_time = Time.now
 
     game_state.sheath_whirlwind_offhand
 
-    if @last_worn_type
+    if @cycle_regalia
+      game_state.swap_regalia_type = next_armor_type # Mark for SpellProcess casting
+      return
+    elsif @last_worn_type
       @equipment_manager.desc_to_items(@cycle_armors[@last_worn_type]).each { |item| @equipment_manager.remove_item(item) }
     else
       all_swap_pieces = @cycle_armors.map { |_, pieces| pieces }.flatten
@@ -926,13 +948,21 @@ class SpellProcess
     @buff_force_cambrinth = settings.combat_trainer_buffs_force_cambrinth
     echo("  @buff_force_cambrinth: #{@buff_force_cambrinth}") if $debug_mode_ct
 
+    @regalia_array = settings.cycle_armors_regalia
+    echo("  @regalia_array: #{@regalia_array}") if $debug_mode_ct
+
+    @regalia_spell = settings.waggle_sets['regalia']['Regalia']
+    echo("  @regalia_spell: #{@regalia_spell}") if $debug_mode_ct
+    
     @perc_health_timer = Time.now
 
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
 
-    Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
+    Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target', 'Your concentration lapses')
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
+    Flags.add('ct-starlight-depleted', 'enough starlight') if DRStats.trader?
+    Flags.add('ct-regalia-expired', 'Your .* glimmers weakly') if DRStats.trader?
 
     @offensive_spells
       .select { |spell| spell['expire'] }
@@ -987,6 +1017,7 @@ class SpellProcess
       drop_tkt_ammo
     end
     check_slivers(game_state)
+    check_regalia(game_state)
     check_consume(game_state)
     check_cfb(game_state)
     check_bless(game_state)
@@ -1009,6 +1040,11 @@ class SpellProcess
         waitrt?
         pause
         fput("stow #{@tk_ammo}")
+      end
+      if game_state.last_regalia_type
+        @regalia_array[game_state.last_regalia_type].each do |item| 
+          bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
+        end
       end
       return true
     end
@@ -1055,6 +1091,37 @@ class SpellProcess
     game_state.casting = false
   end
 
+  def check_regalia(game_state)
+    game_state.swap_regalia_type = nil if game_state.swap_regalia_type == game_state.last_regalia_type
+    return if game_state.casting
+    return unless game_state.swap_regalia_type
+        
+    if @regalia_spell.nil?
+      echo "Couldn't find a regalia waggle.  Using default values for the spell."
+      @regalia_spell = get_data('spells').spell_data['Regalia']
+    end
+    
+    case game_state.swap_regalia_type
+    when 'Light Armor'
+      armor_word = 'light'
+    when 'Chain Armor'
+      armor_word = 'chain'
+    when 'Brigandine'
+      armor_word = 'brigandine'
+    when 'Plate Armor'
+      armor_word = 'plate'
+    end
+    @regalia_spell['cast'] = "cast #{armor_word} all"
+    prepare_spell(@regalia_spell, game_state)
+    if game_state.last_regalia_type.nil? 
+      @equipment_manager.wear_equipment_set?('regalia')
+    else
+      @regalia_array[game_state.last_regalia_type].each do |item| 
+        bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
+      end
+    end
+	end
+  
   def check_bless(game_state)
     return if game_state.casting
     return unless @buff_spells['Bless']
@@ -1172,8 +1239,10 @@ class SpellProcess
       game_state.casting_moonblade = false
     end
 
-    Flags.reset("ct-#{@reset_expire}") if @reset_expire
+    check_trader_magic(game_state)
 
+    Flags.reset("ct-#{@reset_expire}") if @reset_expire
+    Flags.reset('ct-starlight-depleted') if DRStats.trader?
     return unless @command
     pause 0.5 until DRRoom.npcs.include?('warrior')
     fput("command #{@command}")
@@ -1287,6 +1356,24 @@ class SpellProcess
     end
   end
 
+  def check_trader_magic(game_state)
+    return unless DRStats.trader?
+    if Flags['ct-starlight-depleted'] then
+      echo "----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----"
+      @buff_spells.delete_if { |spell| @buff_spells[spell]['starlight'] }
+      @offensive_spells.delete_if do |spell|
+        if spell['ct-starlight-depleted'] then true end
+      end
+    end
+    if game_state.casting_regalia
+      @equipment_manager.wear_equipment_set('standard') if Flags['ct-starlight-depleted']
+      Flags['ct-starlight-depleted'] ? game_state.last_regalia_type = nil : game_state.last_regalia_type = game_state.swap_regalia_type
+      Flags.reset('ct-regalia-expired')
+      @swap_regalia_type = nil
+      game_state.casting_regalia = false
+    end
+  end
+  
   def check_cfb(game_state)
     return unless DRStats.necromancer?
     return unless @necromancer_zombie['Call from Beyond']
@@ -1425,6 +1512,9 @@ class SpellProcess
         data['cast'] = "cast #{moon}"
       end
     end
+    
+    game_state.casting_regalia = true if data['abbrev'] == 'REGAL'
+    
     prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
     game_state.casting = true
     game_state.cambrinth_charges(data['cambrinth'])
@@ -2623,7 +2713,7 @@ class GameState
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
 
-  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast
+  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_regalia, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :starlight, :last_regalia_type, :swap_regalia_type
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -2643,6 +2733,9 @@ class GameState
     @casting_moonblade = false
     @casting_sorcery = false
     @hide_on_cast = false
+    @casting_regalia = false
+    @last_regalia_type = nil
+    @swap_regalia_type = nil
     @casting_weapon_buff = false
     @casting_consume = false
     @prepare_consume = false
@@ -3317,7 +3410,7 @@ class GameState
   end
 
   attr_accessor :clean_up_step, :current_weapon_skill, :target_weapon_skill, :no_skins, :constructs, :no_stab_mobs, :no_loot, :dancing, :retreating, :action_count, :charges, :aim_queue, :dance_queue, :analyze_combo_array
-  attr_reader :dance_skill, :target_action_count, :dance_threshold, :retreat_threshold, :summoned_weapons, :target_increment, :stances, :weapons_to_train, :use_stealth_attacks, :ambush, :backstab, :charged_maneuvers, :fatigue_regen_threshold, :aim_fillers, :aim_fillers_stealth, :dance_actions, :dance_actions_stealth, :ignored_npcs, :dual_load, :summoned_weapons_element, :summoned_weapons_ingot, :cambrinth, :stored_cambrinth, :cambrinth_cap, :use_weak_attacks, :dedicated_camb_use, :use_barb_combos, :balance_regen_thresholdend
+  attr_reader :dance_skill, :target_action_count, :dance_threshold, :retreat_threshold, :summoned_weapons, :target_increment, :stances, :weapons_to_train, :use_stealth_attacks, :ambush, :backstab, :charged_maneuvers, :fatigue_regen_threshold, :aim_fillers, :aim_fillers_stealth, :dance_actions, :dance_actions_stealth, :ignored_npcs, :dual_load, :summoned_weapons_element, :summoned_weapons_ingot, :cambrinth, :stored_cambrinth, :cambrinth_cap, :use_weak_attacks, :dedicated_camb_use, :use_barb_combos, :balance_regen_threshold
 end
 
 before_dying do
@@ -3338,6 +3431,8 @@ before_dying do
   Flags.delete('ct-damage-ready')
   Flags.delete('ct-need-bless')
   Flags.delete('last-stance')
+  Flags.delete('ct-regalia-expired')
+  Flags.delete('ct-starlight-depleted')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1366,7 +1366,12 @@ class SpellProcess
       end
     end
     if game_state.casting_regalia
-      @equipment_manager.wear_equipment_set('standard') if Flags['ct-starlight-depleted']
+      if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
+        @regalia_array[game_state.swap_regalia_type].each do |item| 
+          bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
+        end
+        @equipment_manager.wear_equipment_set('standard')
+      end
       Flags['ct-starlight-depleted'] ? game_state.last_regalia_type = nil : game_state.last_regalia_type = game_state.swap_regalia_type
       Flags.reset('ct-regalia-expired')
       @swap_regalia_type = nil

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -121,7 +121,7 @@ class SetupProcess
     if @cycle_regalia
       if @cycle_regalia.keys.all? { |skill| DRSkill.getxp(skill) > 24 } && game_state.last_regalia_type != @default_armor  # Different swap threshold because Regalia costs resources, and starlight will run out if used too often.
         return false if Time.now - @last_cycle_time < @cycle_armors_time
-        game_state.swap_regalia_type = @cycle_regalia.member?(@default_armor) ? @default_armor : @cycle_regalia.max_by { |skill| DRSkill.getrank(skill) } # If no default type declared, go by the highest rank.
+        game_state.swap_regalia_type = @cycle_regalia.member?(@default_armor) ? @default_armor : @cycle_regalia.max_by { |skill| DRSkill.getrank(skill) }.first # If no default type declared, go by the highest rank.
       end
     elsif @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
       if @last_worn_type != @default_armor && @cycle_armors.member?(@default_armor)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -295,7 +295,7 @@ class SetupProcess
   
   def regalia_shutdown(game_state)
     if game_state.last_regalia_type
-      game_state.shatter_regalia(@cycle_regalia[game_state.last_regalia_type])
+      DRCA.shatter_regalia(@cycle_regalia[game_state.last_regalia_type])
       game_state.last_regalia_type = nil
       game_state.swap_regalia_type = nil
       game_state.regalia_cancel = nil
@@ -1071,7 +1071,7 @@ class SpellProcess
         pause
         fput("stow #{@tk_ammo}")
       end
-      game_state.shatter_regalia(@regalia_array[game_state.last_regalia_type]) if game_state.last_regalia_type
+      DRCA.shatter_regalia(@regalia_array[game_state.last_regalia_type]) if game_state.last_regalia_type
       return true
     end
     false
@@ -1226,7 +1226,7 @@ class SpellProcess
         @equipment_manager.wear_equipment_set?('regalia')
         @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@settings.gear_sets['standard'].include?(game_state.weapon_name))
       else
-        game_state.shatter_regalia(@regalia_array[game_state.last_regalia_type])
+        DRCA.shatter_regalia(@regalia_array[game_state.last_regalia_type])
       end
     end
     
@@ -1395,13 +1395,14 @@ class SpellProcess
     end
     if game_state.casting_regalia
       if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
-        game_state.shatter_regalia(@regalia_array[game_state.swap_regalia_type])
+        DRCA.shatter_regalia(@regalia_array[game_state.swap_regalia_type])
         @equipment_manager.wear_equipment_set?('standard')
         @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
       end
       if Flags['ct-regalia-succeeded']
         game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
         Flags.reset('ct-regalia-expired')
+        $worn_regalia = @regalia_array[game_state.swap_regalia_type] # Regalia doesn't show up in Active Spells, so it must be tracked to be destroyed before_dying
         game_state.swap_regalia_type = nil
         Flags.reset('ct-regalia-succeeded')
       end
@@ -3248,12 +3249,6 @@ class GameState
   def next_dance_action
     @dance_queue.shift
   end
-  
-  def shatter_regalia(regalia_skill_set)
-    regalia_skill_set.each do |item| 
-       bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
-    end
-  end
 
   def cambrinth_charges(charges)
     cambrinth = case charges.first
@@ -3458,6 +3453,7 @@ end
 
 before_dying do
   DRCA.release_cyclics
+  DRCA.shatter_regalia($worn_regalia)
   Flags.delete('using-corpse')
   Flags.delete('pouch-full')
   Flags.delete('container-full')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -143,6 +143,8 @@ class SetupProcess
     return if Time.now - @last_cycle_time < @cycle_armors_time && !Flags['ct-regalia-expired']
     return if game_state.loaded
     
+    @cycle_regalia = nil if Flags['ct-cancel-regalia']
+    
     armor_types = @cycle_regalia ? @cycle_regalia.map { |skill, _| skill } : @cycle_armors.map { |skill, _| skill }
     next_armor_type = armor_types.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
     return if next_armor_type == @last_worn_type unless Flags['ct-regalia-expired']
@@ -963,6 +965,7 @@ class SpellProcess
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
     Flags.add('ct-starlight-depleted', 'enough starlight') if DRStats.trader?
     Flags.add('ct-regalia-expired', 'Your .* glimmers weakly') if DRStats.trader?
+    Flags.add('ct-cancel-regalia')
 
     @offensive_spells
       .select { |spell| spell['expire'] }
@@ -1095,7 +1098,6 @@ class SpellProcess
     game_state.swap_regalia_type = nil if game_state.swap_regalia_type == game_state.last_regalia_type
     return if game_state.casting
     return unless game_state.swap_regalia_type
-        
     if @regalia_spell.nil?
       echo "Couldn't find a regalia waggle.  Using default values for the spell."
       @regalia_spell = get_data('spells').spell_data['Regalia']
@@ -1364,6 +1366,7 @@ class SpellProcess
       @offensive_spells.delete_if do |spell|
         if spell['starlight'] then true end
       end
+      Flags['ct-cancel-regalia'] = true
     end
     if game_state.casting_regalia
       if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
@@ -1374,7 +1377,7 @@ class SpellProcess
       end
       Flags['ct-starlight-depleted'] ? game_state.last_regalia_type = nil : game_state.last_regalia_type = game_state.swap_regalia_type
       Flags.reset('ct-regalia-expired')
-      @swap_regalia_type = nil
+      game_state.swap_regalia_type = nil
       game_state.casting_regalia = false
     end
   end
@@ -3438,6 +3441,7 @@ before_dying do
   Flags.delete('last-stance')
   Flags.delete('ct-regalia-expired')
   Flags.delete('ct-starlight-depleted')
+  Flags.delete('ct-cancel-regalia')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1122,7 +1122,7 @@ class SpellProcess
         bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
       end
     end
-	end
+  end
   
   def check_bless(game_state)
     return if game_state.casting

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -303,7 +303,7 @@ class SetupProcess
       Flags.reset('ct-regalia-expired')
     end
     @equipment_manager.wear_equipment_set?('standard')
-    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@gear_sets['standard'].include?(game_state.weapon_name))
+    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@gearsets['standard'].include?(game_state.weapon_name))
   end
 end
 
@@ -1391,13 +1391,13 @@ class SpellProcess
       @buff_spells.reject! { |spell| @buff_spells[spell]['starlight'] }
       @offensive_spells.reject! { |spell| spell['starlight'] }
       game_state.regalia_cancel = true
-      Flags.reset('ct-starlight-depleted')
     end
     if game_state.casting_regalia
       if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
         DRCA.shatter_regalia(@regalia_array[game_state.swap_regalia_type])
         @equipment_manager.wear_equipment_set?('standard')
-        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@settings.gear_sets['standard'].include?(game_state.weapon_name))
+        game_state.swap_regalia_type = nil
       end
       if Flags['ct-regalia-succeeded']
         game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
@@ -1406,9 +1406,9 @@ class SpellProcess
         game_state.swap_regalia_type = nil
         Flags.reset('ct-regalia-succeeded')
       end
+      game_state.casting_regalia = false
     end
-    game_state.casting_regalia = false
-    Flags.reset('ct-regalia-succeeded')
+    Flags.reset('ct-starlight-depleted')
   end
   
   def check_cfb(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -286,12 +286,8 @@ class SetupProcess
   end
   
   def regalia_shutdown(game_state)
-    bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing') if Flags['ct-engaged']
-    bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing') if Flags['ct-engaged']
     if game_state.last_regalia_type
-      @cycle_regalia[game_state.last_regalia_type].each do |item| 
-        bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
-      end
+      game_state.shatter_regalia(@cycle_regalia[game_state.last_regalia_type])
       game_state.last_regalia_type = nil
       game_state.swap_regalia_type = nil
       game_state.regalia_cancel = nil
@@ -1062,11 +1058,7 @@ class SpellProcess
         pause
         fput("stow #{@tk_ammo}")
       end
-      if game_state.last_regalia_type
-        @regalia_array[game_state.last_regalia_type].each do |item| 
-          bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
-        end
-      end
+      game_state.shatter_regalia(@regalia_array[game_state.last_regalia_type]) if game_state.last_regalia_type
       return true
     end
     false
@@ -1116,6 +1108,7 @@ class SpellProcess
     game_state.swap_regalia_type = nil if game_state.swap_regalia_type == game_state.last_regalia_type
     return if game_state.casting
     return unless game_state.swap_regalia_type
+    return if mana < @buff_spell_mana_threshold
     
     case game_state.swap_regalia_type
     when 'Light Armor'
@@ -1212,14 +1205,11 @@ class SpellProcess
     end
     
     if game_state.casting_regalia
-      bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
-      bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
       if game_state.last_regalia_type.nil? 
+        DRCT.retreat
         @equipment_manager.wear_equipment_set?('regalia')
       else
-        @regalia_array[game_state.last_regalia_type].each do |item| 
-          bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
-        end
+        game_state.shatter_regalia(@regalia_array[game_state.last_regalia_type])
       end
     end
     
@@ -1387,11 +1377,7 @@ class SpellProcess
     end
     if game_state.casting_regalia
       if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
-        bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
-        bput('retreat', 'You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat', 'retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing')
-        @regalia_array[game_state.swap_regalia_type].each do |item| 
-          bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
-        end
+        game_state.shatter_regalia(@regalia_array[game_state.swap_regalia_type])
         @equipment_manager.wear_equipment_set?('standard')
       end
       game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
@@ -3238,6 +3224,12 @@ class GameState
 
   def next_dance_action
     @dance_queue.shift
+  end
+  
+  def shatter_regalia(regalia_skill_set)
+    regalia_skill_set.each do |item| 
+       bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
+    end
   end
 
   def cambrinth_charges(charges)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1370,7 +1370,7 @@ class SpellProcess
         @regalia_array[game_state.swap_regalia_type].each do |item| 
           bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
         end
-        @equipment_manager.wear_equipment_set('standard')
+        @equipment_manager.wear_equipment_set?('standard')
       end
       Flags['ct-starlight-depleted'] ? game_state.last_regalia_type = nil : game_state.last_regalia_type = game_state.swap_regalia_type
       Flags.reset('ct-regalia-expired')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -121,10 +121,10 @@ class SetupProcess
     if @cycle_regalia
       if @cycle_regalia.keys.all? { |skill| DRSkill.getxp(skill) > 24 } && game_state.last_regalia_type != @default_armor  # Different swap threshold because Regalia costs resources, and starlight will run out if used too often.
         return false if Time.now - @last_cycle_time < @cycle_armors_time
-        game_state.swap_regalia_type = @default_armor ? @default_armor : @cycle_regalia.max_by { |skill| DRSkill.getrank(skill) } # If no default type declared, go by the highest rank.
+        game_state.swap_regalia_type = @cycle_regalia.member?(@default_armor) ? @default_armor : @cycle_regalia.max_by { |skill| DRSkill.getrank(skill) } # If no default type declared, go by the highest rank.
       end
     elsif @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
-      if @last_worn_type != @default_armor
+      if @last_worn_type != @default_armor && @cycle_armors.member?(@default_armor)
         @equipment_manager.worn_items(@all_swap_pieces).each { |item| @equipment_manager.remove_item(item) }
         @equipment_manager.wear_items(@equipment_manager.desc_to_items(@cycle_armors[@default_armor]))
         @last_worn_type = @default_armor
@@ -144,8 +144,8 @@ class SetupProcess
     armor_types = @cycle_regalia ? @cycle_regalia.map { |skill, _| skill } : @cycle_armors.map { |skill, _| skill }
     next_armor_type = armor_types.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
     return if next_armor_type == @last_worn_type unless Flags['ct-regalia-expired']
-    return if DRSkill.getxp(next_armor_type) >= @combat_training_abilities_target
-
+    return if DRSkill.getxp(next_armor_type) >= @combat_training_abilities_target unless (Flags['ct-regalia-expired'] || (game_state.last_regalia_type.nil? && @cycle_regalia))
+    
     @last_cycle_time = Time.now
 
     game_state.sheath_whirlwind_offhand
@@ -282,7 +282,6 @@ class SetupProcess
   
   def validate_regalia(settings)
     return unless @cycle_regalia
-   
     if @cycle_armors
       echo "ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!"
       @cycle_regalia = nil
@@ -988,6 +987,7 @@ class SpellProcess
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
     Flags.add('ct-starlight-depleted', 'enough starlight') if DRStats.trader?
     Flags.add('ct-regalia-expired', 'Your .* glimmers weakly') if DRStats.trader?
+    Flags.add('ct-regalia-succeeded', 'You cup your palms skyward to bask in') if DRStats.trader?
 
     @offensive_spells
       .select { |spell| spell['expire'] }
@@ -1118,7 +1118,8 @@ class SpellProcess
   end
 
   def check_regalia(game_state)
-    game_state.swap_regalia_type = nil if game_state.swap_regalia_type == game_state.last_regalia_type
+    return unless @regalia_array
+    game_state.swap_regalia_type = nil if (game_state.swap_regalia_type == game_state.last_regalia_type && !Flags['ct-regalia-expired'])
     return if game_state.casting
     return if game_state.loaded
     return unless game_state.swap_regalia_type
@@ -1269,7 +1270,7 @@ class SpellProcess
     check_trader_magic(game_state)
 
     Flags.reset("ct-#{@reset_expire}") if @reset_expire
-    Flags.reset('ct-starlight-depleted') if DRStats.trader?
+
     return unless @command
     pause 0.5 until DRRoom.npcs.include?('warrior')
     fput("command #{@command}")
@@ -1390,6 +1391,7 @@ class SpellProcess
       @buff_spells.reject! { |spell| @buff_spells[spell]['starlight'] }
       @offensive_spells.reject! { |spell| spell['starlight'] }
       game_state.regalia_cancel = true
+      Flags.reset('ct-starlight-depleted')
     end
     if game_state.casting_regalia
       if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.
@@ -1397,11 +1399,15 @@ class SpellProcess
         @equipment_manager.wear_equipment_set?('standard')
         @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
       end
-      game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
-      Flags.reset('ct-regalia-expired')
-      game_state.swap_regalia_type = nil
-      game_state.casting_regalia = false
+      if Flags['ct-regalia-succeeded']
+        game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
+        Flags.reset('ct-regalia-expired')
+        game_state.swap_regalia_type = nil
+        Flags.reset('ct-regalia-succeeded')
+      end
     end
+    game_state.casting_regalia = false
+    Flags.reset('ct-regalia-succeeded')
   end
   
   def check_cfb(game_state)
@@ -3470,6 +3476,7 @@ before_dying do
   Flags.delete('last-stance')
   Flags.delete('ct-regalia-expired')
   Flags.delete('ct-starlight-depleted')
+  Flags.delete('ct-regalia-succeeded')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -234,6 +234,14 @@ module DRCA
       .map { |_name, properties| properties['abbrev'] }
       .each { |abbrev| fput("release #{abbrev}") }
   end
+  
+  def shatter_regalia(regalia_set)
+    return unless regalia_set
+    regalia_set.each do |item| 
+       DRC.bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}", 'The leather gauntlets slide')
+    end
+    $worn_regalia = nil
+  end
 
   def parse_mana_message(mana_msg)
     manalevels = if mana_msg.include? 'weak'

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1424,6 +1424,7 @@ spell_data:
     mana: 15
     skill: Utility
     recast: 1
+    starlight: true
   Regenerate:
     skill: Utility
     abbrev: regenerate

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -425,6 +425,7 @@ spell_data:
     cyclic: true
     abbrev: ARS
     mana: 6
+    starlight: true
     prep: prepare
   Arc Light:
     skill: Debilitation
@@ -529,6 +530,7 @@ spell_data:
     mana: 5
     abbrev: blur
     recast: 1
+    starlight: true
   Bond Armaments:
     skill: Utility
     abbrev: BA
@@ -652,6 +654,7 @@ spell_data:
     skill: Targeted Magic
     abbrev: CRD
     mana: 2
+    starlight: true
   Crusader's Challenge:
     skill: Augmentation # Also Utility
     abbrev: CRC
@@ -862,6 +865,7 @@ spell_data:
     mana: 1
     skill: Debilitation
     harmless: true
+    starlight: true
   Flush Poisons:
     skill: Utility
     abbrev: FP
@@ -1673,6 +1677,7 @@ spell_data:
     skill: Targeted Magic
     abbrev: starcrash
     mana: 30
+    starlight: true
   Starlight Sphere:
     skill: Targeted Magic
     abbrev: SLS
@@ -1775,6 +1780,7 @@ spell_data:
     mana: 1
     abbrev: TRC
     recast: 1
+    starlight: true
   Tranquility:
     skill: Augmentation #Warding
     abbrev: TRANQUILITY

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1780,7 +1780,7 @@ spell_data:
     skill: Warding
     mana: 1
     abbrev: TRC
-    recast: 1
+    recast: -1
     starlight: true
   Tranquility:
     skill: Augmentation #Warding

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -39,6 +39,8 @@ stances:
 default_stance: 100 0 80
 stance_override:
 cycle_armors:
+cycle_armors_regalia:
+default_armor_type:
 cycle_armors_time: 125
 cycle_armors_hysteresis: true
 skinning:

--- a/validate.lic
+++ b/validate.lic
@@ -643,6 +643,34 @@ class DRYamlValidator
     error('repair_withdrawal_amount: is invalid. The proper format is 5000 for 5 gold for example')
   end
 
+  def assert_that_regalia_waggle_is_defined(settings)
+    return unless settings.cycle_armors_regalia
+    return if settings.waggle_sets['regalia']['Regalia']
+    
+    warn("No Regalia waggle defined. Combat-trainer will use min prep unless you declare a waggle named 'regalia' with different values")
+  end
+  
+  def assert_that_regalia_gearset_is_defined(settings)
+    return unless settings.cycle_armors_regalia
+    return unless settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?
+    
+    error("Regalia cycling requires a gear_set named 'regalia' that is missing any armor you wish Regalia to replace.")
+  end
+  
+  def assert_that_regalia_does_not_conflict_with_armor_swap(settings)
+    return unless settings.cycle_armors && settings.cycle_armors_regalia
+    
+    error('cycle_armors and cycle_armors_regalia at the same time not currently supported! Combat-trainer will default to cycle_armors only!')
+  end
+ 
+  def assert_that_cycle_regalia_are_skills(settings)
+    return unless settings.cycle_armors_regalia
+
+    settings.cycle_armors_regalia
+            .reject { |skill| ['Light Armor', 'Chain Armor', 'Brigandine', 'Plate Armor'].include?(skill) }
+            .each_key { |skill| error("Skill name in cycle_armors_regalia is not valid: #{skill}") }
+  end
+  
   private
 
   def warn(message)


### PR DESCRIPTION
Added support for Trader Regalia, specifically for its use for full-set armor-swapping using Bespoke Regalia, though it also works for keeping a single set alive.  It handles refreshing Regalia if it starts to expire in combat.  If regalia fails due to lack of starlight it swaps back to your standard gearset.   The cycling uses existing cycle_armors logic with your set cycle_armors_time.  If only one regalia cycle set is defined it will stick with that one, refreshing it when it's about to expire.

As is, it lets me train all four complete armor sets without clown-suiting or carrying a set of plate, chain and brigandine around, then shift into my best type when it's all trained.

I would appreciate some inspection or testing beyond what I've done already, especially for someone without Bespoke Regalia to test this script by setting cycle_armors_regalia with just your highest armor skill.  I can't unlearn the metaspell for a week or two.

Usage:
Define a regalia: gearset that's missing any armor you want to replace.

gear_sets:
  standard:
  - quilted hauberk
  - mail gloves
  - ring balaclava
  - steel shield
  - parry stick
  regalia:
  - steel shield
  - parry stick

Define a cycle_armors_regalia: set that contains the item names that Regalia will be summoning for each skill.  If replacing everything it will look like below, but you could also include, say, just a mask for each set if your regalia set is only missing face armor.

cycle_armors_regalia:
  Brigandine:
    - scale hauberk
    - scale balaclava
    - scale gloves
  Light Armor:
    - carapace gloves
    - carapace balaclava
    - carapace hauberk
  Chain Armor:
    - chain hauberk
    - chain balaclava
    - chain gloves
  Plate Armor:
    - sallet
    - plate gauntlets
    - full plate

That's all you need to define.  Defining a regalia waggle, cycle_armors_time, and default_armor_type will improve its usage.  Defining a cycle_armors_regalia without a regalia gearset will generate a warning and cancel regalia functions.

Attempts to declare the items as gear didn't work out too well, since equipmanager wasn't really designed to handle items that can't be worn or removed.  Instead, it tracks these items by name just so it can bput remove them when they need to be destroyed.

If you have a default_armor_type: defined it will attempt to use that skill when it has no other armors to train, otherwise it will choose the highest-ranked on your list.  I can confirm this works exactly the way I want it for regalia, but I had to add it to the definitions in initialize, so perhaps someone else knows why it wasn't used yet.

If you have a regalia: waggle it will use the spell defined there, otherwise it will use the values in base_spells.

Known Limitations: 
It is not compatible with cycle_armors.  If both are declared it will generate a warning and nil the regalia swapping function before continuing.

If combat-trainer exits gracefully it puts the regalia away and swaps to your standard gearset before leaving.  If it's killed then you'll have old regalia pieces on you getting in the way.  This could cause a pileup if you kill combat-trainer and restart it right away.  Needs more development.

Also other minor changes,
starlight: attribute added to several spells in base-spells.  If combat-trainer detects a spell's failure due to lack of starlight it will delete all offensive_spells and buff_spells that have the starlight: true attribute.  There are probably more graceful ways to do this in the future, but it's better than it continuing to spam spells when it's out of starlight.  This can be overridden by declaring starlight: false in your spell list.

Also, added a 'Your concentration lapses' match to ct-spelllost.  In certain situations when I'm doing something weird and unnatural I might lose focus on a targeted spell without its target dying.

Also, a typo at the end of combat-trainer -- :balance_regen_threshold had an 'end' at the end of it

Please take a look -- I'd like other traders to try this out and I can make changes if we want to implement this a different way.