### PR TITLE
Changing Mountain Tobacco to Pass tobacco

### DIFF
--- a/data/base-stealing.yaml
+++ b/data/base-stealing.yaml
@@ -3974,7 +3974,7 @@
   poorly_max: 407
   poorly_min: 387
 - town: Arthe Dale
-  item: mountain tobacco
+  item: pass tobacco
   item_in: in tobacco case
   room: 19385
   pawnable: false


### PR DESCRIPTION
The correct adjective is Pass, not Mountain.  Full name is Mountain Pass Blend tobacco