### PR TITLE
check against empty crafting_training_spells

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -143,7 +143,7 @@ class Carve
   end
 
   def magic_routine
-    return unless @training_spells
+    return if @training_spells.empty?
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -165,7 +165,7 @@ class Carve
   end
 
   def magic_cleanup
-    return unless @training_spells
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")

--- a/forge.lic
+++ b/forge.lic
@@ -484,7 +484,7 @@ class Forge
   end
 
   def magic_routine
-    return unless @training_spells
+    return if @training_spells.empty?
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -506,7 +506,7 @@ class Forge
   end
 
   def magic_cleanup
-    return unless @training_spells
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")

--- a/mech-lore.lic
+++ b/mech-lore.lic
@@ -81,7 +81,7 @@ class MechLore
   end
 
   def magic_routine
-    return unless @training_spells
+    return if @training_spells.empty?
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -103,7 +103,7 @@ class MechLore
   end
 
   def magic_cleanup
-    return unless @training_spells
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -57,7 +57,7 @@ class Outdoorsmanship
   end
 
   def magic_routine
-    return unless @training_spells
+    return if @training_spells.empty?
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -79,7 +79,7 @@ class Outdoorsmanship
   end
 
   def magic_cleanup
-    return unless @training_spells
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")

--- a/remedy.lic
+++ b/remedy.lic
@@ -367,7 +367,7 @@ class Remedy
   end
 
   def magic_routine
-    return unless @training_spells
+    return if @training_spells.empty?
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -389,7 +389,7 @@ class Remedy
   end
 
   def magic_cleanup
-    return unless @training_spells
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")

--- a/sew.lic
+++ b/sew.lic
@@ -316,7 +316,7 @@ class Sew
   end
 
   def magic_routine
-    return unless @training_spells
+    return if @training_spells.empty?
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -338,7 +338,7 @@ class Sew
   end
 
   def magic_cleanup
-    return unless @training_spells
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")

--- a/shape.lic
+++ b/shape.lic
@@ -218,7 +218,7 @@ class Shape
   end
 
   def magic_routine
-    return unless @training_spells
+    return if @training_spells.empty?
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -240,7 +240,7 @@ class Shape
   end
 
   def magic_cleanup
-    return unless @training_spells
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")


### PR DESCRIPTION
Fix for the script improperly passing a True when checking for Crafting Training Spells because of base.yaml

This addresses Issue #3185 