### PR TITLE
workorders.lic - removed knitting tools

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -92,7 +92,7 @@ class WorkOrders
         exit
       end
       @outfitting_room = @settings.outfitting_room
-      tools = (@settings.outfitting_tools + @settings.knitting_tools).uniq
+      tools = @settings.outfitting_tools
       @belt = @settings.outfitting_belt
       case item['chapter']
       when 4, 2, 3


### PR DESCRIPTION
knitting_tools: was removed from base.  Removed it from workorders