### PR TITLE
Heal herb

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2054,6 +2054,14 @@ class TrainerProcess
       use_almanac(game_state)
     when 'Smite'
       smite(game_state)
+    when 'Herbs'
+      if game_state.npcs.empty?
+        game_state.sheath_whirlwind_offhand
+        wait_for_script_to_complete('heal-herb',['quick'])
+        game_state.wield_whirlwind_offhand
+      else
+        wait_for_script_to_complete('heal-herb',['quick','nohands'])
+      end
     end
     waitrt?
     false

--- a/data/base-herbs.yaml
+++ b/data/base-herbs.yaml
@@ -1,0 +1,43 @@
+---
+remedies:
+  external:
+    skin:
+    limbs:
+    - jadice flower #ext
+    - yelith root #int
+    head:
+    - nemoih root #ext
+    - blocil potion #not sure,something internal
+    chest:
+    - plovik leaf #ext
+    - ithor potion #int
+    neck:
+    - georin salve #ext
+    - riolur leaf #int
+    eyes:
+    - sufil sap #ext
+
+    abdomen:
+    - nilos salve #ext
+    - muljin sap #int
+    back:
+    - hulnik grass #ext
+    - junliar stem #int
+
+  scars:
+    general:
+    skin:
+    - cebi root
+    limbs:
+    - jadice pollen #ext
+    - nuloe stem #int
+    face:
+    - qun pollen #ext  -not neck
+    - hulij elixir #int
+    body:
+    - genich stem #ext
+    - ojhenik potion #int
+    nerves:
+    - hisan salve
+
+

