### PR TITLE
Generalize anvil-cleaning and fix logbook case

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -20,22 +20,26 @@ module DRCC
   end
 
   def clean_anvil?
-    case DRC.bput('look on anvil', 'surface looks clean and ready', 'anvil you see .*bronze', 'anvil you see')
+    case result = DRC.bput('look on anvil', 'surface looks clean and ready', "anvil you see an? (.*)\.", 'anvil you see')
     when /surface looks clean and ready/i
       true
-    when /bronze/
+    when /anvil you see an?/
+      /anvil you see an? (.*)\./ =~ result
+      clutter = Regexp.last_match(1).split.last
       case DRC.bput('clean anvil', 'You drag the', 'remove them yourself')
       when /drag/
         fput('clean anvil')
         pause
         waitrt?
       else
-        case DRC.bput('get ingot from anvil', 'You get', 'the bronze ingot is not yours')
-        when 'the bronze ingot is not yours'
+        case DRC.bput("get #{clutter} from anvil", 'You get', 'is not yours')
+        when 'is not yours'
           fput('clean anvil')
           fput('clean anvil')
+        when 'You get'
+          bput("put #{clutter} in bucket", 'You drop')
         else
-          fput('put ingot in bucket')
+          return false
         end
       end
       true
@@ -155,6 +159,9 @@ module DRCC
     when 'This work order has expired', 'The work order requires items of a higher quality', 'That isn\'t the correct type of item for this work order.'
       dispose_trash(noun)
     end
-    DRC.bput("put my #{logbook} logbook in my #{container}", 'You put')
+    case DRC.bput("put my #{logbook} logbook in my #{container}", 'You put', 'What were you referring to')
+    when 'What were you referring to'
+      DRC.bput("stow my #{logbook} logbook", 'You put', 'What were you referring to')
+    end
   end
 end


### PR DESCRIPTION
Someone or someones have been putting things other than bronze ingots on anvils down in Shard to screw with crafters.  This is meant to generalize the clean_anvil logic.

Examples of how it responds to found items below:
```
[smith]>look on anvil
On the iron anvil you see a tiny coal nugget.
>
[smith]>clean anvil
You glance at the anvil's contents, and realize you should be able to remove them yourself.
>
[smith]>get nugget from anvil
You get a tiny coal nugget from atop an iron anvil.
>
[smith]>put nugget in bucket
You drop a tiny coal nugget in a large waste bucket.
>

[smith]>look on anvil
On the iron anvil you see a bronze ingot.
>
[smith]>clean anvil
You glance at the anvil's contents, and realize you should be able to remove them yourself.
>
[smith]>get ingot from anvil
You get a bronze ingot from atop an iron anvil.
>
[smith]>put ingot in bucket
You drop a bronze ingot in a large waste bucket.
```

And tested with an actual clean anvil as a control.
```
[smith]>look on anvil
The anvil's surface looks clean and ready for forging.
>
--- Lich: forge active.
--- Lich: buff active.
```

Also there's a problem I ran into frequently while crafting containers.  Trying to PUT LOGBOOK IN RUCKSACK when you have a rucksack bundled with your logbook makes the parser get really confused.  In the case that it can't find that container it just stows the logbook instead.

I've been running with that change for about 4 months of crafting, so I'm pretty confident in it.