### PR TITLE
First pass

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1032,7 +1032,7 @@ class MoonWatch
   private
 
   def update_moon(body_name, data)
-    echo("updating #{moon} with #{data}") if @debug
+    echo("updating #{body_name} with #{data}") if @debug
     uri = URI.parse("#{@firebase_url}/moon_data_v2/#{body_name}.json")
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true

--- a/dependency.lic
+++ b/dependency.lic
@@ -1000,7 +1000,7 @@ class MoonWatch
   def load_moon_data
     @last_connect = Time.now
 
-    uri = URI.parse("#{@firebase_url}/moon_data.json")
+    uri = URI.parse("#{@firebase_url}/moon_data_v2.json")
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
@@ -1031,9 +1031,9 @@ class MoonWatch
 
   private
 
-  def update_moon(moon, data)
+  def update_moon(body_name, data)
     echo("updating #{moon} with #{data}") if @debug
-    uri = URI.parse("#{@firebase_url}/moon_data/#{moon}.json")
+    uri = URI.parse("#{@firebase_url}/moon_data_v2/#{body_name}.json")
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -96,7 +96,7 @@ def update_sun_info(latest_data)
   sun_data = latest_data['s']
   return if sun_data['s'].nil? || sun_data['r'].nil?
   set_time = Time.at(sun_data['s']).localtime
-  rise_time = Time.parse(sun_data['r']).localtime
+  rise_time = Time.at(sun_data['r']).localtime
   if set_time > rise_time
     UserVars.sun['day'] = false
     UserVars.sun['night'] = true

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -22,6 +22,9 @@ $debug_mode_mm = UserVars.moon_debug || args.debug
 
 enable_moon_connection
 
+RISE = 1
+SET = 0
+
 if args.alias
   UpstreamHook.run("<c>#{$clean_lich_char}alias add --global moon = #{$clean_lich_char}" + 'eq respond("#{UserVars.moons[\'katamba\'][\'pretty\']} : #{UserVars.moons[\'yavash\'][\'pretty\']} : #{UserVars.moons[\'xibar\'][\'pretty\']}")')
 end
@@ -75,8 +78,8 @@ end
 def moon_change(moon, is_up)
   echo("moon_change #{moon}:#{is_up}") if $debug_mode_mm
   snapshot = Time.now
-  snapshot = (snapshot - snapshot.sec).utc.to_s
-  update_moon_data(moon, 'time' => snapshot, 'event' => is_up ? 'rise' : 'set')
+  snapshot = (snapshot - snapshot.sec)
+  update_moon_data(moon[0], 't' => snapshot.to_i, 'e' => is_up ? RISE : SET)
 end
 
 def minutes_apart(first, second)
@@ -90,10 +93,10 @@ end
 
 def update_sun_info(latest_data)
   return if latest_data.nil? || latest_data.empty?
-  sun_data = latest_data['sun']
-  return if sun_data['set'].nil? || sun_data['rise'].nil?
-  set_time = Time.parse(sun_data['set']).localtime
-  rise_time = Time.parse(sun_data['rise']).localtime
+  sun_data = latest_data['s']
+  return if sun_data['s'].nil? || sun_data['r'].nil?
+  set_time = Time.at(sun_data['s']).localtime
+  rise_time = Time.parse(sun_data['r']).localtime
   if set_time > rise_time
     UserVars.sun['day'] = false
     UserVars.sun['night'] = true
@@ -108,10 +111,10 @@ end
 def update_moon_info(latest_data)
   return if latest_data.nil? || latest_data.empty?
   %w[katamba yavash xibar].each do |moon|
-    data = latest_data[moon]
-    event = data['event']
+    data = latest_data[moon[0]]
+    event = data['e'] == RISE ? 'rise' : 'set'
     coming_event = (%w[rise set] - [event]).first
-    snapshot = Time.parse(data['time']).localtime
+    snapshot = Time.at(data['t']).localtime
 
     UserVars.moons[moon].delete(event)
     UserVars.moons[moon][coming_event] = snapshot + Settings[coming_event][moon]
@@ -138,13 +141,13 @@ loop do
     moon_change(Regexp.last_match(1).downcase, true)
   when /heralding another fine day|rises to create the new day|as the sun rises, hidden|as the sun rises behind it|faintest hint of the rising sun|The rising sun slowly/
     old = get_all_moon_data['sun']
-    if old['set']
-      update_moon_data('sun', 'set' => old['set'], 'rise' => Time.now.utc.to_s)
+    if old['s']
+      update_moon_data('s', 's' => old['s'], 'r' => Time.now.to_i)
     end
   when /The sun sinks below the horizon|night slowly drapes its starry banner|sun slowly sinks behind the scattered clouds and vanishes|grey light fades into a heavy mantle of black/
     old = get_all_moon_data['sun']
-    if old['rise']
-      update_moon_data('sun', 'rise' => old['rise'], 'set' => Time.now.utc.to_s)
+    if old['r']
+      update_moon_data('s', 'r' => old['r'], 's' => Time.now.to_i)
     end
   end
 


### PR DESCRIPTION
Needs tested. To cut-over have someone run a moonbot with these changes for long enough to update all the timers then you can release this. The failure state will be people not updating to latest will get stale moon data once the last old style moonbot is restarted. You can force people to migrate by deleting the old style moon data in the database if you wish. This should cut our moonwatch bandwidth usage in about half.