### PR TITLE
Add alias support to walk_to

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -11,6 +11,8 @@ module DRCT
   def walk_to(target_room, restart_on_fail = true)
     Flags.add('closed-shop', 'The door is locked up tightly for the night', 'You smash your nose', '^A servant (blocks|stops)')
 
+    target_room = tag_to_id(target_room) if target_room.is_a?(String) && target_room.count("a-zA-Z") > 0
+
     return false if target_room.nil?
     room_num = target_room.to_i
     return true if room_num == Room.current.id
@@ -72,6 +74,34 @@ module DRCT
     room_num == Room.current.id
   end
 
+  def tag_to_id(target)
+    start_room = Room.current.id
+    target_list = Map.list.find_all { |room| room.tags.include?(target) }.collect { |room| room.id }
+
+    if target_list.empty?
+      DRC.message("No go2 targets matching #{target} found!")
+      exit
+    end
+
+    if target_list.include?(start_room)
+      echo "You're already here..."
+      exit
+    end
+    previous, shortest_distances = Room.current.dijkstra(target_list)
+    target_list.delete_if { |room_id| shortest_distances[room_id].nil? }
+    if target_list.empty?
+      DRC.message("Couldn't find a path from here to any room with a #{target} tag")
+      exit
+    end
+
+    target_id = target_list.sort { |a,b| shortest_distances[a] <=> shortest_distances[b] }.first
+    unless target_id and (destination = Map[target_id])
+      DRC.message("Something went wrong!  Debug failed with #{target_id}, #{destination}, and #{target}")
+      exit
+    end
+    target_id
+  end
+
   def retreat(ignored_npcs = [])
     return if (DRRoom.npcs - ignored_npcs).empty?
 
@@ -123,5 +153,10 @@ module DRCT
   def find_sorted_empty_room(search_rooms, idle_room, predicate = nil)
     sorted_rooms = sort_destinations(search_rooms)
     find_empty_room(sorted_rooms, idle_room, predicate)
+  end
+
+  def time_to_room(origin, destination)
+    _previous, shortest_paths = Map.dijkstra(origin, destination)
+    shortest_paths[destination]
   end
 end


### PR DESCRIPTION
Adds two functions to common-travel.

time_to_room takes an origin and target id and returns the time_to between them

Second, tag_to_id was largely stolen from go2, and if given an alias string it gives the closest room_id with that tag.  With this you can use tags with walkto.

```
>;en DRCT.walk_to('stables')
--- Lich: exec1 active.
--- Lich: go2 active.
[go2: ETA: 0:00:00 (4 rooms to move through)]
[go2]>west
```

I've been running with this for about 15 days now.