### PR TITLE
Spell spelling check in ;validate

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -678,6 +678,18 @@ class DRYamlValidator
             .any? { |skill| error("Skill name in cycle_armors_regalia is not valid: #{skill}") }
   end
 
+  def assert_that_non_training_spells_are_in_base_spells(settings)
+    return unless settings.offensive_spells || settings.buff_spells
+
+    spell_names = []
+    settings.buff_spells.each { |spell| spell_names.push(spell.first) }
+    settings.offensive_spells.each { |spell| spell_names.push(spell['name']) }
+    spell_data = get_data('spells').spell_data
+
+    spell_names.reject { |name| spell_data.keys.include?(name) }
+               .each { |name| warn("Spell not found in base_spells '#{name}'! Check its spelling and capitalization.") }
+  end
+
   private
 
   def warn(message)


### PR DESCRIPTION
A number of tech problems have been coming up due to misspelled/miscapitalized spells in buff-spells or offensive_spells.  Especially problematic with buffs and cyclics.  Adding a check to validate to catch that.

I wasn't really sure whether this should be a warning or error but I tentatively went with warning.

```
>
[validate: WARNING:< Spell not found in base_spells 'Trabe chalice'! Check its spelling and capitalization.  >]
  WARNINGS:1 ERRORS:0
  All done!
```