### PR TITLE
base.yaml - Added sanowret_adjective default

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1163,6 +1163,7 @@ spell_cycle:
 
 restock_shop:
 
+sanowret_adjective: sanowret
 sanowret_no_use_scripts:
 - sew
 - carve


### PR DESCRIPTION
Added sanowret_adjective: sanowret to base.yaml for the new update to sanowret-crystal.lic