### PR TITLE
equipmanager.lic - add support for swappable offhand

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -152,7 +152,7 @@ class EquipmentManager
     end
   end
 
-  def wield_weapon_offhand(description)
+  def wield_weapon_offhand(description, skill = nil)
     return if description.empty?
 
     weapon = item_by_desc(description)
@@ -162,6 +162,7 @@ class EquipmentManager
     end
 
     get_item?(weapon)
+    swap_to_skill(weapon.name, skill) if skill && weapon.swappable
   end
 
   def wield_weapon(description, skill = nil)


### PR DESCRIPTION
Add support for swappable offhand weapons.
This is specifically so something like a throwing spike can be used with aiming_trainables.