### PR TITLE
trade minor adjustments and caravan name fix

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -582,14 +582,14 @@ class Trade
       /You seem to recall that you left your (?<description>.*) (?<name>.*) right behind you/ =~ response
       @caravan.noun ||= name
       echo "@caravan.noun: #{@caravan.noun}" if debugging?
-      @caravan.adjective ||= description
+      @caravan.adjective ||= description.split.first
       echo "@caravan.adjective: #{@caravan.adjective}" if debugging?
       true
     when /You recall that your (?<description>.*) (?<name>.*) should be located in/
       /You recall that your (?<description>.*) (?<name>.*) should be located in/ =~ response
       @caravan.noun ||= name
       echo "@caravan.noun: #{@caravan.noun}" if debugging?
-      @caravan.adjective ||= description
+      @caravan.adjective ||= description.split.first
       echo "@caravan.adjective #{@caravan.adjective}" if debugging?
       false
     when /You are far too occupied/
@@ -1088,7 +1088,7 @@ class Trade
 
   def find_crates(origin_town) # handles finding the crate that matches the expired contract.
     echo "find_crates from #{origin_town}" if debugging?
-    result = DRC.bput("look #{@caravan.adjective.split.first} #{@caravan.noun}", 'You tell the driver', 'I could not find', 'There is nothing', 'You carefully go over')
+    result = DRC.bput("look #{@caravan.adjective} #{@caravan.noun}", 'You tell the driver', 'I could not find', 'There is nothing', 'You carefully go over')
     pause 1
     text = reget(10)
     text.delete_if { |item| !item.include?('sturdy crate') }
@@ -1262,7 +1262,6 @@ class Trade
   end
 
   def training_cleanup # all training shuts down immediately upon arrival. Any routine that needs sanitizing goes here.
-    magic_cleanup
     outfitting_cleanup
     engineering_cleanup
     first_aid_cleanup
@@ -1270,6 +1269,7 @@ class Trade
     locksmithing_cleanup
     @step_toggle = -1
     wipe_token
+    magic_cleanup
   end
 
   def walk_training
@@ -1760,7 +1760,7 @@ class Trade
 
   def check_hunting
     return unless @hunt
-    @cooldown_timers['Hunting'] ||= Time.now - 1100
+    @cooldown_timers['Hunting'] ||= Time.now - 600
     return unless closest_town == @settings.hometown # right now it only runs hunt when you reach your hometown
     return unless DRSkill.getxp('Trading') > 12
     return unless Time.now - @cooldown_timers['Hunting'] >= 1200


### PR DESCRIPTION
Adjusted hunt start timer, no real impact, but behaves more intuitively.

Moved magic_cleanup after other sections to catch when crafting might start a spell after magic_cleanup but before engineering_cleanup.

Caravan adjectives now defined as adjective.split.first.  A caravan with a two word recall name like TWO AUROCH CARAVAN responds to TWO CARAVAN only. smh.