### PR TITLE
base-hunting - removed adanf safe room from adanf zone

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1039,7 +1039,6 @@ hunting_zones:
   # https://elanthipedia.play.net/Adan%27f_blood_warrior                 250-325
   # Spawn is hit or miss
   adanf_warriors_and_mages:
-  - 9459
   - 15354
   - 9514
   - 9513


### PR DESCRIPTION
Removed the safe room from the adan'f warrior/mage hunting area

Closes issue #4275 