### PR TITLE
Add missing responses for 'check balance' and 'deposit all'

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -85,12 +85,12 @@ class SellLoot
     walk_to @hometown['deposit']['id']
     release_invisibility
     bput('wealth', 'Wealth:')
-    case bput('deposit all', 'you drop all your', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit', "We don't serve necromancers or sorcerers here.")
+    case bput('deposit all', 'you drop all your', 'drop your coins inside', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit', "We don't serve necromancers or sorcerers here.")
     when 'There is no teller here', "We don't serve necromancers or sorcerers here."
       return
     end
     minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, @settings) }
-    bput('check balance', 'your current balance is')
+    bput('check balance', 'your current balance is', 'As expected, there are')
   end
 
   def give_money_to_bankbot(currency, keep)


### PR DESCRIPTION
sell-loot is missing some possible responses from the bank at Fang Cove for checking your balance and depositing coins.