### PR TITLE
Stow feet after hunt complete

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -128,7 +128,9 @@ class HuntingBuddy
       end
 
       stop_actions(during_actions)
-
+      DRCI.stow_hand('left') unless !DRC.right_hand || !DRC.left_hand
+      while DRC.bput('stow feet', /You pick up/, /Stow what/) =~ /You pick up/
+      end
       wait_for_script_to_complete('bescort', @exit) if @exit
       release_cyclics
 


### PR DESCRIPTION
I can't see any reason this wouldn't work, and my initial tests seem like they are handled just fine.  After combat-trainer ends on any given hunt, but before afters like go2 are called, do what afk does and Stow feet until you can't anymore.

Anyone see a problem with this?  I'll ask around in a bit to see if anyone who routinely ends up with stuff at their feet minds trying it.