### PR TITLE
Add support for forcing crafting hometown 

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -115,23 +115,23 @@ class Craft
 
   def train_forging
     rank = DRSkill.getrank('Forging')
-    if rank <= 25 # Tier 1 - Extremely Easy
+    if rank <= 25 # Tier 1 - Extremely Easy - Utility Forging	 
       smith('a shallow metal cup')
-    elsif rank <= 50 # Tier 2 - Very Easy
+    elsif rank <= 50 # Tier 2 - Very Easy - Utility Forging	
       smith('a short metal mug')
-    elsif rank <= 100 # Tier 3 - Easy
+    elsif rank <= 100 # Tier 3 - Easy - Utility Forging	
       smith('a back scratcher')
-    elsif rank <= 175 # Tier 4 - Simple
+    elsif rank <= 175 # Tier 4 - Simple - Decorative Forging (Should change to flask)
       smith('a metal ankle band')
-    elsif rank <= 300 # Tier 5 - Basic
+    elsif rank <= 300 # Tier 5 - Basic - Utility Forging	
       smith('a metal lockpick ring')
-    elsif rank <= 425 # Tier 6 - Somewhat Challenging
+    elsif rank <= 425 # Tier 6 - Somewhat Challenging - Decorative Forging (Should change to large flas)
       smith('a metal armband')
-    elsif rank <= 550 # Tier 7 - Challenging
+    elsif rank <= 550 # Tier 7 - Challenging - Utility Forging	
       smith('some metal clippers')
-    elsif rank <= 700 # Tier 8 - Complicated
-      smith('some squat knitting needles')
-    elsif rank <= 850 # Tier 9 - Intricate
+    elsif rank <= 700 # Tier 8 - Complicated - Basic Outfitting Design	(No Utility Forging options available)
+      smith('some knobby sewing needles')
+    elsif rank <= 850 # Tier 9 - Intricate - Proficient Outfitting Design (Should change to polished <metal> knitting needles)
       smith('a serrated hide scraper')
     elsif rank <= 1175 # Tier 10 - Difficult
       smith('some serrated scissors')
@@ -148,7 +148,7 @@ class Craft
 
     if rank <= 25 # Tier 1  Extremely Easy
       # Buy an abolution sigil and wood totem
-      ensure_copper_on_hand(2000, @settings)
+      ensure_copper_on_hand(2000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 2)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 6)
       stow_item(right_hand)
@@ -159,7 +159,7 @@ class Craft
       dispose_trash('totem')
     elsif rank <= 50 # Tier 2 - Very Easy
       # Buy an induction sigil and wood totem
-      ensure_copper_on_hand(2000, @settings)
+      ensure_copper_on_hand(2000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 1)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 6)
       stow_item(right_hand)
@@ -170,7 +170,7 @@ class Craft
       dispose_trash('totem')
     elsif rank <= 100 # Tier 3 - Easy
       # Buy an rarefaction sigil and wood totem
-      ensure_copper_on_hand(2000, @settings)
+      ensure_copper_on_hand(2000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 5)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 6)
       stow_item(right_hand)
@@ -181,7 +181,7 @@ class Craft
       dispose_trash('totem')
     elsif rank <= 175 # Tier 4 - Simple
       # Buy an permutation sigil and wood totem
-      ensure_copper_on_hand(2000, @settings)
+      ensure_copper_on_hand(2000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 4)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 6)
       stow_item(right_hand)
@@ -192,7 +192,7 @@ class Craft
       dispose_trash('totem')
     elsif rank <= 300 # Tier 5 - Basic
       # Buy an abolution and induction sigils and wood totem
-      ensure_copper_on_hand(2000, @settings)
+      ensure_copper_on_hand(2000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 1)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 2)
       stow_item(right_hand)
@@ -205,7 +205,7 @@ class Craft
       dispose_trash('totem')
     elsif rank <= 425 # Tier 6 - Somewhat Challenging
       # Buy a permutation and rarefaction sigils and runestone
-      ensure_copper_on_hand(4000, @settings)
+      ensure_copper_on_hand(4000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 4)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 5)
       stow_item(right_hand)
