### PR TITLE
Create buffother.lic

### DIFF
--- a/buffother.lic
+++ b/buffother.lic
@@ -20,8 +20,9 @@ class Buffother
     @recipient = args.recipient.capitalize
     @waggle = args.waggle
     @room = args.room
+    
     move_to_room
-    cast_buff_spells
+    do_buffs
   end
 
   def move_to_room
@@ -29,16 +30,81 @@ class Buffother
     pause 1
   end
 
-  def cast_buff_spells
-    data = @settings.waggle_sets["#{@waggle}"].values.each do |data|
-      data['cast'] = "cast #{@recipient}"
-      DRCA.do_buffs(@settings, @waggle)
+  def do_buffs
+    # takes a waggle and sends it to the appropriate helper
+    return unless @settings.waggle_sets["#{@waggle}"]
+    spells = @settings.waggle_sets["#{@waggle}"]
+
+    spells.values
+          .select { |spell| spell['use_auto_mana'] }
+          .each { |spell| check_discern(spell, settings) }
+    cast_spells(spells, @settings, @settings.waggle_force_cambrinth)
+  end
+
+  def cast_spells(spells, settings, force_cambrinth = false)
+    spells.each do |name, data|
+      next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
+      while (mana < settings.waggle_spells_mana_threshold || DRStats.concentration < settings.waggle_spells_concentration_threshold)
+        echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
+        pause 15
+      end
+
+      cast_spell(data, settings, force_cambrinth)
     end
   end
+
+def cast_spell(data, settings, force_cambrinth = false)
+    return unless data
+    return unless settings
+
+    data = update_astral_data(data)
+    data['cast'] = "cast #{@recipient}"
+    return unless data # update_astral_data returns nil on failure
+
+    release_cyclics if data['cyclic']
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+
+    if data['ritual']
+      ritual(data, settings)
+      return
+    end
+
+    command = 'prep'
+    command = data['prep'] if data['prep']
+    command = data['prep_type'] if data['prep_type']
+
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
+    prepare_time = Time.now
+
+    unless settings.cambrinth_items[0]['name']
+      settings.cambrinth_items = [{
+        'name' => settings.cambrinth,
+        'cap' => settings.cambrinth_cap,
+        'stored' => settings.stored_cambrinth
+      }]
+    end
+    settings.cambrinth_items.each_with_index do |item, index|
+      case data['cambrinth'].first
+      when Array
+        find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'][index], settings.cambrinth_invoke_exact_amount)
+      when Fixnum, Integer
+        find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'], settings.cambrinth_invoke_exact_amount)
+      end
+    end
+
+    if data['prep_time']
+      pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
+    else
+      waitcastrt?
+    end
+    cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
+  end
+
 end
 
 before_dying do
-    fput("release mana")
+  fput("release mana")
 end
 
 Buffother.new

--- a/buffother.lic
+++ b/buffother.lic
@@ -16,24 +16,24 @@ class Buffother
       ]
     ]
     args = parse_args(arg_definitions)
-    @settings = get_settings
-    @recipient = args.recipient.capitalize
-    @waggle = args.waggle
-    @room = args.room
-    move_to_room
-    cast_buff_spells
+    settings = get_settings
+    recipient = args.recipient.capitalize
+    waggle = args.waggle
+    room = args.room
+    move_to_room(room)
+    cast_buff_spells(settings, recipient, waggle)
   end
 
-  def move_to_room
-    DRCT.walk_to(@room)
+  def move_to_room(room)
+    DRCT.walk_to(room)
     pause 1
   end
 
-  def cast_buff_spells
-    data = @settings.waggle_sets["#{@waggle}"].values.each do |data|
-      data['cast'] = "cast #{@recipient}"
+  def cast_buff_spells(settings, recipient, waggle)
+    data = settings.waggle_sets[waggle].values.each do |data|
+      data['cast'] = "cast #{recipient}"
       pause 1 while DRStats.mana < 40
-      DRCA.cast_spell(data, @settings, @settings.waggle_force_cambrinth)
+      DRCA.cast_spell(data, settings, settings.waggle_force_cambrinth)
     end
   end
 

--- a/buffother.lic
+++ b/buffother.lic
@@ -21,27 +21,24 @@ class Buffother
     @waggle = args.waggle
     @room = args.room
     move_to_room
+    cast_buff_spells
   end
 
   def move_to_room
-    echo "Moving to room"
     DRCT.walk_to(@room)
-    cast_buff_spells
     pause 1
   end
 
   def cast_buff_spells
-    echo "In cast_buff_spells"
     data = @settings.waggle_sets["#{@waggle}"].values.each do |data|
       data['cast'] = "cast #{@recipient}"
       DRCA.do_buffs(@settings, @waggle)
     end
-    cleanup
   end
-
-  def cleanup
-    fput("release mana")
-  end
-
 end
+
+before_dying do
+    fput("release mana")
+end
+
 Buffother.new

