### PR TITLE
Added the ability for barbs to customize their meditation timer. 

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -68,13 +68,13 @@ module DRCA
     end
   end
 
-  def start_barb_abilities(skills, _settings)
+  def start_barb_abilities(skills, settings)
     skills
       .reject { |name| DRSpells.active_spells[name] }
       .each do |name|
         activate_barb_buff(name)
         waitrt?
-        pause 6 if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'
+        pause settings.meditation_pause_timer.to_i if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'
       end
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -182,6 +182,10 @@ loot_bodies: true
 dump_junk: false
 # items to wait for before junking
 dump_item_count: 9
+# used to set a pause timer for barbarian meditations, this number should go down with a chakrel, circles, and stats... 
+# as an example, chuno currently runs it at 6 being circle 195
+# defaulting to 25, as 20 for lower skilled barbs was explained to be common
+meditation_pause_timer: 25
 # use the analyze combos to train
 use_barb_combos: false
 # list of weapon skills to use with whirlwind.  See Chuno-setup


### PR DESCRIPTION
There is a script roaming around that barbs are using for it, but this is a better fix. I implemented the buffing well into my circles at around 175th or so, so I didn't experience needing more than 6s. 

Defaulting to 25 as 20 was explained to me as being a current actual timer for barbs of sub 100, even with chakrel. 

It is my opinion that barbs do not need meditations without Yogi for combat, but that's just me. I can understand wanting to use abilities you get.