### PR TITLE
Update Rising Mists Expiration

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1775,7 +1775,7 @@ spell_data:
     abbrev: RM
     mana: 15
     recast: 1
-    expire: The unnatural fog breaks apart with the passing of an errant breeze.
+    expire: The unnatural fog breaks apart 
     mana_type: elemental
   Rite of Contrition:
     skill: Utility


### PR DESCRIPTION
The current message is:

The unnatural fog breaks apart, fading into barely perceptible wisps before vanishing altogether. 

This may only be when Zephyr is currently up as well, but I think we can be more general here.