### PR TITLE
[script] [attunement] Feedback from Binu (#4485)

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -19,7 +19,6 @@ class Attunement
     @exp_timer = settings.exp_timers['Attunement'] || 90
     @exp_max_threshold = settings.crossing_training_max_threshold
     @lunar_perceive_index = -1
-    @start_timer = Time.now
     train_attunement(settings)
   end
 
@@ -66,8 +65,13 @@ class Attunement
   end
 
   def train_attunement(settings)
+    # Buff first then start timer so that
+    # cast time doesn't count against you
+    DRCA.do_buffs(settings, 'attunement')
+    @start_timer = Time.now
     room_list = get_rooms
     until done_training?
+      # If we keep looping, ensure buffs stay active
       DRCA.do_buffs(settings, 'attunement')
       room_list.each do |room_id|
         walk_to(room_id)

--- a/attunement.lic
+++ b/attunement.lic
@@ -16,10 +16,20 @@ class Attunement
     @stationary_skills_only = settings.crossing_training_stationary_skills_only
     @hometown = settings.hometown
     @attunement_rooms = settings.attunement_rooms
-    @exp_timer = settings.exp_timers['Attunement'] || 90
     @exp_max_threshold = settings.crossing_training_max_threshold
+    @exp_target_increment = settings.attunement_target_increment
+    @exp_start_mindstate = DRSkill.getxp('Attunement')
+    @exp_stop_mindstate = get_target_mindstate(@exp_start_mindstate, @exp_target_increment, @exp_max_threshold)
     @lunar_perceive_index = -1
     train_attunement(settings)
+  end
+
+  # Determines the target mind state to train to
+  # based on the starting value of `mindstate` and
+  # a target goal of increasing by `increment` without
+  # exceeding a max mind state of `threshold`.
+  def get_target_mindstate(mindstate, increment, threshold)
+    mindstate + [increment, [threshold - mindstate, 0].max].min
   end
 
   def is_lunar_mage?
@@ -48,23 +58,11 @@ class Attunement
     end
   end
 
-  def reached_exp_learn_threshold?
-    DRSkill.getxp('Attunement') >= @exp_max_threshold
-  end
-
-  def reached_exp_timer_threshold?
-    Time.now - @start_timer >= @exp_timer
-  end
-
   def done_training?
-    reached_exp_learn_threshold? || reached_exp_timer_threshold?
+    DRSkill.getxp('Attunement') >= @exp_stop_mindstate
   end
 
   def train_attunement(settings)
-    # Buff first then start timer so that
-    # cast time doesn't count against you
-    DRCA.do_buffs(settings, 'attunement')
-    @start_timer = Time.now
     room_list = get_rooms
     until done_training?
       # If we keep looping, ensure buffs stay active

--- a/attunement.lic
+++ b/attunement.lic
@@ -9,21 +9,42 @@ class Attunement
   include DRCA
   include DRCT
 
+  LUNAR_PERCEIVE_COMMANDS = ['mana', 'moons', 'planets']
+
   def initialize
     settings = get_settings
     @stationary_skills_only = settings.crossing_training_stationary_skills_only
     @hometown = settings.hometown
     @attunement_rooms = settings.attunement_rooms
+    @exp_timer = settings.exp_timers['Attunement'] || 90
+    @exp_max_threshold = settings.crossing_training_max_threshold
+    @lunar_perceive_index = -1
     @start_timer = Time.now
     train_attunement(settings)
   end
 
+  def is_lunar_mage?
+    DRStats.moon_mage? || DRStats.trader?
+  end
+
+  def get_next_lunar_perceive_index
+    @lunar_perceive_index = @lunar_perceive_index + 1
+    if @lunar_perceive_index >= LUNAR_PERCEIVE_COMMANDS.length
+      @lunar_perceive_index = 0
+    end
+    @lunar_perceive_index
+  end
+
   def get_perceive_command
-    DRStats.moon_mage? || DRStats.trader? ? 'perceive mana' : 'perceive'
+    if is_lunar_mage?
+      "perceive #{LUNAR_PERCEIVE_COMMANDS[get_next_lunar_perceive_index]}"
+    else
+      "perceive"
+    end
   end
 
   def get_rooms
-    if @stationary_skills_only || DRStats.moon_mage? || DRStats.trader?
+    if @stationary_skills_only || is_lunar_mage?
       [Room.current.id]
     elsif !@attunement_rooms.empty?
       @attunement_rooms
@@ -32,18 +53,25 @@ class Attunement
     end
   end
 
+  def reached_exp_learn_threshold?
+    DRSkill.getxp('Attunement') >= @exp_max_threshold
+  end
+
+  def reached_exp_timer_threshold?
+    Time.now - @start_timer >= @exp_timer
+  end
+
   def done_training?
-    DRSkill.getxp('Attunement') >= 30 || @start_timer - Time.now >= 90
+    reached_exp_learn_threshold? || reached_exp_timer_threshold?
   end
 
   def train_attunement(settings)
-    command = get_perceive_command
     room_list = get_rooms
     until done_training?
       DRCA.do_buffs(settings, 'attunement')
       room_list.each do |room_id|
         walk_to(room_id)
-        bput(command, 'You reach out')
+        bput(get_perceive_command, 'You reach out', 'Roundtime')
         waitrt?
         break if done_training?
       end

--- a/attunement.lic
+++ b/attunement.lic
@@ -27,11 +27,7 @@ class Attunement
   end
 
   def get_next_lunar_perceive_index
-    @lunar_perceive_index = @lunar_perceive_index + 1
-    if @lunar_perceive_index >= LUNAR_PERCEIVE_COMMANDS.length
-      @lunar_perceive_index = 0
-    end
-    @lunar_perceive_index
+    @lunar_perceive_index = (@lunar_perceive_index + 1) % LUNAR_PERCEIVE_COMMANDS.length
   end
 
   def get_perceive_command

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -377,6 +377,10 @@ exp_timers:
   Theurgy: 720
   Thievery: 600
   Attunement: 130
+# The attunement script will continuously train
+# until you've increased by this many mind states,
+# or until you've reached crossing_training_max_threshold.
+attunement_target_increment: 17
 # Listen to classes in your safe-room
 listen: false
 listen_observe: false

--- a/validate.lic
+++ b/validate.lic
@@ -790,6 +790,19 @@ class DRYamlValidator
     end
   end
 
+  def assert_that_crossing_training_config_is_valid(settings)
+    return unless settings.crossing_training
+    unless settings.crossing_training_max_threshold.is_a? Numeric
+      error("crossing_training_max_threshold is not a numeric value. This may cause problems with the crossing-training script.")
+    end
+  end
+
+  def assert_that_attunement_config_is_valid(settings)
+    unless settings.attunement_target_increment.is_a? Numeric
+      error("attunement_target_increment is not a numeric value. This may cause problems with the attunement script.")
+    end
+  end
+
   private
 
   def warn(message)


### PR DESCRIPTION
### Changes
* Fixes #4485, feedback from @BinuDR
* Lunar mages will alternate between perceiving mana, moons, and planets
* Removed timer logic since it was wasn't working to begin with and replaced with new setting `attunement_target_increment` for how many mind states you want to increase by before script exits
* Made exp learning rate upper threshold configurable by looking at setting `crossing_training_max_threshold` (existing setting)
* Added validations for the settings
* Added `attunement_target_increment` to `base.yaml`

Inspired by the [outdoorsmanship](https://github.com/rpherbig/dr-scripts/blob/master/outdoorsmanship.lic#L15) script, the new setting `attunement_target_increment` lets players limit how long the script runs by specifying the number of mind states they want to increase by. A low number will run the script for less time than a high number.

### Examples

**Example 1**
```yaml
crossing_training_max_threshold: 30
attunement_target_increment: 6
```
Player's attunement is at 20. The player runs attunement script and it checks if skill(20) >= threshold(30). It's not so we proceed to next step to determine how long to run the script. The threshold(30) - skill(20) is 10 mind states to go. However, the target increment is 6 so once the skill(20) has increased to at least 26 then the script will stop.

**Example 2**
```yaml
crossing_training_max_threshold: 30
attunement_target_increment: 6
```
Player's attunement is at 28. The player runs attunement script and it checks if skill(28) >= threshold(30). It's not so we proceed to next step to determine how long to run the script. The threshold(30) - skill(28) is 2 mind states to go. Even though the target increment is 6 the script will stop once the skill is at 30 (28+2), not 34 (28+6).

**Example 3**
```yaml
crossing_training_max_threshold: 30
attunement_target_increment: 6
```
Player's attunement is at 34. The player runs attunement script and it checks if skill(34) >= threshold(30). It is so the script stops because the player has met or exceeded the max threshold.

### Summary
If players want the previous behavior for lunar mages to do one perceive then script exits then they only need set `attunement_target_increment` to a sufficiently low value.

If players want to ensure their lunar mage keeps training until attain a certain mind state then they only need set `attunement_target_increment` to a sufficiently high value.

For both players, ensure `crossing_training_max_threshold` is set to a desired threshold.