### PR TITLE
Fix bug with using global idle timers before initialized

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -17,7 +17,9 @@ end
 
 def idle?(line)
   return true if line =~ /you have been idle too long/i
-  return true if Time.now - $_IDLETIMESTAMP_ > 360 && Time.now - $_SCRIPTIDLETIMESTAMP_ > 360
+  if $_IDLETIMESTAMP_ && $_SCRIPTIDLETIMESTAMP_
+    return true if Time.now - $_IDLETIMESTAMP_ > 360 && Time.now - $_SCRIPTIDLETIMESTAMP_ > 360
+  end
   false
 end
 


### PR DESCRIPTION
The lich global idle timers are not initialized immediately after
startup, but rather a few seconds after. This would cause afk.lic
to crash when autostarted. This fix alleviates that by skip their
check if falsey.