### PR TITLE
Bescort: Added Gate of Souls/Blasted Plains support

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -804,7 +804,7 @@ class Bescort
     when /exit/i
       if XMLData.room_title.include?('The Fangs of Ushnish')
         wander_maze_until('steep cliff', 'climb cliff')
-    	gos_temple_leave
+        gos_temple_leave
       end
       if XMLData.room_title.include?('Temple of Ushnish')
         gos_temple_leave

--- a/bescort.lic
+++ b/bescort.lic
@@ -115,6 +115,10 @@ class Bescort
         { name: 'mode', options: %w[exit enter], description: 'Where do you need to get to?' }
       ],
       [
+        { name: 'gate_of_souls', regex: /gate_of_souls/i, description: 'For crossing the Blasted Plain between the Gate of Souls and Temple of Ushnish' },
+        { name: 'mode', options: %w[exit blasted temple fangs], description: 'Where do you need to get to?' }
+      ],
+      [
         { name: 'segoltha', regex: /segoltha/i, description: 'The Segoltha south of the crossing' },
         { name: 'mode', options: %w[north south], description: 'Where do you need to get to?' }
       ],
@@ -200,6 +204,8 @@ class Bescort
       faldesu(args.mode)
     elsif args.zaulfang
       zaulfang(args.mode)
+    elsif args.gate_of_souls
+      gate_of_souls(args.mode)
     elsif args.segoltha
       segoltha(args.mode)
     elsif args.crocs
@@ -723,7 +729,7 @@ class Bescort
   end
 
   def zaulfang(mode)
-    Flags.add('zfswamp-reset', 'The noxious swamp gas takes its toll on your mind, and your surroundings seem to shift as you grow immensely dizzy')
+    Flags.add('maze-reset', 'The noxious swamp gas takes its toll on your mind, and your surroundings seem to shift as you grow immensely dizzy')
     case mode
     when /enter/i
       unless Room.current.id == 8540
@@ -747,8 +753,8 @@ class Bescort
   def wander_maze_until(target, exit_command)
     current_room = MazeRoom.new
     loop do
-      if Flags['zfswamp-reset']
-        Flags.reset('zfswamp-reset')
+      if Flags['maze-reset']
+        Flags.reset('maze-reset')
         result = bput('look', 'Obvious paths:.*').split(':').last.split(', ').first.delete('.')
         move(result)
         pause
@@ -764,6 +770,88 @@ class Bescort
       end
       current_room = current_room.wander
     end
+  end
+  
+  def gate_of_souls(mode)
+    Flags.add('maze-reset', 'Plumes of lava belch into the air, sending molten rock spraying about')
+    case mode
+    when /blasted/i
+      unless Room.current.id == 1784
+        echo('Must start at Gate of Souls, room number 1784')
+        exit
+      end
+      gos_blasted_plains
+      find_room_maze
+    when /temple/i
+      unless Room.current.id == 1784
+        echo('Must start at Gate of Souls, room number 1784')
+        exit
+      end
+      gos_blasted_plains
+      wander_maze_until('golden sandstone temple', 'go temple')
+      manual_go2(13625)
+      find_room_list(%w[sw e e e se s sw w w w w nw n ne se s ne se n ne w nw])
+    when /fangs/i
+      unless Room.current.id == 1784
+        echo('Must start at Gate of Souls, room number 1784')
+        exit
+      end
+      gos_blasted_plains
+      wander_maze_until('golden sandstone temple', 'go temple')
+      manual_go2(13643)
+      fput('climb cliff')
+      find_room_maze
+    when /exit/i
+      if XMLData.room_title.include?('The Fangs of Ushnish')
+        wander_maze_until('steep cliff', 'climb cliff')
+    	gos_temple_leave
+      end
+      if XMLData.room_title.include?('Temple of Ushnish')
+        gos_temple_leave
+      end
+      if XMLData.room_title.include?('Blasted Plain')
+        gos_plains_leave
+      end
+      if XMLData.room_title.include?('Before the Gate of Souls')
+        gos_tunnel
+      end
+    end
+  end
+
+  def gos_blasted_plains
+      unless DRRoom.room_objs.include?('low tunnel')
+        push_boulder
+      end
+      retreat
+      gos_tunnel
+      fput('go field')
+    end
+  
+  def push_boulder
+    fix_standing
+    fput('push boulder', 'You lean against the boulder and push with all your might', 'You\'re already pushing')
+    case waitfor('a low tunnel is revealed', 'You stop pushing', 'blocking all access to a low tunnel')
+    when 'You stop pushing', 'blocking all access to a low tunnel'
+      push_boulder
+    end
+  end
+  
+  def gos_tunnel
+    fput('kneel')
+    fput('go tunnel')
+    waitfor 'you crawl out of the passage into'
+    fix_standing
+  end
+	
+  def gos_temple_leave
+    manual_go2(13159)
+    fput('go field')
+    gos_plains_leave
+  end
+	
+  def gos_plains_leave
+    wander_maze_until('low cavern', 'go cavern')
+    gos_tunnel
   end
 
   def segoltha(mode)


### PR DESCRIPTION
Added support to navigate the Blasted Plains to the Temple of Ushnish and Fangs of Ushnish.  Must start at room 1784, which is in front of the boulder in Fire Sprites/Maidens.

Options:
Blasted: Leaves you in the Blasted Plains maze area
Temple: Leaves you through the door in the Temple of Ushnish
Fangs: Leaves you in the Fangs of Ushnish maze area
Exit: Exits from any of the rooms past the boulder