### PR TITLE
dependency.lic: remove yaml formattting from help_me posts.

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -528,7 +528,7 @@ class ScriptManager
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
     request = Net::HTTP::Post.new(uri.request_uri)
-    request.set_form_data(api_dev_key: @paste_bin_token, api_paste_code: message_body, api_paste_private: '1', api_paste_format: 'yaml', api_paste_expire_date: '1W', api_option: 'paste')
+    request.set_form_data(api_dev_key: @paste_bin_token, api_paste_code: message_body, api_paste_private: '1', api_paste_expire_date: '1W', api_option: 'paste')
 
     response = http.request(request)
     result = response.body.chomp


### PR DESCRIPTION
This has been throwing me off for the past few weeks, yaml formatting on pastebin sometimes gets whitespace wrong and its making valid yamls that look fine locally invalid on pastebin.