### PR TITLE
[script] [common] New method: can_see_sky?

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -163,10 +163,14 @@ module DRC
   end
 
   def can_see_sky?
-    # If you are indoors and not able to see the sky, you'll get 'That's a bit hard to do while inside' message.
-    # If you are indoors but able to see the sky (e.g. a window or skylight), you'll get 'You glance outside' message.
-    # If you are outdoors, you'll get 'You glance up at the sky' message.
-    bput('weather', 'inside', 'You glance up at the sky', 'You glance outside') != 'inside'
+    # If you are indoors and not able to see the sky.
+    inside_no_sky = "That's a bit hard to do while inside."
+    # If you are indoors but able to see the sky (e.g. a window or skylight).
+    inside_yes_sky = "You glance up at the sky"
+    # If you are outdoors.
+    outside = "You glance outside"
+    # Can we see the sky?
+    bput("weather", inside_no_sky, inside_yes_sky, outside) != inside_no_sky
   end
 
   def forage?(item, tries=5)


### PR DESCRIPTION
Discord Lich thread: https://discordapp.com/channels/745675889622384681/745676101392793651/746953119006588980

Answers the simple question: can I see the sky?

Some abilities, such as casting Lunar Magic spells or doing Moon Mage celestial observations, require seeing the sky. This new function is a easy way to check if you can see the sky or not then take appropriate action. For example, to not whip out a telescope and try to observe the sky that you cannot see.

I'm proposing this function to `common` lib instead of `common-arcana` or `common-moonmage` because checking if you can see the sky or not doesn't seem inherently magical to me (although my initial use cases for it are for updates to `walkingastro` or other arcana based scripts).

### Examples of checking for the sky before taking action
_These are candidates to be refactored to use this function, but more broadly sharing these references as credibility to the need of a common function and proof that this technique works._
* https://github.com/rpherbig/dr-scripts/blob/master/common-arcana.lic#L608
* https://github.com/rpherbig/dr-scripts/blob/master/combat-trainer.lic#L1618
* https://github.com/rpherbig/dr-scripts/blob/master/crossing-training.lic#L511

### Tests
I tested this new function in the following rooms in Crossing.
Apply the change to `common.lic` then reload the file via `;common`.
The test command used was `;e echo DRC.can_see_sky?`

* 897 => can_see_sky? `true` (outside on the street)
```
> weather
You glance up at the sky.
```

* 5995 => can_see_sky? `true` (inside Raven's Court but open air)
```
> weather
You glance outside.
```

* 6006 => can_see_sky? `false` (inside Raven's Court gallery with no window)
```
> weather
That's a bit hard to do while inside.
```