### PR TITLE
Trader starlight development + regalia support in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1420,7 +1420,6 @@ class SpellProcess
       if Flags['ct-regalia-succeeded']
         Flags.reset('ct-regalia-expired')
         Flags.reset('ct-regalia-succeeded')
-        #game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
         game_state.last_regalia_type = game_state.swap_regalia_type
         game_state.swap_regalia_type = nil
       end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -27,11 +27,18 @@ class SetupProcess
     @last_cycle_time = Time.now - @cycle_armors_time
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
+    @cycle_regalia = settings.cycle_armors_regalia
+    echo("  @cycle_regalia: #{@cycle_regalia}") if $debug_mode_ct
+    @default_armor = settings.default_armor_type
+    echo("  @default_armor: #{@default_armor}") if $debug_mode_ct
 
+    @gearsets = settings.gear_sets
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
     @last_warhorn = Time.now - 305
 
+    validate_regalia(settings)
+    
     return unless @warhorn
 
     if DRCI.wearing?(@warhorn)
@@ -81,7 +88,7 @@ class SetupProcess
       check_stance(game_state)
     end
 
-    check_armor_swap(game_state)
+    @cycle_regalia ? check_regalia_swap(game_state) : check_armor_swap(game_state)
     false
   end
 
@@ -111,7 +118,7 @@ class SetupProcess
     return false unless @armor_hysteresis
     return false if @cycle_armors.keys.any? { |skill| DRSkill.getxp(skill) < 25 }
     if @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
-      if @last_worn_type != @default_armor
+      if @last_worn_type != @default_armor && @cycle_armors.keys.include?(@default_armor)
         @equipment_manager.worn_items(@all_swap_pieces).each { |item| @equipment_manager.remove_item(item) }
         @equipment_manager.wear_items(@equipment_manager.desc_to_items(@cycle_armors[@default_armor]))
         @last_worn_type = @default_armor
@@ -120,6 +127,17 @@ class SetupProcess
     true
   end
 
+  def regalia_hysteresis?(game_state)
+    return false unless @armor_hysteresis
+    # Override hysteresis logic if regalia is about to expire.
+    return false if @cycle_regalia.any? { |skill| DRSkill.getxp(skill) < 22 } || game_state.last_regalia_type.nil? || Flags['ct-regalia-expired'] 
+    if @cycle_regalia.all? { |skill| DRSkill.getxp(skill) > 24 } && game_state.last_regalia_type != @default_armor 
+        return false if Time.now - @last_cycle_time < @cycle_armors_time
+        game_state.swap_regalia_type = @cycle_regalia.include?(@default_armor) ? @default_armor : @cycle_regalia.max_by { |skill| DRSkill.getrank(skill) } # If no default type declared, go by the highest rank.
+    end
+    true
+  end
+  
   def check_armor_swap(game_state)
     return if armor_hysteresis?
     return if Time.now - @last_cycle_time < @cycle_armors_time
@@ -145,6 +163,23 @@ class SetupProcess
     @last_worn_type = next_armor_type
 
     game_state.wield_whirlwind_offhand
+  end
+  
+  def check_regalia_swap(game_state)
+    return if regalia_hysteresis?(game_state)
+    return if Time.now - @last_cycle_time < @cycle_armors_time && !Flags['ct-regalia-expired']
+    # if CT is done with regalia (usually starlight depleted) don't process anymore until it starts to expire naturally, then close it down.
+    if game_state.regalia_cancel 
+      regalia_shutdown(game_state) if Flags['ct-regalia-expired'] 
+      return
+    end
+    armor_types = @cycle_regalia
+    next_armor_type = armor_types.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
+    return if next_armor_type == @last_worn_type unless Flags['ct-regalia-expired']
+    return if DRSkill.getxp(next_armor_type) >= @combat_training_abilities_target unless Flags['ct-regalia-expired'] || game_state.last_regalia_type.nil? 
+    
+    @last_cycle_time = Time.now
+    game_state.swap_regalia_type = next_armor_type # Mark for SpellProcess casting in check_regalia
   end
 
   def determine_next_to_train(game_state, weapon_training, ending_ranged)
