### PR TITLE
sanowret-crystal.lic - added option for adjective

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -14,6 +14,7 @@ class SanowretCrystal
     @invalid_rooms = []
     @worn_crystal = false
     args = parse_args(arg_definitions)
+    @noun = args.sanowret_noun ? args.sanowret_noun : 'sanowret'
     @no_use_scripts = get_settings.sanowret_no_use_scripts
     check_crystal if args.run && !hiding? && !invisible?
     passive unless args.run
@@ -25,9 +26,9 @@ class SanowretCrystal
     return if XMLData.room_title.include? 'Carousel Chamber'
 
     if DRSkill.getxp('Arcana') <= 10 && @worn_crystal
-      response = DRC.bput('gaze my sanowret crystal', /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.', 'That would be difficult to do while you attempt to keep the trail in sight.')
+      response = DRC.bput("gaze my #{@noun} crystal", /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     elsif DRSkill.getxp('Arcana') <= 25
-      response = DRC.bput('exhale my sanowret crystal', 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.', 'That would be difficult to do while you attempt to keep the trail in sight.')
+      response = DRC.bput("exhale my #{@noun} crystal", 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     end
 
     return if response !~ /This is not a good place for that\./
@@ -45,17 +46,17 @@ class SanowretCrystal
     if @worn_crystal
       use_crystal
     else
-      case DRC.bput('tap my sanowret crystal', /^You tap (?:a|an) .*sanowret crystal inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal that you are holding.$/, 'I could not find what you were referring to.', 'Not here, ', 'a wave of Corruption magic')
+      case DRC.bput("tap my #{@noun} crystal", /^You tap (?:a|an) .*sanowret crystal inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal that you are holding.$/, 'I could not find what you were referring to.', 'Not here, ', 'a wave of Corruption magic')
       when /You tap (?:a|an) .*sanowret crystal inside your/
-        DRC.bput('get my sanowret crystal', 'You get', 'What were you referring to')
+        DRC.bput("get my #{@noun} crystal", 'You get', 'What were you referring to')
         use_crystal
-        DRC.bput('stow my sanowret crystal', 'You put', 'Stow what')
+        DRC.bput("stow my #{@noun} crystal", 'You put', 'Stow what')
       when /^You tap (?:a|an) .*sanowret crystal.* that you are wearing\.$/
         @worn_crystal = true
         use_crystal
       when /^You tap (?:a|an) .*sanowret crystal that you are holding\.$/
         use_crystal
-        DRC.bput('stow my sanowret crystal', 'You put', 'Stow what')
+        DRC.bput("stow my #{@noun} crystal", 'You put', 'Stow what')
       when /Not here, /, /a wave of Corruption magic/
         echo "Pausing #{Script.current.name} script until you move"
         non_sano_room_id = Room.current.id

--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -14,7 +14,7 @@ class SanowretCrystal
     @invalid_rooms = []
     @worn_crystal = false
     args = parse_args(arg_definitions)
-    @noun = args.sanowret_noun ? args.sanowret_noun : 'sanowret'
+    @adjective = get_settings.sanowret_adjective ? get_settings.sanowret_adjective : 'sanowret'
     @no_use_scripts = get_settings.sanowret_no_use_scripts
     check_crystal if args.run && !hiding? && !invisible?
     passive unless args.run
@@ -26,9 +26,9 @@ class SanowretCrystal
     return if XMLData.room_title.include? 'Carousel Chamber'
 
     if DRSkill.getxp('Arcana') <= 10 && @worn_crystal
-      response = DRC.bput("gaze my #{@noun} crystal", /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.', 'That would be difficult to do while you attempt to keep the trail in sight.')
+      response = DRC.bput("gaze my #{@adjective} crystal", /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     elsif DRSkill.getxp('Arcana') <= 25
-      response = DRC.bput("exhale my #{@noun} crystal", 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.', 'That would be difficult to do while you attempt to keep the trail in sight.')
+      response = DRC.bput("exhale my #{@adjective} crystal", 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     end
 
     return if response !~ /This is not a good place for that\./
@@ -46,17 +46,17 @@ class SanowretCrystal
     if @worn_crystal
       use_crystal
     else
-      case DRC.bput("tap my #{@noun} crystal", /^You tap (?:a|an) .*sanowret crystal inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal that you are holding.$/, 'I could not find what you were referring to.', 'Not here, ', 'a wave of Corruption magic')
+      case DRC.bput("tap my #{@adjective} crystal", /^You tap (?:a|an) .*sanowret crystal inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal that you are holding.$/, 'I could not find what you were referring to.', 'Not here, ', 'a wave of Corruption magic')
       when /You tap (?:a|an) .*sanowret crystal inside your/
-        DRC.bput("get my #{@noun} crystal", 'You get', 'What were you referring to')
+        DRC.bput("get my #{@adjective} crystal", 'You get', 'What were you referring to')
         use_crystal
-        DRC.bput("stow my #{@noun} crystal", 'You put', 'Stow what')
+        DRC.bput("stow my #{@adjective} crystal", 'You put', 'Stow what')
       when /^You tap (?:a|an) .*sanowret crystal.* that you are wearing\.$/
         @worn_crystal = true
         use_crystal
       when /^You tap (?:a|an) .*sanowret crystal that you are holding\.$/
         use_crystal
-        DRC.bput("stow my #{@noun} crystal", 'You put', 'Stow what')
+        DRC.bput("stow my #{@adjective} crystal", 'You put', 'Stow what')
       when /Not here, /, /a wave of Corruption magic/
         echo "Pausing #{Script.current.name} script until you move"
         non_sano_room_id = Room.current.id

--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -14,8 +14,9 @@ class SanowretCrystal
     @invalid_rooms = []
     @worn_crystal = false
     args = parse_args(arg_definitions)
-    @adjective = get_settings.sanowret_adjective ? get_settings.sanowret_adjective : 'sanowret'
-    @no_use_scripts = get_settings.sanowret_no_use_scripts
+    settings = get_settings
+    @adjective = settings.sanowret_adjective
+    @no_use_scripts = settings.sanowret_no_use_scripts
     check_crystal if args.run && !hiding? && !invisible?
     passive unless args.run
   end


### PR DESCRIPTION
I added a new setting sanowret_noun that can be used to specify the noun of your crystal if it's something other than sanowret.

There is no need to use this setting if your crystal responds to 'sanowret crystal', but someone mentioned on lnet last night that it didn't work with their hoarfrost white sanowret crystal.