### PR TITLE
combat-trainer.lic - add swappable for aiming_trainables

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3258,7 +3258,7 @@ class GameState
     return if skill.eql?'Brawling'
     return if skill.eql?'Tactics'
 
-    @equipment_manager.wield_weapon_offhand(weapon_training[skill])
+    @equipment_manager.wield_weapon_offhand(weapon_training[skill], skill)
     weapon_training[skill]
   end
 


### PR DESCRIPTION
Added support for swappable weapons in assuming_trainable. This should work for stuff like a throwing spike if you want to use it for small blunt and small edged. It also doesn't create issues if you use the spike for light thrown too.