### PR TITLE
Fix a few trade bugs

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -61,7 +61,7 @@ class Trade
     @no_ride_rooms = ['Interior', 'Hodierna', 'Kertigen', 'Damaris', 'Evening', 'Ferry', 'Star', 'Northern' 'Lounge', 'Deck', 'Wharf', 'Desert', 'South Bank', 'Gondola', 'Platform', 'Pier', 'Riverhaven', 'Theren', 'Suncatcher', 'Dock']
     @no_forage_rooms = @no_ride_rooms + ['Crossing', 'Lava', 'Dirge', 'Ghazal', 'Hibarnhvidar', 'Mountain', 'Dock', 'Theren', 'Muspar', 'Arnshal', "Ker'leor", 'Shard']
     @outside_exits = { 'Crossing' => ['go doors', 'out'], 'Arthe Dale' => ['go door', 'out'], 'Stone Clan' => ['go outpost', 'out'],
-                       'Dirge' => ['go dingy stables', 'out'], 'Leth Deriel' => ['go shanty', 'out'], 'Tiger Clan' => ['go outpost', 'out'],
+                       'Dirge' => ['go dingy stables', 'out'], 'Leth Deriel' => ['go shanty', 'out'], 'Tiger Clan' => ['go outpost', 'out'], 'LethFerry' => ['south', 'north'],
                        'Wolf Clan' => ['go outpost', 'out'], 'Shard' => ['go arch', 'out'], 'Darkling Wood' => ['go building', 'out'],
                        "Fayrin's Rest" => ['go outpost', 'out'], 'Steelclaw Clan' => ['go entrance', 'out'], 'Hibarnhvidar' => ['go guild', 'out'],
                        'Boar Clan' => ['go building', 'out'], "Raven's Point" => ['go outpost', 'go pine door'], 'Ain Ghazal' => ['west', 'east'],
@@ -197,6 +197,7 @@ class Trade
       mark_towns
       @current_caravan_destination = find_closest_id('trader_outpost')
     end
+    command_caravan?('wait')
     town_business
     echo "The current destination is #{@current_caravan_destination}"
     do_lead_from
@@ -368,7 +369,7 @@ class Trade
   end
 
   def town_lead_name(town_name) # very different lead command parsing for some town names
-    town_map = { 'Leth Deriel' => 'Leth', 'Darkling Wood' => 'Darkling', "Raven's Point" => 'Raven' }
+    town_map = { 'Leth Deriel' => 'Leth', 'Darkling Wood' => 'Darkling', "Raven's Point" => 'Raven', 'LethFerry' => 'Crossing' }
     town_map[town_name] ? town_map[town_name] : town_name
   end
 
@@ -382,8 +383,7 @@ class Trade
 
     case nearest_town
     when 'Leth Deriel'
-      take_caravan_to(1968) unless lead_caravan_to?('Crossing') # walk it out the bower gate
-      lead_caravan_to?('Crossing') # lead the caravan to the Ferry
+      take_caravan_to(1968) unless lead_caravan_to?('LethFerry') # lead the caravan to the Ferry
       take_caravan_to(895) # walk it across the Ferry, then proceed.
     when 'Boar Clan'
       lead_caravan_to?('Hibarnhvidar')
@@ -525,6 +525,7 @@ class Trade
     return unless @caravan_interior
     echo 'perform_outside_move' if debugging?
     be_outside_caravan
+    command_caravan?('wait')
     Flags.reset('caravan-arrived')
     if room_exits.is_a?(String)
       move room_exits
@@ -533,7 +534,7 @@ class Trade
         move r_exit
       end
     end
-    wait_for_caravan
+    wait_for_caravan(1)
   end
 
   def be_inside_caravan # call whenever you need to be inside the caravan


### PR DESCRIPTION
Missed a condition that could cause someone with a caravan interior to fail to get on the south side of the leth ferry, and added a command to wait in startup in case someone starts ;trade.lic while being led by their caravan.