@@ -258,6 +293,32 @@ class SetupProcess
     offhand_skill = temp_array.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
     game_state.update_whirlwind_weapon_info(offhand_skill)
     game_state.wield_whirlwind_offhand
+  end
+  
+  def validate_regalia(settings)
+    return unless @cycle_regalia
+    if @cycle_armors
+      echo "ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!"
+      @cycle_regalia = nil
+    end
+    
+    if (settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?)
+      echo "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
+      @cycle_regalia = nil
+    end
+    # reset swap clock if you start CT already wearing a regalia.
+    @last_cycle_time = Time.now unless DRCA.parse_regalia.empty?
+  end
+  
+  def regalia_shutdown(game_state) 
+    DRCA.shatter_regalia?
+    game_state.last_regalia_type = nil
+    game_state.swap_regalia_type = nil
+    game_state.regalia_cancel = nil
+    @cycle_regalia = nil
+    Flags.reset('ct-regalia-expired')
+    @equipment_manager.wear_equipment_set?('standard')
+    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@gearsets['standard'].include?(game_state.weapon_name)) # The above will put away worn weapons
   end
 end
 
@@ -926,6 +987,12 @@ class SpellProcess
     @buff_force_cambrinth = settings.combat_trainer_buffs_force_cambrinth
     echo("  @buff_force_cambrinth: #{@buff_force_cambrinth}") if $debug_mode_ct
 
+    @regalia_array = settings.cycle_armors_regalia
+    echo("  @regalia_array: #{@regalia_array}") if $debug_mode_ct
+
+    @regalia_spell = settings.waggle_sets['regalia']['Regalia']
+    echo("  @regalia_spell: #{@regalia_spell}") if $debug_mode_ct
+    
     @perc_health_timer = Time.now
 
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
@@ -933,8 +1000,12 @@ class SpellProcess
 
     Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
+    Flags.add('ct-starlight-depleted', 'enough starlight') if DRStats.trader?
+    Flags.add('ct-regalia-expired', 'Your .* glimmers? weakly') if DRStats.trader?
+    Flags.add('ct-regalia-succeeded', 'You cup your palms skyward to bask in') if DRStats.trader?
 
     @offensive_spells
+      .select { |spell| spell['expire'] }
       .select { |spell| spell['expire'] }
       .each { |spell| add_spell_flag(spell['abbrev'], spell['expire']) }
     @buff_spells
@@ -952,6 +1023,11 @@ class SpellProcess
     @tk_spell = @offensive_spells.find { |spell| spell['abbrev'] =~ /tkt|tks/i }
     drop_tkt_ammo
     Flags.add('need-tkt-ammo', 'There is nothing here that can be thrown')
+    if DRStats.trader? && @regalia_array
+      @regalia_spell = get_data('spells').spell_data['Regalia'] if (@regalia_array && @regalia_spell.nil?) # get data from the regalia waggle or base-spells
+      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None' # prepare to check for bespoke regalia
+      @know_bespoke = DRC.bput('pre bspk', 'Bespoke Regalia', 'You have no idea', 'fully prepared', 'already preparing') == 'Bespoke Regalia' # check for bespoke regalia
+    end
   end
 
   def drop_tkt_ammo
@@ -987,6 +1063,7 @@ class SpellProcess
       drop_tkt_ammo
     end
     check_slivers(game_state)
+    check_regalia(game_state)
     check_consume(game_state)
     check_cfb(game_state)
     check_bless(game_state)
@@ -1010,6 +1087,7 @@ class SpellProcess
         pause
         fput("stow #{@tk_ammo}")
       end
+      DRCA.shatter_regalia? if @regalia_array
       return true
     end
     false
@@ -1055,6 +1133,29 @@ class SpellProcess
     game_state.casting = false
   end
 
