### PR TITLE
Item check on performance-end

### DIFF
--- a/performance.lic
+++ b/performance.lic
@@ -150,7 +150,10 @@ end
 
 before_dying do
   fput('stop play')
-
+  snapshot = "#{DRC.right_hand}#{DRC.left_hand}"
+  cloth = get_settings.cleaning_cloth
+  DRC.bput('wear my zills', 'You slide', 'You are already', 'Wear what') if snapshot.include?('zills')
+  DRC.bput("stow my #{cloth}", 'You put', 'Stow what') if snapshot.include?(cloth)
   instrument = get_settings.instrument
   DRC.bput("stow #{instrument}", 'You put') if instrument
 end


### PR DESCRIPTION
Closes https://github.com/rpherbig/dr-scripts/issues/3494

Stows zills or cloth if performance is killed during cleaning.

```
>;kill performance
[performance]>stop play
In the name of love?
>
[performance]>wear my zills
You slide a pair of copper zills onto your finger.
>
[performance]>stow my chamois cloth
You put your cloth in your cartographer's trunk.
```