### PR TITLE
common-arcana.lic - Fix barb meditate

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -69,15 +69,19 @@ module DRCA
   end
 
   def start_barb_abilities(skills, _settings)
+    Flags.add('med-done', /You feel a jolt as your vision snaps shut/)
     skills
       .reject { |name| DRSpells.active_spells[name] }
       .each do |name|
         activate_barb_buff(name)
         waitrt?
-        pause 6 if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'
+        if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'
+          pause 0.5 while !Flags['med-done']
+        end
       end
+    Flags.delete('med-done')
   end
-
+  
   def activate_barb_buff(name)
     ability_data = get_data('spells').barb_abilities[name]
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting')


### PR DESCRIPTION
Lower level barbs were having an issue where it would stand up before the meditation was done and break the meditate early.

I added in a flag to look for the meditate finishing message and have it check for that before standing.