### PR TITLE
Update workorders.lic - Fix for deed packets in wyvern packs and hitm…

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -699,7 +699,7 @@ class WorkOrders
     end
 
     return unless @deed_own_ingot
-    unless exists?('packet')
+    unless DRC.bput('look my deed packet', /You count \d+ deed claim forms remaining/, /I could not find what you were referring to/) =~ /You count \d+ deed claim forms remaining/
       ensure_copper_on_hand(@cash_on_hand || 10_000, @settings)
       order_item(@deeds_room, @deeds_number)
       fput('stow my packet')


### PR DESCRIPTION
…an's backpacks

Since you can't tap items in a wyvern hide hunting pack or a hitman's backpack, I changed the line that checks for the deed packet to use look instead.
Oh, and I did check the packet with only 1 deed left.  It still says claim forms and not form.