### PR TITLE
Add catches for DRCM

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -138,12 +138,14 @@ module DRCM
     DRCT.walk_to(get_data('town')[town]['deposit']['id'])
     DRC.release_invisibility
     loop do
-      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money")
+      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account')
       when 'The clerk counts', 'You count out'
         break true
       when 'The clerk glares at you.', 'Hey!  Slow down!'
         pause 15
-      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'You do not have an account'
+      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account'
+        break false
+      else
         break false
       end
     end


### PR DESCRIPTION
I've got bescort pulling money from nearby banks if you lack fare on the ferries, barges, and dirigibles and such, but first I need to improve the reliability of DRCM.get_money_from_specific_bank and send it out a while ahead of time.

Generalized having no account messaging, and added a catchall break out of the loop in case the messaging doesn't match anything.  I'm pretty sure the only script that uses this is restock, but I tested it as best as I could anyway.