### PR TITLE
Toggle hide and add fare withdrawal to bescort

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -656,12 +656,12 @@ class Bescort
       manual_go2(12_862)
       if wealth('Shard') < DRStats.circle * 50
         echo('Get money you slob!')
-        return unless get_fare?('10 gold', 'Shard', 12862)
+        return unless get_fare?(DRStats.circle * 50, 'Shard', 12862)
       end
     when 'shard'
       if wealth('Aesry') < DRStats.circle * 50
         echo('Get money you slob!')
-        return unless get_fare?('10 gold', 'Aesry', 12942)
+        return unless get_fare?(DRStats.circle * 50, 'Aesry', 12942)
       end
       manual_go2(12_942)
     end
@@ -686,12 +686,12 @@ class Bescort
       manual_go2(8793)
       if wealth('Therenborough') < DRStats.circle * 50
         echo('Get money you slob!')
-        return unless get_fare?('10 gold', 'Therenborough', 8793)
+        return unless get_fare?(DRStats.circle * 50, 'Therenborough', 8793)
       end
     when 'langenfirth'
       if wealth("Mer'Kresh") < DRStats.circle * 50
         echo('Get money you slob!')
-        return unless get_fare?('10 gold', 'Mer'Kresh', 8794)
+        return unless get_fare?(DRStats.circle * 50, "Mer'Kresh", 8794)
       end
       manual_go2(8794)
     end
@@ -1151,7 +1151,7 @@ class Bescort
 
     if UserVars.citizenship != 'Zoluren' && wealth('Crossing') < 35
       echo('Get money you slob!')
-      return unless Room.current.id == 1904 ? get_fare?('4 bronze', 'Leth Deriel', 1904) : get_fare?('4 bronze','Crossing', 957)
+      return unless Room.current.id == 1904 ? get_fare?(35, 'Leth Deriel', 1904) : get_fare?(70,'Crossing', 957)
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /the ferry/ }
@@ -1179,7 +1179,7 @@ class Bescort
 
     if wealth('Shard') < 31
       echo('Get money you slob!')
-      return unless Room.current.id == 3986 ? get_fare?('8 bronze', 'Shard', 3986) : false
+      return unless Room.current.id == 3986 ? get_fare?(60, 'Shard', 3986) : false
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /Damaris. Kiss|Evening Star/ }
@@ -1209,7 +1209,7 @@ class Bescort
     if wealth('Riverhaven') < 300
       echo('Get money you slob!')
       room = Room.current.id
-      return unless room == 3434 ? get_fare?('3 silver', 'Therenborough', room) : get_fare?('3 silver', 'Riverhaven', room)
+      return unless room == 3434 ? get_fare?(300, 'Therenborough', room) : get_fare?(300, 'Riverhaven', room)
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /the barge/ }
@@ -1241,7 +1241,7 @@ class Bescort
 
     if wealth('Riverhaven') < 300
       echo('Get money you slob!')
-      return unless Room.current.id == 452 ? get_fare?('3 silver', 'Riverhaven', 452) : get_fare?('3 silver', 'Throne City', 3084)
+      return unless Room.current.id == 452 ? get_fare?(300, 'Riverhaven', 452) : get_fare?(300, 'Throne City', 3084)
     end
 
     if DRRoom.room_objs.find { |x| x =~ /the barge Imperial Glory/ }
@@ -1319,22 +1319,24 @@ class Bescort
 
   def get_fare?(amount, town, room)
     return false unless get_settings.bescort_fare_handling
+    settings = get_settings
     town_data = get_data('town')
+    echo "GETTING MONEY, YOU SLOB."
+    echo "Heading to #{town} for public transportation fare"
+    pause 1
+    manual_go2(get_data('town')[town]['deposit']['id'])
     bput('JUSTICE', 'After assessing', 'lawless and unsafe')
     result = reget(5, 'You are also fairly sure that the people are convinced')
     if result
       echo "You might be a necromancer!  Get some money manually!"
       return false
-    else
-      echo "GETTING MONEY, YOU SLOB."
-      echo "Heading to #{town} for public transportation fare"
-      pause 1
-      manual_go2(get_data('town')[town]['deposit']['id'])
-      succeeded = DRCM.get_money_from_specific_bank?(amount, town)
-      echo "Put some fare money in the #{town} bank!" unless succeeded
-      manual_go2(room)
-      return succeeded
     end
+    settings.hometown = town
+    succeeded = false
+    DRCM.minimize_coins(amount).each { |each_amount| succeeded = DRCM.get_money_from_bank(each_amount, settings) }
+    echo "Put some fare money in the #{town} bank!" unless succeeded
+    manual_go2(room)
+    return succeeded
   end
 
   def hide?

--- a/bescort.lic
+++ b/bescort.lic
@@ -654,14 +654,14 @@ class Bescort
     case mode
     when 'aesry'
       manual_go2(12_862)
