### PR TITLE
Fix ratha's sandsprite hunting zone

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1675,18 +1675,18 @@ hunting_zones:
   # Decent boxes
   sandsprites:
   - 5220
-  - 5521
-  - 5515
-  - 5517
-  - 5514
-  - 5516
-  - 5522
-  - 5523
-  - 5524
-  - 5525
-  - 5526
-  - 5527
-  - 5528
+  - 5221
+  - 5215
+  - 5217
+  - 5214
+  - 5216
+  - 5222
+  - 5223
+  - 5224
+  - 5225
+  - 5226
+  - 5227
+  - 5228
   # https://elanthipedia.play.net/Blood_wolf_(2)                           75-90
   # https://elanthipedia.play.net/bobcat                                   45-65
   qi_blood_wolves: 


### PR DESCRIPTION
Ratha's sandsprite hunting zone has many entries that are offset by 300 from their real room ids.  This means that if the first room isn't free it will take you all the way to the Aesry graveyard.  There are no sandsprites outside of Ratha's wreck, and you can see some of the duplicate rooms in the entries for the ghoul_crows and ghoul_ravens.

I've hunted there for a long time and never noticed this, but ALL of the 55xx rooms are in Aesry, and improperly tagged with 'sandsprites' in their room data (I'll fix this in the map later)  

The real rooms are the -300 offset versions.  5521 becomes 5221, etc.  All of these offset rooms have been checked to make sure they are the right versions, so it looks like just a simple fumbled number when they were put in originally.