### PR TITLE
Introduce mefwatch.lic

### DIFF
--- a/mefwatch.lic
+++ b/mefwatch.lic
@@ -1,0 +1,104 @@
+=begin
+Alternates between mental focus wands to keep MEF up at all times
+Requires two of the same wand
+=end
+custom_require.call(%w[common drinfomon equipmanager])
+
+class MEFWatch
+  include DRC
+
+  def initialize
+    @settings = get_settings
+    @wand = @settings['mefwatch']['wand'].nil? ? 'bloodwood branch' : @settings['mefwatch']['wand']
+    @no_use_scripts = get_settings['mefwatch']['no_use_scripts']
+    @mef_duration = 34 * 60  #minutes * seconds
+    @cooldown_pad = 2 * 60 #minutes * seconds
+    @equipmanager = EquipmentManager.new
+    @debug = UserVars.mefwatch_debug
+    UserVars.mefwatch_last_use ||= Time.now - @mef_duration
+    
+    unless can_find_wands?
+      echo "*** Unable to find two wands named #{@wand} ***"
+      exit
+    end
+
+    watch
+  end
+
+  def can_find_wands?
+    case fput("push #{@wand}", 'I don\'t think pushing that would', 'Push what')
+    when 'Push what'
+      return false
+    end
+    case fput("push second #{@wand}", 'I don\'t think pushing that would', 'Push what')
+    when 'I don\'t think pushing that would'
+      return true
+    when 'Push what'
+      return false
+    end
+  end
+
+  def watch
+    loop do
+      check_mef
+      pause 20
+    end
+  end
+
+  def check_mef
+    echo "*** Checking MEF. It expires in: #{((UserVars.mefwatch_last_use + @mef_duration) - Time.now).round} seconds ***" if @debug
+    return if Time.now - (@mef_duration - @cooldown_pad) < UserVars.mefwatch_last_use
+    return if @no_use_scripts.any? { |name| Script.running?(name) }
+    return if hidden?
+    refresh_mef
+  end
+
+  def refresh_mef
+    echo "*** MEF is not up or will expire soon, attempting to use a wand ***" if @debug 
+    # pause other scripts
+    Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != 'mefwatch' }.each(&:pause)
+    waitrt?
+    if right_hand && left_hand
+      left_hand_contents = left_hand
+      if @equipmanager.item_by_desc(left_hand_contents)
+        @equipmanager.stow_weapon(left_hand_contents)
+      else
+        bput('stow left', 'You put')
+      end
+    end
+
+    if use_wand
+      echo "*** MEF Refreshed ***" if @debug
+    else
+      echo "*** Unable to find a wand, or both wands are in cooldown ***"
+    end
+
+    if left_hand_contents
+      if @equipmanager.item_by_desc(left_hand_contents)
+        @equipmanager.wield_weapon(left_hand_contents)
+      else
+        bput("get my #{left_hand_contents}", 'You get')
+      end
+    end
+
+    Script.running.find_all { |s| s.paused? && !s.no_pause_all && s.name != 'mefwatch' }.each(&:unpause)
+
+  end
+
+  def use_wand(last_attempt = false)
+    bput("get my second #{@wand}", 'You get', 'I could not')
+    case bput("tap my #{@wand}", 'The world around you seems', 'remains inert')
+    when 'remains inert'
+      return false if last_attempt == true
+      bput("stow my #{@wand}", "You put")
+      use_wand true
+    when 'The world around you seems'
+      bput("stow my #{@wand}", "You put")
+      UserVars.mefwatch_last_use = Time.now
+      return true
+    end
+  end
+
+end
+
+MEFWatch.new


### PR DESCRIPTION
mefwatch.lic is primarily useful to thieves, and uses two Mental Focus wands to keep Mental Focus up all the time.

Defaults assume that 'bloodwood branch' is the name of both wands, and the user is fine with mefwatch interrupting any other script. However, these can be changed in the user's setup.yaml. At present, mefwatch requires both MEF wands to be the same adjective & noun.

```
mefwatch:
  wand: bloodwood branch
  no_use_scripts: []
```

Debug may be enabled with `;vars add mefwatch_debug=true`.