### PR TITLE
Add combat match for bad balance and change Trader PERC

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2318,7 +2318,7 @@ class TrainerProcess
     return if game_state.npcs.empty?
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
-    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* [weakness|opening]/, /Your analysis reveals an? .* [weakness|opening]/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') # unless
+    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* [weakness|opening]/, /Your analysis reveals an? .* [weakness|opening]/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
     when 'Analyze what'
       case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
       when 'There is nothing else', 'What are you trying'
@@ -2352,7 +2352,7 @@ class TrainerProcess
   def moon_mage_perc(game_state)
     return if game_state.retreating?
 
-    retreat unless DRSkill.getrank('Attunement') > 500
+    retreat unless DRSkill.getrank('Attunement') > 500 || DRStats.trader?
     bput('perc mana', 'You reach out')
   end
 
@@ -2591,7 +2591,7 @@ class AttackProcess
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip' )
     end
 
     pause
@@ -2749,7 +2749,7 @@ class AttackProcess
   end
 
   def execute_aiming_action?(action, game_state)
-    case bput(action, 'Roundtime', 'close enough', 'What are you', 'There is nothing', 'must be closer')
+    case bput(action, 'Roundtime', 'close enough', 'What are you', 'There is nothing', 'must be closer', 'Bumbling, you slip')
     when 'close enough', 'must be closer'
       return false if game_state.retreating?
       fput('engage')
@@ -3692,5 +3692,4 @@ end
 
 $COMBAT_TRAINER = CombatTrainer.new
 $COMBAT_TRAINER.start_combat
-
 


### PR DESCRIPTION
When balance is extremely low you can fall when analyzing, shooting, or meleeing.  I've only run into this in ochre-la'heke, which has a balance debuff, but it makes you sit there for 15 seconds until safety process picks you back up.

Also, for PercMana, base RT for a trader with no attunement is ~8 seconds, and it only goes down from there.  Compared to the upwards of 30 second RT for low-level moonies, I don't think traders need to retreat here.