### PR TITLE
restock: use has_key

### DIFF
--- a/restock.lic
+++ b/restock.lic
@@ -100,7 +100,7 @@ class Restock
   end
 
   def valid_item_data?(item_data)
-    (%w[name size room price stackable quantity]).all?{|x| item_data[x]}    
+    (%w[name size room price stackable quantity]).all?{|x| item_data.has_key?(x)}    
   end
 end
 Restock.new


### PR DESCRIPTION
>There's a small chance that this should actually be `item_data.has_key?(x)` 

```yaml
restock:
  red wine:
     name: red wine
     room: 19073
     price: 250
     size: 1
     stackable: false
     quantity: 3
```
>error message I am getting is:  [restock: No hometown of explicit data for 'red wine']

the error is due to the falsiness of the stackable key