### PR TITLE
Fix handling of no game response to `load`

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2739,12 +2739,12 @@ class AttackProcess
       end
     else
       if game_state.dual_load?
-        pause 0.5 until load_return = bput('load arrows', 'You reach into', 'already loaded', 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands')
+        pause 0.5 until '' != (load_return = bput('load arrows', 'You reach into', 'already loaded', 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands'))
         if ['but are unable to draw upon its majesty', 'without steadier hands', 'Such a feat would be impossible without the winds to guide'].include?(load_return)
-          pause 0.5 until bput('load', 'You reach into', 'You carefully load', 'already loaded')
+          pause 0.5 until '' != bput('load', 'You reach into', 'You carefully load', 'already loaded')
         end
       else
-        pause 0.5 until bput('load', 'You reach into', 'You carefully load', 'already loaded')
+        pause 0.5 until '' != bput('load', 'You reach into', 'You carefully load', 'already loaded')
       end
 
       waitrt?


### PR DESCRIPTION
Occasionally the game will not respond to the `load` command, resulting in a hang and endless loop in aiming_trainables. Testing against an empty string (as returned by `bput` with a timeout) will allow combat-trainer to retry the load command, which in testing has been successful.