### PR TITLE
Change to allow for different types of lockpick stackers

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -151,7 +151,7 @@ module DRCI
   end
 
   def count_lockpick_container(container)
-    count = DRC.bput("app my lockpick #{container}", 'and it appears to be full', 'and it might hold an additional \d+', '\d+ lockpicks would probably fit').scan(/\d+/).first.to_i
+    count = DRC.bput("app my #{container}", 'and it appears to be full', 'and it might hold an additional \d+', '\d+ lockpicks would probably fit').scan(/\d+/).first.to_i
     waitrt?
     count
   end
@@ -174,7 +174,7 @@ module DRCI
 
     count.times do
       buy_item(room, "#{lockpick_type} lockpick")
-      DRC.bput("put my lockpick on my lockpick #{container}", 'You put')
+      DRC.bput("put my lockpick on my #{container}", 'You put')
     end
 
     # Be polite to Thieves, who need the room to be empty

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -706,7 +706,7 @@ stop_pick_on_mindlock: true
 pick_blind: false
 use_lockpick_ring: true
 skip_lockpick_ring_refill: false
-lockpick_container: ring
+lockpick_container: lockpick ring
 lockpick_type: ordinary
 harvest_traps: true
 component_container:


### PR DESCRIPTION
This will allow people to specify both the adjective and noun in the setting so that any type of stacker can be used.  For example:
lockpick_container: golden key
lockpick_container: lockpick ankle-cuff

I changed the default in base.yaml to:  lockpick_container: lockpick ring


