### PR TITLE
Add clamps to shaping tools

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -476,6 +476,7 @@ shaping_tools:
 - shaper
 - drawknife
 - rasp
+- clamps
 alchemy_tools:
 - mortar
 - pestle


### PR DESCRIPTION
Closes https://github.com/rpherbig/dr-scripts/issues/3660

For those using base's shaping_tools, recipes will continue to use clamps for their work, but won't actually repair them.  Since the common-crafting repair changes earlier this year this won't break anything for anyone without clamps so it should be harmless.