### PR TITLE
Support safe-room declaration by hometown

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -920,6 +920,15 @@ class SetupFiles
     s.bankbot_room_id ||= UserVars.bankbot_room_id
     s.prehunt_buffs ||= UserVars.prehunt_buffs
 
+    # Pull town-specific room_ids iff defined
+    s.safe_room = s.safe_room[s.hometown] if s.safe_room.is_a?(Hash) && s.safe_room[s.hometown]
+    s.compost_room = s.compost_room[s.hometown] if s.compost_room.is_a?(Hash) && s.compost_room[s.hometown]
+    s.lockpick_room_id = s.lockpick_room_id[s.hometown] if s.lockpick_room_id.is_a?(Hash) && s.lockpick_room_id[s.hometown]
+    s.engineering_room = s.engineering_room[s.hometown] if s.engineering_room.is_a?(Hash) && s.engineering_room[s.hometown]
+    s.outfitting_room = s.outfitting_room[s.hometown] if s.outfitting_room.is_a?(Hash) && s.outfitting_room[s.hometown]
+    s.alchemy_room = s.alchemy_room[s.hometown] if s.alchemy_room.is_a?(Hash) && s.alchemy_room[s.hometown]
+    s.crossing_training_sorcery_room = s.crossing_training_sorcery_room[s.hometown] if s.crossing_training_sorcery_room.is_a?(Hash) && s.crossing_training_sorcery_room[s.hometown]
+
     # Merge legacy appraisal settings into target appraisal settings
     unless s.appraisal_training.include?('pouches')
       s.appraisal_training.unshift('pouches') if s.train_appraisal_with_pouches


### PR DESCRIPTION
This is mucking with dependency so consider this more of a 'Hey, what does everyone think of this?'  Take a look, and this could go back to the drawing board.

This adds some entries to transform_settings to handle declaring various rooms as a hash, for example:
```
safe_room:
  Crossing: XXXX
  Shard: YYYY
lockpick_room_id:
  Crossing: XXXX
  Shard: YYYY
engineering_room:
  Crossing: XXXX
  Shard: YYYY
outfitting_room:
  Crossing: XXXX
  Shard: YYYY
```
Transform_settings will ensure any script sees the entry corresponding to the hometown you've set, or not do anything at all if you've just set it normally. As such, this shouldn't impact any existing yamls and should be opaque to any scripts.  I've been running with it for a couple weeks now swapping between Shard and Crossing, and it has saved me time, but mostly I just like the idea of setting room ids once and not having to update them whenever I change hunting grounds.

Anyone have any thoughts about this, or ideas on improvement?  Think this'll cause trouble?