### PR TITLE
base-hunting - added the heading back for void moths

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -829,6 +829,7 @@ hunting_zones:
   - 12705
   # https://elanthipedia.play.net/Void_black_umbral_moth               1450-1750
   # Incredible swarm
+  void_moths:
   - 12165
   - 12171
   - 12166


### PR DESCRIPTION
void_moths: heading was removed by mistake in the last pull request.  Added it back.