### PR TITLE
Tessera in combat and cycling fix

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -120,9 +120,10 @@ class SetupProcess
   def armor_hysteresis?
     return false unless @armor_hysteresis
     return false if @cycle_armors.keys.any? { |skill| DRSkill.getxp(skill) < 25 }
+    all_swap_pieces = @cycle_armors.keys.map { |armortype| @cycle_armors[armortype] }.flatten
     if @cycle_armors.keys.all? { |skill| DRSkill.getxp(skill) > 32 }
       if @last_worn_type != @default_armor && @cycle_armors.keys.include?(@default_armor)
-        @equipment_manager.worn_items(@all_swap_pieces).each { |item| @equipment_manager.remove_item(item) }
+        @equipment_manager.worn_items(all_swap_pieces).each { |item| @equipment_manager.remove_item(item) }
         @equipment_manager.wear_items(@equipment_manager.desc_to_items(@cycle_armors[@default_armor]))
         @last_worn_type = @default_armor
       end
@@ -1915,7 +1916,7 @@ class TrainerProcess
                    'Stealth' => 'Stealth', 'Ambush Stun' => settings.stun_skill, 'Ambush Choke' => 'Debilitation', 'App Pouch' => 'Appraisal',
                    'Favor Orb' => 'Anything', 'Charged Maneuver' => 'Expertise', 'Meraud' => 'Theurgy', 'Recall' => 'Scholarship',
                    'Barb Research Warding' => 'Warding', 'Barb Research Augmentation' => 'Augmentation',
-                   'Barb Research Debilitation' => 'Debilitation', 'Collect' => 'Outdoorsmanship', 'Smite' => 'Conviction', 'Locks' => 'Locksmithing' }
+                   'Barb Research Debilitation' => 'Debilitation', 'Collect' => 'Outdoorsmanship', 'Smite' => 'Conviction', 'Locks' => 'Locksmithing', 'Tessera' => 'Trading' }
 
     @skill_map['Hunt'] = %w[Perception Scouting] if DRStats.ranger?
     @favor_god = settings.favor_god
@@ -2097,6 +2098,8 @@ class TrainerProcess
       else
         wait_for_script_to_complete('heal-remedy', %w[quick nohands])
       end
+    when 'Tessera'
+      invoke_tessera(game_state)
     end
     waitrt?
     false
@@ -2465,6 +2468,19 @@ class TrainerProcess
       stow_hands
       return
     end
+  end
+  
+  def invoke_tessera(game_state)
+    return unless DRStats.trader?
+    return if game_state.retreating?
+    return if game_state.loaded || game_state.offhand?
+    DRC.retreat
+    return unless /inside your (.*)/ =~ DRC.bput("get my tessera", 'You get a .+ tessera from inside your (.*).', 'What were you')
+    container = Regexp.last_match(1).split
+    game_state.starlight_values['level'] = 0 if bput('invoke my tessera', '^The .+ tessera has already been invoked', 'You send your') == 'You send your'
+    bput("put my tessera in my #{container.last}", 'You put', 'What were you')
+    DRCI.stow_hand('left') if DRC.left_hand.include?('tessera')
+    DRCI.stow_hand('right') if DRC.right_hand.include?('tessera')
   end
 
   def reset_ability(game_state, ability_name, offset = 0)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2469,16 +2469,16 @@ class TrainerProcess
       return
     end
   end
-  
+
   def invoke_tessera(game_state)
     return unless DRStats.trader?
     return if game_state.retreating?
     return if game_state.loaded || game_state.offhand?
     DRC.retreat
-    return unless /inside your (.*)/ =~ DRC.bput("get my tessera", 'You get a .+ tessera from inside your (.*).', 'What were you')
-    container = Regexp.last_match(1).split
+    return unless /inside your (.*)\./ =~ DRC.bput("get my tessera", 'You get a .+ tessera from inside your (.*).', 'What were you')
+    container = DRC.get_noun(Regexp.last_match(1))
     game_state.starlight_values['level'] = 0 if bput('invoke my tessera', '^The .+ tessera has already been invoked', 'You send your') == 'You send your'
-    bput("put my tessera in my #{container.last}", 'You put', 'What were you')
+    bput("put my tessera in my #{container}", 'You put', 'What were you')
     DRCI.stow_hand('left') if DRC.left_hand.include?('tessera')
     DRCI.stow_hand('right') if DRC.right_hand.include?('tessera')
   end


### PR DESCRIPTION
I'll remove this from the previous PR.

First, this includes the tessera changes from before.  Also, someone in lnet identified a very rare fail condition for armor cycling with a default_armor set.

If all armor skills are simultaneously above 32, and armor_hysteresis is true, and you have a default_armor set (not default) then it tries to remove @all_swap_pieces, which isn't defined anywhere, then wear the other default piece from cycle_armors.