+  def check_regalia(game_state) # designed to catch a signal from SetupProcess and prep regalia
+    return unless @regalia_array
+    return unless game_state.swap_regalia_type
+    return if game_state.swap_regalia_type == game_state.last_regalia_type && !Flags['ct-regalia-expired'] # Don't swap to same armortype unless expiring
+    return if game_state.casting
+    return if game_state.loaded
+    return if mana < @buff_spell_mana_threshold
+    
+    case game_state.swap_regalia_type
+    when 'Light Armor'
+      armor_word = 'light'
+    when 'Chain Armor'
+      armor_word = 'chain'
+    when 'Brigandine'
+      armor_word = 'brigandine'
+    when 'Plate Armor'
+      armor_word = 'plate'
+    end
+    
+    @regalia_spell['cast'] = @know_bespoke ? "cast #{armor_word} all" : "cast"
+    prepare_spell(@regalia_spell, game_state)
+  end
+  
   def check_bless(game_state)
     return if game_state.casting
     return unless @buff_spells['Bless']
@@ -1135,6 +1236,17 @@ class SpellProcess
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
 
+    if game_state.casting_regalia
+      result = DRCA.parse_regalia
+      if result.empty? # if not wearing a regalia, retreat, swap to regalia gearset, then cast
+        DRCT.retreat
+        @equipment_manager.wear_equipment_set?('regalia')
+        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@settings.gear_sets['regalia'].include?(game_state.weapon_name))
+      else # otherwise break what you're already wearing then cast.
+        DRCA.shatter_regalia?(result)
+      end
+    end
+    
     snapshot = DRSkill.getxp(@skill)
     success = cast?(@custom_cast, @symbiosis, @before, @after)
     if @symbiosis && @use_auto_mana
@@ -1171,6 +1283,8 @@ class SpellProcess
 
       game_state.casting_moonblade = false
     end
+
+    check_trader_magic(game_state)
 
     Flags.reset("ct-#{@reset_expire}") if @reset_expire
 
@@ -1287,6 +1401,34 @@ class SpellProcess
     end
   end
 
+  def check_trader_magic(game_state) # handles starlight-related effects and cleans flags
+    return unless DRStats.trader?
+    if Flags['ct-starlight-depleted']
+      echo "----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----"
+      @buff_spells.reject! { |spell| @buff_spells[spell]['starlight_threshold'] > -1 } # delete all buffs and offensive spells. Potential to add stellar collector support later
+      @offensive_spells.reject! { |spell| spell['starlight_threshold'] > -1 }
+      game_state.regalia_cancel = true # stop all regalia swap functions and clean it up next time it expires.
+    end
+    if game_state.casting_regalia
+      if Flags['ct-starlight-depleted']  # In some conditions, regalia can run out of starlight partway through creation.  Don't want a partial regalia on.
+        DRCA.shatter_regalia?
+        @equipment_manager.wear_equipment_set?('standard')
+        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if (@settings.gear_sets['standard'].include?(game_state.weapon_name))
+        game_state.last_regalia_type = nil
+        game_state.swap_regalia_type = nil
+      end
+      if Flags['ct-regalia-succeeded']
+        Flags.reset('ct-regalia-expired')
+        Flags.reset('ct-regalia-succeeded')
+        #game_state.last_regalia_type = Flags['ct-starlight-depleted'] ? nil : game_state.swap_regalia_type
+        game_state.last_regalia_type = game_state.swap_regalia_type
+        game_state.swap_regalia_type = nil
+      end
+      game_state.casting_regalia = false
+    end
+    Flags.reset('ct-starlight-depleted')
+  end
+  
   def check_cfb(game_state)
     return unless DRStats.necromancer?
     return unless @necromancer_zombie['Call from Beyond']
@@ -1425,6 +1567,9 @@ class SpellProcess
         data['cast'] = "cast #{moon}"
       end
     end
+    
+    game_state.casting_regalia = data['abbrev'].casecmp('REGAL').zero?
+    
     prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
     game_state.casting = true
     game_state.cambrinth_charges(data['cambrinth'])
@@ -2534,7 +2679,7 @@ class CombatTrainer
     @equipment_manager = EquipmentManager.new(settings)
     setup(settings)
     settings.storage_containers.each { |container| fput("open my #{container}") }
