### PR TITLE
Smelt metals

### DIFF
--- a/data/base-items.yaml
+++ b/data/base-items.yaml
@@ -156,9 +156,19 @@ scroll_nouns:
 - moldy papyrus
 
 metal_types:
+- steel
+- brass
+- pewter
+- bronze
+- copper
 - covellite
+- iron
 - lead
+- nickel
+- oravir
 - silver
+- tin
+- zinc
 - electrum
 - kadepa
 - muracite

--- a/data/base-items.yaml
+++ b/data/base-items.yaml
@@ -154,3 +154,113 @@ scroll_nouns:
 - seishaka leaf
 - papyrus roll
 - moldy papyrus
+
+metal_types:
+- covellite
+- lead
+- silver
+- electrum
+- kadepa
+- muracite
+- niello
+- niniam
+- orichalcum
+- aldamdin
+- animite
+- audrualm
+- damite
+- darkstone
+- glaes
+- haledroth
+- haralun
+- icesteel
+- indurium
+- kertig
+- kiralan
+- lumium
+- platinum
+- quelium
+- silversteel
+- telothian
+- tyrium
+- vardite
+- yellow gold
+
+stone_types:
+- alabaster
+- andesite
+- basalt
+- breccia
+- dolomite
+- gabbro
+- granite
+- jade
+- limestone
+- marble
+- obsidian
+- onyx
+- pumice
+- quartzite
+- sandstone
+- schist
+- serpentine
+- soapstone
+- travertine
+- anjisis
+- belzune
+- blackwater jet
+- diamondique
+- felstone
+- fulginode
+- senci
+- xenomite
+
+lumber_types:
+- ash #shortbows
+- bamboo # martial
+- durian # martial
+- mahogany # martial
+- mangrove #martial, shortbows
+- maple # longbows
+- sandalwood #composite
+# rare
+- adder # alterations
+- aformosia # alterations
+- albarco # shortbow
+- alerce # alterations
+- avodire # composite
+- azurelle # longbows
+- bloodwood # longbows, shortbows
+- bocote # martial
+- cherry # longbows
+- copperwood # longbows
+- crabwood # martial
+- darkspine	# martial
+- diamondwood # martial
+- dragonwood # alterations
+- e'erdream # ???
+- felwood # martial, shortbows, composite
+- finivire # all bows
+- glitvire # ???
+- gloomwood # ???
+- goldwood # longbows, shortbows
+- greenheart # martial
+- hickory # martial, composite
+- ilomba # alterations
+- iroko # alterations
+- ironwood #martial
+- kapok # alterations
+- lelori #composite
+- macawood #alterations
+- mistwood # longbow, shortbow
+- osage	# longbows
+- ramin # longbows
+- redwood # alterations
+- rockwood # martial
+- rosewood # longbows
+- shadowbark # ???
+- silverwood # shortbows, composite bows
+- smokewood	# alterations
+- tamarak # alterations
+- tamboti # ???
+- yew # longbows

--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -16,8 +16,10 @@ class SmeltDeeds
       ]
     ]
     args = parse_args(arg_definitions)
-    @metals = get_data('items').metal_types
-
+    alloys = ['steel', 'bronze', 'pewter', 'brass']
+    all_metals = get_data('items').metal_types - alloys
+    all_metals += [args.material] if args.material && alloys.include?(args.material)
+    
     unless %w[rod bellows shovel].all? { |tool| exists?(tool) }
       echo "A TOOL WAS MISSING. FIND IT AND RESTART"
       exit
@@ -38,7 +40,7 @@ class SmeltDeeds
     results
       .each_with_object([]) { |line, array| array << line.match(/Your (.*) deed is in/)[1] }
       .each_with_object(Hash.new(0)) { |name, counts| counts[name] += 1 }
-      .select { |metal, _count| @metals.include?(metal) }
+      .select { |metal, _count| all_metals.include?(metal) }
       .reject { |_metal, count| count <= 1 }
       .reject { |metal, _count| metal.nil? }
       .reject { |metal, _count| args.material && metal !~ /#{args.material}/i }

--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -16,6 +16,12 @@ class SmeltDeeds
       ]
     ]
     args = parse_args(arg_definitions)
+    @metals = get_data('items').metal_types
+
+    unless %w[rod bellows shovel].all? { |tool| exists?(tool) }
+      echo "A TOOL WAS MISSING. FIND IT AND RESTART"
+      exit
+    end
 
     unless search?('deed')
       echo '***NO DEEDS FOUND TO SMELT***'
@@ -32,6 +38,7 @@ class SmeltDeeds
     results
       .each_with_object([]) { |line, array| array << line.match(/Your (.*) deed is in/)[1] }
       .each_with_object(Hash.new(0)) { |name, counts| counts[name] += 1 }
+      .select { |metal, _count| @metals.include?(metal) }
       .reject { |_metal, count| count <= 1 }
       .reject { |metal, _count| metal.nil? }
       .reject { |metal, _count| args.material && metal !~ /#{args.material}/i }


### PR DESCRIPTION
Closes https://github.com/rpherbig/dr-scripts/issues/3433

Added some materials to base-items, though they could go in other places.  This could open up adding the ability for clean-lumber to process all the wood in your pack, but for now I've only touched smelt-deeds.

Notably, this doesn't smelt alloys like Bronze, Steel, Brass or Pewter, because I think people are most likely to have steel mixes sitting around and not realize it, but if you call it specifically (;smelt-deed steel) then it will.

Also added a tool check, since if you don't have all the tools, smelt-deeds will just tap everything and dump it all in the crucible in a big pile.

Below, I outpat the metals it saw during a run when I dumped some things out from my register.

```
[smelt-deeds]>inv search deed
You rummage about your person, looking for something...

  Your copperwood deed is in a camlet inventor's satchel.
  Your silversteel deed is in a camlet inventor's satchel.
  Your audrualm deed is in a camlet inventor's satchel.
  Your deed packet is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your lumium deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your lumium deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your darkstone deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your darkstone deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your vardite deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your deed register is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your maple deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your brass deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your pewter deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your steel deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your bloodwood deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your haralun deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your ruazin wool deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your ruazin wool deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your quartzite deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your quartzite deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your oravir deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your steel deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your quartzite deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your korograth-hide deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your ruazin wool deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your alabaster deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your alabaster deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your quartzite deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your niniam deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your bronze deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your muracite-alloy deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your dragonwood deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your pewter deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your redwood deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your steel deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your hickory deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your yew deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your cedar deed is in a cartographer's trunk adorned with water-damaged carvings of amorphous horrors.
  Your hickory deed is in a rucksack.

Roundtime:  10 secs

[Type INVENTORY HELP for more options]
>
[smelt-deeds: {"silversteel"=>1, "audrualm"=>1, "lumium"=>2, "darkstone"=>2, "vardite"=>1, "haralun"=>1, "oravir"=>1, "niniam"=>1}]
```