### PR TITLE
Update carve.lic - Pick up the item if it's on the ground

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -183,6 +183,7 @@ class Carve
     end
     waitrt?
     magic_cleanup
+    fput "get #{@noun}" unless left_hand =~ /#{@noun}/i || right_hand =~ /#{@noun}/i 
     exit
   end
 end


### PR DESCRIPTION
When carving from boulders and other rock sizes that are too heavy to pick up, the item is left on the ground at the end of the carve script.
This fix will pick it up if it doesn't detect the item in one of your hands.