### PR TITLE
Support using starlight_threshold in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -996,7 +996,11 @@ class SpellProcess
     @regalia_spell = settings.waggle_sets['regalia']['Regalia']
     echo("  @regalia_spell: #{@regalia_spell}") if $debug_mode_ct
 
+    @aura_frequency = settings.aura_frequency
+    echo("  @aura_frequency: #{@aura_frequency}") if $debug_mode_ct
+
     @perc_health_timer = Time.now
+    @aura_timer = 0
 
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
@@ -1073,6 +1077,7 @@ class SpellProcess
     check_ignite(game_state)
     check_rutilors_edge(game_state)
     check_health(game_state)
+    check_starlight(game_state)
     check_buffs(game_state)
     check_training(game_state)
     check_offensive(game_state)
@@ -1350,6 +1355,7 @@ class SpellProcess
                        .select { |_name, data| data['recast'] || data['recast_every'] || data['expire'] }
                        .select { |_name, data| data['expire'] ? Flags["ct-#{data['abbrev']}"] : true }
                        .select { |name, _data| check_buff_conditions?(name, game_state) }
+                       .select { |_name, data| data['starlight_threshold'] ? enough_starlight?(game_state, data) : true }
 
     name, data = recastable_buffs.find do |name, data|
       if data['pet_type']
@@ -1404,12 +1410,26 @@ class SpellProcess
     end
   end
 
-  def check_trader_magic(game_state) # handles starlight-related effects and cleans flags
+  def check_starlight(game_state)
+    return unless DRStats.trader?
+    return unless @aura_frequency > 0 && (Time.now - @aura_timer).to_i > @aura_frequency
+    @aura_timer = Time.now
+    game_state.starlight_values = DRCA.perc_aura
+  end
+
+  def enough_starlight?(game_state, data)
+    return UserVars.sun['night'] unless DRStats.trader?
+    return true unless game_state.starlight_values
+    data['starlight_threshold'] <= game_state.starlight_values['level']
+  end
+
+  def check_trader_magic(game_state) # handles starlight-depletion and regalia
     return unless DRStats.trader?
     if Flags['ct-starlight-depleted']
       echo '----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----'
       @buff_spells.reject! { |spell| @buff_spells[spell]['starlight_threshold'] > -1 } # delete all buffs and offensive spells. Potential to add stellar collector support later
       @offensive_spells.reject! { |spell| spell['starlight_threshold'] > -1 }
+      @aura_frequency = 0
       game_state.regalia_cancel = true # stop all regalia swap functions and clean it up next time it expires.
     end
     if game_state.casting_regalia
@@ -1480,6 +1500,7 @@ class SpellProcess
                    .select { |spell| spell['night'] ? UserVars.sun['night'] : true }
                    .select { |spell| spell['day'] ? UserVars.sun['day'] : true }
                    .select { |spell| spell['slivers'] ? DRSpells.slivers : true }
+                   .select { |spell| spell['starlight_threshold'] ? enough_starlight?(game_state, spell) : true }
     data = if @offensive_spell_cycle.empty?
              ready_spells.min_by { |spell| DRSkill.getxp(spell['skill']) }
            else
@@ -2806,7 +2827,7 @@ class GameState
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
 
-  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type, :casting_regalia
+  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type, :casting_regalia, :starlight_values
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -2830,6 +2851,7 @@ class GameState
     @regalia_cancel = false
     @last_regalia_type = nil
     @swap_regalia_type = nil
+    @starlight_values = nil
     @casting_weapon_buff = false
     @casting_consume = false
     @prepare_consume = false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -302,6 +302,9 @@ cambrinth_items:
 cambrinth_num_charges: 4 
 # invoke a specific cambrinth amount -- useful for traders with Avtalia Array
 cambrinth_invoke_exact_amount: false
+# Trader only - enables starlight management - how many seconds in between checking starlight auras in combat
+# see https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials 
+aura_frequency:
 
 
 


### PR DESCRIPTION
Second phase of implementation of trader starlight aura handling.  Might take a week or two to run this by other traders first, so no hurry.

Usage:
A user sets aura_frequency: to a time period in seconds.  At startup and at each aura_frequency interval afterwards SpellProcess runs DRCA.perc_aura and records the information in game_state.starlight_values.  

Then, for any buff_spell or offensive_spell that has starlight_threshold: defined, it will only select it if the current starlight level is equal to or above the defined threshold.  This lets me set, say:

```
- skill: Debilitation
  name: Fluoresce
  abbrev: flu
  mana: 15
  harmless: true
  min_threshold: 3
  starlight_threshold: 1
  cast_only_to_train: true
  cambrinth:
  - 10
  - 10
  
- skill: Targeted Magic
  name: Arbiter's Stylus
  abbrev: ars
  cyclic: true
  starlight_threshold: 2
  mana: 9

- skill: Targeted Magic
  name: Starcrash
  abbrev: star
  mana: 30
  starlight_threshold: 2
  min_threshold: 3
  
- skill: Targeted Magic
  name: Crystal Dart
  abbrev: crd
  starlight_threshold: 1
  mana: 18

- skill: Targeted Magic
  name: Strange Arrow
  abbrev: stra
  mana: 18
```
In other words, Starcrash and Arbiter's Stylus will only cast if my aura is at level 2 or higher, otherwise it will use Crystal Dart instead and continue to cast Fluoresce.  At level 0 (minimum) it will only use Strange Arrow, and reserve the remaining starlight for defensive spells like Blur and Trabe Chalice (threshold 0).  

All spells that use starlight are already marked in base-spells at starlight_threshold: 0 (except Enrichment, which is default 3 due to being uncastable below certain levels).  Also, if aura_frequency is not set, then all casting is identical to before -- it casts all spells until you run out of starlight, at which point it gets rid of them.

This has been tested on my trader and other non-trader magic users that I own.  I'll hunt around for other testing and feedback first.