### PR TITLE
Use leather shield handle for leather shields

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -1255,6 +1255,10 @@ recipe_parts:
     Boar Clan: 
       part-room: 8892 # Hibarnhvidar
       part-number: 
+  leather shield handle:
+    Crossing:
+      part-room: 16667
+      part-number: 16
   shield handle:
     Crossing:
       part-room: 8776

--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -3035,7 +3035,7 @@ crafting_recipes:
   work_order: false
   chapter: 10
   part:
-  - shield handle
+  - leather shield handle
   - long cord
 - name: leather oval shield
   noun: shield


### PR DESCRIPTION
The other shield handle item refers to metal shield
handle and doesn't work with leather shields.

I noticed this when restock-shop broke when trying to restock gryphon shields

Staging this for review, there are other leather shields which need the switch. Ill give a mention when its ready.