### PR TITLE
;craft 'wood' vs 'articulated wood' bracelet unique name

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -76,7 +76,7 @@ class Craft
     if rank <= 25 # Tier 1  Extremely Easy
       shape(7, 'wood band', 'band')
     elsif rank <= 50 # Tier 2 Very Easy
-      shape(7, 'wood bracelet', 'bracelet')
+      shape(7, 'a wood bracelet', 'bracelet')
     elsif rank <= 100 # Tier 3  Easy
       shape(7, 'wood cloak pin', 'cloak pin')
     elsif rank <= 175 # Tier 4  Simple


### PR DESCRIPTION
Just had someone run into this in the new ;trade, where I stole ruthlessly from ;craft.

If you send recipe_lookup 'wood bracelet' it asks you to choose between 'a wood bracelet' and 'an articulated wood bracelet'.  If you send ;shape 'wood bracelet' it just chooses the articulated one instead, since it's higher up in the row.

I forced myself to this skill level and it crafted the right bracelet.  Already made the change to ;trade.