### PR TITLE
[workorders] Don't craft bubble wands

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -7324,7 +7324,7 @@ crafting_recipes:
 - name: a bubble wand
   noun: wand
   type: artificing
-  work_order: true
+  work_order: false
   chapter: 6
   enchant_stock1: 4
   enchant_stock2: 


### PR DESCRIPTION
Shard Enchanting Society doesn't stock wands, so this prevents removes
recipes that have wands as parts from the workorders list.