### PR TITLE
hangs when wielding implement

### DIFF
--- a/chop-wood.lic
+++ b/chop-wood.lic
@@ -31,7 +31,7 @@ class ChopWood
       snapshot = Room.current.id
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)
-      @equipment_manager.wield_weapon(@lumber_implement)
+     # @equipment_manager.wield_weapon(@lumber_implement)
     end
 
     return unless Flags['chop-danger']


### PR DESCRIPTION
When there's a tree explosion, the script runs safe-room then returns to the original location and resumes chopping.  The implement (axe) is never put away, but when the script returns to chop wood again, it tried to re-equip it.  For some reason there is no logic for already having the axe out in the equipping method, so the script stops.  The easy fix here is to remove line 34 and not re-equip since the implement is never put away.  May not be the most robust fix, however.