### PR TITLE
[clean-leather] Allow careful scraping and crafting bags

### DIFF
--- a/clean-leather.lic
+++ b/clean-leather.lic
@@ -27,7 +27,7 @@ class CleanLeather
 
     ensure_copper_on_hand(2000, @settings)
 
-    @preservative = args.noun == 'bone' ? 'bleaching solution' : 'tanning lotion'
+    @preservative = args.noun =~ /^bones?$/i ? 'bleaching solution' : 'tanning lotion'
 
     @speed = args.speed || ''
 

--- a/clean-leather.lic
+++ b/clean-leather.lic
@@ -14,7 +14,7 @@ class CleanLeather
     arg_definitions = [
       [
         { name: 'source', regex: /\w+/, description: 'bundle, container, etc' },
-        { name: 'noun', regex: /\w+/i, description: 'pelt, hide, skin, etc' },
+        { name: 'noun', regex: /\w+/, description: 'pelt, hide, skin, etc' },
         { name: 'storage', regex: /\w+/, optional: true, description: 'container to put them in, otherwise stow' },
         { name: 'speed', regex: /normal|quick|careful/i, optional: true, description: 'how quickly to scrape' }
       ]
@@ -27,9 +27,11 @@ class CleanLeather
 
     ensure_copper_on_hand(2000, @settings)
 
-    @preservative = args.noun ~= /^bones?$/i ? 'bleaching solution' : 'tanning lotion'
+    @preservative = args.noun == 'bone' ? 'bleaching solution' : 'tanning lotion'
 
     @speed = args.speed || ''
+
+    @bag = @settings.crafting_items_in_container
 
     while bput("get #{args.noun} from my #{args.source}", 'You get', 'You carefully remove', 'What were you') != 'What were you'
       fput('stow left') if left_hand == 'bundling rope'
@@ -39,13 +41,22 @@ class CleanLeather
         waitrt?
       end
       waitrt?
-      fput('stow hide scraper')
+      if @bag.nil?
+        fput('stow hide scraper')
+      else
+        fput("put my hide scraper in my #{@bag}")
+      end
       if bput("get my #{@preservative}", 'You get', 'What were you') == 'What were you'
         order_stow_lotion
       end
       bput("pour #{@preservative} on my #{args.noun}", 'roundtime')
       waitrt?
-      fput("stow my #{@preservative}")
+
+      if @bag.nil?
+        fput("stow my #{@preservative}")
+      else
+        fput("put my #{@preservative} in my #{@bag}")
+      end
 
       if args.storage
         fput("put my #{args.noun} in my #{args.storage}")

--- a/clean-leather.lic
+++ b/clean-leather.lic
@@ -14,8 +14,9 @@ class CleanLeather
     arg_definitions = [
       [
         { name: 'source', regex: /\w+/, description: 'bundle, container, etc' },
-        { name: 'noun', regex: /\w+/, description: 'pelt, hide, skin, etc' },
-        { name: 'storage', regex: /\w+/, optional: true, description: 'container to put them in, otherwise stow' }
+        { name: 'noun', regex: /\w+/i, description: 'pelt, hide, skin, etc' },
+        { name: 'storage', regex: /\w+/, optional: true, description: 'container to put them in, otherwise stow' },
+        { name: 'speed', regex: /normal|quick|careful/i, optional: true, description: 'how quickly to scrape' }
       ]
     ]
     args = parse_args(arg_definitions)
@@ -26,13 +27,15 @@ class CleanLeather
 
     ensure_copper_on_hand(2000, @settings)
 
-    @preservative = args.noun == 'bone' ? 'bleaching solution' : 'tanning lotion'
+    @preservative = args.noun ~= /^bones?$/i ? 'bleaching solution' : 'tanning lotion'
+
+    @speed = args.speed || ''
 
     while bput("get #{args.noun} from my #{args.source}", 'You get', 'You carefully remove', 'What were you') != 'What were you'
       fput('stow left') if left_hand == 'bundling rope'
       fput('stow right') if right_hand == 'bundling rope'
       fput('get my hide scraper')
-      until bput("scrape #{args.noun} with my scraper", 'roundtime', 'looks as clean as you') == 'looks as clean as you'
+      until bput("scrape #{args.noun} with my scraper #{@speed}", 'roundtime', 'looks as clean as you') == 'looks as clean as you'
         waitrt?
       end
       waitrt?


### PR DESCRIPTION
This allows the caller to specify the scraping speed for leather
cleaning (quick, normal, slow), and honors the `craft_item_in_container`
setting if it exists, and prevents the script from trying to pour tanning
lotion on bones.