### PR TITLE
Catch more shaping messages

### DIFF
--- a/shape.lic
+++ b/shape.lic
@@ -162,7 +162,7 @@ class Shape
     check_hand
     assemble_part
     case bput(command,
-              'a wood shaper is needed', 'ready for shaping with a wood shaper',
+              'a wood shaper is needed', 'with a wood shaper',
               'carved with a carving knife', 'further carving with a knife', 'continued knife carving',
               'rubbed out with a rasp', 'A cluster of small knots',
               'Applying the final touches', 'lamination process', 'lightening process', 'cable-backing process',
@@ -173,7 +173,7 @@ class Shape
               'Some wood stain', 'application of stain',
               'You fumble around but',
               'ASSEMBLE Ingredient1')
-    when 'a wood shaper is needed', 'ready for shaping with a wood shaper'
+    when 'a wood shaper is needed', 'with a wood shaper'
       waitrt?
       stow_item(right_hand)
       get_item('shaper')


### PR DESCRIPTION
Sorry for all the little changes recently.  This caravan stuff is touching everything.

There are two/three analyze messages not caught by the current shaping bput, which makes ;shape continue unreliable.  They differ at the beginning, but they all contain 'with a wood shaper'.