### PR TITLE
base.yaml: Switch outfitting_tools back to only knitting needles.

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -460,10 +460,6 @@ tinkering_tools:
 - carving knife
 outfitting_tools:
 - knitting needle
-- sewing needle
-- awl
-- yardstick
-- scissors
 shaping_tools:
 - carving knife
 - shaper


### PR DESCRIPTION
Having the others breaks people who only care about knitting, (aka everyone under 401 ranks) and have not bought all of the sewing tools which you only need for 401+ ranks when using workorders. Non workorder sewing using craft.lic uses knitting only until 650 ranks also. This reverts 6f2ac50613345546dd6538d823859fd58b0a77e1