### PR TITLE
More town info for Ratha

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -627,7 +627,7 @@ Ratha:
   debt_office:
     id: 7160
   guard_house:
-    id: 13023
+    id: 13106
   thief_bin:
     id: 13577
   theurgy_supplies:
@@ -645,6 +645,30 @@ Ratha:
     - 4638
     - 4637
     - 4636
+  strength:
+    outer_room: 14431
+    inner_room:
+  agility:
+    outer_room: 7213
+    inner_room:
+  discipline:
+    outer_room: 7487
+    inner_room:
+  intelligence:
+    outer_room: 12369
+    inner_room:
+  wisdom:
+    outer_room: 12960
+    inner_room:
+  reflex:
+    outer_room: 4851
+    inner_room:
+  charisma:
+    outer_room: 5007
+    inner_room:
+  stamina:
+    outer_room: 12688
+    inner_room:
   guild_leaders:
     Barbarian:
       name: Anhh'shre


### PR DESCRIPTION
Guard house room was off-island. Don't know when that happened -- possibly something I missed during Ratha's remap, but 13106 is where pay-debt should get sacks.

Also added rooms for the tdp training areas.  ;train got to all of them and learned correctly on my alt.