### PR TITLE
register.lic - updated get logic

### DIFF
--- a/register.lic
+++ b/register.lic
@@ -22,13 +22,14 @@ class Register
     container = get_settings.crafting_container
 
     stow_hands
-    if get_item('deed register', container)
-      bput('turn my register to contents', 'You flip your deed register to the contents page.', 'But a deed register is already at the table of contents!')
-      search(args.query)
-    else
-      echo "Can\'t find your deed register."
-      exit
+    unless get_item('deed register', container)
+      unless bput('get my deed register', /You get/, /What were you referring to/) == 'You get'
+        echo "Can\'t find your deed register."
+        exit
+      end
     end
+    bput('turn my register to contents', 'You flip your deed register to the contents page.', 'But a deed register is already at the table of contents!')
+    search(args.query)
     bput("put my register in my #{container}", /You put/, /That.s too heavy to go in there/, /no matter how you arrange/)
     stow_hands
   end


### PR DESCRIPTION
Changed the logic for getting the register to try again if it isn't in your crafting container.  Now it tries your crafting container first, and then tries to just get your deed register.  If that fails, it messages as such exits.  Otherwise it continues to search the register and then puts it in the right container.