### PR TITLE
 * Added options to sell-loot  for use of an alternative gem container

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -722,6 +722,7 @@ sell_loot_bundle: true
 sell_loot_money_on_hand: 3 silver
 sell_loot_skip_bank: false
 sell_loot_skip_exchange: false
+sell_loot_skip_pouch_close: false
 sell_pouches_for_trading: false
 sale_pouches_container: backpack
 
@@ -752,6 +753,7 @@ osrel_favor_god: Meraud
 tie_gem_pouches: true
 spare_gem_pouch_container:
 gem_pouch_adjective:
+gem_pouch_noun: pouch
 
 # https://elanthipedia.play.net/Lich_script_repository#scout
 trail_override:

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -30,7 +30,7 @@ class SellLoot
     skip_exchange = @settings.sell_loot_skip_exchange
     keep_money_by_currency = @settings.sell_loot_money_on_hand
 
-    sell_gems("#{@settings.gem_pouch_adjective} pouch") if @settings.sell_loot_pouch
+    sell_gems("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}") if @settings.sell_loot_pouch
     check_spare_pouch(@settings.spare_gem_pouch_container, @settings.gem_pouch_adjective) if @settings.spare_gem_pouch_container
 
     sell_bundle if @settings.sell_loot_bundle
@@ -168,7 +168,7 @@ class SellLoot
       end
     end
 
-    fput "close my #{container}"
+    fput "close my #{container}" unless @settings.sell_loot_skip_pouch_close
   end
 end
 


### PR DESCRIPTION
Added two settings to base.yaml for defaults to not change how it currently operates.  New settings allow for a noun other than 'pouch' as well as one to disable closing of the pouch after selling the contents.