### PR TITLE
add than exp check to 'butcher' only

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -562,7 +562,7 @@ class LootProcess
     return false unless @ritual_type
     return false if game_state.necro_casting?
     return true if @ritual_type == 'cycle'
-    return true if @ritual_type == 'butcher'
+    return true if @ritual_type == 'butcher' && DRSkill.getxp('Thanatology') < 32
     return true if @ritual_type == 'dissect' && DRSkill.getxp('First Aid') < 32
     return true if @ritual_type == 'harvest' && DRSkill.getxp('Skinning') < 32
     return true if DRSkill.getxp('Thanatology') < 32


### PR DESCRIPTION
Butcher by itself only trains Than, right now there is no exp check for 'butcher' by itself.