### PR TITLE
Return all matches with fz alias

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -42,8 +42,8 @@
   ['hz', "#{$clean_lich_char}e get_data('hunting').hunting_zones.sort.each{ |x| echo x }"],
   # List all escort zones from base-hunting alphabetically by name.
   ['ez', "#{$clean_lich_char}e get_data('hunting').escort_zones.sort.each{ |x| echo x }"],
-  # Search for a hunting zone, e.g. 'fz wark' will return warklin hunting zone rooms
-  ['fz', "#{$clean_lich_char}e echo get_data('hunting').hunting_zones.find{|k,v| k =~ /\\?/i}"]
+  # Search for a hunting zone, e.g. 'fz moth' will find all zones with moth in it
+  ['fz', "#{$clean_lich_char}e get_data('hunting').hunting_zones.find_all { |k, v| k =~ /\\?/i}.each { |zone| respond \"\#\{zone[0]\}:  \#\{zone[1].join(', ')\}\" }"]
 ].each do |trigger, target|
   UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
 end


### PR DESCRIPTION
Returns all matches since thats more useful when your not sure
what the zone is named in base-hunting and there are more than
one potential match. e.g. fz garg returning one match isn't
useful when theres 3 hunting grounds for gargoyles.

Output looks a little cleaner than the previous as well:
```
>fz moth                                                                                       
--- Lich: exec1 active.                                                                        
fuligin_moths:  12041, 12036, 12037, 12038, 12039, 12040, 12042                                
void_moths:  12165, 12171, 12166, 12167, 12168, 12169, 12170                                   
--- Lich: exec1 has exited.                                                                    
>fz garg                                                                                       
--- Lich: exec1 active.                                                                        
granite_gargoyles:  2908, 2909, 2910, 2911, 2915, 2919, 2916, 2917, 2918, 2926, 2927, 2928     
black_marble_gargoyles:  31500, 31502, 31504, 31508, 31512, 31514, 31519, 31521, 31523, 31524  
quartz_gargs:  8290, 8291, 8289                                                                
--- Lich: exec1 has exited.                                                                    
```