### PR TITLE
Walkto closed shop adjustment

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -9,7 +9,7 @@ module DRCT
   module_function
 
   def walk_to(target_room, restart_on_fail = true)
-    Flags.add('closed-shop', 'The door is locked up tightly for the night', 'You smash your nose')
+    Flags.add('closed-shop', 'The door is locked up tightly for the night', 'You smash your nose', '^A servant (blocks|stops)')
 
     return false if target_room.nil?
     room_num = target_room.to_i
@@ -42,7 +42,7 @@ module DRCT
       if Flags['closed-shop']
         Flags.reset('closed-shop')
         kill_script(script_handle)
-        if /You / !~ DRC.bput('open door', 'It is locked', 'You ', 'What were')
+        if /You open/ !~ DRC.bput('open door', 'It is locked', 'You .+', 'What were')
           return false
         end
         timer = Time.now


### PR DESCRIPTION
Items are in the stealing db in Emmeline's cottage, and some people can't get in there.  steal puts the target on cooldown if walk_to returns false, but the current walk_to messaging doesn't handle it.

Some people (Thieves/Necros?) see:  `A servant blocks the way and says, "You can't go there."`
Others get a slightly different message.   `A servant stops you and says, "Paladins are not allowed to go there."`

If you try to open the door you see "You can't do that."
Unfortunately, the 'You' in "You can't do that." matches the 'You' in "You open the door," making success and failure indistinct.

After the change.
```

>;en DRCT.walk_to(12111)
--- Lich: exec1 active.
--- Lich: go2 active.
--- Lich: 'textsubs' has been stopped by go2.
[go2: ETA: 0:00:00 (1 rooms to move through)]
[go2]>go wooden door
A servant stops you and says, "Paladins are not allowed to go there."
>
--- Lich: 'go2' has been stopped by exec1.
[exec1]>open door
--- Lich: go2 has exited.
You can't do that.
>
```