### PR TITLE
Undo abbrev spell-checking

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -685,7 +685,6 @@ class DRYamlValidator
     spell_check = ['buff_spells', 'offensive_spells', 'training_spells', 'crafting_training_spells', 'combat_spell_training', 'waggle_sets']
     spell_check.each do |list|
       spell_names = []
-      spell_abbrevs = []
       case list
       when 'buff_spells'
         settings.buff_spells.each { |spell| spell_names.push(spell.first) }
@@ -694,29 +693,17 @@ class DRYamlValidator
       when 'crafting_training_spells'
         settings.crafting_training_spells
           .each do |skill, data|
-            if data['name']
-              spell_names.push(data['name']) unless spell_data[data['name']]
-            elsif data['abbrev']
-              spell_abbrevs.push(data['abbrev']) unless spell_data[data['abbrev']]
-            end
+            spell_names.push(data['name']) if data['name'] && !spell_data[data['name']]
           end
       when 'training_spells'
         settings.training_spells
           .each do |skill, data|
-            if data['name']
-              spell_names.push(data['name']) unless spell_data[data['name']]
-            elsif data['abbrev']
-              spell_abbrevs.push(data['abbrev']) unless spell_data[data['abbrev']]
-            end
+            spell_names.push(data['name']) if data['name'] && !spell_data[data['name']]
           end
       when 'combat_spell_training'
         settings.combat_spell_training
           .each do |skill, data|
-            if data['name']
-              spell_names.push(data['name']) unless spell_data[data['name']]
-            elsif data['abbrev']
-              spell_abbrevs.push(data['abbrev']) unless spell_data[data['abbrev']]
-            end
+            spell_names.push(data['name']) if data['name'] && !spell_data[data['name']]
           end
       when 'waggle_sets'
         settings.waggle_sets.each { |set_name, set_spells| set_spells.each { |spell| spell_names.push(spell.first) } if set_spells.is_a?(Hash) }
@@ -724,9 +711,6 @@ class DRYamlValidator
 
       name_warnings = spell_names.uniq.reject { |name| spell_data.keys.include?(name) }
       warn("#{list} contains the following spell names not found in data/base_spells, #{name_warnings.to_s} Check spelling and capitalization.") unless name_warnings.empty?
-
-      abbrev_warnings = spell_abbrevs.uniq.reject { |abbrev| abbrev_list.include?(abbrev) }
-      warn("#{list} contains the following spell abbreviations not found in data/base_spells, #{abbrev_warnings.to_s} Check spelling and capitalization.") unless abbrev_warnings.empty?
     end
   end
 


### PR DESCRIPTION
After some time talking to people I think the name-checking portion of this is doing its job, but the number of people with incomplete or non-matching abbrevs in their yamls is pretty high, especially for the spell abbrevs not explicitly defined in SPELLS.  This seems to indicate to me it probably isn't a necessary check and may obscure real problems in validate when working with people.

I'd like to revert only the abbrev checking and keep the name checking as is.  I went through the testing again to make sure it still caught name errors in those sections.