### PR TITLE
[script] [common-items] More options to check which hand holds an item

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -137,7 +137,7 @@ module DRCI
   # Checks if the item is in one or more hands.
   # Hand options are: left, right, either, both.
   def in_hand?(item, whichHand = 'either')
-    item_regex = item.split.size > 1 ? /.*\b#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
+    item_regex = item.split.size > 1 ? /.*\b#{item.split.first}.*\b#{item.split.last}\b/i : /\b#{item}\b/i
     item_found = false
     case whichHand.downcase
     when 'left'

--- a/common-items.lic
+++ b/common-items.lic
@@ -119,17 +119,14 @@ module DRCI
     result =~ /inside/
   end
 
-  # Is the item in either hand?
   def in_hands?(item)
     in_hand?(item, 'either')
   end
 
-  # Is the item in your left hand?
   def in_left_hand?(item)
     in_hand?(item, 'left')
   end
 
-  # Is the item in your right hand?
   def in_right_hand?(item)
     in_hand?(item, 'right')
   end
@@ -141,16 +138,12 @@ module DRCI
     item_found = false
     case which_hand.downcase
     when 'left'
-      # Your holding the item in your left hand?
       item_found = ("#{DRC.left_hand}" =~ item_regex) != nil
     when 'right'
-      # Your holding the item in your right hand?
       item_found = ("#{DRC.right_hand}" =~ item_regex) != nil
     when 'either'
-      # At least one hand is holding the item?
       item_found = in_hand?(item, 'left') || in_hand?(item, 'right')
     when 'both'
-      # You're holding two of the same item, one in each hand?
       item_found = in_hand?(item, 'left') && in_hand?(item, 'right')
     else
       DRC.message("Unknown hand: #{which_hand}. Valid options are: left, right, either, both")

--- a/common-items.lic
+++ b/common-items.lic
@@ -141,9 +141,9 @@ module DRCI
     when 'right'
       DRC.right_hand =~ item_regex
     when 'either'
-      in_hand?(item, 'left') || in_hand?(item, 'right')
+      in_left_hand?(item) || in_right_hand?(item)
     when 'both'
-      in_hand?(item, 'left') && in_hand?(item, 'right')
+      in_left_hand?(item) && in_right_hand?(item)
     else
       DRC.message("Unknown hand: #{which_hand}. Valid options are: left, right, either, both")
       false

--- a/common-items.lic
+++ b/common-items.lic
@@ -136,10 +136,10 @@ module DRCI
 
   # Checks if the item is in one or more hands.
   # Hand options are: left, right, either, both.
-  def in_hand?(item, whichHand = 'either')
+  def in_hand?(item, which_hand = 'either')
     item_regex = item.split.size > 1 ? /#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
     item_found = false
-    case whichHand.downcase
+    case which_hand.downcase
     when 'left'
       # Your holding the item in your left hand?
       item_found = ("#{DRC.left_hand}" =~ item_regex) != nil
@@ -153,7 +153,7 @@ module DRCI
       # You're holding two of the same item, one in each hand?
       item_found = in_hand?(item, 'left') && in_hand?(item, 'right')
     else
-      DRC.message("Unknown hand: #{whichHand}. Valid options are: left, right, either, both")
+      DRC.message("Unknown hand: #{which_hand}. Valid options are: left, right, either, both")
       item_found = false
     end
     return item_found

--- a/common-items.lic
+++ b/common-items.lic
@@ -137,7 +137,7 @@ module DRCI
   # Checks if the item is in one or more hands.
   # Hand options are: left, right, either, both.
   def in_hand?(item, whichHand = 'either')
-    item_regex = item.split.size > 1 ? /.*\b#{item.split.first}.*\b#{item.split.last}\b/i : /\b#{item}\b/i
+    item_regex = item.split.size > 1 ? /\b#{item.split.first}.*\b#{item.split.last}\b/i : /\b#{item}\b/i
     item_found = false
     case whichHand.downcase
     when 'left'

--- a/common-items.lic
+++ b/common-items.lic
@@ -134,12 +134,19 @@ module DRCI
   # Checks if the item is in one or more hands.
   # Hand options are: left, right, either, both.
   def in_hand?(item, which_hand = 'either')
-    item_regex = item.split.size > 1 ? /#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
+    return false unless item
+    if item.is_a?(String)
+      if item.split.size > 1
+        item = DRC::Item.new(adjective: item.split.first, name: item.split.last)
+      else
+        item = DRC::Item.new(name: item)
+      end
+    end
     case which_hand.downcase
     when 'left'
-      DRC.left_hand =~ item_regex
+      DRC.left_hand =~ item.short_regex
     when 'right'
-      DRC.right_hand =~ item_regex
+      DRC.right_hand =~ item.short_regex
     when 'either'
       in_left_hand?(item) || in_right_hand?(item)
     when 'both'

--- a/common-items.lic
+++ b/common-items.lic
@@ -119,9 +119,44 @@ module DRCI
     result =~ /inside/
   end
 
+  # Is the item in either hand?
   def in_hands?(item)
