### PR TITLE
burgle.lic - added equipmanager to custom require

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -6,7 +6,7 @@ Documentation: https://elanthipedia.play.net/Lich_script_repository#burgle
 
 =end
 
-custom_require.call(%w[common common-travel common-items])
+custom_require.call(%w[common common-travel common-items equipmanager])
 
 class Burgle
   include DRC


### PR DESCRIPTION
To fix issue where it's not running and empty_hands is called.