### PR TITLE
Add functions to common-arcana to support regalia

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -234,6 +234,34 @@ module DRCA
       .map { |_name, properties| properties['abbrev'] }
       .each { |abbrev| fput("release #{abbrev}") }
   end
+  
+  def parse_regalia  # generates an array of currently-worn regalia armor nouns
+    return unless DRStats.trader?
+    DRC.bput('inv armor', 'Type INVENTORY HELP for more options')
+    snapshot = reget(40)
+    if snapshot.grep(/All of your armor|You aren't wearing anything like that/).any? && snapshot.grep(/Type INVENTORY HELP/).any?
+      result = snapshot
+        .map(&:strip)
+        .reverse
+        .take_while { |item| !['All of your armor:', "You aren't wearing anything like that."].include?(item) }
+        .drop_while { |item| item != '[Type INVENTORY HELP for more options]' }
+        .drop(1)
+        .select { |item| item.include?('rough-cut crystal') || item.include?('faceted crystal') || item.include?('resplendent crystal')}
+    else
+      parse_regalia
+    end
+    result.each_with_index { |item, index| result[index] = DRC.get_noun(item)}
+  end
+  
+  def shatter_regalia?(worn_armor = nil) # takes an array of armor nouns to remove or gets its own from parse_regalia
+    return false unless DRStats.trader? 
+    worn_armor = parse_regalia unless worn_armor
+    return false if worn_armor.empty?
+    worn_armor.each do |item| 
+       DRC.bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}")
+    end
+    return true
+  end
 
   def parse_mana_message(mana_msg)
     manalevels = if mana_msg.include? 'weak'


### PR DESCRIPTION
Adding two functions to common-arcana.

parse_regalia takes inv armor and returns the nouns for those that match T1, T2, or T3 regalia pieces.

shatter_regalia? takes a list of regalia nouns to remove or gets its own from parse_regalia.  Returns true if it found and destroyed a regalia, false otherwise.