### PR TITLE
[script] [common-money] Ensure convert_to_copper returns numeric value

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -25,7 +25,7 @@ module DRCM
     return (amount.to_i * 1000) if 'gold' =~ /^#{denomination}/
     return (amount.to_i * 100) if 'silver' =~ /^#{denomination}/
     return (amount.to_i * 10) if 'bronze' =~ /^#{denomination}/
-    amount
+    amount.to_i
   end
 
   def convert_currency(amount, from, to, fee)


### PR DESCRIPTION
Fixes issue where `sell-loot` script at [line 92](https://github.com/rpherbig/dr-scripts/blob/master/sell-loot.lic#L92) will fail if the denomination of coins to keep on hand is not one of platinum, gold, silver, or bronze, or if the amount to keep on hand is less than 10 copper. For example, if you want to keep `5 copper` on hand.

### The Problem

The `convert_to_copper` function returns a String instead of an Integer in the default case.

```
--- Lich: error: undefined method `/' for "0":String
	common-money:16:in `block in minimize_coins'
	common-money:13:in `each'

--- Lich: sell-loot has exited.
```

### Steps to Reproduce Error

1. Define the following in your yaml:
```yaml
sell_loot_money_on_hand: 0 copper
```

2. Run `sell-loot` script