### PR TITLE
Fix RM expire matches

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1775,7 +1775,7 @@ spell_data:
     abbrev: RM
     mana: 15
     recast: 1
-    expire: The unnatural fog breaks apart with the passing of an errant breeze.
+    expire: The unnatural fog breaks apart
     mana_type: elemental
   Rite of Contrition:
     skill: Utility


### PR DESCRIPTION
Expire message changes slightly if pushed away by Zephyr or just fades on timer.  Shortened message matches both.