### PR TITLE
[script] [faux-atmo] New script to put those verby items to work ✨

### DIFF
--- a/faux-atmo.lic
+++ b/faux-atmo.lic
@@ -1,0 +1,88 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#faux-atmo
+=end
+
+custom_require.call(%w[common events])
+
+class FauxAtmo
+  include DRC
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug output' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
+    settings = get_settings
+    @debug = UserVars.faux_atmo_debug || args.debug || false
+    @no_use_scripts = settings.faux_atmo_no_use_scripts
+    @no_use_rooms = settings.faux_atmo_no_use_rooms
+    @interval = settings.faux_atmo_interval * 60
+
+    @items = settings.faux_atmo_items
+      .select { |item| item_is_valid?(item) }
+      .each do |item|
+        echo "Item: #{item}" if @debug
+        item['verb_counter'] = 0
+      end
+
+    if @items.empty?
+      DRC.message("No items to check.  Ending script.  Double check your settings.")
+      exit
+    end
+
+    passive_run
+  end
+
+  def item_is_valid?(item)
+    if item['name'].nil? || item['name'].empty?
+      DRC.message("No name for item #{item}.  Ignoring item.  Double check your settings.")
+      false
+    elsif item['verbs'].nil? || item['verbs'].empty?
+      DRC.message("No verbs for item #{item}.  Ignoring item.  Double check your settings.")
+      false
+    else
+      true
+    end
+  end
+
+  def no_use_script?
+    @no_use_scripts.any? { |name| Script.running?(name) }
+  end
+
+  def no_use_room?
+    @no_use_rooms.any? { |room| room === DRRoom.title.to_s()[2..-3] || room == Room.current.id }
+  end
+
+  def ready_to_use_item?
+    !invisible? && !hidden? && !no_use_script? && !no_use_room?
+  end
+
+  def passive_run
+    loop do
+      loop do
+        break if ready_to_use_item?
+        echo "Waiting for conditions to be right..." if @debug
+        pause 10
+      end
+      do_item
+      echo "Waiting #{@interval} seconds to perform an action again" if @debug
+      pause @interval
+    end
+  end
+
+  def do_item
+    do_verb(@items.rotate!.first)
+  end
+
+  def do_verb(item)
+    waitrt?
+    verb = item['verbs'].rotate!.first
+    fput("#{verb} my #{item['name']}")
+    waitrt?
+  end
+
+end
+
+FauxAtmo.new

--- a/faux-atmo.lic
+++ b/faux-atmo.lic
@@ -19,23 +19,16 @@ class FauxAtmo
     @no_use_scripts = settings.faux_atmo_no_use_scripts
     @no_use_rooms = settings.faux_atmo_no_use_rooms
     @interval = settings.faux_atmo_interval * 60
-
-    @items = settings.faux_atmo_items
-      .select { |item| item_is_valid?(item) }
-      .each do |item|
-        echo "Item: #{item}" if @debug
-        item['verb_counter'] = 0
-      end
-
+    @items = settings.faux_atmo_items.select { |item| item_is_valid?(item) }
     if @items.empty?
       DRC.message("No items to check.  Ending script.  Double check your settings.")
       exit
     end
-
     passive_run
   end
 
   def item_is_valid?(item)
+    echo "Validating item: #{item}" if @debug
     if item['name'].nil? || item['name'].empty?
       DRC.message("No name for item #{item}.  Ignoring item.  Double check your settings.")
       false

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -84,3 +84,5 @@ empty_values:
   sanowret_no_use_scripts: []
   sanowret_no_use_rooms: []
   faux_atmo_items: []
+  faux_atmo_no_use_scripts: []
+  faux_atmo_no_use_rooms: []

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -83,3 +83,4 @@ empty_values:
   duskruin: {}
   sanowret_no_use_scripts: []
   sanowret_no_use_rooms: []
+  faux_atmo_items: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1448,3 +1448,21 @@ tarantula_noun: biomechanical tarantula
 tarantula_startup_delay: 15
 tarantula_no_use_scripts:
 tarantula_debug: false
+
+# Number of minutes to wait between performing a verb on an item.
+faux_atmo_interval: 15
+
+# Items that don't have an inherent atmo effect
+# but whose verbs if done periodically would.
+# faux_atmo_items:
+#   - name: blue basilisk
+#     verbs:
+#     - pet
+#     - pinch
+#     - poke
+#   - name: hooded cloak
+#     verbs:
+#     - rub
+#     - pat
+#     - wave
+

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1466,3 +1466,19 @@ faux_atmo_interval: 15
 #     - pat
 #     - wave
 
