### PR TITLE
base-hunting - Fixed the warcat discipline requirement

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -186,14 +186,14 @@ hunting_areas_by_town:
     - swamp_troll_riverhaven
   #https://elanthipedia.play.net/Orc_scout                              160-220?
   #https://elanthipedia.play.net/Vicious_Warcat
-  # warcats calm, need 135 disc
+  # warcats calm, need 35 disc
   # 19097 - Unmappable room
   # Hit or miss spawns, boxes and skins
     - orc_scouts
   # https://elanthipedia.play.net/Hulking_black_barghest                 210-290
     - hulking_black_barghest_riverhaven
   # https://elanthipedia.play.net/Orc_Bandit                             180-317
-  # warcats calm, need 135 disc
+  # warcats calm, need 35 disc
   # Hit or miss spawn, boxes and skins
     - orc_bandits
   # https://elanthipedia.play.net/Baby_forest_gryphon                    250-350
@@ -209,7 +209,7 @@ hunting_areas_by_town:
   # Occasional wandering Maelshyvean_shadow_beast
     - dusky_basilisk
   # https://elanthipedia.play.net/Orc_reiver                             280-350
-  # warcats calm, need 135 disc
+  # warcats calm, need 35 disc
   # Great swarm, boxes and skins
     - orc_reivers
   # https://elanthipedia.play.net/Bristle-backed_peccary                 280-405
@@ -1288,7 +1288,7 @@ hunting_zones:
   - 13918
   #https://elanthipedia.play.net/Orc_scout                              160-220?
   #https://elanthipedia.play.net/Vicious_Warcat
-  # warcats calm, need 135 disc
+  # warcats calm, need 35 disc
   # 19097 - Unmappable room
   # Hit or miss spawns, boxes and skins
   orc_scouts:
@@ -1326,7 +1326,7 @@ hunting_zones:
   - 3046
   - 3043
   # https://elanthipedia.play.net/Orc_Bandit                             180-317
-  # warcats calm, need 135 disc
+  # warcats calm, need 35 disc
   # Hit or miss spawn, boxes and skins
   orc_bandits:
   - 8634
@@ -1395,7 +1395,7 @@ hunting_zones:
   - 12121
   - 12122
   # https://elanthipedia.play.net/Orc_reiver                             280-350
-  # warcats calm, need 135 disc
+  # warcats calm, need 35 disc
   # Great swarm, boxes and skins
   orc_reivers:
   - 8694


### PR DESCRIPTION
It was listed as 135 discipline when it should be 35.