### PR TITLE
[script] [attunement] Loop until done training

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -52,11 +52,4 @@ class Attunement
 
 end
 
-before_dying do
-  # release any mana if preparing a spell
-  fput("release")
-  # put away any cambrinth items
-  EquipmentManager.new.empty_hands
-end
-
 Attunement.new

--- a/attunement.lic
+++ b/attunement.lic
@@ -14,30 +14,49 @@ class Attunement
     @stationary_skills_only = settings.crossing_training_stationary_skills_only
     @hometown = settings.hometown
     @attunement_rooms = settings.attunement_rooms
-    cast_spells(settings.waggle_sets['attunement'], settings)
-    train_attunement
+    @start_timer = Time.now
+    train_attunement(settings)
   end
 
-  def train_attunement
-    command = DRStats.moon_mage? || DRStats.trader? ? 'perc mana' : 'perc'
+  def get_perceive_command
+    DRStats.moon_mage? || DRStats.trader? ? 'perceive mana' : 'perceive'
+  end
 
-    room_list = if @stationary_skills_only || DRStats.moon_mage? || DRStats.trader?
-                  [Room.current.id]
-                elsif !@attunement_rooms.empty?
-                  @attunement_rooms
-                else
-                  get_data('town')[@hometown]['attunement_rooms']
-                end
-
-    start_timer = Time.now
-    room_list.each do |room_id|
-      walk_to(room_id)
-      bput(command, 'You reach out')
-      waitrt?
-      break if DRSkill.getxp('Attunement') >= 30 || start_timer - Time.now > 90
+  def get_rooms
+    if @stationary_skills_only || DRStats.moon_mage? || DRStats.trader?
+      [Room.current.id]
+    elsif !@attunement_rooms.empty?
+      @attunement_rooms
+    else
+      get_data('town')[@hometown]['attunement_rooms']
     end
   end
+
+  def done_training?
+    DRSkill.getxp('Attunement') >= 30 || @start_timer - Time.now >= 90
+  end
+
+  def train_attunement(settings)
+    command = get_perceive_command
+    room_list = get_rooms
+    until done_training?
+      DRCA.do_buffs(settings, 'attunement')
+      room_list.each do |room_id|
+        walk_to(room_id)
+        bput(command, 'You reach out')
+        waitrt?
+        break if done_training?
+      end
+    end
+  end
+
 end
 
-# Call this last to avoid the need for forward declarations
+before_dying do
+  # release any mana if preparing a spell
+  fput("release")
+  # put away any cambrinth items
+  EquipmentManager.new.empty_hands
+end
+
 Attunement.new


### PR DESCRIPTION
* Rather than script stop once exhausted all rooms, repeats itself until at sufficient learning rate or run out of time
* Fixes issue where stationary training or lunar mages (moonies, traders) would only perform once perceive because only in one room
* Refactors code into their own methods

### Test Cases

I've used this to successfully lock Attunement skill on my Moon Mage (stands still) and Paladin (power walks in Crossing)

