### PR TITLE
Combat-Trainer: Use skill attr to determine sorcery spell

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1335,11 +1335,18 @@ class SpellProcess
 
     game_state.hide_on_cast = true if data['use_stealth']
 
-    if needs_training == 'Sorcery' || @training_spells[needs_training]['skill'] == 'Sorcery'
+    if spell_is_sorcery?(data)
       echo 'Preparing a sorcery spell, held items will be stowed to prevent item loss' if $debug_mode_ct
       game_state.casting_sorcery = true
     end
     prepare_spell(data, game_state)
+  end
+
+  def spell_is_sorcery?(spell_data)
+    return true  if spell_data['sorcery']
+    return false if DRStats.native_mana.casecmp(spell_data['mana_type']).zero?
+    return false if spell_data['mana_type'].casecmp('ap').zero?
+    true
   end
 
   def check_buffs(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1335,7 +1335,7 @@ class SpellProcess
 
     game_state.hide_on_cast = true if data['use_stealth']
 
-    if needs_training == 'Sorcery'
+    if needs_training == 'Sorcery' || @training_spells[needs_training]['skill'] == 'Sorcery'
       echo 'Preparing a sorcery spell, held items will be stowed to prevent item loss' if $debug_mode_ct
       game_state.casting_sorcery = true
     end


### PR DESCRIPTION
If the magic skill shows the spell to be sorcery then stow/get weapons. This lets you use a sorcery spell to train a non-sorcery skill with the safety of storing weapons before casting.

Realize this can be a bit confusing, so here is an example: 

```
combat_spell_training:                                    
  Warding:                                                
    name: Ghost Shroud                                    
    mana: 21                                              
    cyclic: true                                          
    skill: Sorcery                                        
    day: true # Keeps from conflicting with SLS           
```
A moon mage uses a cleric (sorcery) spell to train. The spell is warding, sorcery, and cyclic. It trains warding slower than sorcery. So I want combat-trainer to trigger the casting of it based on warding experience. I list the skill as sorcery to use the stow/get weapon mechanics so i dont lose a weapon when casting.