### PR TITLE
remove preserve from butcher only

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -671,7 +671,6 @@ class LootProcess
     echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
     echo ' Only butchering it once!' if $debug_mode_ct && @dissect_and_butcher && !@ritual_type.eql?('butcher')
 
-    do_necro_ritual(mob_noun, 'preserve', game_state)
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     loop do


### PR DESCRIPTION
thanatology:
  ritual_type: butcher
this will allow butcher by itself to run butcher without preserve, butcher is the only one that can run without preserve if trying to NOT train FA.