### PR TITLE
base-hunting - rearranged mice room numbers

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -362,8 +362,6 @@ hunting_zones:
   # https://elanthipedia.play.net/Giant_mechanical_mouse                  0-2000
   # Flex creatures, require special weapon material to hit
   mechanical_mice:
-  - 132
-  - 133
   - 134
   - 135
   - 136
@@ -372,6 +370,8 @@ hunting_zones:
   - 139
   - 140
   - 6873
+  - 132
+  - 133
   # https://elanthipedia.play.net/Musk_Hog                                 10-35
   hogs:
   - 1438


### PR DESCRIPTION
Did this so that the 1st two rooms are last because you can't train perception from the first two rooms via hunt.