@@ -218,7 +218,7 @@ class Craft
       dispose_trash('runestone')
     elsif rank <= 550 # Tier 7 - Challenging
       # Buy a abolition and induction sigils and runestone
-      ensure_copper_on_hand(4000, @settings)
+      ensure_copper_on_hand(4000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 2)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 1)
       stow_item(right_hand)
@@ -231,7 +231,7 @@ class Craft
       dispose_trash('runestone')
     elsif rank <= 700 # Tier 8 - Complicated
       # Buy a rarefaction and induction sigils and runestone
-      ensure_copper_on_hand(4000, @settings)
+      ensure_copper_on_hand(4000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 5)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 1)
       stow_item(right_hand)
@@ -244,7 +244,7 @@ class Craft
       dispose_trash('runestone')
     elsif rank <= 850 # Tier 9 - Intricate
       # Buy a induction and rarefaction sigils and runestone
-      ensure_copper_on_hand(4000, @settings)
+      ensure_copper_on_hand(4000, @settings, @hometown)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 1)
       order_item(crafting_data['artificing'][@hometown]['stock-room'], 5)
       stow_hands
@@ -262,7 +262,7 @@ class Craft
   end
 
   def money_for_training?(amount, skill)
-    if ensure_copper_on_hand(amount, @settings)
+    if ensure_copper_on_hand(amount, @settings, @hometown)
       true
     else
       echo("Low on funds, removing #{skill} from training")
@@ -311,7 +311,7 @@ class Craft
 
   def buy_yarn(skipcoin = false)
     crafting_data = get_data('crafting')
-    ensure_copper_on_hand(3000, @settings) unless skipcoin
+    ensure_copper_on_hand(3000, @settings, @hometown) unless skipcoin
     order_item(crafting_data['tailoring'][@hometown]['stock-room'], 13)
     bput('combine my yarn', 'You combine', 'You must be holding both')
     count = bput('count my yarn', 'You count out \d+ yards').scan(/\d+/).first.to_i

--- a/craft.lic
+++ b/craft.lic
@@ -21,6 +21,7 @@ class Craft
 
     @settings = get_settings
     @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town if @settings.force_crafting_town
     @training_room = (@settings.training_rooms || [@settings.safe_room]).sample
     @settings.storage_containers.each { |container| fput("open my #{container}") }
     @equipment_manager = EquipmentManager.new(@settings)
@@ -31,16 +32,19 @@ class Craft
     @belt = @settings.enchanting_belt
 
     if args.craft == 'engineering'
+      @hometown = @settings.force_shaping_crafting_town if @settings.force_shaping_crafting_town
       exit if DRSkill.getxp('Engineering') > @craft_max_mindstate
       train_engineering
     end
 
     if args.craft == 'outfitting'
+      @hometown = @settings.force_tailoring_crafting_town if @settings.force_tailoring_crafting_town
       exit if DRSkill.getxp('Outfitting') > @craft_max_mindstate
       train_outfitting
     end
 
     if args.craft == 'forging'
+      @hometown = @settings.force_blacksmithing_crafting_town if @settings.force_blacksmithing_crafting_town
       exit if DRSkill.getxp('Forging') > @craft_max_mindstate
       train_forging
     end
@@ -51,6 +55,7 @@ class Craft
     end
 
     if args.craft == 'enchanting'
+      @hometown = @settings.force_artificing_crafting_town if @settings.force_artificing_crafting_town
       exit if DRSkill.getxp('Enchanting') > @craft_max_mindstate
       train_enchanting
     end
@@ -64,11 +69,11 @@ class Craft
     elsif rank <= 50 # Tier 2 Very Easy
       sew(5, 'some knitted mittens', 'mittens')
     elsif rank <= 100 # Tier 3  Easy
-      sew(5, 'a knitted hat', 'hat')
+      sew(5, 'a knitted scarf', 'scarf')
     elsif rank <= 175 # Tier 4  Simple
       sew(5, 'some knitted gloves', 'gloves')
     elsif rank <= 300 # Tier 5  Basic
-      sew(5, 'some knitted hose', 'hose')
+      sew(5, 'a knitted sweater', 'sweater')
     elsif rank <= 425 # Tier 6  Somewhat Challenging
       sew(5, 'a knitted cloak', 'cloak')
     elsif rank <= 650 # Tier 7  Challenging

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -1191,6 +1191,11 @@ deeds:
     small_number: 14
     medium_number: 15
     large_number: 16
