### PR TITLE
Common crafting change to prevent script exit on repair

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -117,7 +117,7 @@ module DRCC
     Regexp.last_match(1)
   end
 
-  def get_crafting_item(name, bag, bag_items, belt)
+  def get_crafting_item(name, bag, bag_items, belt, skip_exit = false)
     waitrt?
     if belt && belt['items'].find { |item| /\b#{name}/i =~ item || /\b#{item}/i =~ name }
       if DRC.bput("untie my #{name} from my #{belt['name']}", 'You (remove|untie)', 'Untie what') =~ /You (remove|untie)/
@@ -128,8 +128,9 @@ module DRCC
     command += " from my #{bag}" if bag_items && bag_items.include?(name)
     case DRC.bput(command, '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
     when 'What do you', 'What were you'
+      beep 
       echo("You seem to be missing: #{name}")
-      exit
+      exit unless skip_exit
     when "can't quite lift it"
       get_crafting_item(name, bag, bag_items, belt)
     end


### PR DESCRIPTION
The default behavior for get_crafting_item works for gathering tools to use in a craft, but often fails for repairing tools due to duplicated entries in various places.

A week from now we can change ;workorders to use that arg for repairs.