### PR TITLE
add razortusk boar hunt and organize ratha base-hunting

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -198,6 +198,32 @@ hunting_areas_by_town:
     - river_boa
   # https://elanthipedia.play.net/Marbled_angiswaerd                     300-400 
     - marbled_angiswaerd
+  Ratha:
+  # https://elanthipedia.play.net/Sand_sprite                              50-73
+  # Decent boxes
+    - sandsprites
+  # https://elanthipedia.play.net/Silver_leucro                           95-110 
+    - silver_leucros_ratha 
+  # https://elanthipedia.play.net/Adult_razortusk_boar                   100-130
+    - razortuzk_boars
+  # https://elanthipedia.play.net/Merrows                                120-150
+    - crimson_merrows 
+  # https://elanthipedia.play.net/Bawdy_swain                            120-150
+    - bawdy_swain
+  # https://elanthipedia.play.net/Kra%27hei_hatchling                    130-210 
+    - kra_hei_hatchlings
+  # https://elanthipedia.play.net/Ochre_la%27heke                        150-240 
+    - ochre_la_heke
+  # https://elanthipedia.play.net/Gaunt_shadow_master                      220-?
+  # Good safe room: 9994
+    - shadow_master
+  # https://elanthipedia.play.net/Spectral_pirate                        250-325 
+    - spectral_pirate
+  # https://elanthipedia.play.net/Retan_dolomar                          260-410 
+    - retan_dolomar
+  # https://elanthipedia.play.net/Asaren_Celpeze                         400-620
+  # add ambergris to loot_additions, which sells like a gem
+    - asaren_celpeze_1
 
 hunting_zones:
 ################################################################################
@@ -1686,6 +1712,16 @@ hunting_zones:
   - 5174
   - 5175
   - 5176
+  # https://elanthipedia.play.net/Adult_razortusk_boar                   100-130
+  razortusk_boars:
+  - 5139
+  - 5140
+  - 5141
+  - 5142
+  - 5143
+  - 5144
+  - 5145
+  - 5146
   # https://elanthipedia.play.net/nightweaver_unyun                      100-188
   nightweaver_unyun:
   - 5642
@@ -1749,7 +1785,7 @@ hunting_zones:
   - 5520
   - 5521
   - 5522
-  # https://elanthipedia.play.net/Kra%27hei                              130-210 
+  # https://elanthipedia.play.net/Kra%27hei_hatchling                    130-210 
   kra_hei_hatchlings:
   - 4890
   - 4892
@@ -1939,6 +1975,7 @@ hunting_zones:
   - 6811
   - 6810
   # https://elanthipedia.play.net/Asaren_Celpeze                         400-620
+  # add ambergris to loot_additions
   asaren_celpeze_1:
   - 4871
   - 4872
@@ -1952,6 +1989,7 @@ hunting_zones:
   - 4880
   - 4881
   # https://elanthipedia.play.net/Asaren_celpeze_(2)                     450-620
+  # add ambergris to loot_additions
   asaren_celpeze_southern:
   - 6633
   - 6632
@@ -1961,6 +1999,7 @@ hunting_zones:
   - 6637
   - 6638
   #https://elanthipedia.play.net/Asaren_celpeze_(3)                      550-800
+  # add ambergris to loot_additions
   asaren_celpeze_northern:
   - 6609
   - 6610


### PR DESCRIPTION
Added a set of spawn rooms for Ratha's razortusk_boars. 

Changed the elanthipedia link for the Kra'hei hatchlings -- the fully grown Kra'hei aren't on the list and will be added once I can safely explore in there.

Added all the mob hunt entries accessible from Ratha to the hunting_areas_by_town section.  Chose to include shadow_masters -- technically on Taisgath, but since you can walk there in moments and Taisgath's not even really a hometown it went with the rest of Ratha's stuff