### PR TITLE
Edit Necro ritual cycle to always check mat supply

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -630,7 +630,7 @@ class LootProcess
 
       ritual = if @redeemed
                   'dissect'
-               elsif @current_harvest_count <= @necro_count
+               elsif @current_harvest_count < @necro_count
                   'harvest'
                elsif @cycle_rituals
                  determine_next_ritual

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -581,7 +581,9 @@ class LootProcess
   def determine_next_ritual
     return unless @cycle_rituals
 
-    next_ritual = if DRSkill.getxp('Skinning') > 31 && DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Thanatology') > 31
+    next_ritual = if @current_harvest_count <= @necro_count
+                    'harvest'
+                  elsif DRSkill.getxp('Skinning') > 31 && DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Thanatology') > 31
                     if @dissect_and_butcher
                       'butcher'
                     else

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -371,6 +371,12 @@ class LootProcess
 
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
+    
+    @redeemed = settings.necro_redeemed
+    echo("  @redeemed: #{@redeemed}") if $debug_mode_ct
+
+    @force_rituals = settings.necro_force_rituals
+    echo("  @force_rituals: #{@force_rituals}") if $debug_mode_ct
 
     @last_ritual = nil
     echo("  @last_ritual: #{@last_ritual}") if $debug_mode_ct
@@ -570,6 +576,7 @@ class LootProcess
     return false unless DRStats.necromancer?
     return false unless @ritual_type
     return false if game_state.necro_casting?
+    return true if @force_rituals
     return true if @ritual_type == 'cycle'
     return true if @ritual_type == 'butcher' && DRSkill.getxp('Thanatology') < 32
     return true if @ritual_type == 'dissect' && DRSkill.getxp('First Aid') < 32
@@ -622,7 +629,12 @@ class LootProcess
         do_necro_ritual(mob_noun, 'arise', game_state)
         return false
       end
-      ritual = if @cycle_rituals
+
+      ritual = if @redeemed
+                  'dissect'
+               elsif @current_harvest_count <= @necro_count
+                  'harvest'
+               elsif @cycle_rituals
                  determine_next_ritual
                elsif @ritual_type.eql?('dissect') && @dissect_and_butcher
                  'butcher'
@@ -705,7 +717,7 @@ class LootProcess
       return
     end
 
-    quality = fput('glance left')
+    quality = fput('glance')
     if quality['great'] || quality['excellent'] || quality['perfect'] || quality['flawless']
       echo 'Harvested high quality material.' if $debug_mode_ct
     else

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -588,9 +588,7 @@ class LootProcess
   def determine_next_ritual
     return unless @cycle_rituals
 
-    next_ritual = if @current_harvest_count <= @necro_count
-                    'harvest'
-                  elsif DRSkill.getxp('Skinning') > 31 && DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Thanatology') > 31
+    next_ritual = if DRSkill.getxp('Skinning') > 31 && DRSkill.getxp('First Aid') > 31 && DRSkill.getxp('Thanatology') > 31
                     if @dissect_and_butcher
                       'butcher'
                     else

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -132,6 +132,10 @@ dance_actions_stealth:
 thanatology:
 # attempts to necromancer dissect after butchering a mob.  This often works.
 dissect_and_butcher: false
+# redeemed tag only allows dissect ritual
+necro_redeemed: false
+# force rituals regardless of mindstates
+necro_force_rituals: false
 # By default necros skip safe-room and skip NPC healing. true forces a visit, which may be useful for the less-perverse
 necro_force_safe_room: false
 # vitality threshold for performing SV as defined in necromancer_healing below.


### PR DESCRIPTION
It can be fatal to be out of materials, this adjusts ritual_type: cycle (most common and best for training) to always check materials before moving on to training considerations.