### PR TITLE
Fix crossing dirt foraging room.

### DIFF
--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -116,7 +116,7 @@ Crossing:
   altar:
     id: 11690
   dirt_foraging:
-    id: 741
+    id: 850
   limb_foraging:
     id: 1030
   bath:


### PR DESCRIPTION
Old room no longer has dirt at 23 outdoorsmanship skill, probably at all.