### PR TITLE
combat-trainer.lic: Remove bob from whirlwind actions

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3266,7 +3266,7 @@ class GameState
       'whirlwind'
     else
       action_reduce if npcs.length > 2
-      %w[jab bob feint].sample
+      %w[jab feint].sample
     end
   end
 


### PR DESCRIPTION
With the new rested exp, some people want to minimize tactics training to conserve rested exp.