### PR TITLE
Adjust trade command for exterior management

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -525,11 +525,11 @@ class Trade
     return unless @caravan_interior
     echo 'perform_outside_move' if debugging?
     be_outside_caravan
-    command_caravan?('wait')
     Flags.reset('caravan-arrived')
     if room_exits.is_a?(String)
       move room_exits
     else
+      command_caravan?('wait')
       room_exits.each do |r_exit|
         move r_exit
       end


### PR DESCRIPTION
Although trade route changes have mostly done away with this, a couple outposts up north still lead you to the town gates rather than the outpost.  For those, when using caravan interiors, there's no need to tell the caravan to wait upon exiting.