### PR TITLE
Add fail_pick_counter

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -221,7 +221,7 @@ class LockPicker
     waitrt?
     echo "attempt_open(#{box})" if UserVars.lockpick_debug
     bput("get my #{box} from my #{@settings.picking_box_source}", 'You get a .* from inside ')
-
+    @pick_fail_counter = 0
     unless disarm?(box)
       if @settings.picking_box_storage && right_hand
         case bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in ', "You just can\'t get", "There isn\'t any more")
@@ -354,6 +354,24 @@ class LockPicker
     end
     waitrt?
     case bput("pick my #{box} #{speed}", 'You discover another lock protecting', 'You are unable to make any progress towards opening the lock', 'Roundtime', /Find a more appropriate tool and try again/)
+    when 'You are unable to make any progress towards opening the lock'
+      @pick_fail_counter += 1
+      if @pick_fail_counter > 5
+        echo("After #{@pick_fail_counter} tries, the conclusion this box is too difficult.")
+        if @settings.picking_box_storage && right_hand
+          case bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in ', "You just can\'t get", "There isn\'t any more")
+          when "You just can\'t get", "There isn\'t any more"
+            dispose_trash(box)
+          end
+        elsif right_hand
+          dispose_trash(box)
+        end
+        return
+      elsif @pick_fail_counter > 3
+        return pick_speed(box, 'careful')
+      else
+        return pick_speed(box, speed)
+      end     
     when 'Roundtime'
       waitrt?
       return false


### PR DESCRIPTION
Third pick fail will force careful speed and a 5th fail will deem it too hard to open then dispose according to same settings for too hard disarms.  With pet boxes dead, failed attempts are an utter waste of time.  Just need to confirm the counter increments work the way I expect?