### PR TITLE
Updated locksmithing script for trainer boxes

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -338,16 +338,19 @@ class CrossingTraining
     return if @researching
     wait_for_script_to_complete('burgle',['start']) if @settings.train_with_burgle
     return if DRSkill.getxp('Locksmithing') >= 30
-    walk_to(@training_room) unless @settings.lockpick_room_id
-    walk_to(@settings.lockpick_room_id) if @settings.lockpick_room_id
+    
+    if @settings.lockpick_room_id
+      walk_to(@settings.lockpick_room_id)
+    else
+      walk_to(@training_room)
+    end
+    
     start_time = Time.now
-    wait_for_script_to_complete('pick')
+    wait_for_script_to_complete('locksmithing')
+    
     if Time.now - start_time > 15
       wait_for_script_to_complete('sell-loot')
       walk_to(@training_room)
-    else
-      echo '***UNABLE TO TRAIN LOCKSMITHING, REMOVING IT FROM THE TRAINING LIST***'
-      @settings.crossing_training.delete('Locksmithing')
     end
   end
 

--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -1,0 +1,116 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#locksmithing
+=end
+
+custom_require.call(%w[common common-items drinfomon equipmanager])
+ 
+class Locksmithing
+  include DRC
+  include DRCI
+  def initialize
+    settings = get_settings
+    @equipment_manager = EquipmentManager.new(settings)
+    @daily_trainer ||= settings.have_training_box
+    @box = settings.picking_lockbox || 'training box'
+    @worn_lockbox = settings.picking_worn_lockbox
+    @box_locked = false
+    @liveboxes = settings.pick_live_boxes
+    @consumable_trainers = settings.consumable_lockboxes
+    @consumable_container = settings.burgle_settings['loot_container']
+
+    @equipment_manager.empty_hands
+
+    live_boxes if @liveboxes
+    daily_lockbox if @daily_trainer
+    consumable_lockbox if @consumable_trainers
+  end
+
+  def daily_lockbox
+    if DRSkill.getxp('Locksmithing') < 34
+      if @worn_lockbox
+        case bput("remove my #{@box}", 'You take', 'Remove what', "You aren't wearing that", 'You sling','You remove')
+        when 'Remove what', "You aren't wearing that"
+          echo('Lockbox is not worn but you declared it is in your yaml, exiting')
+          return
+        end
+        bput("close my #{@box}", 'You close', 'That is already',"You can't close that")
+      else
+        case bput("get my #{@box}", 'You get a', 'What were')
+        when 'What were'
+          echo('Daily Trainer not found! Where is it?')
+          return
+        end
+      end
+      
+      pick_box(@box)
+
+      if @worn_lockbox
+        bput("pick my #{@box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm')
+        bput("wear my #{@box}", 'You put', 'You sling','You attach')
+      else
+        @equipment_manager.empty_hands
+      end
+    end
+    bput("open my #{@box}", 'You open',"You can't open that")
+  end
+
+  def consumable_lockbox
+    consumables = @consumable_trainers
+    if DRSkill.getxp('Locksmithing') < 34
+      consumables.each do | consumable |
+        case bput("get my #{consumable} from my #{@consumable_container}", 'You get', 'What were',"But you aren't holding")
+        when /But you aren't holding/
+          echo('#{consumable} may not be specific enough - catching interference from another item')
+        when /You get/
+          @box = consumable
+          pick_box(@box)
+        when /What were/
+          echo("#{consumable} NOT found!  If you're really out of them, trim or rearrange your yaml to avoid spam.")
+        end        
+      end
+    end
+    bput("put my #{@box} in my #{@consumable_container}", 'You put', 'What were') if DRC.right_hand
+  end
+
+  def live_boxes
+    if DRSkill.getxp('Locksmithing') < 34
+      start_time = Time.now
+      wait_for_script_to_complete('pick')
+      if Time.now - start_time > 15
+        wait_for_script_to_complete('sell-loot')
+      end
+    end
+  end
+
+  def pick_box(trainer)
+    while DRSkill.getxp('Locksmithing') < 34 && DRC.right_hand
+      case bput("pick my #{trainer}", 'not making any progress', "why bother", "it opens.", "isn't locked", 'The lock feels warm',/The lock looks weak/, 'Pick what','You need some type of tool to pick',"But you aren't holding")
+      when /You need some type of tool to pick/
+        echo ('YOU HAVE NO LOCKPICKS ON YOUR LOCKPICK RING/BELT.  SORT THAT OUT!')
+        exit 
+      when /it opens|isn't locked/
+        bput("lock my #{trainer}", 'You quickly lock', 'already locked')
+      when /The lock feels warm/
+        echo('Charges Burned!, checking for other settings.')
+        return
+      when /The lock looks weak/
+        case bput("study my #{trainer}", /0 more times/,/risk breaking the lock/,'Study what')
+        when /0 more times/
+          bput('drop my keepsake box', 'You drop')
+          consumable_lockbox 
+        end
+      when /But you aren't holding/
+          echo("Description: '#{trainer}' may not be specific enough or is in a wrong container - something is interfering.")
+          exit  
+      when /why bother/
+        echo ("The #{trainer} is not a valid option but shares a noun - move it out of your burgle bag to avoid hangups.")  
+        bput('stow', 'You')
+        consumable_lockbox 
+      when /Pick what/
+        return 
+      end
+    end
+  end
+end
+
+Locksmithing.new

--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -10,8 +10,8 @@ class Locksmithing
   def initialize
     settings = get_settings
     @equipment_manager = EquipmentManager.new(settings)
-    @daily_trainer ||= settings.have_training_box
-    @box = settings.picking_lockbox || 'training box'
+    @daily_trainer = settings.have_training_box
+    @box = settings.picking_lockbox
     @worn_lockbox = settings.picking_worn_lockbox
     @box_locked = false
     @liveboxes = settings.pick_live_boxes

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -78,3 +78,4 @@ empty_values:
   cornmaze_containers: {}
   maze_junk: {}
   burgle_settings: {}
+  consumable_lockboxes: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -721,10 +721,21 @@ mining_implement: shovel
 mine_use_packet: true
 mine_while_training: false
 
+## Locksmithing Settings ##
+#https://elanthipedia.play.net/Lich_script_repository#locksmithing
+# use ;pick and pick settings first
+pick_live_boxes: true
+# second option to a daily use lockbox trainer like a training box or harvest bag
+have_training_box: false
+picking_lockbox: training box
+picking_worn_lockbox: false
+# consumable boxes will be pulled from your burgle loot_container and should be kept separate from live boxes.
+# list as many as you want - though it will try from the top down.
+consumable_lockboxes:
+# - keepsake box
+# - liquor cabinet
 
-
-
-# Lockpicking settings
+# pick.lic settings for live boxes
 # https://elanthipedia.play.net/Lich_script_repository#pick
 stop_pick_on_mindlock: true
 pick_blind: false


### PR DESCRIPTION
Updated options across the board for locksmith training boxes to be supported by crossing-training without interrupting anyone's current settings.  Can be used independently or in t2 also.

add support for the daily charge boxes and incidental trainers / keepsake boxes from burgle.  I opted to keep live boxes handled by pick.lic specifically because it's kind of a beast and needs updating but folks really want to use the trainer boxes now since pet boxes are dead.  Settings in new locksmithing.lic will send args to pick.lic as needed.

Handles in order:
- Live boxes based on existing ;pick settings - selected first to clear inventory weight
- Permanent trainer boxes - unlimited or daily charges - selected second to use up available charges before using up consumables.
- Consumable trainer boxes such as burgled keepsake boxes, incidental items