### PR TITLE
Add Velaka desert to bescort

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -171,6 +171,10 @@ class Bescort
         { name: 'mode', options: %w[adult juvenile elder oasis exit], description: 'Where to?' }
       ],
       [
+        { name: 'velaka', regex: /velaka/i, description: 'The Velaka desert, containing zombie nomads and westanuryn.' },
+        { name: 'mode', options: %w[nomads westanuryn slavers exit], description: 'Where to?' }
+      ],
+      [
         { name: 'ferry', regex: /ferry/i, description: 'Ferry between Leth Deriel and the Crossing' },
         { name: 'mode', options: %w[leth crossing], description: 'Which town are you going to?' }
       ],
@@ -238,6 +242,8 @@ class Bescort
       take_sandbarge(args.start_location, args.end_location)
     elsif args.desert
       desert(args.mode)
+    elsif args.velaka
+      velaka_desert(args.mode)
     elsif args.ferry
       take_xing_ferry(args.mode)
     elsif args.ferry1
@@ -327,11 +333,11 @@ class Bescort
     end
   end
 
-  def find_room_maze(valid_move = proc { |_| true }, error_rooms = {})
+  def find_room_maze(valid_move = proc { |_| true }, error_rooms = {}, target = nil)
     loop do
       error_rooms[Room.current.id].call if error_rooms[Room.current.id]
-      return if DRRoom.pcs.empty? && DRRoom.npcs.empty?
-      return if !DRRoom.pcs.empty? && (DRRoom.pcs - UserVars.friends).empty? && DRRoom.pcs.size <= 2
+      return if DRRoom.pcs.empty? && DRRoom.npcs.empty? && (target.nil? || XMLData.room_title.include?(target))
+      return if !DRRoom.pcs.empty? && (DRRoom.pcs - UserVars.friends).empty? && DRRoom.pcs.size <= 2 && (target.nil? || XMLData.room_title.include?(target))
       exits = XMLData.room_exits.dup.shuffle
       exits = %w[nw n ne e se s sw w].shuffle if exits.empty?
       exits.rotate! until valid_move.call(exits.first)
@@ -457,6 +463,37 @@ class Bescort
         move 'south'
         move 'northeast'
         walk_to(6760)
+      end
+    end
+  end
+
+  def velaka_desert_enter
+    walk_to(247)
+    move 'go trail'
+  end
+
+  def velaka_desert(mode)
+    case mode
+    when /nomads/
+      velaka_desert_enter
+      wander_maze_until('high plateau', 'climb plateau')
+    when /westanuryn/
+      velaka_desert_enter
+      find_room_maze
+    when /slavers/
+      velaka_desert_enter
+      find_room_maze( proc { |_| true }, {}, 'Rock Circle')
+    when /exit/
+      unless XMLData.room_title.include?('Velaka Desert')
+        echo "This must be started in the Velaka Desert!"
+        return
+      end
+      if XMLData.room_title.include?('Walk of Bones') # Nomad Area
+        manual_go2(15052)
+        move 'climb trail'
+        return velaka_desert(mode)
+      else
+        wander_maze_until('rocky trail', 'go trail')
       end
     end
   end
@@ -689,7 +726,7 @@ class Bescort
       take_dirigible(mode)
     end
   end
-  
+
   def take_airship_muspari
     case bput('join airship', 'You join a', 'What were you referring to?')
     when /You join a/

--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -67,6 +67,20 @@ escort_zones:
     base: 2317
     area: oshu_manor
     enter: kartais
+  # https://elanthipedia.play.net/Mottled_westanuryn                     180-290
+  # May have a wandering velaka_slaver
+  # Muspar'i
+  velaka_westanuryn:
+    base: 247
+    area: velaka
+    enter: westanuryn
+  # https://elanthipedia.play.net/Velakan_slaver                         225-360
+  # May have a wandering velaka_westanuryn
+  # Muspar'i
+  velaka_slavers:
+    base: 247
+    area: velaka
+    enter: slavers
   # https://elanthipedia.play.net/Red-Gold_scaled_atik%27et_(2)          250-350
   # https://elanthipedia.play.net/Mottled_westanuryn
   # Zoluren
@@ -146,8 +160,13 @@ hunting_areas_by_town:
     - money_grubbers
   # https://elanthipedia.play.net/Shifty-eyed_skinflint                  100-150
     - shifty_eyed_skinflints
+  # https://elanthipedia.play.net/Mottled_westanuryn                     180-290
+    - velaka_westanuryn
+  # https://elanthipedia.play.net/Velakan_slaver                         225-360
+    - velaka_slaver
+  # https://elanthipedia.play.net/Zombie_nomad                           260-410
+    - zombie_nomad
   # https://elanthipedia.play.net/Gam_chaga                              300-450
-  # needs a quick remap, nothing crazy.
     - gam_chaga
   # https://elanthipedia.play.net/Ashu_hhinvi                            500-700
   # needs a quick remap, nothing crazy.
@@ -1438,6 +1457,16 @@ hunting_zones:
   - 8701
   - 8702
   - 8703
+  # https://elanthipedia.play.net/Zombie_nomad                           260-410
+  # Muspari, through the velaka bescort zone
+  zombie_nomads:
+  - 15052
+  - 15053
+  - 15057
+  - 15058
+  - 15059
+  - 15060
+  - 15061
   # https://elanthipedia.play.net/Bristle-backed_peccary                 280-405
   # Great swarm, in town with justice
   bristle_peccs:


### PR DESCRIPTION
Yeah, yeah, yeah, who in their right mind is going to visit a sandblasted wasteland like the Velaka Desert? Call me the Muspar'i Tourism Chair.  Come see our new airship!

Also adding in zombie_nomads, which are in a mapped sub-area through the desert (stringprocs to be added as soon as the bescort changes happen,) as well as westanuryn and velakan slavers bescort hunt zones.

I had to add an option to search by room title to find_maze_room, but I did test it out in one of the existing maze_room areas to make sure I didn't break anything.