### PR TITLE
rezz.lic: Bump the default number of infusion attempts to 15 from 10.

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -83,7 +83,7 @@ class Rezz
 
   def find_soul?(player)
     Flags.add('rotting', /#{player}.s body'?s? (grows paler|seems to|appears to|appearance takes)/)
-    10.times do
+    15.times do
       pause 5 while DRStats.mana < 40
       @settings.osrel_no_harness ? nil : harness_mana([@rezz['mana']])
       match = bput("infuse rezz #{@rezz['mana']}", 'You sense a spirit nearby, but you are unable to make it out clearly', /spirit of #{player} in the Void/)


### PR DESCRIPTION
Someone complained on lnet that they needed 11 attempts to rezz a few times and this number is arbitrary, let's just up it a bit.