### PR TITLE
Allow spells that expire to also have recast_every

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1386,14 +1386,12 @@ class SpellProcess
                        .select { |_name, data| data['starlight_threshold'] ? enough_starlight?(game_state, data) : true }
 
     name, data = recastable_buffs.find do |name, data|
-      if data['pet_type']
+      if data['pet_type'] 
         check_spell_timer?(data) && DRRoom.npcs.include?(data['pet_type'])
-      elsif data['recast_every']
-        check_spell_timer?(data)
-      elsif data['expire']
-        true
       else
-        !DRSpells.active_spells[name] || DRSpells.active_spells[name].to_i <= data['recast']
+        data['recast_every'] && check_spell_timer?(data) ||
+        data['expire'] && Flags["ct-#{data['abbrev']}"] ||
+        data['recast'] && (!DRSpells.active_spells[name] || DRSpells.active_spells[name].to_i <= data['recast'])
       end
     end
     echo("found buff missing: #{name}") if $debug_mode_ct && name

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1381,7 +1381,6 @@ class SpellProcess
 
     recastable_buffs = @buff_spells
                        .select { |_name, data| data['recast'] || data['recast_every'] || data['expire'] }
-                       .select { |_name, data| data['expire'] ? Flags["ct-#{data['abbrev']}"] : true }
                        .select { |name, _data| check_buff_conditions?(name, game_state) }
                        .select { |_name, data| data['starlight_threshold'] ? enough_starlight?(game_state, data) : true }
 


### PR DESCRIPTION
The way the logic was working, spells with expire messages would not be re-castable even if they had recast_every: or recast: arguments. This is especially confusing when spells have expiration messages in base_spells.

Proposed change:

Allow any type of trigger for re-casting if the spell has the arguments and meets the re-cast criteria. I've separated pet casting out because I don't know enough about it to be sure that putting it in with the other expiration conditions will not cause trouble.