### PR TITLE
[data] [base-hunting] Add wiki link to Giant Bears

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -814,6 +814,7 @@ hunting_zones:
   - 19193
   # Brand New Creature - Guestimated around 220 or higher.  Please update as more information comes in.
   # strong swarm, near rock_trolls, strong offense
+  # https://elanthipedia.play.net/Giant_bear
   giant_bears:
   - 15768
   - 15769


### PR DESCRIPTION
Sadly, I don't know any more about this critter than the wiki page. The new area is not available in the DR Test instance to try the [TEST EVALUATE](https://elanthipedia.play.net/Test_command) command.

~ @KatoakDR 