+  Fang Cove:
+    room: 9135
+    small_number: 1
+    medium_number: 2
+    large_number: 3
 recipe_parts:
   small backing:
     Crossing:

--- a/forge.lic
+++ b/forge.lic
@@ -52,6 +52,7 @@ class Forge
 
     @settings = get_settings
     @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town if @settings.force_crafting_town
     @stamp = @settings.mark_crafted_goods
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
@@ -74,9 +75,25 @@ class Forge
       lighten
     elsif args.resume
       @book_type = args.book_type
+      case @book_type
+      when 'black'
+        @hometown = @settings.force_blacksmithing_crafting_town if @settings.force_blacksmithing_crafting_town
+      when 'weapon'
+        @hometown = @settings.force_weaponsmithing_crafting_town if @settings.force_weaponsmithing_crafting_town
+      when 'armors'
+        @hometown = @settings.force_armorsmithing_crafting_town if @settings.force_armorsmithing_crafting_town
+      end
       analyze_item
     else
       @book_type = args.book_type
+      case @book_type
+      when 'black'
+        @hometown = @settings.force_blacksmithing_crafting_town if @settings.force_blacksmithing_crafting_town
+      when 'weapon'
+        @hometown = @settings.force_weaponsmithing_crafting_town if @settings.force_weaponsmithing_crafting_town
+      when 'armors'
+        @hometown = @settings.force_armorsmithing_crafting_town if @settings.force_armorsmithing_crafting_town
+      end
       @chapter = args.chapter
       @instruction = args.instruction
       @recipe_name = args.recipe_name
@@ -115,6 +132,7 @@ class Forge
   end
 
   def hone
+    @hometown = @settings.force_weaponsmithing_crafting_town if @settings.force_weaponsmithing_crafting_town
     find_grindstone(@hometown)
     crafting_magic_routine(@settings)
     get_item('weaponsmithing book')
@@ -126,6 +144,7 @@ class Forge
   end
 
   def balance
+    @hometown = @settings.force_weaponsmithing_crafting_town if @settings.force_weaponsmithing_crafting_town
     find_grindstone(@hometown)
     crafting_magic_routine(@settings)
     get_item('weaponsmithing book')
@@ -137,6 +156,7 @@ class Forge
   end
 
   def lighten
+    @hometown = @settings.force_armorsmithing_crafting_town if @settings.force_armorsmithing_crafting_town
     find_grindstone(@hometown)
     crafting_magic_routine(@settings)
     get_item('armorsmithing book')

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -543,6 +543,20 @@ enchanting_tools:
 - augment loop
 - burin
 
+#override the hometown used for crafting (workorder or craft)
+#it is important to select these intelligently:
+#  don't pick a hometown way far from you
+#  don't pick hometown that don't have the crafting society you need
+force_crafting_town: 
+force_blacksmithing_crafting_town:
+force_weaponsmithing_crafting_town:
+force_armorsmithing_crafting_town:
+force_tailoring_crafting_town:
+force_shaping_crafting_town:
+force_carving_crafting_town:
+force_remedies_crafting_town:
+force_artificing_crafting_town:
+
 forging_belt:
 engineering_belt:
 outfitting_belt:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -554,6 +554,7 @@ force_armorsmithing_crafting_town:
 force_tailoring_crafting_town:
 force_shaping_crafting_town:
 force_carving_crafting_town:
+force_tinkering_crafting_town:
 force_remedies_crafting_town:
 force_artificing_crafting_town:
 

--- a/remedy.lic
+++ b/remedy.lic
@@ -17,11 +17,14 @@ class Remedy
 
   def initialize
     @settings = get_settings
+    @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town if @settings.force_crafting_town
+    @hometown = @settings.force_remedies_crafting_town if @settings.force_remedies_crafting_town
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.alchemy_belt
     @training_spells = @settings.crafting_training_spells
