### PR TITLE
fix dumping in the Junk Yard

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -72,6 +72,8 @@ module DRCI
         trashcan = 'statue'
       elsif trashcan == 'tree'
         trashcan = 'hollow' if DRRoom.room_objs.include?('dead tree with a darkened hollow near its base')
+      elsif XMLData.room_title == '[[A Junk Yard]]'
+        trashcan = 'bin'
       end
 
       if /^You (drop|put)/ =~ DRC.bput("put my #{item} in #{trashcan}", '^You drop', '^You put', "You're kidding, right", 'What were you referring to', "You can't do that")


### PR DESCRIPTION
barrels are often on the ground in the Junk Yard. when thieves get sent there during ;steal they attempt to drop items in barrels, rather than the bin, which isn't successful. then ;afk logs them out after 1 minute. this change should make sure dumping in the Junk Yard uses the bin.