--- a/heal-herb.lic
+++ b/heal-herb.lic
@@ -1,0 +1,117 @@
+# quiet
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#heal-remedy
+=end
+
+custom_require.call(%w[common common-healing common-items])
+
+arg_definitions = [
+  [
+    { name: 'debug', regex: /debug/i, optional: true },
+    { name: 'nohands', regex: /nohands/i, optional: true, description: 'Skip herbs which must be held to use' },
+    { name: 'noscars', regex: /noscars/i, optional: true, description: 'Skip scar healing herbs' },
+    { name: 'quick', regex: /quick/i, optional: true, description: 'Skip delay between wound and scar herbs' },
+    { name: 'level', regex: /\d+/i, optional: true, description: 'Healing level desired.' },
+  ]
+]
+
+args = parse_args(arg_definitions)
+$debug_mode_hr = args.debug
+$nohands_mode = args.nohands
+$noscars_mode = args.noscars
+$quick_mode = args.quick
+if args.level
+  $heal_level = args.level.to_i
+else
+  $heal_level = 0
+end
+
+$remedies = get_data('herbs')
+
+def wounds
+  wounds = DRCH.check_health['wounds']
+  pause 1
+  echo wounds if $debug_mode_hr
+  hurt = wounds.select { |level, _| level >= $heal_level }.values.flatten
+  wound_grouping = { 'right arm' => 'limbs', 'left arm' => 'limbs', 'left leg' => 'limbs', 'right leg' => 'limbs', 'right hand' => 'limbs', 'left hand' => 'limbs', 'right eye' => 'eyes', 'left eye' => 'eyes' }
+  scar_grouping = { 'right arm' => 'limbs', 'left arm' => 'limbs', 'left leg' => 'limbs', 'right leg' => 'limbs', 'right hand' => 'limbs', 'left hand' => 'limbs', 'head' => 'face', 'neck' => 'body', 'eyes' => 'face', 'chest' => 'body', 'abdomen' => 'body', 'back' => 'body' }
+  hurt = hurt.map { |raw| wound_grouping[raw] || raw }.uniq
+  scar = hurt.map { |raw| scar_grouping[raw] || raw }.uniq
+
+
+  if $debug_mode_hr
+    echo 'Wounds: '
+    hurt.each do |key|
+      echo key
+    end
+
+    echo
+
+    echo 'Scars: '
+    scar.each do |key|
+      echo key
+    end
+  end
+  hurt.each do |key|
+    echo key if $debug_mode_hr
+    echo('In hurt loop') if $debug_mode_hr
+    apply_wounds(key)
+  end;
+  if !$quick_mode and hurt.length > 0
+    pause 180 # pause 3 minutes before using scar remedies
+  end
+  scar.each do |key| 
+    echo key if $debug_mode_hr
+    echo('In scar loop') if $debug_mode_hr
+    apply_scars(key) unless $noscars_mode
+  end
+end
+
+def apply_wounds(key)
+  echo("In apply_wounds function and key is #{key}") if $debug_mode_hr
+  rem_wounds = $remedies['remedies']['external'][key]
+  echo(rem_wounds) if $debug_mode_hr
+  rem_wounds.each do |key|
+    loop_debug
+     case key
+     when /salve/, /sap/
+       DRC.bput("get #{key}", 'You get', 'referring to?') unless $nohands_mode
+       DRC.bput("rub my #{key}", 'You', 'Rub what?') unless $nohands_mode
+       DRC.bput("stow #{key}", 'You', 'Stow what?') unless $nohands_mode
+     when /ungent/, /poultices/, /ointment/
+       DRC.bput("rub my #{key}", 'You', 'Rub what?')
+     when /potion/, /tonic/, /elixir/, /draught/
+       DRC.bput("drink my #{key}", 'You', 'Drink what?')
+     when /flower/, /root/, /leaf/, /grass/
+       DRC.bput("eat my #{key}", 'You', 'you referring to?')
+     end
+  end
+end
+
+def apply_scars(key)
+  echo("In apply_scar function and key is #{key}") if $debug_mode_hr
+  rem_scars = $remedies['remedies']['scars'][key]
+  echo(rem_scars) if $debug_mode_hr
+  rem_scars.each do |key|
+    loop_debug
+     case key
+     when /genich/
+       DRC.bput("get #{key}", 'You get', 'referring to?') unless $nohands_mode
+       DRC.bput("inhale my #{key}", 'You') unless $nohands_mode
+       DRC.bput("stow #{key}", 'You', 'Stow what?') unless $nohands_mode
+     when /salve/, /ungent/, /poultices/, /ointment/, /sap/
+       DRC.bput("rub my #{key}", 'You', 'Rub what?')
+     when /tonic/, /draught/, /qun/
+       DRC.bput("drink my #{key}", 'You', 'Drink what?')
+     when /flower/, /root/, /leaf/, /grass/, /potion/, /nuloe/, /elixir/, /jadice/
+       DRC.bput("eat my #{key}", 'You', 'you referring to?')
+     end
+  end
+end
+
+def loop_debug
+  echo('In apply loop') if $debug_mode_hr
+end
+
+wounds
+

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -1,0 +1,106 @@
+#   Documentation: https://elanthipedia.play.net/Lich_script_repository#restock
+custom_require.call(%w[common common-items common-money])
+class Herbstock
+  include DRC
+  include DRCM
+  include DRCI
+  def initialize
+    setup
+    items = parse_restockable_items
+
+    custom_loc_items = items.select { |k| k['hometown'] }
+
+    items -= custom_loc_items
+    restock_items(items, @settings.hometown)
+
+    custom_loc_items.map { |k| k['hometown'] }.uniq
+                    .each do |_hometown|
+      custom_loc_items.group_by { |v| v['hometown'] }
+                      .each { |hometown, items| restock_items(items, hometown) }
+    end
+  end
+
+  def restock_items(item_list, town)
+    items_to_restock = []
+    coin_needed = 0
+
+    item_list.each do |item|
+      remaining = count_combinable_item(item['name'])
+
+      next unless remaining < item['quantity']
+      num_needed = item['quantity'] - remaining
+      buy_num = (num_needed / item['size'].to_f).ceil
+      coin_needed += buy_num * item['price']
+      item['buy_num'] = buy_num
+      items_to_restock.push(item)
+    end
+    get_money_from_specific_bank?("#{coin_needed} copper #{town_currency(town)}", town) if coin_needed > 0
+    items_to_restock.each do |item|
+      item['buy_num'].times do
+        stow_hands
+        bput("get my #{item['name']}", 'You get', 'What were you referring') if item['stackable']
+        buy_item(item['room'], item['name'])
+        split_name = item['name'].split(' ')
+        bput("combine #{split_name.last} with #{split_name.last}", 'You combine', 'You must be holding') if item['stackable']
+        stow_hands
+      end
+    end
+  end
+
+  def setup
+    @settings = get_settings
+    @restock = @settings.herbs
+    @hometown = @settings.hometown
+    get_settings.storage_containers.each { |container| fput("open my #{container}") }
+  end
+
+  def parse_restockable_items
+    item_list = @restock
+    hometown_data = get_data('consumables')[@hometown]
+    items = []
+    item_list.each do |key, value|
+      if hometown_data.key?(key) && !value.key?('hometown')
+        ht_data = hometown_data[key]
+        data = ht_data.each_key { |k| ht_data[k] = value[k] if value.key?(k) }
+        items.push(data)
+      elsif valid_item_data?(value)
+        items.push(value)
+      else
+        echo "No hometown of explicit data for '#{key}'"
+      end
+    end
+    items
+  end
+
+  def count_combinable_item(item)
+    count = 0
+    $ORDINALS.each do |ordinal|
+      count_msg = bput("count my #{ordinal} #{item}", 'I could not find what you were referring to.', 'tell you much of anything.', 'There is only one part', 'There are (.+) parts left of the ')
+      case count_msg
+      when 'I could not find what you were referring to.'
+        break
+      when 'tell you much of anything.'
+        echo "#{item} is marked as stackable but is not!"
+        break
+      when 'There is only one part'
+        count += 1
+      else
+        count_txt = count_msg.match(/There \w+ (.+) \w+ left of the /).captures.first.tr('-', ' ')
+        count += text2num(count_txt)
+      end
+      waitrt?
+    end
+    count
+  end
+
+  def valid_item_data?(item_data)
+    return true if  item_data.key?('name') && \
+                    item_data.key?('size') && \
+                    item_data.key?('room') && \
+                    item_data.key?('price') && \
+                    item_data.key?('stackable') && \
+                    item_data.key?('quantity')
+    false
+  end
+end
+Herbstock.new

