### PR TITLE
Add concentration check and control over mana/conc

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -353,8 +353,8 @@ module DRCA
     infuse_om(!settings.osrel_no_harness, settings.osrel_amount)
     spells.each do |name, data|
       next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
-      while mana < 40
-        echo('Waiting on mana...')
+      while (mana < settings.waggle_spells_mana_threshold || DRStats.concentration < settings.waggle_spells_concentration_threshold)
+        echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
         pause 15
       end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -222,9 +222,9 @@ offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50
 buff_spell_mana_threshold: 40
 # don't cast ;buff waggles without this much mana or concentration
-waggle_spells_concentration_threshold: 80
-# concentration can be 0 to remove the conc check but it cannot be blank.  Must be an integer.
 waggle_spells_mana_threshold: 40
+# concentration can be 0 to remove the conc check but it cannot be blank.  Must be an integer.
+waggle_spells_concentration_threshold: 80
 # what weapon and weapon skill to use with ambush stun
 stun_weapon:
 stun_weapon_skill:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1316,6 +1316,7 @@ sanowret_no_use_scripts:
 - enchant
 - outdoorsmanship
 - combat-trainer
+- buff
 
 almanac_no_use_scripts:
 - sew

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -223,6 +223,7 @@ training_spell_mana_threshold: 50
 buff_spell_mana_threshold: 40
 # don't cast ;buff waggles without this much mana or concentration
 waggle_spells_concentration_threshold: 80
+# concentration can be 0 to remove the conc check but it cannot be blank.  Must be an integer.
 waggle_spells_mana_threshold: 40
 # what weapon and weapon skill to use with ambush stun
 stun_weapon:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -221,6 +221,9 @@ combat_spell_timer: 45
 offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50
 buff_spell_mana_threshold: 40
+# don't cast ;buff waggles without this much mana or concentration
+waggle_spells_concentration_threshold: 80
+waggle_spells_mana_threshold: 40
 # what weapon and weapon skill to use with ambush stun
 stun_weapon:
 stun_weapon_skill:


### PR DESCRIPTION
Higher stat characters don't run into it often but young toons really suffer a lot of backfires during ;buff if their concentration is sapped by a sanowret crystal, back to back rituals, or things like cleric orb building.  Also added ;buff to the sano-no-run list to avoid looping.  
