### PR TITLE
Make almanac less grabby

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -2,10 +2,11 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#almanac
 =end
 
-custom_require.call(%w[common])
+custom_require.call(%w[common common-items])
 
 class Almanac
   include DRC
+  include DRCI
 
   def initialize
     settings = get_settings
@@ -24,6 +25,7 @@ class Almanac
     return if XMLData.room_title.include? 'Carousel Booth'
     return if XMLData.room_title.include? 'Family Vault'
     return if hidden?
+    return if checkleft
 
     unless @almanac_skills.empty?
       training_skill = @almanac_skills
@@ -34,12 +36,16 @@ class Almanac
 
     pause 1 until pause_all
     waitrt?
-    bput('stow left', 'Stow what', 'You put') if checkleft
-    case bput("get my #{@almanac}", 'You get', 'What were', 'You are already')
+    case bput("get my #{@almanac}", 'You get', 'What were', 'You are already', 'You need a free')
     when 'What were'
       echo('Almanac not found, exiting.')
       unpause_all
       exit
+    when 'You need a free'
+      unless DRCI.in_hands?(@almanac)
+        unpause_all
+        return
+      end
     end
     if training_skill
       bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')


### PR DESCRIPTION
Part of a fix for a few crafting-material related changes recently.  I forgot I've been running with a version of almanac for several months that had most of these changes in it.  With this I haven't even needed to keep the crafting scripts (sew, forge, shape, etc.) in almanac_no_use.

Basically, instead of stowing what's in your left hand, it just doesn't fire off if you've got something in that hand, and waits for an opportunity.  If a race condition causes it to fire off just after another script has put something into your hands then it backs off and waits for another opportunity.

The change from the last PR was a final safety in case the bput fought with another script to make sure your almanac gets stowed.