### PR TITLE
Update afk.lic - Get all items at feet!!

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -56,11 +56,22 @@ loop do
   end
 
   if line =~ /You notice (.*) at your feet/
+    pause_script('go2')
     match = Regexp.last_match(1)
     item = DRC.get_noun(match)
-    DRC.bput("get my #{item}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
-	equipment_manager.empty_hands
-    stop_script('go2') if Script.running?('go2')
+    case DRC.bput('inv', /Lying at your feet is/, /Lying at your feet are (.*)/)
+    when /Lying at your feet is/
+      DRC.bput("get my #{item}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
+      equipment_manager.empty_hands
+    when /Lying at your feet are (.*)\./
+      at_feet = Regexp.last_match(1)
+      items = DRC.list_to_nouns(at_feet)
+      items.each do |thing|
+        DRC.bput("get my #{thing}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
+        equipment_manager.empty_hands
+      end
+    end
+    unpause_script('go2')
   end
 
   if Room.current.id == 9610

--- a/afk.lic
+++ b/afk.lic
@@ -56,7 +56,6 @@ loop do
   end
 
   if line =~ /You notice (.*) at your feet/
-    pause_script('go2')
     match = Regexp.last_match(1)
     item = DRC.get_noun(match)
     case DRC.bput('inv', /Lying at your feet is/, /Lying at your feet are (.*)\./)
@@ -71,7 +70,7 @@ loop do
         equipment_manager.empty_hands
       end
     end
-    unpause_script('go2')
+    stop_script('go2') if Script.running?('go2')
   end
 
   if Room.current.id == 9610

--- a/afk.lic
+++ b/afk.lic
@@ -59,7 +59,7 @@ loop do
     pause_script('go2')
     match = Regexp.last_match(1)
     item = DRC.get_noun(match)
-    case DRC.bput('inv', /Lying at your feet is/, /Lying at your feet are (.*)/)
+    case DRC.bput('inv', /Lying at your feet is/, /Lying at your feet are (.*)\./)
     when /Lying at your feet is/
       DRC.bput("get my #{item}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
       equipment_manager.empty_hands


### PR DESCRIPTION
Added some code to check if it's 1 item or multiple items at your feet.  If multiple, it builds a list of the items and gets them all.

In doing this change, I found out that DRC.get_noun() doesn't work for nouns with apostrophes so I am putting in a fix for that too.

I also changed it to pause go2 and then unpause it at the end.  I'm not sure if this is okay with the overall intent here.
I don't know if there's a way to send a signal to go2 to tell it to restart without waiting 30 seconds.
If there is, please let me know.

Or if it's preferred that it just stops go2, I'll change that part back.