### PR TITLE
Added fix for simu "missing" a game command.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2818,11 +2818,13 @@ class AttackProcess
       end
     else
       if game_state.dual_load?
+        fput('load arrows')
         pause 0.5 until (load_return = bput('load arrows', 'You reach into', 'already loaded', 'in your hand', 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')) != ''
         if ['but are unable to draw upon its majesty', 'without steadier hands', 'Such a feat would be impossible without the winds to guide'].include?(load_return)
           pause 0.5 until bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand') != ''
         end
       else
+        fput('load')
         pause 0.5 until bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand') != ''
       end
 
@@ -2862,8 +2864,8 @@ class AttackProcess
       game_state.loaded = true
       check_firing_time
     when 'Your repeating crossbow', 'Your assassin\'s crossbow', 'Your riot crossbow'
-      case bput('push my cross', 'A rapid series of clicks', 'You attempt to ready your repeating crossbow', 'You attempt to ready your assassin\'s crossbow', 'You attempt to ready your riot crossbow')
-      when 'A rapid series of clicks'
+      case bput('push my cross', 'A rapid series of clicks', 'You attempt to ready your repeating crossbow', 'You attempt to ready your assassin\'s crossbow', 'You attempt to ready your riot crossbow','You realize readying')
+      when 'A rapid series of clicks','You realize readying'
         aim(game_state)
       when 'You attempt to ready your repeating crossbow', 'You attempt to ready your assassin\'s crossbow', 'You attempt to ready your riot crossbow', "isn't loaded"
         game_state.loaded = false


### PR DESCRIPTION
After much testing and discussion, the error seems to be in the XML.  Several people have been using this fix for months with no hangups and a near-elimination of the issue.  In cases where the weapon does load correctly the first time, the "already loaded" match passes smoothly to the next action.  

Added match for rare repeater already loaded message.