### PR TITLE
pick.lic - Now wears your armor if it is ended prematurely

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -485,6 +485,7 @@ end
 
 before_dying do
   Flags.delete('disarm-more')
+  EquipmentManager.new.wear_equipment_set?('standard')
 end
 
 LockPicker.new


### PR DESCRIPTION
Added a line to wear your standard gearset in the before_dying do section so if someone kills the script or it errors out, it will wear your armor instead of leaving you naked.