### PR TITLE
[script] [dusk-labyrinth] Search for any pet, move settings to YAML

### DIFF
--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -7,7 +7,8 @@ custom_require.call %w[common common-items events]
 class DuskLab
   include DRC
   include DRCI
-  def initialize(settings)
+  def initialize
+    @settings = get_settings
     @labyrinth_data = settings.duskruin['labyrinth']
     loot_container = @labyrinth_data['loot_container']
     pet_noun = @labyrinth_data['pet_noun']

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -9,6 +9,7 @@ class DuskLab
   include DRCI
   def initialize(settings)
     @labyrinth_data = settings.duskruin['labyrinth']
+    loot_container = @labyrinth_data['loot_container']
     pet_noun = @labyrinth_data['pet_noun']
     redeem_scrip = @labyrinth_data['redeem_scrip']
     Flags.add('five-minute-warning', 'You only have about 5 minutes left in the labyrinth!')
@@ -30,7 +31,7 @@ class DuskLab
       'down' => 'up'
     }
     stow_hands
-    main(@labyrinth_data) until done?
+    main(loot_container) until done?
     redeem if redeem_scrip?
   end
 
@@ -40,7 +41,7 @@ class DuskLab
     end
   end
 
-  def main(args)
+  def main(loot_container)
     # search
     @pause_timer = Time.now
     pause 1 until Flags['no-pet'] || Flags['pet'] || Flags['caught']
@@ -55,7 +56,7 @@ class DuskLab
     elsif Flags['five-minute-warning'] || Flags['caught']
       search
     end
-    stow_loot(args['loot_container'])
+    stow_loot(loot_container)
     wander unless done?
   end
 
@@ -73,10 +74,10 @@ class DuskLab
     @prev_dir = next_dir
   end
 
-  def stow_loot(loot_bag)
-    if loot_bag
-      fput("put my #{DRC.left_hand} in my #{loot_bag}") if DRC.left_hand
-      fput("put my #{DRC.right_hand} in my #{loot_bag}") if DRC.right_hand
+  def stow_loot(loot_container)
+    if loot_container
+      fput("put my #{DRC.left_hand} in my #{loot_container}") if DRC.left_hand
+      fput("put my #{DRC.right_hand} in my #{loot_container}") if DRC.right_hand
     else
       stow_hands
     end

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -15,7 +15,7 @@ class DuskLab
     Flags.add('done', 'A surly Dwarf stomps in and glowers at you in the dim gloom')
     Flags.add('no-pet', "A small #{pet_noun} scurries #{Regexp.new('(?<pet_dir>\w+)')}!")
     Flags.add('pet', "You notice a small #{pet_noun} scurrying around the area")
-    Flags.add('caught', "You pick them both up, claiming your new #{pet_noun}")
+    Flags.add('caught', 'You pick them both up, claiming your new pet')
     @prev_dir = nil
     @dir_to_prev_dir = {
       'northeast' => 'southwest',

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -33,7 +33,7 @@ class DuskLab
     }
     stow_hands
     main(loot_container) until done?
-    redeem if redeem_scrip?
+    redeem if redeem_scrip
   end
 
   def redeem

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -7,17 +7,15 @@ custom_require.call %w[common common-items events]
 class DuskLab
   include DRC
   include DRCI
-  def initialize
-    arg_definitions = [
-      [{ name: 'loot_bag', display: 'container noun', regex: /\w+/i, description: 'Bag for your loot!' },
-       { name: 'redeem_scrip', display: 'redeem', regex: /^redeem/i, optional: true, description: 'Redeem scrip when finished?' }]
-    ]
-    args = parse_args(arg_definitions)
+  def initialize(settings)
+    @labyrinth_data = settings.duskruin['labyrinth']
+    pet_noun = @labyrinth_data['pet_noun']
+    redeem_scrip = @labyrinth_data['redeem_scrip']
     Flags.add('five-minute-warning', 'You only have about 5 minutes left in the labyrinth!')
     Flags.add('done', 'A surly Dwarf stomps in and glowers at you in the dim gloom')
-    Flags.add('no-monkey', 'A small monkey scurries (?<rat_dir>\w+)!')
-    Flags.add('monkey', 'You notice a small monkey scurrying around the area')
-    Flags.add('caught', 'You pick them both up, claiming your new pet')
+    Flags.add('no-pet', "A small #{pet_noun} scurries #{Regexp.new('(?<pet_dir>\w+)')}!")
+    Flags.add('pet', "You notice a small #{pet_noun} scurrying around the area")
+    Flags.add('caught', "You pick them both up, claiming your new #{pet_noun}")
     @prev_dir = nil
     @dir_to_prev_dir = {
       'northeast' => 'southwest',
@@ -32,8 +30,8 @@ class DuskLab
       'down' => 'up'
     }
     stow_hands
