### PR TITLE
Added Crossing Estate Holder Gargoyles

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -620,6 +620,17 @@ hunting_zones:
   - 12991
   - 12992
   - 12996
+  # https://elanthipedia.play.net/Granite_gargoyle                       95 to 125
+  # Estate Holder only - outside Crossing North Gate
+  # Newly separated gargoyles - no skunks or spirits
+  granite_gargoyles_monastary:
+  # - 10732 Do Not Use - room bugged for movement.
+  - 10726
+  - 10727
+  - 10731
+  - 10730
+  - 10728
+  - 10729
   # https://elanthipedia.play.net/Crypt_fiend                            100-145  
   # Add jade apples to loot additions, sells like gems?
   # Need light source to access area


### PR DESCRIPTION
Should not be approved until the map upload with a stringproc for room 1629 is live.  Room data does not transition from 1629 to 10732 but does transition from 10732 to 1629.  Room 1629 appears to be the problem as the entire room is nothing but procs.
Once approved, this is a super yummy new empath-safe hunting spot we are very excited to be using!!!