### PR TITLE
Update ;trade for training and multiple contracts

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -31,10 +31,6 @@ Crossing:
   gemshop:
     id: 4652
     name: appraiser
-  pawnshop:
-    id: 8261
-    name: Cormyn
-    
   tannery:
     id: 8266
     name: Falken
@@ -140,6 +136,14 @@ Crossing:
     Warrior Mage:
       name: Gauthus
       id: 7887
+Darkling Wood:
+  currency: dokoras
+  shipment_clerk:
+    id: 14636
+  trade_minister:
+    id: 14636
+  trader_outpost:
+    id: 2702
 Dirge:
   trade_minister:
     id: 15175
@@ -148,6 +152,14 @@ Dirge:
     id: 8919
   trader_outpost:
     id: 1307
+Fayrin's Rest:
+  currency: dokoras
+  shipment_clerk:
+    id: 19278
+  trade_minister:
+    id: 19278
+  trader_outpost:
+    id: 2840
 Leth Deriel:
   currency: kronars
   leather_repair:
@@ -193,9 +205,6 @@ Shard:
     name:
     - Fatimi
     - Veilex
-  pawnshop:
-    id: 9759
-    name: Aelik
   tannery:
     id: 19340
     name: Tremagis
@@ -307,6 +316,19 @@ Shard:
     Warrior Mage:
       name: Melear
       id: 11197
+  shipment_clerk:
+    id: 8193
+  trade_minister:
+    id: 8197
+  trader_outpost:
+    id: 8191
+Steelclaw Clan:
+  shipment_clerk:
+    id: 19399
+  trade_minister:
+    id: 19399
+  trader_outpost:
+    id: 2874
 Stone Clan:
   currency: kronars
   shipment_clerk:
@@ -338,9 +360,6 @@ Riverhaven:
   gemshop:
     id: 7955
     name: Anthelorm
-  pawnshop:
-    id: 14337
-    name: Ioun
   guard_house:
     id: 7882
   tannery:
@@ -573,7 +592,7 @@ Langenfirth:
     - 12269
     - 12215
     - 12209
-  guild_leaders: 
+  guild_leaders:
     << : *therengia_guild_leaders
 Ratha:
   currency: lirums
@@ -807,6 +826,12 @@ Throne City:
   npc_empath: # None
 Hibarnhvidar:
   currency: dokoras
+  shipment_clerk:
+    id: 7412
+  trade_minister:
+    id: 7412
+  trader_outpost:
+    id: 3903
   leather_repair:
     id: 11206
     name: Ladar
@@ -895,8 +920,22 @@ Hibarnhvidar:
     Warrior Mage:
       name: Jorent
       id: 11498
+Raven's Point:
+  currency: dokoras
+  shipment_clerk:
+    id: 14642
+  trade_minister:
+    id: 14642
+  trader_outpost:
+    id: 4440
 Boar Clan:
   currency: dokoras
+  shipment_clerk:
+    id: 13675
+  trade_minister:
+    id: 13675
+  trader_outpost:
+    id: 4106
   leather_repair:
     id: 12174
     name: Tuzra
@@ -1009,11 +1048,21 @@ Muspar'i:
       id:
 Ain Ghazal:
   currency: dokoras
+  shipment_clerk:
+    id: 14638
+  trade_minister:
+    id: 14638
+  trader_outpost:
+    id: 11033
+  deposit:
+    id: 14640
+  exchange:
+    id: 14641
   locksmithing:
     id: 13190
   guild_leaders:
     Thief:
       name: Ivitha
       id: 13663
-  #Needs attunement_rooms, and premium bank/gem shop.
+  #Needs attunement_rooms
 

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -31,6 +31,9 @@ Crossing:
   gemshop:
     id: 4652
     name: appraiser
+  pawnshop:
+    id: 8261
+    name: Cormyn
   tannery:
     id: 8266
     name: Falken
@@ -205,6 +208,9 @@ Shard:
     name:
     - Fatimi
     - Veilex
+  pawnshop:
+    id: 9759
+    name: Aelik
   tannery:
     id: 19340
     name: Tremagis
@@ -360,6 +366,9 @@ Riverhaven:
   gemshop:
     id: 7955
     name: Anthelorm
+  pawnshop:
+    id: 14337
+    name: Ioun
   guard_house:
     id: 7882
   tannery:

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -62,4 +62,4 @@ empty_values:
   crafting_training_spells: {}
   restock_shop: {}
   theurgy_supply_levels: {}
-  caravan_training_skill: {}
+  caravan_training_skills: {}

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -62,3 +62,4 @@ empty_values:
   crafting_training_spells: {}
   restock_shop: {}
   theurgy_supply_levels: {}
+  caravan_training_skill: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -524,8 +524,9 @@ caravan_training_skills:
   Attunement: 100
   Outdoorsmanship: 5
   Locksmithing: 30
-  Perception: 15
-  Outfitting: 200
+  Perception: 45
+  First Aid: 120
+  # Outfitting: 200
   # Engineering: 200
 
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -488,6 +488,8 @@ crafting_training_spells:
 craft_max_mindstate: 31
 # amount of yarn to keep on hand for craft.lic, don't exceed 300
 yarn_quantity: 100
+# amount of balsa lumber to keep on hand in trade.lic.
+lumber_quantity: 15
 
 
 # Workorder settings
@@ -513,8 +515,9 @@ caravan_coins_on_hand: 9555
 caravan_interior: false
 # skills and cooldowns to train in ;trade.  See https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials for valid skills and what they do
 caravan_training_skills:
-  Augmentation: 5 
-  Warding: 5
+  # Augmentation: 5 
+  # Warding: 5
+  # Utility: 5
   Performance: 120
   Appraisal: 60
   Mechanical Lore: 5
@@ -523,6 +526,7 @@ caravan_training_skills:
   Locksmithing: 30
   Perception: 15
   Outfitting: 200
+  # Engineering: 200
 
 
 # Lumber settings

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -504,6 +504,23 @@ workorder_max_items: 3
 workorder_recipes:
 workorder_cash_on_hand:
 
+#CARAVAN SETTINGS
+# container holding caravan contracts for ;trade
+trade_contract_container: backpack
+# number of copper to carry on-hand while running ;trade
+caravan_coins_on_hand: 15555
+# skills and cooldowns to train in ;trade.  See https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials for valid skills and what they do
+caravan_training_skills:
+  Augmentation: 5 
+  Warding: 5
+  Performance: 120
+  Appraisal: 60
+  Mechanical Lore: 5
+  Attunement: 100
+  Outdoorsmanship: 5
+  Locksmithing: 30
+  Perception: 15
+  Outfitting: 200
 
 
 # Lumber settings

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -508,7 +508,9 @@ workorder_cash_on_hand:
 # container holding caravan contracts for ;trade
 trade_contract_container: backpack
 # number of copper to carry on-hand while running ;trade
-caravan_coins_on_hand: 15555
+caravan_coins_on_hand: 9555
+# Have you purchased a 750plat interior from the trade minister?
+caravan_interior: false
 # skills and cooldowns to train in ;trade.  See https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials for valid skills and what they do
 caravan_training_skills:
   Augmentation: 5 

--- a/trade.lic
+++ b/trade.lic
@@ -124,6 +124,10 @@ class Trade
       echo("No contract container found. Define it in your settings as trade_contract_container: Exiting.")
       exit
     end
+    unless exists?(@craft_bag)
+      echo("No crafting container found for storing items.  This will cause problems if you're doing Outfitting or Engineering.")
+      pause 2
+    end
     @settings.storage_containers.each { |container| fput("open my #{container}") }
     @box = nil unless exists?(@box)
     if @caravan_training_skills.include?('Performance') && !exists?('zills')
@@ -225,10 +229,13 @@ class Trade
   end
 
   def setup_town_data # builds @trading_towns from town_data and will later handle multiple provinces
-    zoluren_towns = ['Wolf Clan', 'Tiger Clan', 'Crossing', 'Arthe Dale', 'Stone Clan', 'Dirge', 'Leth Deriel']
+    zoluren_towns = { 'Wolf Clan' => 2, 'Tiger Clan' => 2, 'Crossing' => 2, 'Arthe Dale' => 2, 'Stone Clan' => 2, 'Dirge' => 2, 'Leth Deriel' => 3 }
     @trading_towns = {}
-    zoluren_towns.each_with_index { |_info, index| @trading_towns[zoluren_towns[index]] = @town_data[zoluren_towns[index]] } #reduce town_data to only the towns in question
-    @trading_towns.each_with_index { |_info, index| @trading_towns[zoluren_towns[index]]['contracts_to'] = @trading_towns[zoluren_towns[index]]['contracts_from'] = 0 }
+    zoluren_towns.each do |town_name, threshold|
+      @trading_towns[town_name] = @town_data[town_name]
+      @trading_towns[town_name]['contracts_to'] = @trading_towns[town_name]['contracts_from'] = 0
+      @trading_towns[town_name]['contract_threshold'] = threshold
+    end
   end
 
   def mark_towns # records some information about contracts to and from towns
@@ -254,10 +261,10 @@ class Trade
     end
 	end
 
-  def check_for_emergency_delivery # if there are 4 or more pieces of business to do at a town, (contracts to deliver + contract to pick up) set it for emergency delivery
+  def check_for_emergency_delivery # go towards a town if you have a certain amount of business there
     echo "checking for emergency" if debugging?
     @trading_towns.find do |name, info|
-      if info['contracts_to'] - info['contracts_from'] >= 3
+      if info['contracts_to'] - info['contracts_from'] >= info['contract_threshold']
         @emergency_delivery_town = name
         echo "Emergency delivery needed to #{@emergency_delivery_town}"
       end
@@ -1417,6 +1424,7 @@ class Trade
   def outfitting_cleanup # sanitizes outfitting_routine
     return unless @training_token == 'Outfitting'
     stop_script('sew') if Script.running?('sew')
+    pause 1
     stow_item('knitting needle')
     bput('stow my wool yarn', 'You put', 'Stow what')
     be_outside_caravan
@@ -1464,9 +1472,9 @@ class Trade
     if left_hand.include?(@crafted_item.split.last) || right_hand.include?(@crafted_item.split.last)
       bput("drop my #{@crafted_item.split.last}", 'You drop', 'You place', 'What were', 'You spread') unless bput("tap my #{@crafted_item.split.last}", 'unfinished', 'You tap', 'I could not find') == 'unfinished'
     end
-    item_container = @settings.storage_containers.find { |container| bput("tap my #{@crafted_item.split.last} in my #{container}", 'unfinished', 'You tap', 'I could not find') == 'unfinished' }
-    if item_container
-      case bput("get my #{@crafted_item.split.last} from my #{item_container}", 'You get', 'What were', 'But that')
+
+    if bput("tap my #{@crafted_item.split.last} in my #{@craft_bag}", 'unfinished', 'You tap', 'I could not find') == 'unfinished'
+      case bput("get my #{@crafted_item.split.last} from my #{@craft_bag}", 'You get', 'What were', 'But that')
       when 'You get'
         echo "Engineering found an uncompleted item #{@crafted_item}"
         be_inside_caravan
@@ -1492,6 +1500,7 @@ class Trade
   def engineering_cleanup # sanitizes engineering
     return unless @training_token == 'Engineering'
     stop_script('shape') if Script.running?('shape')
+    pause 1
     bput("drop my #{@crafted_item.split.last}", 'You drop', 'You place', 'What were', 'You spread') unless bput("tap my #{@crafted_item.split.last}", 'unfinished', 'You tap', 'I could not find') == 'unfinished'
     stow_item(right_hand) if right_hand
     stow_item(left_hand) if left_hand
@@ -1549,7 +1558,7 @@ class Trade
     @cooldown_timers['Performance'] = Time.now
     waitrt?
   end
-  
+
   def check_wounds
     room = Room.current.id
     wait_for_script_to_complete('safe-room')

--- a/trade.lic
+++ b/trade.lic
@@ -117,8 +117,16 @@ class Trade
     end
     @settings.storage_containers.each { |container| fput("open my #{container}") }
     @box = nil unless exists?(@box)
-    unless exists?('zills')
+    if @caravan_training_skills.include?('Performance') && !exists?('zills')
+      echo "NO ZILLS FOUND.  REMOVING PERFORMANCE FROM TRAINING LIST."
       wipe_skill('Performance', @walk_training_skills)
+      wipe_skill('Performance', @lead_training_skills)
+    end
+    if @caravan_training_skills.include?('First Aid')
+      unless @settings.textbook ? exists?(@settings.textbook_type) : exists?('compendium')
+        echo "NO COMPENDIUM OR TEXTBOOK FOUND.  CHECK YOUR ;FIRST-AID SETTINGS"
+        wipe_skill('First Aid', @lead_training_skills) 
+      end
     end
   end
 
@@ -675,12 +683,17 @@ class Trade
     echo "Delivering Contracts"
     walk_to(clerk_id)
     clerk_messages = [
+      'What have you done with the goods',
       '^The \w+ clerk finds everything in order with your merchandise'
     ]
     contracts = find_contracts(@contract_container)
     current_town = find_town(Room.current.id).split.first
     until bput("get my #{current_town} contract from my #{@contract_container}", 'You get', 'What were you' ) == 'What were you'
-	    bput('give my contract to clerk', clerk_messages)
+      case bput('give my contract to clerk', clerk_messages)
+      when 'What have you done with the goods'
+        # Potential to do an immediate parse_contract and force_contract_from that town to 1 so you don't go back there for nothing.
+        dispose_trash('contract')
+      end
     end
   end
 
@@ -1476,8 +1489,8 @@ class Trade
   def performance_routine # runs ;performance for 2 minutes.  Will run ;first-aid too, if it hasn't been done very recently.
     return unless @training_token == 'Performance'
     echo "performance routine" if debugging?
-    if @caravan_being_led && check_ability?('First Aid', 180)
-      @training_token = 'First Aid' if @settings.textbook ? exists?(@settings.textbook_type) : exists?('compendium')
+    if @lead_training_skills.include?('First Aid') && @caravan_being_led && check_ability?('First Aid', 180) 
+      @training_token = 'First Aid'
       return
     end
     @cooldown_timers['perf-timer'] ||= Time.now
@@ -1515,6 +1528,7 @@ class Trade
     end
     if @caravan_training_skills.include?('Engineering') && @times_engineering > 4
       wait_for_script_to_complete('workorders', ['shaping', 'repair'])
+      @times_engineering = 0
     end
   end
 

--- a/trade.lic
+++ b/trade.lic
@@ -967,7 +967,7 @@ class Trade
     return if @training_spells.empty?
     return unless ['Augmentation', 'Warding', 'Utility', 'Outdoorsmanship', 'Perception', 'Mechanical Lore'].include?(@training_token)
     echo "magic_routine" if debugging?
-    if @preparing && Flags['trading-magic-ready'] && mana > 40
+    if @preparing && Flags['trading-magic-ready'] && mana > 40 && DRStats.concentration > 80
       crafting_cast_spell(@preparing, @settings)
       Flags.reset('trading-magic-ready')
       release_symbiosis

--- a/trade.lic
+++ b/trade.lic
@@ -162,6 +162,7 @@ class Trade
     do_lead_to
     take_caravan_to(@current_caravan_destination)
     deliver_contract
+    check_wounds
     hometown_business
   end
 
@@ -200,6 +201,7 @@ class Trade
       dump_expired
       deliver_contract
       pay_dues
+      check_wounds
       hometown_business
       @closeup = true if @time_to_end && Time.now > @time_to_end
     end
@@ -1546,6 +1548,12 @@ class Trade
     stop_script('performance') if is_playing?
     @cooldown_timers['Performance'] = Time.now
     waitrt?
+  end
+  
+  def check_wounds
+    room = Room.current.id
+    wait_for_script_to_complete('safe-room')
+    walk_to(room)
   end
 
   def hometown_business # run every time it delivers/picks up a contract from Crossing/another hub. Replenishes resources and stocks coins

--- a/trade.lic
+++ b/trade.lic
@@ -12,6 +12,24 @@ class Trade
   include DRCM
 
   def initialize