+# Don't perform verbs on items if these scripts are running.
+faux_atmo_no_use_scripts:
+- combat-trainer
+- go2
+- get2
+- bescort
+- steal
+- burgle
+
+# Don't perform verbs on items if in these rooms.
+faux_atmo_no_use_rooms:
+- Carousel Chamber     # Room with vault
+- Carousel Booth       # Room just before vault
+- 1900                 # You can specify room ids, too
+
+

--- a/validate.lic
+++ b/validate.lic
@@ -803,6 +803,21 @@ class DRYamlValidator
     end
   end
 
+  def assert_that_faux_atmo_config_is_valid(settings)
+    return unless settings.faux_atmo_items
+    return if settings.faux_atmo_items.empty?
+    unless settings.faux_atmo_interval.is_a? Numeric
+      error("faux_atmo_interval is not a numeric value. This may cause problems with the faux-atmo script.")
+    end
+    settings.faux_atmo_items.each do |item|
+      if item['name'].nil? || item['name'].empty?
+        error("Entry in faux_atmo_items list has no name property. This may cause problems with the faux-atmo script. #{item}")
+      elsif item['verbs'].nil? || item['verbs'].empty?
+        error("Entry in faux_atmo_items list has no verbs property. This may cause problems with the faux-atmo script. #{item}")
+      end
+    end
+  end
+
   private
 
   def warn(message)


### PR DESCRIPTION
### Summary
_Bring your verby items to life!_

Some items perform [atmospheric](https://elanthipedia.play.net/Atmospheric_item) actions on their own where they emit some messaging to the game window periodically. For example a [robe strewn with twinkling points of starlight](https://elanthipedia.play.net/Item:Black_robe_strewn_with_twinkling_points_of_starlight) periodically emits "The points of starlight on your robe float languidly across the fabric before suddenly beginning to swirl and flicker in wild, hypnotic patterns."

Some items have verbs with fun messaging but the player must actively perform the verb for the messaging to appear, such as a [blue-scaled basilisk with firestained uthamar and ice sapphire eyes](https://elanthipedia.play.net/Item:Blue-scaled_basilisk_with_firestained_uthamar_and_ice_sapphire_eyes). These verby items are classically not atmo items. However, one can cause them to behave like an atmo item if verbs are performed on them periodically. For example, to `pet|rub|touch|push` a worn toy or `wave|rub|pat` a worn cloak.

This new `faux-atmo` script lets players configure which verbs they want performed on which items every N minutes.

### How it works
* The player provides a list of items via `faux_atmo_items`. Each entry in the list has a `name` (string) and a `verbs` (list) properties.
* Every N minutes, the script round-robin chooses one item and one verb and performs the action.

### Conditional execution
Like the `almanac` and `wand-watcher` scripts, players can customize when the script runs.
* Players can provide a `faux_atmo_no_use_scripts` to not perform an action if those scripts are running.
* Players can provide a `faux_atmo_no_use_rooms` to not perform an action if in one of those rooms.
* The script takes no action if the player is hidden or invisible.

### Example config
```yaml
# Number of minutes to wait between performing a verb on an item.
faux_atmo_interval: 15

# Items that don't have an inherent atmo effect
# but whose verbs if done periodically would.
faux_atmo_items:
  - name: blue basilisk
    verbs:
    - pet
    - pinch
    - poke
  - name: red wyvern
    verbs:
    - touch
    - push
    - tilt

# Don't perform verbs on items if these scripts are running.
faux_atmo_no_use_scripts:
- combat-trainer
- go2
- get2
- bescort
- steal
- burgle

# Don't perform verbs on items if in these rooms.
faux_atmo_no_use_rooms:
- Carousel Chamber     # Room with vault
- Carousel Booth       # Room just before vault
- 1900                 # You can specify room ids, too
```

With the above config, the `faux-atmo` script would:
1. Determine if conditions are ok to run the script
2. Round-robin choose an item from the `faux_atmo_items` list, choosing `blue basilisk` first.
3. Round-robin choose a verb from that item, choosing `pet` first.
4. Perform the verb on the item: `pet my blue basilisk`
5. Pause for N minutes, in this case 15 minutes and repeat steps 1-4 again.

On the second round the script would round-robin choose the next item, choosing `red wyvern` and one of its verbs `touch`, perform the verb then pause again.

On the third round the script would round-robin choose the next item, going back to `blue basilisk` in the list and choose that item's next verb, `pinch`, perform the verb then pause again.

And so on iterating through the items and each item's verbs.