### PR TITLE
Update hunting-buddy.lic - fixed walk back after familiar drag

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -270,7 +270,7 @@ class HuntingBuddy
       end
       if Flags['familiar_drag'] && !@bail_on_familiar
         echo('***STATUS*** heading back to room - familiar drug while stunned')
-        DRC.walk_to(hunting_room)
+        DRCT.walk_to(hunting_room)
         Flags.reset('familiar_drag')
       end
       if (counter % 60).zero?


### PR DESCRIPTION
It was trying to use DRC.walk_to, fixed it.