### PR TITLE
Update common.lic - get_noun update for 'titled'

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -218,7 +218,7 @@ module DRC
   end
 
   def get_noun(long_name)
-    long_name.strip.sub(/ with .*| labeled .+/, '').scan(/[a-z\-]+$/i).first
+    long_name.strip.sub(/ with .*| labeled .+| titled .+/, '').scan(/[a-z\-]+$/i).first
   end
 
   # Items class. Name is the noun of the object. Leather/metal boolean. Is the item worn (defaults to true). Does it hinder lockpicking? (false)


### PR DESCRIPTION
Added another option to strip out of long_name to get the proper noun of items.
This is specifically for this item, so that afk can pick it up if it's at your feet.
`a thick book titled ~101 Rational Reasons Why I am Always Right~`