-    @equipment_manager.wear_equipment_set?('standard')
+    @equipment_manager.wear_equipment_set?('standard') if (settings.cycle_armors_regalia.nil? || DRCA.parse_regalia.empty?)
   end
 
   def set_dance(message, settings)
@@ -2623,7 +2768,7 @@ class GameState
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
 
-  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast
+  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type, :casting_regalia
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -2643,6 +2788,10 @@ class GameState
     @casting_moonblade = false
     @casting_sorcery = false
     @hide_on_cast = false
+    @casting_regalia = false
+    @regalia_cancel = false
+    @last_regalia_type = nil
+    @swap_regalia_type = nil
     @casting_weapon_buff = false
     @casting_consume = false
     @prepare_consume = false
@@ -3317,11 +3466,12 @@ class GameState
   end
 
   attr_accessor :clean_up_step, :current_weapon_skill, :target_weapon_skill, :no_skins, :constructs, :no_stab_mobs, :no_loot, :dancing, :retreating, :action_count, :charges, :aim_queue, :dance_queue, :analyze_combo_array
-  attr_reader :dance_skill, :target_action_count, :dance_threshold, :retreat_threshold, :summoned_weapons, :target_increment, :stances, :weapons_to_train, :use_stealth_attacks, :ambush, :backstab, :charged_maneuvers, :fatigue_regen_threshold, :aim_fillers, :aim_fillers_stealth, :dance_actions, :dance_actions_stealth, :ignored_npcs, :dual_load, :summoned_weapons_element, :summoned_weapons_ingot, :cambrinth, :stored_cambrinth, :cambrinth_cap, :use_weak_attacks, :dedicated_camb_use, :use_barb_combos, :balance_regen_thresholdend
+  attr_reader :dance_skill, :target_action_count, :dance_threshold, :retreat_threshold, :summoned_weapons, :target_increment, :stances, :weapons_to_train, :use_stealth_attacks, :ambush, :backstab, :charged_maneuvers, :fatigue_regen_threshold, :aim_fillers, :aim_fillers_stealth, :dance_actions, :dance_actions_stealth, :ignored_npcs, :dual_load, :summoned_weapons_element, :summoned_weapons_ingot, :cambrinth, :stored_cambrinth, :cambrinth_cap, :use_weak_attacks, :dedicated_camb_use, :use_barb_combos, :balance_regen_threshold
 end
 
 before_dying do
   DRCA.release_cyclics
+  DRCA.shatter_regalia?
   Flags.delete('using-corpse')
   Flags.delete('pouch-full')
   Flags.delete('container-full')
@@ -3338,6 +3488,9 @@ before_dying do
   Flags.delete('ct-damage-ready')
   Flags.delete('ct-need-bless')
   Flags.delete('last-stance')
+  Flags.delete('ct-regalia-expired')
+  Flags.delete('ct-starlight-depleted')
+  Flags.delete('ct-regalia-succeeded')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -247,17 +247,17 @@ module DRCA
         .drop_while { |item| item != '[Type INVENTORY HELP for more options]' }
         .drop(1)
         .select { |item| item.include?('rough-cut crystal') || item.include?('faceted crystal') || item.include?('resplendent crystal')}
+        .map { |item| DRC.get_noun(item)}
     else
       parse_regalia
     end
-    result.each_with_index { |item, index| result[index] = DRC.get_noun(item)}
   end
   
-  def shatter_regalia?(worn_armor = nil) # takes an array of armor nouns to remove or gets its own from parse_regalia
+  def shatter_regalia?(worn_regalia = nil) # takes an array of armor nouns to remove or gets its own from parse_regalia
     return false unless DRStats.trader? 
-    worn_armor = parse_regalia unless worn_armor
-    return false if worn_armor.empty?
-    worn_armor.each do |item| 
+    worn_regalia = parse_regalia unless worn_regalia
+    return false if worn_regalia.empty?
+    worn_regalia.each do |item| 
        DRC.bput("remove my #{item}", "into motes of silvery", "Remove what?", "You .*#{item}")
     end
     return true
