### PR TITLE
Add an idle_room to crossing artifice

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -999,6 +999,7 @@ artificing:
     blank-scrolls: 8
     repair-room: 19209
     repair-npc: Rangu
+    idle_room: 14752
   Riverhaven:
     npc: Trainer
     npc_last_name: Trainer


### PR DESCRIPTION
Related to/closes https://github.com/rpherbig/dr-scripts/issues/3945

Crossing's artifice entry has a missing idle_room entry, so if it can't find an empty brazier room then it has trouble. 