### PR TITLE
Added Looks before attempting to exit mazes

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -803,6 +803,7 @@ class Bescort
       find_room_maze
     when /exit/i
       if XMLData.room_title.include?('The Fangs of Ushnish')
+        fput('look')
         wander_maze_until('steep cliff', 'climb cliff')
         gos_temple_leave
       end
@@ -849,6 +850,7 @@ class Bescort
   end
 
   def gos_plains_leave
+    fput('look')
     wander_maze_until('low cavern', 'go cavern')
     gos_tunnel
   end


### PR DESCRIPTION
Added Look to refresh room directions when attempting to leave Blasted Plains and Fangs of Ushnish in order to fix problems where the room directions changed while hunting in those areas, leading to the script getting stuck trying to navigate in a direction that no longer exists.