### PR TITLE
Add forced recast timer to buffother.

### DIFF
--- a/buffother.lic
+++ b/buffother.lic
@@ -1,38 +1,50 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#buffother
 =end
-custom_require.call(%w(common-arcana events spellmonitor drinfomon common-travel))
-class Buffother
+
+custom_require.call(%w(common-arcana common-travel))
+
+class BuffOther
   include DRCA
   include DRCT
 
   def initialize
     arg_definitions = [
       [
-        { name: 'recipient', regex: /\w+/, description: 'Person to buff' },
-        { name: 'waggle', regex: /\w+/, description: 'Waggle set to cast' },
-        { name: 'room', regex: /\d+/, optional: true, description: 'Room to move to' }
+        { name: 'recipient', regex: /\w+/, description: 'Player to buff.' },
+        { name: 'waggle', regex: /\w+/, description: 'Waggle set to buff on player.' },
+        { name: 'room', regex: /\d+/, optional: true, description: 'Will move to room number of target player.' }
       ]
     ]
+
     args = parse_args(arg_definitions)
-    settings = get_settings
-    recipient = args.recipient.capitalize
-    waggle = args.waggle
-    room = args.room
-    move_to_room(room)
-    cast_buff_spells(settings, recipient, waggle)
+
+    @settings = get_settings
+    @recipient = args.recipient.capitalize
+    @waggle_set = args.waggle
+    @room = args.room
+
+    move_to_room() if @room
+    cast_buff_spells()
   end
 
-  def move_to_room(room)
-    DRCT.walk_to(room)
-    pause 1
+  def move_to_room()
+    DRC.message "Tracking down #{@recipient} in room ##{@room}!"
+    DRCT.walk_to(@room)
   end
 
-  def cast_buff_spells(settings, recipient, waggle)
-    data = settings.waggle_sets[waggle].values.each do |data|
-      data['cast'] = "cast #{recipient}"
+  def cast_buff_spells()
+    if !DRRoom.pcs.include? (@recipient)
+      DRC.message "#{@recipient} not found in room. Exiting..."
+      exit
+    end
+
+    spell_data = @settings.waggle_sets[@waggle_set].values.each do |spell_data|
+      spell_data['cast'] = "cast #{@recipient}"
+      spell_data['recast'] = 99  
+      
       pause 1 while DRStats.mana < 40
-      DRCA.cast_spell(data, settings, settings.waggle_force_cambrinth)
+      DRCA.cast_spell(spell_data, @settings, @settings.waggle_force_cambrinth)
     end
   end
 
@@ -42,4 +54,4 @@ before_dying do
   fput("release mana")
 end
 
-Buffother.new
+BuffOther.new


### PR DESCRIPTION
- Added some structure to make it more readable. 
- Added protection logic to not sit and spam with errors if target not found. 
- Forced a recast time to eliminate the recommended be set high to avoid conflict with personal buff timers.
- Made variables class scope.
- Removed excess code.