--- a/profiles/HerbUser-setup.yaml
+++ b/profiles/HerbUser-setup.yaml
@@ -1,0 +1,202 @@
+---
+# Sample settings to show implementation of storebought healing herbs from P1
+# Ensure that your store herbs settings is set for a pouch which remains open and accessible
+
+
+# Hunting settings
+training_manager_hunting_priority: true
+training_manager_priority_skills:
+- Small Edged
+hunting_info:
+- :zone: rats
+  stop_on:
+  - Small Edged
+  after:
+  - herbstock               # This will restock your herbs immediately after a hunt, placed here for example only
+
+# Gear settings
+gear:
+- :adjective: rugged
+  :name: leathers
+  :is_leather: true
+  :hinders_lockpicking: false
+  :is_worn: true
+- :adjective: wide-bladed
+  :name: dagger
+  :is_leather: false
+  :hinders_lockpicking: true
+  :is_worn: true
+- :adjective: parry
+  :name: stick
+  :is_leather: false
+  :hinders_lockpicking: false
+  :is_worn: true
+
+gear_sets:
+  standard:
+  - rugged leathers
+  - parry stick
+
+# Combat settings
+dance_skill: Small Edged
+training_abilities:
+  Herbs: 480                # This will check your health, then quickly apply any herbs
+                            # If in active combat it will skip herbs which require removal from container
+  Stealth: 60
+  Tactics: 30
+weapon_training:
+  Small Edged: wide-bladed dagger
+
+#This section is for the restocking of herbs with herbstock
+#It will add items to your inventory, and some herbs are not stackable
+herbs:
+#  MAURIGAS BOTANICALS
+  jadice_flower:
+    name: jadice flower
+    size: 6
+    stackable: true
+    room: 8259
+    price: 812
+    quantity: 12
+  plovik_leaf:
+    name: plovik leaf
+    size: 6
+    stackable: true
+    room: 8259
+    price: 812
+    quantity: 12
+  nilos_salve:
+    name: nilos salve
+    size: 6
+    stackable: true
+    room: 8259
+    price: 812
+    quantity: 12
+  hulnik_grass:
+    name: hulnik grass
+    size: 6
+    stackable: true
+    room: 8259
+    price: 812
+    quantity: 12
+  nemoih_root:
+    name: nemoih root
+    size: 6
+    stackable: true
+    room: 8259
+    price: 875
+    quantity: 12
+  georin_salve:
+    name: georin salve
+    size: 6
+    stackable: true
+    room: 8259
+    price: 875
+    quantity: 12
+  sufil_sap:
+    name: sufil sap
+    size: 6
+    stackable: true
+    room: 8259
+    price: 875
+    quantity: 12
+  yelith_root:
+    name: yelith root
+    size: 6
+    stackable: true
+    room: 8259
+    price: 937
+    quantity: 12
+  ithor_potion:
+    name: ithor potion
+    size: 6
+    stackable: true
+    room: 8259
+    price: 937
+    quantity: 12
+  muljin_sap:
+    name: muljin sap
+    size: 6
+    stackable: true
+    room: 8259
+    price: 937
+    quantity: 12
+  junliar_stem:
+    name: junliar stem
+    size: 6
+    stackable: true
+    room: 8259
+    price: 937
+    quantity: 12
+  blocil_potion:
+    name: blocil potion
+    size: 6
+    stackable: false
+    room: 8259
+    price: 937
+    quantity: 12
+  riolur_leaf:
+    name: riolur leaf
+    size: 6
+    stackable: true
+    room: 8259
+    price: 1000
+    quantity: 12
+
+#  MIDWIFE NESSAS COTTAGE
+  qun_pollen:
+    name: qun pollen
+    size: 6
+    stackable: true
+    room: 1898
+    price: 500
+    quantity: 12
+  genich_stem:
+    name: genich stem
+    size: 6
+    stackable: false
+    room: 1898
+    price: 500
+    quantity: 12
+  nuloe_stem:
+    name: nuloe stem
+    size: 6
+    stackable: true
+    room: 1898
+    price: 500
+    quantity: 12
+  cebi_root:
+    name: cebi root
+    size: 6
+    stackable: true
+    room: 1898
+    price: 625
+    quantity: 12
+  hulij_elixir:
+    name: hulij elixir
+    size: 6
+    stackable: false
+    room: 1898
+    price: 563
+    quantity: 12
+  hisan_salve:
+    name: hisan salve
+    size: 6
+    stackable: true
+    room: 1898
+    price: 625
+    quantity: 12
+  jadice_pollen:
+    name: jadice pollen
+    size: 6
+    stackable: true
+    room: 1898
+    price: 500
+    quantity: 12
+  ojhenik_potion:
+    name: ojhenik potion
+    size: 6
+    stackable: false
+    room: 1898
+    price: 562
+    quantity: 12

