### PR TITLE
Add in_hands? to common-item

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -99,6 +99,11 @@ module DRCI
     result =~ /inside/
   end
 
+  def in_hands?(item)
+    item_regex = item.split.size > 1 ? /.*\b#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
+    item_regex =~ DRC.left_hand + DRC.right_hand
+  end
+
   def exists?(description)
     result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You thump your fingers', 'The orb is delicate')
     result =~ /You tap|You thump|The orb is delicate/


### PR DESCRIPTION
This sort of thing is used all over the place, and it'd be simpler to just have a common method for it.