### PR TITLE
Better default for zero harvest_count

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -393,7 +393,7 @@ class LootProcess
     @current_harvest_count = rummage('C material', @necro_container).size if DRStats.necromancer?
     echo("  @current_harvest_count: #{@current_harvest_count}") if $debug_mode_ct
 
-    @necro_count = thanatology['harvest_count']
+    @necro_count = thanatology['harvest_count'] || 0
     echo("  @necro_count: #{@necro_count}") if $debug_mode_ct
 
     @make_zombie = settings.zombie['make']


### PR DESCRIPTION
Finding folks have empty thanatology: sections so it's still causing the nil vs zero error.  Adding the zero directly to ;combat.