### PR TITLE
Adding young_ogres_riverhaven to base-hunting.yaml

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -932,6 +932,17 @@ hunting_zones:
   - 264
   - 265
   - 266
+  # https://elanthipedia.play.net/Young_Ogre                              80-120
+  young_ogres_riverhaven:
+  - 8600
+  - 8601
+  - 8602
+  - 8603
+  - 8604
+  - 8605
+  - 8606
+  - 8607
+  - 8608
   # https://elanthipedia.play.net/Gypsy_marauder                         100-125
   # Good spawn
   marauders:


### PR DESCRIPTION
Adding Young Ogres in Riverhaven to the base-hunting.yaml file.
Closes #3089 