### PR TITLE
Check for modern versions of lich and ruby instead of just ruby

### DIFF
--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -9,21 +9,28 @@ arg_definitions = [[{ name: 'wipe_constants', regex: /wipe_constants/i, optional
 
 args = parse_args(arg_definitions, true)
 
+
 def constant_defined?(symbol)
-  if RUBY_VERSION =~ /^2\.[012]\./
-    Scripting.constants.include?(symbol)
-  else
+  if $MODERN_LICH && $MODERN_RUBY
     Object.constants.include?(symbol)
+  else
+    Scripting.constants.include?(symbol)
   end
 end
 
 def remove_constant(symbol)
-  if RUBY_VERSION =~ /^2\.[012]\./
-    Scripting.send(:remove_const,symbol)
-  else
+  if $MODERN_LICH && $MODERN_RUBY
     Object.send(:remove_const,symbol)    
+  else
+    Scripting.send(:remove_const,symbol)
   end
 end
+
+
+RUBY_VERSION =~ /^(\d+)\.(\d+)\./
+$MODERN_RUBY = $1.to_i > 2 || ($1.to_i == 2 && $2.to_i > 2)
+LICH_VERSION =~ /^(\d+)\.(\d+)\./
+$MODERN_LICH = $1.to_i > 4 || ($1.to_i == 4 && $2.to_i > 11)
 
 if args.wipe_constants
   class_defs.each_value { |symb| remove_constant(symb) if constant_defined?(symb) }


### PR DESCRIPTION
Fixes an issue with a user running modern ruby on old lich. Also reversed the order of the if statements in the two functions.