### PR TITLE
[script] [common-moonmage] Helper functions to wear/hold moon weapons

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -127,15 +127,46 @@ module DRCMM
   # Returns false if you're not holding a moon weapon, or you are but can't wear it.
   # https://elanthipedia.play.net/Shape_Moonblade
   def wear_moon_weapon?
-    moon_weapon_regex = /moon[\w]+/
-    moon_wear_messages = ["telekinetic", "already wearing", "You can't wear", "Wear what"]
+    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
+    moon_wear_messages = ["You're already", "You can't wear", "Wear what", "telekinetic"]
     wore_it = false
     if DRC.left_hand =~ moon_weapon_regex
-      wore_it = wore_it || bput("wear #{DRC.left_hand}", *moon_wear_messages) =~ /telekinetic/
+      wore_it = wore_it || DRC.bput("wear #{DRC.left_hand}", *moon_wear_messages) == "telekinetic"
     end
     if DRC.right_hand =~ moon_weapon_regex
-      wore_it = wore_it || bput("wear #{DRC.right_hand}", *moon_wear_messages) =~ /telekinetic/
+      wore_it = wore_it || DRC.bput("wear #{DRC.right_hand}", *moon_wear_messages) == "telekinetic"
     end
     return wore_it
   end
+
+  # Is a moon weapon in your hands?
+  def holding_moon_weapon?
+    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
+    return (DRC.left_hand =~ moon_weapon_regex || DRC.right_hand =~ moon_weapon_regex) != nil
+  end
+
+  # Try to hold a moon weapon.
+  # If one isn't already in your hands then will look to see if
+  # one is floating around you and hold it.
+  # If you end up not holding a moon weapon then returns false.
+  def hold_moon_weapon?
+    return true if holding_moon_weapon?
+    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
+    moon_floating_regex = /((black|red-hot|blue-white) moon[\w]+) bobs lazily in the air next to you/
+    moon_hold_messages = ["You grab", "You aren't wearing", "Hold hands with whom?"]
+    held_it = false
+    # Look at yourself to see if you're wearing a moon weapon.
+    # This regex specifically checks for the messaging that it's in the air next to you
+    # so that we avoid false positives like wearing a "black moonsilk shirt".
+    look_result = DRC.bput("look #{Char.name}", moon_floating_regex, "You are wearing")
+    # Now try to extract just the moon weapon name from what we saw.
+    scan_result = look_result.scan(moon_weapon_regex)
+    # If a match was found then grab it from the captured groups per the regex.
+    if scan_result.length > 0 && scan_result[0].length > 0
+      moon_weapon = scan_result[0][0]
+      held_it = DRC.bput("hold #{moon_weapon}", *moon_hold_messages) == "You grab"
+    end
+    return held_it
+  end
+
 end

--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -139,6 +139,20 @@ module DRCMM
     return wore_it
   end
 
+  # Drops the moon weapon in your hands, if any.
+  # Returns true if dropped something, false otherwise.
+  def drop_moon_weapon?
+    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
+    dropped_it = false
+    if DRC.left_hand =~ moon_weapon_regex
+      dropped_it = dropped_it || DRC.bput("drop #{DRC.left_hand}", "As you open your hand", "What were you referring to") == "As you open your hand"
+    end
+    if DRC.right_hand =~ moon_weapon_regex
+      dropped_it = dropped_it || DRC.bput("drop #{DRC.right_hand}", "As you open your hand", "What were you referring to") == "As you open your hand"
+    end
+    return dropped_it
+  end
+
   # Is a moon weapon in your hands?
   def holding_moon_weapon?
     moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/


### PR DESCRIPTION
Bulk of the logic is to ensure the regex patterns match to actual moon weapons and not get confused by items whose nouns are or start with the word "moon", like "a trio of moons" or "moonsilk shirt". I'm personally invested in these changes because my moon mage wears both those items, haha.

This is a pre-requisite for https://github.com/rpherbig/dr-scripts/pull/4471