### PR TITLE
Add Support and Hunting to Hara'jaal

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -215,7 +215,11 @@ class Bescort
       [
         { name: 'hara_polo', regex: /hara_polo/i, description: 'Traverse Polo Maze.' },
         { name: 'mode', options: %w[up down hunt], description: 'Up Down or Hunt?' }
-      ]    
+      ],
+      [
+        { name: 'jolas', regex: /jolas/i, description: "Ride The Jolas between Hara'jaal and Mer'Kresh." },
+        { name: 'mode', options: %w[harajaal merkresh], description: "harajaal or merkresh?  Can be started while aboard the Jolas." }
+      ]   
     ]
 
     args = parse_args(arg_definitions)
@@ -283,7 +287,9 @@ class Bescort
     elsif args.brocket_elder
       brocket_elder(args.mode)
     elsif args.hara_polo
-      hara_polo(args.mode)  
+      hara_polo(args.mode)
+    elsif args.jolas
+      jolas(args.mode)       
     end
   end
 

--- a/bescort.lic
+++ b/bescort.lic
@@ -289,6 +289,34 @@ class Bescort
 
   private
 
+  def jolas(mode)
+    #Boat has multiple rooms: 15450, 15451, 15452, 15453, 15454
+    unless [15253, 6542, 15450, 15451, 15452, 15453, 15454].include?(Room.current.id)
+      echo "You are not at the correct dock to ride The Jolas."
+      return
+    end
+
+    if (mode.include?('merkresh') && Room.current.id == 6542) || (mode.include?('harajaal') && Room.current.id == 15253)
+      echo "You're already there silly!"
+      exit    
+    else (mode.include?('merkresh') && Room.current.id == 15253) || (mode.include?('harajaal') && Room.current.id == 6542)
+      hide? unless DRRoom.room_objs.find { |x| x =~ /The Jolas/ } || [15253, 6542, 15450, 15451, 15452, 15453, 15454].include?(Room.current.id)
+      pause 1 until DRRoom.room_objs.find { |x| x =~ /The Jolas/ } || [15253, 6542, 15450, 15451, 15452, 15453, 15454].include?(Room.current.id)
+      bput('go Jolas', 'You climb') if (Room.current.id == 6542 || Room.current.id == 15253 )
+      waitfor 'The captain barks the order to tie off the Jolas to the docks'
+      walk_to(15450) if Room.current.id != 15450
+      if DRRoom.room_objs.include?('Sumilo Dock') && mode.include?('harajaal')
+        move 'go dock'
+        exit
+      elsif DRRoom.room_objs.include?('Wharf End') && mode.include?('merkresh')
+        move 'go end'
+        exit
+      else
+        jolas(mode)
+      end
+    end       
+  end  
+
   def hara_polo(mode)
     hara_polo_direction(mode)
 
@@ -312,6 +340,9 @@ class Bescort
     elsif mode == /down/i && (Room.current.id != 11416 || Room.current.id != 11412)
       echo('Going down the maze towards the cliff and boat to Ratha must be started from 11416 or 11412.')
       exit
+    elsif mode == /hunt/i && (Room.current.id != 11416 || Room.current.id != 11412)
+      echo('Going hunting must begin in room 11416 or 11412.')
+      exit      
     else
       move 'n' if mode.include?('hunt')
     end

--- a/bescort.lic
+++ b/bescort.lic
@@ -305,7 +305,7 @@ class Bescort
     if (mode.include?('merkresh') && Room.current.id == 6542) || (mode.include?('harajaal') && Room.current.id == 15253)
       echo "You're already there silly!"
       exit    
