### PR TITLE
Update movement between burgle and pick

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -338,6 +338,7 @@ class CrossingTraining
     return if @researching
     wait_for_script_to_complete('burgle',['start']) if @settings.train_with_burgle
     return if DRSkill.getxp('Locksmithing') >= 30
+    walk_to(@training_room) unless @settings.lockpick_room_id
     walk_to(@settings.lockpick_room_id) if @settings.lockpick_room_id
     start_time = Time.now
     wait_for_script_to_complete('pick')


### PR DESCRIPTION
Users mentioned they're picking boxes in the wrong room after ;burgle before ;pick if they don't have a lockpick_room_id selected.  Thievery,athletics, stealth do not need specific rooms.