### PR TITLE
base-spells.yaml - Added prep message

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -83,6 +83,7 @@ prep_messages:
 - You deftly waggle your fingers in the precise motions
 - You direct your attention toward the heavens and trace the lunar sigils
 - With great force, you slap your hands together before
+- You seem to have forgotten this spell
 
 cast_messages:
 - ^Your spell .*backfires


### PR DESCRIPTION
Added message for when an eel steals your spell so that common-arcana's prepare? method doesn't hang.
`You seem to have forgotten this spell`