### PR TITLE
Adjust play_song to support climbing songs

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -391,42 +391,50 @@ module DRC
     g
   end
 
-  def play_song?(settings, song_list, worn = true, skip_clean = false)
+  def play_song?(settings, song_list, worn = true, skip_clean = false, climbing = false)
     instrument = worn ? settings.worn_instrument : settings.instrument
     UserVars.song = song_list.first.first unless UserVars.song
+    UserVars.climbing_song = @song_list.first.first unless UserVars.climbing_song || !climbing
+    song_to_play = climbing ? UserVars.climbing_song : UserVars.song
     fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
-    result = bput("play #{UserVars.song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
+    result = bput("play #{song_to_play}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
     case result
     when 'Play on what instrument'
       snapshot = "#{right_hand}#{left_hand}"
       fput("get #{instrument}")
       return false if snapshot == "#{right_hand}#{left_hand}"
       fput("wear #{instrument}") if worn
-      play_song?(settings, song_list, worn, skip_clean)
+      play_song?(settings, song_list, worn, skip_clean, climbing)
     when 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing'
       false
     when 'You\'re already playing a song'
       fput('stop play')
-      play_song?(settings, song_list, worn, skip_clean)
+      play_song?(settings, song_list, worn, skip_clean, climbing)
     when 'You cannot play'
       wait_for_script_to_complete('safe-room')
     when 'dirtiness may affect your performance'
       return true if DRSkill.getrank('Performance') < 20
       return true if skip_clean
       return true unless clean_instrument(settings, worn)
-      play_song?(settings, song_list, worn, skip_clean)
+      play_song?(settings, song_list, worn, skip_clean, climbing)
     when 'slightest hint of difficulty', 'fumble slightly'
       true
     when 'You begin a', 'You effortlessly begin', 'You begin some'
-      return true if UserVars.song == 'concerto masterful'
+      return true if song_to_play == 'concerto masterful'
+      # Ignore difficulty messages if we have an offset
+      return true if climbing && UserVars.climbing_song_offset
       stop_playing
-      UserVars.song = song_list[UserVars.song] || song_list.first.first
-      play_song?(settings, song_list, worn, skip_clean)
+      UserVars.climbing_song = song_list[UserVars.climbing_song] || song_list.first.first if climbing
+      UserVars.song = song_list[UserVars.song] || song_list.first.first unless climbing
+      play_song?(settings, song_list, worn, skip_clean, climbing)
     when 'You struggle to begin'
-      return true if UserVars.song == song_list.first.first
+      return true if song_to_play == song_list.first.first
+      # Ignore difficulty messages if we have an offset
+      return true if climbing && UserVars.climbing_song_offset
       stop_playing
-      UserVars.song = song_list.first.first
-      play_song?(settings, song_list, worn, skip_clean)
+      UserVars.climbing_song = song_list.first.first if climbing
+      UserVars.song = song_list.first.first unless climbing
+      play_song?(settings, song_list, worn, skip_clean, climbing)
     else
       false
     end

--- a/common.lic
+++ b/common.lic
@@ -394,7 +394,7 @@ module DRC
   def play_song?(settings, song_list, worn = true, skip_clean = false, climbing = false)
     instrument = worn ? settings.worn_instrument : settings.instrument
     UserVars.song = song_list.first.first unless UserVars.song
-    UserVars.climbing_song = @song_list.first.first unless UserVars.climbing_song || !climbing
+    UserVars.climbing_song = song_list.first.first unless UserVars.climbing_song
     song_to_play = climbing ? UserVars.climbing_song : UserVars.song
     fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
     result = bput("play #{song_to_play}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
@@ -420,7 +420,7 @@ module DRC
     when 'slightest hint of difficulty', 'fumble slightly'
       true
     when 'You begin a', 'You effortlessly begin', 'You begin some'
-      return true if song_to_play == 'concerto masterful'
+      return true if song_to_play == song_list.to_a.last.last
       # Ignore difficulty messages if we have an offset
       return true if climbing && UserVars.climbing_song_offset
       stop_playing


### PR DESCRIPTION
I purchased a climbing rope and changed athletics to use the common play_song logic and support cowbells.  Step 1 would be to change common play_song? to support it for later.

I can show the tests for athletics' climbing song stuff in a later PR, but at the moment as for this change, running performance worked and trained up to max skill, and cleaned the cowbell as expected.  I deleted my song variable and watched it climb the ranks from ditty up to psalm.