### PR TITLE
Add skill timers to t2

### DIFF
--- a/t2.lic
+++ b/t2.lic
@@ -20,6 +20,7 @@ class T2
     @settings = get_settings
     @repair_timer = @settings.repair_timer
     UserVars.repair_timer_snap ||= Time.now
+    UserVars.t2_timers ||= {}
 
     loop do
       trainables = @settings['training_list']
@@ -30,14 +31,30 @@ class T2
           next if trainable['skill'].each.reject { |skill| DRSkill.getxp(skill) >= trainable['start'] }.empty?
         elsif DRSkill.getxp(trainable['skill']) >= trainable['start']
           next
+        elsif has_cooldown? trainable['skill']
+          next unless cooldown_expired? trainable['skill']
         end
 
+        
         # At this point we know that we need to train the skill
         echo "***STATUS*** Starting #{trainable['skill']}"
         execute_actions(trainable['scripts'])
+        update_cooldown trainable['skill'] if has_cooldown? trainable['skill']
         break
       end
     end
+  end
+
+  def has_cooldown?(skill)
+    @settings.exp_timers.keys.include? skill
+  end
+
+  def cooldown_expired?(skill)
+    UserVars.t2_timers[skill].nil? || Time.now - @settings.exp_timers[skill] >= UserVars.t2_timers[skill]
+  end
+
+  def update_cooldown(skill)
+    UserVars.t2_timers[skill] = Time.now
   end
 
   def execute_actions(actions)


### PR DESCRIPTION
This update enables `t2` to respect skill timers (`exp_timers` in setup.yaml) the same way as `crossing-trainer` does.