### PR TITLE
Fix bug in choose-a-skill almanac support

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -22,9 +22,8 @@ class Almanac
     return if XMLData.room_title.include? 'Carousel Chamber'
     return if hidden?
 
-    if @almanac_skills
+    unless @almanac_skills.empty?
       training_skill = @almanac_skills
-                       .select { |skill| @almanac_skills }
                        .select { |skill| DRSkill.getxp(skill) < 18 }
                        .sort_by { |skill| DRSkill.getxp(skill) }.first
       return unless training_skill
@@ -39,7 +38,7 @@ class Almanac
       Script.running.find_all { |s| s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:unpause)
       exit
     end
-    if @almanac_skills
+    if training_skill
       bput("turn almanac to #{training_skill}", 'You turn', 'You attempt to turn')
     end
     bput('study my almanac', 'You set about', 'gleaned all the insight you can', 'Study what', 'interrupt your research')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2111,9 +2111,8 @@ class TrainerProcess
   def use_almanac(game_state)
     return unless Time.now - UserVars.almanac_last_use >= 600
     return if left_hand && !game_state.currently_whirlwinding
-    if @almanac_skills
+    unless @almanac_skills.empty?
       training_skill = @almanac_skills
-                       .select { |skill| @almanac_skills }
                        .select { |skill| DRSkill.getxp(skill) < 18 }
                        .sort_by { |skill| DRSkill.getxp(skill) }.first
       return unless training_skill
@@ -2123,7 +2122,7 @@ class TrainerProcess
     retreat
     fput('engage') unless game_state.npcs.empty? || game_state.retreating?
     bput('get my almanac', 'You get', 'What were')
-    if @almanac_skills
+    if training_skill
       bput("turn almanac to #{training_skill}", 'You turn', 'You attempt to turn')
     end
     bput('study my almanac', 'You set about', 'gleaned all the insight you can', 'Study what')


### PR DESCRIPTION
Adding support for the new choose-a-skill almanacs broke older almanacs (the block to select a skill was always entered into). This update fixes older almanacs. 

**NOTE:** I was unable to find someone to test the newer almanacs against this.