### PR TITLE
common-arcana.lic - added commonized crafting magic routine

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -617,4 +617,26 @@ module DRCA
     command = data['prep_type'] if data['prep_type']
     prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
   end
+
+  def crafting_magic_routine(settings)
+    training_spells = settings.crafting_training_spells
+    return if training_spells.empty?
+    return if mana <= 40
+
+    if !XMLData.prepared_spell.eql?('None') && checkcastrt == 0
+      spell = XMLData.prepared_spell
+      skill = get_data('spells').spell_data[spell]['skill']
+      data = training_spells[skill]
+      crafting_cast_spell(data, settings)
+    end
+    
+    return if checkcastrt > 0
+    needs_training = %w[Warding Utility Augmentation]
+                     .select { |skill| training_spells[skill] }
+                     .select { |skill| DRSkill.getxp(skill) < 31 }
+                     .sort_by { |skill| DRSkill.getxp(skill) }.first
+    return unless needs_training
+
+    crafting_prepare_spell(training_spells[needs_training], settings)
+  end
 end


### PR DESCRIPTION
With this, you only need to call `crafting_magic_routine(@settings)` from each of the scripts that uses `crafting_training_spells`

I also fixed the bug where it would pick up the data for the wrong spell when casting.  This caused problems for Ethereal Fissure and possibly other spells.