### PR TITLE
Handle bug with weird items in steal

### DIFF
--- a/steal.lic
+++ b/steal.lic
@@ -284,21 +284,38 @@ class Steal
   end
 
   def put_item?(item)
-    case bput("put my #{item} in my #{@stealing_bag}", 'You put', "You can't do that", 'no matter how you arrange it', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again')
+    case bput("put my #{item} in my #{@stealing_bag}", 'What were you', 'You put', "You can't do that", 'no matter how you arrange it', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again')
     when 'perhaps try doing that again'
       return put_item?(item)
     when 'You put'
       return true
+    when 'What were you'
+      handheld = held_item(item)
+      drop_item(held_item(item)) if handheld
+      return false
     end
 
     false
   end
 
   def drop_item(item)
-    case bput("drop my #{item}", 'You drop', 'would damage it', 'smashing it to bits', 'Something appears different about')
+    case bput("drop my #{item}", 'You drop', 'would damage it', 'smashing it to bits', 'Something appears different about', 'What were you')
     when 'would damage it', 'Something appears different about'
       drop_item(item)
+    when 'What were you'
+      handheld = held_item(item)
+      return drop_item(held_item(item)) if handheld
     end
+  end
+  
+  def held_item(item)
+    [DRC.right_hand, DRC.left_hand].each do |hand_item|
+      hand_item.split.each do |item_word|
+        return hand_item if item.include?(item_word)
+      end
+    end
+    
+    return nil
   end
 
   def update_target(target, difficulty)


### PR DESCRIPTION
Related to issue https://github.com/rpherbig/dr-scripts/issues/4017

Some stolen items look very different in hand vs. in the catalog, and that breaks it a little when it tries to drop them by name.  Long term, I think we might want to find these items and add a hand-friendly name to their entry, but the base-stealing list is horrifying to navigate, so this is a stopgap.

If ;steal tries and fails to drop/put an item, it checks to see if the item_name shares any words with an item in your hand, and if it does then it drops that.  That should be safer than the original, but still handle most of the weird items.

Three test cases below:
Normal item with no complications
```
[steal]>steal oil in catalog
Moving stealthily, you manage to grab some oil right from underneath the herbalist Ktrini's very nose.
You learned exceptionally well from this nearly impossible theft.
Roundtime: 5 sec.
>
[steal]>drop my oil
>
You come out of hiding.
You think better of leaving this evidence out where anyone can see it, and stuff it somewhere out of sight.
You drop some oil.
```


Broken item that meets the reqs
```
[steal]>steal boar-bristle curry comb in book
Moving stealthily, you manage to grab a boar-bristle curry comb right from underneath Captain Namazzi's very nose.
You learned acceptably from this theft.
Roundtime: 5 sec.
>
[steal]>drop my boar-bristle curry comb
You come out of hiding.
What were you referring to?
>
[steal]>drop my curry comb
You think better of leaving this evidence out where anyone can see it, and stuff it somewhere out of sight.
You drop a boar-bristle curry comb.

```


Finally, an example where this still fails because they don't share words, but doesn't catastrophically drop something.
```
[steal]>hide
You melt into the background, convinced that your attempt to hide went unobserved.
Roundtime: 5 sec.
>;pa
--- Lich: steal paused.
>get my encyclopedia
>
You come out of hiding.
You get a hefty steelsilk-bound encyclopedia with gold-edged vellum pages from inside your swordsman's pack.
>swap
You move a hefty steelsilk-bound encyclopedia with gold-edged vellum pages to your left hand.
>;ua
--- Lich: steal unpaused.
[steal]>steal size 60 hooks in catalog
Moving nonchalantly, you manage to grab a small white envelope right from underneath Drorg's very nose.
You don't feel you learned anything useful from this trivial theft.
Roundtime: 5 sec.
>
[steal]>drop my size 60 hooks
...wait 1 seconds.
>
[steal]>drop my size 60 hooks
What were you referring to?
```

I also tested it with binning.