### PR TITLE
[script] [locksmithing] Wait to begin playing before begin picking

### DIFF
--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -22,10 +22,11 @@ class Locksmithing
     @equipment_manager.empty_hands
 
     live_boxes if @liveboxes
+    # Practice some music while use lock trainers
     start_script('performance', ['noclean']) unless Script.running?('performance')
+    waitfor('as you begin')
     daily_lockbox if @daily_trainer
     consumable_lockbox if @consumable_trainers
-    kill_script('performance') if running?('performance')
   end
 
   def daily_lockbox
@@ -115,6 +116,10 @@ class Locksmithing
         return
       end
     end
+  end
+
+  before_dying do
+    kill_script('performance') if running?('performance')
   end
 end
 


### PR DESCRIPTION
Depending on your config, the `locksmithing` and `performance` scripts may need to remove worn items (e.g. hand armor). 

Currently, the `locksmithing` script starts the `performance` script asynchronously and moves on. There is a race condition where one or both scripts are trying to remove worn items and get boxes/instruments and your hands become full and `bput` commands stall out.

## Key Changes
* Wait for the `performance` script to get the character playing the instrument _then_ resume picking.
* If `locksmithing` script ends abruptly (on purpose or otherwise) then stop `performance` script, too.

---

FYI @Hiinky 
