### PR TITLE
added delay to room check

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -803,7 +803,8 @@ class Bescort
       find_room_maze
     when /exit/i
       if XMLData.room_title.include?('The Fangs of Ushnish')
-        fput('look')
+        bput('look', 'Obvious paths')
+        pause 0.1
         wander_maze_until('steep cliff', 'climb cliff')
         gos_temple_leave
       end
@@ -850,7 +851,8 @@ class Bescort
   end
 
   def gos_plains_leave
-    fput('look')
+    bput('look', 'Obvious paths')
+    pause 0.1
     wander_maze_until('low cavern', 'go cavern')
     gos_tunnel
   end


### PR DESCRIPTION
Added a match string to the Look and a small delay when the script refreshes room directions leaving Fangs and Blasted Plains hunting areas.  The script was running a bit fast and would select a movement direction before the client had received the updated available room directions.