### PR TITLE
Support resuming knitted goods and fix DR caravan bug

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -200,8 +200,30 @@ class Sew
     do_seal !wax
   end
 
+  def resume_knit
+    bput("analyze my knitting needles",
+         /You analyze both the needles and an? unfinished knitted .+ (.+) on them/,
+         'This appears to be a crafting tool',
+         'Roundtime')
+    pause 1
+    results = reget(20)
+    unless results.to_s =~ /You analyze both the needles and an? unfinished knitted .+ (.+) on them/
+      echo "Nothing found on the needles.  Exiting"
+      exit
+    end
+    @noun = Regexp.last_match(1).to_s
+    echo "Found an unfinished #{@noun} on the needles."
+    do_knit('push my knitting needles') if results.to_s.include?('purl stitching')
+    do_knit('knit my knitting needles') if results.to_s.include?('more knitting')
+    do_knit('turn my knitting needles') if results.to_s.include?('need to be turned')
+    cast_and_finish if results.to_s.include?('must be cast')
+    exit
+  end
+
   def resume
     waitrt?
+    resume_knit if @noun.include?('needle') || right_hand.include?('knitting needles') || left_hand.include?('knitting needles')
+
     case bput("analyze my #{@noun}",
               'dimensions changed while working on it',
               'is in need of pinning to help arrange the material for further sewing',
@@ -360,7 +382,8 @@ class Sew
               'You are already knitting',
               'Roundtime',
               'That tool does not seem suitable for that task.',
-              'You need a larger amount of material')
+              'You need a larger amount of material',
+              'is not here!')
     when 'Now the needles must be turned', 'Some ribbing should be added'
       next_command = 'turn my needles'
     when 'Next the needles must be pushed', 'ready to be pushed'
@@ -372,6 +395,8 @@ class Sew
       bput('pull my needles', 'You untie and discard')
       do_knit(command)
       next_command = ''
+    when 'is not here!'
+      do_knit(command.sub(' my', ''))
     when 'That tool does not seem suitable for that task.'
       case bput('analyze my needles', 'is in need of more knitting.', 'The needles need to be turned', 'Some purl stitching is', 'needles must be cast')
       when 'is in need of more knitting.'


### PR DESCRIPTION
Added resume_knit that triggers if called as 'sew resume needles', or with knitting needles in hand.  Analyzing a pair of knitting needles with something on it gives like 40 lines of scroll and TWO separate RTs from one action, which screws up bput entirely.

Tested on knitted items resumed at each stage (push/knit/turn/cast) and on empty needles.

Also, encountered a bug of some sort with the PUSH command in caravans.  PUSH MY Anything inside a caravan while someone is online with a name beginning with 'My' always results in 'Myfoo is not here!'

If it runs into that case it subs out 'my ' and just becomes 'push needles'.  