### PR TITLE
combat-trainer.lic: Handle indoors missed lobs in aiming_trainables

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2534,7 +2534,12 @@ class AttackProcess
 
       actions.each do |action|
         break unless execute_aiming_action?(action, game_state)
-        bput("get my #{weapon_name}", 'You pick up') if action.include?('lob')
+        if action.include?('lob')
+          case bput("get my #{weapon_name}", 'You pick up', 'What were')
+          when 'What were'
+            bput("get #{weapon_name}", 'You pick up')
+          end
+        end
       end
 
       game_state.sheath_offhand_weapon(skill)


### PR DESCRIPTION
This is leaving the weapon on the ground currently so you lose it.

[combat-trainer]>lob left

< You lob a steel bola at a fuligin umbral moth.  A fuligin umbral moth dodges.
The bola hits a wall and falls to the floor!
[You're winded, adeptly balanced and in dominating position.]
[Roundtime 1 sec.]

[combat-trainer]>get my bola

What were you referring to?

[combat-trainer: *** No match was found after 15 seconds, dumping info]

[combat-trainer: messages seen length: 82]