### PR TITLE
Adding peruse match

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -87,7 +87,7 @@ class Enchant
   def study_recipe
     get_item("#{@book_type} book")
     turn_to("page #{find_recipe(@chapter, @recipe)}")
-    bput("study my #{@book_type} book", 'You scan', 'You review')
+    bput("study my #{@book_type} book", 'You scan', 'You review', 'You peruse')
     stow_item("#{@book_type} book")
     get_item(@brazier) if @use_own_brazier
 


### PR DESCRIPTION
Adding match for "You peruse" when reading crafting book to fix the 15 second delay on no match.