### PR TITLE
Correct typos in base recipes/spells

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -700,13 +700,13 @@ crafting_recipes:
   chapter: 4
 - name: some tapered knitting needles
   noun: needles
-  volume: 3
+  volume: 4
   type: blacksmithing
   work_order: true
   chapter: 4
 - name: some squat knitting needles
   noun: needles
-  volume: 3
+  volume: 4
   type: blacksmithing
   work_order: true
   chapter: 4

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -684,7 +684,7 @@ spell_data:
   Courage:
     skill: Augmentation
     abbrev: CO
-    mana: 15
+    mana: 5
     recast: 1
     mana_type: holy
   Crystal Dart:


### PR DESCRIPTION
A couple typos found by chat and myself.

Base volume on all knitting needles should be 4 instead of 3 in base-recipes.  Most were already 4.
Base mana on Courage should be 5 rather than 15 https://elanthipedia.play.net/Courage