### PR TITLE
Safe room tip fix for DRCM.wealth

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -192,7 +192,7 @@ class SafeRoom
       next unless DRRoom.pcs.include?(empath['name'].capitalize!) || @validator.in_game?(empath['name'])
       next unless use_pc_empath?(empath['id'], empath['name'])
       ensure_copper_on_hand(settings.safe_room_tip_threshold || 0, settings)
-      tip(settings.safe_room_tip_threshold, settings.safe_room_tip_amount, empath['name'])
+      tip(settings.safe_room_tip_threshold, settings.safe_room_tip_amount, empath['name'], settings.hometown)
       return true
     end
     false
@@ -226,9 +226,9 @@ class SafeRoom
     take(take_items)
   end
 
-  def tip(tip_threshold, tip_amount, empath)
+  def tip(tip_threshold, tip_amount, empath, hometown)
     return unless tip_threshold
-    return unless wealth > tip_threshold
+    return unless DRCM.wealth(hometown) > tip_threshold
     return unless tip_amount
     return unless empath
 


### PR DESCRIPTION
It always makes me suspicious when I seem to be the only one having a particular bug, but this looks pretty straightforward. 'wealth' on line 231 refers to DRCM.wealth, which accepts one arg, your hometown. Until I made this change it errored out every time it went to tip, and now everything works smoothly.