### PR TITLE
[burgle] Handle more generic container messages

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -119,7 +119,7 @@ class Burgle
       return false
     end
     if @burgle_settings['max_search_count'] > 0
-       if /(That is already open|You open your)/ !~ bput("open my #{@loot_container}", 'That is already open', 'You open your', 'Please rephrase that command', 'What were you referring')
+       if /(is already open|^You.+open)/ !~ bput("open my #{@loot_container}", 'is already open', '^You.+open', 'Please rephrase that command', 'What were you referring')
          message("You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.")
          return false
        end


### PR DESCRIPTION
Shortened the "container is already open" regex to handle more cases

Closes #4191

Regex test can be found here: https://rubular.com/r/OWyJZxwrRSbvLH