### PR TITLE
AFK: Add check for user and script input timer

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -15,6 +15,12 @@ def exit_game(message)
   fput('exit')
 end
 
+def idle?(line)
+  return true if line =~ /you have been idle too long/i
+  return true if Time.now - $_IDLETIMESTAMP_ > 360 && Time.now - $_SCRIPTIDLETIMESTAMP_ > 360
+  false
+end
+
 echo 'Afk script started - pausing for 10 seconds or until health passes threshold'
 pause 10
 
@@ -37,7 +43,7 @@ loop do
   line = script.gets?
   pause 0.05 unless line
 
-  fput(%w[tdp time age].sample) if line =~ /you have been idle too long/i
+  fput(%w[tdp time age].sample) if idle?(line)
 
   justice_message_count += 1 if line =~ /^"Burn .+!  Burn .+!" .* giving you a wide berth/
   justice_message_count += 1 if line =~ /authorities will try to bring you in for endangering the public/

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -1,4 +1,9 @@
 module Harness
+  # Lich global for the last time a user sent a command to the game
+  $_IDLETIMESTAMP_ = Time.now
+  # Lich global for the last time a script sent a command to the game
+  $_SCRIPTIDLETIMESTAMP_ = Time.now
+  
   class Script
     def gets?
       get?


### PR DESCRIPTION
This helps avoid cases where the game logs a user out without sending an idle message

We use $_IDLE and $_SCRIPTIDLE to see the last time a user sent a command and the last time a script sent a command. If its more than 6 minutes then we send the same message we would when receiving a "you are idle" message.