### PR TITLE
Correct observe sky in ;astrology

### DIFF
--- a/astrology.lic
+++ b/astrology.lic
@@ -81,7 +81,7 @@ class Astrology
     end
 
     until (line = get?) =~ /^Roundtime/i
-      result << all_bodies.find { |body| /\b#{body['name']}\b/i =~ line && line !~ /below the horizon/ }
+      result << all_bodies.find { |body| /\b#{body['name'].split.last}\b/i =~ line && line !~ /below the horizon/ }
     end
     result.compact.select { |data| data['circle'] <= DRStats.circle }
   end


### PR DESCRIPTION
Unintended side effect of previous PR, much to my chagrin.  ;astrology isn't seeing the sun during normal observation.  While Elanthian Sun does work for interacting with everything, when ;astrology observes the sky that's not what shows up in the OBSERVE during astrology.  It sees, say, 'late morning sun', which doesn't match.  Young moon mages using ;astrology during the daytime might end up with nothing to look at.

I'm open to another way to fix this, but the sun is the only item in base-constellation with two words. .split.last works.

After this change:

```
The following heavenly bodies are visible:
A cloud has obscured parts of the early morning sun.
Two-thirds of the planet Verena is blocked by cloud cover above.
You focus your enhanced sight, through some of the cloud cover, upon the planet Estrilda.
A cloud has obscured parts of the planet Estrilda.
Most of the planet Yoakena is obscured from view.
You focus your enhanced sight, through some of the cloud cover, upon the planet Dawgolesh.
Fully half of the planet Dawgolesh is blocked by the clouds overhead.
Katamba is below the horizon.
Xibar is below the horizon.
Yavash is below the horizon.
Roundtime: 7 sec.
>
[astrology:  best_eye_data = {"name"=>"Elanthian Sun", "telescope"=>false, "circle"=>1, "constellation"=>false, "pools"=>{"Offense"=>nil, "Defense"=>nil, "Survival"=>1, "Magic"=>nil, "Lore"=>nil}}]
You feel you have sufficiently pondered your latest observation.
>
[astrology:  things_to_try = [{"name"=>"Elanthian Sun", "telescope"=>false, "circle"=>1, "constellation"=>false, "pools"=>{"Offense"=>nil, "Defense"=>nil, "Survival"=>1, "Magic"=>nil, "Lore"=>nil}}]]
[astrology]>get telescope
...wait 1 seconds.
>
[astrology]>get telescope
You get a redwood telescope from inside your mistsilk haversack.
>
[astrology]>center telescope on Elanthian Sun
You put your eye to the telescope and attempt to center on the Elanthian sun.
>
[astrology]>peer telescope
>
You gaze through the telescope at the Elanthian sun.
You focus your enhanced sight, through some of the cloud cover, upon the early morning sun.
A cloud has obscured parts of the early morning sun.
You struggle to make your observation through the clouds, but you manage to pinpoint the early morning sun with the help of your telescope.
The sun shines with a steady, yellow light.
You learned something useful from your observation.
Roundtime: 19 sec.
```

And for non-sun items:

```

The following heavenly bodies are visible:
A cloud has obscured parts of the early morning sun.
Two-thirds of the planet Verena is blocked by cloud cover above.
You focus your enhanced sight, through some of the cloud cover, upon the planet Estrilda.
A cloud has obscured parts of the planet Estrilda.
Most of the planet Yoakena is obscured from view.
You focus your enhanced sight, through some of the cloud cover, upon the planet Dawgolesh.
Fully half of the planet Dawgolesh is blocked by the clouds overhead.
Katamba is below the horizon.
A rather large cloud has covered nearly a third of Xibar.
Yavash is below the horizon.
Roundtime: 7 sec.
>
[astrology:  best_eye_data = {"name"=>"Xibar", "telescope"=>false, "circle"=>1, "constellation"=>false, "pools"=>{"Offense"=>nil, "Defense"=>nil, "Survival"=>nil, "Magic"=>nil, "Lore"=>1}}]
>
[astrology:  things_to_try = [{"name"=>"Xibar", "telescope"=>false, "circle"=>1, "constellation"=>false, "pools"=>{"Offense"=>nil, "Defense"=>nil, "Survival"=>nil, "Magic"=>nil, "Lore"=>1}}]]
[astrology]>get telescope
You get a redwood telescope from inside your mistsilk haversack.
>
[astrology]>center telescope on Xibar
You put your eye to the telescope and attempt to center on the blue moon Xibar.
>
[astrology]>peer telescope
You focus your enhanced sight, through some of the cloud cover, upon Xibar.
A rather large cloud has covered nearly a third of Xibar.
The blue moon Xibar has waned to a narrow crescent of light.
It is fairly close and is shining brightly.

You struggle to make your observation through the clouds, but you manage to pinpoint Xibar with the help of your telescope.
You learned something useful from your observation.
Roundtime: 20 sec.
```