### PR TITLE
Addition of new ;tinker script

### DIFF
--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -27,6 +27,7 @@ empty_values:
   forging_tools: []
   knitting_tools: []
   shaping_tools: []
+  tinkering_tools: []
   carving_tools: []
   alchemy_tools: []
   aim_fillers_stealth: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -437,6 +437,16 @@ forging_tools:
 - tong
 - bellow
 - shovel
+tinkering_tools:
+- tinker tools
+- bellow
+- shovel
+- drawknife
+- clamps
+- rasp
+- shaper
+- pliers
+- carving knife
 knitting_tools:
 - knitting needle
 outfitting_tools:
@@ -1122,6 +1132,7 @@ restock_shop:
 sanowret_no_use_scripts:
 - sew
 - carve
+- tinker
 - forge
 - remedy
 - shape
@@ -1131,6 +1142,7 @@ sanowret_no_use_scripts:
 almanac_no_use_scripts:
 - sew
 - carve
+- tinker
 - forge
 - remedy
 - shape

--- a/tinker.lic
+++ b/tinker.lic
@@ -1,0 +1,342 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#tinker
+=end
+
+custom_require.call(%w[common common-arcana common-crafting common-items])
+
+class Tinker
+  include DRC
+  include DRCC
+  include DRCI
+  include DRCA
+
+  def initialize
+    @settings = get_settings
+    @bag = @settings.crafting_container
+    @bag_items = @settings.crafting_items_in_container
+    @belt = @settings.engineering_belt
+    @hometown = @settings.hometown
+    @stamp = @settings.mark_crafted_goods
+
+    arg_definitions = [
+      [
+        { name: 'finish', options: %w[log stow trash], description: 'What to do with the finished item.' },
+        { name: 'chapter', regex: /\d+/i, variable: true, description: 'Chapter containing the item.' },
+        { name: 'recipe_name', display: 'recipe name', regex: /^[A-z\s\-]+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
+        { name: 'material', regex: /\w+/i, variable: true, description: 'Type of material.' },
+        { name: 'noun', regex: /\w+/i, variable: true },
+        { name: 'mechanism', regex: /\w+/i, variable: true, optional: true, description: 'What metal mechanism to use -brass-oravir-etc. Optional.'  }
+      ],
+      [
+        { name: 'continue', regex: /continue/i, variable: true },
+        { name: 'noun', regex: /\w+/i, variable: true }
+      ],
+      [
+        { name: 'laminate', regex: /laminate/i },
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item to laminate.' }
+      ],
+      [
+        { name: 'lighten', regex: /lighten/i },
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item to lighten.' }
+      ],
+      [
+        { name: 'cable', regex: /cable/i },
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item to cable-back and increase draw-strength.' }
+      ],
+      [
+        { name: 'mechanisms', regex: /mechanisms/i, description: 'Walk to an open gear press and make a single stack of mechanisms from an existing ingot.'},
+        { name: 'material', regex: /\w+/i, variable: true, description: 'What type of metal ingot to use' }
+      ]
+    ]
+    echo
+    args = parse_args(arg_definitions)
+
+    @finish = args.finish
+    @chapter = args.chapter
+    @recipe_name = args.recipe_name
+    @material = args.material
+    @noun = args.noun
+    @mechanism = args.mechanism
+    @training_spells = @settings.crafting_training_spells
+
+    wait_for_script_to_complete('buff', ['tinker'])
+    Flags.add('tinkering-assembly', 'laminated with (backer) material', 'You need another bone, wood or horn (backing) material', 'another bolt (flights)', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* leather (strip|cord)', 'need another (lenses)', 'another finished (mechanism)', 'You must assemble the (strips)')
+    Flags.add('tinker-magic-ready', 'You feel fully prepared to cast your spell.')
+    if args.continue
+      tinker("analyze my #{@noun}")
+    elsif args.laminate
+      laminate
+    elsif args.lighten
+      lighten
+    elsif args.cable
+      cable_back
+    elsif args.mechanisms
+      mechanisms
+    else
+      tinker_item
+    end
+  end
+
+  def get_item(name)
+    get_crafting_item(name, @bag, @belt, @belt)
+  end
+
+  def stow_item(name)
+    stow_crafting_item(name, @bag, @belt)
+  end
+
+  def stow_material
+    return unless @material
+    bput("stow ingot", 'Stow what', 'You put') if @mechanism
+    bput("stow lumber", 'Stow what', 'You put') if bput("stow lumber", 'Stow what', 'You put', 'You can.t put that there!') =~ /You can't put that there!/
+  end
+
+  def turn_to(section)
+    unless section
+      echo('Failed to find recipe in book, buy a better book?')
+      stow_item('book')
+      magic_cleanup
+      exit
+    end
+    bput("turn my book to #{section}", 'You turn your', 'The book is already')
+  end
+
+  def check_hand
+    unless left_hand =~ /#{@noun}|lumber|ingot/i || right_hand =~ /#{@noun}|lumber|ingot/i
+      echo('***Please hold the item or material you wish to work on.***')
+      magic_cleanup
+      exit
+    end
+    bput('swap', 'You move', 'You have nothing') unless left_hand =~ /#{@noun}/i || left_hand =~ /lumber/ || left_hand =~ /ingot/
+  end
+
+  def tinker_item
+    magic_routine
+    get_item('tinkering book')
+    echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
+    turn_to("page #{find_recipe(@chapter, @recipe_name)}")
+    bput('study my book', 'Roundtime')
+    stow_item('book')
+    get_item('drawknife')
+    get_item("#{@material} lumber")
+    tinker('scrape my lumber with my drawknife')
+  end
+
+  def mechanisms
+    @noun = 'mechanisms'
+    find_shaping_room(@hometown, nil)
+    case bput("get my #{@material} ingot", 'You get', 'What were', 'You are already', 'You pick up')
+    when 'What were'
+      echo "No ingot to form the mechanisms!"
+      exit
+    end
+    check_hand
+    stow_item(right_hand)
+    case bput("turn press to 1", "You dial", "Turn what")
+    when "Turn what"
+      echo "Didn't find a room with a gear press!"
+      exit
+    end
+    get_item('shovel')
+    bput('push fuel with my shovel', 'furnace')
+    stow_item('shovel')
+    get_item('pliers')
+    tinker('push my ingot with press')
+  end
+
+  def laminate
+    check_hand
+    get_item('tinkering book')
+    turn_to("page #{find_recipe('8', 'crossbow lamination')}")
+    bput('study my book', 'Roundtime')
+    stow_item('book')
+    get_item('clamps')
+    tinker("push my #{@noun} with my clamp")
+  end
+
+  def lighten
+    check_hand
+    get_item('tinkering book')
+    turn_to("page #{find_recipe('8', 'crossbow lightening')}")
+    bput('study my book', 'Roundtime')
+    stow_item('book')
+    get_item('clamps')
+    tinker("push my #{@noun} with my clamp")
+  end
+
+  def cable_back
+    check_hand
+    get_item('tinkering book')
+    turn_to("page #{find_recipe('8', 'crossbow cable-backing')}")
+    bput('study my book', 'Roundtime')
+    stow_item('book')
+    get_item('clamps')
+    tinker("push my #{@noun} with my clamp")
+  end
+
+  def assemble_part
+    return unless Flags['tinkering-assembly']
+
+    tool = right_hand
+    stow_item(tool)
+    part = Flags['tinkering-assembly'][1..-1].join('.')
+    part = 'backer' if part == 'backing'
+    part = "#{@mechanism} #{part}" if part == 'mechanism'
+    Flags.reset('tinkering-assembly')
+    get_item(part)
+    bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'loop both ends', 'loop the string', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations')
+    if ['long.pole', 'short.pole'].include?(part)
+      3.times do
+        get_item(part)
+        bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'loop both ends', 'loop the string', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations')
+      end
+    end
+    stow_item(part) if part.include?('mechanism')
+    get_item(tool)
+  end
+
+  def tinker(command)
+    waitrt?
+    magic_routine
+    check_hand
+    assemble_part
+    case bput(command,
+              'a wood shaper is needed', 'haping with a wood shaper', 'apply some glue to your', 'series of grooves',
+              /carving .* knife/, 'continued knife carving', 'carved with a knife', 'with a carving knife',
+              'rubbed out with a rasp', 'A cluster of small knots',
+              'Applying the final touches', 'lamination process', 'lightening process', 'complete mechanisms', 'cable-backing process',
+              'That tool does not seem suitable for that task.',
+              'while it is inside of something',
+              'Glue should now be applied', 'glue to fasten it', 'application of glue', 'glue applied',
+              'ready to be clamped', 'with clamps',
+              'Some wood stain', 'application of stain',
+              'adjusting with', 'adjusted with',
+              'mechanisms must be affixed', 'pulling them into place',
+              'pulling on the gear press',
+              'You fumble around but',
+              'ASSEMBLE Ingredient1', 'before proceeding',
+              'You need at least')
+    when 'a wood shaper is needed', 'haping with a wood shaper', 'apply some glue to your', 'series of grooves'
+      waitrt?
+      stow_item(right_hand)
+      get_item('shaper')
+      command = "shape my #{@noun} with my shaper"
+    when /carving.* knife/, 'continued knife carving', 'carved with a knife', 'with a carving knife'
+      waitrt?
+      stow_item(right_hand)
+      get_item('carving knife')
+      command = "carve my #{@noun} with my knife"
+    when 'rubbed out with a rasp', 'A cluster of small knots'
+      waitrt?
+      stow_item(right_hand)
+      get_item('rasp')
+      command = "scrape my #{@noun} with my rasp"
+    when 'ready to be clamped', 'with clamps'
+      waitrt?
+      stow_item(right_hand)
+      get_item('clamp')
+      command = "push my #{@noun} with my clamp"
+    when 'Glue should now be applied', 'glue to fasten it', 'application of glue', 'glue applied'
+      waitrt?
+      stow_item(right_hand)
+      get_item('glue')
+      command = "apply glue to my #{@noun}"
+    when 'adjusting with', 'adjusted with'
+      waitrt?
+      stow_item(right_hand)
+      get_item('tools')
+      command = "adjust my #{@noun} with my tools"
+    when 'Some wood stain', 'application of stain'
+      waitrt?
+      stow_item(right_hand)
+      get_item('stain')
+      command = "apply stain to my #{@noun}"
+    when 'mechanisms must be affixed', 'pulling them into place'
+      stow_item(right_hand)
+      get_item('pliers')
+      command = "pull my #{@noun} with my pliers"
+    when 'while it is inside of something', 'You fumble around but'
+      echo '*** ERROR TRYING TO CRAFT, EXITING ***'
+      stow_item(right_hand)
+      exit
+    when 'pulling on the gear press'
+      stow_item(right_hand)
+      get_item('pliers')
+      command = "pull my #{@noun} with press"
+    when 'That tool does not seem suitable for that task.'
+      tinker("analyze my #{@noun}")
+    when 'before proceeding'
+      assemble_part
+    when 'Applying the final touches', 'lamination process', 'lightening process', 'cable-backing process', 'complete mechanisms'
+      stow_item(right_hand)
+      stow_material
+      finish
+    when 'You need at least'
+      echo '*** NOT ENOUGH MATERIAL, EXITING ***'
+      stow_material
+      exit
+    end
+    magic_routine
+    tinker(command)
+  end
+
+  def magic_routine
+    return unless @training_spells.empty?
+
+    needs_training = %w[Warding Utility Augmentation]
+                     .select { |skill| @training_spells[skill] }
+                     .select { |skill| DRSkill.getxp(skill) < 31 }
+                     .sort_by { |skill| DRSkill.getxp(skill) }.first
+    return unless needs_training
+
+    data = @training_spells[needs_training]
+
+    if Flags['tinker-magic-ready'] && mana > 40
+      crafting_cast_spell(data, @settings)
+      Flags.reset('tinker-magic-ready')
+      @preparing = false
+    end
+
+    return if @preparing
+    crafting_prepare_spell(data, @settings)
+    @preparing = true
+  end
+
+  def magic_cleanup
+    return unless @training_spells.empty?
+
+    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    bput('release mana', 'You release all', "You aren't harnessing any mana")
+    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+  end
+
+  def stamp
+    return unless @stamp && @finish
+    get_item('stamp')
+    bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that')
+    pause
+    waitrt?
+    stow_item('stamp')
+  end
+
+  def finish
+    stamp
+    case @finish
+    when /log/
+      logbook_item('engineering', @noun, @bag)
+    when /stow/
+      stow_item(@noun)
+    when /trash/
+      dispose_trash(@noun)
+    end
+    magic_cleanup
+    exit
+  end
+end
+
+before_dying do
+  Flags.delete('tinkering-assembly')
+  Flags.delete('tinker-magic-ready')
+end
+
+Tinker.new


### PR DESCRIPTION
Beginning the process of tinkering support.  Closes issue https://github.com/rpherbig/dr-scripts/issues/1836

This was made from ;shape and conforms to the same style.
Currently ;tinker args are as follows:

```
  ;tinker <finish> <chapter> <recipe name> <material> <noun> [mechanism]
   finish       What to do with the finished item. [log, stow, trash]
   chapter      Chapter containing the item.
   recipe name  Name of the recipe, wrap in double quotes if this is multiple words.
   material     Type of material.
   noun
   mechanism    What metal mechanism to use -brass-oravir-etc. Optional.

  ;tinker <continue> <noun>
   continue
   noun

  ;tinker laminate <noun>
   laminate
   noun         Noun of item to laminate.

  ;tinker lighten <noun>
   lighten
   noun         Noun of item to lighten.

  ;tinker cable <noun>
   cable
   noun         Noun of item to cable-back and increase draw-strength.

  ;tinker mechanisms <material>
   mechanisms   Walk to an open gear press and make a single stack of mechanisms from an existing ingot.
   material     What type of metal ingot to use
```

Tested with all types of crossbows/stonebows, toys and tools such as telescopes and music boxes, and mechanisms.  Also added tinkering_tools to base and base-empty, and ;tinker to the no_use list for sanowret and almanac usage.

Currently it does not purchase parts or have recipe data in base_recipes.