### PR TITLE
Swap ls alias with a more natural response

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -26,8 +26,9 @@
   ['lfr', "#{$clean_lich_char}e echo Room[\\?].inspect"],
 
   # echos every item in base-stealing for your current room so you know what missing stuff to add
-  ['ls', "#{$clean_lich_char}en echo get_data('stealing')['stealing_options'].select { |item| item['room'] == Room.current.id}.map { |item| item['item'] }"],
-
+  ['liststeal', "#{$clean_lich_char}e echo get_data('stealing')['stealing_options'].select { |item| item['room'] == Room.current.id}.map { |item| item['item'] }"],
+  
+  ['ls', "look"],
   # these work as a pair, for recording room numbers (like setting up a hunting area); run cb, then rec in each room you want to record
   ['cb', "#{$clean_lich_char}e $temp = []"],
   ['rec', "#{$clean_lich_char}e echo $temp << Room.current.id"],


### PR DESCRIPTION
`;en` isn't used in the other non-trusted aliases. I think we're expecting you to be running ruby greater than 2.2 here.

* use `;e` in the old `ls` command instead of `;en`. It used to try to run the `;enchant` script if you have ruby greater than 2.2
* swap old `ls` command with `look`. I don't think shop stealing is used much anymore. I would wager there are folks like me typing `ls` out of habit to look more often than shop stealing nowadays.

Old alias
```
>ls                                                                                                                                             
--- Lich: enchant active.                                                                                                                       
[enchant: ***INVALID ARGUMENTS DON'T MATCH ANY PATTERN***]                                                                                      
Provided Arguments: 'echo get_data('stealing')['stealing_options'].select { |item| item['room'] == Room.current.id}.map { |item| item['item'] }'
                                                                                                                                                
  ;enchant <chapter> <recipe name> <noun>                                                                                                       
   chapter      Chapter containing the item.                                                                                                    
   recipe name  Name of the recipe, wrap in double quotes if this is multiple words.                                                            
   noun                                                                                                                                         
--- Lich: enchant has exited.                                                                                                                   
>'Bummer          
You say, "Bummer."
```
New alias
```
>ls                                                 
[Cormyn's House of Heirlooms]                       
The walls here of an odd white adobe, smeared with s
  obviously Cormyn's idea of elegance.  The merchand
  the stout gold chain about his neck, it dawns on y
  counter and a lunat door.                         
Obvious exits: out.                                 
Room Number: 8261                                   
>'Nice!                                             
You exclaim, "Nice!"                                
```