### PR TITLE
bescort.lic - Update to deal with fog in the river

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -884,6 +884,12 @@ class Bescort
         move 'west'
       elsif XMLData.room_exits.include?(dir_of_travel)
         move dir_of_travel
+      elsif XMLData.room_exits.length == 0
+        break if Room.current.id == 19373 && dir_of_travel == 'south'
+        break if Room.current.id == 19457 && dir_of_travel == 'north'
+        if !(move dir_of_travel)
+          move 'west'
+        end
       else
         break
       end


### PR DESCRIPTION
This should handle all possible fog related issues.  It deals with the following:
There's fog in any of the middle rooms of the river.
You got pushed east into one of those rooms that goes to that slope in crossing.
There's fog in either of the endpoints and you've just reached it.