### PR TITLE
[script] [sanowret-crystal] Configurable rooms to ignore

### DIFF
--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -81,3 +81,5 @@ empty_values:
   burgle_settings: {}
   consumable_lockboxes: []
   duskruin: {}
+  sanowret_no_use_scripts: []
+  sanowret_no_use_rooms: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1322,7 +1322,7 @@ almanac_noun: almanac
 almanac_skills:
 
 sanowret_adjective: sanowret
-sanowret_no_use_scripts:
+sanowret_no_use_scripts: # Don't try use crystal while these scripts are active.
 - sew
 - carve
 - tinker
@@ -1333,6 +1333,12 @@ sanowret_no_use_scripts:
 - outdoorsmanship
 - combat-trainer
 - buff
+- burgle
+- go2
+sanowret_no_use_rooms: # Don't try to use crystal while in these rooms.
+- Carousel Chamber     # Room with vault
+- Carousel Booth       # Room just before vault
+- 1900                 # You can specify room ids, too
 
 almanac_no_use_scripts:
 - sew

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1322,7 +1322,7 @@ almanac_noun: almanac
 almanac_skills:
 
 sanowret_adjective: sanowret
-sanowret_no_use_scripts: # Don't try use crystal while these scripts are active.
+sanowret_no_use_scripts: # Don't try to use crystal while these scripts are active.
 - sew
 - carve
 - tinker

--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -11,30 +11,28 @@ class SanowretCrystal
         { name: 'run', regex: /run/i, description: 'Single run of the script', optional: true }
       ]
     ]
-    @invalid_rooms = []
     @worn_crystal = false
     args = parse_args(arg_definitions)
     settings = get_settings
-    @adjective = settings.sanowret_adjective
-    @no_use_scripts = settings.sanowret_no_use_scripts
-    check_crystal if args.run && !hiding? && !invisible?
+    @adjective = settings.sanowret_adjective || 'sanowret'
+    @no_use_scripts = settings.sanowret_no_use_scripts || []
+    @no_use_rooms = settings.sanowret_no_use_rooms || []
+    check_crystal if args.run
     passive unless args.run
   end
 
   def use_crystal
-    return if @invalid_rooms.include?(Room.current.id)
-    return if hiding? || invisible?
-    return if XMLData.room_title.include? 'Carousel Chamber'
-
     if DRSkill.getxp('Arcana') <= 10 && @worn_crystal
       response = DRC.bput("gaze my #{@adjective} crystal", /A soft light blossoms in the very center of the crystal, and begins to fill your mind with the knowledge of .*\./, 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'However, you realize that you\'re already gleaning knowledge from it.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     elsif DRSkill.getxp('Arcana') <= 25
       response = DRC.bput("exhale my #{@adjective} crystal", 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     end
-
     return if response !~ /This is not a good place for that\./
-    return if @invalid_rooms.include?(Room.current.id)
-    @invalid_rooms.push(Room.current.id)
+    message "Could not use crystal in room #{DRRoom.title}."
+    message "Consider adding this room to your sanowret_no_use_rooms settings."
+    # Go ahead and remember to ignore this room while the script is running
+    # This convenience won't persist between script runs though, go update your yaml
+    @no_use_rooms.push(DRRoom.title) unless @no_use_rooms.include?(DRRoom.title)
   end
 
   def check_crystal
@@ -42,7 +40,7 @@ class SanowretCrystal
     return if DRSkill.getxp('Arcana') >= 25
     return if hiding? || invisible?
     return if @no_use_scripts.any? { |name| Script.running?(name) }
-    return if @invalid_rooms.include?(Room.current.id)
+    return if @no_use_rooms.any? { |name| /#{name}/ =~ DRRoom.title || name.to_s == Room.current.id.to_s }
 
     if @worn_crystal
       use_crystal

--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -14,9 +14,9 @@ class SanowretCrystal
     @worn_crystal = false
     args = parse_args(arg_definitions)
     settings = get_settings
-    @adjective = settings.sanowret_adjective || 'sanowret'
-    @no_use_scripts = settings.sanowret_no_use_scripts || []
-    @no_use_rooms = settings.sanowret_no_use_rooms || []
+    @adjective = settings.sanowret_adjective
+    @no_use_scripts = settings.sanowret_no_use_scripts
+    @no_use_rooms = settings.sanowret_no_use_rooms
     check_crystal if args.run
     passive unless args.run
   end


### PR DESCRIPTION
* Handle rooms without ids that don't support crystals to prevent script from spamming inert actions
* Allow users to configure rooms where they don't want this script to run
* Added `burgle` and `go2` to base.yaml example of when not to run this script
* Removed duplicate checks that are already handled in `check_crystal` function