-    else (mode.include?('merkresh') && Room.current.id == 15253) || (mode.include?('harajaal') && Room.current.id == 6542)
+    elsif (mode.include?('merkresh') && Room.current.id == 15253) || (mode.include?('harajaal') && Room.current.id == 6542)
       hide? unless DRRoom.room_objs.find { |x| x =~ /The Jolas/ } || [15253, 6542, 15450, 15451, 15452, 15453, 15454].include?(Room.current.id)
       pause 1 until DRRoom.room_objs.find { |x| x =~ /The Jolas/ } || [15253, 6542, 15450, 15451, 15452, 15453, 15454].include?(Room.current.id)
       bput('go Jolas', 'You climb') if (Room.current.id == 6542 || Room.current.id == 15253 )

--- a/bescort.lic
+++ b/bescort.lic
@@ -211,7 +211,11 @@ class Bescort
       [
         { name: 'brocket_elder', regex: /brocket_elder/i, description: 'Enter the elder brocket deer hunting area.' },
         { name: 'mode', options: %w[enter exit], description: 'Enter or exit?' }
-      ]
+      ],
+      [
+        { name: 'hara_polo', regex: /hara_polo/i, description: 'Traverse Polo Maze.' },
+        { name: 'mode', options: %w[up down hunt], description: 'Up Down or Hunt?' }
+      ]    
     ]
 
     args = parse_args(arg_definitions)
@@ -278,10 +282,40 @@ class Bescort
       brocket_mid(args.mode)
     elsif args.brocket_elder
       brocket_elder(args.mode)
+    elsif args.hara_polo
+      hara_polo(args.mode)  
     end
   end
 
   private
+
+  def hara_polo(mode)
+    hara_polo_direction(mode)
+
+    if mode.include?('up')
+      move 'climb slope' if Room.current.id == 11411
+      move 'ne' until DRRoom.room_objs.include?('rock')
+      move 's'
+    elsif mode.include?('down')
+      move 'n' if Room.current.id == 11416
+      move 'ne' until DRRoom.room_objs.include?('slope')
+      move 'climb slope'
+    else
+      find_room_list(%w[ne ne ne])
+    end
+  end 
+
+  def hara_polo_direction(mode)
+    if mode == /up/i && (Room.current.id != 11411 || Room.current.id != 11412)
+      echo('Going up the maze to the Enclave must be started from 11411 or 11412.')
+      exit
+    elsif mode == /down/i && (Room.current.id != 11416 || Room.current.id != 11412)
+      echo('Going down the maze towards the cliff and boat to Ratha must be started from 11416 or 11412.')
+      exit
+    else
+      move 'n' if mode.include?('hunt')
+    end
+  end 
 
   def enter_brocket(mode)
     if mode !~ /exit/i && Room.current.id != 3462

--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -2409,6 +2409,110 @@ hunting_zones:
   - 12579
   - 12580
   - 12581
