### PR TITLE
mine.lic - updated get and store methods

### DIFF
--- a/mine.lic
+++ b/mine.lic
@@ -106,7 +106,7 @@ class Mine
   end
 
   def get_mining_tool
-    if @forging_belt['items'].grep(/shovel/i).any?
+    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
       bput("untie my #{@mining_implement}", 'You remove', 'You untie')
     else
       bput("get my #{@mining_implement}", 'You get', 'You are already')
@@ -115,7 +115,7 @@ class Mine
 
   def store_mining_tool
     waitrt?
-    if @forging_belt['items'].grep(/shovel/i).any?
+    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
       fput("tie my #{@mining_implement} to #{@forging_belt['name']}")
     else
       fput("stow my #{@mining_implement}")


### PR DESCRIPTION
Same update as was done to mining-buddy.

The methods to get and store the mining tool were searching for shovel even if the user has mining_implement set to pickaxe.

That would cause it to try and untie the pickaxe from the forging belt if it found a shovel on there.