### PR TITLE
forge.lic - fix for not holding tongs issue

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -265,7 +265,8 @@ class Forge
     waitrt?
     crafting_magic_routine(@settings)
     case bput("pound #{item} on anvil with my #{@hammer}",
-              'You must be holding',
+              /You must be holding .* to do that.$/,
+              /You must be holding some metal tongs in your other hand to do that/,
               'needs more fuel', 'need some more fuel',
               'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel',
               'Roundtime',
@@ -277,8 +278,11 @@ class Forge
               'You believe you can assemble',
               'You need a larger volume of metal',
               'I could not find what you were referring to')
-    when 'You must be holding'
+    when /You must be holding .* to do that.$/
       get_item(@hammer)
+      pound(item)
+    when /You must be holding some metal tongs in your other hand to do that/
+      get_item('tongs')
       pound(item)
     when 'needs more fuel', 'need some more fuel'
       add_fuel


### PR DESCRIPTION
After getting arrested while forging, I ran into an error where it kept trying to get my hammer out and ignored the fact that I didn't have tongs in my other hand because the messaging is similar.  Fixed.

[forge]>pound needles on anvil with my forging hammer
You must be holding some metal tongs in your other hand to do that.  Otherwise who knows where that might bounce off to!
[forge]>untie my forging hammer from my agonite toolstrap
Untie what?
[forge]>get my forging hammer
You are already holding that.
[forge]>pound needles on anvil with my forging hammer
You must be holding some metal tongs in your other hand to do that.  Otherwise who knows where that might bounce off to!