### PR TITLE
Add performance_pause option to make the pause configurable

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -12,6 +12,7 @@ class Athletics
   def initialize
     @settings = get_settings
     @athletics_options = get_data('athletics').athletics_options
+    @performance_pause = @settings.performance_pause
 
     @climbing_target = get_data('athletics').practice_options[@settings.climbing_target]
     @swimming_target = get_data('athletics').swimming_options[@settings.swimming_target]
@@ -222,7 +223,7 @@ class Athletics
       swim_loop(get_data('athletics').swimming_options['arthe_dale']['rooms'])
     elsif UserVars.athletics < 290
       waitrt?
-      pause 3 # to give performance time to complete before_dying if stopped from the previous script
+      pause @performance_pause # to give performance time to complete before_dying if stopped from the previous script
       start_script('performance') unless Script.running?('performance')
       until done_training?
         @athletics_options
@@ -307,7 +308,7 @@ class Athletics
         return if remaining_attempts.zero?
       else
         start_script('performance', ['noclean']) unless Script.running?('performance')
-        pause 2 # make sure you are playing before starting climb practice
+        pause @performance_pause # make sure you are playing before starting climb practice
       end
       Flags.add('ct-climbing-finished', 'You finish practicing your climbing')
       Flags.add('ct-climbing-combat', 'You are engaged in combat')

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -11,6 +11,7 @@ class FirstAid
   def initialize
     @settings = get_settings
     @chart_data = get_data('anatomy-charts').first_aid_charts
+    @performance_pause = @settings.performance_pause
 
     if @settings.bleed_bot
       walk_to(@settings.bleed_bot_room)
@@ -31,7 +32,7 @@ class FirstAid
 
   def compendium_charts
     unless @settings.instrument
-      pause 2 # to give performance time to complete before_dying if stopped from the previous script
+      pause @performance_pause # to give performance time to complete before_dying if stopped from the previous script
       start_script('performance', ['noclean']) unless Script.running?('performance')
     end
     bput('get my compendium', 'You get', 'You are already holding')
@@ -44,7 +45,7 @@ class FirstAid
 
   def textbook_charts
     unless @settings.instrument
-      pause 2 # to give performance time to complete before_dying if stopped from the previous script
+      pause @performance_pause # to give performance time to complete before_dying if stopped from the previous script
       start_script('performance', ['noclean']) unless Script.running?('performance')
     end
     bput("get my #{@booktype}", 'You get', 'You are already holding')

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -359,6 +359,8 @@ crossing_training_requires_movement:
 - Thievery
 - Theurgy
 - Trading
+# Adjust this higher if you are getting hangups starting performance in athletics or first aid
+performance_pause: 2
 # what item to forage/collect with ;outdoorsmanship
 forage_item: rock
 # what item to braid in ;mech-lore

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -360,7 +360,7 @@ crossing_training_requires_movement:
 - Theurgy
 - Trading
 # Adjust this higher if you are getting hangups starting performance in athletics or first aid
-performance_pause: 2
+performance_pause: 3
 # what item to forage/collect with ;outdoorsmanship
 forage_item: rock
 # what item to braid in ;mech-lore

--- a/study-art.lic
+++ b/study-art.lic
@@ -19,9 +19,10 @@ class StudyArt
     args = parse_args(arg_definitions)
 
     @stop_skill = args.skill || 'scholarship'
+    performance_pause = get_settings.performance_pause
 
     art_options = get_data('art').art_options
-    pause 2 unless Script.running?('crossing-training') # to give performance time to complete before_dying if stopped from the previous script
+    pause performance_pause unless Script.running?('crossing-training') # to give performance time to complete before_dying if stopped from the previous script
     start_script('performance') unless Script.running?('performance') || Script.running?('crossing-training')
     study_art(art_options)
   end


### PR DESCRIPTION
performance.lic has an fput which waits for rt to be over in it's before_dying, and lich considers a script in the before_dying phase as already stopped so if you start another script that also starts performance it will hang. I haven't figured out a better way around this but making this specific pause configurable will at least provide a workaround for people hitting it.