### PR TITLE
burgle.lic - Don't try to open stealing bag if dropping loot

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -43,7 +43,7 @@ class Burgle
     return false if @burgle_settings.empty?
     return false if @burgle_settings['room'] == nil or @burgle_settings['room'] =~ /\D/
     return false if @burgle_settings['entry_type'] == nil or @burgle_settings['entry_type'] !~ /lockpick|rope/i
-    if @burgle_settings['max_search_count'] > 0
+    if @burgle_settings['max_search_count'] > 0 && @burgle_settings['loot'] =~ /keep/i
       return false if /(That is already open|You open your)/ !~ bput("open my #{@settings.stealing_bag}", 'That is already open', 'You open your', 'Please rephrase that command', 'What were you referring')
     end
 


### PR DESCRIPTION
Added another condition to the if statement so it doesn't try to open your stealing_bag if you are set to drop loot.