### PR TITLE
Add support for lich v. 4.12 script trust modifications

### DIFF
--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -9,8 +9,24 @@ arg_definitions = [[{ name: 'wipe_constants', regex: /wipe_constants/i, optional
 
 args = parse_args(arg_definitions, true)
 
+def constant_defined?(symbol)
+  if RUBY_VERSION =~ /^2\.[012]\./
+    Scripting.constants.include?(symbol)
+  else
+    Object.constants.include?(symbol)
+  end
+end
+
+def remove_constant(symbol)
+  if RUBY_VERSION =~ /^2\.[012]\./
+    Scripting.send(:remove_const,symbol)
+  else
+    Object.send(:remove_const,symbol)    
+  end
+end
+
 if args.wipe_constants
-  class_defs.each_value { |symb| Scripting.send(:remove_const, symb) if Scripting.constants.include?(symb) }
+  class_defs.each_value { |symb| remove_constant(symb) if constant_defined?(symb) }
   exit
 end
 
@@ -19,14 +35,14 @@ echo scripts_to_run.to_s if UserVars.bootstrap_debug
 until scripts_to_run.empty?
   script_to_run = scripts_to_run.shift
   respond("BS:#{script_to_run}:#{scripts_to_run}") if UserVars.bootstrap_debug
-  next if Script.running?(script_to_run) || (class_defs[script_to_run] && Scripting.constants.include?(class_defs[script_to_run]))
+  next if Script.running?(script_to_run) || (class_defs[script_to_run] && constant_defined?(class_defs[script_to_run]))
   respond("BS:Running #{script_to_run}") if UserVars.bootstrap_debug
   exit unless verify_script(scripts_to_run)
   start_script(script_to_run)
   pause 0.05
   snapshot = Time.now
   if class_defs[script_to_run]
-    pause 0.05 until Scripting.constants.include?(class_defs[script_to_run])
+    pause 0.05 until constant_defined?(class_defs[script_to_run])
     pause 0.05
   else
     until !Script.running?(script_to_run) || Time.now - snapshot > 0.25


### PR DESCRIPTION
Trust was removed for lich users using lich v4.12 and ruby version > 2.2
This change adds backwards compatability as well as support
for the trust changes for users running 2.0.0 or greater.