### PR TITLE
combat-trainer - Updated ritual spell call's arguments

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1539,7 +1539,7 @@ class SpellProcess
     data = update_astral_data(data)
     if data # update_astral_data returns nil on failure
       check_invoke(game_state)
-      ritual(data, @ignored_npcs)
+      ritual(data, @settings)
     end
 
     if summoned


### PR DESCRIPTION
I updated this to go along with the other pull request I made for common arcana.  Now it sends @settings instead of @ignored_npcs.
This lets common-arcana have access to the full settings, which is cleaner and needed for the change I made to common-arcana.

https://github.com/rpherbig/dr-scripts/pull/3679