### PR TITLE
smelt.lic: Specify stirring rod instead of just rod.

### DIFF
--- a/smelt.lic
+++ b/smelt.lic
@@ -24,13 +24,13 @@ class Smelt
 
     args = parse_args(arg_definitions)
 
-    get_crafting_item('rod', @bag, @bag_items, @belt)
+    get_crafting_item('stirring rod', @bag, @bag_items, @belt)
     if args.refine
       refine
     else
       stir
     end
-    stow_crafting_item('rod', @bag, @belt)
+    stow_crafting_item('stirring rod', @bag, @belt)
   end
 
   def refine
@@ -58,7 +58,7 @@ class Smelt
   def stir
     pause 1
     waitrt?
-    case bput('stir crucible with my rod', 'You can only mix a crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'down and needs more fuel', 'roundtime')
+    case bput('stir crucible with my stirring rod', 'You can only mix a crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'down and needs more fuel', 'roundtime')
     when /roundtime/i
       return stir
     when 'You can only mix a crucible'


### PR DESCRIPTION
Fixes: #3609

Double checked that just rod wasn't used in any of the other forging scripts and it's ok.