### PR TITLE
[script] [common-moonmage] Add utility method to wear a summoned moon weapon

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -120,4 +120,18 @@ module DRCMM
 
     store_div_tool(tool_storage)
   end
+
+  # There are many variants of a summoned moon weapon (blade, staff, sword, etc)
+  # This function checks if you're holding one then tries to wear it.
+  # https://elanthipedia.play.net/Shape_Moonblade
+  def wear_moon_weapon
+    moon_weapon_regex = /moon[\w]+/
+    moon_wear_messages = ['telekinetic']
+    if left_hand =~ moon_weapon_regex
+      bput("wear #{left_hand}", *moon_wear_messages)
+    end
+    if right_hand =~ moon_weapon_regex
+      bput("wear #{right_hand}", *moon_wear_messages)
+    end
+  end
 end


### PR DESCRIPTION
Based on https://github.com/rpherbig/dr-scripts/pull/4439#issuecomment-674614817

This PR is a pre-requisite to update `combat-trainer` to use this method, instead of its current logic, to safely wear a moon weapon without conflicting with other "moon" noun items the character is wearing.

There are multiple variants of a summoned moon weapon (moonblade, moonstaff) and many more if you have the [Shape Moonblade](https://elanthipedia.play.net/Shape_Moonblade) spell. The idea here is that if you have a "moon" noun in your hand and you're calling `wear_moon_weapon` then that moon noun is (should be) a summoned moon weapon.

To minimize conflict with already worn moon nouns, like a [trio of multihued moons](https://elanthipedia.play.net/Item:Trio_of_multihued_moons), then the wear command uses the exact `<adjective> <noun>` listed in your hand.