### PR TITLE
Update usage for wonky herbs in heal-remedy.lic

### DIFF
--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -169,17 +169,24 @@ def herb_apply_scars(key)
     loop_debug
     case key
     when /genich/
-      DRC.bput("get #{key}", 'You get', 'referring to?') unless $nohands_mode
-      DRC.bput("inhale my #{key}", 'You') unless $nohands_mode
-      DRC.bput("stow #{key}", 'You', 'Stow what?') unless $nohands_mode
+      case DRC.bput("eat my #{key}", 'You eat', 'trying to inhale')
+      when 'trying to inhale'
+        DRC.bput("get #{key}", 'You get', 'referring to?') unless $nohands_mode
+        DRC.bput("inhale my #{key}", 'You') unless $nohands_mode
+        DRC.bput("stow #{key}", 'You', 'Stow what?') unless $nohands_mode
+      end
     when /salve/, /ungent/, /poultices/, /ointment/, /sap/
       DRC.bput("rub my #{key}", 'You', 'Rub what?')
     when /tonic/, /draught/, /qun/
-      DRC.bput("drink my #{key}", 'You', 'Drink what?')
-    when /potion/
-      DRC.bput("eat my #{key}", 'You', 'you referring to?')
-    when /flower/, /root/, /leaf/, /grass/, /potion/, /nuloe/, /elixir/, /jadice/
-      DRC.bput("eat my #{key}", 'You', 'you referring to?')
+      case DRC.bput("drink my #{key}", 'You drink', 'Drink what?',"can't drink")
+      when "can't drink"
+        DRC.bput("eat my #{key}",'You eat')
+      end
+    when /flower/, /root/, /leaf/, /grass/, /potion/, /nuloe/, /elixir/, /jadice/, /potion/, /pollen/
+      case DRC.bput("eat my #{key}", 'You eat', 'you referring to?','better off trying to drink')
+      when 'better off trying to drink'
+        DRC.bput("drink my #{key}",'drink a portion')
+      end
     end
   end
 end


### PR DESCRIPTION
Several remedies from Crossing Shops are eat/drink/inhale and the same herbs from Shard have a different usage.  Added handling for both types.