@@ -308,11 +308,14 @@ module DRCA
     starlight_messages = [
       'The smallest hint of starlight flickers within your aura',
       'A bare flicker of starlight plays within your aura',
-      'A faint amount of starlight illuminates your aura'
+      'A faint amount of starlight illuminates your aura',
+      'Your aura pulses slowly with starlight',
+      'A steady pulse of starlight runs through your aura',
+      'Starlight dances vividly across the confines of your aura'
     ]
     Flags.add('aura-level', Regexp.union(starlight_messages))
     Flags.add('aura-capped?', 'Your aura contains as much starlight as you can safely handle')
-    Flags.add('aura-growing?', 'Local conditions permit optimal growth of your aura')
+    Flags.add('aura-growing?', 'Local conditions permit optimal growth of your aura', 'Local conditions are hindering the growth of your aura')
     aura = {}
     DRC.bput('perceive aura', 'Roundtime')
     aura['level'] = Flags['aura-level'] ? starlight_messages.index(Flags['aura-level'].first) : 0

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -157,6 +157,7 @@ cast_messages:
 - You begin to target
 - ^Wisps of spectral flame whorl.*$
 - ^You cup your palms skyward to bask in.*$
+- ^Incited by the spell, your starlight aura
 
 khri_preps:
 - With deep breaths
@@ -435,6 +436,7 @@ spell_data:
     abbrev: ARS
     mana: 6
     prep: prepare
+    starlight_threshold: 0
   Arc Light:
     skill: Debilitation
     harmless: true
@@ -551,6 +553,7 @@ spell_data:
     mana: 5
     abbrev: blur
     recast: 1
+    starlight_threshold: 0
     mana_type: lunar
   Bond Armaments:
     skill: Utility
@@ -688,6 +691,7 @@ spell_data:
     skill: Targeted Magic
     abbrev: CRD
     mana: 2
+    starlight_threshold: 0
   Crusader's Challenge:
     skill: Augmentation # Also Utility
     abbrev: CRC
@@ -833,6 +837,7 @@ spell_data:
     ritual: true
     abbrev: ELI
     recast: 1
+    starlight_threshold: 0
   Electrostatic Eddy:
     skill: Debilitation
     harmless: true
@@ -840,6 +845,12 @@ spell_data:
     cyclic: true
     triggers_justice: true
     mana: 6
+  Enrichment:
+    skill: Augmentation
+    abbrev: ENRICH
+    mana: 30
+    recast: -1
+    starlight_threshold: 3
   Essence of Yew:
     skill: Warding
     abbrev: EY
@@ -919,6 +930,7 @@ spell_data:
     mana: 1
     skill: Debilitation
     harmless: true
+    starlight_threshold: 0
     mana_type: lunar
   Flush Poisons:
     skill: Utility
@@ -1536,6 +1548,7 @@ spell_data:
     mana: 15
     skill: Utility
     recast: 1
+    starlight_threshold: 0
     mana_type: lunar
   Regenerate:
     skill: Utility
@@ -1819,6 +1832,7 @@ spell_data:
     skill: Targeted Magic
     abbrev: starcrash
     mana: 30
+    starlight_threshold: 0
   Starlight Sphere:
     skill: Targeted Magic
     abbrev: SLS
@@ -1937,6 +1951,7 @@ spell_data:
     mana: 1
     abbrev: TRC
     recast: 1
+    starlight_threshold: 0
   Tranquility:
     skill: Augmentation #Warding
     abbrev: TRANQUILITY

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -44,10 +44,14 @@ priority_defense:
 stance_override:
 # set armor skill and items to swap to train different armor skills in combat.  See Sarvatt-setup
 cycle_armors:
+# a list of armor skills for trader regalia casting. Used with a 'regalia' gearset to turn on regalia usage in combat.
+cycle_armors_regalia:
 # how often to check for cycle_armors swapping
 cycle_armors_time: 125
 # hysteresis true allows combat-trainer to avoid armor swapping when all set armors are trained, or swap to your default_armor_type
 cycle_armors_hysteresis: true
