### PR TITLE
common-travel.lic: Kill go2 before trying to start another go2 in wal…

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -14,6 +14,7 @@ module DRCT
     return false if target_room.nil?
     room_num = target_room.to_i
     return true if room_num == Room.current.id
+    kill_script('go2') if Script.running?('go2')
     DRC.fix_standing
 
     if Room.current.id.nil?


### PR DESCRIPTION
…k_to

walk_to will force another go2 instance to start even if one is currently running. This can be disasterous if steal is running at the same time as other scripts doing it because it will drop items in hand. 2 scripts running at the same time using walk_to will trigger this, the common cause is a misconfigured hunting-buddy setup killing hunting-buddy and running crossing-repair at the same time as another script.

Close #2642