### PR TITLE
Bescort support for Hvaral passports

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1184,7 +1184,7 @@ class Bescort
 
     if wealth('Shard') < 31
       echo('Get money you slob!')
-      return unless Room.current.id == 3986 ? get_fare?(60, 'Hibarnhvidar', 3986) : false
+      return unless Room.current.id == 3986 ? get_fare?(62, 'Hibarnhvidar', 3986) : false
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /Damaris. Kiss|Evening Star/ }

--- a/bescort.lic
+++ b/bescort.lic
@@ -1184,7 +1184,7 @@ class Bescort
 
     if wealth('Shard') < 31
       echo('Get money you slob!')
-      return
+      return unless Room.current.id == 3986 ? get_fare?(60, 'Hibarnhvidar', 3986) : false
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /Damaris. Kiss|Evening Star/ }

--- a/bescort.lic
+++ b/bescort.lic
@@ -189,6 +189,9 @@ class Bescort
       ],
       [
         { name: 'haven_throne', regex: /haven_throne/i, description: 'Ferry between Riverhaven and Throne City' }
+      ],
+      [
+        { name: 'hvaral_passport', regex: /hvaral_passport/i, description: 'Handles the gate between Hvaral and Muspari' }
       ]
     ]
 
@@ -244,6 +247,8 @@ class Bescort
       enter_thief_guild
     elsif args.haven_throne
       take_haven_throne_ferry
+    elsif args.hvaral_passport
+      hvaral_passport
     end
   end
 
@@ -1179,7 +1184,7 @@ class Bescort
 
     if wealth('Shard') < 31
       echo('Get money you slob!')
-      return unless Room.current.id == 3986 ? get_fare?(60, 'Shard', 3986) : false
+      return
     end
 
     hide? unless DRRoom.room_objs.find { |x| x =~ /Damaris. Kiss|Evening Star/ }
@@ -1291,6 +1296,31 @@ class Bescort
     end
   end
 
+  def hvaral_passport
+    case bput('get my passport', 'Realizing your passport has expired', 'You get', 'You are already', 'What were you', 'You pick up')
+    when 'Realizing your passport has expired', 'What were you'
+      manual_go2(3632)
+      Flags.add('bescort-dustroad', 'Just when it seems you will never reach')
+      move 'e'
+      pause 1 until Flags['bescort-dustroad']
+      Flags.reset('bescort-dustroad')
+      pause 2
+      manual_go2(3147)
+      bput('ask licenser about passport', 'The licenser takes', 'Having a passport will allow')
+      bput('ask licenser about passport', 'The licenser takes', 'Having a passport will allow')
+      bput('stow passport', 'You put')
+      manual_go2(3631)
+      move 'w'
+      pause 1 until Flags['bescort-dustroad']
+      pause 2
+      Flags.delete('bescort-dustroad')
+      manual_go2(3698)
+      bput('get my passport', 'Realizing your passport has expired', 'You get', 'You are already', 'What were you', 'You pick up')
+    end
+    move 'go gate'
+    bput('stow passport', 'You put')
+  end
+
   def enter_thief_guild
     password = get_settings.shard_thief_password
     bput('knock', 'You knock on the door')
@@ -1347,6 +1377,7 @@ end
 
 before_dying do
   Flags.delete('bescort-ur-a-criminal')
+  Flags.delete('bescort-dustroad')
   Flags.delete('maze-reset')
   Flags.delete('rope_wait')
   Flags.delete('harness-check')


### PR DESCRIPTION
Added support for going through the Hvaral gate without a passport. Right now it just tries to walk through the door.  Once it's merged I'll wait a few days then submit a map change for that room to run ;bescort.

I had to do a little chicanery because bescort's manual_go2 wasn't playing nicely with the long dust road.

Also, fare handling was removed from Ain Ghazal. If you're out of money it'll try to run you along the ice road, which also has a bescort, so it breaks. No easy way I can see to juggle that atm.

```

>;bescort hvaral_passport
--- Lich: bescort active.
[bescort]>get passport
What were you referring to?
>
[bescort]>east

***A LOT OF DUMB WALKING BACK TO THERENBOROUGH***

[Ibec Hall, Passport Office]
A finely crafted desk serves as the work space for a bedraggled licenser. On one side of the desk wobbles a stack of documents, each bearing the wax seal of the Baron, granting travel rights throughout the province. A mural of Lake Gwenalion decorates one wall of the room. You also see a bedraggled licenser.
Obvious exits: southwest.
Room Number: 3147
>
[bescort]>ask licenser about passport
"Having a passport will allow you to pass through Therengia unimpeded, and to leave through most of its borders. It lasts for a year, and costs... well, right now, it's free. The Baron's being generous. Just ASK me again if you want one issued."
>
[bescort]>ask licenser about passport
The licenser takes some of the papers from his desk and draws up your passport. "Here you go," he states, as he gingerly hands it to you.
>
[bescort]>stow passport
You put your passport in your cartographer's trunk.
>

*** MORE INTERMINABLE WALKING ***

[Arnshal Keep, First Floor]
The main corridor, which stretches the length of the entire keep, is filled with bright silver candelabra and multihued tapestries. A small gateway, just large enough for a caravan to fit through, leads to a steep and winding path down the mountain outside. You also see an alabaster arch leading to the keep's Great Hall.
Obvious exits: east.
Room Number: 3698
>
[bescort]>get passport
You get a passport from inside your cartographer's trunk.
>
[bescort]>go gate

A soldier moves a pike across the way to block your passage and requests a passport. After you show him your papers, he nods and ushers you through.
[Arnshal Road, Keep Entrance]
Grinning stone gargoyles perch eternally over a small gateway leading into the Keep.  Each gargoyle clasps a long pole in its stone claws.  From one pole hangs the banner of Therengia while the banner of the Keep's current ruler hangs from the other.  
Obvious paths: west.
Room Number: 3706
>
[bescort]>stow passport
You put your passport in your cartographer's trunk.
>
--- Lich: bescort has exited.

```