### PR TITLE
circlecheck.lic: Restrict offhand weapon from all guilds that have we…

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -179,7 +179,7 @@ $GuildReqs = {
       ]
 
     },
-    restricted: %w[Sorcery]
+    restricted: ['Sorcery', 'Offhand Weapon']
   },
   'Warrior Mage' => {
     specific_reqs: {
@@ -219,7 +219,7 @@ $GuildReqs = {
 
     },
     hard_reqs: %w[Summoning],
-    restricted: %w[Sorcery Thievery]
+    restricted: ['Sorcery', 'Thievery', 'Offhand Weapon']
   },
   'Paladin' => {
     specific_reqs: {
@@ -258,7 +258,7 @@ $GuildReqs = {
       ]
     },
     hard_reqs: %w[Conviction Evasion],
-    restricted: %w[Sorcery Thievery]
+    restricted: ['Sorcery', 'Thievery', 'Offhand Weapon']
   },
   'Cleric' => {
     specific_reqs: {
@@ -297,7 +297,7 @@ $GuildReqs = {
 
     },
     hard_reqs: %w[Theurgy],
-    restricted: %w[Sorcery Thievery]
+    restricted: ['Sorcery', 'Thievery', 'Offhand Weapon']
   },
 
   'Barbarian' => {
@@ -447,6 +447,7 @@ $GuildReqs = {
       ]
     },
     hard_reqs: ['Performance']
+    restricted: ['Offhand Weapon']
   },
 
   'Trader' => {
@@ -480,7 +481,7 @@ $GuildReqs = {
 
     },
     hard_reqs: %w[Appraisal Trading],
-    restricted: []
+    restricted: ['Offhand Weapon']
   }
 }
 


### PR DESCRIPTION
…apon requirements.

We were doing this on a case by case basis before when people hit it but no guild can use offhand weapon as a req.