### PR TITLE
Commonize performance in crossing-training

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -58,6 +58,7 @@ class CrossingTraining
     release_cyclics
 
     Flags.add('ct-song', 'you finish playing')
+    Flags.add('ct-no-instrument', 'Play on what instrument')
     Flags.add('research-partial', 'there is still more to learn before you arrive at a breakthrough', 'distracted by combat', 'distracted by your spellcasting', 'You lose your focus on your research project', 'you forget what you were')
     Flags.add('research-complete', '^Breakthrough!')
   end
@@ -768,7 +769,7 @@ class CrossingTraining
     return unless @did_play
     return if @no_instrument
     @did_play = false
-    bput('stop play', 'You stop playing your song', 'In the name of', "But you're not performing")
+    DRC.stop_playing
     Flags['ct-song'] = true
   end
 
@@ -776,85 +777,23 @@ class CrossingTraining
     return true if @researching
     return false if @no_instrument
     return true if DRSkill.getxp('Performance') >= 28
-
-    UserVars.song = @song_list.first.first unless UserVars.song
-    @did_play = true
-    case bput("play #{UserVars.song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'muster the strength to perform')
-    when 'Play on what instrument'
-      @no_instrument = true
-      return false
-    when 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'muster the strength to perform'
-      return true
-    when 'You cannot play'
-      wait_for_script_to_complete('safe-room')
-    when 'dirtiness may affect your performance'
-      if DRSkill.getrank('Performance') < 20
-        echo "Skipping cleaning of zills due to low rank of Performance: #{DRSkill.getrank('Performance')}" if UserVars.crossing_trainer_debug
-        return true
-      end
-      stop_play
-      clean_zills
-      return play_song?
-    when 'You begin a', 'You effortlessly begin', 'You begin some'
-      stop_play
-      UserVars.song = @song_list[UserVars.song] || @song_list.first.first
-      return play_song?
-    when 'You struggle to begin'
-      if UserVars.song != @song_list.first.first
-        stop_play
-        UserVars.song = @song_list.first.first
-        return play_song?
-      end
-    end
-
+    is_instrument_worn = @settings.instrument.nil?
+    Flags.reset('ct-no-instrument')
+    @did_play = DRC.play_song?(@settings, @song_list, is_instrument_worn, false)
+    @no_instrument = Flags['ct-no-instrument'] && !@did_play
+    
+    return false unless @did_play
     return true unless blocking
 
     Flags.reset('ct-song')
     pause 1 until Flags['ct-song']
     true
   end
-
-  def clean_zills
-    cloth = @settings.cleaning_cloth
-
-    case bput("get my #{cloth}", 'You get', 'What were you')
-    when 'What were you'
-      echo('You have no chamois cloth, removing Performance from training')
-      @settings.crossing_training.delete('Performance')
-      return
-    end
-
-    bput('remove my zills', 'You slide')
-
-    loop do
-      case bput("wipe my zills with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
-      when 'not in need of drying'
-        break
-      when 'You should be sitting up'
-        fix_standing
-        next
-      end
-      pause 1
-      waitrt?
-
-      until /you wring a dry/i =~ bput("wring my #{cloth}", 'You wring a dry', 'You wring out')
-        pause 1
-        waitrt?
-      end
-    end
-
-    until /not in need of cleaning/i =~ bput("clean my zills with my #{cloth}", 'Roundtime', 'not in need of cleaning')
-      pause 1
-      waitrt?
-    end
-
-    bput('wear my zills', 'You slide')
-    bput("stow my #{cloth}", 'You put')
-  end
 end
 
 before_dying do
   Flags.delete('ct-song')
+  Flags.delete('ct-no-instrument')
   Flags.delete('research-partial')
   Flags.delete('research-complete')
 end


### PR DESCRIPTION
Crossing training has its own implementation of play_song, but it can use common's instead.  This should close https://github.com/rpherbig/dr-scripts/issues/3765

Everything should be standardized with this now.  play_song? returns true when it did play and false when it didn't, which lets crossing-training decide what to do afterwards.  I kept its user-error check for a missing instrument, but flagged it.

I've tested this with zills and cowbells, but my cowbell is so frustratingly spotless that I haven't seen it clean itself yet.  Still, I don't see any reason for it not to work considering it works in ;performance, and we're using the same method now.