### PR TITLE
Adjust non-standard mortar support in remedy

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -117,7 +117,7 @@ class Remedy
     wait_for_script_to_complete('buff', ['remedy'])
 
     # used for internal remedies (this section is needed for CONTINUE arg to work)
-    if @container != 'mortar'
+    if /mort/ !~ @container
       @pestle = 'mixing stick'
       @verb = 'mix'
     end
@@ -224,7 +224,7 @@ class Remedy
     get_item(@container) # pickup off ground
     get_item(@pestle)
 
-    if @container == 'mortar'
+    if /mort/ =~ @container
       work("#{@verb} my #{@herb1} with my #{@pestle}")
     else
       work("#{@verb} my #{@container} with my #{@pestle}")
@@ -259,7 +259,7 @@ class Remedy
         finish
       when 'Roundtime:'
         waitrt?
-        command = if @container == 'mortar'
+        command = if /mort/ =~ @container
                     "#{@verb} my #{@noun} with my #{@pestle}"
                   else
                     "#{@verb} my #{@container} with my #{@pestle}"


### PR DESCRIPTION
The previous container-related PR worked with base settings, but runs into problems if a user specifies a custom mortar.

See Issue https://github.com/rpherbig/dr-scripts/issues/4088