-      if wealth('Shard') < 10_000
+      if wealth('Shard') < DRStats.circle * 50
         echo('Get money you slob!')
-        return
+        return unless get_fare?('10 gold', 'Shard', 12862)
       end
     when 'shard'
-      if wealth('Aesry') < 10_000
+      if wealth('Aesry') < DRStats.circle * 50
         echo('Get money you slob!')
-        return
+        return unless get_fare?('10 gold', 'Aesry', 12942)
       end
       manual_go2(12_942)
     end
@@ -684,14 +684,14 @@ class Bescort
     case mode
     when 'mriss'
       manual_go2(8793)
-      if wealth('Therenborough') < 10_000
+      if wealth('Therenborough') < DRStats.circle * 50
         echo('Get money you slob!')
-        return
+        return unless get_fare?('10 gold', 'Therenborough', 8793)
       end
     when 'langenfirth'
-      if wealth("Mer'Kresh") < 10_000
+      if wealth("Mer'Kresh") < DRStats.circle * 50
         echo('Get money you slob!')
-        return
+        return unless get_fare?('10 gold', 'Mer'Kresh', 8794)
       end
       manual_go2(8794)
     end
@@ -1151,7 +1151,7 @@ class Bescort
 
     if UserVars.citizenship != 'Zoluren' && wealth('Crossing') < 35
       echo('Get money you slob!')
-      return
+      return unless Room.current.id == 1904 ? get_fare?('4 bronze', 'Leth Deriel', 1904) : get_fare?('4 bronze','Crossing', 957)
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /the ferry/ }
@@ -1179,7 +1179,7 @@ class Bescort
 
     if wealth('Shard') < 31
       echo('Get money you slob!')
-      return
+      return unless Room.current.id == 3986 ? get_fare?('8 bronze', 'Shard', 3986) : false
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /Damaris. Kiss|Evening Star/ }
@@ -1208,7 +1208,8 @@ class Bescort
 
     if wealth('Riverhaven') < 300
       echo('Get money you slob!')
-      return
+      room = Room.current.id
+      return unless room == 3434 ? get_fare?('3 silver', 'Therenborough', room) : get_fare?('3 silver', 'Riverhaven', room)
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /the barge/ }
@@ -1240,7 +1241,7 @@ class Bescort
 
     if wealth('Riverhaven') < 300
       echo('Get money you slob!')
-      return
+      return unless Room.current.id == 452 ? get_fare?('3 silver', 'Riverhaven', 452) : get_fare?('3 silver', 'Throne City', 3084)
     end
 
     if DRRoom.room_objs.find { |x| x =~ /the barge Imperial Glory/ }
@@ -1314,6 +1315,31 @@ class Bescort
       release_invisibility
       bput('knock gate', 'You knock')
     end
+  end
+
+  def get_fare?(amount, town, room)
+    return false unless get_settings.bescort_fare_handling
+    town_data = get_data('town')
+    bput('JUSTICE', 'After assessing', 'lawless and unsafe')
+    result = reget(5, 'You are also fairly sure that the people are convinced')
+    if result
+      echo "You might be a necromancer!  Get some money manually!"
+      return false
+    else
+      echo "GETTING MONEY, YOU SLOB."
+      echo "Heading to #{town} for public transportation fare"
+      pause 1
+      manual_go2(get_data('town')[town]['deposit']['id'])
+      succeeded = DRCM.get_money_from_specific_bank?(amount, town)
+      echo "Put some fare money in the #{town} bank!" unless succeeded
+      manual_go2(room)
+      return succeeded
+    end
+  end
+
+  def hide?
+    return false if get_settings.bescort_hide == false
+    return DRC.hide?
   end
 end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -338,6 +338,10 @@ hand_armor: gloves
 instrument:
 # used in several places.  If defined, go2 will remove this before wearing ice-skates when traveling into Forfedhar
 footwear:
+# if true, will attempt to pull money from the nearest bank if you have no money for fares
+bescort_fare_handling: false
+# hide when on the ferries and suchlike
+bescort_hide: true
 # exit the game when crossing-training is capped
 exit_on_skills_capped: false
 # defines a spell to train sorcery if Sorcery is on your crossing-training list


### PR DESCRIPTION
Two changes, and I'm going to set this out there for a while to do testing and get input, since bescort is so important.

First, spoofed hide? in bescort which does DRC.hide? unless bescort_hide is false.   bescort_hide is going into base.yaml as true by default for now, so functionality should stay the same unless overridden.

Second, added get_fare?.  If bescort_fare_handling is true (default false for now) it will check to see if you've done something horrifying recently, and if not it walks to the nearest bank to withdraw fare, then returns to the room it started in.

I've tested this up and down on the Crossing/Leth ferry and it works fine.  I'll want to test it everywhere.

Also, changed default 10_000 on dirigible fees to circle*50.

Closes https://github.com/rpherbig/dr-scripts/issues/3408