### PR TITLE
Fix error due to missing include in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2033,13 +2033,13 @@ class TrainerProcess
     when 'Khri Prowess'
       unless game_state.npcs.empty?
         if kneel_for_khri?(@kneel_khri, 'khri prowess')
-          fput('retreat')
+          retreat
           fput('kneel')
         end
         bput('khri prowess', 'Remembering the mantra of mind over matter', 'You\'re already using the Prowess meditation.', 'previous use of the Prowess', 'Your body is willing', 'Your mind and body are willing')
         if kneel_for_khri?(@kneel_khri, 'khri prowess')
           waitrt?
-          fput('stand')
+          fix_standing
         end
       end
     when 'Stealth'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1895,6 +1895,7 @@ class TrainerProcess
   include DRCT
   include DRCI
   include DRCMM
+  include DRCA
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager


### PR DESCRIPTION
combat-trainer is encountering an error when the 'Khri Prowess' training ability is enabled, due to missing an include for DRCA. Also updated the 'Khri Prowess' section to use the helpers as requested.