### PR TITLE
Add more hometown control to dependency

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -919,6 +919,8 @@ class SetupFiles
     s.bankbot_name ||= UserVars.bankbot_name
     s.bankbot_room_id ||= UserVars.bankbot_room_id
     s.prehunt_buffs ||= UserVars.prehunt_buffs
+    s.hometown ||= UserVars.hometown
+    s.hometown = $DYNAMIC_HOMETOWN if $DYNAMIC_HOMETOWN
 
     # Pull town-specific room_ids iff defined
     s.safe_room = s.safe_room[s.hometown] if s.safe_room.is_a?(Hash) && s.safe_room[s.hometown]

--- a/dependency.lic
+++ b/dependency.lic
@@ -920,7 +920,7 @@ class SetupFiles
     s.bankbot_room_id ||= UserVars.bankbot_room_id
     s.prehunt_buffs ||= UserVars.prehunt_buffs
     s.hometown ||= UserVars.hometown
-    s.hometown = $DYNAMIC_HOMETOWN if $DYNAMIC_HOMETOWN
+    s.hometown = $HOMETOWN if $HOMETOWN
 
     # Pull town-specific room_ids iff defined
     s.safe_room = s.safe_room[s.hometown] if s.safe_room.is_a?(Hash) && s.safe_room[s.hometown]
@@ -1263,6 +1263,14 @@ end
 
 def update_moon_data(moon, data)
   $moon_watch.queue_update(moon, data)
+end
+
+def shift_hometown(town_name)
+  $HOMETOWN = town_name
+end
+
+def clear_hometown
+  $HOMETOWN = nil
 end
 
 full_install if install


### PR DESCRIPTION
Another change I'm poking around for thoughts on.

Allowing a user to change hometown by UserVars like other settings here seems like a no-brainer, especially since you can now set up a safe-room hash for each town.  I've got a safe-room setup I cut paste to all my alts and I haven't needed to adjust the room numbers for months, so I can adjust my hometown even without having to touch my yaml.

The big change here would be that a script can now set a $DYNAMIC_HOMETOWN global variable to override the hometown setting everywhere.  I wanted to use a UserVars initially, but I got frightened by the thought of trying to troubleshoot someone that lost power in a way that before_dying didn't get a chance to nil it...  What a nightmare that would be.

My first use-case is in ;trade.  When I arrive at Muspar'i I can drop off my caravan at the guild then set $DYNAMIC_HOMETOWN = "Muspar'i" and trust that ;safe-room, ;workorders, buying yarn/lumber, or any bank-stuff are all going to do their business in-town and not try to barge back towards my yaml hometown.  When I'm done, $DYNAMIC_HOMETOWN = nil.

As an example, (where closest_town returns the closest town with a trader_outpost in base-town and time_to_room() gives the map timeto distance between two rooms)

```
  def check_forging
    return unless @caravan_training_skills.include?('Forging')
    return unless check_ability?('Forging', @caravan_training_skills['Forging'])
    return unless @crafting_data['blacksmithing'][closest_town]
    return if time_to_room(Room.current.id, @crafting_data['blacksmithing'][closest_town]['stock-room']) > 60
    $DYNAMIC_HOMETOWN = closest_town
    wait_for_script_to_complete('workorders', ['blacksmithing'])
    $DYNAMIC_HOMETOWN = nil
    @cooldown_timers['Forging'] = Time.now
  end
```

Or, in other words, if the closest town has a blacksmithing entry, then check to see if you can get there in under 60 seconds (looking at you, Langenfirth -> Riverhaven crafting shunt) and if so set $DYNAMIC_HOMETOWN and start workorders.  This means whenever you call check_forging in/near a city that has a forge it'll go there, do a work order, do a repair, then nil $DYNAMIC_HOMETOWN and get back to business.

It might also eventually be useful for stealing in other towns (set hometown right before moving onto another town, then unset it when done or before_dying), or making crafting less location-specific like above.

I've run ;trade up in Therengia for about 60 hours with this going and an order to let me know if it ever starts running somewhere more than a minute away,  Nothing unusual happened.  This should be safe enough on its own as long as any script that implements it is tested thoroughly enough, but I'm going to keep thinking about unintended side-effects for a while.  I'm not above scrapping it either.