+# works with cycle_armors, regalia, and hysteresis.  Which armor type to use when all others on your list are trained.
+default_armor_type:
 # To use arrange_all, make sure to set arrange_count to 1
 skinning:
   skin: true

--- a/validate.lic
+++ b/validate.lic
@@ -643,6 +643,41 @@ class DRYamlValidator
     error('repair_withdrawal_amount: is invalid. The proper format is 5000 for 5 gold for example')
   end
 
+  def assert_that_regalia_waggle_is_defined(settings)
+    return unless settings.cycle_armors_regalia
+    return if settings.waggle_sets['regalia']['Regalia']
+    
+    warn("No Regalia waggle defined. Combat-trainer will use min prep unless you declare a waggle named 'regalia' with different values")
+  end
+  
+  def assert_that_regalia_waggle_has_abbrev(settings)
+    return unless settings.cycle_armors_regalia
+    return if settings.waggle_sets['regalia']['Regalia']['abbrev'].casecmp('REGAL').zero?
+    
+    error("Regalia waggle's abbreviation differs from default. Change to abbrev: REGAL")
+  end
+  
+  def assert_that_regalia_gearset_is_defined(settings)
+    return unless settings.cycle_armors_regalia
+    return unless settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?
+    
+    error("Regalia cycling requires a gear_set named 'regalia' that is missing any armor you wish Regalia to replace.")
+  end
+  
+  def assert_that_regalia_does_not_conflict_with_armor_swap(settings)
+    return unless settings.cycle_armors && settings.cycle_armors_regalia
+    
+    error('cycle_armors and cycle_armors_regalia at the same time not currently supported! Combat-trainer will default to cycle_armors only!')
+  end
+ 
+  def assert_that_cycle_regalia_are_skills(settings)
+    return unless settings.cycle_armors_regalia
+
+    settings.cycle_armors_regalia
+            .reject { |skill| ['Light Armor', 'Chain Armor', 'Brigandine', 'Plate Armor'].include?(skill) }
+            .any? { |skill| error("Skill name in cycle_armors_regalia is not valid: #{skill}") }
+  end
+  
   private
 
   def warn(message)


### PR DESCRIPTION
Changes meant to support trader starlight, regalia armor swapping, and future development of trader magic.

COMMON-ARCANA:
Comments incorporated.  After removing the result.each_with it shouldn't require the 'return parse_regalia' if I understand it right.

starlight_messages added to perc_aura. Message added to the aura-growing flag to capture when your aura is still growing less than optimally.  Eventually I want to use all of these things in CT.  Right now this is not used.

BASE.YAML
values added for regalia variable and default_armor_type.
Should something be in base-empty?

BASE_SPELLS:
previously-planned starlight attribute replaced with starlight_threshold.  Currently this doesn't do anything beyond marking the spell for deletion when you run out of starlight, but it's being built for the future.  Meant to interact with DRCA.perc_aura with the idea being it'll update your aura occasionally and let you tag certain spells to only cast when you have an aura of that level or higher.

A value of -1 means it won't even be removed if you run out of starlight.

Also, Enrichment and its cast message added.

COMBAT-TRAINER:
IMO the critical points are line 91 and 2682.

2682 is what makes players wear their standard gear at the very start of combat.  Supporting starting combat-trainer with a prebuffed regalia required skipping this if you have regalia stuff set or you're wearing regalia.  My thief and cleric don't see any messages from this.

default_armor_type seems to be working now that it's declared up above.  Added a catch to make sure your default_armor_type is actually in your cycle_armors.

New functions in ct:
check_regalia_swap mimics check_armor_swap but tags game_state.swap_regalia_type for SpellProcess to cast regalia.

regalia_hysteresis mimics armor_hysteresis

validate_regalia runs once to catch a couple fatal errors that would make ct throw a fit, and captures a pre-existing regalia on start.

regalia_shutdown totally ends all regalia function and swaps to the standard gearset

check_regalia catches a game_state.swap_regalia or an expired regalia and calls prepare_spell to replace it.

check_trader_magic handles all starlight-related and trader magic stuff after a cast, including handling exhausted starlight and resetting regalia stuff.