### PR TITLE
[script] [common-summoning] Update logic to hold moon weapons

### DIFF
--- a/common-summoning.lic
+++ b/common-summoning.lic
@@ -14,7 +14,7 @@ module DRCS
         echo "Couldn't find any moons to cast moonblade with"
         return
       end
-      fput('get moon')
+      DRCMM.hold_moon_weapon?
     elsif DRStats.warrior_mage?
       get_ingot(ingot, true)
       case DRC.bput("summon weapon #{element} #{skill}", 'You lack the elemental charge', 'you draw out')
@@ -54,8 +54,9 @@ module DRCS
     if DRStats.moon_mage?
       skill_to_shape = { 'Staves' => 'blunt', 'Twohanded Edged' => 'huge', 'Large Edged' => 'heavy', 'Small Edged' => 'normal' }
       shape = skill_to_shape[skill]
-      DRC.bput('get moon', 'already holding that', 'You grab')
-      DRC.bput("shape #{GameObj.right_hand.noun} to #{shape}", 'you adjust the magic that defines its shape', 'already has')
+      if DRCMM.hold_moon_weapon?
+        DRC.bput("shape #{GameObj.right_hand.noun} to #{shape}", 'you adjust the magic that defines its shape', 'already has')
+      end
     elsif DRStats.warrior_mage?
       get_ingot(ingot, false)
       case DRC.bput("shape my #{GameObj.right_hand.noun} to #{skill}", 'You lack the elemental charge', 'You reach out')
@@ -72,17 +73,16 @@ module DRCS
   end
 
   def moon_used_to_summon_weapon
-    glance_to_moon = {
-      'black' => 'katamba',
-      'red-hot' => 'yavash',
-      'blue-white' => 'xibar',
-      'could not find' => nil
-    }
-    # 'glance moon' is a little misleading, but it will glance
-    # at either a moonblade or moonstaff, never a moon
-    glance = DRC.bput('glance moon', glance_to_moon.keys)
-
-    glance_to_moon[glance]
+    case "#{DRC.left_hand}|#{DRC.right_hand}"
+    when /black moon[\w]+/
+      return 'katamba'
+    when /red-hot moon[\w]+/
+      return 'yavash'
+    when /blue-white moon[\w]+/
+      return 'xibar'
+    else
+      return nil
+    end
   end
 
   def turn_summoned_weapon


### PR DESCRIPTION
* Changes ambiguous use of `get moon` with `DRCMM.hold_moon_weapon?` (depends on https://github.com/rpherbig/dr-scripts/pull/4470)
* Changes ambiguous use of `glance moon` with checking what's held in your hands

Bulk of the logic is to ensure the regex patterns match to actual moon weapons and not get confused by items whose nouns are or start with the word "moon", like "a trio of moons" or "moonsilk shirt". I'm personally invested in these changes because my moon mage wears both those items, haha.