### PR TITLE
athletics - remove duplicate logic - add cheap-rope support

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -13,8 +13,6 @@ class Athletics
     @settings = get_settings
     @athletics_options = get_data('athletics').athletics_options
     @performance_pause = @settings.performance_pause
-    # maintains compatibility with those who had instrument unset
-    @instrument = @settings.worn_instrument || 'zills'
 
     @climbing_target = get_data('athletics').practice_options[@settings.climbing_target]
     @swimming_target = get_data('athletics').swimming_options[@settings.swimming_target]
@@ -30,7 +28,8 @@ class Athletics
       [
         { name: 'wyvern', regex: /^wy.*/i, optional: true, description: 'Climb both undergondola and wyvern cliffs' },
         { name: 'undergondola', regex: /^un.*/i, optional: true, description: 'Climb branch etc undergondola' },
-        { name: 'xalas', regex: /^xala.*/i, optional: true, description: 'Climb xalas in zoluren in instead of undergondola' }
+        { name: 'xalas', regex: /^xala.*/i, optional: true, description: 'Climb xalas in zoluren in instead of undergondola' },
+        { name: 'stationary', regex: /^stat.*/i, optional: true, description: 'Stand still and use a climbing rope' }
       ]
     ]
 
@@ -44,7 +43,7 @@ class Athletics
     elsif args.xalas
       climb_xalas
     elsif have_climbing_rope
-      train_with_rope
+      train_with_rope(args.stationary)
     elsif @swimming_target
       swim_loop(@swimming_target['rooms'])
     elsif @climbing_target
@@ -90,82 +89,6 @@ class Athletics
     DRSkill.getxp('Athletics') >= @end_exp
   end
 
