### PR TITLE
;combat-trainer worn box-noun support

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -481,6 +481,9 @@ class LootProcess
     when 'already in your inventory'
       if @gem_nouns.include?(item)
         bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+      elsif @box_nouns.include?(item)
+        item_reg = item.split.join('.*')
+        return stow_loot(DRRoom.room_objs.grep(/\b#{item_reg}$/).first.split.last(2).join(' '), game_state)
       else
         bput("stow other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       end


### PR DESCRIPTION
As someone who wears an enlarged 'cartographer's trunk', the parser gets confused when it tries to do STOW TRUNK to a dropped mob box.  STOW OTHER TRUNK does not resolve the issue, but 'STOW STEEL TRUNK' or 'deobar trunk' or whatever does.

If it gets 'already in your inventory' it searches the room for the item's full description (code pulled from stow_lootables), then pulls the last two words to stow.

This has been working for me for a few months now of fighting box-dropping mobs, so I feel pretty good about it.