### PR TITLE
Add support for climbing target

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -37,13 +37,13 @@ class Athletics
     args = parse_args(arg_definitions)
 
     start_script('skill-recorder') unless Script.running?('skill-recorder')
-    if args.wyvern
+    if args.wyvern || (@settings.climbing_target == 'wyvern')
       climb_wyvern
-    elsif args.undergondola
+    elsif args.undergondola || (@settings.climbing_target == 'undergondola')
       climb_branch
-    elsif args.xalas
+    elsif args.xalas || (@settings.climbing_target == 'xalas')
       climb_xalas
-    elsif args.cliffs
+    elsif args.cliffs || (@settings.climbing_target == 'cliffs')
       climb_cliffs  
     elsif have_climbing_rope
       train_with_rope(args.stationary)


### PR DESCRIPTION
These changes allow 'climbing_target' to work with the climbing targets (xalas, undergondola, wyverns, cliffs) instead of just with practice.  Tested by running athletics with no arguments, as well as with CT.