### PR TITLE
Adding message method.

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -534,4 +534,16 @@ module DRC
 
     DRC.bput("stance set #{stance}", /Setting your/)
   end
+
+  def message(text)
+    string = ''
+    if $fake_stormfront then string.concat("\034GSL\r\n ") else string.concat("<pushBold\/>") end
+    if( text.index('\n') )
+        text.split('\n').each { |line| string.concat("| #{line}") }
+    else
+        string.concat('| ' + text)
+    end
+    if $fake_stormfront then string.concat("\034GSM\r\n ") else string.concat("<popBold\/>") end
+    _respond string
+  end
 end


### PR DESCRIPTION
Re-PR of #3599. 

This method I found in Bigshot.lic from Gemstone 4. It puts up a nice monsterbold text, formatted nicely, and can be used without dependency. From here we can begin using it within the system, and even converting a lot of things over to it that we find useful or could be better [presented](https://imgur.com/nvw6fQs). 

[Here](https://imgur.com/q2696qk) is how it appears in Stormfront, using BigShot.

[Here's ](https://imgur.com/jrn7V3A) an example of it in Stormfront while playing DR.