### PR TITLE
Remove offhand weapon from circling reqs

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -60,7 +60,7 @@ $Skills = [
   { name: 'Crossbow', type: 'Weapon' },
   { name: 'Polearms', type: 'Weapon' },
   { name: 'Heavy Thrown', type: 'Weapon' },
-  { name: 'Offhand Weapon', type: 'Weapon' },
+  { name: 'Offhand Weapon', type: 'Weapon', generic: true },
   { name: 'Brawling', type: 'Weapon' },
   { name: 'Light Thrown', type: 'Weapon' },
   { name: 'Staves', type: 'Weapon' },


### PR DESCRIPTION
Related to https://github.com/rpherbig/dr-scripts/issues/3469

I've been looking around and can't find a guild that actually circles with Offhand.  I can't actually tell with my thief, but I doubt it.  My trader was actually being told he could circle with Offhand until this change went in.