### PR TITLE
Redirect Hibarnhvidar non-forgers to Shard in base-crafting

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -225,7 +225,7 @@ blacksmithing:
     stock-name: bronze ingot
     trash-room: 10767
     idle-room: 10765
-  Hibarnhvidar:
+  Hibarnhvidar: &forfedhar_blacksmithing
     npc: Juln
     npc_last_name: Juln
     npc-rooms:
@@ -310,7 +310,8 @@ blacksmithing:
     stock-number: 11
     trash-room: 8813
     idle-room: 8808
-
+  Boar Clan:
+    << : *forfedhar_blacksmithing
 tailoring:
   Crossing: &zoluren_tailoring
     npc: Milline
@@ -485,6 +486,8 @@ tailoring:
     idle-room: 11251
   Hibarnhvidar:
     << : *ilithi_tailoring
+  Boar Clan:
+    << : *ilithi_tailoring
 shaping:
   Crossing: &zoluren_shaping
     npc: Talia
@@ -626,6 +629,8 @@ shaping:
     idle-room: 11268
   Hibarnhvidar:
     << : *ilithi_shaping
+  Boar Clan:
+    << : *ilithi_shaping
 carving:
   Crossing: &zoluren_carving
     npc: Talia
@@ -731,7 +736,9 @@ carving:
     pattern-book: carving
     part-room: 11272
   Hibarnhvidar:
-    << : &ilithi_carving
+    << : *ilithi_carving
+  Boar Clan:
+    << : *ilithi_carving
 remedies:
   Crossing: &zoluren_remedies
     npc: Lanshado
@@ -857,7 +864,9 @@ remedies:
     catalyst_number: 2
     catalyst_volume: 10
   Hibarnhvidar:
-    << : &ilithi_remedies
+    << : *ilithi_remedies
+  Boar Clan:
+    << : *ilithi_remedies
 deeds:
   Crossing:
     room: 8775
@@ -894,7 +903,17 @@ deeds:
     small_number: 14
     medium_number: 15
     large_number: 16
-
+  Hibarnhvidar:
+    room: 8894
+    small_number: 14
+    medium_number: 15
+    large_number: 16
+  Boar Clan:
+    room: 8894 #Hibarnhvidar
+    small_number: 14
+    medium_number: 15
+    large_number: 16
+    
 recipe_parts:
   small backing:
     Crossing:
@@ -911,7 +930,16 @@ recipe_parts:
       part-number:
     Ratha: 
       part-room: 10755
-      part-number:     
+      part-number:
+    Shard:
+      part-room: 4436
+      part-number:
+    Boar Clan:
+      part-room: 4436 # Shard
+      part-number:
+    Hibarnhvidar:
+      part-room: 4436 # Shard
+      part-number:
   large backing:
     Crossing:
       part-room: 8776
@@ -928,6 +956,15 @@ recipe_parts:
     Ratha: 
       part-room: 10755
       part-number: 
+    Shard:
+      part-room: 4436
+      part-number:
+    Boar Clan:
+      part-room: 4436 # Shard
+      part-number:
+    Hibarnhvidar:
+      part-room: 4436 # Shard
+      part-number:
   small padding:
     Crossing:
       part-room: 16667
@@ -950,6 +987,12 @@ recipe_parts:
     Ratha: 
       part-room: 10755
       part-number: 
+    Boar Clan:
+      part-room: 4436 # Shard
+      part-number:
+    Hibarnhvidar:
+      part-room: 4436 # Shard
+      part-number:
   long pole:
     Crossing:
       part-room: 8776
@@ -974,6 +1017,12 @@ recipe_parts:
       part-number:
     Ratha: 
       part-room: 10755
+      part-number: 
+    Hibarnhvidar: 
+      part-room: 8892
+      part-number: 
+    Boar Clan: 
+      part-room: 8892 # Hibarnhvidar
       part-number: 
   short pole:
     Crossing:
@@ -1000,6 +1049,12 @@ recipe_parts:
     Ratha: 
       part-room: 10755
       part-number: 
+    Hibarnhvidar: 
+      part-room: 8892
+      part-number: 
+    Boar Clan: 
+      part-room: 8892 # Hibarnhvidar
+      part-number: 
   long cord:
     Crossing:
       part-room: 8776
@@ -1022,6 +1077,12 @@ recipe_parts:
     Ratha: 
       part-room: 10755
       part-number: 
+    Boar Clan:
+      part-room: 10939 # Shard
+      part-number: 17
+    Hibarnhvidar:
+      part-room: 10939 # Shard
+      part-number: 17
   short cord:
     Crossing:
       part-room: 8776
@@ -1041,6 +1102,15 @@ recipe_parts:
     Ratha: 
       part-room: 10755
       part-number: 
+    Shard:
+      part-room: 4436
+      part-number:
+    Boar Clan:
+      part-room: 4436 # Shard
+      part-number:
+    Hibarnhvidar:
+      part-room: 4436 # Shard
+      part-number:
   large padding:
     Crossing:
       part-room: 8776
@@ -1060,6 +1130,12 @@ recipe_parts:
     Ratha: 
       part-room: 10755
       part-number: 
+    Boar Clan:
+      part-room: 10939 # Shard
+      part-number: 12
+    Hibarnhvidar: 
+      part-room: 10939 # Shard
+      part-number: 12
   hilt:
     Crossing:
       part-room: 8776
