### PR TITLE
Add failed collect message for super low outdoors

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -192,7 +192,7 @@ module DRC
   end
 
   def collect(item)
-    case bput("collect #{item}", 'You manage to collect a pile', 'The room is too cluttered', 'believe you would probably have better luck trying to find a dragon', 'if you had a bit more luck.', 'You cannot collect anything', 'You forage around but are unable to find anything', 'You wander around and poke your fingers', 'You survey the area and realize that any collecting efforts would be futile', 'You are sure you knew', 'You begin to forage around,')
+    case bput("collect #{item}", 'You manage to collect a pile', 'The room is too cluttered', 'believe you would probably have better luck trying to find a dragon', 'if you had a bit more luck.', 'You cannot collect anything', 'You forage around but are unable to find anything', 'You wander around and poke your fingers', 'You survey the area and realize that any collecting efforts would be futile', 'You are sure you knew', 'You begin to forage around,','As you rummage around')
     when 'The room is too cluttered'
       return unless kick_pile?
       collect(item)


### PR DESCRIPTION
Add a very edge case match on very low characters that try to collect in a bad place.