### PR TITLE
Use Gem::Version to check versions

### DIFF
--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -25,10 +25,13 @@ def remove_constant(symbol)
   end
 end
 
-RUBY_VERSION =~ /^(\d+)\.(\d+)\./
-$MODERN_RUBY = Regexp.last_match(1).to_i > 2 || (Regexp.last_match(1).to_i == 2 && Regexp.last_match(2).to_i > 2)
-LICH_VERSION =~ /^(\d+)\.(\d+)\./
-$MODERN_LICH = Regexp.last_match(1).to_i > 4 || (Regexp.last_match(1).to_i == 4 && Regexp.last_match(2).to_i > 11)
+$MODERN_RUBY = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
+lich_version = Gem::Version.new(LICH_VERSION.gsub(/(f)/, ''))
+$MODERN_LICH = if $1
+                 lich_version > Gem::Version.new('4.11.0')
+               else
+                 lich_version > Gem::Version.new('4.6.48')
+               end
 
 if args.wipe_constants
   class_defs.each_value { |symb| remove_constant(symb) if constant_defined?(symb) }


### PR DESCRIPTION
Uses Gem::Version to simplify version checking. 

Check for non-fork versions of lich as well. Anyone on Ruby > 3.2 and not on the lich fork will have the correct $MODERN_LICH and $MODERN_RUBY vars set