### PR TITLE
Fix sniping in combat-trainer for non-lodging ammo

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2649,11 +2649,9 @@ class AttackProcess
   end
 
   def shoot_aimed(command, game_state)
-    case bput(command, 'isn\'t loaded', 'There is nothing', 'But your', /you (fire|poach|snipe) an? (?:.*\s)?(arrow|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto) at/i, 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'your moving to fire went unobserved', 'notices your attempt to remain hidden', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
-    when /How can you (poach|snipe)/, 'notices your attempt to remain hidden'
+    case bput(command, 'isn\'t loaded', 'There is nothing', 'But your', /you (fire|poach|snipe) an? (?:.*\s)?(arrow|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto) at/i, 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
+    when /How can you (poach|snipe)/
       shoot_aimed('shoot', game_state)
-    when 'your moving to fire went unobserved'
-      game_state.action_taken
     when /you (fire|poach|snipe) an? (?:.*\s)?(arrow|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto) at/i
       game_state.action_taken
       ammo = Regexp.last_match(2)


### PR DESCRIPTION
After the ammo-lands-at-foot patch, sniping doesn't enter the right WHEN in shoot_aimed, so it doesn't pick up fired ammo.  Instead, it enters the 'your moving to fire went unseen' or 'notices your attempt to remain hidden' WHENs, which don't do anything about the ammo.

However, the new WHEN we added does everything we wanted it to do when sniping in the first place, so testing suggests we should just remove it.

If someone stealthier has an opinion on special behavior we should have during sniping then I'm all ears, but at the moment this fixes it so that it will hide, snipe, then stow ammo.