### PR TITLE
fix problem with empty analyze array on mob death

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3069,7 +3069,7 @@ class GameState
   def determine_whirlwind_action
     if @use_weak_attacks && Flags['ct-accuracy-ready']
       update_analyze_array(true) if @analyze_combo_array.empty?
-      @analyze_combo_array.shift
+      @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif (npcs.length > 2) && !balance_low?
       'whirlwind'
     else
@@ -3369,7 +3369,7 @@ class GameState
       brawling? ? 'gouge' : 'jab'
     elsif @use_barb_combos && !offhand? && !brawling?
       update_analyze_array(false) if @analyze_combo_array.empty?
-      @analyze_combo_array.shift
+      @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else
       'attack'
     end
@@ -3439,7 +3439,10 @@ class GameState
       Flags.reset("ct-#{combo_type}-ready")
       return false
     when 'Analyze what?'
-      fput('face next')
+      case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
+      when 'You turn to face'
+        return perform_analyze?(combo_type, expertise_requirement)
+      end
       return true
     end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3440,7 +3440,7 @@ class GameState
       return false
     when 'Analyze what?'
       case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
-      when 'You turn to face'
+      when 'You turn'
         return perform_analyze?(combo_type, expertise_requirement)
       end
       return true


### PR DESCRIPTION
This is related to issue https://github.com/rpherbig/dr-scripts/issues/3143

A condition can trigger whenever a mob is killed at the same time as a barbarian's analyze array is depleted and not replenished by perform_analyze? that causes an empty melee_attack_verb to be generated.

I don't believe there's an easy fix to this 'in-method' for perform_analyze?, since it would need to handle the states of being out of melee and needing to advance or all mobs being dead, and do it before a melee_attack_verb is decided.  So instead whereever update_analyze_array is used it will just default to 'attack' if it returns with an empty array.

Also, for somewhat more reliability, the face next in perform_analyze does try once more to turn on an enemy in melee, which should prevent this most of the time.