### PR TITLE
Remove duplicate recipe from base

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -1310,12 +1310,6 @@ crafting_recipes:
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood cloak pin
-  noun: pin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
 - name: a wood hairpin
   noun: hairpin
   volume: 2


### PR DESCRIPTION
Discovered by a user testing ;trade.  There are two identical recipes for wood cloak pins, which causes certain recipe lookup functions to pause for clarification.

```
- name: a wood cloak pin
  noun: pin
  volume: 2
  type: shaping
  work_order: true
  chapter: 7
- name: a shallow wood cup
  noun: cup
  volume: 2
  type: shaping
  work_order: true
  chapter: 7
- name: a wood cloak pin
  noun: pin
  volume: 2
  type: shaping
  work_order: true
  chapter: 7
```