### PR TITLE
Updte afk.lic - now gets 99% of items at feet!

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -57,10 +57,9 @@ loop do
 
   if line =~ /You notice a (.*) at your feet/
     match = Regexp.last_match(1)
-    match = match.sub('.', '')
-    item = match.split(' ').last
-    DRC.bput("get my #{item}", 'You get', 'You pick up', 'But that is already in your inventory')
-    equipment_manager.empty_hands
+    item = DRC.get_noun(match)
+    DRC.bput("get my #{item}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
+	equipment_manager.empty_hands
     stop_script('go2') if Script.running?('go2')
   end
 

--- a/afk.lic
+++ b/afk.lic
@@ -55,7 +55,7 @@ loop do
     end
   end
 
-  if line =~ /You notice a (.*) at your feet/
+  if line =~ /You notice (.*) at your feet/
     match = Regexp.last_match(1)
     item = DRC.get_noun(match)
     DRC.bput("get my #{item}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)


### PR DESCRIPTION
Updated the section for at feet items to find the noun for items that don't have the noun as the last word.
This fix also requires an update to common.lic.  I will add that in a moment.

I didn't see the need for this line and removed it.  If the original author has a specific case in mind that needs it, please let me know.
    match = match.sub('.', '')