### PR TITLE
Change ;craft recipe that depends on parts

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -80,7 +80,7 @@ class Craft
     elsif rank <= 100 # Tier 3  Easy
       shape(7, 'wood cloak pin', 'cloak pin')
     elsif rank <= 175 # Tier 4  Simple
-      shape(7, 'wood pendant', 'pendant')
+      shape(7, 'wood amulet', 'amulet')
     elsif rank <= 300 # Tier 5  Basic
       shape(7, 'wood brooch', 'brooch')
     elsif rank <= 425 # Tier 6  Somewhat Challenging


### PR DESCRIPTION
Changing wood pendants from 100-175 to wood amulets.

Users reported trouble working with ;craft for wooden pendants.  Apparently that required a short leather cord, which craft doesn't grab.  wood amulets appear to be nearly identical in skill_requirements, and the users seem to be in the right area.  Tested myself by forcing myself into that skill zone and got a completed amulet out of it.

I didn't see any other recipes that seemed to need parts.