### PR TITLE
Adjust pick buffing/worn-container handling

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -101,7 +101,7 @@ module DRCI
 
   def in_hands?(item)
     item_regex = item.split.size > 1 ? /.*\b#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
-    item_regex =~ DRC.left_hand + DRC.right_hand
+    item_regex =~ "#{DRC.right_hand}#{DRC.left_hand}"
   end
 
   def exists?(description)

--- a/pick.lic
+++ b/pick.lic
@@ -139,7 +139,6 @@ class LockPicker
     @harvest_traps = !@make_pets && @settings.harvest_traps
     @component_container = @settings.component_container
     @stop_pick_on_mindlock = !@make_pets && @settings.stop_pick_on_mindlock
-    
     @loot_nouns = @settings.lootables
     echo "Loot nouns: #{@loot_nouns}" if UserVars.lockpick_debug
 
@@ -182,9 +181,9 @@ class LockPicker
     if DRRoom.pcs.include?(@settings.lockpick_buff_bot)
       fput("whisper #{@settings.lockpick_buff_bot} buff hol")
     end
-    
+
     if @settings.waggle_sets['pick']
-      wait_for_script_to_complete('buff', ['pick'])
+      DRCA.do_buffs(@settings, 'pick')
     else
       buffs = @settings.lockpick_buffs
       # TODO: Remove this sometime in end of February. That should be enough time for users to move to waggle
@@ -200,7 +199,6 @@ class LockPicker
         bput("meditate #{med}", 'You feel a jolt as your vision snaps shut', 'Your inner fire lacks the strength')
       end
     end
-    DRCA.do_buffs(@settings, 'pick')
   end
 
   def refill_ring

--- a/pick.lic
+++ b/pick.lic
@@ -83,12 +83,16 @@ class LockPicker
       loop do
         if DRSkill.getxp('Locksmithing') >= 30
           bput("put my #{box} in my #{source}", 'You put your .* in ') if right_hand
+          fput('stow left') unless @settings.use_lockpick_ring
           break
         end
 
         case bput("pick my #{box} blind", 'not even locked', 'Roundtime', 'Find a more appropriate tool')
         when 'not even locked'
           waitrt?
+          fput('stow left') unless @settings.use_lockpick_ring
+          loot(box)
+          dismantle(box)
           break
         when 'Find a more appropriate tool'
           bput("put my #{box} in my #{source}", 'You put your .* in ') if right_hand
@@ -96,10 +100,6 @@ class LockPicker
           break
         end
       end
-
-      fput('stow left') unless @settings.use_lockpick_ring
-      loot(box)
-      dismantle(box)
     end
 
     refill_ring
@@ -182,23 +182,7 @@ class LockPicker
       fput("whisper #{@settings.lockpick_buff_bot} buff hol")
     end
 
-    if @settings.waggle_sets['pick']
-      wait_for_script_to_complete('buff', ['pick'])
-    else
-      buffs = @settings.lockpick_buffs
-      # TODO: Remove this sometime in end of February. That should be enough time for users to move to waggle
-      echo "*** You have outdated settings, please make a waggle_set called 'pick' ***" unless buffs.empty?
-      buffs['spells'].each do |spell|
-        echo "Buffing: #{spell}" if UserVars.lockpick_debug
-        cast_spell(spell, @settings)
-      end
-      buffs['khri']
-        .map { |name| "Khri #{name}" }
-        .each { |name| activate_khri?(@settings.kneel_khri, name) }
-      buffs['meditate'].each do |med|
-        bput("meditate #{med}", 'You feel a jolt as your vision snaps shut', 'Your inner fire lacks the strength')
-      end
-    end
+    DRCA.do_buffs(@settings, 'pick')
   end
 
   def refill_ring

--- a/pick.lic
+++ b/pick.lic
@@ -35,7 +35,6 @@ class LockPicker
     fput 'sit'
 
     do_buffs
-    DRC.fix_standing
 
     boxes.each do |box|
       if stop_picking?
@@ -46,10 +45,15 @@ class LockPicker
       break if @make_pets && @pet_count >= @pet_goal
     end
 
+    DRC.fix_standing
     @equipment_manager.wear_items(removed_items)
 
