### PR TITLE
Carve.lic - minor change to eliminate double space

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -85,7 +85,7 @@ class Carve
     get_item(@main_tool)
     if @type != 'boulder'
       get_item("#{@material} #{@type}")
-      @my = 'my'
+      @my = 'my '
       if @type == 'deed'
         /(\w+) onto/ =~ bput('tap deed', '\w+ onto a sled')
         @type = checkleft || Regexp.last_match(1)
@@ -94,7 +94,7 @@ class Carve
     else
       @my = ''
     end
-    carve("cut #{@my} #{@type} with my #{@main_tool}")
+    carve("cut #{@my}#{@type} with my #{@main_tool}")
   end
 
   def assemble_part
@@ -105,7 +105,7 @@ class Carve
     part = Flags['carve-assembly'][1..-1].join('.')
     Flags.reset('carve-assembly')
     get_item(part)
-    bput("assemble #{@my} #{@noun} with my #{part}", 'affix it securely in place', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations')
+    bput("assemble #{@my}#{@noun} with my #{part}", 'affix it securely in place', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations')
     get_item(tool)
   end
 
@@ -124,17 +124,17 @@ class Carve
       waitrt?
       stow_item(right_hand)
       get_item('rifflers')
-      command = "rub #{@my} #{@noun} with my rifflers"
+      command = "rub #{@my}#{@noun} with my rifflers"
     when 'determine', 'developed an uneven texture along its surface'
       waitrt?
       stow_item(right_hand)
       get_item('rasp')
-      command = "rub #{@my} #{@noun} with my rasp"
+      command = "rub #{@my}#{@noun} with my rasp"
     when 'you see some discolored areas'
       waitrt?
       stow_item(right_hand)
       get_item('polish')
-      command = "apply my polish to #{@my} #{@noun}"
+      command = "apply my polish to #{@my}#{@noun}"
     when 'You cannot figure out how to do that.'
       finish
     else
@@ -143,7 +143,7 @@ class Carve
         stow_item(right_hand)
         get_item(@main_tool)
       end
-      command = "cut #{@my} #{@noun} with my #{@main_tool}"
+      command = "cut #{@my}#{@noun} with my #{@main_tool}"
     end
     waitrt?
     crafting_magic_routine(@settings)
@@ -155,7 +155,7 @@ class Carve
 
     case bput("get #{@noun}", /You get/, /You are already holding/, /You pick up/, /You are not strong enough/, /What were you referring to/)
     when /You get/, /You are already holding/, /You pick up/
-      @my = 'my'
+      @my = 'my '
       DRC.bput('swap', /to your left hand/) unless left_hand.include?(@noun)
     when /You are not strong enough/
       @my = ''
@@ -177,19 +177,19 @@ class Carve
     when /You do not see anything that would (prevent|obstruct) carving/
       waitrt?
       get_item(@main_tool)
-      command = "cut #{@my} #{@noun} with my #{@main_tool}"
+      command = "cut #{@my}#{@noun} with my #{@main_tool}"
     when /corrected by rubbing the .* with a riffler set/
       waitrt?
       get_item('rifflers')
-      command = "rub #{@my} #{@noun} with my rifflers"
+      command = "rub #{@my}#{@noun} with my rifflers"
     when /corrected by scraping the .* with a rasp/, 'angle of cut will improve if scraped with a rasp'
       waitrt?
       get_item('rasp')
-      command = "rub #{@my} #{@noun} with my rasp"
+      command = "rub #{@my}#{@noun} with my rasp"
     when 'by applying some polish to'
       waitrt?
       get_item('polish')
-      command = "apply my polish to #{@my} #{@noun}"
+      command = "apply my polish to #{@my}#{@noun}"
     when 'This appears to be a type of finished'
       echo '*** THIS ITEM IS ALREADY FINISHED ***'
       exit
@@ -212,7 +212,7 @@ class Carve
     stow_item(right_hand)
     if @stamp
       get_item('stamp')
-      fput("mark #{@my} #{@noun} with my stamp")
+      fput("mark #{@my}#{@noun} with my stamp")
       pause
       waitrt?
       stow_item('stamp')


### PR DESCRIPTION
gets rid of the double space issue when you use the new resume function