### PR TITLE
Update smith.lic - replace inv search for oil

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -109,19 +109,7 @@ class Smith
 
   def stamp_item(recipe)
     fput('get my stamp')
-    fput("mark  def check_oil(discipline)
-    $ORDINALS.each do |ord|
-	  case bput("look my #{ord} oil", /A thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
-	  when /A thick and syrupy substance that easily coats and lubricates metal/
-	    return if ord == 'first'
-	    bput("get my #{ord} oil", /You get/)
-		bput("stow oil", /You put/)
-		return
-	  when /I could not find what you were referring to/
-	    break
-	  end
-    end
- my #{recipe['noun']} with my stamp")
+    fput("mark my #{recipe['noun']} with my stamp")
     pause 1
     waitrt?
     fput("put my stamp in my #{@container}")

--- a/smith.lic
+++ b/smith.lic
@@ -90,7 +90,17 @@ class Smith
   end
 
   def check_oil(discipline)
-    return if search?(discipline['finisher-full'])
+    $ORDINALS.each do |ord|
+	    case bput("look my #{ord} oil", /A thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
+	    when /A thick and syrupy substance that easily coats and lubricates metal/
+	      return if ord == 'first'
+	      bput("get my #{ord} oil", /You get/)
+		    bput("stow oil", /You put/)
+		    return
+	    when /I could not find what you were referring to/
+	      break
+	    end
+    end
 
     ensure_copper_on_hand(1000, @settings)
     order_item(discipline['finisher-room'], discipline['finisher-number'])
@@ -99,7 +109,19 @@ class Smith
 
   def stamp_item(recipe)
     fput('get my stamp')
-    fput("mark my #{recipe['noun']} with my stamp")
+    fput("mark  def check_oil(discipline)
+    $ORDINALS.each do |ord|
+	  case bput("look my #{ord} oil", /A thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
+	  when /A thick and syrupy substance that easily coats and lubricates metal/
+	    return if ord == 'first'
+	    bput("get my #{ord} oil", /You get/)
+		bput("stow oil", /You put/)
+		return
+	  when /I could not find what you were referring to/
+	    break
+	  end
+    end
+ my #{recipe['noun']} with my stamp")
     pause 1
     waitrt?
     fput("put my stamp in my #{@container}")

--- a/smith.lic
+++ b/smith.lic
@@ -91,15 +91,15 @@ class Smith
 
   def check_oil(discipline)
     $ORDINALS.each do |ord|
-	    case bput("look my #{ord} oil", /A thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
-	    when /A thick and syrupy substance that easily coats and lubricates metal/
-	      return if ord == 'first'
-	      bput("get my #{ord} oil", /You get/)
-		    bput("stow oil", /You put/)
-		    return
-	    when /I could not find what you were referring to/
-	      break
-	    end
+      case bput("look my #{ord} oil", /A thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
+      when /A thick and syrupy substance that easily coats and lubricates metal/
+        return if ord == 'first'
+        bput("get my #{ord} oil", /You get/)
+        bput("stow oil", /You put/)
+        return
+      when /I could not find what you were referring to/
+        break
+      end
     end
 
     ensure_copper_on_hand(1000, @settings)


### PR DESCRIPTION
I changed the check_oil method to look at the oil instead of using inv search (which takes like 14+ seconds for me with all of my junk).
I looked up all the different oils on elanthipedia and got their look messaging and put that in the bput matches.
If you have other oils as your 1st-10th oils, it will get the forging oil and make it the top item in your container.
If it's already the top item, it continues as normal.
If it's not found, it will go buy it as usual.