-  def stop_play
-    bput('stop play', 'You stop playing your song', 'In the name of', "But you're not performing")
-  end
-
-  def clean_instrument
-    cloth = @settings.cleaning_cloth
-    stow_hands
-    # Slide for zills, remove for cowbell
-    bput("remove my #{@instrument}", 'You slide', 'You remove')
-    bput("get my #{cloth}", 'You get')
-
-    loop do
-      case bput("wipe my #{@instrument} with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
-      when 'not in need of drying'
-        break
-      when 'You should be sitting up'
-        fix_standing
-        next
-      end
-      pause 1
-      waitrt?
-
-      until /you wring a dry/i =~ bput("wring my #{cloth}", 'You wring a dry', 'You wring out')
-        pause 1
-        waitrt?
-      end
-    end
-
-    until /not in need of cleaning/i =~ bput("clean my #{@instrument} with my #{cloth}", 'Roundtime', 'not in need of cleaning')
-      pause 1
-      waitrt?
-    end
-
-    # slide for zills, attach for cowbell
-    bput("wear my #{@instrument}", 'You slide', 'You attach')
-    bput("stow my #{cloth}", 'You put')
-  end
-
-  def play_climbing_song?
-    UserVars.climbing_song = @song_list.first.first unless UserVars.climbing_song
-    case bput("play #{UserVars.climbing_song}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play')
-    when 'Play on what instrument'
-      return false
-    when 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play'
-      return false
-    when 'You cannot play'
-      wait_for_script_to_complete('safe-room')
-      return false
-    when 'dirtiness may affect your performance'
-      if DRSkill.getrank('Performance') < 20
-        echo "Skipping cleaning of #{@instrument} due to low rank of Performance: #{DRSkill.getrank('Performance')}" if UserVars.athletics_debug
-        return true
-      end
-      stop_play
-      clean_instrument
-      return play_climbing_song?
-    when 'You begin a', 'You effortlessly begin', 'You begin some'
-      # Ignore difficulty messages if we have an offset
-      return true if UserVars.climbing_song_offset
-
-      stop_play
-      UserVars.climbing_song = @song_list[UserVars.climbing_song] || @song_list.first.first
-      return play_climbing_song?
-    when 'You struggle to begin'
-      # Ignore difficulty message if we have an offset
-      return true if UserVars.climbing_song_offset
-      return true if UserVars.climbing_song == @song_list.first.first
-
-      stop_play
-      UserVars.climbing_song = @song_list.first.first
-      return play_climbing_song?
-    end
-
-    true
-  end
-
   def offset_climbing_song(direction)
     return unless UserVars.climbing_song_offset
     return unless @song_list
@@ -179,9 +102,9 @@ class Athletics
     end
   end
 
-  def train_with_rope
+  def train_with_rope(stationary)
     return unless exists?("#{@settings.climbing_rope_adjective} rope")
-    return unless exists?("#{@instrument}")
+    return unless exists?(@settings.worn_instrument)
 
     UserVars.climbing_song ||= UserVars.song
     echo "UserVars.climbing_song: #{UserVars.climbing_song}" if UserVars.athletics_debug
@@ -192,20 +115,23 @@ class Athletics
     Flags.add('climbing-finished', 'You finish practicing your climbing', 'The rope\'s will quickly fades away', 'Your focus diverts away from the rope')
     Flags.add('climbing-too-hard', 'This climb is too difficult')
     Flags.add('climbing-too-easy', 'This climb is no challenge at all, so you stop practicing')
+    Flags.add('climbing-dead-rope', '^You believe you can use it for \d+ minutes per day\.', '^You finish practicing your climbing skill just as your rope begins to slacken')
 
     stow_hands
-    walk_to @settings.safe_room
+    walk_to @settings.safe_room unless stationary
     case bput("get #{@settings.climbing_rope_adjective} rope", 'You are already holding that', 'You get', 'What were you', 'But that is already')
     when 'But that is already'
       bput("remove my #{@settings.climbing_rope_adjective} rope", 'You remove')
     end
-    until done_training?
+    check_rope?
+    until done_training? || Flags['climbing-dead-rope']
       fix_standing
       Flags.reset('climbing-finished')
-      break unless play_climbing_song?
+      break unless DRC.play_song?(@settings, @song_list, true, false, true)
       case bput("climb practice #{@settings.climbing_rope_adjective} rope", 'You begin to practice ', 'you mime a convincing climb while pulling the rope hand over hand', 'Directing your attention toward your rope', 'Allows you to climb various things like a tree', 'But you aren\'t holding', 'You should stop practicing')
       when /you mime/
-        break unless play_climbing_song?
+        break unless check_rope?
+        break unless DRC.play_song?(@settings, @song_list, true, false, true)
       when /Directing your/, /You should stop practicing/
         loop do
           pause 1
@@ -213,15 +139,18 @@ class Athletics
           if Flags['climbing-too-hard']
             Flags.reset('climbing-too-hard')
             UserVars.climbing_song_offset = true
-            stop_play
+            DRC.stop_playing
             offset_climbing_song(-1)
             break
           elsif Flags['climbing-too-easy']
             Flags.reset('climbing-too-easy')
             UserVars.climbing_song_offset = true
-            stop_play
+            DRC.stop_playing
             offset_climbing_song(1)
             break
+          elsif Flags['dead-rope']
+            break unless check_rope?
+            break unless DRC.play_song?(@settings, @song_list, true, false, true)
           end
         end
       when /Allows you to climb various things like a tree/
@@ -234,9 +163,21 @@ class Athletics
     Flags.delete('climbing-finished')
     Flags.delete('climbing-too-easy')
     Flags.delete('climbing-too-hard')
+    Flags.delete('climbing-dead-rope')
     bput('stop climb', 'You stop practicing your climbing skills.', "You weren't practicing your climbing skills anyway.")
+    DRC.stop_playing
     fix_standing
     stow_hands
+  end
+
+  def check_rope?
+    fput("study #{@settings.climbing_rope_adjective} rope")
+    if Flags['climbing-dead-rope']
+      DRC.message('Your rope is dead tired! Get a better one, you poor slob!')
+      false
+    else
+      true
+    end
   end
 
   def crossing_athletics


### PR DESCRIPTION
This shouldn't be merged yet due to the recent common change.  Also, I want to find someone with a permanent climbing rope to test this, if possible.

Three changes, first, moved stop_play, clean_instrument, and play_song? out to common.  Second, added a flag to kill the training and quit out if your climbing rope runs out of minutes.  Third, added an arg to just stay in your room and not move with a climbing rope.  Mainly this is so I can climb my rope inside or behind my caravan.

The @instrument var up top isn't used anymore.