### PR TITLE
Guard against corn-maze pebkac error

### DIFF
--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -193,6 +193,8 @@ class CornMaze
       pause 2
     end
 
+    DRC.message("WARNING! THE CORN MAZE IS DIFFICULT TO NAVIGATE, AND IT'S ALWAYS POSSIBLE FOR LAG TO BREAK THE SCRIPT. BE MINDFUL OF YOUR PASSES, AND WATCH IT IN CASE YOU NEED TO TAKE CONTROL.")
+
     Flags.add('maze_done', 'leads you through the twisting passages and brings you to the exit')
     Flags.add('task_done', '10 of 10', '10 of the 10', '5 of the 5', '5 of 5', 'return to one of the Halflings and ASK HALFLING ABOUT TASK again')
     @searching = false if args.restart
@@ -549,7 +551,11 @@ class CornMaze
     wait_on_done_move
     unless XMLData.room_title.include?('Labyrinth') || XMLData.room_title.include?('Corn Maze, Entrance')
       DRC.message("The script can't find its way back from here! Open up ;narost, right click it and open the Corn Maze map, or use elanthipedia, then make your way back towards the northwest Labyrinth then unpause the script!")
-      pause_script('cornmaze')
+      5.times do
+        DRC.beep
+        pause 2
+      end
+      pause_script('corn-maze')
     end
     until @done
       exit if Flags['maze_done']
@@ -620,7 +626,7 @@ class CornMaze
     DRC.message("YOU'VE RUN OUT OF ROOM!  GET SOME MORE SPACE, YOU LAZY SLOB!")
     DRC.bput("drop #{thing}", 'You drop', 'What were you')
   end
-  
+
   def recover_stun
     return if bput('stand', 'You are already standing', 'You are still stunned', 'You stand back up', 'You can\'t do that') == 'You are already standing'
     pause 3


### PR DESCRIPTION
Seeing a number of pebkac-related errors going on in the event.  Adding a couple beeps and bongs, and a disclaimer of use.  Also fixing an improper reference to cornmaze.lic