-    @pick_buffs.each { |name| fput("khri stop #{name}") } if DRStats.thief? && @pick_buffs
-    fput('meditate stop') if DRStats.barbarian? && @pick_buffs
+    lockpick_buffs = @settings.lockpick_buffs
+    if lockpick_buffs['khri']
+      lockpick_buffs['khri'].each { |name| fput("khri stop #{name}") }
+    end
+
+    fput('meditate stop') if lockpick_buffs['meditate']
 
     refill_ring
   end
@@ -135,7 +139,6 @@ class LockPicker
     @harvest_traps = !@make_pets && @settings.harvest_traps
     @component_container = @settings.component_container
     @stop_pick_on_mindlock = !@make_pets && @settings.stop_pick_on_mindlock
-    @pick_buffs = @settings.waggle_sets['pick']
     
     @loot_nouns = @settings.lootables
     echo "Loot nouns: #{@loot_nouns}" if UserVars.lockpick_debug
@@ -179,7 +182,24 @@ class LockPicker
     if DRRoom.pcs.include?(@settings.lockpick_buff_bot)
       fput("whisper #{@settings.lockpick_buff_bot} buff hol")
     end
-
+    
+    if @settings.waggle_sets['pick']
+      wait_for_script_to_complete('buff', ['pick'])
+    else
+      buffs = @settings.lockpick_buffs
+      # TODO: Remove this sometime in end of February. That should be enough time for users to move to waggle
+      echo "*** You have outdated settings, please make a waggle_set called 'pick' ***" unless buffs.empty?
+      buffs['spells'].each do |spell|
+        echo "Buffing: #{spell}" if UserVars.lockpick_debug
+        cast_spell(spell, @settings)
+      end
+      buffs['khri']
+        .map { |name| "Khri #{name}" }
+        .each { |name| activate_khri?(@settings.kneel_khri, name) }
+      buffs['meditate'].each do |med|
+        bput("meditate #{med}", 'You feel a jolt as your vision snaps shut', 'Your inner fire lacks the strength')
+      end
+    end
     DRCA.do_buffs(@settings, 'pick')
   end
 

--- a/pick.lic
+++ b/pick.lic
@@ -35,6 +35,7 @@ class LockPicker
     fput 'sit'
 
     do_buffs
+    DRC.fix_standing
 
     boxes.each do |box|
       if stop_picking?
@@ -45,15 +46,10 @@ class LockPicker
       break if @make_pets && @pet_count >= @pet_goal
     end
 
-    fix_standing
     @equipment_manager.wear_items(removed_items)
 
-    lockpick_buffs = @settings.lockpick_buffs
-    if lockpick_buffs['khri']
-      lockpick_buffs['khri'].each { |name| fput("khri stop #{name}") }
-    end
-
-    fput('meditate stop') if lockpick_buffs['meditate']
+    @pick_buffs.each { |name| fput("khri stop #{name}") } if DRStats.thief? && @pick_buffs
+    fput('meditate stop') if DRStats.barbarian? && @pick_buffs
 
     refill_ring
   end
@@ -139,6 +135,8 @@ class LockPicker
     @harvest_traps = !@make_pets && @settings.harvest_traps
     @component_container = @settings.component_container
     @stop_pick_on_mindlock = !@make_pets && @settings.stop_pick_on_mindlock
+    @pick_buffs = @settings.waggle_sets['pick']
+    
     @loot_nouns = @settings.lootables
     echo "Loot nouns: #{@loot_nouns}" if UserVars.lockpick_debug
 


### PR DESCRIPTION
There exists a failure state when picking pet boxes with a worn container that shares a noun with a box.  Let's say a 'trunk' and a worn 'cartographer's trunk'.  If you get to Locksmithing > 30 mindstates, pick puts the trunk away, then attempts to loot your trunk.  At that point it looks in the cartographer's trunk, which parses first, and empties everything inside it onto the ground.  This orders some of the logic about so you only loot/dismantle if you actually opened the box.

Also, I'm removing lockpick_buffs: after a couple years and moving us over to DRCA.do_buffs unless someone else has an objection.  I ran this on my thief and it Khri'd up, picked some boxes, then stopped my khris and closed down.

Finally, an insignificant change to DRCI.in_hands?  My original testing never ran into this somehow, but adding strings together crashes if one is nil.  Doing it this way instead works in Ruby.