### PR TITLE
crossing-repair.lic - move deposit coins

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -18,12 +18,13 @@ class CrossingRepair
       repair_at(repairer['name'], repairer['id'], items)
     end
 
+    deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
+
     @repair_info.to_a.reverse.each do |(repairer, _items)|
       while tickets_left?(repairer)
       end
     end
-
-    deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
+    
   end
 
   def repair(repairer, item, repeat = false)


### PR DESCRIPTION
Should help with theft in various repair areas.
Moves deposit of coins after you have turned in all your gear.