### PR TITLE
Make almanac less grabby

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -24,6 +24,7 @@ class Almanac
     return if XMLData.room_title.include? 'Carousel Booth'
     return if XMLData.room_title.include? 'Family Vault'
     return if hidden?
+    return if checkleft
 
     unless @almanac_skills.empty?
       training_skill = @almanac_skills
@@ -34,12 +35,14 @@ class Almanac
 
     pause 1 until pause_all
     waitrt?
-    bput('stow left', 'Stow what', 'You put') if checkleft
-    case bput("get my #{@almanac}", 'You get', 'What were', 'You are already')
+    case bput("get my #{@almanac}", 'You get', 'What were', 'You are already', 'You need a free')
     when 'What were'
       echo('Almanac not found, exiting.')
       unpause_all
       exit
+    when 'You need a free'
+      unpause_all
+      return
     end
     if training_skill
       bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')


### PR DESCRIPTION
A few times recently we've fielded issues where almanac has fired off and interrupted material buying/combining.  We could add workorders to almanac_no_use, or I favor fixing it this way.

Here, almanac won't fire off if there's something in your left hand, and if it fails to pick itself up anyway (race condition) then it backs off and goes back to waiting.