### PR TITLE
Alchemy and workorders tweaks

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -59,8 +59,8 @@ class Remedy
     @herb1 = args.herb1
     @herb2 = args.herb2
     @catalyst = args.catalyst
-    @container = args.container
-    @pestle = 'pestle'
+    @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool  ) } || args.container 
+    @pestle = @settings.alchemy_tools.find { |tool| /pestle/ =~ tool  ) } || 'pestle'
     @verb = 'crush'
     @noun = args.noun
     @count = 0

--- a/workorders.lic
+++ b/workorders.lic
@@ -340,18 +340,18 @@ class WorkOrders
         end
         stow_tool('glue')
 
-        if search?('stain')
-          bput('get my stain', 'What were', 'You get')
+        if search?('wood stain')
+          bput('get my wood stain', 'What were', 'You get')
           /(\d+)/ =~ bput('count my wood stain', 'The wood stain has *\d+ uses remaining')
           if Regexp.last_match(1).to_i < quantity
-            stow_tool('stain')
-            dispose('stain')
+            stow_tool('wood stain')
+            dispose('wood stain')
             order_item(info['tool-room'], info['stain-number'])
           end
         else
           order_item(info['tool-room'], info['stain-number'])
         end
-        stow_tool('stain')
+        stow_tool('wood stain')
 
         case bput('get my clamps', 'What were', 'You get')
         when 'What were'


### PR DESCRIPTION
Closes issues https://github.com/rpherbig/dr-scripts/issues/4027 and https://github.com/rpherbig/dr-scripts/issues/3988

Changes the search in workorders to wood stain, which does work and is more specific than 'stain'.  Also, remedy pulls matching tools in from your alchemy_tools if it finds one.  Since workorders calls ;remedy by 'bowl' and 'mortar' this gives a bit more control over it.