### PR TITLE
Propagate skip_clean in performance

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -402,31 +402,31 @@ module DRC
       fput("get #{instrument}")
       return false if snapshot == "#{right_hand}#{left_hand}"
       fput("wear #{instrument}") if worn
-      play_song?(settings, song_list, worn)
+      play_song?(settings, song_list, worn, skip_clean)
     when 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing'
       false
     when 'You\'re already playing a song'
       fput('stop play')
-      play_song?(settings, song_list, worn)
+      play_song?(settings, song_list, worn, skip_clean)
     when 'You cannot play'
       wait_for_script_to_complete('safe-room')
     when 'dirtiness may affect your performance'
       return true if DRSkill.getrank('Performance') < 20
       return true if skip_clean
       return true unless clean_instrument(settings, worn)
-      play_song?(settings, song_list, worn)
+      play_song?(settings, song_list, worn, skip_clean)
     when 'slightest hint of difficulty', 'fumble slightly'
       true
     when 'You begin a', 'You effortlessly begin', 'You begin some'
       return true if UserVars.song == 'concerto masterful'
       stop_playing
       UserVars.song = song_list[UserVars.song] || song_list.first.first
-      play_song?(settings, song_list, worn)
+      play_song?(settings, song_list, worn, skip_clean)
     when 'You struggle to begin'
       return true if UserVars.song == song_list.first.first
       stop_playing
       UserVars.song = song_list.first.first
-      play_song?(settings, song_list, worn)
+      play_song?(settings, song_list, worn, skip_clean)
     else
       false
     end


### PR DESCRIPTION
skip_clean is sent to play_song? initially, however if the first play attempt fails it isn't propagated to subsequent calls.