+    arg_definitions = [
+      [
+        { name: 'destination', regex: /\d+/i, optional: true, description: 'Give a room ID to bring your caravan to' }
+      ],
+      [
+        { name: 'closeup', regex: /closeup/i, optional: false, description: 'Close up by delivering all remaining crates and accepting no new contracts' },
+        { name: 'exit', regex: /exit/i, optional: true, description: 'Exits the game after delivering all crates and returning the caravan' }
+      ],
+      [
+        { name: 'outpost', regex: /outpost/i, optional: false, description: 'Bring the caravan to the trade outpost of a town.' },
+        { name: 'town_name', regex: /\w+/i, variable: true, description: 'First word of the town name.' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
+    @closeup = args.closeup
+    @exit = args.exit
+    @caravan = OpenStruct.new
+    
     @town_data = get_data('town')
     @equipment_manager = EquipmentManager.new
     @settings = get_settings
@@ -22,6 +40,7 @@ class Trade
     @caravan_coins_on_hand = @settings.caravan_coins_on_hand.to_i
     @caravan_interior = @settings.caravan_interior
     @caravan_being_led = false
+    @held_contracts = []
     @force_contract_from = []
     Flags.add('lead-arrived', 'having arrived at its destination', 'You feel the momentum of the room shift and then hear a voice from outside announce')
     Flags.add('lead-failed', 'Your caravan guide comes to you and suggests')
@@ -38,10 +57,10 @@ class Trade
     @equipment_manager = EquipmentManager.new(@settings)
     @cooldown_timers = {}
     @caravan_training_skills = @settings.caravan_training_skills
-    @lead_training_skills = @caravan_training_skills.select { |skill, _cooldown| !['Mechanical Lore', 'Augmentation', 'Utility', 'Warding'].include?(skill) }
+    @lead_training_skills = @caravan_training_skills.reject { |skill, _cooldown| ['Mechanical Lore', 'Augmentation', 'Utility', 'Warding'].include?(skill) }
     @walk_training_skills = @caravan_training_skills.select { |skill, _cooldown| ['Augmentation', 'Utility', 'Warding', 'Attunement', 'Performance', 'Appraisal', 'Mechanical Lore'].include?(skill) }
     @craft_bag = @settings.crafting_container
-    @craft_belt = @settings.engineering_belt
+    @craft_belt = nil
 
     @yarn_quantity = @settings.yarn_quantity > 300 ? 301 : @settings.yarn_quantity
     @lumber_quantity = @settings.lumber_quantity > 30 ? 30 : @settings.lumber_quantity
@@ -57,30 +76,9 @@ class Trade
     @loot_nouns = @settings.lootables
     @trash_nouns = get_data('items').trash_nouns
 
-    arg_definitions = [
-      [
-        { name: 'destination', regex: /\d+/i, optional: true, description: 'Give a room ID to bring your caravan to' }
-      ],
-      [
-        { name: 'closeup', regex: /closeup/i, optional: false, description: 'Close up by delivering all remaining crates and accepting no new contracts' },
-        { name: 'exit', regex: /exit/i, optional: true, description: 'Exits the game after delivering all crates and returning the caravan' }
-      ],
-      [
-        { name: 'outpost', regex: /outpost/i, optional: false, description: 'Bring the caravan to the trade outpost of a town.' },
-        { name: 'town_name', regex: /\w+/i, variable: true, description: 'First word of the town name.' }
-      ]
-    ]
-    args = parse_args(arg_definitions)
-    validate_requirements(args)
     setup_town_data
-
-    @closeup = args.closeup
-    @exit = args.exit
-    @caravan = OpenStruct.new
-    recall_caravan?
-
-    @held_contracts = []
-
+    validate_requirements(args)
+    
     bput("open my #{@contract_container}", 'You open', 'That is already', 'You can.t')
     @equipment_manager.empty_hands
 
@@ -167,7 +165,6 @@ class Trade
         magic_cleanup
         wait_for_script_to_complete('buff', ['trade'])
         get_contract
-        load_caravan
       else
         close_out unless exists?('contract')
       end
@@ -501,9 +498,12 @@ class Trade
 
   def compute_path(destination)
     echo "computing path #{destination}" if debugging?
+    Script.pause('skill-recorder') if Script.running?('skill-recorder')
+    UserVars.athletics = 1
     previous, _shortest_paths = Map.dijkstra(Room.current.id, destination)
     path = [destination]
     path.push(previous[path[-1]]) until previous[path[-1]].nil?
+    Script.unpause('skill-recorder') if Script.running?('skill-recorder')
     path.reverse
   end
 
@@ -716,6 +716,7 @@ class Trade
     else
       @force_contract_from - [find_town(minister_id)] if @force_contract_from.include?(find_town(minister_id))
     end
+    load_caravan
   end
 
   def caravan_check?(stationary = true) # The traders' guild hands out identical caravans
@@ -732,7 +733,7 @@ class Trade
   end
 
   def caravan_exists?
-    return false unless @caravan.adjective && @caravan.noun
+    return recall_caravan? unless @caravan.adjective && @caravan.noun
     true
   end
 
@@ -869,7 +870,7 @@ class Trade
 
   def magic_routine
     return if @training_spells.empty?
-    return unless %w[Augmentation Warding Utility Outdoorsmanship Perception].include?(@training_token)
+    return unless ['Augmentation', 'Warding', 'Utility', 'Outdoorsmanship', 'Perception', 'Mechanical Lore'].include?(@training_token)
     echo "magic_routine" if debugging?
     if @preparing && Flags['trading-magic-ready'] && mana > 40
       crafting_cast_spell(@preparing, @settings)
@@ -1092,7 +1093,7 @@ class Trade
     bput('close my feedbag', 'You close', 'What were', 'That is already')
     bput('get my grass', 'You get', 'What were you')
     bput('open my feedbag', 'You open', 'What were')
-    result = bput('stow my grass', 'You stow', 'You put', 'What were you') if braid?('grass')
+    result = bput('stow my grass', 'You stow', 'You put', 'What were you', 'The braided grass is too long') if braid?('grass')
     drop_grass
     @training_token = nil
     @step_toggle = @step_toggle == 100 ? 2 : 0
@@ -1248,6 +1249,7 @@ class Trade
   def outfitting_routine # knits. If interrupted, put the needles away.  Will resume any unfinished project.
     return unless @training_token == 'Outfitting'
     return if Script.running?('sew')
+    @craft_belt = @settings.outfitting_belt
     if @crafted_item && left_hand.include?(@crafted_item.split.last) || right_hand.include?(@crafted_item.split.last)
       bput("drop my #{@crafted_item.split.last}", 'You drop', 'You place', 'What were', 'You spread')
     end
@@ -1315,6 +1317,7 @@ class Trade
   def engineering_routine # shapes.  Will stow unfinished projects, and search your storage_containers for them later.
     return unless @training_token == 'Engineering'
     return if Script.running?('shape')
+    @craft_belt = @settings.engineering_belt
     rank = DRSkill.getrank('Engineering')
 
     if rank <= 25 # Tier 1  Extremely Easy
@@ -1476,6 +1479,7 @@ before_dying do
   Flags.delete('lead-arrived')
   Flags.delete('lead-failed')
   Flags.delete('lockbox-done')
+  Script.unpause('skill-recorder') if Script.paused?('skill-recorder')
 end
 
 Trade.new.run

--- a/trade.lic
+++ b/trade.lic
@@ -30,6 +30,12 @@ class Trade
         { name: 'exit', regex: /exit/i, optional: true, description: 'Exits the game after delivering all crates and returning the caravan' }
       ]
     ]
+    
+    echo "**********************************************************************"
+    echo "**** DETAILS ON SCRIPT USAGE AND CONFIGURATION CAN BE FOUND ON    ****"
+    echo "**** https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials ****"
+    echo "**********************************************************************"
+    
     args = parse_args(arg_definitions)
     @closeup = args.closeup
     @exit = args.exit

--- a/trade.lic
+++ b/trade.lic
@@ -396,6 +396,8 @@ class Trade
         lead_caravan_to?('Boar Clan')
       elsif nearest_town == 'Boar Clan'
         lead_caravan_to?(destination_town)
+      elsif nearest_town == 'Hibarnhvidar'
+        take_caravan_to(3991) unless lead_caravan_to?('Boar Clan')
       end
     when "Raven's Point", 'Ain Ghazal'
       if nearest_town == 'Hibarnhvidar'
@@ -588,7 +590,6 @@ class Trade
   def forage_grass # periodically forages for grass if below 70
     return if @current_grass_count > 70 || @training_token
     return if ['Crossing', 'Lava', 'Dirge', 'Ghazal'].any? { |roomcheck| XMLData.room_title.include?(roomcheck) }
-    return unless @step_toggle > 1
     @cooldown_timers['Grass'] ||= Time.now - 10
     return if Time.now - @cooldown_timers['Grass'] < 10
     if forage?('grass')
@@ -597,7 +598,6 @@ class Trade
     end
     restore_skill('Mechanical Lore', @caravan_training_skills['Mechanical Lore'], @walk_training_skills) if @current_grass_count > 50 && @caravan_training_skills.include?('Mechanical Lore') && !@walk_training_skills.include?('Mechanical Lore')
     @cooldown_timers['Grass'] = Time.now
-    @step_toggle = 0
   end
 
   def forage?(item) # common's forage loops.  Can't do that in rooms where there might be nothing, so we use this
@@ -1437,6 +1437,7 @@ class Trade
     crafting_data = get_data('crafting')
     stow_hands
     ensure_copper_on_hand(3000, @settings) unless skipcoin
+    walk_to(crafting_data['shaping'][@hub_city]['stock-room'])
     bput('get my balsa lumber', 'You get', 'You are already', 'What were you')
     order_item(crafting_data['shaping'][@hub_city]['stock-room'], 11)
     bput('combine', 'combine')
@@ -1450,6 +1451,7 @@ class Trade
     crafting_data = get_data('crafting')
     stow_hands
     ensure_copper_on_hand(3000, @settings) unless skipcoin
+    walk_to(crafting_data['tailoring'][@hub_city]['stock-room'])
     bput('get my wool yarn', 'You get', 'You are already', 'What were you')
     order_item(crafting_data['tailoring'][@hub_city]['stock-room'], 13)
     bput('combine my yarn', 'You combine', 'You must be holding both')
@@ -1678,6 +1680,7 @@ class Trade
   end
 
   def repair_tools
+    room = Room.current.id
     if @caravan_training_skills.include?('Outfitting') && @times_outfitting > 4
       wait_for_script_to_complete('workorders', ['tailoring', 'repair'])
       @times_outfitting = 0
@@ -1686,6 +1689,7 @@ class Trade
       wait_for_script_to_complete('workorders', ['shaping', 'repair'])
       @times_engineering = 0
     end
+    walk_to(room)
   end
 
   def restocked_restore # restore material-limited skills once bought by hometown_business

--- a/trade.lic
+++ b/trade.lic
@@ -1,12 +1,14 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#trade
 =end
-custom_require.call(%w[common common-items common-money common-travel drinfomon equipmanager events])
+custom_require.call(%w[common common-items common-arcana common-crafting common-money common-travel drinfomon equipmanager events])
 
 class Trade
   include DRC
+  include DRCA
   include DRCT
   include DRCI
+  include DRCC
   include DRCM
 
   def initialize
@@ -14,65 +16,404 @@ class Trade
     @equipment_manager = EquipmentManager.new
     @settings = get_settings
     @contract_container = @settings.trade_contract_container
-    @hometown = @settings.hometown
-    bput("open my #{@contract_container}", 'You open', 'That is already')
-    @equipment_manager.empty_hands
+    @hub_city = 'Crossing'
+    @emergency_delivery_town = nil
+    @current_caravan_destination = nil
+    @caravan_coins_on_hand = @settings.caravan_coins_on_hand.to_i || 25555
+    @caravan_interior = @settings.caravan_interior || false
+    @caravan_being_led = false
+    @force_contract_from = []
+    Flags.add('lead-arrived', 'having arrived at its destination', 'You feel the momentum of the room shift and then hear a voice from outside announce')
+    Flags.add('lead-failed', 'Your caravan guide comes to you and suggests')
+    Flags.add('caravan-arrived', /^Your .*, following you/)
+
+    #TRAINING
+    @gem_pouch_adjective = @settings.gem_pouch_adjective
+    @full_pouch_container = @settings.full_pouch_container
+    @training_spells = @settings.crafting_training_spells
+    @step_toggle = -1
+    wipe_token
+    Flags.add('trading-magic-ready', 'You feel fully prepared to cast your spell.')
+
+    @equipment_manager = EquipmentManager.new(@settings)
+    @cooldown_timers = {}
+    @caravan_training_skills = @settings.caravan_training_skills
+    @lead_training_skills = @caravan_training_skills.select { |skill, _cooldown| !['Mechanical Lore', 'Augmentation', 'Utility', 'Warding'].include?(skill) }
+    @walk_training_skills = @caravan_training_skills.select { |skill, _cooldown| ['Augmentation', 'Utility', 'Warding', 'Attunement', 'Performance', 'Appraisal', 'Mechanical Lore'].include?(skill) }
+    @craft_bag = @settings.crafting_container
+    @craft_belt = @settings.engineering_belt
+
+    @yarn_quantity = @settings.yarn_quantity > 300 ? 301 : @settings.yarn_quantity
+    @lumber_quantity = @settings.lumber_quantity > 30 ? 30 : @settings.lumber_quantity
+    @current_yarn_count = 0
+    @current_lumber_count = 0
+    @current_grass_count = 100
+    @times_outfitting = 0
+    @times_engineering = 0
+
+    @box = @settings.picking_lockbox
+    @worn_lockbox = @settings.picking_worn_lockbox
+    @pet_box_source = @settings.picking_pet_box_source
+    @loot_nouns = @settings.lootables
+    @trash_nouns = get_data('items').trash_nouns
+
+    arg_definitions = [
+      [
+        { name: 'destination', regex: /\d+/i, optional: true, description: 'Give a room ID to bring your caravan to' }
+      ],
+      [
+        { name: 'closeup', regex: /closeup/i, optional: false, description: 'Close up by delivering all remaining crates and accepting no new contracts' },
+        { name: 'exit', regex: /exit/i, optional: true, description: 'Exits the game after delivering all crates and returning the caravan' }
+      ],
+      [
+        { name: 'outpost', regex: /outpost/i, optional: false, description: 'Bring the caravan to the trade outpost of a town.' },
+        { name: 'town_name', regex: /\w+/i, variable: true, description: 'First word of the town name.' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
+    validate_requirements(args)
+    setup_town_data
+
+    @closeup = args.closeup
+    @exit = args.exit
     @caravan = OpenStruct.new
-    recall_caravan
-  end
+    recall_caravan?
 
-  def run
-    unless exists?('contract')
-      nearest_minister = find_closest_id('trade_minister')
-      get_new_contract(nearest_minister)
+    @held_contracts = []
+
+    bput("open my #{@contract_container}", 'You open', 'That is already', 'You can.t')
+    @equipment_manager.empty_hands
+
+    if args.destination
+      track_caravan
+      echo "Taking the caravan directly to room #{args.destination}"
+      take_caravan_to(args.destination.to_i)
+      exit
+    elsif args.outpost
+      unless @current_caravan_destination = find_town_from_arg(args.town_name)
+        echo "TOWN NOT FOUND OR NOT SUPPORTED.  CURRENTLY SUPPORTS ZOLUREN ONLY"
+        exit
+      end
+      track_caravan
+      echo "Taking the caravan directly to #{args.town_name}'s trade outpost"
+      take_caravan_to(outpost_from_name(@current_caravan_destination))
+      exit
+    else
+      start_up
     end
-    contract = parse_contract
-    unless contract.presented
-      load_caravan(contract.origin_clerk)
-      recall_caravan
-      walk_to(contract.origin_outpost)
+  end
+
+  def find_town_from_arg(town_arg)
+    zoluren_towns = ['Wolf Clan', 'Tiger Clan', 'Crossing', 'Arthe Dale', 'Stone Clan', 'Dirge', 'Leth Deriel']
+    return zoluren_towns.find { |town_data| town_data.split.first.casecmp(town_arg).zero? }
+  end
+
+  def validate_requirements(args) # warnings and errors for items you may be missing
+    unless exists?('feedbag') || args.destination
+      echo "You need a feedbag to use this script. Buy it from the Trader Shop in the guild, or ask another Trader for access"
+      exit
     end
-    feed_caravan
-    take_caravan_to(contract.destination_outpost)
-    bput('get my contract', 'You get')
-    deliver_contract(contract.destination_clerk)
-    pay_dues(contract.destination_clerk)
-    walk_to(contract.destination_outpost)
-    deposit_coins(500, Room.current.id) if contract.destination_town == @hometown
-  end
-
-  def debugging?
-    UserVars.trade_debug
-  end
-
-  def deposit_coins(withdraw_amt, return_to_id)
-    return if wealth(@hometown) < withdraw_amt
-
-    walk_to(@town_data[@hometown]['deposit']['id'])
-    case bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit')
-    when 'There is no teller here'
-      walk_to(return_to_id)
-      return
+    unless exists?(@contract_container)
+      echo("No contract container found. Define it in your settings as trade_contract_container: Exiting.")
+      exit
     end
-    minimize_coins(withdraw_amt).each { |amount| withdraw_exact_amount?(amount, @hometown) }
-    walk_to(return_to_id)
+    @settings.storage_containers.each { |container| fput("open my #{container}") }
   end
 
-  def find_closest_id(entity)
+  def start_up # should parse contracts, check mats, handle expireds, get the caravan to a useful outpost, deliver any contracts, then begin the loop.
+    get_caravan unless caravan_exists?
+    fput('look')
+    track_caravan
+    if exists?('contract')
+      mark_towns
+      dump_expired
+      check_for_emergency_delivery
+      set_next_outpost
+    else
+      mark_towns
+      @current_caravan_destination = find_closest_id('trader_outpost')
+    end
+    echo "The current destination is #{@current_caravan_destination}"
+
+    count_grass
+    count_materials('wool yarn') if @caravan_training_skills.include?('Outfitting')
+    count_materials('balsa lumber') if @caravan_training_skills.include?('Engineering')
+    command_caravan?('follow')
+    do_lead_from
+    do_lead_to
+    take_caravan_to(@current_caravan_destination)
+    deliver_contract
+    hometown_business
+  end
+
+  def close_out # makes sure your caravan is at an outpost, then returns it.  Future stable_handling?
+    echo "close_out" if debugging?
+    track_caravan
+    take_caravan_to(find_closest_id('trader_outpost'))
+    walk_to(find_closest_id('shipment_clerk'))
+    fput('return caravan')
+    fput('exit') if @exit
+    exit
+  end
+
+  def run # Primary loop
+    while true
+      walk_to(find_closest_id('trader_outpost'))
+      unless @closeup
+        magic_cleanup
+        wait_for_script_to_complete('buff', ['trade'])
+        get_contract
+        load_caravan
+      else
+        close_out unless exists?('contract')
+      end
+      walk_to(find_closest_id('trader_outpost'))
+      feed_caravan
+      mark_towns
+      check_for_emergency_delivery unless @closeup
+      set_next_outpost
+      echo "Destination town is #{find_town(@current_caravan_destination)}"
+      do_lead_from
+      do_lead_to
+      take_caravan_to(@current_caravan_destination)
+      dump_expired
+      deliver_contract
+      pay_dues
+      hometown_business
+    end
+  end
+
+  def find_closest_id(entity, need_business = false) # finds the closest room in @town_data that matches 'entity' (ie, trader_outpost, trade_minister). 'need_business' true requires a contract to pick up or deliver there
+    echo "find_closest_id" if debugging?
     rooms = @town_data.to_h.values.select { |data| data[entity] }
                       .map { |data| data[entity]['id'] }
     echo "rooms: #{rooms}" if debugging?
-    sort_destinations(rooms).first
+    result = sort_destinations(rooms)
+    echo "sorted rooms #{rooms}" if debugging?
+    if need_business
+      result.find do |data|
+        echo "data in room search is #{data}" if debugging?
+        should_go_to_town?(find_town(data))
+      end
+    else
+      result.first
+    end
   end
 
-  def parse_contract
+  def setup_town_data # builds @trading_towns from town_data and will later handle multiple provinces
+    zoluren_towns = ['Wolf Clan', 'Tiger Clan', 'Crossing', 'Arthe Dale', 'Stone Clan', 'Dirge', 'Leth Deriel']
+    @trading_towns = {}
+    zoluren_towns.each_with_index { |_info, index| @trading_towns[zoluren_towns[index]] = @town_data[zoluren_towns[index]] } #reduce town_data to only the towns in question
+    @trading_towns.each_with_index { |_info, index| @trading_towns[zoluren_towns[index]]['contracts_to'] = @trading_towns[zoluren_towns[index]]['contracts_from'] = 0 }
+  end
+
+  def mark_towns # records some information about contracts to and from towns
+    setup_town_data
+    gather_contracts
+    @held_contracts.each do |contract|
+      @trading_towns[contract.origin_town]['contracts_from'] += 1
+      @trading_towns[contract.destination_town]['contracts_to'] += 1
+    end
+    @force_contract_from.each do |town|
+      @trading_towns[town]['contracts_from'] += 1
+    end
+  end
+
+  def set_next_outpost # main method that determines the next outpost you're trying to reach
+	  echo "set_next_outpost" if debugging?
+    if @emergency_delivery_town
+      @current_caravan_destination = closer_to_emergency_town
+      echo "The next outpost on the way to #{@emergency_delivery_town} is #{find_town(@current_caravan_destination)}"
+      @emergency_delivery_town = nil
+    else
+      @current_caravan_destination = find_closest_id('trader_outpost', true)
+    end
+	end
+
+  def check_for_emergency_delivery # if there are 4 or more pieces of business to do at a town, (contracts to deliver + contract to pick up) set it for emergency delivery
+    echo "checking for emergency" if debugging?
+    @trading_towns.find do |name, info|
+      if info['contracts_to'] - info['contracts_from'] >= 3
+        @emergency_delivery_town = name
+        echo "Emergency delivery needed to #{@emergency_delivery_town}"
+      end
+    end
+  end
+
+  def closer_to_emergency_town # from the set of all outposts closer than you to the emergency_town, return the one closest to you that you have business in
+    echo "closer_to_emergency_town" if debugging?
+    return Room.current.id if outpost_from_name(@emergency_delivery_town) == Room.current.id
+    rooms = @trading_towns.to_h.values.select { |data| data['trader_outpost'] }
+                          .map { |data| data['trader_outpost']['id'] }
+    target_list = rooms.collect(&:to_i)
+    _previous, shortest_distances = Map.dijkstra(outpost_from_name(@emergency_delivery_town))
+    target_list.delete_if { |room_num| shortest_distances[room_num].nil? && room_num == Room.current.id }
+    target_list.each { |room_num| echo "Distance from emergency_town to #{room_num} : #{shortest_distances[room_num]} and distance to current room is #{shortest_distances[Room.current.id]}" } if debugging?
+    target_list.delete_if { |room_num| shortest_distances[room_num] > shortest_distances[Room.current.id] + 0.5 }
+    target_list = DRCT.sort_destinations(target_list)
+    return target_list.find do |room_num|
+      should_go_to_town?(find_town(room_num))
+    end
+  end
+
+  def do_lead_from # you must escape the gravity of certain towns for your caravan to break orbit and lead you away
+    echo "do_lead_from" if debugging?
+    nearest_town = find_town(find_closest_id('trader_outpost'))
+    destination_town = find_town(@current_caravan_destination)
+    return if nearest_town == destination_town
+
+    case nearest_town
+    when 'Dirge'
+      take_caravan_to(1220) # get out of the lava fields. potential inefficiency if starting up near Dirge due to above return
+    when 'Leth Deriel'
+      take_caravan_to(1968) unless lead_caravan_to?('Crossing') # walk it out the bower gate
+      lead_caravan_to?('Crossing') # lead the caravan to the Ferry
+      take_caravan_to(895) # walk it across the Ferry, then proceed.
+    when 'Wolf Clan', 'Tiger Clan'
+      take_caravan_to(863) unless destination_town == 'Wolf Clan' || destination_town == 'Tiger Clan' # no leading around the western clans
+    end
+  end
+
+  def do_lead_to # handles final lead-to approach to certain towns AFTER escaping do_lead_from
+    echo "do_lead_to #{@current_caravan_destination}" if debugging?
+    no_lead_towns = ['Tiger Clan', 'Wolf Clan']
+    destination_town = find_town(@current_caravan_destination)
+    nearest_town = find_town(find_closest_id('trader_outpost'))
+    return if no_lead_towns.include?(nearest_town)
+
+    case destination_town
+    when 'Tiger Clan', 'Wolf Clan'
+      lead_caravan_to?('Crossing') # driver can only take you as far as Crossing
+    when 'Leth Deriel'
+      if nearest_town == 'Leth Deriel'
+        lead_caravan_to?('Leth Deriel') # if already on the south bank (startup mid run), just try leading there first
+      else
+        lead_caravan_to?('Crossing') # otherwise go to crossing,
+        take_caravan_to(1904) # then to the ferry
+        lead_caravan_to?('Leth Deriel') # then to Leth
+      end
+    else
+      lead_caravan_to?(destination_town)
+    end
+  end
+
+  def lead_caravan_to?(town_name) # Primary method for being led by or riding in a caravan
+    track_caravan
+    return true if Room.current.id == outpost_from_name(town_name)
+    @caravan_being_led = true
+    successful_lead = command_caravan?("lead to #{town_name}")
+    return false unless successful_lead
+    be_inside_caravan
+
+    until Flags['lead-arrived'] || Flags['lead-failed'] # main wait loop while training happens
+      lead_training
+      pause 1.5
+    end
+
+    lead_training_cleanup
+    be_outside_caravan
+
+    Flags.reset('lead-arrived')
+    if Flags['lead-failed']
+      Flags.reset('lead-failed')
+      false
+    else
+      true
+    end
+  end
+
+  def be_inside_caravan # call whenever you need to be inside the caravan
+    return unless @caravan_interior
+    return if ["Interior", "Hodierna", "Kertigen", "Ferry", "South Bank"].any? { |name| XMLData.room_title.include?(name) } # Don't do this on ferrys - you can't tell when you've arrived.
+    track_caravan
+    bput("go caravan", 'You open the door')
+    pause 1.5
+  end
+
+  def be_outside_caravan # call whenever you need to be outside the caravan
+    return unless XMLData.room_title.include?("Interior")
+    bput("go door", 'You open the door')
+    pause 0.5
+    fput('look')
+  end
+
+  def track_caravan # requires caravan to be in-room with you.
+    echo "track caravan" if debugging?
+    unless caravan_check?
+      pause 2
+      find_timer = Time.now
+      echo "CARAVAN NOT PRESENT IN THE ROOM.  SCRIPT WILL EXIT IN 2 MINUTES UNLESS YOU FIND THE CARAVAN" unless caravan_check?
+      pause 5 until caravan_check? || Time.now - find_timer > 120
+    end
+    Flags.reset('caravan-arrived')
+  end
+
+  def recall_caravan? # gets information about your caravan. Also returns true if it's in the room with you.
+    recall_messages = [
+      /^You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/,
+      /^You recall that your (?<description>.*) (?<name>.*) should be located in/,
+      /^You don't recall where you left your caravan\./,
+      /^You don't recall having a caravan\./,
+      /^You are far too occupied/,
+      /^You seem to recall your (?<description>.*) (?<name>.*) should be somewhere to the/
+    ]
+    response = bput('recall caravan', recall_messages)
+    echo("Response: #{response}") if debugging?
+    case response
+    when /You don't recall where you left your caravan/, /You don't recall having a caravan/
+      echo('No caravan found') if debugging?
+      false
+    when /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/
+      /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
+      @caravan.noun = name
+      echo "@caravan.noun: #{@caravan.noun}" if debugging?
+      @caravan.adjective = description
+      echo "@caravan.adjective: #{@caravan.adjective}" if debugging?
+      true
+    when /You recall that your (?<description>.*) (?<name>.*) should be located in/
+      /You recall that your (?<description>.*) (?<name>.*) should be located in/ =~ response
+      @caravan.noun = name
+      echo "@caravan.noun: #{@caravan.noun}" if debugging?
+      @caravan.adjective = description
+      echo "@caravan.adjective #{@caravan.adjective}" if debugging?
+      false
+    when /You are far too occupied/
+      DRC.retreat
+      recall_caravan?
+    else
+      false
+    end
+  end
+
+  def find_town(room_id) # takes a room_id and returns a town_name if find_value? finds it in a town's data.
+    return @trading_towns.find { |name, data| find_value?(data, room_id) }.first
+  end
+
+  def find_value?(towninfo, room_id)
+    return towninfo['shipment_clerk']['id'] == room_id || towninfo['trade_minister']['id']  == room_id || towninfo['trader_outpost']['id'] == room_id
+  end
+
+  def outpost_from_name(town_name) # gives the trader_outpost room_id from a specific town name
+    return @trading_towns[town_name]['trader_outpost']['id'].to_i
+  end
+
+  def gather_contracts # reads every contract you have and adds their data to @held_contracts for use elsewhere
+    echo "gathering contracts" if debugging?
+    @held_contracts = []
+    contracts = find_contracts(@contract_container)
+    (0..contracts.length - 1).each do |ord|
+      @held_contracts.push(parse_contract($ORDINALS[ord]))
+    end
+  end
+
+  def parse_contract(ordinal = 'first') # parses an individual contract based on an ordinal
     destination_re = /^ The guild office at (?:The )?(?<destination>.*) requires .*/
     payment_re = /^You estimate these goods are currently worth (.*) (Kronars|Dokoras|Lirums) on delivery\./
     origin_re = /^ Trading Contract Issued by:  (?:The )?(?<origin>.*)/
     contract = OpenStruct.new
     contract.presented = true
     contract.expired = false
-    fput('read my contract')
+    fput("read my #{ordinal} contract")
     while line = get
       echo line if debugging?
       if line =~ destination_re
@@ -106,42 +447,61 @@ class Trade
     contract
   end
 
-  def recall_caravan
-    recall_messages = [
-      /^You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/,
-      /^You recall that your (?<description>.*) (?<name>.*) should be located in/,
-      /^You don't recall where you left your caravan\./,
-      /^You don't recall having a caravan\./,
-      /^You seem to recall your (?<description>.*) (?<name>.*) should be somewhere to the/
-    ]
-    response = bput('recall caravan', recall_messages)
-    echo("Response: #{response}") if debugging?
-    case response
-    when /You don't recall where you left your caravan/, /You don't recall having a caravan/
-      echo('No caravan found') if debugging?
-    when /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/
-      /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
-      @caravan.noun = name
-      echo "@caravan.noun: #{@caravan.noun}" if debugging?
-      @caravan.adjective = description
-      echo "@caravan.adjective: #{@caravan.adjective}" if debugging?
-    when /You recall that your (?<description>.*) (?<name>.*) should be located in/
-      /You recall that your (?<description>.*) (?<name>.*) should be located in/ =~ response
-      @caravan.noun = name
-      echo "@caravan.noun: #{@caravan.noun}" if debugging?
-      @caravan.adjective = description
-      echo "@caravan.adjective #{@caravan.adjective}" if debugging?
+  def find_contracts(container) # returns an array of the contracts in the container
+    result = DRC.bput("look in my #{container}", 'That is closed', 'you see .*', 'While it\'s closed', 'I could not find', 'There is nothing')
+    case result
+    when 'That is closed'
+      fput("open my #{container}")
+      return find_contracts(container)
     end
+    text = result.match(/you see (.*)\.$/).to_a[1]
+    DRC.list_to_array(text).select{ |item| item.include?('contract') }
+  end
+
+  def count_grass # sets @current_grass_count of grass in feedbag
+    result = DRC.bput("look in my feedbag", 'That is closed', 'you see .*', 'While it\'s closed', 'I could not find', 'There is nothing', 'Maybe if you')
+    case result
+    when 'That is closed', 'Maybe if you'
+      fput("open my feedbag")
+      return count_grass
+    when 'I could not find'
+      echo("No feedbag.  Exiting.")
+      exit
+    end
+
+    text = result.match(/you see (.*)\.$/).to_a[1]
+    @current_grass_count = DRC.list_to_array(text).select{ |item| item.include?('some grass') }.length
+    echo "current grass count is #{@current_grass_count}" if debugging?
+  end
+
+  def forage_grass # periodically forages for grass if below 70
+    return if @current_grass_count > 70 || @training_token
+    return if ['Crossing', 'Lava', 'Dirge'].any? { |roomcheck| XMLData.room_title.include?(roomcheck) }
+    return unless @step_toggle > 1
+    @cooldown_timers['Grass'] ||= Time.now - 10
+    return if Time.now - @cooldown_timers['Grass'] < 10
+    bput('put my grass in my feedbag', 'You put', 'What were you') if forage?('grass')
+    count_grass
+    restore_skill('Mechanical Lore', @caravan_training_skills['Mechanical Lore'], @walk_training_skills) if @current_grass_count > 50 && @caravan_training_skills.include?('Mechanical Lore') && !@walk_training_skills.include?('Mechanical Lore')
+    @cooldown_timers['Grass'] = Time.now
+    @step_toggle = 0
+  end
+
+  def forage?(item) # common's forage loops.  Can't do that in rooms where there might be nothing, so we use this
+    snapshot = "#{right_hand}#{left_hand}"
+    bput("forage #{item}", 'Roundtime', 'The room is too cluttered to find anything here', 'You really need to have at least one hand free to forage properly', 'You survey the area and realize that any foraging efforts would be futile')
+    "#{right_hand}#{left_hand}" == snapshot ? false : true
   end
 
   def compute_path(destination)
+    echo "computing path #{destination}" if debugging?
     previous, _shortest_paths = Map.dijkstra(Room.current.id, destination)
     path = [destination]
     path.push(previous[path[-1]]) until previous[path[-1]].nil?
     path.reverse
   end
 
-  def step(dir)
+  def step(dir) # takes normal steps and handles stringprocs
     echo "step dir: #{dir}" if debugging?
     case dir
     when String
@@ -151,25 +511,79 @@ class Trade
     end
   end
 
+  def handle_special_room?(dir) # handles very specific rooms (bescort rooms currently) - allows training on ferries.
+  ### Note: Needs an entry for the Shard gondola eventually.  Bescort will jump two rooms ahead and leave the caravan behind.
+    case dir
+    when StringProc
+      if dir.inspect.include?("ferry', 'crossing'")
+        ferry_run('crossing')
+        return true
+      elsif dir.inspect.include?("ferry', 'leth'")
+        ferry_run('leth')
+        return true
+      end
+    else
+      return false
+    end
+  end
+
+  def ferry_run(town) # Crossing-Leth Fery
+    echo "ferry_run #{town}" if debugging?
+    walk_training_cleanup
+    start_script('bescort', ['ferry', town])
+    @caravan_being_led = true
+    wipe_skill('Outdoorsmanship', @lead_training_skills)
+    wipe_skill('Perception', @lead_training_skills)
+    until !Script.running?('bescort')
+      pause 1.5
+      lead_training
+    end
+    lead_training_cleanup
+    restore_skill('Outdoorsmanship', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills)
+    restore_skill('Perception', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills)
+    @caravan_being_led = false
+  end
+
   def get_next_dir(path)
     Room.current.wayto[path[path.index(Room.current.id) + 1].to_s]
   end
 
-  def take_caravan_to(outpost_id)
-    command_caravan('follow')
-    path = compute_path(outpost_id)
+  def take_caravan_to(room_id) # primary method for leading your caravan to a destination step-by-step.
+    @caravan_being_led = false
+    track_caravan
+    echo "destination is #{room_id}" if debugging?
+    command_caravan?('follow')
+    path = compute_path(room_id)
     echo "path: #{path}" if debugging?
-    echo "caravan_present?: #{caravan_present?}" if debugging?
-    until Room.current.id == outpost_id
+    pause 0.2 until Flags['caravan-arrived'] || caravan_check?(false)
+    until Room.current.id == room_id
       dir = get_next_dir(path)
-      step(dir) if caravan_present?
-      waitfor 'following you'
+      if handle_special_room?(dir)
+        Flags.reset('caravan-arrived')
+        wait_for_caravan(3)
+      else
+        step(dir)
+        walk_training
+        wait_for_caravan
+        @step_toggle += 1
+      end
+      Flags.reset('caravan-arrived')
       echo 'Caravan arrival detected' if debugging?
     end
-    command_caravan('wait')
+    command_caravan?('wait')
+    walk_training_cleanup
   end
 
-  def command_caravan(command)
+  def wait_for_caravan(wait_time = 6)
+    time_waiting = Time.now
+    until Flags['caravan-arrived']
+      pause 0.2
+      break if Time.now - time_waiting > wait_time && caravan_check?
+    end
+  end
+
+  def command_caravan?(command)
+    pause 1
     case command
     when 'follow'
       follow_messages = [
@@ -177,23 +591,57 @@ class Trade
         'You pass on the order to follow to your driver, who makes sure your .* does your bidding.'
       ]
       bput("tell #{@caravan.noun} to follow", follow_messages)
+      return true
     when 'wait'
       wait_messages = [
         'You pass on the order to wait to your driver, who makes sure your .* does your bidding'
       ]
       bput("tell #{@caravan.noun} to wait", wait_messages)
+      return true
+    when /lead/
+      lead_success = [
+        'You pass on the order to lead to your driver'
+      ]
+      lead_fail = [
+        'but turns back and says',
+        'The driver of the sturdy caravan looks at you confused and says'
+      ]
+      result = bput("tell #{@caravan.noun} to #{command}", lead_success + lead_fail)
+      lead_fail.include?(result) ? false : true
     end
   end
 
-  def deliver_contract(clerk_id)
+  def should_go_to_town?(town_name) # is there any reason at all to visit this town's outpost?
+    if @closeup
+      echo "closeup #{town_name} and #{@trading_towns[town_name]['contracts_to']}" if debugging?
+      return true if @trading_towns[town_name]['contracts_to'] > 0
+    else
+      return true if @trading_towns[town_name]['contracts_to'] > 0 || @trading_towns[town_name]['contracts_from'].zero?
+    end
+    false
+  end
+
+  def get_contract
+    nearest_minister = find_closest_id('trade_minister')
+    get_new_contract(nearest_minister)
+  end
+
+  def deliver_contract
+    clerk_id = find_closest_id('shipment_clerk')
+    echo "Delivering Contracts"
     walk_to(clerk_id)
     clerk_messages = [
       '^The \w+ clerk finds everything in order with your merchandise'
     ]
-    bput('give my contract to clerk', clerk_messages)
+    contracts = find_contracts(@contract_container)
+    current_town = find_town(Room.current.id).split.first
+    until bput("get my #{current_town} contract from my #{@contract_container}", 'You get', 'What were you' ) == 'What were you'
+	    bput('give my contract to clerk', clerk_messages)
+    end
   end
 
-  def pay_dues(clerk_id)
+  def pay_dues
+    clerk_id = find_closest_id('shipment_clerk')
     echo "Paying dues at clerk_room: #{clerk_id}" if debugging?
     clerk_messages = [
       /^You don't have any coins on you to pay dues\./,
@@ -205,7 +653,13 @@ class Trade
     bput('pay clerk', clerk_messages)
   end
 
-  def feed_caravan
+  def get_caravan
+    echo "NOT YET IMPLEMENTED.  GO GET A CARAVAN AND PARK IT AT THE OUTPOST DOORS"
+    exit
+  end
+
+  def feed_caravan # feeds your caravan from a feedbag.
+    bput('open my feedbag', 'You open', 'What were', 'That is already')
     feed_messages = [
       'The driver takes the feedbag from you',
       'You offer the .* feedbag to the caravan driver',
@@ -213,23 +667,32 @@ class Trade
       'The .* sticks its nose into your feedbag and munches away happily'
     ]
     @equipment_manager.empty_hands
-    bput('remove feedbag', 'You remove')
-    bput("give #{@caravan.noun}", feed_messages)
-    bput('wear feedbag', 'You attach')
+    case bput('remove my feedbag', 'You remove', 'You aren.t wearing that', 'Remove what')
+    when 'You remove'
+      @current_grass_count -= 1 if ['The driver takes the feedbag from you', 'The .* sticks its nose into your feedbag and munches away happily'].include?(bput("give #{@caravan.noun}", feed_messages))
+      bput('wear feedbag', 'You attach')
+    else
+      bput('get my feedbag', 'You get')
+      @current_grass_count -= 1 if ['The driver takes the feedbag from you', 'The .* sticks its nose into your feedbag and munches away happily'].include?(bput("give #{@caravan.noun}", feed_messages))
+      bput('stow my feedbag', 'You put')
+    end
   end
 
-  def load_caravan(clerk_id)
+  def load_caravan
+    clerk_id = find_closest_id('shipment_clerk')
     echo "Presenting contract to clerk in room: #{clerk_id}" if debugging?
     walk_to(clerk_id)
-    give_clerk(clerk_id)
+    give_clerk
   end
 
   def get_new_contract(minister_id)
+    return if @trading_towns[find_town(minister_id)]['contracts_from'] > 0
     echo "Getting a new contract from room #{minister_id}" if debugging?
     walk_to(minister_id)
     minister_messages = [
       'The minister plucks a contract from the hands',
-      'The minister reminds you that you still owe .*'
+      'The minister reminds you that you still owe .*',
+      'You still have another contract'
     ]
     response = bput('ask minister for contract', minister_messages)
     case response
@@ -237,26 +700,769 @@ class Trade
       /The minister reminds you that you still owe (?<dues_amt>.*) (?<dues_currency>Kronars|Lirums|Dokoras) in dues to (?:The )?(?<outpost>.*) and asks that you pay the clerk before s?he issues you a new contract\./ =~ response
       echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if debugging?
       ensure_copper_on_hand(dues_amt.to_i, @settings)
-      pay_dues(@town_data[outpost]['shipment_clerk']['id'])
+      pay_dues
       get_new_contract(minister_id)
+    when /You still have another contract/
+      @force_contract_from.push(find_town(minister_id)) unless @trading_towns['contracts_from'] # force_contract_from handles contracts that have somehow been lost.  The minister won't give another until it would have expired
+    else
+      @force_contract_from - [find_town(minister_id)] if @force_contract_from.include?(find_town(minister_id))
     end
   end
 
+  def caravan_check?(stationary = true) # The traders' guild hands out identical caravans
+    return false unless caravan_present?
+    pause 1.5 unless stationary
+    return true if Flags['caravan-arrived']
+    return recall_caravan?
+  end
+
   def caravan_present?
-    return unless @caravan.adjective
-    return unless @caravan.noun
+    return false unless @caravan.adjective
+    return false unless @caravan.noun
     DRRoom.room_objs.find { |obj| obj =~ /#{@caravan.adjective} #{@caravan.noun}/ }
   end
 
-  def give_clerk(clerk_id)
+  def caravan_exists?
+    return false unless @caravan.adjective && @caravan.noun
+    true
+  end
+
+  def dump_expired # checks for expired contracts, and gets rid of them and the matching crate.
+    return unless @held_contracts
+    echo @held_contracts if debugging?
+    @held_contracts.each_with_index do |contract, index|
+      if contract['expired']
+        find_crates(contract.origin_town)
+        bput("get my #{$ORDINALS[index]} contract from #{@contract_container}", "You get")
+        bput("drop my contract", 'You drop')
+        gather_contracts
+        return dump_expired
+      end
+    end
+  end
+
+  def dump_crate(ordinal) # removes a crate
+    bput("push #{ordinal} sturdy crate", 'You grab onto')
+    bput('pull sturdy crate', 'You begin to pull')
+    bput('pull sturdy crate', 'You begin to pull', 'You continue to pull')
+  end
+
+  def find_crates(origin_town) # handles finding the crate that matches the expired contract.
+    echo "find_crates from #{origin_town}" if debugging?
+    result = DRC.bput("look #{@caravan.adjective.split.first} #{@caravan.noun}", 'You tell the driver', 'I could not find', 'There is nothing')
+    text = reget(10)
+    text.delete_if { |item| !item.include?('sturdy crate') }
+    text.each_with_index do |crate, index|
+      if crate =~ /from.* #{origin_town} and destined for/
+        echo "FOUND AN EXPIRED CRATE AT #{$ORDINALS[index]}"
+        dump_crate($ORDINALS[index])
+        return
+      end
+    end
+  end
+
+  def give_clerk
+    clerk_id = find_closest_id('shipment_clerk')
     walk_to(clerk_id)
     bput('get my contract', 'You get', 'You are already holding that')
     Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
     bput('give my contract to clerk', /The .* clerk accepts your contract and peruses it\./)
-    recall_caravan if Flags['caravan-upgrade']
+    recall_caravan? if Flags['caravan-upgrade']
     bput("put my contract in my #{@contract_container}", 'You put')
     Flags.delete('caravan-upgrade')
   end
+
+
+  def deposit_coins(withdraw_amt, return_to_id)
+    return if wealth(@hub_city) < withdraw_amt
+
+    walk_to(@town_data[@hub_city]['deposit']['id'])
+    case bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit')
+    when 'There is no teller here'
+      walk_to(return_to_id)
+      return
+    end
+    minimize_coins(withdraw_amt).each { |amount| withdraw_exact_amount?(amount, @settings) }
+    walk_to(return_to_id)
+  end
+
+  def debugging?
+    UserVars.trade_debug
+  end
+
+### TRAINING SECTION ###
+
+  def attunement_routine
+    return unless @training_token == 'Attunement'
+    echo "attunement_routine" if debugging?
+    return unless @caravan_being_led || @step_toggle > 1
+    bput("perc mana", 'You reach out')
+    @step_toggle = 0
+    wipe_token
+    waitrt?
+  end
+
+  def appraisal_routine
+    return unless @training_token == 'Appraisal'
+    @caravan_being_led ? lead_appraisal : walk_appraisal
+  end
+
+  def walk_appraisal # TO DO swap pouches through ordinals
+    echo "walk_appraisal" if debugging?
+    return unless @training_token == 'Appraisal'
+    return unless @caravan_being_led || @step_toggle > 1
+    case bput("appraise my #{@gem_pouch_adjective} pouch", 'Roundtime', 'You can.t appraise the', 'Appraise what')
+    when 'You can.t appraise the'
+      case bput("get pouch from my #{@full_pouch_container}", '^You get ', '^What were you referring')
+      when /^You get /
+        bput("appraise my #{@gem_pouch_adjective} pouch quick", 'Roundtime')
+        waitrt?
+        bput("put my pouch in my #{@full_pouch_container}", 'You put')
+      end
+    end
+    @step_toggle = 0
+    wipe_token
+  end
+
+  def lead_appraisal
+    echo "lead_appraisal" if debugging?
+    return unless @training_token == 'Appraisal'
+    @appraisal_timer ||= Time.now
+    return appraisal_cleanup if Time.now - @appraisal_timer > 100 || DRSkill.getxp('Appraisal') > 30
+    return if Script.running?('appraisal')
+    be_inside_caravan
+    start_script('appraisal')
+  end
+
+  def appraisal_cleanup
+    return unless @training_token == 'Appraisal'
+    echo "appraisal_cleanup" if debugging?
+    wipe_token
+    @appraisal_timer = nil
+    return unless Script.running?('appraisal')
+    stop_script('appraisal')
+    @cooldown_timers['Appraisal'] = Time.now
+    waitrt?
+    @equipment_manager.empty_hands
+    waitrt?
+  end
+
+  def wipe_token
+    echo "wiping @training_token #{@training_token}" if debugging?
+    @training_token = nil
+  end
+
+  def is_playing?
+    return Script.running?('performance')
+  end
+
+  def magic_routine
+    return if @training_spells.empty?
+    return unless %w[Augmentation Warding Utility Outdoorsmanship Perception].include?(@training_token)
+    echo "magic_routine" if debugging?
+    if @preparing && Flags['trading-magic-ready'] && mana > 40
+      crafting_cast_spell(@preparing, @settings)
+      Flags.reset('trading-magic-ready')
+      @preparing = nil
+      wipe_token if %w[Augmentation Warding Utility].include?(@training_token)
+    end
+
+    unless %w[Augmentation Warding Utility].include?(@training_token)
+      needs_training = %w[Warding Utility Augmentation]
+                       .select { |skill| @training_spells[skill] }
+                       .select { |skill| DRSkill.getxp(skill) < 31 }
+                       .sort_by { |skill| DRSkill.getxp(skill) }.first
+    else
+      needs_training = @training_token
+    end
+    return unless needs_training
+    return if @preparing
+    @preparing = @training_spells[needs_training]
+    crafting_prepare_spell(@preparing, @settings)
+  end
+
+  def lead_training # Training that is done while being led or riding a caravan. Can have much longer RTs than in walk_training
+    training_skills = @lead_training_skills
+    echo "in lead training - training token is #{@training_token}" if debugging?
+    @training_token = select_ability(training_skills) unless @training_token
+    attunement_routine
+    locksmithing_routine
+    outdoorsmanship_routine
+    performance_routine
+    appraisal_routine
+    first_aid_routine
+    outfitting_routine
+    engineering_routine
+  end
+  
+  def lead_training_cleanup # all training shuts down immediately upon arrival. Any routine that needs sanitizing goes here.
+    outfitting_cleanup
+    engineering_cleanup
+    first_aid_cleanup
+    performance_cleanup
+    locksmithing_cleanup
+    appraisal_cleanup
+    magic_cleanup
+  end
+
+  def walk_training
+    forage_grass
+    training_skills = @walk_training_skills
+    @training_token = select_ability(training_skills) unless @training_token
+    attunement_routine
+    appraisal_routine
+    magic_routine
+    mechlore_routine
+    performance_routine
+  end
+
+  def walk_training_cleanup
+    echo "training_cleanup" if debugging?
+    magic_cleanup
+    performance_cleanup
+    appraisal_cleanup
+    wipe_token
+    @step_toggle = -1
+  end
+
+  def select_ability(training_skills) # selects a skill from the pool and returns it for @training_token - each skill routine can know what tokens it's compatible with.
+    echo "select_ability" if debugging?
+
+    ability = training_skills.sort_by { |skill, _cooldown| DRSkill.getxp(skill) }
+                                .find { |skill, cooldown| check_ability?(skill, cooldown) }.first
+
+    echo("Selected: #{ability}") if ability && debugging?
+    @cooldown_timers[ability] = Time.now
+    ability
+  end
+
+  def check_ability?(skill, cooldown) # stolen from combat-trainer. Skill cooldowns and other timing related data stored in @cooldown_timers
+
+    expcheck = DRSkill.getxp(skill) < 25
+    return expcheck unless @cooldown_timers[skill]
+
+    Time.now - @cooldown_timers[skill] >= cooldown ? expcheck : false
+  end
+
+  def locksmithing_routine # runs training boxes and pets
+    return unless @training_token == 'Locksmithing'
+
+    return locksmithing_cleanup if DRSkill.getxp('Locksmithing') > 32 || Flags['lockbox-done']
+    return if Script.running?('lockbox')
+    if @box
+      be_outside_caravan # can't pick inside a caravan because reasons
+      Flags.add('lockbox-done', 'The lock feels warm')
+      start_script('lockbox')
+    else
+      be_outside_caravan
+      pick_pet
+    end
+  end
+
+  def pick_pet # single pick of a pet box
+    box = get_boxes(@pet_box_source).first
+    unless box
+      echo '***UNABLE TO TRAIN LOCKSMITHING, REMOVING IT FROM THE TRAINING LIST***'
+      locksmithing_cleanup
+      wipe_skill('Locksmithing', @lead_training_skills)
+      return
+    end
+
+    bput("get #{box} from my #{@pet_box_source}", 'You get', 'What were')
+    case bput("pick my #{box} blind", 'not even locked', 'Roundtime', 'Find a more appropriate tool', 'You realize that would be next to impossible')
+    when 'not even locked'
+      bput("open my #{box}", 'You open', 'That is already open')
+      loot(box)
+      2.times do
+        case bput("dismantle my #{box}", 'You can not dismantle', 'You dump the contents', 'You move your hands', 'You must be holding the object', 'Unable to locate', 'You realize that would be next to impossible while in combat')
+        when 'You realize that would be next to impossible while in combat'
+          retreat
+          bput("dismantle my #{box}", 'You can not dismantle', 'You dump the contents', 'You move your hands', 'You must be holding the object', 'Unable to locate')
+        end
+      end
+      waitrt?
+    when 'Find a more appropriate tool'
+      echo '***UNABLE TO TRAIN LOCKSMITHING, REMOVING IT FROM THE TRAINING LIST***'
+      locksmithing_cleanup
+      wipe_skill('Locksmithing', @lead_training_skills)
+      return
+    else
+      waitrt?
+      bput("put my #{box} in my  #{@pet_box_source}", 'You put')
+    end
+  end
+
+  def loot(box) # stolen from pick
+    waitrt?
+    if bput("open my #{box}", /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
+      return
+    end
+    raw_contents = bput("look in my #{box}", /^In the .* you see .*\./, 'There is nothing in there')
+    return if raw_contents == 'There is nothing in there'
+
+    loot = list_to_nouns(raw_contents.match(/^In the .* you see (.*)\./).to_a[1])
+    loot.each { |item| loot_item(item, box) }
+  end
+
+  def loot_item(item, box) # stolen from pick
+    return if item =~ /fragment/i
+    message = bput("get #{item} from my #{box}", 'You get .* from inside', 'You pick up')
+    return if message == 'You pick up'
+    message =~ /You get (.*) from inside/
+    item_long = Regexp.last_match(1)
+    special = @settings.loot_specials.find { |x| /\b#{x['name']}\b/i =~ item_long }
+    if special
+      bput("put #{item} in my #{special['bag']}", 'you put')
+      return
+    end
+    if @loot_nouns.find { |thing| item_long.include?(thing) && !item_long.include?('sunstone runestone') }
+      message = bput("stow my #{item}", 'You put', 'You open', 'You think the .* pouch is too full to fit', 'You\'d better tie it up before putting')
+      return if ['You put', 'You open'].include?(message)
+      fput("drop #{item}")
+      return unless @settings.spare_gem_pouch_container
+      bput("remove my #{@gem_pouch_adjective} pouch", 'You remove')
+      if @full_pouch_container
+        bput("put my #{@gem_pouch_adjective} pouch in my #{@full_pouch_container}", 'You put')
+      else
+        bput("stow my #{@gem_pouch_adjective} pouch", 'You put')
+      end
+      bput("get #{@gem_pouch_adjective} pouch from my #{@settings.spare_gem_pouch_container}", 'You get a')
+      bput('wear my pouch', 'You attach')
+      bput("stow #{item}", 'You pick')
+      if message =~ /tie it up/
+        fput('close my pouch')
+      else
+        bput('tie my pouch', 'You tie')
+      end
+    elsif @trash_nouns.find { |thing| item_long =~ /\b#{thing}\b/i }
+      dispose_trash(item)
+    else
+      beep
+      echo('***Unrecognized Item! trashing it.***')
+      dispose_trash(item)
+    end
+  end
+
+  def locksmithing_cleanup # sanitizes locksmithing_routine
+    return unless @training_token == 'Locksmithing'
+    echo "locksmithing cleanup" if debugging?
+    wipe_token
+    stop_script('lockbox') if Script.running?('lockbox')
+    @cooldown_timers['Locksmithing'] = Time.now
+    waitrt?
+    if @box && @worn_lockbox
+      bput("pick my #{@box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm')
+      bput("open my #{@box}", 'You open')
+      bput("wear my #{@box}", 'You put')
+    else
+      @equipment_manager.empty_hands
+    end
+    @box = nil if Flags['lockbox-done']
+    Flags.delete('lockbox-done')
+  end
+
+  def outdoorsmanship_routine # steps outside and collects rocks
+    return if is_playing? || !%w[Outdoorsmanship Perception].include?(@training_token)
+    be_outside_caravan
+    collect('rock')
+    waitrt?
+    wipe_token
+  end
+
+  def mechlore_routine
+    return unless @training_token.include?('Mechanical Lore')
+    if @current_grass_count < 30
+      @training_token = nil
+      return wipe_skill('Mechanical Lore', @walk_training_skills) 
+    end
+    return unless @caravan_being_led || @step_toggle > 1
+    be_inside_caravan if @caravan_being_led
+    bput('close my feedbag', 'You close', 'What were', 'That is already')
+    bput('get my grass', 'You get', 'What were you')
+    bput('open my feedbag', 'You open', 'What were')
+    result = bput('stow my grass', 'You stow', 'You put', 'What were you') if braid?('grass')
+    drop_grass
+    @training_token = nil
+    @step_toggle = @step_toggle == 100 ? 2 : 0
+  end
+
+  def drop_grass
+    dispose_trash(right_hand) if right_hand.include?('grass')
+    dispose_trash(left_hand) if left_hand.include?('grass')
+  end
+
+  def braid?(item)
+    case bput("braid my #{item}", 'You need to have more', 'Roundtime', 'You need both hands to do that', 'Braid what', 'You need to be holding', 'You can\'t braid the .* into your braided', 'is already as long as you can make it', 'You are in no condition')
+    when 'Roundtime'
+      rt = reget(10, 'Roundtime').last.scan(/\d+/).first.to_i
+      waitrt
+      echo "rt is #{rt}" if debugging?
+      @step_toggle = 100 if rt < 4 # time optimization - see routine
+      rt >= 9 ? false : true
+    when 'is already as long as you can make it'
+      waitrt?
+      false
+    when 'You need to be holding', 'You need to have more'
+      get_grass
+      return braid?('grass')
+    when 'You need both hands to do that', /into your braided/
+      waitrt?
+      false
+    when 'Braid what'
+      wipe_skill('Mechanical Lore', @walk_training_skills)
+      @training_token = nil
+      false
+    else
+      false
+    end
+  end
+
+  def get_grass
+    fput('open my feedbag')
+    case bput('get my grass from my feedbag', 'You get', 'What were you')
+    when 'What were you'
+      bput('open my feedbag', 'You open', 'What were')
+      bput('get my grass from my feedbag', 'You get', 'What were you')
+    end
+    @current_grass_count -= 1
+  end
+
+  def empty_trash
+    trash_nouns = get_data('items').trash_nouns
+
+    if trash_nouns.any? { |noun| /\b#{noun}/i =~ GameObj.right_hand.noun } && !@equipment_manager.is_listed_item?(right_hand)
+      dispose_trash(right_hand)
+    end
+
+    if trash_nouns.any? { |noun| /\b#{noun}/i =~ GameObj.left_hand.noun } && !@equipment_manager.is_listed_item?(left_hand)
+      dispose_trash(left_hand)
+    end
+  end
+
+  def wipe_skill(skill_name, training_skills) # removes a skill by name from the list of trainables (out of materials/boxes, for example)
+    return unless training_skills.include?(skill_name)
+    echo "Wiping skill #{skill_name} from training"
+    training_skills.reject! { |skill, _cooldown| skill == skill_name }
+  end
+
+  def restore_skill(skill_name, cooldown, training_skills) # restores a skill wiped from trainables (restocked materials, for example)
+    echo "Restoring skill #{skill_name} to training"
+    skill_hash = { skill_name => cooldown }
+    training_skills.merge!(skill_hash)
+  end
+
+  def sorcery_routine
+    #NOT YET IMPLEMENTED - ONLY PERFORM IN CARAVAN INTERIOR
+  end
+
+  def count_materials(material) # Gets a count of crafting mats. DOES NOT BUY THEM.
+    echo "count material #{material}" if debugging?
+    result = DRC.bput("count my #{material}", 'I could not', 'You count out \d+')
+    case result
+    when 'I could not'
+      @current_yarn_count = 0 if material == 'wool yarn'
+      @current_lumber_count = 0 if material == 'balsa lumber'
+    else
+      @current_yarn_count = result.scan(/\d+/).first.to_i if material == 'wool yarn'
+      @current_lumber_count = result.scan(/\d+/).first.to_i if material == 'balsa lumber'
+    end
+    stow_hands
+  end
+
+  def check_yarn # checks and buys yarn
+    return unless @caravan_training_skills.include?('Outfitting')
+    return unless exists?('knitting needles')
+    result = DRC.bput('count my wool yarn', 'I could not', 'You count out \d+ yards')
+    case result
+    when 'I could not'
+      @current_yarn_count = 0
+    else
+      @current_yarn_count = result.scan(/\d+/).first.to_i
+    end
+    buy_yarn if @current_yarn_count < @yarn_quantity
+    stow_hands
+  end
+
+  def check_wood # checks and buys wood
+    return unless @caravan_training_skills.include?('Engineering')
+    case DRC.bput('count my balsa lumber', 'You count out \d+', 'I could not')
+    when 'What were you'
+      buy_wood
+    when 'You count out \d+ piece'
+      @current_lumber_count = bput('count my balsa lumber', 'You count out \d+').scan(/\d+/).first.to_i
+    end
+    buy_wood if @current_lumber_count < @lumber_quantity
+    stow_hands
+  end
+
+  def buy_wood(skipcoin = false)
+    be_outside_caravan
+    room = Room.current.id
+    crafting_data = get_data('crafting')
+    stow_hands
+    ensure_copper_on_hand(3000, @settings) unless skipcoin
+    bput('get my balsa lumber', 'You get', 'You are already', 'What were you')
+    order_item(crafting_data['shaping'][@hub_city]['stock-room'], 11)
+    bput('combine', 'combine')
+    @current_lumber_count = bput('count my balsa lumber', 'You count out \d+').scan(/\d+/).first.to_i
+    buy_wood(true) if @current_lumber_count < @lumber_quantity
+    stow_hands
+    walk_to(room)
+  end
+
+  def buy_yarn(skipcoin = false)
+    be_outside_caravan
+    room = Room.current.id
+    crafting_data = get_data('crafting')
+    stow_hands
+    ensure_copper_on_hand(3000, @settings) unless skipcoin
+    bput('get my wool yarn', 'You get', 'You are already', 'What were you')
+    order_item(crafting_data['tailoring'][@hub_city]['stock-room'], 13)
+    bput('combine my yarn', 'You combine', 'You must be holding both')
+    @current_yarn_count = bput('count my wool yarn', 'You count out \d+ yards').scan(/\d+/).first.to_i
+    buy_yarn(true) if @current_yarn_count < @yarn_quantity
+    stow_hands
+    walk_to(room)
+  end
+
+  def get_item(item)
+    get_crafting_item(item, @craft_bag, @craft_belt, @craft_belt)
+  end
+
+  def stow_item(item)
+    stow_crafting_item(item, @craft_bag, @craft_belt)
+  end
+
+  def outfitting_routine # knits. If interrupted, put the needles away.  Will resume any unfinished project.
+    return unless @training_token == 'Outfitting'
+    return if Script.running?('sew')
+    if @crafted_item && left_hand.include?(@crafted_item.split.last) || right_hand.include?(@crafted_item.split.last)
+      bput("drop my #{@crafted_item.split.last}", 'You drop', 'You place', 'What were', 'You spread')
+    end
+    result =  bput('look my knitting needles',
+              /The knitting needles are in the process of knitting an? unfinished knitted .+ (.+)\./,
+              'The knitting needles are not in the process', 'I could not find')
+    if result =~ /The knitting needles are in the process of knitting an? unfinished knitted .+ (.+)\./
+      @crafted_item = Regexp.last_match(1)
+      echo "sewing found an item to resume: #{@crafted_item}"
+      get_item('knitting needle')
+      be_inside_caravan
+      magic_cleanup
+      start_script('sew', ['resume', @crafted_item])
+      return
+    else
+      rank = DRSkill.getrank('Outfitting')
+
+      if rank <= 25 # Tier 1  Extremely Easy
+        @crafted_item = 'knitted socks'
+      elsif rank <= 50 # Tier 2 Very Easy
+        @crafted_item = 'knitted mittens'
+      elsif rank <= 100 # Tier 3  Easy
+        @crafted_item = 'knitted hat'
+      elsif rank <= 175 # Tier 4  Simple
+        @crafted_item = 'knitted gloves'
+      elsif rank <= 300 # Tier 5  Basic
+        @crafted_item = 'knitted hose'
+      elsif rank <= 425 # Tier 6  Somewhat Challenging
+        @crafted_item = 'knitted cloak'
+      elsif rank <= 700 # Tier 7  Challenging
+        @crafted_item = 'knitted blanket'
+      else # Tier 12  Extremely Difficult
+        echo('*** NO RECIPES ABOVE 700.  NOT YET IMPLEMENTED ***')
+        wipe_skill('Outfitting', @lead_training_skills)
+        return outfitting_cleanup
+      end
+    end
+    recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /tailoring/i }
+    recipe = recipe_lookup(recipes, @crafted_item)
+    echo recipe
+    if recipe['volume'] > @current_yarn_count
+      wipe_skill('Outfitting', @lead_training_skills)
+      return outfitting_cleanup
+    else
+      be_inside_caravan
+      magic_cleanup
+      @current_yarn_count -= recipe['volume']
+      start_script('sew', ['trash', 'knitting', recipe['chapter'], recipe['name'], recipe['noun'], 'wool'].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg })
+    end
+  end
+
+  def outfitting_cleanup # sanitizes outfitting_routine
+    return unless @training_token == 'Outfitting'
+    stop_script('sew') if Script.running?('sew')
+    stow_item('knitting needle')
+    bput('stow my wool yarn', 'You put', 'Stow what')
+    be_outside_caravan
+    bput("drop my #{@crafted_item}", 'You drop', 'You place', 'What were', 'You spread')
+    magic_cleanup
+    stow_hands
+    wipe_token
+    @times_outfitting += 1
+  end
+
+  def engineering_routine # shapes.  Will stow unfinished projects, and search your storage_containers for them later.
+    return unless @training_token == 'Engineering'
+    return if Script.running?('shape')
+    rank = DRSkill.getrank('Engineering')
+
+    if rank <= 25 # Tier 1  Extremely Easy
+       @crafted_item = 'wood band'
+    elsif rank <= 50 # Tier 2 Very Easy
+      @crafted_item = 'wood bracelet'
+    elsif rank <= 80 # Tier 3  Easy
+      @crafted_item = 'wood cloak pin'
+    elsif rank <= 140 # Tier 4  Simple
+      @crafted_item = 'wood amulet'
+    elsif rank <= 255 # Tier 5  Basic
+      @crafted_item = 'wood brooch'
+    elsif rank <= 380 # Tier 6  Somewhat Challenging
+      @crafted_item = 'wood armband'
+    elsif rank <= 555 # Tier 7  Challenging
+      @crafted_item = 'wood choker'
+    elsif rank <= 640 # Tier 8 - Complicated
+      @crafted_item = 'articulated wood necklace'
+    elsif rank <= 765 # Tier 9 - Intricate
+      @crafted_item = 'wood crown'
+    elsif rank <= 1050 # Tier 10 - Difficult
+      @crafted_item = 'wood comb'
+    elsif rank <= 1400 # Tier 11 - Very Difficult
+      @crafted_item = 'wood haircomb'
+    else # Tier 12  Extremely Difficult
+      echo('*** NOT YET IMPLEMENTED ***')
+      wipe_skill('Engineering', @lead_training_skills)
+      return engineering_cleanup
+    end
+
+    if left_hand.include?(@crafted_item.split.last) || right_hand.include?(@crafted_item.split.last)
+      bput("drop my #{@crafted_item.split.last}", 'You drop', 'You place', 'What were', 'You spread') unless bput("tap my #{@crafted_item.split.last}", 'unfinished', 'You tap', 'I could not find') == 'unfinished'
+    end
+    item_container = @settings.storage_containers.find { |container| bput("tap my #{@crafted_item.split.last} in my #{container}", 'unfinished', 'You tap', 'I could not find') == 'unfinished' }
+    if item_container
+      case bput("get my #{@crafted_item.split.last} from my #{item_container}", 'You get', 'What were', 'But that')
+      when 'You get'
+        echo "Engineering found an uncompleted item #{@crafted_item}"
+        be_inside_caravan
+        magic_cleanup
+        start_script('shape', ['continue', @crafted_item.split.last])
+        return
+      end
+    end
+
+    recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /shaping/i }
+    recipe = recipe_lookup(recipes, @crafted_item)
+    if recipe['volume'] > @current_lumber_count
+      wipe_skill('Engineering', @lead_training_skills)
+      return engineering_cleanup
+    else
+      be_inside_caravan
+      magic_cleanup
+      @current_lumber_count -= recipe['volume']
+      start_script('shape', ['trash', recipe['chapter'], recipe['name'], 'balsa', recipe['noun']].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg })
+    end
+  end
+
+  def engineering_cleanup # sanitizes engineering
+    return unless @training_token == 'Engineering'
+    stop_script('shape') if Script.running?('shape')
+    bput("drop my #{@crafted_item.split.last}", 'You drop', 'You place', 'What were', 'You spread') unless bput("tap my #{@crafted_item.split.last}", 'unfinished', 'You tap', 'I could not find') == 'unfinished'
+    stow_item(right_hand) if right_hand
+    stow_item(left_hand) if left_hand
+    stow_hands
+    bput('get my balsa lumber', 'You get', 'You pick up', 'You are already', 'What were you')
+    stow_hands
+    be_outside_caravan
+    wipe_token
+    magic_cleanup
+    @times_engineering += 1
+  end
+
+  def first_aid_routine # runs ;first-aid on compendiums or textbooks for a time.
+    return unless @training_token == 'First Aid'
+    return first_aid_cleanup if DRSkill.getxp('First Aid') > 30
+    return first_aid_cleanup if @cooldown_timers['fa-timer'] && !Script.running?('first-aid')
+    @cooldown_timers['fa-timer'] ||= Time.now
+    return if Script.running?('first-aid')
+    be_inside_caravan
+    start_script('first-aid')
+  end
+
+  def first_aid_cleanup
+    return unless @training_token == 'First Aid'
+    echo "first_aid cleanup" if debugging?
+    wipe_token
+    stop_script('first-aid') if Script.running?('first-aid')
+    @cooldown_timers['First Aid'] = Time.now
+    @cooldown_timers['fa-timer'] = nil
+    waitrt?
+  end
+
+  def performance_routine # runs ;performance for 2 minutes.  Will run ;first-aid too, if it hasn't been done very recently.
+    return unless @training_token == 'Performance'
+    echo "performance routine" if debugging?
+    if @caravan_being_led && check_ability?('First Aid', 180)
+      @training_token = 'First Aid' if @settings.textbook ? exists?(@settings.textbook_type) : exists?('compendium')
+      return
+    end
+    @cooldown_timers['perf-timer'] ||= Time.now
+    return performance_cleanup if Time.now - @cooldown_timers['perf-timer'] > 120 || DRSkill.getxp('Performance') > 30
+    return if is_playing?
+    magic_cleanup
+    be_inside_caravan if @caravan_being_led
+    start_script('performance')
+  end
+
+  def performance_cleanup
+    return unless @training_token == 'Performance'
+    wipe_token
+    bput('wear my zills', 'You slide') if left_hand.include?('zills') || right_hand.include?('zills')
+    stow_hands
+    @cooldown_timers['perf-timer'] = nil
+    stop_script('performance') if is_playing?
+    @cooldown_timers['Performance'] = Time.now
+    waitrt?
+  end
+
+  def hometown_business # run every time it delivers/picks up a contract from Crossing/another hub. Replenishes resources and stocks coins
+    return unless find_town(find_closest_id('trader_outpost')) == @hub_city
+    deposit_coins(@caravan_coins_on_hand, Room.current.id)
+    check_yarn
+    check_wood
+    repair_tools
+    restocked_restore
+  end
+
+  def repair_tools
+    if @caravan_training_skills.include?('Outfitting') && @times_outfitting > 2
+      wait_for_script_to_complete('workorders', ['tailoring', 'repair'])
+      @times_outfitting = 0
+    end
+    if @caravan_training_skills.include?('Engineering') && @times_engineering > 2
+      wait_for_script_to_complete('workorders', ['shaping', 'repair'])
+    end
+  end
+
+  def restocked_restore # restore material-limited skills once bought by hometown_business
+    restore_skill('Outfitting', @caravan_training_skills['Outfitting'], @lead_training_skills) if @current_yarn_count > 70 && @caravan_training_skills.include?('Outfitting') && !@lead_training_skills.include?('Outfitting')
+    restore_skill('Engineering', @caravan_training_skills['Engineering'], @lead_training_skills) if @current_lumber_count > 5 && @caravan_training_skills.include?('Engineering') && !@lead_training_skills.include?('Engineering')
+  end
+
+  def magic_cleanup
+    echo "magic cleanup" if debugging?
+    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    return if @training_spells.empty? || !@preparing
+    @preparing = false
+    Flags.reset('trading-magic-ready')
+    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+    bput('release mana', 'You release all', "You aren't harnessing any mana")
+  end
+end
+
+before_dying do
+  Flags.delete('trading-magic-ready')
+  Flags.delete('caravan-arrived')
+  Flags.delete('lead-arrived')
+  Flags.delete('lead-failed')
+  Flags.delete('lockbox-done')
 end
 
 Trade.new.run

--- a/trade.lic
+++ b/trade.lic
@@ -201,7 +201,7 @@ class Trade
       deliver_contract
       pay_dues
       hometown_business
-      @closeup = true if Time.now > @time_to_end
+      @closeup = true if @time_to_end && Time.now > @time_to_end
     end
   end
 
@@ -350,13 +350,13 @@ class Trade
     return unless @caravan_being_led
     return if ["Interior", "Hodierna", "Kertigen", "Ferry", "South Bank", "Gondola", "Platform"].any? { |name| XMLData.room_title.include?(name) } # Don't do this on ferrys - you can't tell when you've arrived.
     track_caravan
-    bput("go caravan", 'You open the door')
+    bput('go caravan', 'You open the door')
     pause 1.5
   end
 
   def be_outside_caravan # call whenever you need to be outside the caravan
     return unless XMLData.room_title.include?("Interior")
-    bput("go door", 'You open the door')
+    bput('go door', 'You open the door')
     pause 0.5
     fput('look')
   end
@@ -484,7 +484,7 @@ class Trade
   end
 
   def count_grass # sets @current_grass_count of grass in feedbag
-    result = DRC.bput("look in my feedbag", 'That is closed', 'you see .*', 'While it\'s closed', 'I could not find', 'There is nothing', 'Maybe if you')
+    result = DRC.bput('look in my feedbag', 'That is closed', 'you see .*', 'While it\'s closed', 'I could not find', 'There is nothing', 'Maybe if you')
     case result
     when 'That is closed', 'Maybe if you'
       fput("open my feedbag")
@@ -806,7 +806,7 @@ class Trade
       if contract['expired']
         find_crates(contract.origin_town)
         bput("get my #{$ORDINALS[index]} contract from #{@contract_container}", "You get")
-        bput("drop my contract", 'You drop')
+        bput('drop my contract', 'You drop')
         gather_contracts
         return dump_expired
       end
@@ -868,7 +868,7 @@ class Trade
     return unless @training_token == 'Attunement'
     echo "attunement_routine" if debugging?
     return unless @caravan_being_led || @step_toggle > 1
-    bput("perc mana", 'You reach out')
+    bput('perc mana', 'You reach out')
     @step_toggle = 0
     wipe_token
     waitrt?

--- a/trade.lic
+++ b/trade.lic
@@ -19,8 +19,8 @@ class Trade
     @hub_city = 'Crossing'
     @emergency_delivery_town = nil
     @current_caravan_destination = nil
-    @caravan_coins_on_hand = @settings.caravan_coins_on_hand.to_i || 25555
-    @caravan_interior = @settings.caravan_interior || false
+    @caravan_coins_on_hand = @settings.caravan_coins_on_hand.to_i
+    @caravan_interior = @settings.caravan_interior
     @caravan_being_led = false
     @force_contract_from = []
     Flags.add('lead-arrived', 'having arrived at its destination', 'You feel the momentum of the room shift and then hear a voice from outside announce')
@@ -118,6 +118,7 @@ class Trade
       exit
     end
     @settings.storage_containers.each { |container| fput("open my #{container}") }
+    @box = nil unless exists?(@box)
   end
 
   def start_up # should parse contracts, check mats, handle expireds, get the caravan to a useful outpost, deliver any contracts, then begin the loop.
@@ -539,8 +540,8 @@ class Trade
       lead_training
     end
     lead_training_cleanup
-    restore_skill('Outdoorsmanship', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills)
-    restore_skill('Perception', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills)
+    restore_skill('Outdoorsmanship', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills) if @caravan_training_skills['Outdoorsmanship']
+    restore_skill('Perception', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills) if @caravan_training_skills['Perception']
     @caravan_being_led = false
   end
 
@@ -574,7 +575,7 @@ class Trade
     walk_training_cleanup
   end
 
-  def wait_for_caravan(wait_time = 6)
+  def wait_for_caravan(wait_time = 6) # The wait time is how long to wait until doing noisy RECALL CARAVANs.  A grace period for the caravan to arrive quietly.
     time_waiting = Time.now
     until Flags['caravan-arrived']
       pause 0.2
@@ -640,7 +641,7 @@ class Trade
     end
   end
 
-  def pay_dues
+  def pay_dues # TODO: Handle Missing DUES
     clerk_id = find_closest_id('shipment_clerk')
     echo "Paying dues at clerk_room: #{clerk_id}" if debugging?
     clerk_messages = [
@@ -654,7 +655,7 @@ class Trade
   end
 
   def get_caravan
-    echo "NOT YET IMPLEMENTED.  GO GET A CARAVAN AND PARK IT AT THE OUTPOST DOORS"
+    echo "NOT YET IMPLEMENTED.  GO RENT A CARAVAN FROM THE CLERK AND START TRADE IN THE SAME ROOM!"
     exit
   end
 
@@ -727,7 +728,7 @@ class Trade
     true
   end
 
-  def dump_expired # checks for expired contracts, and gets rid of them and the matching crate.
+  def dump_expired # checks for expired contracts, and gets rid of them and the matching crate. TODO: recheck contracts before tossing them.  Hasn't broken yet, but...
     return unless @held_contracts
     echo @held_contracts if debugging?
     @held_contracts.each_with_index do |contract, index|
@@ -767,11 +768,10 @@ class Trade
     bput('get my contract', 'You get', 'You are already holding that')
     Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
     bput('give my contract to clerk', /The .* clerk accepts your contract and peruses it\./)
-    recall_caravan? if Flags['caravan-upgrade']
+    recall_caravan? if Flags['caravan-upgrade'] # Doesn't do anything yet.
     bput("put my contract in my #{@contract_container}", 'You put')
     Flags.delete('caravan-upgrade')
   end
-
 
   def deposit_coins(withdraw_amt, return_to_id)
     return if wealth(@hub_city) < withdraw_amt
@@ -828,7 +828,7 @@ class Trade
     echo "lead_appraisal" if debugging?
     return unless @training_token == 'Appraisal'
     @appraisal_timer ||= Time.now
-    return appraisal_cleanup if Time.now - @appraisal_timer > 100 || DRSkill.getxp('Appraisal') > 30
+    return appraisal_cleanup if Time.now - @appraisal_timer > 100 || DRSkill.getxp('Appraisal') >= 30
     return if Script.running?('appraisal')
     be_inside_caravan
     start_script('appraisal')
@@ -1057,6 +1057,7 @@ class Trade
     else
       @equipment_manager.empty_hands
     end
+    stow_hands
     @box = nil if Flags['lockbox-done']
     Flags.delete('lockbox-done')
   end
@@ -1376,7 +1377,7 @@ class Trade
     @times_engineering += 1
   end
 
-  def first_aid_routine # runs ;first-aid on compendiums or textbooks for a time.
+  def first_aid_routine # runs ;first-aid on compendiums or textbooks
     return unless @training_token == 'First Aid'
     return first_aid_cleanup if DRSkill.getxp('First Aid') > 30
     return first_aid_cleanup if @cooldown_timers['fa-timer'] && !Script.running?('first-aid')
@@ -1432,11 +1433,11 @@ class Trade
   end
 
   def repair_tools
-    if @caravan_training_skills.include?('Outfitting') && @times_outfitting > 2
+    if @caravan_training_skills.include?('Outfitting') && @times_outfitting > 4
       wait_for_script_to_complete('workorders', ['tailoring', 'repair'])
       @times_outfitting = 0
     end
-    if @caravan_training_skills.include?('Engineering') && @times_engineering > 2
+    if @caravan_training_skills.include?('Engineering') && @times_engineering > 4
       wait_for_script_to_complete('workorders', ['shaping', 'repair'])
     end
   end

--- a/trade.lic
+++ b/trade.lic
@@ -1543,7 +1543,7 @@ class Trade
     if rank <= 25 # Tier 1  Extremely Easy
        @crafted_item = 'wood band'
     elsif rank <= 50 # Tier 2 Very Easy
-      @crafted_item = 'wood bracelet'
+      @crafted_item = 'a wood bracelet'
     elsif rank <= 80 # Tier 3  Easy
       @crafted_item = 'wood cloak pin'
     elsif rank <= 140 # Tier 4  Simple

--- a/trade.lic
+++ b/trade.lic
@@ -326,7 +326,7 @@ class Trade
   def be_inside_caravan # call whenever you need to be inside the caravan
     return unless @caravan_interior
     return unless @caravan_being_led
-    return if ["Interior", "Hodierna", "Kertigen", "Ferry", "South Bank"].any? { |name| XMLData.room_title.include?(name) } # Don't do this on ferrys - you can't tell when you've arrived.
+    return if ["Interior", "Hodierna", "Kertigen", "Ferry", "South Bank", "Gondola", "Platform"].any? { |name| XMLData.room_title.include?(name) } # Don't do this on ferrys - you can't tell when you've arrived.
     track_caravan
     bput("go caravan", 'You open the door')
     pause 1.5
@@ -527,10 +527,45 @@ class Trade
       elsif dir.inspect.include?("ferry', 'leth'")
         ferry_run('leth')
         return true
+      elsif dir.inspect.include?("'gondola'")
+        ride_gondola
+        return true
       end
     else
       return false
     end
+  end
+  
+  def ride_gondola
+    mode = 'south' if Room.current.id == 2249
+    mode = 'north' if Room.current.id == 2904
+    Flags.add('trade-gondola-arrive', 'The gondola stops on the platform and the door silently swings open', 'With a soft bump, the gondola comes to a stop at its destination')
+    @caravan_being_led = true
+    wipe_skill('Outdoorsmanship', @lead_training_skills)
+    wipe_skill('Perception', @lead_training_skills)
+    Flags.reset('caravan-arrived')
+    case bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
+    when /no wooden gondola here/i
+      waitfor 'The gondola stops on the platform and the door silently swings open'
+      until Flags['trade-gondola-arrive']
+        pause 1.5
+        lead_training
+      end
+    when /Gondola, Cab/
+      wait_for_caravan
+      Flags.reset('caravan-arrived')
+      move mode
+    end
+    until Flags['trade-gondola-arrive']
+      pause 1.5
+      lead_training
+    end
+    Flags.reset('caravan-arrived')
+    move 'out'
+    lead_training_cleanup
+    restore_skill('Outdoorsmanship', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills) if @caravan_training_skills['Outdoorsmanship']
+    restore_skill('Perception', @caravan_training_skills['Outdoorsmanship'], @lead_training_skills) if @caravan_training_skills['Perception']
+    @caravan_being_led = false
   end
 
   def ferry_run(town) # Crossing-Leth Fery
@@ -859,7 +894,7 @@ class Trade
       @pouch_ordinal += 1
       true
     else
-      @appraisal_queue -= 'full-pouch' if @pouch_ordinal == 0
+      @appraisal_queue -= ['full-pouch'] if @pouch_ordinal == 0
       @pouch_ordinal = 0
       false
     end
@@ -1506,6 +1541,7 @@ before_dying do
   Flags.delete('lead-arrived')
   Flags.delete('lead-failed')
   Flags.delete('lockbox-done')
+  Flags.delete('trade-gondola-arrive')
   Script.unpause('skill-recorder') if Script.paused?('skill-recorder')
 end
 

--- a/trade.lic
+++ b/trade.lic
@@ -85,7 +85,6 @@ class Trade
     @equipment_manager.empty_hands
 
     if args.destination
-      track_caravan
       echo "Taking the caravan directly to room #{args.destination}"
       take_caravan_to(args.destination.to_i)
       exit
@@ -94,7 +93,6 @@ class Trade
         echo "TOWN NOT FOUND OR NOT SUPPORTED.  CURRENTLY SUPPORTS ZOLUREN ONLY"
         exit
       end
-      track_caravan
       echo "Taking the caravan directly to #{args.town_name}'s trade outpost"
       take_caravan_to(outpost_from_name(@current_caravan_destination))
       exit
@@ -152,7 +150,6 @@ class Trade
 
   def close_out # makes sure your caravan is at an outpost, then returns it.  Future stable_handling?
     echo "close_out" if debugging?
-    track_caravan
     take_caravan_to(find_closest_id('trader_outpost'))
     walk_to(find_closest_id('shipment_clerk'))
     fput("return #{@caravan.noun}")
@@ -344,6 +341,7 @@ class Trade
 
   def track_caravan # requires caravan to be in-room with you.
     echo "track caravan" if debugging?
+    return false unless caravan_exists?
     unless caravan_check?
       pause 2
       find_timer = Time.now

--- a/trade.lic
+++ b/trade.lic
@@ -52,7 +52,9 @@ class Trade
     @training_spells = @settings.crafting_training_spells
     @step_toggle = -1
     wipe_token
-    Flags.add('trading-magic-ready', 'You feel fully prepared to cast your spell.')
+    Flags.add('trading-magic-ready', '^You feel fully prepared to cast your spell.')
+    Flags.add('trading-symbiosis-ready', '^You recall the exact details of the Chaos symbiosis')
+    Flags.add('trading-symbiosis-done', '^You twist the mana streams', 'You pause for a moment as the details of the Chaos symbiosis')
 
     @equipment_manager = EquipmentManager.new(@settings)
     @cooldown_timers = {}
@@ -492,7 +494,7 @@ class Trade
     @cooldown_timers['Grass'] ||= Time.now - 10
     return if Time.now - @cooldown_timers['Grass'] < 10
     bput('put my grass in my feedbag', 'You put', 'What were you') if forage?('grass')
-    count_grass
+    @current_grass_count += 6
     restore_skill('Mechanical Lore', @caravan_training_skills['Mechanical Lore'], @walk_training_skills) if @current_grass_count > 50 && @caravan_training_skills.include?('Mechanical Lore') && !@walk_training_skills.include?('Mechanical Lore')
     @cooldown_timers['Grass'] = Time.now
     @step_toggle = 0
@@ -956,6 +958,7 @@ class Trade
     if @preparing && Flags['trading-magic-ready'] && mana > 40
       crafting_cast_spell(@preparing, @settings)
       Flags.reset('trading-magic-ready')
+      release_symbiosis
       @preparing = nil
       wipe_token if %w[Augmentation Warding Utility].include?(@training_token)
     end
@@ -973,7 +976,15 @@ class Trade
     @preparing = @training_spells[needs_training]
     crafting_prepare_spell(@preparing, @settings)
   end
-
+  
+  def release_symbiosis
+    if Flags['trading-symbiosis-ready']
+       bput('release symbiosis', "But you haven't", 'You release', 'Repeat this command') unless Flags['trading-symbiosis-done']
+    end
+    Flags.reset('trading-symbiosis-done')
+    Flags.reset('trading-symbiosis-ready')
+  end
+  
   def lead_training # Training that is done while being led or riding a caravan. Can have much longer RTs than in walk_training
     training_skills = @lead_training_skills
     echo "in lead training - training token is #{@training_token}" if debugging?
@@ -1517,6 +1528,7 @@ class Trade
     deposit_coins(@caravan_coins_on_hand, Room.current.id)
     check_yarn
     check_wood
+    count_grass
     repair_tools
     restocked_restore
   end
@@ -1539,7 +1551,7 @@ class Trade
 
   def magic_cleanup
     echo "magic cleanup" if debugging?
-    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    release_symbiosis
     return if @training_spells.empty? || !@preparing
     @preparing = false
     Flags.reset('trading-magic-ready')

--- a/trade.lic
+++ b/trade.lic
@@ -306,8 +306,7 @@ class Trade
     track_caravan
     return true if Room.current.id == outpost_from_name(town_name)
     @caravan_being_led = true
-    successful_lead = command_caravan?("lead to #{town_name}")
-    return false unless successful_lead
+    return false unless command_caravan?("lead to #{town_name}")
     be_inside_caravan
 
     until Flags['lead-arrived'] || Flags['lead-failed'] # main wait loop while training happens
@@ -1118,20 +1117,14 @@ class Trade
 
   def mechlore_routine
     return unless @training_token.include?('Mechanical Lore')
-    @unfinished_grass ||= true
     if @current_grass_count < 30
       @training_token = nil
       return wipe_skill('Mechanical Lore', @walk_training_skills) 
     end
     return unless @caravan_being_led || @step_toggle > 1
     be_inside_caravan # if @caravan_being_led
-    if @unfinished_grass
-      bput('close my feedbag', 'You close', 'What were', 'That is already')
-      bput('get my grass', 'You get', 'What were you')
-      bput('open my feedbag', 'You open', 'What were')
-    end
-    result = bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long') if braid?('grass')
-    @unfinished_grass = result == 'You put' ? true : false
+    bput('get my braided grass', 'You get', 'What were you')
+    bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long') if braid?('grass')
     drop_grass
     wipe_token
     @step_toggle = @step_toggle == 100 ? 2 : 0
@@ -1148,7 +1141,7 @@ class Trade
       rt = reget(10, 'Roundtime').last.scan(/\d+/).first.to_i
       waitrt
       echo "rt is #{rt}" if debugging?
-      @step_toggle = 100 if rt < 4 # time optimization - see routine
+      @step_toggle = 100 if rt <= 4 # time optimization - see routine
       rt >= 9 ? false : true
     when 'is already as long as you can make it'
       waitrt?
@@ -1169,10 +1162,8 @@ class Trade
   end
 
   def get_grass
-    fput('open my feedbag')
     case bput('get my grass from my feedbag', 'You get', 'What were you')
     when 'What were you'
-      bput('open my feedbag', 'You open', 'What were')
       bput('get my grass from my feedbag', 'You get', 'What were you')
     end
     @current_grass_count -= 1

--- a/trade.lic
+++ b/trade.lic
@@ -61,6 +61,7 @@ class Trade
     @walk_training_skills = @caravan_training_skills.select { |skill, _cooldown| ['Augmentation', 'Utility', 'Warding', 'Attunement', 'Performance', 'Appraisal', 'Mechanical Lore'].include?(skill) }
     @craft_bag = @settings.crafting_container
     @craft_belt = nil
+    @appraisal_queue = ['zills', 'pouch', 'full-pouch', 'bundle']
 
     @yarn_quantity = @settings.yarn_quantity > 300 ? 301 : @settings.yarn_quantity
     @lumber_quantity = @settings.lumber_quantity > 30 ? 30 : @settings.lumber_quantity
@@ -78,6 +79,7 @@ class Trade
 
     setup_town_data
     validate_requirements(args)
+    be_outside_caravan
     
     bput("open my #{@contract_container}", 'You open', 'That is already', 'You can.t')
     @equipment_manager.empty_hands
@@ -327,6 +329,7 @@ class Trade
 
   def be_inside_caravan # call whenever you need to be inside the caravan
     return unless @caravan_interior
+    return unless @caravan_being_led
     return if ["Interior", "Hodierna", "Kertigen", "Ferry", "South Bank"].any? { |name| XMLData.room_title.include?(name) } # Don't do this on ferrys - you can't tell when you've arrived.
     track_caravan
     bput("go caravan", 'You open the door')
@@ -816,47 +819,80 @@ class Trade
 
   def appraisal_routine
     return unless @training_token == 'Appraisal'
-    @caravan_being_led ? lead_appraisal : walk_appraisal
-  end
-
-  def walk_appraisal # TO DO swap pouches through ordinals
-    echo "walk_appraisal" if debugging?
-    return unless @training_token == 'Appraisal'
     return unless @caravan_being_led || @step_toggle > 1
-    case bput("appraise my #{@gem_pouch_adjective} pouch", 'Roundtime', 'You can.t appraise the', 'Appraise what')
-    when 'You can.t appraise the'
-      case bput("get pouch from my #{@full_pouch_container}", '^You get ', '^What were you referring')
-      when /^You get /
-        bput("appraise my #{@gem_pouch_adjective} pouch quick", 'Roundtime')
-        waitrt?
-        bput("put my pouch in my #{@full_pouch_container}", 'You put')
+    be_inside_caravan
+    case @appraisal_queue.first
+    when 'zills'
+      @appraisal_queue = @appraisal_queue.rotate
+      return appraisal_routine unless assess_zills?
+    when 'bundle'
+      @appraisal_queue = @appraisal_queue.rotate
+      return appraisal_routine unless appraise_bundle? 
+    when 'pouch'
+      @appraisal_queue = @appraisal_queue.rotate
+      return appraisal_routine unless appraise_worn_pouch?
+    when 'full-pouch'
+      unless appraise_held_pouch?
+        @appraisal_queue = @appraisal_queue.rotate
+        return appraisal_routine
       end
     end
     @step_toggle = 0
     wipe_token
-  end
-
-  def lead_appraisal
-    echo "lead_appraisal" if debugging?
-    return unless @training_token == 'Appraisal'
-    @appraisal_timer ||= Time.now
-    return appraisal_cleanup if Time.now - @appraisal_timer > 100 || DRSkill.getxp('Appraisal') >= 30
-    return if Script.running?('appraisal')
-    be_inside_caravan
-    start_script('appraisal')
-  end
-
-  def appraisal_cleanup
-    return unless @training_token == 'Appraisal'
-    echo "appraisal_cleanup" if debugging?
-    wipe_token
-    @appraisal_timer = nil
-    return unless Script.running?('appraisal')
-    stop_script('appraisal')
     @cooldown_timers['Appraisal'] = Time.now
+  end
+  
+  def appraise_worn_pouch?
+    case bput("appraise my #{@gem_pouch_adjective} pouch", 'Roundtime', 'You can.t appraise the', 'Appraise what')
+    when 'You can.t appraise the', 'Appraise what'
+      @appraisal_queue -= ['pouch']
+      false
+    end
+    true
+  end
+  
+  def appraise_held_pouch?
+    @pouch_ordinal ||= 0
+    @pouch_ordinal = 0 if @pouch_ordinal > 10
+    case bput("get #{$ORDINALS[@pouch_ordinal]} pouch from my #{@full_pouch_container}", '^You get ', '^What were you referring')
+    when /^You get /
+      bput('appraise my pouch', 'Roundtime')
+      waitrt?
+      bput("put my pouch in my #{@full_pouch_container}", 'You put')
+      @pouch_ordinal += 1
+      true
+    else
+      @appraisal_queue -= 'full-pouch' if @pouch_ordinal == 0
+      @pouch_ordinal = 0
+      false
+    end
+  end
+  
+  def appraise_bundle?
+    case bput('appraise my bundle', 'Roundtime', 'Appraise what', 'You cannot appraise')
+    when 'Appraise what', 'You cannot appraise'
+      @appraisal_queue -= ['bundle']
+      return false
+    end
     waitrt?
-    @equipment_manager.empty_hands
+    true
+  end
+
+  def assess_zills?
+    if DRSkill.getrank('Appraisal') >= 250
+      @appraisal_queue -= ['zills']
+      return false
+    end
+
+    case bput('remove my zill', 'You slide', 'Remove what')
+    when 'Remove what'
+      @appraisal_queue -= ['zills']
+      return false
+    end
+    bput('assess my zill', 'you carefully look them over')
     waitrt?
+    bput('wear my zill', 'You slide')
+    true
   end
 
   def wipe_token
@@ -913,7 +949,6 @@ class Trade
     first_aid_cleanup
     performance_cleanup
     locksmithing_cleanup
-    appraisal_cleanup
     magic_cleanup
   end
 
@@ -932,7 +967,6 @@ class Trade
     echo "training_cleanup" if debugging?
     magic_cleanup
     performance_cleanup
-    appraisal_cleanup
     wipe_token
     @step_toggle = -1
   end
@@ -1084,18 +1118,22 @@ class Trade
 
   def mechlore_routine
     return unless @training_token.include?('Mechanical Lore')
+    @unfinished_grass ||= true
     if @current_grass_count < 30
       @training_token = nil
       return wipe_skill('Mechanical Lore', @walk_training_skills) 
     end
     return unless @caravan_being_led || @step_toggle > 1
-    be_inside_caravan if @caravan_being_led
-    bput('close my feedbag', 'You close', 'What were', 'That is already')
-    bput('get my grass', 'You get', 'What were you')
-    bput('open my feedbag', 'You open', 'What were')
-    result = bput('stow my grass', 'You stow', 'You put', 'What were you', 'The braided grass is too long') if braid?('grass')
+    be_inside_caravan # if @caravan_being_led
+    if @unfinished_grass
+      bput('close my feedbag', 'You close', 'What were', 'That is already')
+      bput('get my grass', 'You get', 'What were you')
+      bput('open my feedbag', 'You open', 'What were')
+    end
+    result = bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long') if braid?('grass')
+    @unfinished_grass = result == 'You put' ? true : false
     drop_grass
-    @training_token = nil
+    wipe_token
     @step_toggle = @step_toggle == 100 ? 2 : 0
   end
 

--- a/trade.lic
+++ b/trade.lic
@@ -23,13 +23,19 @@ class Trade
       [
         { name: 'outpost', regex: /outpost/i, optional: false, description: 'Bring the caravan to the trade outpost of a town.' },
         { name: 'town_name', regex: /\w+/i, variable: true, description: 'First word of the town name.' }
+      ],
+      [
+        { name: 'duration', regex: /duration/i, optional: false, description: 'Run for a certain amount of time plus the time required to closeup.' },
+        { name: 'minutes', regex: /\d+/i, optional: false, variable: true, description: 'Duration of the run in minutes.' },
+        { name: 'exit', regex: /exit/i, optional: true, description: 'Exits the game after delivering all crates and returning the caravan' }
       ]
     ]
     args = parse_args(arg_definitions)
     @closeup = args.closeup
     @exit = args.exit
     @caravan = OpenStruct.new
-    
+    @duration = args.minutes
+
     @town_data = get_data('town')
     @equipment_manager = EquipmentManager.new
     @settings = get_settings
@@ -82,7 +88,8 @@ class Trade
     setup_town_data
     validate_requirements(args)
     be_outside_caravan
-    
+    @time_to_end = Time.now + 60 * @duration.to_i if @duration
+
     bput("open my #{@contract_container}", 'You open', 'That is already', 'You can.t')
     @equipment_manager.empty_hands
 
@@ -127,7 +134,7 @@ class Trade
     if @caravan_training_skills.include?('First Aid')
       unless @settings.textbook ? exists?(@settings.textbook_type) : exists?('compendium')
         echo "NO COMPENDIUM OR TEXTBOOK FOUND.  CHECK YOUR ;FIRST-AID SETTINGS"
-        wipe_skill('First Aid', @lead_training_skills) 
+        wipe_skill('First Aid', @lead_training_skills)
       end
     end
   end
@@ -163,6 +170,10 @@ class Trade
     take_caravan_to(find_closest_id('trader_outpost'))
     walk_to(find_closest_id('shipment_clerk'))
     fput("return #{@caravan.noun}")
+    walk_to(find_closest_id('trader_outpost'))
+    bput('get my balsa lumber', 'You get', 'You are already', 'What were you')
+    bput('drop my balsa lumber', 'You drop', 'What were you')
+    fput('DUMP JUNK')
     fput('exit') if @exit
     exit
   end
@@ -190,6 +201,7 @@ class Trade
       deliver_contract
       pay_dues
       hometown_business
+      @closeup = true if Time.now > @time_to_end
     end
   end
 
@@ -268,7 +280,7 @@ class Trade
 
   def do_lead_from # you must escape the gravity of certain towns for your caravan to break orbit and lead you away
     echo "do_lead_from" if debugging?
-    return unless @caravan.noun == 'caravan' 
+    return unless @caravan.noun == 'caravan'
     nearest_town = find_town(find_closest_id('trader_outpost'))
     destination_town = find_town(@current_caravan_destination)
     return if nearest_town == destination_town
@@ -287,7 +299,7 @@ class Trade
 
   def do_lead_to # handles final lead-to approach to certain towns AFTER escaping do_lead_from
     echo "do_lead_to #{@current_caravan_destination}" if debugging?
-    return unless @caravan.noun == 'caravan' 
+    return unless @caravan.noun == 'caravan'
     no_lead_towns = ['Tiger Clan', 'Wolf Clan']
     destination_town = find_town(@current_caravan_destination)
     nearest_town = find_town(find_closest_id('trader_outpost'))
@@ -545,7 +557,7 @@ class Trade
       return false
     end
   end
-  
+
   def ride_gondola
     mode = 'south' if Room.current.id == 2249
     mode = 'north' if Room.current.id == 2904
@@ -646,7 +658,7 @@ class Trade
     when 'wait'
       wait_messages = [
         'You pass on the order to wait to your driver, who makes sure your .* does your bidding',
-        'You grab hold of your .* harness and make it wait.'        
+        'You grab hold of your .* harness and make it wait.'
       ]
       bput("tell #{@caravan.noun} to wait", wait_messages)
       return true
@@ -676,8 +688,29 @@ class Trade
   end
 
   def get_contract
-    nearest_minister = find_closest_id('trade_minister')
-    get_new_contract(nearest_minister)
+    minister_id = find_closest_id('trade_minister')
+    return if @trading_towns[find_town(minister_id)]['contracts_from'] > 0
+    echo "Getting a new contract from room #{minister_id}" if debugging?
+    walk_to(minister_id)
+    minister_messages = [
+      'The minister plucks a contract from the hands',
+      'The minister reminds you that you still owe .*',
+      'You still have another contract'
+    ]
+    response = bput('ask minister for contract', minister_messages)
+    case response
+    when /The minister reminds you/
+      /The minister reminds you that you still owe (?<dues_amt>.*) (?<dues_currency>Kronars|Lirums|Dokoras) in dues to (?:The )?(?<outpost>.*) and asks that you pay the clerk before s?he issues you a new contract\./ =~ response
+      echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if debugging?
+      ensure_copper_on_hand(dues_amt.to_i, @settings)
+      pay_dues
+      get_contract
+    when /You still have another contract/
+      @force_contract_from.push(find_town(minister_id)) unless @trading_towns['contracts_from'] # force_contract_from handles contracts that have somehow been lost.  The minister won't give another until it would have expired
+    else
+      @force_contract_from - [find_town(minister_id)] if @force_contract_from.include?(find_town(minister_id))
+    end
+    load_caravan
   end
 
   def deliver_contract
@@ -713,8 +746,12 @@ class Trade
   end
 
   def get_caravan
-    echo "NOT YET IMPLEMENTED.  GO RENT A CARAVAN FROM THE CLERK AND START TRADE IN THE SAME ROOM!"
-    exit
+    clerk_id = find_closest_id('shipment_clerk')
+    walk_to(clerk_id)
+    bput('rent caravan', 'You want to upgrade from a', 'The clerk nods and says')
+    trader_outpost = find_closest_id('trader_outpost')
+    walk_to(trader_outpost)
+    recall_caravan?
   end
 
   def feed_caravan # feeds your caravan from a feedbag.
@@ -742,31 +779,6 @@ class Trade
     echo "Presenting contract to clerk in room: #{clerk_id}" if debugging?
     walk_to(clerk_id)
     give_clerk
-  end
-
-  def get_new_contract(minister_id)
-    return if @trading_towns[find_town(minister_id)]['contracts_from'] > 0
-    echo "Getting a new contract from room #{minister_id}" if debugging?
-    walk_to(minister_id)
-    minister_messages = [
-      'The minister plucks a contract from the hands',
-      'The minister reminds you that you still owe .*',
-      'You still have another contract'
-    ]
-    response = bput('ask minister for contract', minister_messages)
-    case response
-    when /The minister reminds you/
-      /The minister reminds you that you still owe (?<dues_amt>.*) (?<dues_currency>Kronars|Lirums|Dokoras) in dues to (?:The )?(?<outpost>.*) and asks that you pay the clerk before s?he issues you a new contract\./ =~ response
-      echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if debugging?
-      ensure_copper_on_hand(dues_amt.to_i, @settings)
-      pay_dues
-      get_new_contract(minister_id)
-    when /You still have another contract/
-      @force_contract_from.push(find_town(minister_id)) unless @trading_towns['contracts_from'] # force_contract_from handles contracts that have somehow been lost.  The minister won't give another until it would have expired
-    else
-      @force_contract_from - [find_town(minister_id)] if @force_contract_from.include?(find_town(minister_id))
-    end
-    load_caravan
   end
 
   def caravan_check?(stationary = true) # The traders' guild hands out identical caravans
@@ -828,10 +840,7 @@ class Trade
     bput('get my contract', 'You get', 'You are already holding that')
     Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
     bput('give my contract to clerk', /The .* clerk accepts your contract and peruses it\./)
-    if Flags['caravan-upgrade']
-      bput('rent caravan', 'You want to upgrade from a')
-      recall_caravan?
-    end
+    get_caravan if Flags['caravan-upgrade']
     bput("put my contract in my #{@contract_container}", 'You put')
     Flags.delete('caravan-upgrade')
   end
@@ -875,7 +884,7 @@ class Trade
       return appraisal_routine unless assess_zills?
     when 'bundle'
       @appraisal_queue = @appraisal_queue.rotate
-      return appraisal_routine unless appraise_bundle? 
+      return appraisal_routine unless appraise_bundle?
     when 'pouch'
       @appraisal_queue = @appraisal_queue.rotate
       return appraisal_routine unless appraise_worn_pouch?
@@ -889,7 +898,7 @@ class Trade
     wipe_token
     @cooldown_timers['Appraisal'] = Time.now
   end
-  
+
   def appraise_worn_pouch?
     case bput("appraise my #{@gem_pouch_adjective} pouch", 'Roundtime', 'You can.t appraise the', 'Appraise what')
     when 'You can.t appraise the', 'Appraise what'
@@ -898,7 +907,7 @@ class Trade
     end
     true
   end
-  
+
   def appraise_held_pouch?
     @pouch_ordinal ||= 0
     @pouch_ordinal = 0 if @pouch_ordinal > 10
@@ -915,7 +924,7 @@ class Trade
       false
     end
   end
-  
+
   def appraise_bundle?
     case bput('appraise my bundle', 'Roundtime', 'Appraise what', 'You cannot appraise')
     when 'Appraise what', 'You cannot appraise'
@@ -977,7 +986,7 @@ class Trade
     @preparing = @training_spells[needs_training]
     crafting_prepare_spell(@preparing, @settings)
   end
-  
+
   def release_symbiosis
     if Flags['trading-symbiosis-ready']
        bput('release symbiosis', "But you haven't", 'You release', 'Repeat this command') unless Flags['trading-symbiosis-done']
@@ -985,7 +994,7 @@ class Trade
     Flags.reset('trading-symbiosis-done')
     Flags.reset('trading-symbiosis-ready')
   end
-  
+
   def lead_training # Training that is done while being led or riding a caravan. Can have much longer RTs than in walk_training
     training_skills = @lead_training_skills
     echo "in lead training - training token is #{@training_token}" if debugging?
@@ -999,7 +1008,7 @@ class Trade
     outfitting_routine
     engineering_routine
   end
-  
+
   def lead_training_cleanup # all training shuts down immediately upon arrival. Any routine that needs sanitizing goes here.
     outfitting_cleanup
     engineering_cleanup
@@ -1038,7 +1047,7 @@ class Trade
     @cooldown_timers[ability] = Time.now
     ability
   end
-  
+
   def next_to_train(skill_list)
     return skill_list.sort_by { |skill, _cooldown| DRSkill.getxp(skill) }
                           .find { |skill, cooldown| check_ability?(skill, cooldown) }.first
@@ -1054,11 +1063,13 @@ class Trade
 
   def locksmithing_routine # runs training boxes and pets
     return unless @training_token == 'Locksmithing'
-
     return locksmithing_cleanup if DRSkill.getxp('Locksmithing') > 32 || Flags['lockbox-done']
+    return locksmithing_cleanup if Script.running?('lockbox') && Time.now - @cooldown_timers['lockbox-timer'] > 60
     return if Script.running?('lockbox')
+
     if @box
       be_outside_caravan # can't pick inside a caravan because reasons
+      @cooldown_timers['lockbox-timer'] ||= Time.now
       Flags.add('lockbox-done', 'The lock feels warm')
       start_script('lockbox')
     else
@@ -1157,6 +1168,7 @@ class Trade
     wipe_token
     stop_script('lockbox') if Script.running?('lockbox')
     @cooldown_timers['Locksmithing'] = Time.now
+    @cooldown_timers['lockbox-timer'] = nil
     waitrt?
     if @box && @worn_lockbox
       bput("pick my #{@box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm')
@@ -1182,7 +1194,7 @@ class Trade
     return unless @training_token.include?('Mechanical Lore')
     if @current_grass_count < 30
       @training_token = nil
-      return wipe_skill('Mechanical Lore', @walk_training_skills) 
+      return wipe_skill('Mechanical Lore', @walk_training_skills)
     end
     return unless @caravan_being_led || @step_toggle > 1
     be_inside_caravan
@@ -1191,11 +1203,10 @@ class Trade
       bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long')
       drop_grass
     end
-
     wipe_token unless next_to_train(@walk_training_skills) == 'Mechanical Lore'
     @step_toggle = @step_toggle == 100 ? 2 : 0
   end
-  
+
   def mechlore_cleanup
     bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long') if right_hand.include?('grass') || left_hand.include?('grass')
     drop_grass
@@ -1514,7 +1525,7 @@ class Trade
   def performance_routine # runs ;performance for 2 minutes.  Will run ;first-aid too, if it hasn't been done very recently.
     return unless @training_token == 'Performance'
     echo "performance routine" if debugging?
-    if @lead_training_skills.include?('First Aid') && @caravan_being_led && check_ability?('First Aid', 180) 
+    if @lead_training_skills.include?('First Aid') && @caravan_being_led && check_ability?('First Aid', 180)
       @training_token = 'First Aid'
       return
     end

--- a/trade.lic
+++ b/trade.lic
@@ -630,7 +630,7 @@ class Trade
   def handle_special_room?(dir) # handles very specific rooms (bescort rooms currently) - allows training on ferries.
     case dir
     when StringProc
-      if dir.inspect.include?("ferry.?'")
+      if dir.inspect.include?('ferry')
         ferry_run
         return true
       elsif dir.inspect.include?("'gondola'")
@@ -688,7 +688,6 @@ class Trade
   end
 
   def ferry_run
-    echo "ferry_run #{town}" if debugging?
     case Room.current.id
     when 3986
       town = 'hibarnhvidar'
@@ -703,14 +702,12 @@ class Trade
       town = 'leth'
       mode = 'ferry'
     end
-
     walk_training_cleanup
     start_script('bescort', [mode, town])
     @caravan_being_led = true
     wipe_skill('Outdoorsmanship', @lead_training_skills)
     wipe_skill('Perception', @lead_training_skills)
     until !Script.running?('bescort')
-      Flags.reset('caravan-arrived') if Flags['caravan-arrived']
       pause 1.5
       lead_training
     end

--- a/trade.lic
+++ b/trade.lic
@@ -30,12 +30,6 @@ class Trade
         { name: 'exit', regex: /exit/i, optional: true, description: 'Exits the game after delivering all crates and returning the caravan' }
       ]
     ]
-    
-    echo "**********************************************************************"
-    echo "**** DETAILS ON SCRIPT USAGE AND CONFIGURATION CAN BE FOUND ON    ****"
-    echo "**** https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials ****"
-    echo "**********************************************************************"
-    
     args = parse_args(arg_definitions)
     @closeup = args.closeup
     @exit = args.exit
@@ -46,7 +40,9 @@ class Trade
     @equipment_manager = EquipmentManager.new
     @settings = get_settings
     @contract_container = @settings.trade_contract_container
-    @hub_city = 'Crossing'
+    @hub_city = nil
+    @trading_towns = {}
+    @no_ride_rooms = ["Interior", "Hodierna", "Kertigen", 'Damaris', 'Evening', "Ferry", "South Bank", "Gondola", "Platform",]
     @emergency_delivery_town = nil
     @current_caravan_destination = nil
     @caravan_coins_on_hand = @settings.caravan_coins_on_hand.to_i
@@ -105,7 +101,7 @@ class Trade
       exit
     elsif args.outpost
       unless @current_caravan_destination = find_town_from_arg(args.town_name)
-        echo "TOWN NOT FOUND OR NOT SUPPORTED.  CURRENTLY SUPPORTS ZOLUREN ONLY"
+        echo "TOWN NOT FOUND OR NOT SUPPORTED.  CURRENTLY SUPPORTS ZOLUREN, ILITHI, FORFEDHAR ONLY"
         exit
       end
       echo "Taking the caravan directly to #{args.town_name}'s trade outpost"
@@ -117,8 +113,10 @@ class Trade
   end
 
   def find_town_from_arg(town_arg)
-    zoluren_towns = ['Wolf Clan', 'Tiger Clan', 'Crossing', 'Arthe Dale', 'Stone Clan', 'Dirge', 'Leth Deriel']
-    return zoluren_towns.find { |town_data| town_data.split.first.casecmp(town_arg).zero? }
+    all_towns = ['Wolf Clan', 'Tiger Clan', 'Crossing', 'Arthe Dale', 'Stone Clan', 'Dirge', 'Leth Deriel',
+                 'Shard', "Fayrin's Rest", 'Steelclaw Clan', 'Darkling Wood',
+                 'Ain Ghazal', 'Boar Clan', 'Hibarnhvidar', "Raven's Point"]
+    return all_towns.find { |town_data| town_data.split.first.casecmp(town_arg).zero? }
   end
 
   def validate_requirements(args) # warnings and errors for items you may be missing
@@ -221,9 +219,7 @@ class Trade
     echo "find_closest_id" if debugging?
     rooms = @town_data.to_h.values.select { |data| data[entity] }
                       .map { |data| data[entity]['id'] }
-    echo "rooms: #{rooms}" if debugging?
     result = sort_destinations(rooms)
-    echo "sorted rooms #{rooms}" if debugging?
     if need_business
       result.find do |data|
         echo "data in room search is #{data}" if debugging?
@@ -235,12 +231,32 @@ class Trade
   end
 
   def setup_town_data # builds @trading_towns from town_data and will later handle multiple provinces
-    zoluren_towns = { 'Wolf Clan' => 2, 'Tiger Clan' => 2, 'Crossing' => 2, 'Arthe Dale' => 2, 'Stone Clan' => 2, 'Dirge' => 2, 'Leth Deriel' => 3 }
-    @trading_towns = {}
-    zoluren_towns.each do |town_name, threshold|
+    case find_province
+    when 'Zoluren'
+      province_towns = { 'Wolf Clan' => 2, 'Tiger Clan' => 2, 'Crossing' => 2, 'Arthe Dale' => 2, 'Stone Clan' => 2, 'Dirge' => 2, 'Leth Deriel' => 3 }
+      @hub_city = 'Crossing'
+    when 'Ilithi'
+      province_towns = { 'Shard' => 3, 'Steelclaw Clan' => 3, "Fayrin's Rest" => 3, 'Darkling Wood' => 3 }
+      @hub_city = 'Shard'
+    when 'Forfedhar'
+      province_towns = { 'Hibarnhvidar' => 3, 'Boar Clan' => 3, "Raven's Point" => 3, 'Ain Ghazal' => 3 }
+      @hub_city = 'Hibarnhvidar'
+    end
+    province_towns.each do |town_name, threshold|
       @trading_towns[town_name] = @town_data[town_name]
       @trading_towns[town_name]['contracts_to'] = @trading_towns[town_name]['contracts_from'] = 0
       @trading_towns[town_name]['contract_threshold'] = threshold
+    end
+  end
+
+  def find_province
+    case find_town(find_closest_id('trader_outpost'))
+    when 'Wolf Clan', 'Tiger Clan', 'Crossing', 'Arthe Dale', 'Stone Clan', 'Dirge', 'Leth Deriel'
+      'Zoluren'
+    when 'Shard', "Fayrin's Rest", 'Steelclaw Clan', 'Darkling Wood'
+      'Ilithi'
+    when 'Ain Ghazal', 'Boar Clan', 'Hibarnhvidar', "Raven's Point"
+      'Forfedhar'
     end
   end
 
@@ -293,11 +309,18 @@ class Trade
     end
   end
 
+  def town_lead_name(town_name) # very different parsing for some town names
+      town_map = {'Leth Deriel' => 'Leth', 'Darkling Wood' => 'Darkling', "Raven's Point" => 'Raven' }
+      town_map[town_name] ? town_map[town_name] : town_name
+  end
+
   def do_lead_from # you must escape the gravity of certain towns for your caravan to break orbit and lead you away
     echo "do_lead_from" if debugging?
     return unless @caravan.noun == 'caravan'
     nearest_town = find_town(find_closest_id('trader_outpost'))
     destination_town = find_town(@current_caravan_destination)
+    echo "destination is #{destination_town}" if debugging?
+    echo "nearest_town is #{nearest_town}" if debugging?
     return if nearest_town == destination_town
 
     case nearest_town
@@ -309,15 +332,44 @@ class Trade
       take_caravan_to(895) # walk it across the Ferry, then proceed.
     when 'Wolf Clan', 'Tiger Clan'
       take_caravan_to(863) unless destination_town == 'Wolf Clan' || destination_town == 'Tiger Clan' # no leading around the western clans
+    when 'Darkling Wood'
+      take_caravan_to(2663)
+    when 'Shard'
+      take_caravan_to(2780)
+    when 'Boar Clan'
+      lead_caravan_to?('Hibarnhvidar')
+    when 'Ain Ghazal'
+      if destination_town == 'Boar Clan'
+        take_caravan_to(3986) unless lead_caravan_to?('Hibarnhvidar')
+      else
+        take_caravan_to(3986) unless lead_caravan_to?(destination_town)
+      end
+    when "Raven's Point"
+      if destination_town == 'Boar Clan'
+        take_caravan_to(4452) unless lead_caravan_to?('Hibarnhvidar')
+      else
+        take_caravan_to(4452) unless lead_caravan_to?(destination_town)
+      end
+    when 'Hibarnhvidar'
+      if destination_town == 'Boar Clan'
+        unless lead_caravan_to?('Boar Clan')
+          lead_caravan_to?('Hibarnhvidar')
+          take_caravan_to(3991)
+        end
+      else
+        take_caravan_to(3943) unless lead_caravan_to?(destination_town)
+      end
     end
   end
 
   def do_lead_to # handles final lead-to approach to certain towns AFTER escaping do_lead_from
     echo "do_lead_to #{@current_caravan_destination}" if debugging?
     return unless @caravan.noun == 'caravan'
-    no_lead_towns = ['Tiger Clan', 'Wolf Clan']
+    no_lead_towns = ['Tiger Clan', 'Wolf Clan', "Fayrin's Rest", 'Steelclaw Clan']
     destination_town = find_town(@current_caravan_destination)
     nearest_town = find_town(find_closest_id('trader_outpost'))
+    echo "destination is #{destination_town}" if debugging?
+    echo "nearest_town is #{nearest_town}" if debugging?
     return if no_lead_towns.include?(nearest_town)
 
     case destination_town
@@ -325,11 +377,24 @@ class Trade
       lead_caravan_to?('Crossing') # driver can only take you as far as Crossing
     when 'Leth Deriel'
       if nearest_town == 'Leth Deriel'
-        lead_caravan_to?('Leth Deriel') # if already on the south bank (startup mid run), just try leading there first
+        lead_caravan_to?(destination_town) # if already on the south bank (startup mid run), just try leading there first
       else
         lead_caravan_to?('Crossing') # otherwise go to crossing,
         take_caravan_to(1904) # then to the ferry
-        lead_caravan_to?('Leth Deriel') # then to Leth
+        lead_caravan_to?(destination_town) # then to Leth
+      end
+    when 'Boar Clan'
+      if ["Raven's Point", 'Ain Ghazal'].include?(nearest_town)
+        take_caravan_to(3943) unless lead_caravan_to?('Hibarnhvidar')
+        take_caravan_to(3991)
+        lead_caravan_to?('Boar Clan')
+      elsif nearest_town == 'Boar Clan'
+        lead_caravan_to?(destination_town)
+      end
+    when "Raven's Point", 'Ain Ghazal'
+      if nearest_town == 'Hibarnhvidar'
+        take_caravan_to(3943) unless lead_caravan_to?(destination_town)
+        lead_caravan_to?(destination_town) unless find_town(find_closest_id('trader_outpost')) == destination_town
       end
     else
       lead_caravan_to?(destination_town)
@@ -340,7 +405,7 @@ class Trade
     track_caravan
     return true if Room.current.id == outpost_from_name(town_name)
     @caravan_being_led = true
-    return false unless command_caravan?("lead to #{town_name}")
+    return false unless command_caravan?("lead to #{town_lead_name(town_name)}")
     be_inside_caravan
 
     until Flags['lead-arrived'] || Flags['lead-failed'] # main wait loop while training happens
@@ -363,7 +428,7 @@ class Trade
   def be_inside_caravan # call whenever you need to be inside the caravan
     return unless @caravan_interior
     return unless @caravan_being_led
-    return if ["Interior", "Hodierna", "Kertigen", "Ferry", "South Bank", "Gondola", "Platform"].any? { |name| XMLData.room_title.include?(name) } # Don't do this on ferrys - you can't tell when you've arrived.
+    return if @no_ride_rooms.any? { |name| XMLData.room_title.include?(name) } # Don't do this on ferrys - you can't tell when you've arrived.
     track_caravan
     bput('go caravan', 'You open the door')
     pause 1.5
@@ -426,7 +491,7 @@ class Trade
   end
 
   def find_town(room_id) # takes a room_id and returns a town_name if find_value? finds it in a town's data.
-    return @trading_towns.find { |name, data| find_value?(data, room_id) }.first
+    return @town_data.to_h.find { |name, data| find_value?(data, room_id) }.first.to_s
   end
 
   def find_value?(towninfo, room_id)
@@ -516,7 +581,7 @@ class Trade
 
   def forage_grass # periodically forages for grass if below 70
     return if @current_grass_count > 70 || @training_token
-    return if ['Crossing', 'Lava', 'Dirge'].any? { |roomcheck| XMLData.room_title.include?(roomcheck) }
+    return if ['Crossing', 'Lava', 'Dirge', 'Ghazal'].any? { |roomcheck| XMLData.room_title.include?(roomcheck) }
     return unless @step_toggle > 1
     @cooldown_timers['Grass'] ||= Time.now - 10
     return if Time.now - @cooldown_timers['Grass'] < 10
@@ -557,22 +622,31 @@ class Trade
   end
 
   def handle_special_room?(dir) # handles very specific rooms (bescort rooms currently) - allows training on ferries.
-  ### Note: Needs an entry for the Shard gondola eventually.  Bescort will jump two rooms ahead and leave the caravan behind.
     case dir
     when StringProc
-      if dir.inspect.include?("ferry', 'crossing'")
-        ferry_run('crossing')
-        return true
-      elsif dir.inspect.include?("ferry', 'leth'")
-        ferry_run('leth')
+      if dir.inspect.include?("ferry.?'")
+        ferry_run
         return true
       elsif dir.inspect.include?("'gondola'")
         ride_gondola
         return true
+      elsif dir.inspect.include?('iceroad')
+        run_iceroad
+        return true
+     # elsif Room.current.id == 4056 # There's a weird room that normally you won't run into
       end
     else
       return false
     end
+  end
+
+  def run_iceroad
+    echo "DOESN'T SUPPORT THE ICEROAD ATM.  YOU SHOULD HAVE BEEN LED THROUGH HERE"
+    exit
+    #case Room.current.id
+    #when 4430 #shardside
+    #when 4366 #hibside
+    #end
   end
 
   def ride_gondola
@@ -607,14 +681,30 @@ class Trade
     @caravan_being_led = false
   end
 
-  def ferry_run(town) # Crossing-Leth Fery
+  def ferry_run
     echo "ferry_run #{town}" if debugging?
+    case Room.current.id
+    when 3986
+      town = 'hibarnhvidar'
+      mode = 'ferry1'
+    when 11027
+      town = 'ainghazal'
+      mode = 'ferry1'
+    when 1904
+      town = 'crossing'
+      mode = 'ferry'
+    when 957
+      town = 'leth'
+      mode = 'ferry'
+    end
+
     walk_training_cleanup
-    start_script('bescort', ['ferry', town])
+    start_script('bescort', [mode, town])
     @caravan_being_led = true
     wipe_skill('Outdoorsmanship', @lead_training_skills)
     wipe_skill('Perception', @lead_training_skills)
     until !Script.running?('bescort')
+      Flags.reset('caravan-arrived') if Flags['caravan-arrived']
       pause 1.5
       lead_training
     end
@@ -685,10 +775,9 @@ class Trade
       ]
       lead_fail = [
         'but turns back and says',
-        'The driver of the sturdy caravan looks at you confused and says'
+        "The driver of the .* looks at you confused and says"
       ]
-      result = bput("tell #{@caravan.noun} to #{command}", lead_success + lead_fail)
-      lead_fail.include?(result) ? false : true
+      bput("tell #{@caravan.noun} to #{command}", lead_success + lead_fail) == 'You pass on the order to lead to your driver' ? true : false
     else
       false
     end
@@ -696,7 +785,6 @@ class Trade
 
   def should_go_to_town?(town_name) # is there any reason at all to visit this town's outpost?
     if @closeup
-      echo "closeup #{town_name} and #{@trading_towns[town_name]['contracts_to']}" if debugging?
       return true if @trading_towns[town_name]['contracts_to'] > 0
     else
       return true if @trading_towns[town_name]['contracts_to'] > 0 || @trading_towns[town_name]['contracts_from'].zero?
@@ -719,7 +807,9 @@ class Trade
     when /The minister reminds you/
       /The minister reminds you that you still owe (?<dues_amt>.*) (?<dues_currency>Kronars|Lirums|Dokoras) in dues to (?:The )?(?<outpost>.*) and asks that you pay the clerk before s?he issues you a new contract\./ =~ response
       echo "Need to pay #{dues_amt} #{dues_currency} to #{outpost}" if debugging?
+      room = Room.current.id
       ensure_copper_on_hand(dues_amt.to_i, @settings)
+      walk_to(room)
       pay_dues
       get_contract
     when /You still have another contract/
@@ -749,7 +839,7 @@ class Trade
     end
   end
 
-  def pay_dues # TODO: Handle Missing DUES
+  def pay_dues
     clerk_id = find_closest_id('shipment_clerk')
     echo "Paying dues at clerk_room: #{clerk_id}" if debugging?
     clerk_messages = [
@@ -812,13 +902,13 @@ class Trade
   end
 
   def caravan_exists?
+    recall_caravan? unless @caravan.adjective && @caravan.noun
     return recall_caravan? unless @caravan.adjective && @caravan.noun
     true
   end
 
   def dump_expired # checks for expired contracts, and gets rid of them and the matching crate. TODO: recheck contracts before tossing them.  Hasn't broken yet, but...
     return unless @held_contracts
-    echo @held_contracts if debugging?
     @held_contracts.each_with_index do |contract, index|
       if contract['expired']
         find_crates(contract.origin_town)
@@ -1338,7 +1428,6 @@ class Trade
 
   def buy_wood(skipcoin = false)
     be_outside_caravan
-    room = Room.current.id
     crafting_data = get_data('crafting')
     stow_hands
     ensure_copper_on_hand(3000, @settings) unless skipcoin
@@ -1348,12 +1437,10 @@ class Trade
     @current_lumber_count = bput('count my balsa lumber', 'You count out \d+').scan(/\d+/).first.to_i
     buy_wood(true) if @current_lumber_count < @lumber_quantity
     stow_hands
-    walk_to(room)
   end
 
   def buy_yarn(skipcoin = false)
     be_outside_caravan
-    room = Room.current.id
     crafting_data = get_data('crafting')
     stow_hands
     ensure_copper_on_hand(3000, @settings) unless skipcoin
@@ -1363,7 +1450,6 @@ class Trade
     @current_yarn_count = bput('count my wool yarn', 'You count out \d+ yards').scan(/\d+/).first.to_i
     buy_yarn(true) if @current_yarn_count < @yarn_quantity
     stow_hands
-    walk_to(room)
   end
 
   def get_item(item)
@@ -1576,8 +1662,10 @@ class Trade
   def hometown_business # run every time it delivers/picks up a contract from Crossing/another hub. Replenishes resources and stocks coins
     return unless find_town(find_closest_id('trader_outpost')) == @hub_city
     deposit_coins(@caravan_coins_on_hand, Room.current.id)
+    room = Room.current.id
     check_yarn
     check_wood
+    walk_to(room)
     count_grass
     repair_tools
     restocked_restore

--- a/trade.lic
+++ b/trade.lic
@@ -119,6 +119,9 @@ class Trade
     end
     @settings.storage_containers.each { |container| fput("open my #{container}") }
     @box = nil unless exists?(@box)
+    unless exists?('zills')
+      wipe_skill('Performance', @walk_training_skills)
+    end
   end
 
   def start_up # should parse contracts, check mats, handle expireds, get the caravan to a useful outpost, deliver any contracts, then begin the loop.
@@ -152,7 +155,7 @@ class Trade
     track_caravan
     take_caravan_to(find_closest_id('trader_outpost'))
     walk_to(find_closest_id('shipment_clerk'))
-    fput('return caravan')
+    fput("return #{@caravan.noun}")
     fput('exit') if @exit
     exit
   end
@@ -259,6 +262,7 @@ class Trade
 
   def do_lead_from # you must escape the gravity of certain towns for your caravan to break orbit and lead you away
     echo "do_lead_from" if debugging?
+    return unless @caravan.noun == 'caravan' 
     nearest_town = find_town(find_closest_id('trader_outpost'))
     destination_town = find_town(@current_caravan_destination)
     return if nearest_town == destination_town
@@ -277,6 +281,7 @@ class Trade
 
   def do_lead_to # handles final lead-to approach to certain towns AFTER escaping do_lead_from
     echo "do_lead_to #{@current_caravan_destination}" if debugging?
+    return unless @caravan.noun == 'caravan' 
     no_lead_towns = ['Tiger Clan', 'Wolf Clan']
     destination_town = find_town(@current_caravan_destination)
     nearest_town = find_town(find_closest_id('trader_outpost'))
@@ -595,7 +600,8 @@ class Trade
       return true
     when 'wait'
       wait_messages = [
-        'You pass on the order to wait to your driver, who makes sure your .* does your bidding'
+        'You pass on the order to wait to your driver, who makes sure your .* does your bidding',
+        'You grab hold of your .* harness and make it wait.'        
       ]
       bput("tell #{@caravan.noun} to wait", wait_messages)
       return true
@@ -609,6 +615,8 @@ class Trade
       ]
       result = bput("tell #{@caravan.noun} to #{command}", lead_success + lead_fail)
       lead_fail.include?(result) ? false : true
+    else
+      false
     end
   end
 
@@ -750,7 +758,7 @@ class Trade
 
   def find_crates(origin_town) # handles finding the crate that matches the expired contract.
     echo "find_crates from #{origin_town}" if debugging?
-    result = DRC.bput("look #{@caravan.adjective.split.first} #{@caravan.noun}", 'You tell the driver', 'I could not find', 'There is nothing')
+    result = DRC.bput("look #{@caravan.adjective.split.first} #{@caravan.noun}", 'You tell the driver', 'I could not find', 'There is nothing', 'You carefully go over')
     text = reget(10)
     text.delete_if { |item| !item.include?('sturdy crate') }
     text.each_with_index do |crate, index|
@@ -768,7 +776,10 @@ class Trade
     bput('get my contract', 'You get', 'You are already holding that')
     Flags.add('caravan-upgrade', /Unfortunately, this load would kill/)
     bput('give my contract to clerk', /The .* clerk accepts your contract and peruses it\./)
-    recall_caravan? if Flags['caravan-upgrade'] # Doesn't do anything yet.
+    if Flags['caravan-upgrade']
+      bput('rent caravan', 'You want to upgrade from a')
+      recall_caravan?
+    end
     bput("put my contract in my #{@contract_container}", 'You put')
     Flags.delete('caravan-upgrade')
   end
@@ -1461,6 +1472,7 @@ end
 before_dying do
   Flags.delete('trading-magic-ready')
   Flags.delete('caravan-arrived')
+  Flags.delete('caravan-upgrade')
   Flags.delete('lead-arrived')
   Flags.delete('lead-failed')
   Flags.delete('lockbox-done')

--- a/trade.lic
+++ b/trade.lic
@@ -520,8 +520,10 @@ class Trade
     return unless @step_toggle > 1
     @cooldown_timers['Grass'] ||= Time.now - 10
     return if Time.now - @cooldown_timers['Grass'] < 10
-    bput('put my grass in my feedbag', 'You put', 'What were you') if forage?('grass')
-    @current_grass_count += 6
+    if forage?('grass')
+      bput('put my grass in my feedbag', 'You put', 'What were you')
+      @current_grass_count += 6
+    end
     restore_skill('Mechanical Lore', @caravan_training_skills['Mechanical Lore'], @walk_training_skills) if @current_grass_count > 50 && @caravan_training_skills.include?('Mechanical Lore') && !@walk_training_skills.include?('Mechanical Lore')
     @cooldown_timers['Grass'] = Time.now
     @step_toggle = 0

--- a/trade.lic
+++ b/trade.lic
@@ -810,6 +810,7 @@ class Trade
   def find_crates(origin_town) # handles finding the crate that matches the expired contract.
     echo "find_crates from #{origin_town}" if debugging?
     result = DRC.bput("look #{@caravan.adjective.split.first} #{@caravan.noun}", 'You tell the driver', 'I could not find', 'There is nothing', 'You carefully go over')
+    pause 1
     text = reget(10)
     text.delete_if { |item| !item.include?('sturdy crate') }
     text.each_with_index do |crate, index|
@@ -1023,6 +1024,7 @@ class Trade
     echo "training_cleanup" if debugging?
     magic_cleanup
     performance_cleanup
+    mechlore_cleanup
     wipe_token
     @step_toggle = -1
   end
@@ -1030,12 +1032,16 @@ class Trade
   def select_ability(training_skills) # selects a skill from the pool and returns it for @training_token - each skill routine can know what tokens it's compatible with.
     echo "select_ability" if debugging?
 
-    ability = training_skills.sort_by { |skill, _cooldown| DRSkill.getxp(skill) }
-                                .find { |skill, cooldown| check_ability?(skill, cooldown) }.first
+    ability = next_to_train(training_skills)
 
     echo("Selected: #{ability}") if ability && debugging?
     @cooldown_timers[ability] = Time.now
     ability
+  end
+  
+  def next_to_train(skill_list)
+    return skill_list.sort_by { |skill, _cooldown| DRSkill.getxp(skill) }
+                          .find { |skill, cooldown| check_ability?(skill, cooldown) }.first
   end
 
   def check_ability?(skill, cooldown) # stolen from combat-trainer. Skill cooldowns and other timing related data stored in @cooldown_timers
@@ -1179,12 +1185,20 @@ class Trade
       return wipe_skill('Mechanical Lore', @walk_training_skills) 
     end
     return unless @caravan_being_led || @step_toggle > 1
-    be_inside_caravan # if @caravan_being_led
-    bput('get my braided grass', 'You get', 'What were you')
-    bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long') if braid?('grass')
-    drop_grass
-    wipe_token
+    be_inside_caravan
+    bput('get my braided grass', 'You get', 'What were you', 'You are already') unless right_hand.include?('grass') || left_hand.include?('grass')
+    if braid?('grass') && next_to_train(@walk_training_skills) != 'Mechanical Lore'
+      bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long')
+      drop_grass
+    end
+
+    wipe_token unless next_to_train(@walk_training_skills) == 'Mechanical Lore'
     @step_toggle = @step_toggle == 100 ? 2 : 0
+  end
+  
+  def mechlore_cleanup
+    bput('stow my grass', 'You put', 'What were you', 'The braided grass is too long') if right_hand.include?('grass') || left_hand.include?('grass')
+    drop_grass
   end
 
   def drop_grass

--- a/validate.lic
+++ b/validate.lic
@@ -715,7 +715,6 @@ class DRYamlValidator
   
   def assert_that_caravan_training_skills_are_valid(settings)
     return unless settings.caravan_training_skills.empty?
-    valid_caravan_skills = ['Augmentation', 'Utility', 'Warding', 'Attunement', 'Performance', 'Appraisal', 'Mechanical Lore',]
     settings.caravan_training_skills
             .reject { |_skill, cooldown| cooldown.is_a?(Integer) }
             .each { |skill, cooldown| error("caravan_training_skills has an invalid cooldown at skill: '#{skill}'") }

--- a/validate.lic
+++ b/validate.lic
@@ -712,6 +712,22 @@ class DRYamlValidator
       warn("#{list} contains the following spell names not found in data/base_spells, #{name_warnings} Check spelling and capitalization.") unless name_warnings.empty?
     end
   end
+  
+  def assert_that_caravan_training_skills_are_valid(settings)
+    return unless settings.caravan_training_skills
+    valid_caravan_skills = ['Augmentation', 'Utility', 'Warding', 'Attunement', 'Performance', 'Appraisal', 'Mechanical Lore',]
+    settings.caravan_training_skills
+            .reject { |_skill, cooldown| cooldown.is_a?(Integer) }
+            .each { |skill, cooldown| error("caravan_training_skills has an invalid cooldown at skill: '#{skill}'") }
+
+    settings.caravan_training_skills.reject { |skill, _cooldown| @valid_caravan_skills.include?(skill) }
+            .each { |skill, _cooldown| error("caravan_training_skills: skills not recognized as valid skills '#{skill}'") }
+
+    settings.caravan_training_skills.select { |skill, _cooldown| %w[Augmentation Utility Warding].include?(skill) }
+                                    .reject { |skill, _cooldown| settings.crafting_training_spells.keys.include?(skill) }
+                                    .each { |skill, _cooldown| error("caravan_training_skills: #{skill} is included, but no corresponding spell in crafting_training_spells!") }
+
+  end
 
   private
 
@@ -737,6 +753,9 @@ class DRYamlValidator
     @valid_summon_skills = @valid_thrown_skills + @valid_melee_skills - ['Offhand Weapon', 'Brawling']
     @valid_research_skills = ['Arcana', 'Life Magic', 'Holy Magic', 'Lunar Magic', 'Elemental Magic', 'Arcane Magic', 'Attunement', 'Warding', 'Augmentation', 'Utility']
     @valid_defensive_skills = ['Shield Usage', 'Parry Ability', 'Evasion']
+    @valid_caravan_skills = ['Attunement', 'Warding', 'Augmentation', 'Utility', 'Scholarship', 'Appraisal',
+                             'Perception', 'Locksmithing', 'First Aid', 'Outfitting', 'Engineering',
+                             'Performance', 'Outdoorsmanship', 'Mechanical Lore']
 
     @all_skills = ['Scouting', 'Evasion', 'Athletics', 'Stealth', 'Perception', 'Locksmithing', 'First Aid', 'Skinning',
                    'Outdoorsmanship', 'Thievery', 'Backstab', 'Thanatology', 'Forging', 'Outfitting', 'Engineering',

--- a/validate.lic
+++ b/validate.lic
@@ -714,7 +714,7 @@ class DRYamlValidator
   end
   
   def assert_that_caravan_training_skills_are_valid(settings)
-    return unless settings.caravan_training_skills
+    return unless settings.caravan_training_skills.empty?
     valid_caravan_skills = ['Augmentation', 'Utility', 'Warding', 'Attunement', 'Performance', 'Appraisal', 'Mechanical Lore',]
     settings.caravan_training_skills
             .reject { |_skill, cooldown| cooldown.is_a?(Integer) }


### PR DESCRIPTION
And now for the huge, time-consuming update literally twos of people were asking for.

Previously ;trade went to an outpost, got a contract, then drove to that destination outpost, got another one, rinse and repeat.  This uses those methods to expand that, but it still only runs in Zoluren.  More to come.

Changes:
- Now goes around Zoluren visiting the closest nearest outpost it can either get a contract from or deliver a contract to. It only visits an outpost if it has business there, but it will accumulate multiple contracts in the process.
- Uses LEAD TO functions to train larger RT skills on the road.  If caravan_interior: true is set, it'll ride inside when useful.
- If enough contracts pile up, it will lock in on that destination outpost and head towards it, stopping at any useful outpost along the way (Primarily Leth and Dirge)
- ;trade room_id   - takes your caravan to a specified room_id
- ;trade outpost <town> - takes you to the trade outpost at that town
- ;trade closeup   - delivers all current outstanding contracts and returns the caravan to avoid fees.

- ;trade can ALWAYS be started in the field. Scans your contracts on startup, so you can restart after a DC, though you may have to leave the room and jump back in so drinfomon loads up your room_objs. The only requirement is that you start it in the same room as your caravan.
- Trains the following skills atm:
  #DONE WHILE WALKING THE CARAVAN - Only done every other step to avoid increasing travel time at all
  Utility: Uses crafting_training_spells
  Augmentation:  Uses crafting_training_spells
  Warding:  Uses crafting_training_spells
  Performance: Zills
  Appraisal: Runs ;appraisal while being led, or appraises a pouch on your person while walking
  Mechanical Lore: Braids grass from your feedbag - feedbag automatically filled up over time
  Attunement:  PERC MANAs while walking 

  #ONLY WHILE BEING LED ON A TRADE ROUTE OR INSIDE THE CARAVAN
  First Aid: Either a compendium or a textbook with textbook: true
  Outfitting:  Knits - need knitting needles - replenishes yarn every time you stop at Crossing up to yarn_quantity
  Engineering:  Shapes - needs shaping tools and lumber_quantity - replenishes each time you stop at Crossing
  Outdoorsmanship: Collects rocks while being led or riding in a caravan
  Perception: Collects rocks while being led or riding in a caravan
  Locksmithing: uses ;lockbox if you have those settings set, or pet boxes otherwise.

- offloads coins in excess of your caravan_coins_on_hand limit when stopping for business in Crossing
- Dumps expired contracts and crates.
- Refills feedbags over time
- trains on the Leth/Crossing ferry

Usage:
Rent a caravan, then run ;trade in the room with it. When you're done, kill ;trade and run ;trade closeup.
