### PR TITLE
Fix for using new HOTR highwayman's belts with crafting tools

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -167,8 +167,10 @@ module DRCC
         return stow_crafting_item(name, bag, belt)
       end
     else
-      case DRC.bput("put my #{name} in my #{bag}", 'You put your', 'What were you referring to', 'is too \w+ to fit', 'You can\'t put that there', 'You combine')
-      when /is too \w+ to fit/
+      case DRC.bput("put my #{name} in my #{bag}", 'You put your', 'What were you referring to', 'is too \w+ to fit', 'Weirdly, you can\'t manage', 'There\'s no room', 'You can\'t put that there', 'You combine')
+      when /is too \w+ to fit/, 'Weirdly, you can\'t manage', 'There\'s no room'
+        fput("stow my #{name}")
+      when 'Weirdly, you can\'t manage'
         fput("stow my #{name}")
       when 'You can\'t put that there'
         fput("put my #{name} in my other #{bag}")


### PR DESCRIPTION
The new HOTR highwayman's belts from incidental loot do not allow storing containers. This catches that and stores things like bowls and mortars in your normal stow location.