--- a/validate.lic
+++ b/validate.lic
@@ -409,7 +409,7 @@ class DRYamlValidator
     return unless settings.training_abilities
 
     settings.training_abilities
-            .reject { |skill, _cooldown| ['PercMana', 'Perc', 'Perc Health', 'Astro', 'App', 'App Quick', 'App Careful', 'Tactics', 'Hunt', 'Pray', 'Scream', 'Khri Prowess', 'Stealth', 'Ambush Stun', 'Ambush Choke', 'Favor Orb', 'Charged Maneuver', 'Meraud', 'Recall', 'Barb Research Debilitation', 'Barb Research Augmentation', 'Barb Research Warding', 'Collect', 'Analyze', 'Flee', 'PrayerMat', 'Smite', 'Locks', 'Teach', 'Almanac'].include?(skill) }
+            .reject { |skill, _cooldown| ['PercMana', 'Perc', 'Perc Health', 'Astro', 'App', 'App Quick', 'App Careful', 'Tactics', 'Hunt', 'Pray', 'Scream', 'Khri Prowess', 'Stealth', 'Ambush Stun', 'Ambush Choke', 'Favor Orb', 'Charged Maneuver', 'Meraud', 'Recall', 'Barb Research Debilitation', 'Barb Research Augmentation', 'Barb Research Warding', 'Collect', 'Analyze', 'Flee', 'PrayerMat', 'Smite', 'Locks', 'Teach', 'Almanac','Herbs'].include?(skill) }
             .each_key { |skill| error("Ability in training_abilities is not valid: #{skill}") }
   end
 


### PR DESCRIPTION
Implementation of storebought healing herb scripts

Add heal-herb.lic               - Checks wounds and uses storebought
                                   herbs based on data/base-herbs.yaml
Add herb-stock.lic              - Refers to herbs section of 
                                   player-setup.yaml to stock herbs,
                                   allows for combinable herbs
Add data/base-herbs.lic         - Listing of storebought herbs and
                                   their covered areas for use with 
                                   heal-herb.lic
Add profiles/HerbUser-setup.lic - Usage ref for storebought herbs

Modify combat-trainer.lic       - Added 'Herbs' to trainer process
                                  runs heal-herb with arguments with
                                  reduced functionality for combat
Modify vaidate.lic              - Added 'Herbs' option to list of
                                  allowed training_abilities

TODO: Test with herbs from other towns