### PR TITLE
[script] [common-moonmage] Support shadowsilk cloaks hiding worn moon weapons

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -143,12 +143,13 @@ module DRCMM
   # Returns true if dropped something, false otherwise.
   def drop_moon_weapon?
     moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
+    moon_drop_messages = ["As you open your hand", "What were you referring to"]
     dropped_it = false
     if DRC.left_hand =~ moon_weapon_regex
-      dropped_it = dropped_it || DRC.bput("drop #{DRC.left_hand}", "As you open your hand", "What were you referring to") == "As you open your hand"
+      dropped_it = dropped_it || DRC.bput("drop #{DRC.left_hand}", *moon_drop_messages) == "As you open your hand"
     end
     if DRC.right_hand =~ moon_weapon_regex
-      dropped_it = dropped_it || DRC.bput("drop #{DRC.right_hand}", "As you open your hand", "What were you referring to") == "As you open your hand"
+      dropped_it = dropped_it || DRC.bput("drop #{DRC.right_hand}", *moon_drop_messages) == "As you open your hand"
     end
     return dropped_it
   end
@@ -172,13 +173,21 @@ module DRCMM
     # Look at yourself to see if you're wearing a moon weapon.
     # This regex specifically checks for the messaging that it's in the air next to you
     # so that we avoid false positives like wearing a "black moonsilk shirt".
-    look_result = DRC.bput("look #{Char.name}", moon_floating_regex, "You are wearing")
+    # Known caveat, this won't work if you're wearing a shadowsilk cloak or something that hides all worn items.
+    look_result = DRC.bput("look #{Char.name}", moon_floating_regex, "You are wearing", "You are wrapped")
     # Now try to extract just the moon weapon name from what we saw.
     scan_result = look_result.scan(moon_weapon_regex)
     # If a match was found then grab it from the captured groups per the regex.
     if scan_result.length > 0 && scan_result[0].length > 0
       moon_weapon = scan_result[0][0]
       held_it = DRC.bput("hold #{moon_weapon}", *moon_hold_messages) == "You grab"
+    else
+      # At this point you're neither holding a moon weapon nor did we see one
+      # hovering around you. In case you're wearing a shadowsilk cloak or other
+      # item that hides all your features then we will brute force try to hold
+      # all known moon weapon types as a last ditch effort.
+      held_it = held_it || DRC.bput("hold moonblade", *moon_hold_messages) == "You grab"
+      held_it = held_it || DRC.bput("hold moonstaff", *moon_hold_messages) == "You grab"
     end
     return held_it
   end


### PR DESCRIPTION
### Changes
* When trying to hold a moon weapon, if one is not already in your hands and we can't see one on you then fallback to brute force of wearing a `moonblade` or `moonstaff`.

While testing these changes, I determined the wiki for [Shape Moonblade](https://elanthipedia.play.net/Shape_Moonblade) was outdated and I've since updated it. There seems to only be two nouns now as compared to the plethora of options before, so the brute force method only tries those two nouns (moonblade, moonstaff) for now.

### Testing

**_Output when we CAN see what moon weapon you have suspended on you_**

```
[combat-trainer]>look Monoak

> 
You are Stargazer Monoak, a Dwarven Moon Mage.
You have a round face, blah blah blah.
You are short for a Dwarf.
A trio of multihued moons float lazily around your right forearm, glowing with a lustrous sheen against your skin.
You are young.
A cold blue-white moonblade bobs lazily in the air next to you.

You are holding a steel hurling axe in your right hand.
You are wearing <stuff and things>.
> 
[combat-trainer]>hold blue-white moonblade

You grab your blue-white moonblade from the air.

> 
[combat-trainer]>drop blue-white moonblade

As you open your hand to release the moonblade, it is consumed in a cold blue-white fire.
> 
[combat-trainer]>prep moonblade 1
```

**_Output when we CANNOT see what moon weapon is suspended on you_**

```
[combat-trainer]>look Monoak

You are wrapped in dark shadows, concealing all but a steel hurling axe in your right hand.
 
[combat-trainer]>hold moonblade

You grab your blue-white moonblade from the air.
 
[combat-trainer]>drop blue-white moonblade

As you open your hand to release the moonblade, it is consumed in a cold blue-white fire.
 
[combat-trainer]>prep moonblade 1
```