### PR TITLE
base-hunting.yaml: Fix up cave trolls after the map was updated.

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -629,7 +629,7 @@ hunting_zones:
   cave_trolls:
   - 19194
   - 19195
-  - 19203
+  - 19196
   - 19204
   - 19193
   # https://elanthipedia.play.net/Treehopper_Toad                        300-370


### PR DESCRIPTION
19203 doesn't exist anymore, and 19196 was missing.