### PR TITLE
Use stricter version checking

### DIFF
--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -28,9 +28,9 @@ end
 $MODERN_RUBY = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
 lich_version = Gem::Version.new(LICH_VERSION.gsub(/(f)/, ''))
 $MODERN_LICH = if $1
-                 lich_version > Gem::Version.new('4.11.0')
+                 lich_version >= Gem::Version.new('4.12.0')
                else
-                 lich_version > Gem::Version.new('4.6.48')
+                 lich_version >= Gem::Version.new('4.6.49')
                end
 
 if args.wipe_constants


### PR DESCRIPTION
This change enforces the minimum possible version when qualifying something as modern