-    @stock = get_data('crafting')['remedies'][@settings.hometown]
+    @stock = get_data('crafting')['remedies'][@hometown]
 
     arg_definitions = [
       [
@@ -59,7 +62,7 @@ class Remedy
     @herb1 = args.herb1
     @herb2 = args.herb2
     @catalyst = args.catalyst
-    @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool } || args.container 
+    @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool } || args.container
     @pestle = @settings.alchemy_tools.find { |tool| /pestle/ =~ tool } || 'pestle'
     @verb = 'crush'
     @noun = args.noun
@@ -357,7 +360,7 @@ class Remedy
   end
 
   def buy_item(name)
-    get_money_from_bank('5 silver', @settings)
+    get_money_from_bank('5 silver', @settings, @hometown)
 
     case name
     when 'coal'

--- a/sew.lic
+++ b/sew.lic
@@ -18,6 +18,8 @@ class Sew
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.outfitting_belt
     @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town if @settings.force_crafting_town
+    @hometown = @settings.force_tailoring_crafting_town if @settings.force_tailoring_crafting_town
     @hometown_data = get_data('crafting')['tailoring'][@hometown]
 
     arg_definitions = [

--- a/sew.lic
+++ b/sew.lic
@@ -91,7 +91,7 @@ class Sew
   def check_thread
     return if exists?('cotton thread')
     room = Room.current.id
-    ensure_copper_on_hand(1000, @settings)
+    ensure_copper_on_hand(1000, @settings, @hometown)
     order_item(@hometown_data['stock-room'], 6)
     stow_item('cotton thread')
     walk_to(room)
@@ -99,7 +99,7 @@ class Sew
 
   def check_pins
     return unless Flags['sew-pins'] || !exists?('straight pins')
-    ensure_copper_on_hand(125, @settings)
+    ensure_copper_on_hand(125, @settings, @hometown)
     item = left_hand
     stow_item(item)
     room = Room.current.id

--- a/smith.lic
+++ b/smith.lic
@@ -28,11 +28,14 @@ class Smith
 
     args = parse_args(arg_definitions)
 
+    recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
+    recipe = recipe_lookup(recipes, args.item_name)
+    return unless recipe
+
     @settings = get_settings
-    discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
     @hometown = @settings.hometown
     @hometown = @settings.force_crafting_town if @settings.force_crafting_town
-    case discipline
+    case recipe['type']
     when 'blacksmithing'
       @hometown = @settings.force_blacksmithing_crafting_town if @settings.force_blacksmithing_crafting_town
     when 'weaponsmithing'
@@ -40,11 +43,9 @@ class Smith
     when 'armorsmithing'
       @hometown = @settings.force_armorsmithing_crafting_town if @settings.force_armorsmithing_crafting_town
     end
+    discipline = get_data('crafting')['blacksmithing'][@hometown]
 
     @container = get_settings.crafting_container
-    recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
-    recipe = recipe_lookup(recipes, args.item_name)
-    return unless recipe
 
     parts = recipe['part'] || []
     smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten)
@@ -71,7 +72,7 @@ class Smith
   end
 
   def buy_parts(parts)
-    ensure_copper_on_hand(700, @settings)
+    ensure_copper_on_hand(700, @settings, @hometown)
     stow_hands
 
     parts.each do |part|
@@ -88,7 +89,7 @@ class Smith
   end
 
   def buy_ingot(discipline)
-    ensure_copper_on_hand(700, @settings)
+    ensure_copper_on_hand(700, @settings, @hometown)
     order_item(discipline['stock-room'], discipline['stock-number'])
     bput("put ingot in my #{@container}", 'You put')
     stow_hands
@@ -113,7 +114,7 @@ class Smith
       end
     end
 
-    ensure_copper_on_hand(1000, @settings)
+    ensure_copper_on_hand(1000, @settings, @hometown)
     order_item(discipline['finisher-room'], discipline['finisher-number'])
     bput("put oil in my #{@container}", 'You put')
     stow_hands

--- a/smith.lic
+++ b/smith.lic
@@ -31,6 +31,16 @@ class Smith
     @settings = get_settings
     discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
     @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town if @settings.force_crafting_town
