### PR TITLE
[script] [arenawatch] Ignore NPCs outside of the Duskruin Arena

### DIFF
--- a/arenawatch.lic
+++ b/arenawatch.lic
@@ -1,7 +1,7 @@
 custom_require.call(%w[common common-arcana common-healing common-items common-summoning common-travel drinfomon equipmanager events spellmonitor])
 
 def mainloop
-  ignore_npcs = %w[Usdiwi Servant]
+  ignore_npcs = %w[Usdiwi Servant, Traumatologist Usdiwi]
   npcs = DRRoom.npcs - ignore_npcs
   loop do
     watch_complete = false

--- a/arenawatch.lic
+++ b/arenawatch.lic
@@ -10,7 +10,7 @@ def mainloop
       while !DRRoom.npcs.empty? && watch_complete == false
         target = DRRoom.npcs.first
         waitrt?
-        case bput("watch #{target}", 'you could try to pedal', 'you could try to bob', 'you could try to duck', 'you could try to jump', 'you could try to lean', 'you could try to cower', '.*')
+        case bput("watch #{target}", 'you could try to pedal', 'you could try to bob', 'you could try to duck', 'you could try to jump', 'you could try to lean', 'you could try to cower', 'Watch out for whom', 'may not be the best use of your time', '.*')
         when 'you could try to pedal'
           bput('pedal', '.*')
           watch_complete = true
@@ -28,6 +28,10 @@ def mainloop
           watch_complete = true
         when 'you could try to cower'
           bput('cower', '.*')
+          watch_complete = true
+        when 'Watch out for whom'
+          watch_complete = true
+        when 'may not be the best use of your time'
           watch_complete = true
         end
       end


### PR DESCRIPTION
Adds NPCs to ignore that are in Duskruin zone that otherwise cause this script to loop indefinitely and spam the game window.

---

When exit the arena you are at `[Duskruin, Victor Lounge]`. In several instances for me, an Empath had a construct in the room. Trying to watch an empath's construct gives "Watch out for whom?" which repeatedly spammed my game window.

When at the entrance to the arena, `[Duskruin, Antechamber]`, Traumatologist Usdiwi is standing there. Trying to watch Traumatologist Usdiwi gives "Disturbing Usdiwi may not be the best use of your time." which repeatedly spammed my game window.

This PR sets `watch_complete = true` for these NPCs you may encounter in Duskruin near the Arena.