### PR TITLE
[script] [combat-trainer] [common-items] Be explicit when 'wear moon' to reduce conflicts with worn items

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -266,9 +266,7 @@ class SetupProcess
     elsif !next_summoned && !DRStats.moon_mage?
       break_summoned_weapon(game_state.last_weapon_name)
     elsif !next_summoned && DRStats.moon_mage?
-      if right_hand =~ /moon/ || left_hand =~ /moon/
-        bput('wear moon', 'telekinetic')
-      end
+      wear_moon_weapon
     end
 
     # Prepare the next weapon
@@ -371,7 +369,7 @@ class LootProcess
 
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
-    
+
     @redeemed = settings.necro_redeemed
     echo("  @redeemed: #{@redeemed}") if $debug_mode_ct
 
@@ -946,7 +944,7 @@ class SpellProcess
 
     @training_spells_max_threshold = settings.combat_spell_training_max_threshold
     echo("  @training_spells_max_threshold: #{@training_spells_max_threshold}") if $debug_mode_ct
-    
+
     @training_spells_wait = settings.combat_spell_timer
     echo("  @training_spells_wait: #{@training_spells_wait}") if $debug_mode_ct
 
@@ -1325,7 +1323,7 @@ class SpellProcess
     if game_state.casting_moonblade
       if left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?
         # The moonblade was summoned or refreshed while training something else
-        bput('wear moon', 'telekinetic')
+        wear_moon_weapon
       end
 
       game_state.casting_moonblade = false

--- a/common-items.lic
+++ b/common-items.lic
@@ -9,12 +9,12 @@ $PUT_AWAY_ITEM_SUCCESS_PATTERNS = [/^You put your .* in/]
 $PUT_AWAY_ITEM_OPEN_PATTERNS = [/^But that's closed/]
 $PUT_AWAY_ITEM_FAILURE_PATTERNS = [/^What were you referring to/]
 
-$OPEN_CONTAINER_SUCCESS_PATTERNS = [/^You open/, 
+$OPEN_CONTAINER_SUCCESS_PATTERNS = [/^You open/,
                                     /^That is already open/]
 $OPEN_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
 
 
-$CLOSE_CONTAINER_SUCCESS_PATTERNS = [/^You close/, 
+$CLOSE_CONTAINER_SUCCESS_PATTERNS = [/^You close/,
                                      /^That is already closed/]
 $CLOSE_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
 
@@ -266,6 +266,20 @@ module DRCI
       return false
     else
       return false
+    end
+  end
+
+  # There are many variants of a summoned moon weapon (blade, staff, sword, etc)
+  # This function checks if you're holding one then tries to wear it.
+  # https://elanthipedia.play.net/Shape_Moonblade
+  def wear_moon_weapon
+    moon_weapon_regex = /moon/
+    moon_wear_messages = ['telekinetic']
+    if left_hand =~ moon_weapon_regex
+      bput("wear #{left_hand}", *moon_wear_messages)
+    end
+    if right_hand =~ moon_weapon_regex
+      bput("wear #{right_hand}", *moon_wear_messages)
     end
   end
 end


### PR DESCRIPTION
Response to this feedback: https://github.com/rpherbig/dr-scripts/pull/4416#issuecomment-671445603

* Be explicit about wearing what's in the right/left hand to minimize chances of conflicting with already worn items whose noun is "moon"
* Previous forked repo was deleted and GitHub lost track of the original branch for https://github.com/rpherbig/dr-scripts/pull/4416 so needed to create this new PR