### PR TITLE
Update base-spells.yaml - Regalia cast messaging

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -160,7 +160,7 @@ cast_messages:
 - ^Wisps of spectral flame whorl.*$
 - ^You cup your palms skyward to bask in.*$
 - ^Incited by the spell, your starlight aura
-- ^Cupping your palms skyward, you bask in a cascade of starlight.*$
+- ^Cupping your palms skyward, you bask in a cascade.*$
 
 khri_preps:
 - With deep breaths


### PR DESCRIPTION
Regalia cast messaging changes depending on the available source of light.

I updated the match to this  /^Cupping your palms skyward, you bask in a cascade.*$/

Cupping your palms skyward, you bask in a cascade of moonlight.
The moonlight coalesces into a rough-cut crystal scale balaclava atop your head!
The moonlight coalesces into some rough-cut crystal scale gloves around your hands!
The moonlight coalesces into a rough-cut crystal scale hauberk around your body!
Roundtime: 2 sec.