### PR TITLE
rezz.lic - prevent infuse method from returning 0 mana

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -92,6 +92,7 @@ class Rezz
     else
       @rezz['mana']
     end
+    @rezz['mana'] = @rezz['mana'] == 0 ? 1 : @rezz['mana']
   end
 
   def find_soul?(player)


### PR DESCRIPTION
If @rezz['mana'] is less than 5/4/3, it will return 0.  This ensures that it at least returns a 1