### PR TITLE
carve.lic - added resume function

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -23,6 +23,11 @@ class Carve
         { name: 'material', regex: /\w+/i, variable: true, description: 'Type of stone/bone to use.' },
         { name: 'type', options: %w[stack rock stone pebble boulder deed], description: 'What material noun you are using.' },
         { name: 'noun', regex: /\w+/i, variable: true }
+      ],
+      [
+        { name: 'resume', regex: /resume/i },
+        { name: 'type', options: %w[bone stone], description: 'Which material type the item is.' },
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item to resume.' }
       ]
     ]
 
@@ -35,7 +40,7 @@ class Carve
     @noun = args.noun
     @training_spells = @settings.crafting_training_spells
 
-    @main_tool = if @type == 'stack'
+    @main_tool = if @type == 'stack' || @type == 'bone'
                    'saw'
                  else
                    'chisel'
@@ -44,7 +49,11 @@ class Carve
     wait_for_script_to_complete('buff', ['carve'])
     Flags.add('carve-assembly', 'another finished wooden (hilt|haft)', 'another finished (long|short) wooden (pole)', 'another finished (long|short) leather (cord)')
 
-    carve_item
+    if args.resume
+      resume
+    else
+      carve_item
+    end
   end
 
   def get_item(name)
@@ -138,6 +147,56 @@ class Carve
     end
     waitrt?
     crafting_magic_routine(@settings)
+    carve(command)
+  end
+
+  def resume
+    waitrt?
+
+    case bput("get #{@noun}", /You get/, /You are already holding/, /You pick up/, /You are not strong enough/, /What were you referring to/)
+    when /You get/, /You are already holding/, /You pick up/
+      @my = 'my'
+      DRC.bput('swap', /to your left hand/) unless left_hand.include?(@noun)
+    when /You are not strong enough/
+      @my = ''
+    else
+      echo '*** ITEM NOT FOUND ***'
+      exit
+    end
+
+    stow_item(right_hand) if right_hand
+
+    case bput("analyze my #{@noun}",
+              /You do not see anything that would (prevent|obstruct) carving/,
+              /corrected by rubbing the .* with a riffler set/,
+              /corrected by scraping the .* with a rasp/,
+              'angle of cut will improve if scraped with a rasp',
+              'by applying some polish to',
+              'This appears to be a type of finished',
+              'Roundtime')
+    when /You do not see anything that would (prevent|obstruct) carving/
+      waitrt?
+      get_item(@main_tool)
+      command = "cut #{@my} #{@noun} with my #{@main_tool}"
+    when /corrected by rubbing the .* with a riffler set/
+      waitrt?
+      get_item('rifflers')
+      command = "rub #{@my} #{@noun} with my rifflers"
+    when /corrected by scraping the .* with a rasp/, 'angle of cut will improve if scraped with a rasp'
+      waitrt?
+      get_item('rasp')
+      command = "rub #{@my} #{@noun} with my rasp"
+    when 'by applying some polish to'
+      waitrt?
+      get_item('polish')
+      command = "apply my polish to #{@my} #{@noun}"
+    when 'This appears to be a type of finished'
+      echo '*** THIS ITEM IS ALREADY FINISHED ***'
+      exit
+    else
+      echo '*** UNKNOWN NEXT COMMAND WHEN TRYING TO RESUME ***'
+      exit
+    end
     carve(command)
   end
 


### PR DESCRIPTION
You can now resume carving an item!

Syntax:`;carve resume <bone/stone> <noun>`

Please test and if you find any analyze lines that don't get detected by this, let me know.