### PR TITLE
base.yaml - Added burgle to almanac_no_use_scripts

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1300,6 +1300,7 @@ almanac_no_use_scripts:
 - outdoorsmanship
 - mech-lore
 - corn-maze
+- burgle
 
 walkingastro_no_use_scripts:
 - sew


### PR DESCRIPTION
Added burgle to the almanac_no_use_scripts section as an additional safeguard on top of the burgle script pausing scripts.