### PR TITLE
add new reusable common methods

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -5,6 +5,19 @@
 
 $TRASH_STORAGE = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot]
 
+$PUT_AWAY_ITEM_SUCCESS_PATTERNS = [/^You put your .* in/]
+$PUT_AWAY_ITEM_OPEN_PATTERNS = [/^But that's closed/]
+$PUT_AWAY_ITEM_FAILURE_PATTERNS = [/^What were you referring to/]
+
+$OPEN_CONTAINER_SUCCESS_PATTERNS = [/^You open/, 
+                                    /^That is already open/]
+$OPEN_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
+
+
+$CLOSE_CONTAINER_SUCCESS_PATTERNS = [/^You close/, 
+                                     /^That is already closed/]
+$CLOSE_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
+
 custom_require.call(%w[common common-travel])
 
 module DRCI
@@ -203,5 +216,56 @@ module DRCI
   def get_item(item, container)
     result = DRC.bput("get #{item} in my #{container}", 'You get', 'I could not', 'What were you', 'You need a free')
     result =~ /^You get/
+  end
+
+  def get_item_list(container)
+    container_contents = DRC.bput("look in #{container}",'In the .* you see (.*)\.').match(/In the .* you see (?:a|an|some) (?<items>.*)\./)[:items].split(/(?:, | and )?(?:a|an|some) /)
+  end
+
+  def put_away_item?(item, container)
+    result = put_away_item_safe?(item, container)
+  end
+
+  def put_away_item_safe?(item, container)
+    container = "my " + container
+    result = put_away_item_unsafe?(item, container)
+  end
+
+  def put_away_item_unsafe?(item, container)
+    result = DRC.bput("put my #{item} in #{container}", $PUT_AWAY_ITEM_SUCCESS_PATTERNS, $PUT_AWAY_ITEM_OPEN_PATTERNS, $PUT_AWAY_ITEM_FAILURE_PATTERNS)
+
+    case result
+    when *$PUT_AWAY_ITEM_OPEN_PATTERNS
+      return false if open_container?(container) == false
+      return put_away_item_unsafe?(item,container)
+    when *$PUT_AWAY_ITEM_SUCCESS_PATTERNS
+      return true
+    when $PUT_AWAY_ITEM_FAILURE_PATTERNS
+      return false
+    else
+      return false
+    end
+  end
+
+  def open_container?(container)
+    case DRC.bput("open #{container}", $OPEN_CONTAINER_SUCCESS_PATTERNS, $OPEN_CONTAINER_FAILURE_PATTERNS)
+    when *$OPEN_CONTAINER_SUCCESS_PATTERNS
+      return true
+    when *$OPEN_CONTAINER_FAILURE_PATTERNS
+      return false
+    else
+      return false
+    end
+  end
+
+  def close_container?(container)
+    case DRC.bput("close #{container}", $CLOSE_CONTAINER_SUCCESS_PATTERNS, $CLOSE_CONTAINER_FAILURE_PATTERNS)
+    when *$CLOSE_CONTAINER_SUCCESS_PATTERNS
+      return true
+    when *$CLOSE_CONTAINER_FAILURE_PATTERNS
+      return false
+    else
+      return false
+    end
   end
 end

--- a/common.lic
+++ b/common.lic
@@ -32,7 +32,7 @@ $HOMETOWN_LIST = ["Arthe Dale",
                   "Ain Ghazal"
                 ]
 
-$ORDINALS = %w[first second third fourth fifth sixth seventh eighth ninth tenth eleventh]
+$ORDINALS = %w[first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth sixteenth seventeenth eighteenth nineteenth twentieth]
 
 $CURRENCIES = %w[Kronars Lirums Dokoras]
 
@@ -81,6 +81,8 @@ $NUM_MAP = {
   'eighty' => 80,
   'ninety' => 90
 }
+
+$box_regex = /((?:brass|copper|deobar|driftwood|iron|ironwood|mahogany|oaken|pine|steel|wooden) (?:box|caddy|casket|chest|coffer|crate|skippet|strongbox|trunk))/
 
 custom_require.call(%w[spellmonitor drinfomon])
 
@@ -204,8 +206,12 @@ module DRC
     end
 
     text = result.match(/looking for .* and see (.*)\.$/).to_a[1]
-
-    list_to_nouns(text)
+    case parameter
+    when 'B'
+      box_list_to_adj_and_noun(text)
+    else
+      list_to_nouns(text)
+    end
   end
 
   def get_boxes(container)
@@ -237,6 +243,12 @@ module DRC
   # is this ever useful compared to the list_to_nouns?
   def list_to_array(list)
     list.strip.split(/(?:,|(?:, |\s)?and\s?)(?:\s?<pushBold\/>\s?)?(?=\s\ba\b|\s\ban\b|\s\bsome\b|\s\bthe\b)/i).reject(&:empty?)
+  end
+
+  # Take a game formated list of boxes "a reinforced wooden strongbox and a plain ironwood crate"
+  # And return an array ["wooden strongbox", "ironwood crate"]
+  def box_list_to_adj_and_noun(list)
+    list.strip.split($box_regex).reject(&:empty?).select{ |item| item =~ $box_regex}
   end
 
   # Take a game formatted list "an arrow, silver coins and a deobar strongbox"
@@ -557,6 +569,19 @@ module DRC
     $pause_all_lock.unlock
 
     true
+  end
+
+  def smart_pause_all
+    paused_script_list = []
+    Script.running.find_all { |s| !s.paused? && !s.no_pause_all && s.name != Script.self.name}.each do  |s|
+      s.pause
+      paused_script_list << s.name
+    end
+    return paused_script_list
+  end
+
+  def unpause_all_list(scripts_to_unpause)
+    Script.running.find_all { |s| s.paused? && !s.no_pause_all && scripts_to_unpause.include?(s.name) }.each(&:unpause)
   end
 
   def set_stance(skill)


### PR DESCRIPTION
**common.lic**
* Update ordinals to twentieth, to match support in DR
* box_list_to_adj_and_noun(text) - Add new method for getting box adj + noun.  Allows mixing of critter boxes and keepsake boxes (and other nouns that match critter box nouns).
* smart_pause_all - pauses all unpaused scripts that don't have no_pause_all.  returns a list of those scripts
* unpause_all_list - unpauses a list of scripts

**common-items.lic**
Add reusable methods.

* get_item_list(container) - gets an array of items in a container, filled with short names

The following methods are designed to be used in place of one-offs that are used in many scripts currently.  It gives a single place to update success/failure regex
* put_away_item?(item, container) - puts an item in your container.  Uses next function (put_away_item_safe) which automatically uses 'my'.
* put_away_item_safe?(item, container) - puts an item in your container
* put_away_item_unsafe?(item, container) - puts an item in container, does not specify my
* open_container?(container) - attempts to open a container
* close_container?(container) - attempts to close a container