### PR TITLE
Adjust returns on common-crafting

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -165,8 +165,6 @@ module DRCC
         wait_for_script_to_complete('safe-room', ['force'])
         DRCT.walk_to(craft_room)
         return stow_crafting_item(name, bag, belt)
-      else
-        return
       end
     else
       case DRC.bput("put my #{name} in my #{bag}", 'You put your', 'What were you referring to', 'is too \w+ to fit', 'You can\'t put that there', 'You combine')
@@ -182,7 +180,7 @@ module DRCC
 
   def logbook_item(logbook, noun, container)
     DRC.bput("get my #{logbook} logbook", 'You get')
-    case bput("bundle my #{noun} with my logbook", 'You notate the', 'This work order has expired', 'The work order requires items of a higher quality', 'That isn\'t the correct type of item for this work order.')
+    case DRC.bput("bundle my #{noun} with my logbook", 'You notate the', 'This work order has expired', 'The work order requires items of a higher quality', 'That isn\'t the correct type of item for this work order.')
     when 'This work order has expired', 'The work order requires items of a higher quality', 'That isn\'t the correct type of item for this work order.'
       dispose_trash(noun)
     end


### PR DESCRIPTION
One of the crafting scripts cares about the true/false values of stow_crafting_item as opposed to get_crafting_item, and removing this else gives the right result, as it passes through to the end and evaluates true.

Also, I can use logbook item in a couple places so long as the DRC. is referenced for bput.