### PR TITLE
Starting Avtalia Array Support

### DIFF
--- a/avtalia.lic
+++ b/avtalia.lic
@@ -1,3 +1,7 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#avtalia
+=end
+
 custom_require.call(%w[common common-arcana])
 
 no_kill_all

--- a/avtalia.lic
+++ b/avtalia.lic
@@ -1,0 +1,34 @@
+custom_require.call(%w[common common-arcana])
+
+no_kill_all
+no_pause_all
+
+### Avtalia defines an UserVars listing items in your avtalia_array.
+### Each cambrinth has a value representing how much mana is available
+### as well as how fresh the reading is.  It can be used by other scripts as-needed
+
+
+class Avtalia
+  include DRC
+  include DRCA
+
+  def initialize
+    @settings = get_settings
+    
+    DRCA.add_avtalia_flags(@settings)
+    execute
+  end
+  
+  def execute
+    loop do
+      pause 10
+      DRCA.process_avtalia(@settings)
+    end
+  end
+end
+
+before_dying do
+  DRCA.remove_avtalia_flags(get_settings)
+end
+
+Avtalia.new

--- a/avtalia.lic
+++ b/avtalia.lic
@@ -18,21 +18,57 @@ class Avtalia
 
   def initialize
     @settings = get_settings
-    
-    DRCA.add_avtalia_flags(@settings)
+    @avtalia_array = @settings.avtalia_array
+    exit if @avtalia_array.empty?
+    add_avtalia_flags
     execute
   end
-  
+
   def execute
     loop do
       pause 10