+    case discipline
+    when 'blacksmithing'
+      @hometown = @settings.force_blacksmithing_crafting_town if @settings.force_blacksmithing_crafting_town
+    when 'weaponsmithing'
+      @hometown = @settings.force_weaponsmithing_crafting_town if @settings.force_weaponsmithing_crafting_town
+    when 'armorsmithing'
+      @hometown = @settings.force_armorsmithing_crafting_town if @settings.force_armorsmithing_crafting_town
+    end
+
     @container = get_settings.crafting_container
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = recipe_lookup(recipes, args.item_name)

--- a/tinker.lic
+++ b/tinker.lic
@@ -16,6 +16,8 @@ class Tinker
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
     @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town if @settings.force_crafting_town
+    @hometown = @settings.force_tinkering_crafting_town if @settings.force_tinkering_crafting_town
     @stamp = @settings.mark_crafted_goods
 
     arg_definitions = [

--- a/workorders.lic
+++ b/workorders.lic
@@ -31,6 +31,28 @@ class WorkOrders
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @hometown = @settings.hometown
+    #override hometown if using force_crafting_town
+    @hometown = @settings.force_crafting_town if @settings.force_crafting_town
+    #override hometown if using force_<discipline>_crafting_town
+    case discipline
+    when 'blacksmithing'
+      @hometown = @settings.force_blacksmithing_crafting_town if @settings.force_blacksmithing_crafting_town
+    when 'weaponsmithing'
+      @hometown = @settings.force_weaponsmithing_crafting_town if @settings.force_weaponsmithing_crafting_town
+    when 'armorsmithing'
+      @hometown = @settings.force_armorsmithing_crafting_town if @settings.force_armorsmithing_crafting_town
+    when 'tailoring'
+      @hometown = @settings.force_tailoring_crafting_town if @settings.force_tailoring_crafting_town
+    when 'shaping'
+      @hometown = @settings.force_shaping_crafting_town if @settings.force_shaping_crafting_town
+    when 'carving'
+      @hometown = @settings.force_carving_crafting_town if @settings.force_carving_crafting_town
+    when 'remedies'
+      @hometown = @settings.force_remedies_crafting_town if @settings.force_remedies_crafting_town
+    when 'artificing'
+      @hometown = @settings.force_artificing_crafting_town if @settings.force_artificing_crafting_town
+    end
+
     @use_own_ingot_type = @settings.use_own_ingot_type
     @deed_own_ingot = @settings.deed_own_ingot
     deeds_data = get_data('crafting').deeds[@hometown]
@@ -219,7 +241,7 @@ class WorkOrders
   end
 
   def carve_items(info, item, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
     material_noun = %w[deed pebble stone rock rock boulder]
     material_volume = 0
@@ -420,7 +442,7 @@ class WorkOrders
   end
 
   def sew_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
 
     existing = if bput("get #{info['sew-stock-name']} cloth from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
@@ -451,7 +473,7 @@ class WorkOrders
   end
 
   def knit_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
 
     existing = if bput("get yarn from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
@@ -568,7 +590,7 @@ class WorkOrders
   end
 
   def remedy_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
     herb2_needed = ''
     liquid_used = ''
 
@@ -627,7 +649,7 @@ class WorkOrders
     recipe, = find_recipe(info, item, quantity)
     remaining_volume = 0
 
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
 
     quantity.times do
       if remaining_volume < recipe['volume']
@@ -714,7 +736,7 @@ class WorkOrders
 
     return unless @deed_own_ingot
     unless DRC.bput('look my deed packet', /You count \d+ deed claim forms remaining/, /I could not find what you were referring to/) =~ /You count \d+ deed claim forms remaining/
-      ensure_copper_on_hand(@cash_on_hand || 10_000, @settings)
+      ensure_copper_on_hand(@cash_on_hand || 10_000, @settings, @hometown)
       order_item(@deeds_room, @deeds_number)
       fput('stow my packet')
     end
@@ -726,7 +748,7 @@ class WorkOrders
   end
 
   def enchanting_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 20_000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 20_000, @settings, @hometown)
     # Enchant Sigil #1
     order_enchant(info['stock-room'], quantity, recipe['enchant_stock1'], @bag, @belt)
 


### PR DESCRIPTION
This adds support for several new yaml settings to allow hometown overrides on where to do crafting, similar to how it is handled with force_healer_town and saferoom.

I've tested for shaping and remedies, and works perfect, but could probably stand to be tested with others as well.