### PR TITLE
[script] [equipmanager] Updates "wear/remove" logic to handle tie_to, wield, container

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -142,16 +142,12 @@ class EquipmentManager
       echo('failed to match an item, try turning on debugging with ;e UserVars.equipmanager_debug = true')
       return false
     end
-    case bput("get my #{item.short_name}", item.short_regex, '^You get ', '^What were you referring')
-    when item.short_regex
+    if get_item?(item)
       bput("wear my #{item.short_name}", 'You sling', 'You attach', 'You .* unload', 'You strap', 'You slide', 'You work your way into', 'You spin', 'You put', 'You carefully loop', 'slide effortlessly onto your', 'You slip', "^You .* #{item.short_regex}")
       waitrt?
       return true
-    when /^You get /
-      bput("stow my #{item.short_name}", "You put .*#{item.name}", 'You .* unload', 'close the fan', 'You easily strap', "You don't seem to be able to move", 'You secure', 'is too small to hold that', 'You hang', '^The .* slides easily', "^You .* #{item.short_regex}")
-    else
-      return false
     end
+    return false
   end
 
   def wield_weapon_offhand(description, skill = nil)

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -129,9 +129,13 @@ class EquipmentManager
   def remove_item(item)
     bput("remove my #{item.short_name}", "You .*#{item.name}", 'The leather gauntlets slide', 'Without any effort')
     waitrt?
-    if item.container
+    if item.tie_to
+      stow_helper("tie my #{item.short_name} to #{item.tie_to}", item.short_name, 'You attach', 'you tie', 'You are a little too busy', 'Your wounds hinder your ability to do that')
+    elsif item.wield
+      stow_helper("sheath my #{item.short_name}", item.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'You secure your', 'You slip', 'You hang', 'You .* strap')
+    elsif item.container
       stow_helper("put my #{item.short_name} into #{item.container}", item.short_name, 'You put', 'You should unload', 'You easily strap', 'You secure your')
-    elsif /more room/ =~ bput("stow my #{item.short_name}", 'You put', 'You easily strap', 'There isn\'t any more room', 'straps have all been used')
+    elsif /more room|too long to fit/ =~ bput("stow my #{item.short_name}", 'You put', 'You should unload', 'You easily strap', 'You secure your', 'There isn\'t any more room', 'straps have all been used', 'is too long to fit')
       bput("wear my #{item.short_name}", 'You ')
     end
     waitrt?


### PR DESCRIPTION
### What's changing?

The `remove_item` and `wear_item` functions were out of date with new gear options for where/how an item should be stowed, such as tied to a strap, use "wield/sheath" mechanics, "transforming" items, or put it in a specified container.

A recent change to this file made some progress. This change continues the improvement effort.

The updates are largely based on what `return_held_gear` is doing.

### Why is this necessary?

An example where the existing logic fails is I wear a longbow that I want tied to a bag with straps. When trying to wear a gearset that includes the longbow, the existing logic tries to `get longbow` and fails with "You should untie the longbow from the bag first." With these changes, the logic respects the `tie_to`, `wield`, or `container` settings.

Similarly, if someone were to _not_ specify a gear item's `tie_to`, `wield`, or `container` in their yaml, then the default case when trying to remove an item and just "stow longbow" may fail with "The longbow is too long to fit in the backpack." With these changes, the character will re-wear the item and keep their hands empty as the original logic was doing.

FYI @vtcifer 