### PR TITLE
[script] [combat-trainer] Handle already worn items whose noun is "moon"

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -837,7 +837,7 @@ class LootProcess
     waitrt?
     if game_state.need_bundle && snap != [left_hand, right_hand]
       stored_moon = false
-      if DRStats.moon_mage? && bput('wear moon', 'suspend', 'already telekinetic', 'wear what') == 'suspend'
+      if DRStats.moon_mage? && bput('wear moon', 'suspend', 'already telekinetic', 'wear what', 'already wearing that') == 'suspend'
         stored_moon = true
       elsif summoned = game_state.summoned_info(game_state.weapon_skill)
         break_summoned_weapon(game_state.weapon_name)


### PR DESCRIPTION
Honestly, I don't know what line 840 is trying to do but I'm a Moon Mage who wears "moonsilk shirt" and "moonsilk pants" armor and this line hangs because the command "wear moon" referenced something the script didn't anticipate.

If there's a better fix, as well as if someone could clarify what "wear moon" refers to, that'd be helpful :)