### PR TITLE
Update common.lic - fix for nouns with apostrophes

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -218,7 +218,7 @@ module DRC
   end
 
   def get_noun(long_name)
-    long_name.strip.sub(/ with .*| labeled .+| titled .+/, '').scan(/[a-z\-]+$/i).first
+    long_name.strip.sub(/ with .*| labeled .+| titled .+/, '').scan(/[a-z\-']+$/i).first
   end
 
   # Items class. Name is the noun of the object. Leather/metal boolean. Is the item worn (defaults to true). Does it hinder lockpicking? (false)


### PR DESCRIPTION
`get_noun` returns only the portion after the apostrophe.
`get_noun("a tempered hhr'ata")` returns "ata"