### PR TITLE
Add two missing tool-rooms to base-crafting

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -434,6 +434,7 @@ tailoring:
     repair-room: 10744
     repair-npc: clerk
     stock-room: 10746
+    tool-room: 10749
     sew-stock-number: 8
     sew-stock-name: burlap
     knit-stock-number: 13
@@ -458,6 +459,7 @@ tailoring:
     repair-room: 8392
     repair-npc: Osmandikar # Fang Cove metal-repairer
     stock-room: 9125
+    tool-room: 9124
     sew-stock-number: 8
     sew-stock-name: burlap
     knit-stock-number: 13


### PR DESCRIPTION
A missing tool-room in Ratha prevents restocking pins during ;sew. 

I checked all the towns to see if any others were missing and found Fang Cove was out as well.