### PR TITLE
Add gem pouch adjective and full container handling

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -510,12 +510,15 @@ class LootProcess
     end
     bput("remove my #{@gem_pouch_adjective} pouch", 'You remove')
     if @full_pouch_container
-      bput("put my #{@gem_pouch_adjective} pouch in my #{@full_pouch_container}", 'You put')
+      case bput("put my #{@gem_pouch_adjective} pouch in my #{@full_pouch_container}", 'You put','too heavy to go in there')
+      when 'too heavy to go in there'
+        bput("stow my #{@gem_pouch_adjective} pouch", 'You put')
+      end
     else
       bput("stow my #{@gem_pouch_adjective} pouch", 'You put')
     end
     bput("get #{@gem_pouch_adjective} pouch from my #{@spare_gem_pouch_container}", 'You get a')
-    bput('wear my pouch', 'You attach')
+    bput("wear my #{@settings.gem_pouch_adjective} pouch", 'You attach')
     bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
     if @tie_pouch
       bput('tie my pouch', 'You tie')


### PR DESCRIPTION
Add gem pouch adjective and a default STOW for full gem pouches to avoid looping or dropping full pouches.