### PR TITLE
Fix for gate of souls stuck boulder

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -855,10 +855,10 @@ class Bescort
     case bput('go tunnel', /^Wriggling on your stomach/, /^You are engaged/, /^What were you referring to/)
     when /^You are engaged/
       retreat
-      gos_tunnel
+      return gos_tunnel
     when /^What were you referring to/
       push_boulder
-      gos_tunnel
+      return gos_tunnel
     end
     waitfor /^After a seemingly interminable length of time/
     fix_standing


### PR DESCRIPTION
Fix for Issue https://github.com/rpherbig/dr-scripts/issues/3896

If gos_tunnel fails once due to either the boulder falling back into place or due to engagement with a mob, it recurses.  But after finishing recursing the earlier instances of gos_tunnel will still resolve and hit the waitfor message, hanging infinitely.