### PR TITLE
Prevent tinker ambiguity failure with toolstraps

### DIFF
--- a/tinker.lic
+++ b/tinker.lic
@@ -243,8 +243,8 @@ class Tinker
     when 'adjusting with', 'adjusted with'
       waitrt?
       stow_item(right_hand)
-      get_item('tools')
-      command = "adjust my #{@noun} with my tools"
+      get_item('tinker tools')
+      command = "adjust my #{@noun} with my tinker tools"
     when 'Some wood stain', 'application of stain'
       waitrt?
       stow_item(right_hand)


### PR DESCRIPTION
Sometimes the new toolstraps can take syntax priority over tinker tools, which breaks everything.

Luckily I've never seen any toolset that wasn't called 'tinker's tools', so this just solves the issue.  Tested by Aurayn