### PR TITLE
fix for starting in maze rooms

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -751,6 +751,7 @@ class Bescort
   end
 
   def wander_maze_until(target, exit_command)
+    Flags.add('maze-reset', 'You can\'t go there')
     current_room = MazeRoom.new
     loop do
       if Flags['maze-reset']
@@ -803,8 +804,6 @@ class Bescort
       find_room_maze
     when /exit/i
       if XMLData.room_title.include?('The Fangs of Ushnish')
-        bput('look', 'Obvious paths')
-        pause 0.1
         wander_maze_until('steep cliff', 'climb cliff')
         gos_temple_leave
       end
@@ -851,8 +850,6 @@ class Bescort
   end
 
   def gos_plains_leave
-    bput('look', 'Obvious paths')
-    pause 0.1
     wander_maze_until('low cavern', 'go cavern')
     gos_tunnel
   end


### PR DESCRIPTION
A fix for starting bescort in a maze room that has changed available directions since you entered.