### PR TITLE
shape.lic - magic routine fix for ethereal fissure

### DIFF
--- a/shape.lic
+++ b/shape.lic
@@ -219,6 +219,13 @@ class Shape
 
   def magic_routine
     return if @training_spells.empty?
+    return if mana < 41
+
+    if Flags['shape-magic-ready']
+      crafting_cast_spell(@data_prepped, @settings)
+      Flags.reset('shape-magic-ready')
+      @preparing = false
+    end
 
     needs_training = %w[Warding Utility Augmentation]
                      .select { |skill| @training_spells[skill] }
@@ -228,17 +235,12 @@ class Shape
 
     data = @training_spells[needs_training]
 
-    if Flags['shape-magic-ready'] && mana > 40
-      crafting_cast_spell(data, @settings)
-      Flags.reset('shape-magic-ready')
-      @preparing = false
-    end
-
     return if @preparing
     crafting_prepare_spell(data, @settings)
+    @data_prepped = data
     @preparing = true
   end
-
+  
   def magic_cleanup
     return if @training_spells.empty?
 


### PR DESCRIPTION
Fixes any spell that has to be cast as  `cast <option>`.

Before it would load up the cast data from a different spell sometimes and try to just cast, now it always uses the data from the correct spell when it casts.