### PR TITLE
Specify Elanthian Sun in base-constellation

### DIFF
--- a/data/base-constellations.yaml
+++ b/data/base-constellations.yaml
@@ -1,5 +1,5 @@
 constellations:
-  - name: Sun
+  - name: Elanthian Sun
     telescope: false
     circle: 1
     constellation: false


### PR DESCRIPTION
Closes https://github.com/rpherbig/dr-scripts/issues/3464

Turns out Elanthian Sun is completely unambiguous for observations and centering telescopes.

Actually, Elanthian Sun in Elanthian Heavens works too, and it might eventually be worth adding these things to common-moonmage, but for now...