### PR TITLE
Mitigate peer tag crashes

### DIFF
--- a/afk.lic
+++ b/afk.lic
@@ -75,7 +75,7 @@ loop do
     stop_script('go2') if Script.running?('go2')
   end
 
-  if Room.current.id == 9610
+  if XMLData.room_title.include?('Skeletal Claw') && Room.current.id == 9610
     DRC.fix_standing
     move('out')
   end

--- a/go2.lic
+++ b/go2.lic
@@ -10,10 +10,12 @@
 	original author: Tillmen (tillmen@lichproject.org)
 	           game: DR
 	           tags: core, movement
-	        version: 1.21f
+	        version: 1.22f
 	       required: Lich >= 4.6.14
 
 	changelog:
+		1.22f
+			kill room_numbers if running through a room with peer_tags
 		1.21f (2017-11-29):
 			fix DragonRealms drag feature
 		1.21 (2017-10-07):
@@ -868,11 +870,6 @@ if start_room.id == destination.id
 	exit
 end
 
-if Script.running?('textsubs')
-  stop_script('textsubs')
-  before_dying { start_script('textsubs') }
-end
-
 start_time   = nil
 error_count  = 0
 $go2_restart = false
@@ -913,6 +910,19 @@ loop {
 	path.reverse!
 	est_time = shortest_distances[destination.id]
 	previous = shortest_distances = nil
+
+  if Script.running?('roomnumbers')
+    rooms = [Room.current.id] + path
+    if rooms.any? { |room| Room[room].tags.first.include?('peer') }
+      stop_script('roomnumbers')
+      before_dying { start_script('roomnumbers') } unless Room[rooms.last].tags.first.include?('peer')
+    end
+  end
+
+  if Script.running?('textsubs') && est_time > 5
+    stop_script('textsubs')
+    before_dying { start_script('textsubs') }
+  end
 
 	if XMLData.game =~ /^GS/
 		needed_silvers = get_silver_cost.call(path)

--- a/go2.lic
+++ b/go2.lic
@@ -911,18 +911,18 @@ loop {
 	est_time = shortest_distances[destination.id]
 	previous = shortest_distances = nil
 
-  if Script.running?('roomnumbers')
-    rooms = [Room.current.id] + path
-    if rooms.any? { |room| Room[room].tags.first.include?('peer') }
-      stop_script('roomnumbers')
-      before_dying { start_script('roomnumbers') } unless Room[rooms.last].tags.first.include?('peer')
-    end
-  end
+	if Script.running?('roomnumbers')
+		rooms = [Room.current.id] + path
+		if rooms.any? { |room| Room[room].tags.first.include?('peer') }
+			stop_script('roomnumbers')
+			before_dying { start_script('roomnumbers') } unless Room[rooms.last].tags.first.include?('peer')
+		end
+	end
 
-  if Script.running?('textsubs') && est_time > 5
-    stop_script('textsubs')
-    before_dying { start_script('textsubs') }
-  end
+	if Script.running?('textsubs') && est_time > 5
+		stop_script('textsubs')
+		before_dying { start_script('textsubs') }
+	end
 
 	if XMLData.game =~ /^GS/
 		needed_silvers = get_silver_cost.call(path)

--- a/test/test_afk.rb
+++ b/test/test_afk.rb
@@ -20,6 +20,12 @@ class Map
   end
 end
 
+class XMLData
+  def room_title
+    'Middle of Nowhere'
+  end
+end
+
 class TestAfk < Minitest::Test
   def setup
     $history.clear

--- a/test/test_afk.rb
+++ b/test/test_afk.rb
@@ -21,7 +21,7 @@ class Map
 end
 
 class XMLData
-  def room_title
+  def self.room_title
     'Middle of Nowhere'
   end
 end


### PR DESCRIPTION
Infrequently (~5-10% of the time), when pulling a roomnumber for a room with a peer tag, lich will suffer a fatal hang and eventually crash.  I did a great deal of hunting for the bug and failed miserably, so instead this PR does 3 things.

1.) Gates afk's room id check by seeing the room title, which prevents it from triggering a roomnumber check when walking into every room.

2.) go2 kills roomnumbers if the calculated path includes a room with a peer tag in it.  Normally it will restart on go2 exit, but if it ends directly in a peer tag room then it'll just leave it stopped.

3.) Moves the textsub kill to after estimated destination time has been calculated, and only kill it if it'll be > 5 seconds.  This isn't directly related to the issue, just adjacent to it.

This is worth sitting on and testing for awhile, but it shouldn't add any new dependencies to go2.