### PR TITLE
Switch scripts using DRCT.retreat over to using DRC.retreat. Remove u…

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1243,7 +1243,7 @@ class SpellProcess
     if game_state.casting_regalia
       result = DRCA.parse_regalia
       if result.empty? # if not wearing a regalia, retreat, swap to regalia gearset, then cast
-        DRCT.retreat
+        DRC.retreat
         @equipment_manager.wear_equipment_set?('regalia')
         @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if @settings.gear_sets['regalia'].include?(game_state.weapon_name)
       else # otherwise break what you're already wearing then cast.

--- a/common-summoning.lic
+++ b/common-summoning.lic
@@ -118,7 +118,7 @@ module DRCS
   def summon_admittance
     case DRC.bput('summon admittance', 'You align yourself to it', 'further increasing your proximity', 'Going any further while in this plane would be fatal', 'Summon allows Warrior Mages to draw', 'You are a bit too distracted')
     when 'You are a bit too distracted'
-      DRCT.retreat
+      DRC.retreat
       summon_admittance
     end
     pause 1

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -2,12 +2,11 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#equipmanager
 =end
 
-custom_require.call(%w[common common-items common-travel events])
+custom_require.call(%w[common common-items events])
 
 class EquipmentManager
   include DRC
   include DRCI
-  include DRCT
 
   def initialize(settings = nil)
     items(settings)


### PR DESCRIPTION
…nused DRCT include from equipmanager.

I figured it would be best to leave DRCT.retreat that calls DRC.retreat in common-travel to not break third party scripts for now.