### PR TITLE
circle-check.lic: Remove mech lore from circle requirements

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -25,7 +25,6 @@ $Skills = [
   { name: 'Scholarship', type: 'Lore' },
   { name: 'Appraisal', type: 'Lore' },
   { name: 'Tactics', type: 'Lore' },
-  { name: 'Mechanical Lore', type: 'Lore' },
   { name: 'Performance', type: 'Lore' },
   { name: 'Empathy', type: 'Lore' },
   { name: 'Enchanting', type: 'Lore' },


### PR DESCRIPTION
There is no longer any way to train this skill. It can be used if you already have it people need to convert it to a craft to keep circling.