### PR TITLE
Fixed possible hang due to missing therugy_container

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -300,6 +300,7 @@ class TheurgyActions
       walk_to(@data['holy_water']['id'])
       bput("get my #{@water_holder}", 'You get', 'You are already')
       pause 0.1 while bput("fill #{@water_holder} with water from #{@data['holy_water']['noun']}", 'You fill', 'There is no more room') == 'You fill'
+      put_in_container(@water_holder)
       stow_hands
     end
 


### PR DESCRIPTION
Theurgy.lic was using only "Stow" to put away holy_water instead of putting it in theurgy container. This caused Theurgy to hang the next time it tried to get  holy_water from the theurgy_container as stow may not be the same container. 

added -  put_in_container(@water_holder) - at line 303 just above stow_hands.

