### PR TITLE
common-arcana - change check_to_harness

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -544,9 +544,7 @@ module DRCA
 
   def check_to_harness(should_harness)
     return false unless should_harness
-    return false if DRSkill.getxp('Attunement') >= DRSkill.getxp('Arcana')
-    return false if DRSkill.getxp('Attunement') >= 30
-
+    return false if DRSkill.getxp('Attunement') > DRSkill.getxp('Arcana')
     true
   end
 


### PR DESCRIPTION
Currently it will always use cambrinth if both are at the same field exp OR if attunement is >= 30/34.  This negates the following setting:
use_harness_when_arcana_locked: true

I changed it to use arcana if attunement's mindstate is > than Arcana's and removed the check for attunement being >= 30.

This seems more inline with the intention of the other setting, and makes more sense to me from the perspective of lowering RT.