### PR TITLE
Add "fill pouch with box"

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -270,6 +270,7 @@ class LockPicker
     if bput("open my #{box}", /You open/, /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
       return
     end
+    bput("fill my #{@settings.gem_pouch_adjective} pouch with my #{box}", 'You open your', 'What were you referring to', /any gems/, /too full to fit/)
     raw_contents = bput("look in my #{box}", /^In the .* you see .*\./, 'There is nothing in there')
     return if raw_contents == 'There is nothing in there'
 


### PR DESCRIPTION
Added "fill pouch with box" line immediately after box opens and before it LOOKs to read the contents.  Reduces the number of actions needed and dramatically lowers the chance of dropping a gem that didn't parse correctly.