### PR TITLE
Update commune_eluned for new forage? timeout

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -459,22 +459,21 @@ class TheurgyActions
 
   def commune_eluned
     safe_walk_to @data['dirt_foraging']['id']
-    forage? 'dirt'
-
-    get_from_container(@water_holder)
-    match = bput('commune eluned',
-                 'completed this commune too recently',
-                 'You struggle to commune',
-                 'you have attempted a commune too recently in the past',
-                 'You grind some dirt in your fist')
-    put_in_container(@water_holder)
-    if [left_hand, right_hand].include?('dirt')
-      bput('drop dirt', 'You drop some',
-           'But you aren\'t holding',
-           'What were you referring')
+    if forage?('dirt', 5
+      get_from_container(@water_holder)
+      match = bput('commune eluned',
+                   'completed this commune too recently',
+                   'You struggle to commune',
+                   'you have attempted a commune too recently in the past',
+                   'You grind some dirt in your fist')
+      put_in_container(@water_holder)
+      if [left_hand, right_hand].include?('dirt')
+        bput('drop dirt', 'You drop some',
+             'But you aren\'t holding',
+             'What were you referring')
+      end
+      match == 'You grind some dirt in your fist'
     end
-
-    match == 'You grind some dirt in your fist'
   end
 
   def commune_tamsine

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -459,7 +459,7 @@ class TheurgyActions
 
   def commune_eluned
     safe_walk_to @data['dirt_foraging']['id']
-    if forage?('dirt', 5
+    if forage?('dirt', 5)
       get_from_container(@water_holder)
       match = bput('commune eluned',
                    'completed this commune too recently',

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -472,7 +472,9 @@ class TheurgyActions
              'But you aren\'t holding',
              'What were you referring')
       end
-      match == 'You grind some dirt in your fist'
+      return match == 'You grind some dirt in your fist'
+    else
+      return false
     end
   end
 


### PR DESCRIPTION
This fix ensures that forage will timeout instead of attempting to forage indefinitely.

This PR depends on https://github.com/rpherbig/dr-scripts/pull/4361

This is an incomplete fix but it's better than what is in there today, so it's ready to merge.

It looks like the script tries to commune eluned over and over until it completes with the wrong dirt. Instead, it should warn the player that there is no dirt at their foraging spot and drop eluned from the commune list for the duration of the script.