### PR TITLE
;sew return to room upon buying, and dampen pin-tapping

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -89,9 +89,11 @@ class Sew
 
   def check_thread
     return if exists?('cotton thread')
+    room = Room.current.id
     ensure_copper_on_hand(1000, @settings)
     order_item(@hometown_data['stock-room'], 6)
     stow_item('cotton thread')
+    walk_to(room)
   end
 
   def check_pins
@@ -99,8 +101,10 @@ class Sew
     ensure_copper_on_hand(125, @settings)
     item = left_hand
     stow_item(item)
+    room = Room.current.id
     order_item(@hometown_data['tool-room'], 5)
     stow_item('pin')
+    walk_to(room)
     get_item(item)
     Flags.reset('sew-pins')
   end
@@ -243,7 +247,6 @@ class Sew
     end
     get_item(tool)
     @last_command = command
-    check_pins
     assemble_part
     next_command = "push my #{@noun} with my needles"
     case bput(command,
@@ -266,6 +269,7 @@ class Sew
     when 'and could use some pins to'
       tool = 'pins'
       next_command = "poke my #{@noun} with my pins"
+      check_pins
     when 'deep crease develops along', 'wrinkles from all the handling and could use'
       tool = 'slickstone'
       next_command = "scrape my #{@noun} with my slickstone"


### PR DESCRIPTION
Lots of little things today.

Two changes.  One is changing ;sew to return to the room you started in if you have to leave to go buy pins or thread.  Otherwise you continue crafting inside the crafting society.

Second is moving check_pins into the pins section so you don't tap your pins in between every sewing command.  When it gets the pins message, it'll check to see if you've got a pin collection, buy some if you don't, then come back.

I've been running this for about a month and had it run through pins and thread a number of times in that period.