### PR TITLE
Crossing-training.lic - idle command update

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -132,16 +132,16 @@ class CrossingTraining
       if @researching
         echo '***Skills capped and researching***' if UserVars.crossing_trainer_debug
         pause 30
+        fput 'research status'
       else
         @idling = true
         echo '***Skills capped, sleeping***' if UserVars.crossing_trainer_debug
         fput 'exit' if @settings.exit_on_skills_capped
         walk_to(@training_room)
         play_song?
+        fput 'tdp'
       end
-
-      # Output a harmless command to prevent being logged out
-      fput 'research status'
+      
       return
     end
 
@@ -725,7 +725,7 @@ class CrossingTraining
   end
 
   def train_enchanting
-  eligible = @settings.train_workorders & %w[Artificing]
+    eligible = @settings.train_workorders & %w[Artificing]
     unless eligible.empty?
       return unless money_for_training?(20000, 'Enchanting')
       wait_for_script_to_complete('workorders', [eligible.first])


### PR DESCRIPTION
Only do 'research status' when researching, otherwise 'tdp'
fix whitespace issue.