### PR TITLE
common-arcana - Update to ritual spell method

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -110,10 +110,10 @@ module DRCA
     match
   end
 
-  def ritual(spell, ignored_npcs)
-    DRC.retreat(ignored_npcs) unless spell['skip_retreat']
+  def ritual(spell, settings)
+    DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
     DRC.release_invisibility
-    DRC.bput('stance set 100 0 80', 'Setting your')
+    DRC.bput("stance set #{settings.default_stance}", 'Setting your')
 
     command = 'prepare'
     command = spell['prep'] if spell['prep']
@@ -124,11 +124,11 @@ module DRCA
 
     invoke(spell['focus'], nil, nil)
     stow_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'])
-    DRC.retreat(ignored_npcs) unless spell['skip_retreat']
+    DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
 
     waitcastrt?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
-    DRC.retreat(ignored_npcs) unless spell['skip_retreat']
+    DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
   end
 
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])
@@ -442,7 +442,7 @@ module DRCA
     DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
 
     if data['ritual']
-      ritual(data, settings.ignored_npcs)
+      ritual(data, settings)
       return
     end
 


### PR DESCRIPTION
It now uses your default_stance instead of being hard coded to 100 80 0.

I also changed the second argument in the method to settings from only ignored_npcs so that I could pull default_stance from it, and for forward compatibility for any other possible additions from settings.

There will be another pull request for combat trainer to update its use of this method.