### PR TITLE
Fix a match for having no account in get_money_from_bank

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -100,12 +100,14 @@ module DRCM
     DRCT.walk_to(get_data('town')[settings.hometown]['deposit']['id'])
     DRC.release_invisibility
     loop do
-      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money")
+      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account')
       when 'The clerk counts', 'You count out'
         break true
       when 'The clerk glares at you.', 'Hey!  Slow down!'
         pause 15
-      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'You do not have an account'
+      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account'
+        break false
+      else
         break false
       end
     end


### PR DESCRIPTION
Same as previous PR, except in get_money_from_bank.  There was a 'You do not have an account' match, but nothing in the corresponding bput, and this will catch a different 'do not have an account' message.

Also a general else break to avoid getting stuck in the loop forever.