### PR TITLE
update logic for exiting from junk yard

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -46,10 +46,11 @@ loop do
   end
 
   if line =~ /For a current status of how many items you have, use LOOK PORTAL./
-    echo "Looks like you're in the junk yard.  We'll log you out in 60 seconds.  You can ';kill afk' to stay in the game, just remember to restart it once you get out of the junk yard"
-    pause 60
-
-    exit_game('Exiting from the Junk Yard') if XMLData.room_title == '[[A Junk Yard]]'
+    echo "Looks like you're in the junk yard.  We'll log you out in 60 seconds unless you exit the junk yard.  You can also ';kill afk' to stay in the game, just remember to restart it once you get out of the junk yard."
+    junk_timer = Time.now
+    while XMLData.room_title == '[[A Junk Yard]]'
+      exit_game('Exiting from the Junk Yard') if Time.now - junk_timer > 60
+    end
   end
 
   if Room.current.id == 9610

--- a/afk.lic
+++ b/afk.lic
@@ -49,6 +49,7 @@ loop do
     echo "Looks like you're in the junk yard.  We'll log you out in 60 seconds unless you exit the junk yard.  You can also ';kill afk' to stay in the game, just remember to restart it once you get out of the junk yard."
     junk_timer = Time.now
     while XMLData.room_title == '[[A Junk Yard]]'
+      pause 1
       exit_game('Exiting from the Junk Yard') if Time.now - junk_timer > 60
     end
   end


### PR DESCRIPTION
The old logic checked if a user was still in the junk yard 60 seconds after entering. The new logic only exits the game if you don't leave the junk yard for a *consecutive* 60 seconds.

People on the verge of item limits can go in and out of the junk yard frequently. This fixes the situation where a player exits because they happen to be back in the junk yard 60 seconds after initially triggering the ;afk script.