### PR TITLE
Update scripts to use common pause_all and unpause_all methods

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -29,13 +29,13 @@ class Almanac
       return unless training_skill
     end
 
-    Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:pause)
+    pause 1 until pause_all
     waitrt?
     bput('stow left', 'Stow what', 'You put') if checkleft
     case bput('get my almanac', 'You get', 'What were', 'You are already')
     when 'What were'
       echo('Almanac not found, exiting.')
-      Script.running.find_all { |s| s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:unpause)
+      unpause_all
       exit
     end
     if training_skill
@@ -45,7 +45,7 @@ class Almanac
     waitrt?
     bput('stow my almanac', 'You put', 'Stow what')
     UserVars.almanac_last_use = Time.now
-    Script.running.find_all { |s| s.paused? && !s.no_pause_all && s.name != 'almanac' }.each(&:unpause)
+    unpause_all
   end
 
   def passive_loop

--- a/glyph-of-mana.lic
+++ b/glyph-of-mana.lic
@@ -21,9 +21,9 @@ class GlyphMana
     while line = get
       waitrt?
       next unless line =~ /^You sense the holy power return to normal/
-      Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
+      pause 1 until pause_all
       bput('glyph mana', 'You trace a glyph into the air in', 'Paladin now', 'but you sense that this glyph is already in effect here', 'You trace a glyph into the air managing only to look foolish')
-      Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
+      unpause_all
     end
   end
 end

--- a/healer.lic
+++ b/healer.lic
@@ -20,7 +20,7 @@ class Healer
   end
 
   def stop_training
-    Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != 'healme' }.each(&:pause)
+    pause 1 until pause_all
   end
 
   def start_training
@@ -30,7 +30,7 @@ class Healer
     fput("get my #{@left}") if @left
     @left = nil
     @right = nil
-    Script.running.find_all { |s| s.paused? && !s.no_pause_all && s.name != 'healme' }.each(&:unpause)
+    unpause_all
   end
 
   def ready_for_patient

--- a/jail-buddy.lic
+++ b/jail-buddy.lic
@@ -51,7 +51,7 @@ def recover_gear
 end
 
 def get_out_of_jail(old_loc)
-  Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
+  pause 1 until pause_all
   stop_script('go2') if Script.running?('go2')
   echo('** DON\'T PANIC JAIL BUDDY HAS YOUR BACK! **')
 
@@ -81,7 +81,7 @@ def get_out_of_jail(old_loc)
 
   DRC.wait_for_script_to_complete('go2', [old_loc.to_s], force: true) if old_loc
 
-  Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
+  unpause_all
 end
 
 loop do

--- a/ranger-companion.lic
+++ b/ranger-companion.lic
@@ -43,7 +43,7 @@ class Companion
         bput('pet raccoon', 'You pet', 'Touch what')
       end
       if line =~ /^A .* wolf begins to whimper./
-        Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
+        pause 1 until pause_all
         waitrt?
         bput('stow left', 'Stow what', 'You put')
         case bput('get my milk', 'You get', 'You are already holding', 'What were you referring to')
@@ -59,10 +59,10 @@ class Companion
           exit
         end
         bput('stow my milk', 'You put your', 'Stow what')
-        Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
+        unpause_all
       end
       next unless line =~ /^A .* raccoon begins to whimper./
-      Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
+      pause 1 until pause_all
       waitrt?
       bput('stow left', 'Stow what', 'You put')
       case bput('get my corn', 'You get', 'You are already holding', 'What were you referring to')
@@ -72,7 +72,7 @@ class Companion
       end
       bput('feed my corn to raccoon', 'raccoon greedily eats')
       bput('stow my corn', 'You put your', 'Stow what')
-      Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
+      unpause_all
     end
   end
 end

--- a/smartlisten.lic
+++ b/smartlisten.lic
@@ -45,7 +45,7 @@ loop do
 
   next unless listen_skills.include?(skill)
   echo "Attempting to listen to #{teacher}"
-  Script.running.find_all { |s| !s.paused? && !s.no_pause_all }.each(&:pause)
+  pause 1 until pause_all
   DRC.listen?(teacher, get_settings.listen_observe)
-  Script.running.find_all { |s| s.paused? && !s.no_pause_all }.each(&:unpause)
+  unpause_all
 end


### PR DESCRIPTION
With PR #3602 merged, this PR updates the scripts that were using the previous approach to pause/unpause all other scripts to use the new methods.