### PR TITLE
Move super easy pick identify from blind to quick

### DIFF
--- a/data/base-picking.yaml
+++ b/data/base-picking.yaml
@@ -13,11 +13,12 @@ picking:
   - should not take long with your skills
   - You think this lock is precisely at your skill level
   - with only minor troubles
-
-  pick_blind:
   - trivially constructed gadget which you can take down any time
   - An aged grandmother could
-  - you could do it blindfolded
+  - you could do it blindfolded  
+  
+
+  pick_blind:
   - You really don't have any chance
   - Prayer would be a good start for any
   - You could just jump off a cliff and save


### PR DESCRIPTION
No real value to pick blind by default (they can still override if they really want blind) and several people asked for this change.  Best training and best farming is accomplished by fastest success.