### PR TITLE
Update clean_brazier for public room

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -157,7 +157,7 @@ class Enchant
       items = items.split(' and ')
       items.each do |item|
         item = item.split.last
-        get_item(item)
+        bput("get #{item} from brazier",'You get')
         stow_crafting_item(item, @bag, @belt)
       end
     end


### PR DESCRIPTION
get_item method uses "get my item" but a public brazier is not in "my" possession.  Updated to bput.