### PR TITLE
Add common-moonmage

### DIFF
--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#bootstrap
 =end
 
-class_defs = { 'equipmanager' => :EquipmentManager, 'common' => :DRC, 'common-travel' => :DRCT, 'common-crafting' => :DRCC, 'common-summoning' => :DRCS, 'common-money' => :DRCM, 'common-arcana' => :DRCA, 'common-items' => :DRCI, 'common-healing' => :DRCH, 'common-validation' => :CharacterValidator }
+class_defs = { 'equipmanager' => :EquipmentManager, 'common' => :DRC, 'common-travel' => :DRCT, 'common-crafting' => :DRCC, 'common-summoning' => :DRCS, 'common-money' => :DRCM, 'common-arcana' => :DRCA, 'common-items' => :DRCI, 'common-healing' => :DRCH, 'common-validation' => :CharacterValidator, 'common-moonmage' => :DRCMM }
 
 arg_definitions = [[{ name: 'wipe_constants', regex: /wipe_constants/i, optional: true }]]
 

--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -1,0 +1,43 @@
+# quiet
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_development#common-moonmage
+=end
+
+module DRCMM
+  module_function
+
+  def predict_weather
+    DRC.bput('predict weather', 'You predict that', 'You are far too', 'you lack the skill to grasp them fully', 'roundtime')
+  end
+
+  def get_telescope
+    DRC.bput('get my telescope', 'you get', 'You are already holding that.', "That can't be picked up", 'You need a free hand to pick that up.', 'You should stop practicing your Athletics skill before you do that')
+  end
+  
+  def peer_telescope
+    DRC.bput('peer telescope', 'The pain is too much', 'You learned something useful from your observation', 'Clouds obscure the sky', "While the sighting wasn't quite", 'You peer aimlessly through your telescope', 'You have not pondered your last observation sufficiently', 'You see nothing regarding the future', "You believe you've learned all that you can about", 'Too many futures cloud your mind - you learn nothing.', 'open it to make any use of it', 'You see nothing regarding the future')
+  end
+
+  def center_telescope_on(target)
+    DRC.bput("center telescope on #{target}", 'You put your eye', 'open it to make any use of it', 'The pain is too much', "That's a bit tough to do when you can't see the sky", 'Your search for')
+  end
+
+  def align(skill)
+    DRC.bput("align #{skill}", 'You focus internally')
+  end
+
+  def roll_bones(is_tied, container)
+    if is_tied
+      bput("untie bones from my #{container}", 'divination bones')
+    else
+      bput("get bones from my #{container}", 'divination bones', 'you get')
+    end
+    bput('roll my bones', 'roundtime')
+    waitrt?
+    if is_tied
+      bput("tie bones to my #{container}", 'divination bones')
+    else
+      bput("put bones in my #{container}", 'divination bones', 'you put')
+    end
+  end
+end

--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -3,6 +3,8 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-moonmage
 =end
 
+custom_require.call(%w[common])
+
 module DRCMM
   module_function
 

--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -30,16 +30,16 @@ module DRCMM
 
   def roll_bones(is_tied, container)
     if is_tied
-      bput("untie bones from my #{container}", 'divination bones')
+      DRC.bput("untie bones from my #{container}", 'divination bones')
     else
-      bput("get bones from my #{container}", 'divination bones', 'you get')
+      DRC.bput("get bones from my #{container}", 'divination bones', 'you get')
     end
-    bput('roll my bones', 'roundtime')
+    DRC.bput('roll my bones', 'roundtime')
     waitrt?
     if is_tied
-      bput("tie bones to my #{container}", 'divination bones')
+      DRC.bput("tie bones to my #{container}", 'divination bones')
     else
-      bput("put bones in my #{container}", 'divination bones', 'you put')
+      DRC.bput("put bones in my #{container}", 'divination bones', 'you put')
     end
   end
 end


### PR DESCRIPTION
A module for common methods related to moon mages. This will help cut down
on code duplication for astrology related functionality.

Ive taken a look through walkingastro, astrology, and the PR by @aruthas which adds more astrology functionality. A lot of these scripts can be helped by refactoring. In the case of astrology, there are a lot of methods which need to be broken up into smaller methods (some of which can then be commonized). 