### PR TITLE
Fix tinker crafting-spell-training

### DIFF
--- a/tinker.lic
+++ b/tinker.lic
@@ -281,29 +281,26 @@ class Tinker
   end
 
   def magic_routine
-    return unless @training_spells.empty?
+    return if @training_spells.empty?
+
+    if @preparing && Flags['tinker-magic-ready'] && mana > 40
+      crafting_cast_spell(@preparing, @settings)
+      Flags.reset('tinker-magic-ready')
+      @preparing = nil
+    end
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| DRSkill.getxp(skill) < 31 }
                      .sort_by { |skill| DRSkill.getxp(skill) }.first
     return unless needs_training
-
-    data = @training_spells[needs_training]
-
-    if Flags['tinker-magic-ready'] && mana > 40
-      crafting_cast_spell(data, @settings)
-      Flags.reset('tinker-magic-ready')
-      @preparing = false
-    end
-
     return if @preparing
-    crafting_prepare_spell(data, @settings)
-    @preparing = true
+    @preparing = @training_spells[needs_training]
+    crafting_prepare_spell(@preparing, @settings)
   end
 
   def magic_cleanup
-    return unless @training_spells.empty?
+    return if @training_spells.empty?
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")


### PR DESCRIPTION
First, fixing my obvious if/unless mistake in tinker spell logic on crafting_training_spells.empty? caused by a persistent failure with my brain.

Second, I'm changing the structure of magic_routine here a bit, and I'd like to see if we want to do it to the others.

Basically, there is a case when magic_routine is entered with an already prepped training spell and nearly maxed magic mindstates -- this happens about every other cast once you do enough crafting.  So, magic_routine gets past needs_training, casts successfully, but then prepares a new spell even though your mind states are now too high to cast it the next time this is called.  The next time magic_routine would be called it would return on needs_training being nil before casting.

Normally this just means you let the prepped spell time out, but symbiosis stays up longer, and if you have a mix of some spells with symbiosis and some without then this could cause you to cast the wrong spell with symbioisis still up.  Rare, but it did occasionally give me some nerve damage when I was making the transition into being able to cast all of my schools with symbiosis.

Instead, this will store the spell being prepped in the preparing variable rather than making it true/false, then check to see if it needs to be cast before doing a needs_training check.