### PR TITLE
trade.lic - Move caravan wait

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -197,7 +197,6 @@ class Trade
       mark_towns
       @current_caravan_destination = find_closest_id('trader_outpost')
     end
-    command_caravan?('wait')
     town_business
     echo "The current destination is #{@current_caravan_destination}"
     do_lead_from
@@ -1731,6 +1730,7 @@ class Trade
   def town_business # run every time it delivers/picks up a contract from Crossing/another hub. Replenishes resources and stocks coins
     return if time_to_room(Room.current.id, find_closest_id('trader_outpost')) > 5.0
     room = Room.current.id
+    command_caravan?('wait')
     deposit_coins(@caravan_coins_on_hand)
     withdraw_coins(@caravan_coins_on_hand)
     check_hunting


### PR DESCRIPTION
Should resolve issue https://github.com/rpherbig/dr-scripts/issues/3959

The caravan should wait in place before any attempt to leave the room along caravan-passable rooms.  That was only caught some of the time.