### PR TITLE
Add blowgun darts to fired ammo

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2672,7 +2672,7 @@ class AttackProcess
     case bput(command, 'isn\'t loaded', 'There is nothing', 'But your', /you (fire|poach|snipe) an? (?:.*\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto).* at/i, 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
     when /How can you (poach|snipe)/
       shoot_aimed('shoot', game_state)
-    when /you (fire|poach|snipe) an? (?:.*\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto).* at/i
+    when /you (fire|poach|snipe) an? (?:.*\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quill|stone|stopper|verretto|blowgun dart).* at/i
       game_state.action_taken
       ammo = Regexp.last_match(2)
       bput("stow my #{ammo}", 'You pick up', 'Stow what')


### PR DESCRIPTION
Fixes an issue where combat-trainer got confused waiting for messages after
firing a dart from a blowgun.