### PR TITLE
equipmanager - fix for when tie to action with severe wounds

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -217,7 +217,7 @@ class EquipmentManager
         true
       elsif info = items.find { |item| item.short_regex =~ held_item }
         if info.tie_to
-          stow_helper("tie my #{info.short_name} to #{info.tie_to}", info.short_name, 'You attach', 'you tie', 'You are a little too busy')
+          stow_helper("tie my #{info.short_name} to #{info.tie_to}", info.short_name, 'You attach', 'you tie', 'You are a little too busy', 'Your wounds hinder your ability to do that')
         elsif info.wield
           stow_helper("sheath my #{info.short_name}", info.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'You secure your', 'You slip', 'You hang', 'You .* strap')
         elsif info.container
@@ -363,7 +363,7 @@ class EquipmentManager
     elsif weapon.worn
       stow_helper("wear my #{weapon.short_name}", weapon.short_name, 'You sling', 'You attach', 'You .* unload', 'You slide', 'You place', 'close the fan', 'You hang', 'You spin', 'You strap', 'You put', 'You carefully loop', "You don't seem to be able to move")
     elsif !weapon.tie_to.nil?
-      stow_helper("tie my #{weapon.short_name} to #{weapon.tie_to}", weapon.short_name, 'You attach', 'close the fan', 'you tie', 'You are a little too busy', "You don't seem to be able to move")
+      stow_helper("tie my #{weapon.short_name} to #{weapon.tie_to}", weapon.short_name, 'You attach', 'close the fan', 'you tie', 'You are a little too busy', "You don't seem to be able to move", 'Your wounds hinder your ability to do that')
     elsif weapon.transforms_to
       stow_helper("#{weapon.transform_verb} my #{weapon.short_name}", weapon.short_name, weapon.transform_text)
       stow_weapon(weapon.transforms_to)
@@ -389,6 +389,8 @@ class EquipmentManager
     when /is too small to hold that/
       fput("swap my #{weapon_name}")
       stow_helper(action, weapon_name, accept_strings)
+    when /Your wounds hinder your ability to do that/
+      stow_helper("stow my #{weapon_name}", weapon_name, 'You put', 'You should unload', 'You easily strap', 'You secure your')
     end
   end
 end


### PR DESCRIPTION
For example, when this gets called by bescort for the ice road after combat-trainer bails because you blew off a hand with sorcery, it can't tie the weapon to the tie item because of wounds and then it can't pick up your skates because your other hand is missing.

This fixes that by stowing the weapon when tying fails.