### PR TITLE
[script] [burgle] Robustify item_whitelist logic

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -22,14 +22,11 @@ class Burgle
         { name: 'roomid', regex: /\d+/, optional: true, description: 'Override yaml setting and go to room id (#) specified.  The room should be chosen VERY carefully.'},
         { name: 'loot_type', options: %w[drop keep pawn bin], optional: true, description: 'Override yaml setting for loot. (items on item_whitelist are always kept.)' },
         { name: 'hometown', options: $HOMETOWN_LIST, optional: true, description: 'Override yaml hometown settings for bin and pawn.  If no bin or pawnshop in that hometown, loot_type will revert to drop.'},
-        { name: 'follow', options: %w[follow], optional: true, description: "Follow another player, don't actually burgle.  You must group with them first."},
-        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug output' },
+        { name: 'follow', options: %w[follow], optional: true, description: "Follow another player, don't actually burgle.  You must group with them first."}
       ]
     ]
 
     args = parse_args(arg_definitions)
-
-    $debug_mode_burgle = UserVars.burgle_debug || args.debug || false
 
     #Ensure hometown is in sentence case if it's specified - fixes the fact parse_args is always lower case
     args.hometown = args.hometown.gsub(/\b('?[a-z])/) { $1.capitalize } if args.hometown
@@ -272,14 +269,13 @@ class Burgle
 
     #leave the group/disband so you aren't carried around
     if Flags['group-burgle-leave']
-      fput('leave') 
+      fput('leave')
     elsif Flags['group-burgle-disband']
       fput('disband stalk')
       fput('disband group')
     else
       pause 1   # need a pause because there is no indicator if you are part of a group currently with 2 person rope entry
     end
-
 
     if @burgle_settings['max_search_count'] > 0
       @search_count = 0
@@ -425,25 +421,29 @@ class Burgle
     #if you've seen footsteps, don't bother storing items, and just get out if in safe mode
     return if Flags['burgle-footsteps']
     #store loot in your loot container, unless the item in your hands is a rope or lockpick
-    if DRC.right_hand
-      if GameObj.right_hand.noun =~ /lockpick|rope/
-        stow_hand("right")
-      else
-        temp_loot = DRC.right_hand
-        @loot_list.push(temp_loot) if put_item?(DRC.right_hand)
-      end
+    case DRC.right_hand
+    when nil
+    when /(?:lockpick|rope)$/
+      stow_hand("right")
+    when *@burgle_settings['item_whitelist']
+      put_item?(DRC.right_hand)
+    else
+      temp_loot = DRC.right_hand
+      @loot_list.push(temp_loot) if put_item?(DRC.right_hand)
     end
 
     #if you've seen footsteps, don't bother still storing items, and just get out if in safe mode
     return if Flags['burgle-footsteps']
     #store loot in your loot container, unless the item in your hands is a rope or lockpick
-    if DRC.left_hand
-      if GameObj.left_hand.noun =~ /lockpick|rope/
-        stow_hand("left")
-      else
-        temp_loot = DRC.left_hand
-        @loot_list.push(temp_loot) if put_item?(DRC.left_hand)
-      end
+    case DRC.left_hand
+    when nil
+    when /(?:lockpick|rope)$/
+      stow_hand("left")
+    when *@burgle_settings['item_whitelist']
+      put_item?(DRC.left_hand)
+    else
+      temp_loot = DRC.left_hand
+      @loot_list.push(temp_loot) if put_item?(DRC.left_hand)
     end
   end
 
@@ -525,10 +525,6 @@ class Burgle
   def process_loot
     #return if loot_type isn't one of the supported process kind
     return if @loot_type !~ /drop|pawn|bin/
-    #remove whitelisted items from the loot_list
-    echo("loot_list before filtering: #{@loot_list}") if $debug_mode_burgle
-    @loot_list.select! { |loot| @burgle_settings['item_whitelist'].none?{ |keep| loot =~ /\b#{keep}\b/ } }
-    echo("loot_list after filtering: #{@loot_list}") if $debug_mode_burgle
     #return if loot_list is empty.
     return if @loot_list.empty?
 

--- a/burgle.lic
+++ b/burgle.lic
@@ -22,11 +22,14 @@ class Burgle
         { name: 'roomid', regex: /\d+/, optional: true, description: 'Override yaml setting and go to room id (#) specified.  The room should be chosen VERY carefully.'},
         { name: 'loot_type', options: %w[drop keep pawn bin], optional: true, description: 'Override yaml setting for loot. (items on item_whitelist are always kept.)' },
         { name: 'hometown', options: $HOMETOWN_LIST, optional: true, description: 'Override yaml hometown settings for bin and pawn.  If no bin or pawnshop in that hometown, loot_type will revert to drop.'},
-        { name: 'follow', options: %w[follow], optional: true, description: "Follow another player, don't actually burgle.  You must group with them first."}
+        { name: 'follow', options: %w[follow], optional: true, description: "Follow another player, don't actually burgle.  You must group with them first."},
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug output' },
       ]
     ]
 
     args = parse_args(arg_definitions)
+
+    $debug_mode_burgle = UserVars.burgle_debug || args.debug || false
 
     #Ensure hometown is in sentence case if it's specified - fixes the fact parse_args is always lower case
     args.hometown = args.hometown.gsub(/\b('?[a-z])/) { $1.capitalize } if args.hometown
@@ -123,10 +126,10 @@ class Burgle
       return false
     end
     if @burgle_settings['max_search_count'] > 0
-       if /(already open|^You.+open)/ !~ bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring')
-         message("You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.")
-         return false
-       end
+      if /(already open|^You.+open)/ !~ bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring')
+        message("You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.")
+        return false
+      end
     end
 
     case @loot_type
@@ -495,7 +498,7 @@ class Burgle
   end
 
   def pawn_item(item)
-     case bput("sell my #{item}",
+    case bput("sell my #{item}",
       'You sell your',                        # success
       /shakes (his|her) head and says/,       # not worth enough (generic)
       'Relf briefly glances at your',         # not worth enough (hib - special messaging)
@@ -523,16 +526,16 @@ class Burgle
     #return if loot_type isn't one of the supported process kind
     return if @loot_type !~ /drop|pawn|bin/
     #remove whitelisted items from the loot_list
-    @loot_list.select! { | item | !(@burgle_settings['item_whitelist'].include?(item)) }
+    echo("loot_list before filtering: #{@loot_list}") if $debug_mode_burgle
+    @loot_list.select! { |loot| @burgle_settings['item_whitelist'].none?{ |keep| loot =~ /\b#{keep}\b/ } }
+    echo("loot_list after filtering: #{@loot_list}") if $debug_mode_burgle
     #return if loot_list is empty.
     return if @loot_list.empty?
 
     walk_to(@loot_room_id) unless @loot_room_id == nil
 
     @loot_list.each do |item|
-      case bput("get #{item} from my #{@loot_container}",
-                  'You get',
-                  'What were you referring to?')
+      case bput("get #{item} from my #{@loot_container}", 'You get', 'What were you referring to?')
       when /^You get/
         case @loot_type
         when 'bin'
@@ -549,7 +552,6 @@ class Burgle
   end
 
 end
-
 
 before_dying do
   #resume the previously paused scripts


### PR DESCRIPTION
(description updated)

### Changes
* Updates `store_loot` function to exclude items in the `item_whitelist` list from being counted as loot so that they aren't later pawned/dropped/binned.
* Adds support for regular expression for `item_whitelist` (new feature), or as a list of strings (current behavior).
* Fixes some whitespace inconsistencies.

### Example Item Whitelist Configs

_Regular Expression_
```yaml
burgle_settings:
  item_whitelist: !ruby/regexp /\b(memory orb|keepsake box|telescope|blunt-tipped|fabric)\b/
  ...
```

_List of strings (must match item's `<adjective> <noun>` exactly)_
```yaml
burgle_settings:
  item_whitelist:
    - memory orb
    - keepsake box
    - puzzle box
  ...
```