+    in_hand?(item, 'either')
+  end
+
+  # Is the item in your left hand?
+  def in_left_hand?(item)
+    in_hand?(item, 'left')
+  end
+
+  # Is the item in your right hand?
+  def in_right_hand?(item)
+    in_hand?(item, 'right')
+  end
+
+  # Checks if the item is in one or more hands.
+  # Hand options are: left, right, either, both.
+  def in_hand?(item, whichHand = 'either')
     item_regex = item.split.size > 1 ? /.*\b#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
-    item_regex =~ "#{DRC.right_hand}#{DRC.left_hand}"
+    item_found = false
+    case whichHand.downcase
+    when 'left'
+      # Your holding the item in your left hand?
+      item_found = ("#{DRC.left_hand}" =~ item_regex) != nil
+    when 'right'
+      # Your holding the item in your right hand?
+      item_found = ("#{DRC.right_hand}" =~ item_regex) != nil
+    when 'either'
+      # At least one hand is holding the item?
+      item_found = in_hand?(item, 'left') || in_hand?(item, 'right')
+    when 'both'
+      # You're holding two of the same item, one in each hand?
+      item_found = in_hand?(item, 'left') && in_hand?(item, 'right')
+    else
+      DRC.message("Unknown hand: #{whichHand}. Valid options are: left, right, either, both")
+      item_found = false
+    end
+    return item_found
   end
 
   def exists?(description)

--- a/common-items.lic
+++ b/common-items.lic
@@ -137,7 +137,7 @@ module DRCI
   # Checks if the item is in one or more hands.
   # Hand options are: left, right, either, both.
   def in_hand?(item, whichHand = 'either')
-    item_regex = item.split.size > 1 ? /\b#{item.split.first}.*\b#{item.split.last}\b/i : /\b#{item}\b/i
+    item_regex = item.split.size > 1 ? /#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
     item_found = false
     case whichHand.downcase
     when 'left'

--- a/common-items.lic
+++ b/common-items.lic
@@ -135,21 +135,19 @@ module DRCI
   # Hand options are: left, right, either, both.
   def in_hand?(item, which_hand = 'either')
     item_regex = item.split.size > 1 ? /#{item.split.first}.*\b#{item.split.last}/i : /\b#{item}/i
-    item_found = false
     case which_hand.downcase
     when 'left'
-      item_found = ("#{DRC.left_hand}" =~ item_regex) != nil
+      DRC.left_hand =~ item_regex
     when 'right'
-      item_found = ("#{DRC.right_hand}" =~ item_regex) != nil
+      DRC.right_hand =~ item_regex
     when 'either'
-      item_found = in_hand?(item, 'left') || in_hand?(item, 'right')
+      in_hand?(item, 'left') || in_hand?(item, 'right')
     when 'both'
-      item_found = in_hand?(item, 'left') && in_hand?(item, 'right')
+      in_hand?(item, 'left') && in_hand?(item, 'right')
     else
       DRC.message("Unknown hand: #{which_hand}. Valid options are: left, right, either, both")
-      item_found = false
+      false
     end
-    return item_found
   end
 
   def exists?(description)


### PR DESCRIPTION
### New Features
* Is item in the left hand?
* Is item in the right hand?
* Is item in either hand?
* Does each hand hold one of the items?

These new methods supports both `String` or `DRC::Item` as the 'item' argument. Use of the `DRC::Item` class standardizes on regex used in `DRC::Item`'s `short_regex` method rather than duplicate that logic here and there. This also ensures this method picks up the updated regex if #4484 gets merged, or if the regex ever changes in the future.

### Use Cases

One use case is when deciding if to swap a weapon between hands to train offhand weapon skill. If the weapon is already in your left hand, you don't need to swap.

Or, perhaps an action requires the item in a particular hand, you can check if it's already there or not with these new utility functions.

### Test Cases

Hold a **vault book** in your left hand.

Hold a **bank book** in your right hand.

#### Assert can find 'vault book' in left hand or in either hand
```
> glance

You glance down to see a leather bank book in your right hand and a vault book in your left hand.

,e echo !!DRCI.in_hand?('vault book', 'left')

[exec1: true]

,e echo !!DRCI.in_hand?('vault book', 'right')

[exec1: false]

,e echo !!DRCI.in_hand?('vault book', 'either')

[exec1: true]

,e echo !!DRCI.in_hand?('vault book', 'both')

[exec1: false]

,e echo !!DRCI.in_hand?(DRC::Item.new(adjective:'vault', name:'book'), 'either')

[exec1: true]
```

#### Assert can find any 'book' in any hand.
```
> glance

You glance down to see a leather bank book in your right hand and a vault book in your left hand.

,e echo !!DRCI.in_hand?('book', 'left')

[exec1: true]

,e echo !!DRCI.in_hand?('book', 'right')

[exec1: true]

,e echo !!DRCI.in_hand?('book', 'either')

[exec1: true]

,e echo !!DRCI.in_hand?('book', 'both')

[exec1: true]

,e echo !!DRCI.in_hand?(DRC::Item.new(name:'book'), 'either')

[exec1: true]
```