### PR TITLE
[clean-lumber] Fix *my* deed

### DIFF
--- a/clean-lumber.lic
+++ b/clean-lumber.lic
@@ -40,7 +40,7 @@ class CleanLumber
     while bput("get #{args.type} #{size} from my #{args.source}", 'You get', 'You carefully remove', 'What were you') != 'What were you'
       if size == 'deed'
         was_deed = true
-        fput('tap deed')
+        fput('tap my deed')
         pause
         until right_hand
           fput('swap')


### PR DESCRIPTION
Fixes an issue with clean-lumber where the script would break if a deed was
on the ground.