### PR TITLE
almanac.lic: Add support for the droghtmans almanacs

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -33,7 +33,7 @@ class Almanac
     Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:pause)
     waitrt?
     bput('stow left', 'Stow what', 'You put') if checkleft
-    case bput('get my almanac', 'You get', 'What were')
+    case bput('get my almanac', 'You get', 'What were', 'You are already')
     when 'What were'
       echo('Almanac not found, exiting.')
       Script.running.find_all { |s| s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:unpause)

--- a/almanac.lic
+++ b/almanac.lic
@@ -8,8 +8,10 @@ class Almanac
   include DRC
 
   def initialize
+    settings = get_settings
     UserVars.almanac_last_use ||= Time.now - 600
-    @no_use_scripts = get_settings.almanac_no_use_scripts
+    @no_use_scripts = settings.almanac_no_use_scripts
+    @almanac_skills = settings.almanac_skills
 
     passive_loop
   end
@@ -20,6 +22,14 @@ class Almanac
     return if XMLData.room_title.include? 'Carousel Chamber'
     return if hidden?
 
+    if @almanac_skills
+      training_skill = @almanac_skills
+                       .select { |skill| @almanac_skills }
+                       .select { |skill| DRSkill.getxp(skill) < 18 }
+                       .sort_by { |skill| DRSkill.getxp(skill) }.first
+      return unless training_skill
+    end
+
     Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:pause)
     waitrt?
     bput('stow left', 'Stow what', 'You put') if checkleft
@@ -28,6 +38,9 @@ class Almanac
       echo('Almanac not found, exiting.')
       Script.running.find_all { |s| s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:unpause)
       exit
+    end
+    if @almanac_skills
+      bput("turn almanac to #{training_skill}", 'You turn', 'You attempt to turn')
     end
     bput('study my almanac', 'You set about', 'gleaned all the insight you can', 'Study what', 'interrupt your research')
     waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1994,6 +1994,9 @@ class TrainerProcess
 
     @gem_pouch_adjective = settings.gem_pouch_adjective
     echo("  @gem_pouch_adjective: #{@gem_pouch_adjective}") if $debug_mode_ct
+
+    @almanac_skills = settings.almanac_skills
+    echo("  @almanac_skills: #{@almanac_skills}") if $debug_mode_ct
   end
 
   def execute(game_state)
@@ -2108,11 +2111,21 @@ class TrainerProcess
   def use_almanac(game_state)
     return unless Time.now - UserVars.almanac_last_use >= 600
     return if left_hand && !game_state.currently_whirlwinding
+    if @almanac_skills
+      training_skill = @almanac_skills
+                       .select { |skill| @almanac_skills }
+                       .select { |skill| DRSkill.getxp(skill) < 18 }
+                       .sort_by { |skill| DRSkill.getxp(skill) }.first
+      return unless training_skill
+    end
 
     game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
     retreat
     fput('engage') unless game_state.npcs.empty? || game_state.retreating?
     bput('get my almanac', 'You get', 'What were')
+    if @almanac_skills
+      bput("turn almanac to #{training_skill}", 'You turn', 'You attempt to turn')
+    end
     bput('study my almanac', 'You set about', 'gleaned all the insight you can', 'Study what')
     waitrt?
     bput('stow my almanac', 'You put', 'Stow what')

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -63,3 +63,4 @@ empty_values:
   restock_shop: {}
   theurgy_supply_levels: {}
   caravan_training_skills: {}
+  almanac_skills: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1190,6 +1190,8 @@ forge_container:
 spell_cycle:
 
 restock_shop:
+# For almanacs that let you pick which skill to use
+almanac_skills:
 
 sanowret_adjective: sanowret
 sanowret_no_use_scripts:

--- a/validate.lic
+++ b/validate.lic
@@ -99,7 +99,7 @@ class DRYamlValidator
     settings.almanac_skills
             .keys
             .reject { |skill_name| @all_skills.include?(skill_name) }
-            .each { |skill_name| error("Invalid almanac_skills: skill name '#{skill_name}'. Valid skills are '#{all_skills}'") }
+            .each { |skill_name| error("Invalid almanac_skills: skill name '#{skill_name}'. Valid skills are '#{@all_skills}'") }
   end
 
   def assert_that_weapon_training_are_skills(settings)

--- a/validate.lic
+++ b/validate.lic
@@ -93,6 +93,15 @@ class DRYamlValidator
     error('water_holder: must be defined in your yaml to use favor_altars. ex: water_holder: chalice')
   end
 
+  def assert_that_almanac_skills_are_skills(settings)
+    return unless settings.almanac_skills
+
+    settings.almanac_skills
+            .keys
+            .reject { |skill_name| @all_skills.include?(skill_name) }
+            .each { |skill_name| error("Invalid almanac_skills: skill name '#{skill_name}'. Valid skills are '#{all_skills}'") }
+  end
+
   def assert_that_weapon_training_are_skills(settings)
     return unless settings.weapon_training
 

--- a/validate.lic
+++ b/validate.lic
@@ -97,7 +97,6 @@ class DRYamlValidator
     return unless settings.almanac_skills
 
     settings.almanac_skills
-            .keys
             .reject { |skill_name| @all_skills.include?(skill_name) }
             .each { |skill_name| error("Invalid almanac_skills: skill name '#{skill_name}'. Valid skills are '#{@all_skills}'") }
   end


### PR DESCRIPTION
These can be turned to individual skills. This adds support for a yaml setting to pick which skills to use, and it will pick whichever skill is at the lowest mindstate to study. If none of the skills are under 18/34 it will loop every 20 seconds checking to use it when one is.

Skills to use can be customized like

```
almanac_skills:
- Mechanical Lore
- Outdoorsmanship
- Scouting

```
Fixes #3559