### PR TITLE
Anchor drinfomon message triggered by lnet

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -720,7 +720,7 @@ end
 
 while line = script.gets
   begin
-    if line =~ /Log-on system converted \d+% of your character/
+    if line =~ /^\* Log-on system converted \d+% of your character/
       put('exp all')
     elsif line =~ /^#{$lich_char}banks$/
       if CharSettings['bank_accounts'].empty?


### PR DESCRIPTION
Due to REXP discussion we found a global lnet trigger for making everyone do an EXP ALL.

Not exactly critical, but this change no longer triggers on chat messages but does trigger on login messages.