### PR TITLE
[script] [common-moonmage] Handle when you are hidden or invisible

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -174,7 +174,7 @@ module DRCMM
     # This regex specifically checks for the messaging that it's in the air next to you
     # so that we avoid false positives like wearing a "black moonsilk shirt".
     # Known caveat, this won't work if you're wearing a shadowsilk cloak or something that hides all worn items.
-    look_result = DRC.bput("look #{Char.name}", moon_floating_regex, "You are wearing", "You are wrapped")
+    look_result = DRC.bput("look #{Char.name}", moon_floating_regex, "You are wearing", "You are wrapped", "I could not find")
     # Now try to extract just the moon weapon name from what we saw.
     scan_result = look_result.scan(moon_weapon_regex)
     # If a match was found then grab it from the captured groups per the regex.


### PR DESCRIPTION
If you can't see yourself then the game responds with `I could not find what you were referring to.`

This change keeps the `bput` command from hanging and will move on as if it didn't see a moon weapon floating around you and will do the backup logic instead.

_Context_
This came about because I had Refractive Field spell on and I pulsed invisible when the script tried to check what moon weapon I was wearing.