### PR TITLE
Update smith.lic

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -65,8 +65,6 @@ class Smith
     stow_hands
 
     parts.each do |part|
-      next if exists?(part)
-
       data = get_data('crafting')['recipe_parts'][part][@hometown]
       if data['part-number']
         order_item(data['part-room'], data['part-number'])


### PR DESCRIPTION
Removing 'exists?' check - it precludes buying multiple parts for larger recipes
Ring hauberk requires 1 large padding and 2 small paddings - second small padding was being skipped due to existence of the first bought small padding.

```2019-10-05 03:03:24 [smith]>order 11
2019-10-05 03:03:24 The attendant says, "You can purchase some small cloth padding for 62 Kronars.  Just order it again and we'll see it done!"
2019-10-05 03:03:24 [smith]>order 11
2019-10-05 03:03:24 The attendant takes some coins from you and hands you some small cloth padding.
2019-10-05 03:03:24 [smith]>put small padding in my haversack
2019-10-05 03:03:25 You put your padding in your haversack.
2019-10-05 03:03:25 [smith]>tap my small padding
2019-10-05 03:03:25 You tap some small cloth padding inside your haversack.
2019-10-05 03:03:25 --- Lich: buff active.
2019-10-05 03:03:25 --- Lich: buff has exited.
2019-10-05 03:03:27 [smith]>look my first oil```