### PR TITLE
workorders.lic - specify which logbook to read

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -304,7 +304,7 @@ class WorkOrders
       end
 
       wait_for_script_to_complete('shape', ['log', recipe['chapter'], recipe['name'], info['stock-name'], recipe['noun']])
-      case bput('read my logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
+      case bput('read my engineering logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
         break if count + 1 + log_num != quantity
@@ -357,7 +357,7 @@ class WorkOrders
 
     quantity.times do |count|
       wait_for_script_to_complete('sew', ['log', 'sewing', recipe['chapter'], recipe['name'], recipe['noun'], info['sew-stock-name']])
-      case bput('read my logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
+      case bput('read my outfitting logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
         break if count + 1 + log_num != quantity
@@ -382,7 +382,7 @@ class WorkOrders
 
     quantity.times do |count|
       wait_for_script_to_complete('sew', ['log', 'knitting', recipe['chapter'], recipe['name'], recipe['noun'], info['knit-stock-name']])
-      case bput('read my logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
+      case bput('read my outfitting logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
         break if count + 1 + log_num != quantity


### PR DESCRIPTION
Someone was having problems with it reading a different logbook in another container when it would read the logbook after the shape script put it away.