### PR TITLE
Common-arcana Trabe Chalice fix and aura update

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -123,7 +123,8 @@ module DRCA
 
     Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
-
+    Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
+    
     case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
     when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
@@ -133,8 +134,9 @@ module DRCA
     end
     waitrt?
 
-    if Flags['cyclic-too-recent']
+    if Flags['cyclic-too-recent'] || Flags['spell-full-prep']
       pause 1
+      Flags.delete('spell-full-prep')
       return cast?(cast_command, symbiosis, [], after)
     end
 
@@ -311,7 +313,9 @@ module DRCA
       'A faint amount of starlight illuminates your aura',
       'Your aura pulses slowly with starlight',
       'A steady pulse of starlight runs through your aura',
-      'Starlight dances vividly across the confines of your aura'
+      'Starlight dances vividly across the confines of your aura',
+      'Strong pulses of starlight flare within your aura',
+      'Your aura seethes with brilliant starlight'      
     ]
     Flags.add('aura-level', Regexp.union(starlight_messages))
     Flags.add('aura-capped?', 'Your aura contains as much starlight as you can safely handle')
@@ -596,7 +600,6 @@ module DRCA
         data['cast'] = "cast #{moon}"
       end
     end
-
     command = 'prep'
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -124,7 +124,7 @@ module DRCA
     Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
-    
+
     case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
     when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
@@ -315,7 +315,7 @@ module DRCA
       'A steady pulse of starlight runs through your aura',
       'Starlight dances vividly across the confines of your aura',
       'Strong pulses of starlight flare within your aura',
-      'Your aura seethes with brilliant starlight'      
+      'Your aura seethes with brilliant starlight'
     ]
     Flags.add('aura-level', Regexp.union(starlight_messages))
     Flags.add('aura-capped?', 'Your aura contains as much starlight as you can safely handle')
@@ -600,6 +600,7 @@ module DRCA
         data['cast'] = "cast #{moon}"
       end
     end
+
     command = 'prep'
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']

--- a/textsubs.lic
+++ b/textsubs.lic
@@ -965,12 +965,14 @@ TextSubs.add("#{spell_recognition} (Worm\'s Mist) spell\.", '\1 of the \2 spell.
 TextSubs.add("#{spell_recognition} (Butcher\'s Eye|Philosopher\'s Preservation|Kura-Silma|Ivory Mask) spell\.", '\1 of the \2 spell. [signature Necromancer (Transcendental Necromancy): basic augmentation]')
 
 if DRStats.trader?
-  TextSubs.add('The smallest hint of starlight flickers within your aura.', 'The smallest hint of starlight flickers within your aura (0/5).')
-  TextSubs.add('A bare flicker of starlight plays within your aura.', 'A bare flicker of starlight plays within your aura (1/5.)')
-  TextSubs.add('A faint amount of starlight illuminates your aura.', 'A faint amount of starlight illuminates your aura (2/5).')
-  TextSubs.add('Your aura pulses slowly with starlight.', 'Your aura pulses slowly with starlight (3/5).')
-  TextSubs.add('A steady pulse of starlight runs through your aura.', 'A steady pulse of starlight runs through your aura (4/5).')
-  TextSubs.add('Starlight dances vividly across the confines of your aura.', 'Starlight dances vividly across the confines of your aura (5/5).')
+  TextSubs.add('The smallest hint of starlight flickers within your aura.', 'The smallest hint of starlight flickers within your aura (0/7).')
+  TextSubs.add('A bare flicker of starlight plays within your aura.', 'A bare flicker of starlight plays within your aura (1/7.)')
+  TextSubs.add('A faint amount of starlight illuminates your aura.', 'A faint amount of starlight illuminates your aura (2/7).')
+  TextSubs.add('Your aura pulses slowly with starlight.', 'Your aura pulses slowly with starlight (3/7).')
+  TextSubs.add('A steady pulse of starlight runs through your aura.', 'A steady pulse of starlight runs through your aura (4/7).')
+  TextSubs.add('Starlight dances vividly across the confines of your aura.', 'Starlight dances vividly across the confines of your aura (5/7).')
+  TextSubs.add('Strong pulses of starlight flare within your aura.', 'Strong pulses of starlight flare within your aura (6/7).')
+  TextSubs.add('Your aura seethes with brilliant starlight.', 'Your aura seethes with brilliant starlight (7/7).')
 end
 
 if DRStats.moon_mage?


### PR DESCRIPTION
First, added 'spell-full-prep' flag to common-arcana cast?  If it gets TRC's 'This pattern can only be cast with full preparation' message it joins up with 'cyclic-too-recent' -- waits a second then tries again.

It looks like this:
```
[buff]>prep trc 15
You raise your arms skyward, chanting the equation of the Trabe Chalice spell.
>
[buff]>cast
You gesture.
This pattern may only be cast with full preparation.
>
[buff]>cast
You feel fully prepared to cast your spell.
>
You gesture.
The spell strives to reconstruct your Trabe Chalice, but the two patterns clash.  You will have to let the Chalice break down on its own, or make a stronger pattern.
```

I also deleted the flag after using it.  I THINK cyclic-too-recent should do that too, but I don't have the context to say for sure and it doesn't seem to be causing problems?

Second change - added more starlight levels to perc aura and textsubs.