### PR TITLE
base-hunting - Corrected room# 135 in mech mice

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -363,7 +363,7 @@ hunting_zones:
   # Flex creatures, require special weapon material to hit
   mechanical_mice:
   - 134
-  - 135
+  - 13468
   - 136
   - 137
   - 138


### PR DESCRIPTION
Room 135 is in Arthe Dale, I updated base hunting to have the correct room# for mech mice.