### PR TITLE
Slight adjustment to DRCT.tag_to_id

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -85,7 +85,7 @@ module DRCT
 
     if target_list.include?(start_room)
       echo "You're already here..."
-      exit
+      return start_room
     end
     previous, shortest_distances = Room.current.dijkstra(target_list)
     target_list.delete_if { |room_id| shortest_distances[room_id].nil? }


### PR DESCRIPTION
The proper behavior for this should be to return the room id you're standing in, not exit the script.