### PR TITLE
drinfomon: Reset only modifies a skills baseline

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -293,7 +293,7 @@ class DRSkill
   @@start_time ||= Time.now
   @@list ||= []
   attr_reader :name, :rank, :exp, :percent, :current, :baseline
-  attr_writer :rank, :exp, :percent, :current
+  attr_writer :rank, :exp, :percent, :current, :baseline
   def initialize(name, rank, exp, percent)
     # UserVars.athletics = ra.to_i if name == 'Athletics'
     @name = name
@@ -308,7 +308,7 @@ class DRSkill
   def self.reset
     @@gained_skills = []
     @@start_time = Time.now
-    @@list = []
+    @@list.each { |skill| skill.baseline = skill.current }
   end
 
   def self.start_time


### PR DESCRIPTION
Edge cases occur after doing a reset when the list of all skills
is reset; Any script which checks a skill rank or exp level shortly
after a reset will incorrectly read a 0. Instead this sets the baseline
to the current skill level, which is what we're after when doing a reset.