### PR TITLE
Handle no worn pouch in ;appraisal

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -47,7 +47,7 @@ class Appraisal
   end
 
   def train_appraisal_with_pouches(full_pouch_container, gem_pouch_adjective)
-    bput("appraise my #{gem_pouch_adjective} pouch", 'Roundtime') if gem_pouch_adjective
+    bput("appraise my #{gem_pouch_adjective} pouch", 'Roundtime', 'You can.t appraise the', 'Appraise what') if gem_pouch_adjective
     $ORDINALS.each do |ordinal|
       case bput("get #{ordinal} pouch from my #{full_pouch_container}", '^You get ', '^What were you referring')
       when /^You get /


### PR DESCRIPTION
On occasion you can end up appraising a gem pouch with nothing worn, and appraisal hangs for 15seconds whereupon it moves on to things in your full_pouch_container