### PR TITLE
Add drinfomon to buff requires

### DIFF
--- a/buff.lic
+++ b/buff.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#buff
 =end
 
-custom_require.call(%w[common common-arcana events spellmonitor])
+custom_require.call(%w[common drinfomon common-arcana events spellmonitor])
 
 class Waggle
   include DRC


### PR DESCRIPTION
Sorry for all these little changes recently. 

A thief reported seeing an error with the recent buff change that triggered because DRStats.thief? returned false.

I can see DRStats.thief? on mine, and restarting drinfomon fixed the problem for him.  I'm guessing no custom_require for drinfomon did this somehow?