### PR TITLE
fix for plain ammo

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2493,12 +2493,12 @@ class AttackProcess
   end
 
   def shoot_aimed(command, game_state)
-    case bput(command, 'isn\'t loaded', 'There is nothing', 'But your', /you (fire|poach|snipe) a .* (arrow|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto) at/i, 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'your moving to fire went unobserved', 'notices your attempt to remain hidden', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
+    case bput(command, 'isn\'t loaded', 'There is nothing', 'But your', /you (fire|poach|snipe) an? (?:.*\s)?(arrow|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto) at/i, 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'your moving to fire went unobserved', 'notices your attempt to remain hidden', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
     when /How can you (poach|snipe)/, 'notices your attempt to remain hidden'
       shoot_aimed('shoot', game_state)
     when 'your moving to fire went unobserved'
       game_state.action_taken
-    when /you (fire|poach|snipe) a .* (arrow|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto) at/i
+    when /you (fire|poach|snipe) an? (?:.*\s)?(arrow|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto) at/i
       game_state.action_taken
       ammo = Regexp.last_match(2)
       bput("stow my #{ammo}", 'You pick up', 'Stow what')


### PR DESCRIPTION
Fix for issue #3258 

an?
Added "N" and a quantifier to account for situations where the next word starts with a vowel.  While not necessarily part of the reported issue, may be an issue at other points

(?:.*\s)?
Non-capture group to avoid complications for dealing with which group the next line should be using
\s (white space) is included in the group to avoid checking against double spaces in situations where an adjective is not present
? Quantifier at the end to allow for instances where there is no adjective (I.E. the reported problem)