### PR TITLE
Fix for status-monitor percWindow change

### DIFF
--- a/status-monitor.lic
+++ b/status-monitor.lic
@@ -44,6 +44,7 @@ class GameFilter
       /pushStream id="logons"/i,
       /pushStream id="death"/i,
       /pushStream id="shopWindow"/i,
+      /pushStream id="percWindow"/i,
       /component id='room/i,
       /component id='exp/i,
       %r{</prompt>$},
@@ -58,6 +59,7 @@ class GameFilter
       /<indicator id='IconINVISIBLE'/,
       %r{<roundTime value='\d+'/>}
     ]
+    @percWindowCheck = false
     @responses = ["'Hmmm?", "'Yes", "'Ok?"].shuffle
     @settings = get_settings
     @recent_seen = []
@@ -86,6 +88,11 @@ class GameFilter
       @recent_seen_lines.delete(line)
     end
     save if save_required
+  end
+
+  def check_spells(line) # toggle for the percWindow changes.  Ignores lines until percWindow spell updates are done.
+    @percWindowCheck = line =~ /pushStream id="percWindow"/i unless @percWindowCheck
+    @percWindowCheck = line !~ /<popStream/ if @percWindowCheck
   end
 
   def unseen?(line)
@@ -161,7 +168,8 @@ class GameFilter
   def clean(line)
     update_players(line)
     migrate_recent
-    return nil if line.nil? || line.empty? || @non_useful_tags.find { |bad_tag| bad_tag =~ line }
+    check_spells(line)
+    return nil if line.nil? || line.empty? || @non_useful_tags.find { |bad_tag| bad_tag =~ line } || @percWindowCheck
     return nil if @room_players.find { |name| line.include?(name) } || UserVars.npcs.find { |name| line.include?(name) }
     if UserVars.players_online
       players_to_check = UserVars.players_online - [checkname, 'Endith']


### PR DESCRIPTION
Related to issue rpherbig#3291

Intended to fix status-monitor pulling percWindow data into its seen messages.  When status-monitor sees the start of an open percWindow stream it toggles @percWindowCheck, and stops running lines until it sees the end </popStream> tag.

I ran this for a while after removing my seenMessages and telling it to echo whatever it was ignoring when @percWindowCheck was true and saw nothing besides what I wanted it to, as shown below.  Normal status-monitor learning continued to dump into seen_messages as expected.

```
[status-monitor: Ignoring <pushStream id="percWindow"/>Stellar Collector  (0%, 46 roisaen)]
[status-monitor: Ignoring Membrach's Greed  (13 roisaen)]
[status-monitor: Ignoring Finesse  (7 roisaen)]
[status-monitor: Ignoring Nonchalance  (13 roisaen)]
[status-monitor: Ignoring <popStream/><prompt time="1544904795">&gt;</prompt>]
>
[status-monitor: Ignoring <pushStream id="percWindow"/>Stellar Collector  (0%, 46 roisaen)]
[status-monitor: Ignoring Membrach's Greed  (13 roisaen)]
[status-monitor: Ignoring Finesse  (7 roisaen)]
[status-monitor: Ignoring Nonchalance  (13 roisaen)]
[status-monitor: Ignoring <popStream/><prompt time="1544904805">&gt;</prompt>]
```

