### PR TITLE
Slightly expand sew resume knitting

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -201,12 +201,12 @@ class Sew
   end
 
   def resume_knit
-    bput("analyze my knitting needles",
+    bput('analyze my knitting needles',
          /You analyze both the needles and an? unfinished knitted .+ (.+) on them/,
          'This appears to be a crafting tool',
          'Roundtime')
     pause 1
-    results = reget(20)
+    results = reget(40)
     unless results.to_s =~ /You analyze both the needles and an? unfinished knitted .+ (.+) on them/
       echo "Nothing found on the needles.  Exiting"
       exit


### PR DESCRIPTION
;sew resume on knitted needles generates so much absurd scroll that on a couple occasions 20 lines of reget was just not quite enough.  Expanding it to 40.