### PR TITLE
Reverted some analyze changes, and made setting.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2614,10 +2614,6 @@ class AttackProcess
       bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip')
     end
     
-    if reget(5, 'Wouldn\'t it be better if you used a melee weapon?')
-      bput('attack', 'Wouldn\'t it be better if you used a melee weapon?', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip')
-    end
-
     pause
     waitrt?
 
@@ -3136,6 +3132,9 @@ class GameState
     @use_barb_combos = settings.use_barb_combos
     echo("  @use_barb_combos: #{@use_barb_combos}") if $debug_mode_ct
 
+    @use_analyze_combos = settings.use_analyze_combos
+    echo(" @use_analyze_combos: #{@use_analyze_combos}") if $debug_mode_ct 
+
     @skip_last_kill = settings.skip_last_kill
     echo("  @skip_last_kill: #{@skip_last_kill}") if $debug_mode_ct
 
@@ -3155,7 +3154,7 @@ class GameState
     @whirlwind_trainables = settings.whirlwind_trainables
     echo("  @whirlwind_trainables: #{@whirlwind_trainables}") if $debug_mode_ct
 
-    if @use_barb_combos
+    if @use_barb_combos || @use_analyze_combos
       Flags.add('ct-accuracy-ready', 'You sense your combat accuracy decrease')
       Flags['ct-accuracy-ready'] = true
       Flags.add('ct-damage-ready', 'You sense your ability to land deadly blows decrease')
@@ -3585,7 +3584,11 @@ class GameState
       attack_override
     elsif @use_weak_attacks
       brawling? ? 'gouge' : 'jab'
-    elsif @use_barb_combos
+    # @use_barb_combos needs to be removed given people time to switch
+    # !offhand is there because you can't combo while training offhand weapon without main hand
+    # !brawling is there because you can't use a weapon for brawling commands
+    # Both of these issues will cause problems with the combo array system
+    elsif @use_barb_combos || @use_analyze_combos && !offhand? && !brawling?
       update_analyze_array(false) if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else
@@ -3675,14 +3678,13 @@ class GameState
   end
 
   def update_analyze_array(only_accuracy)
-    return if DRStats.barbarian? && !offhand? && !brawling?
-    return perform_analyze?('accuracy', 50) if only_accuracy
-    if !DRStats.barbarian?
-        perform_analyze?('', 0)
+    return if offhand? || brawling?
+    return perform_analyze?('accuracy', 50) if only_accuracy # Barb only setting
+    if DRStats.barbarian?
+      { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }.each do |type, expertise|
+      break if perform_analyze?(type, expertise)
     else
-        { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }.each do |type, expertise|
-        break if perform_analyze?(type, expertise)
-    end
+      perform_analyze?('', 0)
     end
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3130,7 +3130,7 @@ class GameState
     echo("  @use_weak_attacks: #{@use_weak_attacks}") if $debug_mode_ct
 
     @use_analyze_combos = settings.use_analyze_combos || settings.use_barb_combos
-    echo(" @use_analyze_combos: #{@use_analyze_combos}") if $debug_mode_ct 
+    echo(" @use_analyze_combos: #{@use_analyze_combos}") if $debug_mode_ct
 
     @skip_last_kill = settings.skip_last_kill
     echo("  @skip_last_kill: #{@skip_last_kill}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3678,7 +3678,7 @@ class GameState
   end
 
   def update_analyze_array(only_accuracy)
-    return if offhand? || brawling?
+    return unless !offhand? && !brawling?
     return perform_analyze?('accuracy', 50) if only_accuracy # Barb only setting
     if DRStats.barbarian?
       { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }.each do |type, expertise|

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3588,7 +3588,7 @@ class GameState
     # !offhand is there because you can't combo while training offhand weapon without main hand
     # !brawling is there because you can't use a weapon for brawling commands
     # Both of these issues will cause problems with the combo array system
-    elsif @use_barb_combos || @use_analyze_combos && !offhand? && !brawling?
+    elsif (@use_barb_combos || @use_analyze_combos) && !offhand? && !brawling?
       update_analyze_array(false) if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3151,7 +3151,7 @@ class GameState
     @whirlwind_trainables = settings.whirlwind_trainables
     echo("  @whirlwind_trainables: #{@whirlwind_trainables}") if $debug_mode_ct
 
-    if @use_analyze_combos
+    if @use_analyze_combos && DRStats.barbarian?
       Flags.add('ct-accuracy-ready', 'You sense your combat accuracy decrease')
       Flags['ct-accuracy-ready'] = true
       Flags.add('ct-damage-ready', 'You sense your ability to land deadly blows decrease')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3581,9 +3581,8 @@ class GameState
       attack_override
     elsif @use_weak_attacks
       brawling? ? 'gouge' : 'jab'
-    # !offhand is there because you can't combo while training offhand weapon without main hand
-    # !brawling is there because you can't use a weapon for brawling commands
-    # Both of these issues will cause problems with the combo array system
+    # !offhand & !brawling are there because you can't use a weapon for brawling commands
+    # This issue will cause problems with the combo array system
     elsif @use_analyze_combos && !offhand? && !brawling?
       update_analyze_array(false) if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3129,10 +3129,7 @@ class GameState
     @use_weak_attacks = settings.use_weak_attacks
     echo("  @use_weak_attacks: #{@use_weak_attacks}") if $debug_mode_ct
 
-    @use_barb_combos = settings.use_barb_combos
-    echo("  @use_barb_combos: #{@use_barb_combos}") if $debug_mode_ct
-
-    @use_analyze_combos = settings.use_analyze_combos
+    @use_analyze_combos = settings.use_analyze_combos || settings.use_barb_combos
     echo(" @use_analyze_combos: #{@use_analyze_combos}") if $debug_mode_ct 
 
     @skip_last_kill = settings.skip_last_kill
@@ -3154,7 +3151,7 @@ class GameState
     @whirlwind_trainables = settings.whirlwind_trainables
     echo("  @whirlwind_trainables: #{@whirlwind_trainables}") if $debug_mode_ct
 
-    if @use_barb_combos || @use_analyze_combos
+    if @use_analyze_combos
       Flags.add('ct-accuracy-ready', 'You sense your combat accuracy decrease')
       Flags['ct-accuracy-ready'] = true
       Flags.add('ct-damage-ready', 'You sense your ability to land deadly blows decrease')
@@ -3566,7 +3563,7 @@ class GameState
   end
 
   def stop_analyze_combo
-    @use_barb_combos = false
+    @use_analyze_combos = false
   end
 
   def set_barb_accuracy_flag
@@ -3584,11 +3581,10 @@ class GameState
       attack_override
     elsif @use_weak_attacks
       brawling? ? 'gouge' : 'jab'
-    # @use_barb_combos needs to be removed given people time to switch
     # !offhand is there because you can't combo while training offhand weapon without main hand
     # !brawling is there because you can't use a weapon for brawling commands
     # Both of these issues will cause problems with the combo array system
-    elsif (@use_barb_combos || @use_analyze_combos) && !offhand? && !brawling?
+    elsif @use_analyze_combos && !offhand? && !brawling?
       update_analyze_array(false) if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else
@@ -3697,7 +3693,7 @@ class GameState
   end
 
   attr_accessor :clean_up_step, :current_weapon_skill, :target_weapon_skill, :no_skins, :constructs, :no_stab_mobs, :no_loot, :dancing, :retreating, :action_count, :charges, :aim_queue, :dance_queue, :analyze_combo_array
-  attr_reader :dance_skill, :target_action_count, :dance_threshold, :retreat_threshold, :target_increment, :stances, :weapons_to_train, :use_stealth_attacks, :ambush, :backstab, :charged_maneuvers, :fatigue_regen_threshold, :aim_fillers, :aim_fillers_stealth, :dance_actions, :dance_actions_stealth, :ignored_npcs, :dual_load, :summoned_weapons_element, :summoned_weapons_ingot, :cambrinth, :stored_cambrinth, :cambrinth_cap, :use_weak_attacks, :dedicated_camb_use, :use_barb_combos, :balance_regen_threshold
+  attr_reader :dance_skill, :target_action_count, :dance_threshold, :retreat_threshold, :target_increment, :stances, :weapons_to_train, :use_stealth_attacks, :ambush, :backstab, :charged_maneuvers, :fatigue_regen_threshold, :aim_fillers, :aim_fillers_stealth, :dance_actions, :dance_actions_stealth, :ignored_npcs, :dual_load, :summoned_weapons_element, :summoned_weapons_ingot, :cambrinth, :stored_cambrinth, :cambrinth_cap, :use_weak_attacks, :dedicated_camb_use, :use_analyze_combos, :balance_regen_threshold
 end
 
 before_dying do

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3673,7 +3673,6 @@ class GameState
   end
 
   def update_analyze_array(only_accuracy)
-    return unless !offhand? && !brawling?
     return perform_analyze?('accuracy', 50) if only_accuracy # Barb only setting
     if DRStats.barbarian?
       { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }.each do |type, expertise|

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -186,7 +186,7 @@ dump_item_count: 9
 # as an example, chuno currently runs it at 6 being circle 195
 # defaulting to 25, as 20 for lower skilled barbs was explained to be common
 meditation_pause_timer: 25
-# use the analyze combos to train for the barb - is deprecated!
+# This is deprecated, instead switch to use_analyze_combos
 use_barb_combos: false
 # use the analyze combos to train for all guilds, brawling analyze isn't supported
 use_analyze_combos: false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -186,8 +186,10 @@ dump_item_count: 9
 # as an example, chuno currently runs it at 6 being circle 195
 # defaulting to 25, as 20 for lower skilled barbs was explained to be common
 meditation_pause_timer: 25
-# use the analyze combos to train
+# use the analyze combos to train for the barb - is deprecated!
 use_barb_combos: false
+# use the analyze combos to train for all guilds, brawling analyze isn't supported
+use_analyze_combos: false
 # list of weapon skills to use with whirlwind.  See Chuno-setup
 whirlwind_trainables:
 # a - list of weapon skills to pull out and use in offhand while waiting for a crossbow to aim.  Make sure they're light!

--- a/validate.lic
+++ b/validate.lic
@@ -555,7 +555,7 @@ class DRYamlValidator
   def assert_that_barb_combos_is_deprecated(settings)
     return unless settings.use_barb_combos
 
-    error("use_barb_combos is deprecated, please change to use_analyze_combos for the replacement.")
+    warn("use_barb_combos is deprecated, please change to use_analyze_combos for the replacement.")
   end
 
   def assert_that_barb_buffs_are_in_base_spells(settings)

--- a/validate.lic
+++ b/validate.lic
@@ -555,7 +555,7 @@ class DRYamlValidator
   def assert_that_barb_combos_is_deprecated(settings)
     return unless settings.use_barb_combos
 
-    error("use_barb_combos is deprecated, please change to use_analyze_combos for the replacement.") }
+    error("use_barb_combos is deprecated, please change to use_analyze_combos for the replacement.")
   end
 
   def assert_that_barb_buffs_are_in_base_spells(settings)

--- a/validate.lic
+++ b/validate.lic
@@ -552,6 +552,12 @@ class DRYamlValidator
             .each { |info| error("Hunt '#{info[:zone]}' has a retreat threshold set, but no ranged weapon skills to train. You may get stuck retreating and not training any weapons because enemies will not be attacked.") }
   end
 
+  def assert_that_barb_combos_is_deprecated(settings)
+    return unless settings.use_barb_combos
+
+    error("use_barb_combos is deprecated, please change to use_analyze_combos for the replacement.") }
+  end
+
   def assert_that_barb_buffs_are_in_base_spells(settings)
     return unless settings.buff_nonspells
     return unless settings.buff_nonspells['barb_buffs']


### PR DESCRIPTION
I am submitting this to change some of the issues with the PR #3664 .

1.)  Naming convention needs to change to be more accurate.
2.)  If you let the user use brawling analyzes, it will continue over (if you don't finish the array) and break with other weapons. This is an issue which is why I simply just didn't let people use brawling combos. There's no need. It adds a code and processes for a one-off situation where it's beneficial.
3.) If you don't include while !offhand, the user will be training offhand and get errors with the commands not lining up. You will then be issuing "attack", offhand will not go up, and therefore be trained again, this endless cycle of failure. 
