### PR TITLE
Adding adjective for leather coat stealable

### DIFF
--- a/data/base-stealing.yaml
+++ b/data/base-stealing.yaml
@@ -3839,7 +3839,7 @@
   trivial_max: 1750
   trivial_min: 503
 - town: Arthe Dale
-  item: coat
+  item: leather coat
   item_in: in catalog
   room: 19237
   pawnable: false


### PR DESCRIPTION
The item stolen for some reason gets captured by steal as 'tailed coat', which causes it to get backed up in your inventory's steal bag. Adding the adjective _should_ help.

H>steal leather coat in catalog
Moving stealthily, you manage to grab a tooled leather coat right from underneath Bobba Bandicoot's very nose.
You learned somewhat poorly from this simple theft.
Roundtime: 5 sec.

Will test further with my local copy on the next steal run.