### PR TITLE
[script] [sanowret-crystal] Fix: use DRC.message instead of echo

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -28,8 +28,8 @@ class SanowretCrystal
       response = DRC.bput("exhale my #{@adjective} crystal", 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     end
     return if response !~ /This is not a good place for that\./
-    echo "Could not use crystal in room #{DRRoom.title}."
-    echo "Consider adding this room to your sanowret_no_use_rooms settings."
+    DRC.message("Could not use crystal in room #{DRRoom.title}.")
+    DRC.message("Consider adding this room to your sanowret_no_use_rooms settings.")
     # Go ahead and remember to ignore this room while the script is running
     # This convenience won't persist between script runs though, go update your yaml
     @no_use_rooms.push(DRRoom.title) unless @no_use_rooms.include?(DRRoom.title)
@@ -57,11 +57,11 @@ class SanowretCrystal
         use_crystal
         DRC.bput("stow my #{@adjective} crystal", 'You put', 'Stow what')
       when /Not here, /, /a wave of Corruption magic/
-        echo "Pausing #{Script.current.name} script until you move"
+        DRC.message("Pausing #{Script.current.name} script until you move to another room.")
         non_sano_room_id = Room.current.id
         pause 1 until Room.current.id != non_sano_room_id
       else
-        echo 'Sanowret crystal not found, exiting'
+        DRC.message("Sanowret crystal not found, exiting!")
         exit
       end
     end

--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -28,8 +28,8 @@ class SanowretCrystal
       response = DRC.bput("exhale my #{@adjective} crystal", 'you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.', 'However, nothing much else happens, as you lack the concentration to focus.', 'This is not a good place for that.', 'Doing that would give away your hiding place.', 'That would be difficult to do while you attempt to keep the trail in sight.')
     end
     return if response !~ /This is not a good place for that\./
-    message "Could not use crystal in room #{DRRoom.title}."
-    message "Consider adding this room to your sanowret_no_use_rooms settings."
+    echo "Could not use crystal in room #{DRRoom.title}."
+    echo "Consider adding this room to your sanowret_no_use_rooms settings."
     # Go ahead and remember to ignore this room while the script is running
     # This convenience won't persist between script runs though, go update your yaml
     @no_use_rooms.push(DRRoom.title) unless @no_use_rooms.include?(DRRoom.title)


### PR DESCRIPTION
The `message` function is not defined in this context, causes "undefined method" error. I'm not sure why these lines of code were using message. Though, my guess for why this bug wasn't found until now was because I had added the `sanowret_no_use_rooms` logic so normally you wouldn't whip out the crystal and use it in the Bank, for example.

This edge case came up because the script started while I was outside the bank. A second later I was already at the teller window when the script tried to use the crystal and BOOM.

### Error

```
[sanowret-crystal]>exhale my sanowret crystal

This is not a good place for that.
> 
--- Lich: error: undefined method `message' for #<SanowretCrystal:0x02f53c80>
	sanowret-crystal:31:in `use_crystal'
	sanowret-crystal:51:in `check_crystal'

--- Lich: sanowret-crystal has exited.
```

### Fixed

With this fix, rather than crashing in such a scenario, the script will remind you this isn't a room where you can use the  crystal and consider adding it to your `sanowret_no_use_rooms` config (which it very well might be already, but at least we aren't crashing anymore).

```
> ;sanowret-crystal run

--- Lich: sanowret-crystal active.

[sanowret-crystal]>tap my sanowret crystal

You tap a sanowret crystal inside your hitman's backpack.
> 
[sanowret-crystal]>get my sanowret crystal

You get a sanowret crystal from inside your hitman's backpack.
> 
[sanowret-crystal]>exhale my sanowret crystal

This is not a good place for that.
> 
[sanowret-crystal: Could not use crystal in room [[First Provincial Bank, Lobby]].]

[sanowret-crystal: Consider adding this room to your sanowret_no_use_rooms settings.]

[sanowret-crystal]>stow my sanowret crystal

You put your crystal in your hitman's backpack.
> 
--- Lich: sanowret-crystal has exited.
```