### PR TITLE
Create tithe.lic

### DIFF
--- a/tithe.lic
+++ b/tithe.lic
@@ -1,0 +1,66 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#tithe
+=end
+
+custom_require.call(%w[common common-money common-travel events drinfomon])
+
+class TitheActions
+  include DRC
+  include DRCT
+  include DRCM
+
+  def initialize
+    arg_definitions = [[]]
+
+    args = parse_args(arg_definitions, true)
+
+    @settings = get_settings(args.flex)
+    @hometown = @settings.hometown
+    @pray_to_chadatru = @settings.pray_to_chadatru
+    @chadatru_prayer_cooldown = 3600
+    UserVars.chadatru_prayer_last ||= Time.now - @chadatru_prayer_cooldown
+
+    check_tithe
+    check_chadatru
+  end
+
+  def check_tithe
+    return unless @settings.tithe
+    return unless almsbox = @settings.tithe_almsbox || get_data('town')[@hometown]['almsbox']['id']
+    delta = Time.now - (UserVars.tithe_timer || Time.now - 14_400)
+    return if (delta < 4 * 60 * 60 && DRStats.paladin?) || (delta < 60 * 10 && DRStats.cleric?)
+
+    currency = hometown_currency(@hometown)
+    return unless withdraw_exact_amount?('5 silver', @settings)
+
+    wait_for_script_to_complete('pay-debt')
+
+    UserVars.tithe_timer = Time.now
+    walk_to(almsbox)
+    bput("put 5 silver #{currency} in almsbox", 'You drop', 'But you do not', 'attend to thy own woes')
+  end
+
+  def check_chadatru
+    return unless DRStats.paladin? && @pray_to_chadatru
+    return unless Time.now - UserVars.chadatru_prayer_last > @chadatru_prayer_cooldown
+
+    altar_loc = get_data('theurgy')[@hometown]['chadatru_altar']['id']
+    if altar_loc.nil?
+      echo "***CHADATRU PRAYER SUPPORT NOT YET IMPLEMENTED IN #{@hometown}, REMOVING CHADATRU PRAYER***"
+      @pray_to_chadatru = false
+      return
+    end
+
+    walk_to(altar_loc)
+
+    bput('kneel', 'You kneel', 'You are already', 'You rise')
+    case bput('pray chadatru', 'As you kneel', 'decide it would be inappropriate')
+    when 'As you kneel'
+      waitfor('soothing sensation washes over your soul')
+    end
+
+    UserVars.chadatru_prayer_last = Time.now
+  end
+end
+
+TitheActions.new


### PR DESCRIPTION
This script breaks out the tithe functions from theurgy and crossing-training, allowing them to be run as a standalone script (for example, for use in t2). It additionally includes praying to Chadatru if a paladin to bolster soul state. As the two actions are on a similar timer, coupling them makes sense (but oth actions are tracked separately, just in case).