+############################# Hara'jaal   ######################################
+# Technically Qi but at the end of the universe so by itself for convenience. 
+################################################################################
+  #https://elanthipedia.play.net/Bawdy_swain                              120-150
+  bawdy_swain_hara:
+  - 15273
+  - 15275
+  - 15276
+  - 15277
+  #https://elanthipedia.play.net/Clouded_arzumos                          230-340
+  clouded_arzumos_hara:
+  - 15317
+  - 15318
+  - 15319
+  - 15320
+  - 15321
+  - 15322
+  #https://elanthipedia.play.net/Corsair                                   ? - ?
+  #in town - interesting mechanics - make sure to read Wiki
+  #guestimated around same size as bawdy_swains - approach with caution
+  corsair_hara:
+  - 15267
+  - 15268
+  - 15269
+  - 15270
+  - 15257
+  #https://elanthipedia.play.net/Heggarangi_boar                           150-200
+  heggarangi_boar_hara:
+  - 15330
+  - 15331
+  - 15332
+  - 11415
+  - 11414
+  #https://elanthipedia.play.net/Lachmate                                   150-250
+  #Strong currents in these rooms - need ~200 athletics for easy movement
+  lachmate_hara:
+  - 15340
+  - 15341
+  - 15342
+  - 15343
+  #https://elanthipedia.play.net/Sleek_hele%27la                            250-360
+  helela_hara:
+  - 15424
+  - 15425
+  - 15427
+  - 15423
+  - 15421  
+  #https://elanthipedia.play.net/Piranha                                    275-420
+  piranha_hara:
+  - 15432
+  - 15433
+  - 15435
+  - 15436
+  - 15437
+  #https://elanthipedia.play.net/Retan_dolomar                               260-410
+  #heavy webs in the area can proc RT between rooms
+  retan_hara:
+  - 11399
+  - 11398
+  - 11397
+  - 11396
+  #https://elanthipedia.play.net/River_boa                                    275-350
+  river_boa_hara:
+  - 15415
+  - 15417
+  - 15416
+  - 15418
+  - 15419
+  - 15414
+  #https://elanthipedia.play.net/Sailfin_lizard                               300-500
+  sailfin_hara:                           
+  - 15442
+  - 15443
+  - 15444
+  - 15445
+  - 15448
+  #https://elanthipedia.play.net/Spider_crab                                   300-450
+  spider_crab_hara:
+  - 15429
+  - 15430
+  - 15439
+  - 15440
+  #https://elanthipedia.play.net/Telga_moradu       (may be lower - old data?) 360-400
+  #need ~120 athletics to enter area
+  telga_moradu_hara:
+  - 15406
+  - 15407
+  - 15408
+  - 15409
+  - 15410
+  #https://elanthipedia.play.net/Scaly_seordmaor                               400-530
+  #swarmy, immune to electricity, have strong magics
+  scaly_seordmaor_hara:
+  - 11405
+  - 11406
+  - 11408
+  - 11409
+  - 11410  
+  #https://elanthipedia.play.net/Poloh%27izh                                    500-700
+  # Poloh'izh are a escort zone.
+  polohizh_hara:
+    base: 11416
+    area: hara_polo
+    enter: hunt
 ################################################################################
 ##########                                                            ##########
 ##########                          FANG COVE                         ##########

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -1166,3 +1166,54 @@ Ain Ghazal:
       name: Ivitha
       id: 13663
   #Needs attunement_rooms
+  
+Hara'jaal:
+  currency: lirum
+  leather_repair:
+    id: 15313
+    name: Ushei
+  metal_repair:
+    id: 15313
+    name: Ushei
+  deposit:
+    id: 15314
+  exchange:
+    id: 15315
+    fee: 0.05
+  gemshop:
+    id: 15293
+    name: Abira
+  tannery:
+    id: 15307
+    name: assistant
+  npc_empath:
+    id: 15283
+  debt_office:
+    id: 15291
+  attunement_rooms:
+    - 15263
+    - 15262
+    - 15261
+    - 15281
+    - 15279
+    - 15271
+    - 15257
+    - 15271
+    - 15279
+    - 15280
+    - 15267
+    - 15266
+    - 15265
+    - 15264
+    - 15263
+  perceive_health_rooms:
+    - 15313
+    - 15283
+    - 15264
+    - 15293
+    - 15294
+    - 15297
+    - 15311
+    - 15272
+    - 15307
+    - 15298

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -54,7 +54,8 @@ class SafeRoom
         'Come along.  Leave room for the others.', 
         "I think you don't really need healing", 
         "Now move along, I can't do anything more for you now", 
-        'Gaktrhn bends down as if to touch you')
+        'Gaktrhn bends down as if to touch you',
+        'After a quick diagnosis')        
       Flags.add('moved', 'grabs you and drags you', 'grabs your arm and drags you .* with')
       Flags.add('idle', 'you have been idle too long')
 


### PR DESCRIPTION
Hara'jaal has good hunting options if you don't mind isolation. 
- added map/go2/town tags
- added bescort handling for polo maze and boat to get there
- added base-town details for hunting-buddy, sell-loot, safe-room, etc
- added all hunting zones