### PR TITLE
[athletics] Add cowbell support

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -14,7 +14,7 @@ class Athletics
     @athletics_options = get_data('athletics').athletics_options
     @performance_pause = @settings.performance_pause
     # maintains compatibility with those who had instrument unset
-    @instrument = @settings.instrument || 'zills'
+    @instrument = @settings.worn_instrument || 'zills'
 
     @climbing_target = get_data('athletics').practice_options[@settings.climbing_target]
     @swimming_target = get_data('athletics').swimming_options[@settings.swimming_target]

--- a/athletics.lic
+++ b/athletics.lic
@@ -13,6 +13,8 @@ class Athletics
     @settings = get_settings
     @athletics_options = get_data('athletics').athletics_options
     @performance_pause = @settings.performance_pause
+    # maintains compatibility with those who had instrument unset
+    @instrument = @settings.instrument || 'zills'
 
     @climbing_target = get_data('athletics').practice_options[@settings.climbing_target]
     @swimming_target = get_data('athletics').swimming_options[@settings.swimming_target]
@@ -92,14 +94,15 @@ class Athletics
     bput('stop play', 'You stop playing your song', 'In the name of', "But you're not performing")
   end
 
-  def clean_zills
+  def clean_instrument
     cloth = @settings.cleaning_cloth
     stow_hands
-    bput('remove my zills', 'You slide')
+    # Slide for zills, remove for cowbell
+    bput("remove my #{@instrument}", 'You slide', 'You remove')
     bput("get my #{cloth}", 'You get')
 
     loop do
-      case bput("wipe my zills with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
+      case bput("wipe my #{@instrument} with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
       when 'not in need of drying'
         break
       when 'You should be sitting up'
@@ -115,12 +118,13 @@ class Athletics
       end
     end
 
-    until /not in need of cleaning/i =~ bput("clean my zills with my #{cloth}", 'Roundtime', 'not in need of cleaning')
+    until /not in need of cleaning/i =~ bput("clean my #{@instrument} with my #{cloth}", 'Roundtime', 'not in need of cleaning')
       pause 1
       waitrt?
     end
 
-    bput('wear my zills', 'You slide')
+    # slide for zills, attach for cowbell
+    bput("wear my #{@instrument}", 'You slide', 'You attach')
     bput("stow my #{cloth}", 'You put')
   end
 
@@ -136,11 +140,11 @@ class Athletics
       return false
     when 'dirtiness may affect your performance'
       if DRSkill.getrank('Performance') < 20
-        echo "Skipping cleaning of zills due to low rank of Performance: #{DRSkill.getrank('Performance')}" if UserVars.athletics_debug
+        echo "Skipping cleaning of #{@instrument} due to low rank of Performance: #{DRSkill.getrank('Performance')}" if UserVars.athletics_debug
         return true
       end
       stop_play
-      clean_zills
+      clean_instrument
       return play_climbing_song?
     when 'You begin a', 'You effortlessly begin', 'You begin some'
       # Ignore difficulty messages if we have an offset
@@ -177,7 +181,7 @@ class Athletics
 
   def train_with_rope
     return unless exists?("#{@settings.climbing_rope_adjective} rope")
-    return unless exists?('zills')
+    return unless exists?("#{@instrument}")
 
     UserVars.climbing_song ||= UserVars.song
     echo "UserVars.climbing_song: #{UserVars.climbing_song}" if UserVars.athletics_debug


### PR DESCRIPTION
Removes hard-coded references to zills and adds messaging hooks for
cowbells. Fixes an issue where cowbells would play but not be cleaned by
athletics.

Leverages the `instrument` field of setup.yaml that crossing-training
already uses.

n.b.: I don't have a cowbell to test this with, but didn't notice any regressions with my zills