### PR TITLE
common-items.lic - fix COS trees messing up trash

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-items
 =end
 
-$TRASH_STORAGE = %w[bin gloop barrel bucket urn log arms stump tree]
+$TRASH_STORAGE = %w[bin gloop barrel bucket urn log arms stump tree statue]
 
 custom_require.call(%w[common common-travel])
 
@@ -61,9 +61,12 @@ module DRCI
   def dispose_trash(item)
     return if item.nil?
     trashcans = DRRoom.room_objs
+                      .reject { |obj| obj =~ /azure \w+ tree/ }
                       .map { |long_name| DRC.get_noun(long_name) }
                       .select { |obj| $TRASH_STORAGE.include?(obj) }
-
+    
+    echo trashcans
+    
     trashcans.each do |trashcan|
       if trashcan == 'gloop'
         trashcan = 'bucket' if DRRoom.room_objs.include? 'bucket of viscous gloop'

--- a/common-items.lic
+++ b/common-items.lic
@@ -64,9 +64,7 @@ module DRCI
                       .reject { |obj| obj =~ /azure \w+ tree/ }
                       .map { |long_name| DRC.get_noun(long_name) }
                       .select { |obj| $TRASH_STORAGE.include?(obj) }
-    
-    echo trashcans
-    
+
     trashcans.each do |trashcan|
       if trashcan == 'gloop'
         trashcan = 'bucket' if DRRoom.room_objs.include? 'bucket of viscous gloop'


### PR DESCRIPTION
Fix for Circle of Sympathy trees messing up dispose_trash trash cans.
Added statue due to get_noun being better at find the actual nouns now