### PR TITLE
update combat-trainer - messaging for target loss

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1005,7 +1005,7 @@ class SpellProcess
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
 
-    Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target', 'Your secondary spell pattern dissipates because your target is dead, but the main spell remains intact, 'Your concentration lapses and you lose your targeting pattern')
+    Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target', 'Your secondary spell pattern dissipates because your target is dead, but the main spell remains intact', 'Your concentration lapses and you lose your targeting pattern')
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
     Flags.add('ct-starlight-depleted', 'enough starlight') if DRStats.trader?
     Flags.add('ct-regalia-expired', 'Your .* glimmers? weakly') if DRStats.trader?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1005,7 +1005,7 @@ class SpellProcess
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
 
-    Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target')
+    Flags.add('ct-spelllost', 'Your pattern dissipates with the loss of your target', 'Your secondary spell pattern dissipates because your target is dead, but the main spell remains intact, 'Your concentration lapses and you lose your targeting pattern')
     Flags.add('ct-need-bless', ' passes through the .* with no effect')
     Flags.add('ct-starlight-depleted', 'enough starlight') if DRStats.trader?
     Flags.add('ct-regalia-expired', 'Your .* glimmers? weakly') if DRStats.trader?


### PR DESCRIPTION
Added messages to the flag ct-spelllost to detect other messages you get when losing a targeted spell.