### PR TITLE
add user level control for fill pouch

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -270,7 +270,7 @@ class LockPicker
     if bput("open my #{box}", /You open/, /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
       return
     end
-    bput("fill my #{@settings.gem_pouch_adjective} pouch with my #{box}", 'You open your', 'What were you referring to', /any gems/, /too full to fit/)
+    bput("fill my #{@settings.gem_pouch_adjective} pouch with my #{box}", 'You open your', 'What were you referring to', /any gems/, /too full to fit/)  if (@settings.fill_pouch_with_box || @settings.loot_specials.empty?)
     raw_contents = bput("look in my #{box}", /^In the .* you see .*\./, 'There is nothing in there')
     return if raw_contents == 'There is nothing in there'
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -764,6 +764,8 @@ lockpick_buffs:
 lockpick_room_id:
 lockpick_ignore_difficulty: false
 lockpick_force_disarm_careful: false
+#leave empty to use fill pouch only when no loot_specials are present or true = always and false = never
+fill_pouch_with_box: 
 
 # Bankbot Settings
 bankbot_name:


### PR DESCRIPTION
true = always use fill no matter what
false = never ever
blank = depends on if loot_special is empty - most user friendly