### PR TITLE
Provide mechanism to use divination tools other than bones.

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -24,6 +24,9 @@ class Astrology
 
     @equipment_manager = EquipmentManager.new
     @constellations = get_data('constellations').constellations
+    @divination_tool = settings.divination_tool['name']
+    @divination_tool_container = settings.divination_tool['container']
+    @divination_tool_tied = settings.divination_tool['tied']
     @have_divination_bones = settings.have_divination_bones
     @divination_bones_container = settings.divination_bones_storage['container']
     @divination_bones_tied = settings.divination_bones_storage['tied']
@@ -308,6 +311,36 @@ class Astrology
     end
   end
 
+  def execute_tool
+    verbs = {
+      "charts" => "review",
+      "bones" => "roll",
+      "mirror" => "gaze",
+      "bowl" => "gaze",
+      "prism" => "raise"
+    }
+
+    if @divination_tool_tied
+      bput("untie #{@divination_tool} from my #{@divination_tool_container}", @divination_tool)
+    else
+      bput("get my #{@divination_tool} from my #{@divination_tool_container}", @divination_tool, 'you get')
+    end
+
+    verbs.each do | tool, verb |
+      if @divination_tool.include? tool
+        bput("#{verb} my #{@divination_tool}", 'roundtime')
+        waitrt?
+        break
+      end
+    end
+
+    if @divination_tool_tied
+      bput("tie #{@divination_tool} to my #{@divination_tool_container}", @divination_tool)
+    else
+      bput("put #{@divination_tool} in my #{@divination_tool_container}", @divination_tool, 'you put')
+    end
+  end
+
   def align(skill)
     if skill == 'future events'
       bput('predict event', 'You focus inwardly')
@@ -317,6 +350,8 @@ class Astrology
     waitrt?
     if @have_divination_bones
       roll_bones
+    elsif @divination_tool
+      execute_tool
     else
       bput('predict future', 'roundtime')
     end


### PR DESCRIPTION
# What is this?
Currently astrology.lic only provides support for bones as a divination tool. This pull adds a mechanism for using any divination tool currently in the game.

## Configuration Examples

### Celestial Charts
```yaml
divination_tool:
  name: 'vellum.charts'
  container: 'case'
```
### Bones
```yaml
divination_tool:
  name: 'enruned.bones'
  container: 'belt'
  tied: true
```
### Mirror
```yaml
divination_tool:
  name: 'clouded mirror'
  container: 'cloak'
```
### Bowl
```yaml
divination_tool:
  name: 'clay bowl'
  container: 'backpack'
```
### Prism
```yaml
divination_tool:
  name: 'glittering prism'
  container: 'backpack'
```
## Current Bones Functionality
This pull leaves the current bone rolling functionality in place to not break users' existing configurations. Ideally it would be marked as deprecated and removed in a future version.  That said, it's not really hurting anything by still having it in there.