### PR TITLE
Fix resolution of return values in pick

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -391,11 +391,11 @@ class LockPicker
     when 'Roundtime', *@disarm_careful
       disarm_speed?(box, 'careful')
     when *@disarm_quick
-      disarm_speed?(box, 'careful') if @settings.lockpick_force_disarm_careful
-      disarm_speed?(box, 'quick') unless @settings.lockpick_force_disarm_careful
+      speed = @settings.lockpick_force_disarm_careful ? 'careful' : 'quick'
+      disarm_speed?(box, speed)
     when *@disarm_normal
-      disarm_speed?(box, 'careful') if @settings.lockpick_force_disarm_careful
-      disarm_speed?(box, 'normal') unless @settings.lockpick_force_disarm_careful
+      speed = @settings.lockpick_force_disarm_careful ? 'careful' : 'normal'
+      disarm_speed?(box, speed)
     when *@disarm_identify_failed
       disarm?(box)
     when *@disarm_too_hard


### PR DESCRIPTION
disarm? and disarm_speed? rely on the last evaluated value, and when the force_careful setting is set then

```
      disarm_speed?(box, 'careful') if @settings.lockpick_force_disarm_careful
      disarm_speed?(box, 'quick') unless @settings.lockpick_force_disarm_careful
```

evaluates nil, because the first 'if' evaluates true/false, then the second 'unless' evaluates nil.  

This can screw up the handling of boxes with multiple traps on it for people with force_careful set.

I tested this with normal pick pets as well as with force_careful set and verified it works right with multiply-trapped boxes.