### PR TITLE
smelt.lic - add better support for stirring rods

### DIFF
--- a/smelt.lic
+++ b/smelt.lic
@@ -59,7 +59,7 @@ class Smelt
   def stir
     pause 1
     waitrt?
-    case bput('stir crucible with my stirring rod', 'You can only mix a crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'down and needs more fuel', 'roundtime')
+    case bput("stir crucible with my #{@rod}", 'You can only mix a crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'down and needs more fuel', 'roundtime')
     when /roundtime/i
       return stir
     when 'You can only mix a crucible'

--- a/smelt.lic
+++ b/smelt.lic
@@ -15,6 +15,7 @@ class Smelt
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container
     @belt = settings.forging_belt
+    @rod = settings.forging_tools.find { |item| /rod/ =~ item }
 
     arg_definitions = [
       [
@@ -24,13 +25,13 @@ class Smelt
 
     args = parse_args(arg_definitions)
 
-    get_crafting_item('stirring rod', @bag, @bag_items, @belt)
+    get_crafting_item(@rod, @bag, @bag_items, @belt)
     if args.refine
       refine
     else
       stir
     end
-    stow_crafting_item('stirring rod', @bag, @belt)
+    stow_crafting_item(@rod, @bag, @belt)
   end
 
   def refine


### PR DESCRIPTION
stout stirring rods adjective is "stout" not "stirring"
If you had one, smelt wouldn't find it