### PR TITLE
[scripts] [athletics] stop climbing practice if script exits

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -392,6 +392,7 @@ end
 
 before_dying do
   stop_script('performance') if Script.running?('performance')
+  put('stop climb')
 end
 
 Athletics.new


### PR DESCRIPTION
If you abort the script prematurely, you'll still be in practice mode. This ensures both the performance and climbing practice both stop.

```
> ,athletics

--- Lich: athletics active.

--- Lich: performance active.

[performance]>play scales halt

You struggle to begin a halting ruff on your silversteel cowbell.
> 
[athletics]>climb practice embrasure

You begin to practice your climbing skills.

> ,k athletics

--- Lich: 'performance' has been stopped by athletics.

[athletics]>stop climb

--- Lich: athletics has exited.

[performance]>stop play

> 
You stop practicing your climbing skills.
> 
You stop playing your song.
> 
--- Lich: performance has exited.
```