### PR TITLE
[script] [common-moonmage] Explicitly reference DRC module

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -128,13 +128,14 @@ module DRCMM
   # https://elanthipedia.play.net/Shape_Moonblade
   def wear_moon_weapon?
     moon_weapon_regex = /moon[\w]+/
-    moon_wear_messages = ['telekinetic', 'already wearing', 'Wear what']
+    moon_wear_messages = ["telekinetic", "already wearing", "You can't wear", "Wear what"]
+    wore_it = false
     if DRC.left_hand =~ moon_weapon_regex
-      return bput("wear #{DRC.left_hand}", *moon_wear_messages) =~ /telekinetic/
+      wore_it = wore_it || bput("wear #{DRC.left_hand}", *moon_wear_messages) =~ /telekinetic/
     end
     if DRC.right_hand =~ moon_weapon_regex
-      return bput("wear #{DRC.right_hand}", *moon_wear_messages) =~ /telekinetic/
+      wore_it = wore_it || bput("wear #{DRC.right_hand}", *moon_wear_messages) =~ /telekinetic/
     end
-    return false
+    return wore_it
   end
 end

--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -123,15 +123,18 @@ module DRCMM
 
   # There are many variants of a summoned moon weapon (blade, staff, sword, etc)
   # This function checks if you're holding one then tries to wear it.
+  # Returns true if what is in your hands is a summoned moon weapon that becomes worn.
+  # Returns false if you're not holding a moon weapon, or you are but can't wear it.
   # https://elanthipedia.play.net/Shape_Moonblade
   def wear_moon_weapon
     moon_weapon_regex = /moon[\w]+/
-    moon_wear_messages = ['telekinetic']
+    moon_wear_messages = ['telekinetic', 'already wearing', 'Wear what']
     if DRC.left_hand =~ moon_weapon_regex
-      bput("wear #{DRC.left_hand}", *moon_wear_messages)
+      return bput("wear #{DRC.left_hand}", *moon_wear_messages) =~ /telekinetic/
     end
     if DRC.right_hand =~ moon_weapon_regex
-      bput("wear #{DRC.right_hand}", *moon_wear_messages)
+      return bput("wear #{DRC.right_hand}", *moon_wear_messages) =~ /telekinetic/
     end
+    return false
   end
 end

--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -127,11 +127,11 @@ module DRCMM
   def wear_moon_weapon
     moon_weapon_regex = /moon[\w]+/
     moon_wear_messages = ['telekinetic']
-    if left_hand =~ moon_weapon_regex
-      bput("wear #{left_hand}", *moon_wear_messages)
+    if DRC.left_hand =~ moon_weapon_regex
+      bput("wear #{DRC.left_hand}", *moon_wear_messages)
     end
-    if right_hand =~ moon_weapon_regex
-      bput("wear #{right_hand}", *moon_wear_messages)
+    if DRC.right_hand =~ moon_weapon_regex
+      bput("wear #{DRC.right_hand}", *moon_wear_messages)
     end
   end
 end

--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -126,7 +126,7 @@ module DRCMM
   # Returns true if what is in your hands is a summoned moon weapon that becomes worn.
   # Returns false if you're not holding a moon weapon, or you are but can't wear it.
   # https://elanthipedia.play.net/Shape_Moonblade
-  def wear_moon_weapon
+  def wear_moon_weapon?
     moon_weapon_regex = /moon[\w]+/
     moon_wear_messages = ['telekinetic', 'already wearing', 'Wear what']
     if DRC.left_hand =~ moon_weapon_regex


### PR DESCRIPTION
In some contexts when `wear_moon_weapon` is called then `left_hand` and `right_hand` variables are not in scope. This ensures we reference the class variables explicitly via `DRC.left_hand` or `DRC.right_hand`.

```
--- Lich: error: undefined local variable or method `left_hand' for DRCMM:Module
Did you mean?  lefthand
               lefthand?
	common-moonmage:130:in `wear_moon_weapon'
	combat-trainer:839:in `check_skinning'

--- Lich: combat-trainer has exited.
```