### PR TITLE
Create autocontingency.lic

### DIFF
--- a/autocontingency.lic
+++ b/autocontingency.lic
@@ -1,7 +1,7 @@
 =begin
-  
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#autocontingency
 =end
-custom_require.call(%w(common common-arcana events spellmonitor drinfomon))
+custom_require.call(%w(common common-arcana events spellmonitor drinfomon common-travel))
 class Contingency
   include DRC
   include DRCA
@@ -35,7 +35,7 @@ class Contingency
                    .first
     echo "moon=#{moon}"
     return unless moon
-    walk_to(@room)
+    DRCT.walk_to(@room)
     cast_contingency_spells
     pause 1
   end

--- a/autocontingency.lic
+++ b/autocontingency.lic
@@ -1,0 +1,60 @@
+=begin
+  
+=end
+custom_require.call(%w(common common-arcana events spellmonitor drinfomon))
+class Contingency
+  include DRC
+  include DRCA
+  include DRCT
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'anchor', regex: /\w+/, description: 'Contingency to create' },
+        { name: 'room', regex: /\d+/, description: 'Room to move to' }
+      ],
+      [
+        { name: 'invoke', regex: /invoke/i }
+      ]
+    ]
+    args = parse_args(arg_definitions)
+    @settings = get_settings
+    @anchor = args.anchor.capitalize
+    @room = args.room
+    if args.invoke
+      check_contingency
+    else
+      contingency_saferoom
+    end
+  end
+
+  def contingency_saferoom
+    moon = UserVars.moons.select { |moon, _data| UserVars.moons['visible'].include?(moon) }
+                   .reject { |_moon, data| data['timer'] < 32 }
+                   .max_by { |_moon, data| data['timer'] }
+                   .first
+    echo "moon=#{moon}"
+    return unless moon
+    walk_to(@room)
+    cast_contingency_spells
+    pause 1
+  end
+
+  def cast_contingency_spells
+    data = @settings.waggle_sets['contingency'].values.each do |data|
+      data['cast'] = "cast #{@anchor}"
+      cast_spell(data, @settings)
+    end
+  end
+
+  def check_contingency
+    if DRSpells.active_spells['Contingency'].to_i <=0
+      pause 1
+      echo("No contingency")
+    else
+      fput("invoke contingency")
+    end
+  end
+
+end
+Contingency.new


### PR DESCRIPTION
New script for MM's to allow for SEER + Contingency automation, assuming the moons are up.

Usage: As a `before` in a hunt, or in a T2 training_list, include `autocontingency ANCHOR ROOMNUMBER`. i.e. `autocontingency Etreu 788`. Autocontingency will move your character to 788 and proceed to cast the spells in your contingency waggle. This needs to include SEER as well as Contingency. An example of the waggle is included below.

```
   contingency:
    Seer's Sense:
      abbrev: SEER
      recast: 2
      mana: 15
      cambrinth:
      - 5
      - 5
    Contingency:
      abbrev: CONTINGENCY
      recast: 1
      mana: 15
      cambrinth:
      - 7
      - 7
```

At the end of the hunt, you can include `autocontingency invoke` to try and invoke the Contingency you put up previously. This has the ability to save significant travel time, or keep you safe if you are PvP Open.