### PR TITLE
Update theurgy.lic for rare issue

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -767,7 +767,7 @@ class TheurgyActions
     (@data['bath']['path_in'] || []).each { |dir| move(dir) }
     (@data['herbs'] || %w[sage lavender]).each do |herb|
       get_from_container(herb)
-      fput "rub #{herb}"
+      fput "rub my #{herb}"
       pause 1
     end
     waitfor 'You wake up once more, blinking dazedly.'


### PR DESCRIPTION
[A Dark Grove, A Deep Pool]
The sand below your feet is soft as silk and as black and absolute as night.  The waters are deathly cold, causing you to shiver.  All is still, and even the ripples your movements cause soon fade back into pure, untouched water.
You also see a bag of lavender and a bag of sage.
Also here: Benalm.
Obvious paths: out.

Room Number: 13215

> 
[theurgy]>get sage from my backpack

You get a bag of sage from inside your black backpack.
> 
[theurgy]>rub sage

You must be holding the sage first.
> 
[theurgy]>get lavender from my backpack

You get a bag of lavender from inside your black backpack.
> 
[theurgy]>rub lavender

You must be holding the lavender first.



I believe this should fix this issue. Some mischievous or well-meaning individual placed a bag of lavender and a bag of sage in the room, breaking the theurgy script for most lich users pretty much all day.