### PR TITLE
Splitting out shard gryphons

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -910,12 +910,27 @@ hunting_zones:
   - 11229
   - 11230
   # https://elanthipedia.play.net/Baby_forest_gryphon                    250-350
+  # https://elanthipedia.play.net/Young_forest_gryphon                   300-420
+  # https://elanthipedia.play.net/Fledgling_forest_gryphon_(1)           300-400
   # Good swarm, few rooms usually full
-  shard_gryphons:
-  - 6236
-  - 6237
-  - 6238
+  shard_gryphons: #fledgling/young
   - 6239
+  - 6238
+  - 6237
+  - 6236
+  shard_gryphons1: #baby/fledgling
+  - 6239
+  - 6249
+  - 6248
+  - 6247
+  - 6246
+  shard_gryphons2: #fledgling/young (some water rooms!)
+  - 6245
+  - 6244
+  - 6243
+  - 6241
+  - 6242
+  - 6240
   # https://elanthipedia.play.net/Adan%27f_shadow_mage                   250-370
   # https://elanthipedia.play.net/Adan%27f_blood_warrior                 250-325
   # Spawn is hit or miss


### PR DESCRIPTION
Adding some rooms and splitting things out. I left the default of "shard_gryphons" as taking you to the higher tiered gryphons, and gave the 1 and 2 option as being lower tier. This way anyone who had "shard_gryphons" as their hunting zone won't see a change.

There's some overlap in rooms between shard_gryphons and shard_gryphons1, but that was as before. I don't see matures spawning anywhere, so I think the map is wrong.