### PR TITLE
Allow for no empty hunting room messages

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -199,7 +199,7 @@ class HuntingBuddy
                           waitrt?
                           return UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
                         end
-                        fput("say #{@settings.empty_hunting_room_messages.sample}")
+                        fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
                         20.times do |_|
                           pause 0.5
                           return true if UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }


### PR DESCRIPTION
We should allow for a user to skip saying messages when checking a room. This means they do not say anything, but still pause for the allotted time to see what happens. We do this by blanking out the empty_hunting_room_messages setting.

Currently, iff a user blanks out their empty hunting room messages then it the room gets detected as occupied because the script will send the `say` command and get back a bunch of help text.

```
[go2: travel time: 0:01:37]
--- Lich: go2 has exited.
[hunting-buddy]>search
You search around for a moment.
Roundtime: 3 sec.
You don't find anything of interest here.
R>
[hunting-buddy]>say
Usage:
  SAY message                        Will say a message for all of the room to hear
  " message                          Will say a message for all of the room to hear
  ' message                          Will say a message for all of the room to hear
  NOTE:  SAY, ', and " are interchangable
 
  SAY /EMOTE message                 Will say a message for all of the room to hear with emotion
  SAY @PERSON message                Will say a message for all of the room to hear but directed to
                                       PERSON
  SAY /EMOTE @PERSON message         Will say a message for all of the room to hear but directed to
                                       PERSON with emotion
  SAY @PERSON /EMOTE message         Will say a message for all of the room to hear but directed to
                                       PERSON with emotion
  SAY /SETEMOTE EMOTE                Will set a default emote.  If you speak without specifying an emote
                                       you will use you default emote.
  SAY /SETEMOTE CLEAR                Will clear your default emote.
 
  SAY /HELP EMOTE                    Displays a list of valid emotes
  SAY /HELP EXAMPLES                 Display some examples for using SAY
R>
--- Lich: go2 active.
--- Lich: 'textsubs' has been stopped by go2.
[go2: ETA: 0:00:00 (1 rooms to move through)]
R>
Your body below the waist is dripping with water.  Pools of it are forming all around you.
R>
You feel fully rested.
>
[go2]>s
You stroll south.
[Arthelun Ruins, Edifice]
The broken stumps of several black marble caryatids stand here, their 
```