--- a/buffother.lic
+++ b/buffother.lic
@@ -1,0 +1,47 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#buffother
+=end
+custom_require.call(%w(common common-arcana events spellmonitor drinfomon common-travel))
+class Buffother
+  include DRC
+  include DRCA
+  include DRCT
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'recipient', regex: /\w+/, description: 'Person to buff' },
+        { name: 'waggle', regex: /\w+/, description: 'Waggle set to cast' },
+        { name: 'room', regex: /\d+/, optional: true, description: 'Room to move to' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
+    @settings = get_settings
+    @recipient = args.recipient.capitalize
+    @waggle = args.waggle
+    @room = args.room
+    move_to_room
+  end
+
+  def move_to_room
+    echo "Moving to room"
+    DRCT.walk_to(@room)
+    cast_buff_spells
+    pause 1
+  end
+
+  def cast_buff_spells
+    echo "In cast_buff_spells"
+    data = @settings.waggle_sets["#{@waggle}"].values.each do |data|
+      data['cast'] = "cast #{@recipient}"
+      DRCA.do_buffs(@settings, @waggle)
+    end
+    cleanup
+  end
+
+  def cleanup
+    fput("release mana")
+  end
+
+end
+Buffother.new

--- a/buffother.lic
+++ b/buffother.lic
@@ -1,9 +1,8 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#buffother
 =end
-custom_require.call(%w(common common-arcana events spellmonitor drinfomon common-travel))
+custom_require.call(%w(common-arcana events spellmonitor drinfomon common-travel))
 class Buffother
-  include DRC
   include DRCA
   include DRCT
 

--- a/buffother.lic
+++ b/buffother.lic
@@ -20,9 +20,8 @@ class Buffother
     @recipient = args.recipient.capitalize
     @waggle = args.waggle
     @room = args.room
-    
     move_to_room
-    do_buffs
+    cast_buff_spells
   end
 
   def move_to_room
@@ -30,75 +29,12 @@ class Buffother
     pause 1
   end
 
-  def do_buffs
-    # takes a waggle and sends it to the appropriate helper
-    return unless @settings.waggle_sets["#{@waggle}"]
-    spells = @settings.waggle_sets["#{@waggle}"]
-
-    spells.values
-          .select { |spell| spell['use_auto_mana'] }
-          .each { |spell| check_discern(spell, settings) }
-    cast_spells(spells, @settings, @settings.waggle_force_cambrinth)
-  end
-
-  def cast_spells(spells, settings, force_cambrinth = false)
-    spells.each do |name, data|
-      next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
-      while (mana < settings.waggle_spells_mana_threshold || DRStats.concentration < settings.waggle_spells_concentration_threshold)
-        echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
-        pause 15
-      end
-
-      cast_spell(data, settings, force_cambrinth)
+  def cast_buff_spells
+    data = @settings.waggle_sets["#{@waggle}"].values.each do |data|
+      data['cast'] = "cast #{@recipient}"
+      pause 1 while DRStats.mana < 40
+      DRCA.cast_spell(data, @settings, @settings.waggle_force_cambrinth)
     end
-  end
-
-def cast_spell(data, settings, force_cambrinth = false)
-    return unless data
-    return unless settings
-
-    data = update_astral_data(data)
-    data['cast'] = "cast #{@recipient}"
-    return unless data # update_astral_data returns nil on failure
-
-    release_cyclics if data['cyclic']
-    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
-    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
-
-    if data['ritual']
-      ritual(data, settings)
-      return
-    end
-
-    command = 'prep'
-    command = data['prep'] if data['prep']
-    command = data['prep_type'] if data['prep_type']
-
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
-    prepare_time = Time.now
-
-    unless settings.cambrinth_items[0]['name']
-      settings.cambrinth_items = [{
-        'name' => settings.cambrinth,
-        'cap' => settings.cambrinth_cap,
-        'stored' => settings.stored_cambrinth
-      }]
-    end
-    settings.cambrinth_items.each_with_index do |item, index|
-      case data['cambrinth'].first
-      when Array
-        find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'][index], settings.cambrinth_invoke_exact_amount)
-      when Fixnum, Integer
-        find_charge_invoke_stow(item['name'], item['stored'], item['cap'], settings.dedicated_camb_use, data['cambrinth'], settings.cambrinth_invoke_exact_amount)
-      end
-    end
-
-    if data['prep_time']
-      pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
-    else
-      waitcastrt?
-    end
-    cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
   end
 
 end


### PR DESCRIPTION
New helper script to use when wanting to buff a friend or alt. Has required args for who you buff (recipient) and which waggle set to call (waggle), with an optional room number arg (room) to move you there first before buffing. The script can be called manually, as an item in your t2 training_list, or as a before/after in a hunt file. Example usage:

;buffother Etreu buffsomeone 798

That will move you to room #798 and cycle through each of the spells in your buffsomeone waggle set, appending a cast of "cast Etreu" to each of them.

Example waggle setup shown below:

```
   buffsomeone:
    Shadows:
      abbrev: Shadows
      recast: 2
      mana: 20
      cambrinth:
      - 8
      - 8
      - 8
      - 8
    Clear Vision:
      abbrev: CV
      recast: 2
      mana: 20
      cambrinth:
      - 8
      - 8
      - 8
      - 8
    Psychic Shield:
      abbrev: PSY
      recast: 2
      mana: 20
      cambrinth:
      - 8
      - 8
      - 8
      - 8
```