### PR TITLE
Update Back Slot removal message

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -130,7 +130,7 @@ class SellLoot
 
     return unless walk_to @hometown['tannery']['id']
 
-    return if bput('remove my bundle', 'You remove', 'You sling', 'Remove what') == 'Remove what'
+    return if bput('remove my bundle', 'You remove', 'You sling', 'Remove what','You take') == 'Remove what'
     release_invisibility
     bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection')
     bput('stow rope', 'You put')


### PR DESCRIPTION
Rare folks using back slot for a bundle get a mismatch on removal message.  "You take a tight bundle off your back."