### PR TITLE
Update bescort.lic

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -668,7 +668,7 @@ class Bescort
         EquipmentManager.new.wear_equipment_set?('swimming')
       end
       swim_faldesu(mode =~ /haven/i)
-      EquipmentManager.new.wear_equipment_set?('standard')
+      EquipmentManager.new.wear_equipment_set?('standard') unless UserVars.athletics >= 300
     else
       take_rh_ferry(mode =~ /haven/i)
     end


### PR DESCRIPTION
Prevents bescort from trying to wear your standard gearset after going through the faldesu when you're at 300+ ranks of athletics since it doesn't change into a swimming gearset at that point.