### PR TITLE
base-spells.yaml: Unhide before recasting EM

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -820,6 +820,11 @@ spell_data:
     abbrev: EM
     mana: 5
     recast: 1
+    before:
+    - message: unhide
+      matches:
+      - You come out of hiding
+      - But you are not
     mana_type: life
   Echoes of Aether:
     skill: Augmentation


### PR DESCRIPTION
For silly people that like to train with the spell outside of combat instead of a better spell like SKS.