### PR TITLE
[spellmonitor] Remove game check

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -3,10 +3,6 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#spellmonitor
 =end
 
-unless XMLData.game =~ /^(?:DRF|DR|DRT||DRPlat|DRX)$/
-  echo "This script is meant for DragonRealms Prime, Platinum, or Fallen.  It will likely cause problems on whatever game you're trying to run it on..."
-  exit
-end
 custom_require.call %w[drinfomon]
 no_kill_all
 no_pause_all


### PR DESCRIPTION
This game check causes problems when the game isn't detected correctly. Lets leave it to the user to figure out if they want to run a script in a given game.