### PR TITLE
Bescort - When swimming segoltha, only wear standard gear if swimming gear used

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -914,7 +914,7 @@ class Bescort
 
   def segoltha(mode)
     EquipmentManager.new.empty_hands
-    EquipmentManager.new.wear_equipment_set?('swimming')
+    have_changed_gear = EquipmentManager.new.wear_equipment_set?('swimming')
     if mode =~ /^n/i
       dir_of_travel = 'north'
       start_room = 19_373
@@ -941,7 +941,7 @@ class Bescort
         break
       end
     end
-    EquipmentManager.new.wear_equipment_set?('standard')
+    EquipmentManager.new.wear_equipment_set?('standard') if have_changed_gear
   end
 
   def croc_swamp(mode)


### PR DESCRIPTION
When running steal in xing and needing to swim the segoltha, you would wear your standard gear afterwards. This meant continuing the pilfering spree with a suit of armor on.

This seems like a reasonable check outside of the stealing issue, in any case.