### PR TITLE
Walkingastro: Change custom requirements

### DIFF
--- a/walkingastro.lic
+++ b/walkingastro.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#walkingastro
 =end
 
-custom_require.call %w[events]
+custom_require.call %w[common drinfomon]
 
 class WalkingAstro
   def initialize


### PR DESCRIPTION
The script required events but did not use the Flags class, so
this was removed. The script uses common and drinfomon so these
were added