### PR TITLE
Wounds when tying tools to belts

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -137,13 +137,15 @@ module DRCC
         craft_room = Room.current.id
         wait_for_script_to_complete('safe-room', ['force'])
         DRCT.walk_to(craft_room)
-        get_crafting_item(name, bag, bag_items, belt)
+        return get_crafting_item(name, bag, bag_items, belt)
       end
     end
     command = "get my #{name}"
     command += " from my #{bag}" if bag_items && bag_items.include?(name)
     case DRC.bput(command, '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
     when 'What do you', 'What were you'
+      pause 2
+      return if DRCI.in_hands?(name)
       beep
       echo("You seem to be missing: #{name}")
       exit unless skip_exit
@@ -157,7 +159,15 @@ module DRCC
 
     waitrt?
     if belt && belt['items'].find { |item| /\b#{name}/i =~ item || /\b#{item}/i =~ name }
-      DRC.bput("tie my #{name} to my #{belt['name']}", 'you attach')
+      case DRC.bput("tie my #{name} to my #{belt['name']}", 'you attach', 'Your wounds hinder')
+      when 'Your wounds hinder'
+        craft_room = Room.current.id
+        wait_for_script_to_complete('safe-room', ['force'])
+        DRCT.walk_to(craft_room)
+        return stow_crafting_item(name, bag, bag_items, belt)
+      else
+        return
+      end
     else
       case DRC.bput("put my #{name} in my #{bag}", 'You put your', 'What were you referring to', 'is too \w+ to fit', 'You can\'t put that there', 'You combine')
       when /is too \w+ to fit/
@@ -191,7 +201,7 @@ module DRCC
     end
   end
 
-def fount(stock_room, stock_needed, stock_number, quantity, bag, bag_items, belt)
+  def fount(stock_room, stock_needed, stock_number, quantity, bag, bag_items, belt)
     case bput('tap my fount', /You tap .* inside your .*/, /You tap .*your .*/, /I could not find what you were referring to./)
     when /You tap (.*) inside your (.*)/, /You tap (.*) your (.*)/
       /(\d+)/ =~ bput('analyze my fount', 'This appears to be a crafting tool and it has approximately \d+ uses remaining')

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -164,7 +164,7 @@ module DRCC
         craft_room = Room.current.id
         wait_for_script_to_complete('safe-room', ['force'])
         DRCT.walk_to(craft_room)
-        return stow_crafting_item(name, bag, bag_items, belt)
+        return stow_crafting_item(name, bag, belt)
       else
         return
       end

--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -3879,24 +3879,32 @@ crafting_recipes:
   type: weaponsmithing
   work_order: true
   chapter: 4
+  part:
+  - haft
 - name: a metal dire mace
   noun: mace
   volume: 16
   type: weaponsmithing
   work_order: true
   chapter: 6
+  part:
+  - haft
 - name: a metal duraka skefne
   noun: skefne
   volume: 10
   type: weaponsmithing
   work_order: true
   chapter: 7
+  part:
+  - long pole
 - name: a metal ilglaiks skefne
   noun: skefne
   volume: 15
   type: weaponsmithing
   work_order: true
   chapter: 7
+  part:
+  - long pole
 - name: a metal throwing club
   noun: club
   volume: 5


### PR DESCRIPTION
Closes issue https://github.com/rpherbig/dr-scripts/issues/4087

There's a section in get_crafting_item for when you can't get an item because you're too wounded, but apparently it can happen when you're tying an item at different wound thresholds.  This can lead to gumming up the works, so I copied that logic over.

Also, 'What do you'/'What were you' are semi-common bput results, and if enough stuff get's thrown around when multiple scripts are running, I can sometimes see a crafting script exit fatally because it tried 'get shaper from my trunk' 3 times, and the second one succeeded, but the 3rd one failed.

Then you're stuck with items in your hands.