### PR TITLE
herb-stock coin withdraw adjustment

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3670,7 +3670,6 @@ end
 before_dying do
   DRCA.release_cyclics
   DRCA.shatter_regalia?
-  fput('close fissure') if DRStats.warrior_mage? && DRRoom.room_objs.any? { |x| /fissure/ =~x }
   Flags.delete('using-corpse')
   Flags.delete('pouch-full')
   Flags.delete('container-full')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3670,6 +3670,7 @@ end
 before_dying do
   DRCA.release_cyclics
   DRCA.shatter_regalia?
+  fput('close fissure') if DRStats.warrior_mage? && DRRoom.room_objs.any? { |x| /fissure/ =~x }
   Flags.delete('using-corpse')
   Flags.delete('pouch-full')
   Flags.delete('container-full')

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -33,7 +33,8 @@ class Herbstock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-    get_money_from_specific_bank?("#{coin_needed} copper #{town_currency(town)}", town) if coin_needed > 0
+    get_money_from_specific_bank?("#{coin_needed/1000} gold #{town_currency(town)}", town) if coin_needed > 0
+    get_money_from_specific_bank?("#{coin_needed%1000} copper #{town_currency(town)}", town) if coin_needed > 0
     items_to_restock.each do |item|
       item['buy_num'].times do
         stow_hands


### PR DESCRIPTION
To keep herb-stock from getting too many copper coins, now gold will be used when possible.