### PR TITLE
Add snipe messaging to hunting-buddy roomcheck

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -191,7 +191,7 @@ class HuntingBuddy
                         return false if (DRRoom.pcs - DRRoom.group_members).any?
                         # No visible friends in the room and no visible people
                         UserVars.friends.each { |friend| Flags.add("room-check-#{friend}", friend) }
-                        Flags.add('room-check', 'says, ', 'say, ', 'You hear')
+                        Flags.add('room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
                         bput('search', 'roundtime')
                         data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
                         if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?


### PR DESCRIPTION
LNET suggestion - An arrow is as good as an 'excuse me', in my opinion.

If hunting-buddy sees snipe messaging it will move on, since it's unlikely the sniper will break cover in the time period allotted for room_check.