### PR TITLE
fix for incorrect exchange amount

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -36,7 +36,7 @@ module DRCM
     exchange_rates = {
       'dokoras' => {
         'dokoras' => 1,
-        'kronars' => 1.38580991,
+        'kronars' => 1.385808991,
         'lirums' => 1.108646953
       },
       'kronars' => {


### PR DESCRIPTION
Examining the exchange rates and doing some quick calculations, you figure 1,000,000,000 Dokoras is equivalent to:
138,580 platinum, 8 gold, 9 silver, 9 bronze, and 1 copper Kronars (1,385,808,991 copper Kronars)
110,864 platinum, 6 gold, 9 silver, 5 bronze, and 3 copper Lirums (1,108,646,953 copper Lirums)