### PR TITLE
changing the waitfor to pause

### DIFF
--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -24,7 +24,7 @@ class Locksmithing
     live_boxes if @liveboxes
     # Practice some music while use lock trainers
     start_script('performance', ['noclean']) unless Script.running?('performance')
-    waitfor('as you begin')
+    pause 3
     daily_lockbox if @daily_trainer
     consumable_lockbox if @consumable_trainers
   end


### PR DESCRIPTION
Getting reports of mismatching this morning - the waitfor assumes  you just started playing when there's a few reasons why that may not be the case.  I think a short pause that allows you to get your hands/instrument sorted is less of a stumbling block.  I would consider it an edge case to not be using a worn_instrument these days.