### PR TITLE
dragon's breath won't go up

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -795,8 +795,9 @@ spell_data:
     mana_type: holy
   Dragon's Breath:
     skill: Targeted Magic
-    heavy: true
-    mana: 15
+    abbrev: DB
+    mana: 30
+    mana_type: elemental
   Drums of the Snake:
     skill: Augmentation
     mana: 15

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -796,7 +796,7 @@ spell_data:
   Dragon's Breath:
     skill: Targeted Magic
     abbrev: DB
-    mana: 30
+    mana: 15
     mana_type: elemental
   Drums of the Snake:
     skill: Augmentation


### PR DESCRIPTION
I don't' know what heavy: true does but its only when I remove it that ;buff  or ;combat will maintain it.  for mechanical purposes DB is considered a buff.  Tested many ways.  this is the only way it works.