### PR TITLE
Add Merkresh Starting room for Ways

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1367,7 +1367,8 @@ class Bescort
       6867 => 'Auilusi',
       8302 => 'Vellano',
       3777 => "Dor'na'torna",
-      287 => 'Tabelrem'
+      287 => 'Tabelrem',
+      6991 => 'Besoge'
     }
 
     mode_to_shard = {


### PR DESCRIPTION
was never added as starting point for the < 100 moonies that have to be in the room with the shard to access the ways.