### PR TITLE
Adjust room sampling in common-travel

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -102,7 +102,8 @@ module DRCT
       (check_mana = min_mana > 0) && !check_mana
 
       if idle_room
-        walk_to(idle_room.sample)
+        idle_room = idle_room.sample if idle_room.is_a?(Array)
+        walk_to(idle_room)
         echo '***Failed to find an empty room, pausing***'
         pause 30
       else


### PR DESCRIPTION
Someone reported that common-travel throws a fit if idle_room is defined:
`idle_room: 12345` instead of
```
idle_room:
- 12345
```
This pulls the sample only if it's working with an array, otherwise uses it as-is.