### PR TITLE
Buff persistence in mining/forestry

### DIFF
--- a/buff.lic
+++ b/buff.lic
@@ -16,27 +16,10 @@ class Waggle
     ]
 
     args = parse_args(arg_definitions)
-
     settings = get_settings
 
-    waggle_spells = settings.waggle_sets
-
-    spells = args.spells ? waggle_spells[args.spells] : waggle_spells['default']
-
-    return unless spells
-
-    if DRStats.barbarian?
-      start_barb_abilities(spells, settings)
-    elsif DRStats.thief?
-      start_khris(spells, settings)
-    else
-      spells.each_value do |value|
-        next unless value['use_auto_mana']
-        check_discern(value, settings)
-      end
-
-      cast_spells(spells, settings, settings.waggle_force_cambrinth)
-    end
+    setname = args.spells ? args.spells : 'default'
+    DRCA.do_buffs(settings, setname)
   end
 end
 

--- a/forestry-buddy.lic
+++ b/forestry-buddy.lic
@@ -27,7 +27,7 @@ class ForestryBuddy
         fput('stow my packet')
       end
     end
-    wait_for_script_to_complete('buff', ['forestry']) if @settings.waggle_sets['forestry']
+    DRCA.do_buffs(@settings, 'forestry')
     bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| chop_rooms(@area_list[area_name]) }
   end
@@ -81,7 +81,7 @@ class ForestryBuddy
       wait_for_script_to_complete('safe-room') if bleeding?
       if chop?(room)
         check_repair
-        wait_for_script_to_complete('buff', ['forestry']) if @settings.waggle_sets['forestry']
+        DRCA.do_buffs(@settings, 'forestry')
         bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
       end
     end

--- a/forestry-buddy.lic
+++ b/forestry-buddy.lic
@@ -28,6 +28,7 @@ class ForestryBuddy
       end
     end
     wait_for_script_to_complete('buff', ['forestry'])
+    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| chop_rooms(@area_list[area_name]) }
   end
 
@@ -78,7 +79,11 @@ class ForestryBuddy
   def chop_rooms(rooms)
     rooms.each do |room|
       wait_for_script_to_complete('safe-room') if bleeding?
-      check_repair if chop?(room)
+      if chop?(room)
+        check_repair
+        wait_for_script_to_complete('buff', ['forestry'])
+        bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
+      end
     end
   end
 

--- a/forestry-buddy.lic
+++ b/forestry-buddy.lic
@@ -27,7 +27,7 @@ class ForestryBuddy
         fput('stow my packet')
       end
     end
-    wait_for_script_to_complete('buff', ['forestry'])
+    wait_for_script_to_complete('buff', ['forestry']) if @settings.waggle_sets['forestry']
     bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| chop_rooms(@area_list[area_name]) }
   end
@@ -81,7 +81,7 @@ class ForestryBuddy
       wait_for_script_to_complete('safe-room') if bleeding?
       if chop?(room)
         check_repair
-        wait_for_script_to_complete('buff', ['forestry'])
+        wait_for_script_to_complete('buff', ['forestry']) if @settings.waggle_sets['forestry']
         bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
       end
     end

--- a/forestry-buddy.lic
+++ b/forestry-buddy.lic
@@ -28,7 +28,7 @@ class ForestryBuddy
       end
     end
     wait_for_script_to_complete('buff', ['forestry'])
-    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
+    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| chop_rooms(@area_list[area_name]) }
   end
 
@@ -82,7 +82,7 @@ class ForestryBuddy
       if chop?(room)
         check_repair
         wait_for_script_to_complete('buff', ['forestry'])
-        bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
+        bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
       end
     end
   end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -28,6 +28,7 @@ class MiningBuddy
       end
     end
     wait_for_script_to_complete('buff', ['mining'])
+    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
 
@@ -95,7 +96,11 @@ class MiningBuddy
   def mine_rooms(rooms)
     rooms.each do |room|
       wait_for_script_to_complete('safe-room') if bleeding?
-      check_repair if mine?(room)
+      if mine?(room)
+        check_repair
+        wait_for_script_to_complete('buff', ['mining'])
+        bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
+      end
     end
   end
 

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -27,7 +27,7 @@ class MiningBuddy
         fput('stow my packet')
       end
     end
-    wait_for_script_to_complete('buff', ['mining']) if @settings.waggle_sets['mining']
+    DRCA.do_buffs(@settings, 'mining')
     bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
@@ -98,7 +98,7 @@ class MiningBuddy
       wait_for_script_to_complete('safe-room') if bleeding?
       if mine?(room)
         check_repair
-        wait_for_script_to_complete('buff', ['mining']) if @settings.waggle_sets['mining']
+        DRCA.do_buffs(@settings, 'mining')
         bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
       end
     end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -28,7 +28,7 @@ class MiningBuddy
       end
     end
     wait_for_script_to_complete('buff', ['mining'])
-    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
+    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
 
@@ -99,7 +99,7 @@ class MiningBuddy
       if mine?(room)
         check_repair
         wait_for_script_to_complete('buff', ['mining'])
-        bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.') if DRStats.trader? && DRStats.circle >= 65
+        bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
       end
     end
   end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -27,7 +27,7 @@ class MiningBuddy
         fput('stow my packet')
       end
     end
-    wait_for_script_to_complete('buff', ['mining'])
+    wait_for_script_to_complete('buff', ['mining']) if @settings.waggle_sets['mining']
     bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
@@ -98,7 +98,7 @@ class MiningBuddy
       wait_for_script_to_complete('safe-room') if bleeding?
       if mine?(room)
         check_repair
-        wait_for_script_to_complete('buff', ['mining'])
+        wait_for_script_to_complete('buff', ['mining']) if @settings.waggle_sets['mining']
         bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
       end
     end


### PR DESCRIPTION
Closes issue https://github.com/rpherbig/dr-scripts/issues/3955

Currently mining/forestry-buddy calls buff at script start, but in any successful prospect some will fall off.  If mine/chop actually runs in a room then it now runs ;buff again.

Also adding in Trader Spec Luck to these.  I was considering adding a section to ;buff and common-arcana for speculates, except as far as I know this is the only one remaining, and they're moving away from speculates in favor of magic?