### PR TITLE
Expand/Fix Favor Support

### DIFF
--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -324,7 +324,7 @@ Shard:
     Kerenhappuch:
       id: 14320
       adjective: pine
-    Hodierna:
+    Phelim:
       id: 8128
       adjective:
   primer_npc: theurgist

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -45,6 +45,8 @@ Crossing:
     id: 19073
   favor_altar: &zoluren_favor_altar
     id: 5865
+  favor_puzzle: &zoluren_favor_puzzle
+    id: 1420   
   debt_office:
     id: 8282
   guard_house:
@@ -238,6 +240,8 @@ Shard:
     id: 13161
   favor_altar: &southern_favor_altar
     id: 11381
+  favor_puzzle: &southern_favor_puzzle
+    id: 12413
   attunement_rooms:
     - 2780
     - 2779
@@ -403,6 +407,8 @@ Riverhaven:
     id: 12048
   favor_altar: &northern_favor_altar
     id: 445
+  favor_puzzle: &northern_favor_puzzle
+    id: 513
   attunement_rooms:
     - 352
     - 353
@@ -541,6 +547,8 @@ Therenborough:
     id: 11606
   favor_altar:
     << : *northern_favor_altar
+  favor_puzzle:
+    << : *northern_favor_puzzle 
   locksmithing:
     id:
   guard_house:
@@ -598,6 +606,8 @@ Langenfirth:
     id: 11606
   favor_altar:
     << : *northern_favor_altar
+  favor_puzzle:
+    << : *northern_favor_puzzle 
   locksmithing:
     id:
   guard_house:
@@ -934,6 +944,8 @@ Hibarnhvidar:
     id:
   favor_altar:
     << : *southern_favor_altar
+  favor_puzzle:
+    << : *southern_favor_puzzle
   debt_office:
     id: 11696
   guard_house:
@@ -1039,6 +1051,8 @@ Boar Clan:
     id:
   favor_altar:
     << : *southern_favor_altar
+  favor_puzzle:
+    << : *southern_favor_puzzle
   debt_office:
     id: 11696
   guard_house:
@@ -1106,6 +1120,8 @@ Muspar'i:
     id: 10063
   favor_altar:
     << : *northern_favor_altar
+  favor_puzzle:
+    << : *northern_favor_puzzle    
   locksmithing:
     id: 7613
   debt_office:

--- a/favor.lic
+++ b/favor.lic
@@ -20,6 +20,10 @@ class CrossingFavor
     args = parse_args(arg_definitions, true)
     @settings = get_settings
     @hometown = @settings.hometown
+    @town_data = get_data('town')
+    @hometown_data = @town_data[@settings.hometown]
+    
+
     if args.immortal
       @immortal = args.immortal.capitalize
       @all_theurgy_data = get_data('theurgy')
@@ -105,11 +109,11 @@ class CrossingFavor
   end
 
   def use_puzzle
-    walk_to 1420
+    walk_to @hometown_data['favor_puzzle']['id']
 
     case bput('pray', 'You feel a sense of peace settle over you', 'The gods ignore the pleas of your decaying spirit')
     when 'The gods ignore the pleas of your decaying spirit'
-      echo '***CANNOT GET A FAVOR***'
+      echo '***CANNOT GET A FAVOR YOU HEATHEN!***'
       return
     end
     fput 'pray'
@@ -117,13 +121,12 @@ class CrossingFavor
     fput "say #{@settings.favor_god}"
     fix_standing
     fput "get #{@settings.favor_god} orb from altar"
-
     start_puzzle('arch')
   end
 
   def start_puzzle(location)
     pause 1
-    case bput("go #{location}", 'giddy', 'jug', 'tinders', 'sponge', 'ancient window', 'vase on top of the altar')
+    case bput("go #{location}", 'giddy', 'jug', 'tinders', 'sponge', 'ancient window', 'vase on top of the altar','You cannot go through a closed window')
     when 'jug'
       jug
       leave_room
@@ -135,6 +138,8 @@ class CrossingFavor
       leave_room
     when 'ancient window'
       window
+    when 'You cannot go through a closed window'
+      window  
     when 'vase on top of the altar'
       vase
     end

--- a/favor.lic
+++ b/favor.lic
@@ -20,8 +20,7 @@ class CrossingFavor
     args = parse_args(arg_definitions, true)
     @settings = get_settings
     @hometown = @settings.hometown
-    @town_data = get_data('town')
-    @hometown_data = @town_data[@settings.hometown]
+    @hometown_data = get_data('town')[@settings.hometown]
     
 
     if args.immortal

--- a/validate.lic
+++ b/validate.lic
@@ -95,13 +95,6 @@ class DRYamlValidator
 	warn("The favor_god: #{settings.favor_god} you have set does not have a favor altar in your hometown: #{settings.hometown}.  You will not be able to get favors if you fall below your favor_goal.")
   end
 
-  def assert_that_hometown_is_crossing_if_not_using_altars(settings)
-	return if settings.use_favor_altars
-	return if settings.hometown.capitalize == 'Crossing'
-
-    warn("You are set to use the favor puzzle in Crossing but your hometown is #{settings.hometown}.  You will run to Crossing to get favors you fall below your favor_goal.")
-  end
-
   def assert_that_water_holder_is_set_when_using_altars(settings)
     return unless settings.use_favor_altars
     return if settings.water_holder


### PR DESCRIPTION
- Altar at 8128 was incorrectly named for Hodierna.  Updated to Phelim.
- Update base-town rooms for northern and southern puzzle rooms.
- Update favor to read hometown information and added bug handling for window puzzle.
- Removed Validate error messaging - no longer applies.