### PR TITLE
Common methods for instruments

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -383,4 +383,86 @@ module DRC
 
     g
   end
+
+  def play_song?(settings, song_list, worn = true)
+    instrument = worn ? settings.worn_instrument : settings.instrument
+    result = bput("play #{UserVars.song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
+    case result
+    when 'Play on what instrument'
+      snapshot = "#{right_hand}#{left_hand}"
+      fput("get #{instrument}")
+      return false if snapshot == "#{right_hand}#{left_hand}"
+      fput("wear #{instrument}") if worn
+      play_song?(settings, song_list, worn)
+    when 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing'
+      false
+    when 'You\'re already playing a song'
+      fput('stop play')
+      play_song?(settings, song_list, worn)
+    when 'You cannot play'
+      wait_for_script_to_complete('safe-room')
+    when 'dirtiness may affect your performance'
+      return true if DRSkill.getrank('Performance') < 20
+      return true unless clean_instrument(settings, worn)
+      play_song?(settings, song_list, worn)
+    when 'slightest hint of difficulty', 'fumble slightly'
+      true
+    when 'You begin a', 'You effortlessly begin', 'You begin some'
+      return true if UserVars.song == 'concerto masterful'
+      stop_playing
+      UserVars.song = song_list[UserVars.song] || song_list.first.first
+      play_song?(settings, song_list, worn)
+    when 'You struggle to begin'
+      return true if UserVars.song == song_list.first.first
+      stop_playing
+      UserVars.song = song_list.first.first
+      play_song?(settings, song_list, worn)
+    else
+      false
+    end
+  end
+
+  def stop_playing
+    bput('stop play', 'You stop playing your song', 'In the name of', "But you're not performing")
+  end
+
+  def clean_instrument(settings, worn = true)
+    cloth = settings.cleaning_cloth
+    instrument = worn ? settings.worn_instrument : settings.instrument
+    case bput("get my #{cloth}", 'You get', 'What were you')
+    when 'What were you'
+      echo('You have no chamois cloth -- this could cause problems with playing an instrument!')
+      beep
+      return false
+    end
+    stop_playing
+    
+    worn ? bput("remove my #{instrument}", 'You slide', 'You remove') : bput("get #{instrument}", 'You get', 'What were you', 'You are already')
+
+    loop do
+      case bput("wipe my #{instrument} with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
+      when 'not in need of drying'
+        break
+      when 'You should be sitting up'
+        fix_standing
+        next
+      end
+      pause 1
+      waitrt?
+
+      until /you wring a dry/i =~ bput("wring my #{cloth}", 'You wring a dry', 'You wring out')
+        pause 1
+        waitrt?
+      end
+    end
+
+    until /not in need of cleaning/i =~ bput("clean my #{instrument} with my #{cloth}", 'Roundtime', 'not in need of cleaning')
+      pause 1
+      waitrt?
+    end
+
+    bput("wear my #{instrument}", 'You slide', 'You attach') if worn
+    bput("stow my #{cloth}", 'You put')
+    true
+  end
 end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -341,6 +341,8 @@ safe_room: 851
 hand_armor: gloves
 # define an instrument to pick up before playing (if you're not using zills)
 instrument:
+# an instrument that can be played while worn, such as zills, or a cowbell.
+worn_instrument: zills
 # used in several places.  If defined, go2 will remove this before wearing ice-skates when traveling into Forfedhar
 footwear:
 # if true, will attempt to pull money from the nearest bank if you have no money for fares


### PR DESCRIPTION
Added play_song? to common.lic to reduce dependency on ;performance which has caused a number of issues.

play_song? defaults to a worn_instrument, but tested well with held instruments if given worn false.

Little was changed from ;performance's play_song, which was used as a base, except...

worn_instrument: added to base.  Defaults to zills, but can be made to be be cowbell, nose-flute, whatever.

Some unecessary returns were removed from play_song.  play_song? itself returns true if it succeeded in starting to play a tune of the right type, and false if it didn't get what it needed.

clean_instrument also works for worn/nonworn instruments, but other than letting instrument = worn_instrument or instrument little was changed.  It won't exit if it can't find a shamwow now, since anything could be calling it.  Instead, if it can't find a cloth then clean_instrument will return false and keep playing.  Any script that wants to use it can account for that.

I've been running this with performance calling these methods on the roads for a while, and haven't had any problems.  So far it worked with zills and cowbells, and a non-worn instrument, and it's cleaned all three.