### PR TITLE
almanac.lic - add exception for family vault

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -21,6 +21,8 @@ class Almanac
     return if Time.now - UserVars.almanac_last_use < 600
     return if @no_use_scripts.any? { |name| Script.running?(name) }
     return if XMLData.room_title.include? 'Carousel Chamber'
+    return if XMLData.room_title.include? 'Carousel Booth'
+    return if XMLData.room_title.include? 'Family Vault'
     return if hidden?
 
     unless @almanac_skills.empty?


### PR DESCRIPTION
Skip if in family vault or the first room of the normal vault, Carousel Booth.