### PR TITLE
[drinfomon] Remove game check

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -3,11 +3,6 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-unless XMLData.game =~ /^(?:DRF|DR|DRT|DRPlat|DRX)$/
-  echo "This script is meant for DragonRealms Prime, Platinum, or Fallen.  It will likely cause problems on whatever game you're trying to run it on..."
-  exit
-end
-
 no_kill_all
 no_pause_all
 # hide_me


### PR DESCRIPTION
This does more harm than good. I recently started playing DR Fallen and the XMLData.game shows "unknown". Even if the game could be detected correctly, I dont think this check should exist.

I would argue either all the scripts should have this check (but why) or none of them should.