### PR TITLE
Spin.lic - Spins 400 yards of silk instead of 390

### DIFF
--- a/spin.lic
+++ b/spin.lic
@@ -34,21 +34,21 @@ class Spin
     @belt = @settings.outfitting_belt
     ensure_copper_on_hand(data[:cost] * data[:count], @settings)
 
-    data[:count].times do |c|
+    data[:count].times do |index|
       stock_room = get_data('crafting')['tailoring'][@settings.hometown]['stock-room']
       order_item(stock_room, data[:index])
-      if c == 0 && data[:name] == 'silk'
-        fput('mark my fibers at 10')
+      if index == 0 && data[:name] == 'silk'
+        bput('mark my fibers at 10', /mark it for cutting/)
         get_item('scissors')
-        fput('cut my fibers with my scissors')
+        bput('cut my fibers with my scissors', /You carefully cut off/)
         stow_item('scissors')
-        fput('drop my other fibers')
-        fput('get my fibers')
+        bput('drop my other fibers', /You drop some/)
+        bput('get my fibers', /You pick up the fibers lying at your feet/)
       else
         fput('combine my fiber')
       end
     end
-
+exit
     until find_wheel(@settings.hometown)
       move('go door')
       pause 30

--- a/spin.lic
+++ b/spin.lic
@@ -48,7 +48,7 @@ class Spin
         fput('combine my fiber')
       end
     end
-exit
+
     until find_wheel(@settings.hometown)
       move('go door')
       pause 30

--- a/spin.lic
+++ b/spin.lic
@@ -20,7 +20,7 @@ class Spin
     args = parse_args(arg_definitions)
 
     mat_data = {
-      'silk' => { name: 'silk', index: 1, cost: 187, count: 13 },
+      'silk' => { name: 'silk', index: 1, cost: 187, count: 14 },
       'cotton' => { name: 'cotton', index: 2, cost: 185, count: 8 },
       'linen' => { name: 'linen', index: 3, cost: 167, count: 8 },
       'wool' => { name: 'wool', index: 4, cost: 133, count: 8 },
@@ -28,16 +28,28 @@ class Spin
     }
 
     data = mat_data[args.material]
-    settings = get_settings
-    ensure_copper_on_hand(data[:cost] * data[:count], settings)
+    @settings = get_settings
+    @bag = @settings.crafting_container
+    @bag_items = @settings.crafting_items_in_container
+    @belt = @settings.outfitting_belt
+    ensure_copper_on_hand(data[:cost] * data[:count], @settings)
 
-    data[:count].times do
-      stock_room = get_data('crafting')['tailoring'][settings.hometown]['stock-room']
+    data[:count].times do |c|
+      stock_room = get_data('crafting')['tailoring'][@settings.hometown]['stock-room']
       order_item(stock_room, data[:index])
-      fput('combine my fiber')
+      if c == 0 && data[:name] == 'silk'
+        fput('mark my fibers at 10')
+        get_item('scissors')
+        fput('cut my fibers with my scissors')
+        stow_item('scissors')
+        fput('drop my other fibers')
+        fput('get my fibers')
+      else
+        fput('combine my fiber')
+      end
     end
 
-    until find_wheel(settings.hometown)
+    until find_wheel(@settings.hometown)
       move('go door')
       pause 30
     end
@@ -69,6 +81,15 @@ class Spin
 
     fput("stow my #{right_hand || left_hand}")
   end
+  
+  def get_item(name)
+    get_crafting_item(name, @bag, @bag_items, @belt)
+  end
+
+  def stow_item(name)
+    @bag = "other #{@bag}" unless stow_crafting_item(name, @bag, @belt)
+  end
+
 end
 
 Spin.new


### PR DESCRIPTION
The script will now cut 10 yards off the first set of fibers it buys and drop the excess 20 from that, then buy the other 390 so it ends up with 400 yards total.
This allows you to not waste any when converting to cloth.