### PR TITLE
common-travel.lic - small fix for reverse_path()

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -161,6 +161,7 @@ module DRCT
   end
 
   def reverse_path(path)
+    path = path.to_a unless path.class == Array
     dir_to_prev_dir = {
       'northeast' => 'southwest',
       'southwest' => 'northeast',

--- a/common-travel.lic
+++ b/common-travel.lic
@@ -161,7 +161,6 @@ module DRCT
   end
 
   def reverse_path(path)
-    path = path.to_a unless path.class == Array
     dir_to_prev_dir = {
       'northeast' => 'southwest',
       'southwest' => 'northeast',
@@ -177,6 +176,10 @@ module DRCT
     reverse_path = []
     path = path.reverse
     for i in 0..path.length-1
+      if dir_to_prev_dir[path[i]].nil?
+        DRC.message("Error: No reverse direction found for #{path[i]}.  Please use the full direction, northeast instead of ne, check your spelling, and make sure the path parameter is an array.")
+        exit
+      end
       reverse_path.push(dir_to_prev_dir[path[i]])
     end
     return reverse_path


### PR DESCRIPTION
If it's sent a a direction as a string instead of an array, it would return an array of nils.  This takes care of that.

```
;e echo DRCT.reverse_path('east')
--- Lich: exec1 active.
[exec1: [nil, nil, nil, nil]]
--- Lich: exec1 has exited.
```

After change:
```
>;common-travel
;e echo DRCT.reverse_path('east')
--- Lich: exec1 active.
[exec1: ["west"]]
--- Lich: exec1 has exited.
```