### PR TITLE
Add exit and catch for locked box

### DIFF
--- a/lockbox.lic
+++ b/lockbox.lic
@@ -32,6 +32,7 @@ class Lockbox
       case bput("get my #{@box}", "You get a", 'What were')
       when 'What were'
         echo('Lockbox not found, exiting.')
+        exit
       end
     end
     while DRSkill.getxp('Locksmithing') < 34
@@ -54,7 +55,7 @@ class Lockbox
   def cleanup
     if @worn_lockbox
       bput("pick my #{@box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm')
-      bput("open my #{@box}", 'You open')
+      bput("open my #{@box}", 'You open', 'It is locked')
       bput("wear my #{@box}", 'You put')
     else
       @equipment_manager.empty_hands


### PR DESCRIPTION
There wasn't an 'exit' if it couldn't find a lockbox.  Also added a single bput match.