### PR TITLE
Correcting ring hauberk recipe list

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -5685,6 +5685,7 @@ crafting_recipes:
   part:
   - large padding
   - small padding
+  - small padding
 - name: a metal chain robe
   noun: robe
   volume: 45


### PR DESCRIPTION
Correcting recipe for 'ring hauberk', from the armorcrafting master book:

        -=   Chapter 1, Page 38: Instructions for crafting a metal ring hauberk    =-

  A metal ring hauberk is a craftable item in the Forging society under the Armorsmithing crafting discipline.  This is considered to be a challenging piece to make, though knowledge of the Complete Chain Armor Design technique will be
  beneficial to the crafter.

  This item is listed as a "finished metal chain armor" ingredient type and is created using a forging hammer, some tongs, some metalworking oil, a metal anvil with forge.  A crafter may also find it helpful to have some pliers a shovel
  and a bellows on hand.

 A list of ingredients is provided:

   (1) refined metal ingot (70 volume)
   (1) finished large cloth padding
   (2) finished small cloth padding