### PR TITLE
Fix syntax - remedy

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -59,8 +59,8 @@ class Remedy
     @herb1 = args.herb1
     @herb2 = args.herb2
     @catalyst = args.catalyst
-    @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool  ) } || args.container 
-    @pestle = @settings.alchemy_tools.find { |tool| /pestle/ =~ tool  ) } || 'pestle'
+    @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool } || args.container 
+    @pestle = @settings.alchemy_tools.find { |tool| /pestle/ =~ tool } || 'pestle'
     @verb = 'crush'
     @noun = args.noun
     @count = 0


### PR DESCRIPTION
I made a mistake when I copied over code from what I was working on into my branch, and left a right paran behind.

I took this version and ran an alchemy remedies workorder with it, watching it use my 'iron pestle' and 'large bowl'