### PR TITLE
Update combat-trainer to replace direct references to @kneel_khri

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1814,10 +1814,10 @@ class AbilityProcess
       fput action
       waitrt?
     end
-    return if game_state.danger && @kneel_khri
     @khri
       .map { |name| "Khri #{name}" }
       .each do |name|
+        next if game_state.danger && kneel_for_khri?(@kneel_khri, name)
         timer = game_state.cooldown_timers[name]
         next unless !timer || (Time.now - timer).to_i > 30
         game_state.cooldown_timers[name] = Time.now if activate_khri?(@kneel_khri, name)
@@ -2030,14 +2030,16 @@ class TrainerProcess
     when 'Scream'
       bput('Scream conc', 'Inhaling deeply', 'There is nothing', 'You open your mouth, then close it suddenly, looking somewhat like a fish') unless game_state.npcs.empty?
     when 'Khri Prowess'
-      if @kneel_khri
-        fput('retreat')
-        fput('kneel')
-      end
-      bput('khri prowess', 'Remembering the mantra of mind over matter', 'You\'re already using the Prowess meditation.', 'previous use of the Prowess', 'Your body is willing', 'Your mind and body are willing') unless game_state.npcs.empty?
-      if @kneel_khri
-        waitrt?
-        fput('stand')
+      unless game_state.npcs.empty?
+        if kneel_for_khri?(@kneel_khri, 'khri prowess')
+          fput('retreat')
+          fput('kneel')
+        end
+        bput('khri prowess', 'Remembering the mantra of mind over matter', 'You\'re already using the Prowess meditation.', 'previous use of the Prowess', 'Your body is willing', 'Your mind and body are willing')
+        if kneel_for_khri?(@kneel_khri, 'khri prowess')
+          waitrt?
+          fput('stand')
+        end
       end
     when 'Stealth'
       if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'


### PR DESCRIPTION
I missed that combat-trainer references @kneel_khri (boolean) directly, so this PR addresses that by having combat-trainer call `kneel_for_khri?` as appropriate. This PR also includes a change to the Khri Prowess training ability so that it won't retreat and kneel (without activating prowess) if there are no mobs in the room.