### PR TITLE
Update book for scholarship training in crossing-training.lic

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -562,7 +562,7 @@ class CrossingTraining
       return
     end
 
-    case bput('get my black book', 'What were you', 'You get')
+    case bput('get my blacksmithing book', 'What were you', 'You get')
     when 'What were you'
       echo '***UNABLE TO TRAIN SCHOLARSHIP, REMOVING IT FROM THE TRAINING LIST***'
       @settings.crossing_training.delete('Scholarship')


### PR DESCRIPTION
Switched 'black book' for scholarship training to 'blacksmithing book' to avoid grabbing other black books.