### PR TITLE
carve.lic - support for long/short cords

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -42,7 +42,7 @@ class Carve
                  end
 
     wait_for_script_to_complete('buff', ['carve'])
-    Flags.add('carve-assembly', 'another finished wooden (hilt|haft)', 'another finished (long|short) wooden (pole)')
+    Flags.add('carve-assembly', 'another finished wooden (hilt|haft)', 'another finished (long|short) wooden (pole)', 'another finished (long|short) leather (cord)')
     Flags.add('carve-magic-ready', 'You feel fully prepared to cast your spell.')
 
     carve_item


### PR DESCRIPTION
Script wasn't detecting that it needed to assemble a long cord while carving something.  Added support for both long and short leather cords.