### PR TITLE
Update definition of @gear_sets to flatten the gear list array

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -15,7 +15,7 @@ class EquipmentManager
   def items(settings = nil)
     return @items if @items
     settings ||= get_settings
-    @gear_sets = settings.gear_sets.each { | set_name, gear_list | @gear_sets[set_name] = gear_list.flatten.uniq }
+    @gear_sets = settings.gear_sets.each { | set_name, gear_list | @gear_sets[set_name] = gear_list.flatten!.uniq! }
     @sort_head = settings.sort_auto_head
     @items = settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound], wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text], lodges: item[:lodges], skip_repair: item[:skip_repair]) }
   end

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -15,7 +15,7 @@ class EquipmentManager
   def items(settings = nil)
     return @items if @items
     settings ||= get_settings
-    @gear_sets = settings.gear_sets
+    @gear_sets = settings.gear_sets.each { | set_name, gear_list | @gear_sets[set_name] = gear_list.flatten.uniq }
     @sort_head = settings.sort_auto_head
     @items = settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound], wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text], lodges: item[:lodges], skip_repair: item[:skip_repair]) }
   end


### PR DESCRIPTION
I would like to introduce this change to equipmanager to allow the use of anchors and references within gear_sets. For example, the following configuration allows cascading changes to each script with its own gear set. The flatten is harmless to existing configuration.
```
gear_sets:
  armor: &armor
  - quilted pants
  - quilted shirt
  - quilted gloves
  - quilted hood
  bow: &bow
  - battle longbow
  shield: &shield
  - target shield
  parry_stick: &parry_stick
  - parry stick
  brawling: &brawling
  - brass knuckles
  - elbow spikes
  standard: [ *armor, *bow, *shield, *brawling, *parry_stick ]
  stealing: [ *bow,  *parry_stick, *brawling ]
  nothing: []
```

Secondly, I see this as enabling the development of a manual equip/unequip gear set feature, which is convenient for interactive game play without needing to write separate scripts. (Forgive me if this exists, I haven't been able to find it but am new to Lich/dr-scripts.)