### PR TITLE
Add new starlight level

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -328,7 +328,8 @@ module DRCA
       'A steady pulse of starlight runs through your aura',
       'Starlight dances vividly across the confines of your aura',
       'Strong pulses of starlight flare within your aura',
-      'Your aura seethes with brilliant starlight'
+      'Your aura seethes with brilliant starlight',
+      'Your aura is blinding'
     ]
     Flags.add('aura-level', Regexp.union(starlight_messages))
     Flags.add('aura-capped?', 'Your aura contains as much starlight as you can safely handle')

--- a/textsubs.lic
+++ b/textsubs.lic
@@ -970,14 +970,15 @@ TextSubs.add("#{spell_recognition} (Worm\'s Mist) spell\.", '\1 of the \2 spell.
 TextSubs.add("#{spell_recognition} (Butcher\'s Eye|Philosopher\'s Preservation|Kura-Silma|Ivory Mask) spell\.", '\1 of the \2 spell. [signature Necromancer (Transcendental Necromancy): basic augmentation]')
 
 if DRStats.trader?
-  TextSubs.add('The smallest hint of starlight flickers within your aura.', 'The smallest hint of starlight flickers within your aura (0/7).')
-  TextSubs.add('A bare flicker of starlight plays within your aura.', 'A bare flicker of starlight plays within your aura (1/7.)')
-  TextSubs.add('A faint amount of starlight illuminates your aura.', 'A faint amount of starlight illuminates your aura (2/7).')
-  TextSubs.add('Your aura pulses slowly with starlight.', 'Your aura pulses slowly with starlight (3/7).')
-  TextSubs.add('A steady pulse of starlight runs through your aura.', 'A steady pulse of starlight runs through your aura (4/7).')
-  TextSubs.add('Starlight dances vividly across the confines of your aura.', 'Starlight dances vividly across the confines of your aura (5/7).')
-  TextSubs.add('Strong pulses of starlight flare within your aura.', 'Strong pulses of starlight flare within your aura (6/7).')
-  TextSubs.add('Your aura seethes with brilliant starlight.', 'Your aura seethes with brilliant starlight (7/7).')
+  TextSubs.add('The smallest hint of starlight flickers within your aura.', 'The smallest hint of starlight flickers within your aura (0/8).')
+  TextSubs.add('A bare flicker of starlight plays within your aura.', 'A bare flicker of starlight plays within your aura (1/8.)')
+  TextSubs.add('A faint amount of starlight illuminates your aura.', 'A faint amount of starlight illuminates your aura (2/8).')
+  TextSubs.add('Your aura pulses slowly with starlight.', 'Your aura pulses slowly with starlight (3/8).')
+  TextSubs.add('A steady pulse of starlight runs through your aura.', 'A steady pulse of starlight runs through your aura (4/8).')
+  TextSubs.add('Starlight dances vividly across the confines of your aura.', 'Starlight dances vividly across the confines of your aura (5/8).')
+  TextSubs.add('Strong pulses of starlight flare within your aura.', 'Strong pulses of starlight flare within your aura (6/8).')
+  TextSubs.add('Your aura seethes with brilliant starlight.', 'Your aura seethes with brilliant starlight (7/8).')
+  TextSubs.add('Your aura is blinding!', 'Your aura is blinding (8/8)!')
 end
 
 if DRStats.moon_mage?


### PR DESCRIPTION
A trader has expanded the boundaries of starlight magic, illuminating a 9th level (zero-indexed, since there's no message to distinguish between no starlight at all and only a tiny amount.)