### PR TITLE
Move more stuff into common play

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -392,8 +392,10 @@ module DRC
     g
   end
 
-  def play_song?(settings, song_list, worn = true)
+  def play_song?(settings, song_list, worn = true, skip_clean = false)
     instrument = worn ? settings.worn_instrument : settings.instrument
+    UserVars.song = song_list.first.first unless UserVars.song
+    fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
     result = bput("play #{UserVars.song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
     case result
     when 'Play on what instrument'
@@ -411,6 +413,7 @@ module DRC
       wait_for_script_to_complete('safe-room')
     when 'dirtiness may affect your performance'
       return true if DRSkill.getrank('Performance') < 20
+      return true if skip_clean
       return true unless clean_instrument(settings, worn)
       play_song?(settings, song_list, worn)
     when 'slightest hint of difficulty', 'fumble slightly'


### PR DESCRIPTION
Adding a few more universal items from performance, as well as skip_clean.

Right now, my ;performance has an entry to remove hand items, calls play_song?, then goes into the watch loop until it's done.  I bet that behavior could be put into other scripts with a flag instead, and I'll try it in ;trade.

After this goes live I can at least add the performance changes so it'll support zills and cowbells.