### PR TITLE
Add Ret Stealth

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -417,7 +417,7 @@ class DRYamlValidator
     return unless settings.training_abilities
 
     settings.training_abilities
-            .reject { |skill, _cooldown| ['PercMana', 'Perc', 'Perc Health', 'Astro', 'App', 'App Quick', 'App Careful', 'Tactics', 'Hunt', 'Pray', 'Scream', 'Khri Prowess', 'Stealth', 'Ambush Stun', 'Ambush Choke', 'Favor Orb', 'Charged Maneuver', 'Meraud', 'Recall', 'Barb Research Debilitation', 'Barb Research Augmentation', 'Barb Research Warding', 'Collect', 'Analyze', 'Flee', 'PrayerMat', 'Smite', 'Locks', 'Teach', 'Almanac', 'Herbs', 'App Pouch'].include?(skill) }
+            .reject { |skill, _cooldown| ['PercMana', 'Perc', 'Perc Health', 'Astro', 'App', 'App Quick', 'App Careful', 'Tactics', 'Hunt', 'Pray', 'Scream', 'Khri Prowess', 'Ret Stealth', 'Stealth', 'Ambush Stun', 'Ambush Choke', 'Favor Orb', 'Charged Maneuver', 'Meraud', 'Recall', 'Barb Research Debilitation', 'Barb Research Augmentation', 'Barb Research Warding', 'Collect', 'Analyze', 'Flee', 'PrayerMat', 'Smite', 'Locks', 'Teach', 'Almanac', 'Herbs', 'App Pouch'].include?(skill) }
             .each_key { |skill| error("Ability in training_abilities is not valid: #{skill}") }
   end
 


### PR DESCRIPTION
Add Ret Stealth to accepted training_abilities to stop misleading validate errors.