### PR TITLE
[script] [crossing-repair] sort worn items after repairing them

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -24,6 +24,8 @@ class CrossingRepair
       while tickets_left?(repairer)
       end
     end
+
+    fput('sort auto head') if settings.sort_auto_head
   end
 
   def repair(repairer, item, repeat = false)


### PR DESCRIPTION
Mimic behavior from [equipmanager](https://github.com/rpherbig/dr-scripts/blob/master/equipmanager.lic#L34) after it wears all your items it also sorts your inventory per yaml setting.

The way in which `crossing-repair` uses `equipmanager`, it makes multiple calls to wear the item that just got repaired. Putting the "sort" command in `equipmanager` would introduce an extra command per item being worn via `equipmanager` and I felt that was an inefficient change.

`equipmanager` is the only script I'm aware of that uses `sort_auto_head` but being that this setting isn't prefixed or namespaced to `equipmanager` then I felt it's safe enough to use in `crossing-repair` script too for the same purpose.