### PR TITLE
Setting for left hand free during aiming_trainables

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -15,6 +15,7 @@ class Almanac
     @almanac_skills = settings.almanac_skills
     @almanac = settings.almanac_noun
 
+
     passive_loop
   end
 
@@ -37,6 +38,9 @@ class Almanac
     pause 1 until pause_all
     waitrt?
     case bput("get my #{@almanac}", 'You get', 'What were', 'You are already', 'You need a free')
+    bput('stow left', 'Stow what', 'You put') if checkleft
+    case bput("get my #{@almanac}", 'You get', 'What were', 'You are already')
+
     when 'What were'
       echo('Almanac not found, exiting.')
       unpause_all

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3734,7 +3734,7 @@ class GameState
     thrown_types = ['Light Thrown', 'Heavy Thrown']
     options = @aiming_trainables
     options -= held_types if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow)
-    options -= thrown_types if (weapon_skill.eql?('Bow') && @bow_left_free)
+    options -= thrown_types if (weapon_skill.eql?('Bow') && @left_hand_free)
     echo "determine_aiming_skill::options: #{options}" if $debug_mode_ct
     options.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2011,6 +2011,7 @@ class TrainerProcess
     echo("  @almanac_skills: #{@almanac_skills}") if $debug_mode_ct
 
     @almanac = settings.almanac_noun
+
     echo("  @almanac: #{@almanac}") if $debug_mode_ct
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3199,6 +3199,9 @@ class GameState
     @using_light_crossbow = settings.using_light_crossbow
     echo("  @using_light_crossbow: #{@using_light_crossbow}") if $debug_mode_ct
 
+    @left_hand_free = settings.left_hand_free
+    echo("  @left_hand_free: #{@left_hand_free}") if $debug_mode_ct 
+
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
 
@@ -3728,8 +3731,10 @@ class GameState
 
   def determine_aiming_skill
     held_types = ['Small Edged', 'Large Edged', 'Small Blunt', 'Large Blunt', 'Staves', 'Polearms']
+    thrown_types = ['Light Thrown', 'Heavy Thrown']
     options = @aiming_trainables
     options -= held_types if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow)
+    options -= thrown_types if (weapon_skill.eql?('Bow') && @bow_left_free)
     echo "determine_aiming_skill::options: #{options}" if $debug_mode_ct
     options.min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
   end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -201,6 +201,8 @@ whirlwind_trainables:
 aiming_trainables:
 # allow melee offhand weapon training while aiming crossbow in aiming_trainables
 using_light_crossbow: false
+# allow left hand to be kept clear for Bows during aiming_trainables
+left_hand_free: false
 # use attack overrides for aiming trainable skills
 use_overrides_for_aiming_trainables: false
 # threshold in mind-states to train combat_spell_training spells up to.
@@ -595,7 +597,7 @@ lumber_buddy_tree_list:
 - Cherry # longbows
 - Copperwood # longbows
 - Crabwood # martial
-- Darkspine	# martial
+- Darkspine # martial
 - Diamondwood # martial
 - Dragonwood # alterations
 - E'erdream # ???
@@ -613,14 +615,14 @@ lumber_buddy_tree_list:
 - Lelori #Composite
 - Macawood #alterations
 - Mistwood # longbow, shortbow
-- Osage	# longbows
+- Osage # longbows
 - Ramin # longbows
 - Redwood # alterations
 - Rockwood # martial
 - Rosewood # longbows
 - Shadowbark # ???
 - Silverwood # shortbows, composite bows
-- Smokewood	# alterations
+- Smokewood # alterations
 - Tamarak # alterations
 - Tamboti # ???
 - Yew # Longbows
@@ -856,6 +858,7 @@ listen_skills:
 - Twohanded Edged
 - Utility
 - Warding
+- Thievery
 
 # https://github.com/rpherbig/dr-scripts/wiki/Waggle-Sets
 waggle_sets:


### PR DESCRIPTION
option to keep left hand 100% free during aiming_trainables to avoid losing aim as skill lowers aim time required.