### PR TITLE
Update stow_hands to empty_hands

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -206,7 +206,11 @@ class Burgle
 
     #entry method must be in your right hand, or have a worn lockpick ring
     #the item in your takes priority, so store any items in your hands before beginning
-    stow_hands
+    EquipmentManager.new.empty_hands
+    if DRC.right_hand || DRC.left_hand
+      echo "Exited due to item that could not be stowed.  Please check your hands and gear settings then try again."
+      exit
+    end
 
     if !walk_to(@burgle_room)
       message("Unable to get to your burgle room.  Exiting to prevent errors.")


### PR DESCRIPTION
Needs to properly handle known gear settings .  Current version incorrectly drops items if they weren't stowed before hand.  Added exit on failure to empty hands.