-      DRCA.process_avtalia(@settings)
+      process_avtalia
+    end
+  end
+
+  def add_avtalia_flags
+    UserVars.avtalia = {}
+
+    @settings.avtalia_array.each do |camb|
+      first = camb['name'].split.first
+      second = camb['name'].split.last
+      short_reg = first == second ? /\b#{first}/i : /#{first}.*\b#{second}/i
+      Flags.add("avtalia-full-#{camb['name']}", /^Your.* #{short_reg} pulses brightly with Lunar energy/)
+      Flags.add("avtalia-focus-#{camb['name']}", /A.* #{short_reg}.* pulses? .+ (\d+)/)
+      UserVars.avtalia[camb['name']] = {'mana' => 0, 'cap' => camb['cap'], 'time_seen' => Time.now}
+    end
+  end
+
+  def process_avtalia
+    return if @avtalia_array.empty?
+
+    @avtalia_array.each do |camb|
+      if Flags["avtalia-focus-#{camb['name']}"]
+        UserVars.avtalia[camb['name']]['mana'] = Flags["avtalia-focus-#{camb['name']}"][1].to_i
+        UserVars.avtalia[camb['name']]['time_seen'] = Time.now
+      end
+      if Flags["avtalia-full-#{camb['name']}"]
+        UserVars.avtalia[camb['name']]['mana'] = camb['cap']
+        UserVars.avtalia[camb['name']]['time_seen'] = Time.now
+      end
+
+      Flags.reset("avtalia-full-#{camb['name']}")
+      Flags.reset("avtalia-focus-#{camb['name']}")
     end
   end
 end
 
 before_dying do
-  DRCA.remove_avtalia_flags(get_settings)
+  UserVars.avtalia = {}
+  get_settings.avtalia_array.each do |camb|
+    Flags.delete("avtalia-full-#{camb['name']}")
+    Flags.delete("avtalia-focus-#{camb['name']}")
+  end
 end
 
 Avtalia.new

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -659,53 +659,9 @@ module DRCA
     end
   end
 
-  def add_avtalia_flags(settings)
-    return if settings.avtalia_array.empty?
-    return unless Script.running?('avtalia')
-    UserVars.avtalia = {}
-
-    settings.avtalia_array.each do |camb|
-      first = camb['name'].split.first
-      second = camb['name'].split.last
-      short_reg = first == second ? /\b#{first}/i : /#{first}.*\b#{second}/i
-      Flags.add("avtalia-full-#{camb['name']}", /^Your.* #{short_reg} pulses brightly with Lunar energy/)
-      Flags.add("avtalia-focus-#{camb['name']}", /A.* #{short_reg}.* pulses? .+ (\d+)/)
-      UserVars.avtalia[camb['name']] = {'mana' => 0, 'cap' => camb['cap'], 'time_seen' => Time.now}
-    end
-  end
-
-  def remove_avtalia_flags(settings)
-    return if settings.avtalia_array.empty?
-    UserVars.avtalia = {}
-
-    settings.avtalia_array.each do |camb|
-      Flags.delete("avtalia-full-#{camb['name']}")
-      Flags.delete("avtalia-focus-#{camb['name']}")
-    end
-  end
-
   def update_avtalia
     DRC.bput("focus cambrinth", /^The .+ pulses? .+ (\d+)/, 'dim, almost magically null', '^You let your magical senses wander')
     waitrt?
-  end
-
-  def process_avtalia(settings)
-    return unless Script.running?('avtalia')
-    return if settings.avtalia_array.empty?
-
-    settings.avtalia_array.each do |camb|
-      if Flags["avtalia-focus-#{camb['name']}"]
-        UserVars.avtalia[camb['name']]['mana'] = Flags["avtalia-focus-#{camb['name']}"][1].to_i
-        UserVars.avtalia[camb['name']]['time_seen'] = Time.now
-      end
-      if Flags["avtalia-full-#{camb['name']}"]
-        UserVars.avtalia[camb['name']]['mana'] = camb['cap']
-        UserVars.avtalia[camb['name']]['time_seen'] = Time.now
-      end
-
-      Flags.reset("avtalia-full-#{camb['name']}")
-      Flags.reset("avtalia-focus-#{camb['name']}")
-    end
   end
 
   def invoke_avtalia(cambrinth, dedicated_camb_use, invoke_amount)
@@ -727,7 +683,7 @@ module DRCA
       # Assume 10% every 5 minutes.  No falloff in starlight, but that's not tracked ATM.
       time_diff = Time.now - UserVars.avtalia[cambrinth]['time_seen']
       time_mod = (time_diff / 300.0).floor
-      time_adjust = 1 - [time_mod * 0.10, 1.0].min 
+      time_adjust = 1 - [time_mod * 0.10, 1.0].min
       assumed_reserve = (UserVars.avtalia[cambrinth]['mana'] * time_adjust).floor + charge_amount
       UserVars.avtalia[cambrinth]['mana'] = [assumed_reserve, UserVars.avtalia[cambrinth]['cap']].min
     end
@@ -740,7 +696,7 @@ module DRCA
                                   .select { |camb, data| (data['mana'].to_f / data['cap'].to_f) * 100 >= mana_percentage }
                                   .select { |camb, data| data['mana'] > charge_needed / 10 }
                                   .max_by { |camb, data| data['mana'] }
-                                  
+
     return camb_to_use ? camb_to_use : {}
   end
 end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -658,4 +658,89 @@ module DRCA
       cast_spells(spells, settings, settings.waggle_force_cambrinth)
     end
   end
+
+  def add_avtalia_flags(settings)
+    return if settings.avtalia_array.empty?
+    return unless Script.running?('avtalia')
+    UserVars.avtalia = {}
+
+    settings.avtalia_array.each do |camb|
+      first = camb['name'].split.first
+      second = camb['name'].split.last
+      short_reg = first == second ? /\b#{first}/i : /#{first}.*\b#{second}/i
+      Flags.add("avtalia-full-#{camb['name']}", /^Your.* #{short_reg} pulses brightly with Lunar energy/)
+      Flags.add("avtalia-focus-#{camb['name']}", /A.* #{short_reg}.* pulses? .+ (\d+)/)
+      UserVars.avtalia[camb['name']] = {'mana' => 0, 'cap' => camb['cap'], 'time_seen' => Time.now}
+    end
+  end
+
+  def remove_avtalia_flags(settings)
+    return if settings.avtalia_array.empty?
+    UserVars.avtalia = {}
+
+    settings.avtalia_array.each do |camb|
+      Flags.delete("avtalia-full-#{camb['name']}")
+      Flags.delete("avtalia-focus-#{camb['name']}")
+    end
+  end
+
+  def update_avtalia
+    DRC.bput("focus cambrinth", /^The .+ pulses? .+ (\d+)/, 'dim, almost magically null', '^You let your magical senses wander')
+    waitrt?
+  end
+
+  def process_avtalia(settings)
+    return unless Script.running?('avtalia')
+    return if settings.avtalia_array.empty?
+
+    settings.avtalia_array.each do |camb|
+      if Flags["avtalia-focus-#{camb['name']}"]
+        UserVars.avtalia[camb['name']]['mana'] = Flags["avtalia-focus-#{camb['name']}"][1].to_i
+        UserVars.avtalia[camb['name']]['time_seen'] = Time.now
+      end
+      if Flags["avtalia-full-#{camb['name']}"]
+        UserVars.avtalia[camb['name']]['mana'] = camb['cap']
+        UserVars.avtalia[camb['name']]['time_seen'] = Time.now
+      end
+
+      Flags.reset("avtalia-full-#{camb['name']}")
+      Flags.reset("avtalia-focus-#{camb['name']}")
+    end
+  end
+
+  def invoke_avtalia(cambrinth, dedicated_camb_use, invoke_amount)
+    return unless cambrinth
+    return unless Script.running?('avtalia')
+
+    invoke(cambrinth, dedicated_camb_use, invoke_amount)
+    UserVars.avtalia[cambrinth]['mana'] -= [mana, invoke_amount].min
+  end
+
+  def charge_avtalia(cambrinth, charge_amount)
+    return unless cambrinth
+    return unless Script.running?('avtalia')
+
+    if !charge?(cambrinth, charge_amount)
+      UserVars.avtalia[cambrinth]['mana'] = UserVars.avtalia[cambrinth]['cap']
+    else
+      # Experiments show very roughly 10% falloff regardless of cap every 10 minutes
+      # Assume 10% every 5 minutes.  No falloff in starlight, but that's not tracked ATM.
+      time_diff = Time.now - UserVars.avtalia[cambrinth]['time_seen']
+      time_mod = (time_diff / 300.0).floor
+      time_adjust = 1 - [time_mod * 0.10, 1.0].min 
+      assumed_reserve = (UserVars.avtalia[cambrinth]['mana'] * time_adjust).floor + charge_amount
+      UserVars.avtalia[cambrinth]['mana'] = [assumed_reserve, UserVars.avtalia[cambrinth]['cap']].min
+    end
+    UserVars.avtalia[cambrinth]['time_seen'] = Time.now
+  end
+
+  def choose_avtalia(charge_needed, mana_percentage)
+    camb_to_use = UserVars.avtalia.select { |camb, data| data['time_seen'] && data['cap'] && data['mana'] }
+                                  .select { |camb, data| Time.now - data['time_seen'] < 600.0 }
+                                  .select { |camb, data| (data['mana'] / data['cap']) * 100 >= mana_percentage }
+                                  .select { |camb, data| data['mana'] > charge_needed / 10 }
+                                  .max_by { |camb, data| data['mana'] }
+                                  
+    return camb_to_use ? camb_to_use : {}
+  end
 end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -737,7 +737,7 @@ module DRCA
   def choose_avtalia(charge_needed, mana_percentage)
     camb_to_use = UserVars.avtalia.select { |camb, data| data['time_seen'] && data['cap'] && data['mana'] }
                                   .select { |camb, data| Time.now - data['time_seen'] < 600.0 }
-                                  .select { |camb, data| (data['mana'] / data['cap']) * 100 >= mana_percentage }
+                                  .select { |camb, data| (data['mana'].to_f / data['cap'].to_f) * 100 >= mana_percentage }
                                   .select { |camb, data| data['mana'] > charge_needed / 10 }
                                   .max_by { |camb, data| data['mana'] }
                                   

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -71,3 +71,4 @@ empty_values:
   smoke: {}
   divination_tool: {}
   divination_bones_storage: {}
+  avtalia_array: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -320,8 +320,8 @@ cambrinth_invoke_exact_amount: false
 # Trader only - enables starlight management - how many seconds in between checking starlight auras in combat
 # see https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials
 aura_frequency:
-
-
+# Trader-use avtalia.lic to build a list of avtalia cambrinth. See https://github.com/rpherbig/dr-scripts/wiki/Trader-Tutorials
+avtalia_array:
 
 # Looting settings
 # add or subtract these items to the list of treasure to loot

--- a/validate.lic
+++ b/validate.lic
@@ -753,7 +753,7 @@ class DRYamlValidator
   end
 
   def assert_that_caravan_training_skills_are_valid(settings)
-    return unless settings.caravan_training_skills.empty?
+    return if settings.caravan_training_skills.empty?
     settings.caravan_training_skills
             .reject { |_skill, cooldown| cooldown.is_a?(Integer) }
             .each { |skill, _cooldown| error("caravan_training_skills has an invalid cooldown at skill: '#{skill}'") }
@@ -764,6 +764,20 @@ class DRYamlValidator
     settings.caravan_training_skills.select { |skill, _cooldown| %w[Augmentation Utility Warding].include?(skill) }
             .reject { |skill, _cooldown| settings.crafting_training_spells.keys.include?(skill) }
             .each { |skill, _cooldown| error("caravan_training_skills: #{skill} is included, but no corresponding spell in crafting_training_spells!") }
+  end
+
+  def assert_that_avtalia_array_is_valid(settings)
+    return if settings.avtalia_array.empty?
+
+    settings.avtalia_array.each do |camb|
+      first = camb['name'].split.first
+      second = camb['name'].split.last
+      short_reg = first == second ? /\b#{first}/i : /#{first}.*\b#{second}/i
+      error("avtalia_array appears to include your normal casting cambrinth.  This could break it horribly.") if short_reg =~ settings.cambrinth
+      if settings.avtalia_array.select { |camb| short_reg =~ camb['name'] }.to_a.length > 1
+        error("avtalia_array has a duplicate entry for #{camb['name']}. Any cambrinth used in avtalia_array must be unique.") if settings.avtalia_array.find { |search| short_reg =~ search['name'] }
+      end
+    end
   end
 
   private
@@ -792,7 +806,7 @@ class DRYamlValidator
     @valid_defensive_skills = ['Shield Usage', 'Parry Ability', 'Evasion']
     @valid_caravan_skills = ['Attunement', 'Warding', 'Augmentation', 'Utility', 'Scholarship', 'Appraisal',
                              'Perception', 'Locksmithing', 'First Aid', 'Outfitting', 'Engineering',
-                             'Performance', 'Outdoorsmanship', 'Enchanting']
+                             'Performance', 'Outdoorsmanship', 'Athletics', 'Forging']
 
     @all_skills = ['Scouting', 'Evasion', 'Athletics', 'Stealth', 'Perception', 'Locksmithing', 'First Aid', 'Skinning',
                    'Outdoorsmanship', 'Thievery', 'Backstab', 'Thanatology', 'Forging', 'Outfitting', 'Engineering',


### PR DESCRIPTION
Okay, this is a biggish one this time.  We can take time for this, though I think I've worked all the kinks out already.

Trader Avtalia Array currently isn't very useful for lich and this is the start of fixing it.  I have all of this working in combat-trainer, but before that all the common stuff needs to go in.  AVTA spins mana into worn cambrinth while taking in starlight, and avtalia.lic is intended to monitor it.  avtalia.lic starts up and runs in the background, watching any cambrinth defined in avtalia_array:

```
avtalia_array:
 - name: cambrinth bracer
   cap: 32
 - name: watersilk bag
   cap: 108
 - name: cambrinth anklet
   cap: 12
 - name: tattered robe
   cap: 50
 - name: cambrinth chains
   cap: 50
```

Any time AVTA brings the camb up to max mana it generates an atmospheric message that makes avtalia.lic set its mana to full, and anytime you FOCUS one of them or do FOCUS CAMBRINTH, it updates its mana level and the last-seen time for that value.

Every 10 seconds avtalia.lic looks at the relevant flags and processes them, setting mana and time values in your UserVars.

 avtalia:  {"cambrinth bracer"=>{"mana"=>32, "cap"=>32, "time_seen"=>2019-10-23 20:12:33 -0400}, "watersilk bag"=>{"mana"=>96, "cap"=>108, "time_seen"=>2019-10-23 20:08:03 -0400}, "cambrinth anklet"=>{"mana"=>12, "cap"=>12, "time_seen"=>2019-10-23 20:12:33 -0400}, "tattered robe"=>{"mana"=>36, "cap"=>50, "time_seen"=>2019-10-23 20:08:03 -0400}, "cambrinth chains"=>{"mana"=>26, "cap"=>50, "time_seen"=>2019-10-23 20:08:03 -0400}}

DRCA.charge_avtalia can be used to add mana to one of them, and invoke_avtalia can be used to pull mana from them.  DRCA.choose_avtalia picks one of them based on mana levels, time seen, and the relative percentage of charge it's looking for, so any script can choose whether it wants a cambrinth that's mostly full or if it doesn't mind either way.  Similarly, any script can charge to and invoke from the avtalia, and call DRCA.update_cambrinth to refresh all their data.

So, in my version of combat-trainer, it'll get down to 60% mana, try to buff Last Gift of Vithwok IV with a cambrinth charge of -25 and -25.  It asks DRCA.choose_avtalia( 50, 0 ) and choose_avtalia returns the watersilk bag, which has 96 mana in it, and has been seen in the last ten minutes. It invokes 50 from it instead of charging something else.