### PR TITLE
mining-buddy - updated get and store

### DIFF
--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -59,7 +59,7 @@ class MiningBuddy
   end
 
   def get_mining_tool
-    if @forging_belt['items'].grep(/shovel/i).any?
+    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
       bput("untie my #{@mining_implement}", 'You remove', 'You untie')
     else
       bput("get my #{@mining_implement}", 'You get', 'You are already')
@@ -68,7 +68,7 @@ class MiningBuddy
 
   def store_mining_tool
     waitrt?
-    if @forging_belt['items'].grep(/shovel/i).any?
+    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
       fput("tie my #{@mining_implement} to #{@forging_belt['name']}")
     else
       fput("stow my #{@mining_implement}")


### PR DESCRIPTION
It was always searching to see if there is a shovel on the forging belt even if the person specified their mining implement to be a pickaxe.  This caused it to try to untie the pickaxe from the forging belt if the person had a shovel on their belt.

Now it searches for whatever your mining implement is.