@@ -1081,6 +1157,12 @@ recipe_parts:
       part-number:
     Ratha: 
       part-room: 10755
+      part-number:
+    Hibarnhvidar: 
+      part-room: 8892
+      part-number: 
+    Boar Clan: 
+      part-room: 8892 # Hibarnhvidar
       part-number: 
   haft:
     Crossing:
@@ -1104,6 +1186,12 @@ recipe_parts:
     Ratha: 
       part-room: 10755
       part-number: 
+    Hibarnhvidar: 
+      part-room: 8892
+      part-number: 
+    Boar Clan: 
+      part-room: 8892 # Hibarnhvidar
+      part-number: 
   shield handle:
     Crossing:
       part-room: 8776
@@ -1126,6 +1214,12 @@ recipe_parts:
     Ratha: 
       part-room: 10746
       part-number: 16
+    Hibarnhvidar:
+      part-room: 10939 # Shard
+      part-number: 16
+    Boar Clan:
+      part-room: 10939 # Shard
+      part-number: 16
   thread:
     Crossing:
       part-room: 16667
@@ -1141,6 +1235,15 @@ recipe_parts:
       part-number: 6
     Ratha: 
       part-room: 10746
+      part-number: 6
+    Shard:
+      part-room: 10939
+      part-number: 6
+    Boar Clan:
+      part-room: 10939 # Shard
+      part-number: 6
+    Hibarnhvidar: 
+      part-room: 10939 # Shard
       part-number: 6
   pins:
     Crossing:
@@ -1158,6 +1261,15 @@ recipe_parts:
     Ratha: 
       part-room: 10749
       part-number: 5
+    Shard:
+      part-room: 10938
+      part-number: 5
+    Boar Clan:
+      part-room: 10938 # Shard
+      part-number: 5
+    Hibarnhvidar: 
+      part-room: 10938 # Shard
+      part-number: 5
   bow string:
     Crossing:
       part-room: 8864
@@ -1174,6 +1286,15 @@ recipe_parts:
     Ratha: 
       part-room: 10738
       part-number: 
+    Shard:
+      part-room: 4436
+      part-number:
+    Boar Clan:
+      part-room: 4436 # Shard
+      part-number:
+    Hibarnhvidar: 
+      part-room: 4436 # Shard
+      part-number:
   bone backer:
     Crossing:
       part-room: 8864
@@ -1192,7 +1313,13 @@ recipe_parts:
       part-number:
     Ratha: 
       part-room: 10738
-      part-number: 
+      part-number:
+    Hibarnhvidar:
+      part-room: 19306 # Shard
+      part-number:
+    Boar Clan:
+      part-room: 19306 # Shard
+      part-number:      
   leather strip:
     Crossing:
       part-room: 8864
@@ -1212,4 +1339,9 @@ recipe_parts:
     Ratha: 
       part-room: 10738
       part-number: 
-      
+    Hibarnhvidar:
+      part-room: 19306 # Shard
+      part-number:
+    Boar Clan:
+      part-room: 19306 # Shard
+      part-number:      

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -375,7 +375,7 @@ tailoring:
     knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 9720
-  Shard:
+  Shard: &ilithi_tailoring
     npc: Jakke
     npc_last_name: Jakke
     npc-rooms:
@@ -483,6 +483,8 @@ tailoring:
     knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 11251
+  Hibarnhvidar:
+    << : *ilithi_tailoring
 shaping:
   Crossing: &zoluren_shaping
     npc: Talia
@@ -568,7 +570,7 @@ shaping:
     pattern-book: shaping
     part-room: 10737
     idle-room:
-  Shard:
+  Shard: &ilithi_shaping
     npc: Master
     npc_last_name: Master
     npc-rooms:
@@ -622,6 +624,8 @@ shaping:
     pattern-book: shaping
     part-room: 11272
     idle-room: 11268
+  Hibarnhvidar:
+    << : *ilithi_shaping
 carving:
   Crossing: &zoluren_carving
     npc: Talia
@@ -665,7 +669,7 @@ carving:
     stock-name: alabaster
     stock-volume: 1
     pattern-book: carving
-  Shard:
+  Shard: &ilithi_carving
     npc: Master
     npc_last_name: Master
     npc-rooms:
@@ -726,7 +730,8 @@ carving:
     stock-bone-volume: 10
     pattern-book: carving
     part-room: 11272
-
+  Hibarnhvidar:
+    << : &ilithi_carving
 remedies:
   Crossing: &zoluren_remedies
     npc: Lanshado
@@ -782,7 +787,7 @@ remedies:
     catalyst-room: 8785
     catalyst_number: 2
     catalyst_volume: 10
-  Shard:
+  Shard: &ilithi_remedies
     npc: Benzia
     npc_last_name: Benzia
     npc-rooms:
@@ -851,6 +856,8 @@ remedies:
     catalyst-room: 10758
     catalyst_number: 2
     catalyst_volume: 10
+  Hibarnhvidar:
+    << : &ilithi_remedies
 deeds:
   Crossing:
     room: 8775


### PR DESCRIPTION
Added a reference to redirect anyone trying to do remedies, tailoring, shaping, or carving in Hibarnhvidar over to Shard since there is only a Forging Society there.