### PR TITLE
fixed broken cave_troll hunting room

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -629,7 +629,7 @@ hunting_zones:
   cave_trolls:
   - 19194
   - 19195
-  - 19203
+  - 19196
   - 19204
   - 19193
   # https://elanthipedia.play.net/Treehopper_Toad                        300-370


### PR DESCRIPTION
cave_trolls map area contained two duplicate rooms, 19196 and 19203, the latter being one where the exits were obscured in thick fog and had broken pathing.

Dartellum removed 19203 and re-pathed the hunting zone, but now 19196 is the true room and 19203 doesn't exist.