### PR TITLE
Update rezz.lic - rejuv fades before rezz, bug fix

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -74,6 +74,7 @@ class Rezz
       pause 5 while DRStats.mana < 40
       cast_spell(spell, @settings)
     end
+    Flags.reset('rejuv-silver')
   end
 
   def vigil(player)


### PR DESCRIPTION
There was already a section to call rejuv again before rezz, but it never rejuved because the flag for when the memories are silver was still set.
I changed it to reset the flag when it's done rejuving so it can call the quick rejuv right before gesturing.