### PR TITLE
Equipmanager fput to bput

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -247,12 +247,15 @@ class EquipmentManager
       },
       tied: {
         verb: 'untie',
-        matches: [/^You .*#{item.short_regex}/, "^You remove.*#{item.name}", /^.*you untie your .*#{item.short_regex} from it./, '^What were you referring', '^Untie what', '^You are a little too busy'],
-        failures: ['You remove', /^You are a little too busy/],
+        matches: [/^You .*#{item.short_regex}/, "^You remove.*#{item.name}", /^.*you untie your .*#{item.short_regex} from it./, '^What were you referring', '^Untie what', '^You are a little too busy', '^You are a bit too busy'],
+        failures: ['You remove', /^You are a little too busy/, /^You are a bit too busy/],
         failure_recovery: proc { |_noun, item, *matches|
                             case matches
                             when ['You are a little too busy']
                               retreat
+                              get_item?(item)
+                            when ['You are a bit too busy']
+                              DRC.stop_playing
                               get_item?(item)
                             else
                               stow_weapon

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -142,11 +142,11 @@ class EquipmentManager
     end
     case bput("get my #{item.short_name}", item.short_regex, '^You get ', '^What were you referring')
     when item.short_regex
-      fput("wear my #{item.short_name}")
+      bput("wear my #{item.short_name}", 'You sling', 'You attach', 'You .* unload', 'You strap', 'You slide', 'You work your way into', 'You spin', 'You put', 'You carefully loop', 'slide effortlessly onto your', 'You slip', "^You .* #{item.short_regex}")
       waitrt?
       return true
     when /^You get /
-      fput("stow my #{item.short_name}")
+      bput("stow my #{item.short_name}", "You put .*#{item.name}", 'You .* unload', 'close the fan', 'You easily strap', "You don't seem to be able to move", 'You secure', 'is too small to hold that', 'You hang', '^The .* slides easily', "^You .* #{item.short_regex}")
     else
       return false
     end


### PR DESCRIPTION
Closes issue https://github.com/rpherbig/dr-scripts/issues/3931

I think the sudden appearance of RT from mobs or environmental effects breaks that fput in wear_item.  I pulled bput messages from the rest of equipman and added a catch-all `"^You .* #{item.short_regex}"`

I can swap this in and rotate my armor/weapons on all my characters.  I'll see about finding someone else.