### PR TITLE
Allow kneel_khri to be specified as a list

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -48,8 +48,9 @@ module DRCA
       end
   end
 
-  def activate_khri?(kneel, ability)
+  def activate_khri?(settings_kneel, ability)
     return false if DRSpells.active_spells[ability]
+    kneel = kneel_for_khri?(settings_kneel, ability)
     DRC.retreat if kneel
     DRC.bput('kneel', 'You kneel', 'You are already', 'You rise') if kneel && !kneeling?
     result = DRC.bput(ability, get_data('spells').khri_preps)
@@ -57,6 +58,14 @@ module DRCA
     DRC.fix_standing
 
     ['Your body is willing', 'You have not recovered'].include?(result)
+  end
+
+  def kneel_for_khri?(kneel, ability)
+    if(kneel.is_a? Array)
+      kneel.map(&:downcase).include? ability.downcase.sub('khri ', '')
+    else
+      kneel
+    end
   end
 
   def start_barb_abilities(skills, _settings)


### PR DESCRIPTION
Introduces the capability of specify a list of khri to kneel for, supplementing the option of kneeling for all or none.

The following configuration will only kneel when activating 'khri guile' or 'khri slight':
```
kneel_khri:
  - Guile
  - Slight
```

`kneel_khri: true` and `kneel_khri: false` continue to behave the same, kneeling for all khri activations or none, respectively.