### PR TITLE
Add pause_all and unpause_all to common

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -465,4 +465,37 @@ module DRC
     bput("stow my #{cloth}", 'You put')
     true
   end
+
+  def pause_all
+    return false if $pause_all_lock
+    $pause_all_lock = caller[0][/^[a-z0-9_-]+/i]
+    @pause_all_no_unpause = []
+
+    Script.running.find_all { |script| script.paused? }.each do |script| 
+       @pause_all_no_unpause << script.name
+    end
+
+    Script.running.find_all { |script| 
+      !script.paused? && 
+      !script.no_pause_all && 
+       script.name != $pause_all_lock }
+    .each(&:pause)
+
+    return true
+  end
+  
+  def unpause_all
+    return false if caller[0][/^[a-z0-9_-]+/i] != $pause_all_lock
+
+    Script.running.find_all { |script| 
+      script.paused? && 
+      !@pause_all_no_unpause.include?(script.name) }
+    .each(&:unpause)
+
+    @pause_all_no_unpause = []
+    $pause_all_lock = nil
+
+    return true
+  end
+  
 end

--- a/common.lic
+++ b/common.lic
@@ -56,6 +56,7 @@ $NUM_MAP = {
 custom_require.call(%w[spellmonitor drinfomon])
 
 module DRC
+  $pause_all_lock ||= Mutex.new
   module_function
 
   def bput(message, *matches)
@@ -465,11 +466,11 @@ module DRC
     bput("stow my #{cloth}", 'You put')
     true
   end
-
+  
   def pause_all
-    return false if $pause_all_lock
-    $pause_all_lock = caller[0][/^[a-z0-9_-]+/i]
+    return false unless $pause_all_lock.try_lock
     @pause_all_no_unpause = []
+    calling_script = caller[0][/^[a-z0-9_-]+/i]
 
     Script.running.find_all { |script| script.paused? }.each do |script| 
        @pause_all_no_unpause << script.name
@@ -478,7 +479,7 @@ module DRC
     Script.running.find_all { |script| 
       !script.paused? && 
       !script.no_pause_all && 
-       script.name != $pause_all_lock }
+       script.name != calling_script }
     .each(&:pause)
 
     pause 1
@@ -486,7 +487,7 @@ module DRC
   end
   
   def unpause_all
-    return false if caller[0][/^[a-z0-9_-]+/i] != $pause_all_lock
+    return false unless $pause_all_lock.owned?
 
     Script.running.find_all { |script| 
       script.paused? && 
@@ -494,7 +495,7 @@ module DRC
     .each(&:unpause)
 
     @pause_all_no_unpause = []
-    $pause_all_lock = nil
+    $pause_all_lock.unlock
 
     return true
   end

--- a/common.lic
+++ b/common.lic
@@ -481,6 +481,7 @@ module DRC
        script.name != $pause_all_lock }
     .each(&:pause)
 
+    pause 1
     return true
   end
   

--- a/common.lic
+++ b/common.lic
@@ -470,16 +470,15 @@ module DRC
   def pause_all
     return false unless $pause_all_lock.try_lock
     @pause_all_no_unpause = []
-    calling_script = caller[0][/^[a-z0-9_-]+/i]
 
     Script.running.find_all { |script| script.paused? }.each do |script| 
-       @pause_all_no_unpause << script.name
+       @pause_all_no_unpause << script
     end
 
     Script.running.find_all { |script| 
       !script.paused? && 
       !script.no_pause_all && 
-       script.name != calling_script }
+       script != Script.current }
     .each(&:pause)
 
     pause 1
@@ -491,7 +490,7 @@ module DRC
 
     Script.running.find_all { |script| 
       script.paused? && 
-      !@pause_all_no_unpause.include?(script.name) }
+      !@pause_all_no_unpause.include?(script) }
     .each(&:unpause)
 
     @pause_all_no_unpause = []


### PR DESCRIPTION
There are a handful of scripts that seek to pause/unpause all other running scripts. These methods standardize the way we handle pausing/unpausing, and introduce a few improvements:

* Won't unpause scripts that were already paused; and,
* One script will hold a lock on pause_all functions until it unpauses, to prevent two "pause all" scripts from pausing each other.