### PR TITLE
base-hunting.yaml: Remove unmappable dark spirits area.

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -411,13 +411,6 @@ hunting_zones:
   - 6850
   - 6843
   - 6849
-  # https://elanthipedia.play.net/Dark_spirit                            130-170
-  # Unreal, incorp
-  dark_spirits:
-  - 8499
-  - 8497
-  - 8498
-  - 8500
   # https://elanthipedia.play.net/Scavenger_Troll                        170-220
   # STEAL WEAPONS
   scavenger_trolls:


### PR DESCRIPTION
Closes #3085