### PR TITLE
added training_ability: Ret Stealth

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2065,27 +2065,11 @@ class TrainerProcess
           fix_standing
         end
       end
+     when 'Stealth'
+      hide_action(game_state)
     when 'Ret Stealth'
       retreat
-      if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
-        stalked = bput('stalk', 'Stalk what',
-                       'Try being out of sight',
-                       'You move into position',
-                       'already stalking',
-                       'discovers you, ruining your hiding place') == ('You move into position' || 'already stalking')
-        bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
-      end
-      bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden       
-    when 'Stealth'
-      if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
-        stalked = bput('stalk', 'Stalk what',
-                       'Try being out of sight',
-                       'You move into position',
-                       'already stalking',
-                       'discovers you, ruining your hiding place') == ('You move into position' || 'already stalking')
-        bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
-      end
-      bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden
+      hide_action(game_state)
     when 'Ambush Stun'
       return ambush_stun(game_state)
     when 'Ambush Choke'
@@ -2135,6 +2119,18 @@ class TrainerProcess
   end
 
   private
+  
+  def hide_action(game_state)
+    if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
+      stalked = bput('stalk', 'Stalk what',
+                     'Try being out of sight',
+                     'You move into position',
+                     'already stalking',
+                     'discovers you, ruining your hiding place') == ('You move into position' || 'already stalking')
+      bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
+    end
+    bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden
+  end
 
   def use_almanac(game_state)
     return unless Time.now - UserVars.almanac_last_use >= 600

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2065,6 +2065,17 @@ class TrainerProcess
           fix_standing
         end
       end
+    when 'Ret Stealth'
+      retreat
+      if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
+        stalked = bput('stalk', 'Stalk what',
+                       'Try being out of sight',
+                       'You move into position',
+                       'already stalking',
+                       'discovers you, ruining your hiding place') == ('You move into position' || 'already stalking')
+        bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
+      end
+      bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden       
     when 'Stealth'
       if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
         stalked = bput('stalk', 'Stalk what',


### PR DESCRIPTION
I get asked fairly often about retreating before hiding and this seemed the least intrusive way to add it.  Was actually working quite well for my cleric's stealth hunt during testing when she can just barely hide on the current mob.  - open to different names.