### PR TITLE
Update to afk.lic for grabbing at foot ammo

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -65,14 +65,12 @@ loop do
     item = DRC.get_noun(match)
     case DRC.bput('inv', /Lying at your feet is/, /Lying at your feet are (.*)\./)
     when /Lying at your feet is/
-      DRC.bput("get my #{item}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
-      equipment_manager.empty_hands
+      DRC.bput("stow my #{item}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
     when /Lying at your feet are (.*)\./
       at_feet = Regexp.last_match(1)
       items = DRC.list_to_nouns(at_feet)
       items.each do |thing|
-        DRC.bput("get my #{thing}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
-        equipment_manager.empty_hands
+        DRC.bput("stow my #{thing}", 'You get', 'You pick up', 'But that is already in your inventory', /What were you referring to/)
       end
     end
     stop_script('go2') if Script.running?('go2')


### PR DESCRIPTION
The get step is not needed and due to a bug with the new Droughtman's blunt-tip arrows, afk will not grab them. Individual arrows show up as "arrows" instead of "arrow" and if you "get my arrows" it will grab the arrows on your person and get stuck in a loop.