### PR TITLE
Fix overbuying herb2 + add support for retaining unused mats

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -508,6 +508,9 @@ workorder_min_items: 2
 workorder_max_items: 3
 workorder_recipes:
 workorder_cash_on_hand:
+# Whether to retain unused crafting materials or dispose of them.
+#   Only implemented for remedies
+retain_crafting_materials: false
 
 #CARAVAN SETTINGS
 # container holding caravan contracts for ;trade

--- a/workorders.lic
+++ b/workorders.lic
@@ -42,6 +42,7 @@ class WorkOrders
     @recipe_overrides = @settings.workorder_recipes || {}
     @cash_on_hand = @settings.workorder_cash_on_hand
     @craft_max_mindstate = @settings.craft_max_mindstate
+    @retain_crafting_materials = @settings.retain_crafting_materials
 
     info = crafting_data[discipline][@hometown]
     if discipline == 'weaponsmithing'
@@ -401,7 +402,7 @@ class WorkOrders
   end
 
   # Function which will attempt to combine any stacks of herbs in your inventory, will count them, and determine if more need to be ordered.
-  def count_combine_rem(stock_room, quantity, herb, herb_stock)
+  def count_combine_rem(stock_room, quantity, herb, herb_stock, is_herb2 = false)
     # Initialize variables
     found_stack = true
     herb_volume_total = 0
@@ -415,8 +416,8 @@ class WorkOrders
     herb_for_tapping = herb.gsub(/\s+/m, ' ').strip.split(' ').last
 
     # Calculate the volume of the herbs that we will be searching our inventory for and/or buying.
-    # Assume that each unit we need to craft will take 25 volumes of our herb.
-    need_herb_volume = (quantity * 25.0)
+    # Assume that each unit we need to craft will take 25 volumes of our herb. If it's a second herb, it requires a minimum of one volume, but may require more.
+    need_herb_volume = is_herb2 ? (quantity * 2) : (quantity * 25)
 
     # Loop through all the stacks of herbs we might have in our backpack and find out how much volume we have total.
     ordinals = $ORDINALS.dup
@@ -567,7 +568,7 @@ class WorkOrders
     if recipe['herb2'].nil?
       herb2_needed = 'na'
     else
-      count_combine_rem(info['stock-room'], quantity, recipe['herb2'], recipe['herb2_stock'])
+      count_combine_rem(info['stock-room'], quantity, recipe['herb2'], recipe['herb2_stock'], true)
     end
 
     walk_to(@alchemy_room)
@@ -597,16 +598,16 @@ class WorkOrders
         bput('stow my logbook', 'You put')
       when 'The work order requires items of a higher quality'
         dispose_trash(recipe['noun'])
-        dispose(recipe['herb1']) while recipe['herb1'] && exists?(recipe['herb1'])
-        dispose(recipe['herb2']) while recipe['herb2'] && exists?(recipe['herb2'])
+        dispose(recipe['herb1']) while recipe['herb1'] && exists?(recipe['herb1']) unless @retain_crafting_materials
+        dispose(recipe['herb2']) while recipe['herb2'] && exists?(recipe['herb2']) unless @retain_crafting_materials
         stow_tool(left_hand)
         stow_tool(right_hand)
         break
       end
     end
     leftovers.times { |_| dispose(recipe['noun']) }
-    dispose(recipe['herb1']) while recipe['herb1'] && exists?(recipe['herb1'])
-    dispose(recipe['herb2']) while recipe['herb2'] && exists?(recipe['herb2'])
+    dispose(recipe['herb1']) while recipe['herb1'] && exists?(recipe['herb1']) unless @retain_crafting_materials
+    dispose(recipe['herb2']) while recipe['herb2'] && exists?(recipe['herb2']) unless @retain_crafting_materials
   end
 
   def forge_items(info, item, quantity)


### PR DESCRIPTION
There was a known issue in remedies workorders about buying too many herbs and then dumping them in the trash. I trace the cause of this to an assumption made about the quantity of herbs in recipes requiring two herbs both being 25 volumes. However, the second herb only requires 1 volume (though 1 additional volume may be needed).

I've also added a setting `retain_crafting_materials` that will override disposing unused materials in the trash.