### PR TITLE
[combat-trainer] Allow wearing bundles on other locations than shoulders

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -352,6 +352,9 @@ class LootProcess
     @tie_bundle = skinning['tie_bundle'] || false
     echo("  @tie_bundle: #{@tie_bundle}") if $debug_mode_ct
 
+    @pull_bundle_count = skinning['pull_count'] || 0
+    echo("  @pull_bundle_count: #{@pull_bundle_count}") if $debug_mode_ct
+
     @arrange_types = skinning['arrange_types'] || {}
     echo("  @arrange_types: #{@arrange_types}") if $debug_mode_ct
 
@@ -829,6 +832,9 @@ class LootProcess
       end
       if bput('get bundling rope', 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
         fput('bundle')
+        @pull_bundle_count.times do
+          bput('pull my bundle', 'You adjust')          
+        end
         fput('wear my bundle')
         if @tie_bundle
           bput('tie my bundle', 'TIE the bundle again')


### PR DESCRIPTION
The default location for wearing a lumpy bundle is the shoulder, but
it's a fairly in-demand slot. This change adds a new skinning option to
`PULL MY BUNDLE` a number of times, allowing it to be worn on the
shoulders, back or waist as well.

Example:

```yaml
skinning:
  skin: true
  pull_count: 1
```

This will pull the bundle once, draping across the shoulders.