### PR TITLE
Change Barbarian meditation activation messages

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -301,27 +301,27 @@ barb_abilities:
   Contemplation:
     type: meditation
     start_command: med contemplation
-    activated_message: ^You .* to meditate
+    activated_message: feel a jolt as your vision snaps shut
     expired_message: contemplate enhanced defensive strategies drifts
   Bastion:
     type: meditation
     start_command: med bastion
-    activated_message: ^You .* to meditate
+    activated_message: feel a jolt as your vision snaps shut
     expired_message: bastion of strength slips from your mind
   Tenacity:
     type: meditation
     start_command: med tenacity
-    activated_message: ^You .* to meditate
+    activated_message: feel a jolt as your vision snaps shut
     expired_message: leaving you vulnerable to physical harm
   Serenity:
     type: meditation
     start_command: med serenity
-    activated_message: ^You .* to meditate
+    activated_message: feel a jolt as your vision snaps shut
     expired_message: leaving you vulnerable to magic
   Focus:
     type: meditation
     start_command: med focus
-    activated_message: ^You .* to meditate
+    activated_message: feel a jolt as your vision snaps shut
     expired_message: Focus meditation slips away from your mind
 
 spell_data:


### PR DESCRIPTION
The Barbarian meditations previously had their activated messages of when you start the meditation. Without the Yogi Mastery, it still takes a few seconds to complete after the round time before you can stand up. Instead we should use the 'meditation active' message.

Closes #3171 