### PR TITLE
Shape: Update regex to include 'leather'

### DIFF
--- a/shape.lic
+++ b/shape.lic
@@ -53,7 +53,7 @@ class Shape
     @training_spells = @settings.crafting_training_spells
 
     wait_for_script_to_complete('buff', ['shape'])
-    Flags.add('shaping-assembly', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* leather (strip|cord)', 'You must assemble the (backer)', 'You must assemble the (strips)')
+    Flags.add('shaping-assembly', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* (leather (?:strip|cord))', 'You must assemble the (backer)', 'You must assemble the (strips)')
     Flags.add('shape-magic-ready', 'You feel fully prepared to cast your spell.')
     if args.continue
       shape("analyze my #{@noun}")


### PR DESCRIPTION
If you're wearing a 'strip' (e.g. the faeweave strip from Dusk Ruin) shape will break trying to assemble something that requires a leather strip.