-    main(args) until done?
-    redeem if args.redeem_scrip
+    main(@labyrinth_data) until done?
+    redeem if redeem_scrip?
   end
 
   def redeem
@@ -45,19 +43,19 @@ class DuskLab
   def main(args)
     # search
     @pause_timer = Time.now
-    pause 1 until Flags['no-monkey'] || Flags['monkey'] || Flags['caught']
-    if Flags['no-monkey'] && Flags['five-minute-warning']
+    pause 1 until Flags['no-pet'] || Flags['pet'] || Flags['caught']
+    if Flags['no-pet'] && Flags['five-minute-warning']
       search
-      Flags.reset('no-monkey')
-    elsif Flags['no-monkey']
-      Flags.reset('no-monkey')
-    elsif Flags['monkey']
+      Flags.reset('no-pet')
+    elsif Flags['no-pet']
+      Flags.reset('no-pet')
+    elsif Flags['pet']
       search
-      Flags.reset('monkey')
+      Flags.reset('pet')
     elsif Flags['five-minute-warning'] || Flags['caught']
       search
     end
-    stow_loot(args.loot_bag)
+    stow_loot(args['loot_container'])
     wander unless done?
   end
 
@@ -77,8 +75,8 @@ class DuskLab
 
   def stow_loot(loot_bag)
     if loot_bag
-      fput("stow left in my #{loot_bag}") if DRC.left_hand
-      fput("stow right in my #{loot_bag}") if DRC.right_hand
+      fput("put my #{DRC.left_hand} in my #{loot_bag}") if DRC.left_hand
+      fput("put my #{DRC.right_hand} in my #{loot_bag}") if DRC.right_hand
     else
       stow_hands
     end
@@ -98,9 +96,9 @@ end
 before_dying do
   Flags.delete('five-minute-warning')
   Flags.delete('done')
-  Flags.delete('no-monkey')
-  Flags.delete('monkey')
+  Flags.delete('no-pet')
+  Flags.delete('pet')
   Flags.delete('caught')
 end
 
-DuskLab.new
+DuskLab.new(get_settings)

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -103,4 +103,4 @@ before_dying do
   Flags.delete('caught')
 end
 
-DuskLab.new(get_settings)
+DuskLab.new

--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -9,7 +9,7 @@ class DuskLab
   include DRCI
   def initialize
     @settings = get_settings
-    @labyrinth_data = settings.duskruin['labyrinth']
+    @labyrinth_data = @settings.duskruin['labyrinth']
     loot_container = @labyrinth_data['loot_container']
     pet_noun = @labyrinth_data['pet_noun']
     redeem_scrip = @labyrinth_data['redeem_scrip']

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -80,3 +80,4 @@ empty_values:
   maze_junk: {}
   burgle_settings: {}
   consumable_lockboxes: []
+  duskruin: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1403,3 +1403,20 @@ burgle_settings:
 # Attempts to use ;burgle during Athletics, Locksmithing, Thievery, or Stealth
 # Uses burgle_settings for entry method
 train_with_burgle: false
+
+# To group all Duskruin related settings.
+# https://elanthipedia.play.net/Drathrok%27s_Duskruin
+duskruin:
+  # Settings specific to the labyrinth.
+  # https://elanthipedia.play.net/Drathrok%27s_Duskruin#Labyrinth
+  labyrinth:
+    # The pet you're looking for. Like "rat" or "monkey".
+    # This is required.
+    pet_noun: rat
+    # Which container to put the bloodscrip and items you find when searching.
+    # If not specified then the default is to "stow left|right"
+    # so make sure to have your STORE settings configured.
+    loot_container:
+    # Set to true to immediately redeem bloodscrip that you find.
+    # If not specified then the default is false.
+    redeem_scrip: false


### PR DESCRIPTION
* Externalize settings to yaml
* Search for any pet, just specify `pet_noun` in your yaml (e.g. "rat" or "monkey")
* Puts item in your loot container, `stow left|right` was using your STORE settings not the container you specified

Example YAML settings:
```yaml
# To group all Duskruin related settings.
# https://elanthipedia.play.net/Drathrok%27s_Duskruin
duskruin:
  # Settings specific to the labyrinth.
  # https://elanthipedia.play.net/Drathrok%27s_Duskruin#Labyrinth
  labyrinth:
    # The pet you're looking for. Like "rat" or "monkey".
    # This is required.
    pet_noun: rat
    # Which container to put the bloodscrip and items you find when searching.
    # If not specified then the default is to "stow left|right"
    # so make sure to have your STORE settings configured.
    loot_container: backpack
    # Set to true to immediately redeem bloodscrip that you find.
    # If not specified then the default is false.
    redeem_scrip: false
```