### PR TITLE
[script] [combat-trainer] Handle typo when shoot blunt-tipped arrows|bolts|stones

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2768,8 +2768,8 @@ class AttackProcess
       game_state.action_taken
       ammo = Regexp.last_match(2)
       @firing_check = 0
-      bput("stow my #{ammo}", 'You pick up', 'Stow what')
-      bput("stow my #{ammo}", 'You pick up', 'Stow what') if game_state.dual_load?
+      stow_ammo(ammo)
+      stow_ammo(ammo) if game_state.dual_load?
     when 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire'
       pause 1
       shoot_aimed(command, game_state)
@@ -2952,6 +2952,17 @@ class AttackProcess
     pause 7
     waitrt?
     game_state.use_charged_maneuvers = false
+  end
+
+  def stow_ammo(ammo)
+    return unless ammo
+    if bput("stow my #{ammo}", 'You pick up', 'Stow what') == 'Stow what'
+      # Bug fix for typo with burgled arrows.
+      # Messaging will say "you fire a blunt-tipped arrows" (note the trailing 's')
+      # when you actually only shot a singular arrow and the item itself
+      # only responds to 'stow arrow' (no 's').
+      stow_ammo(ammo.delete_suffix('s')) if ammo.end_with?('s')
+    end
   end
 end
 


### PR DESCRIPTION
### Background
The [blunt-tipped arrows](https://elanthipedia.play.net/Weapon:Blunt-tipped_arrows_with_stripes) obtained from [Breaking and Entering/Armory loot](https://elanthipedia.play.net/Breaking_and_Entering/Armory_loot) (and possibly also with the blunt-tipped stones and blunt-tipped bolts) have a typo in them when they are fired from a bow.

The game will say "`you fire a blunt-tipped arrows with red stripe at a goblin`", incorrectly using the plural **arrows** when it should have been the singular **arrow**.

### Problem
The problem is that the `combat-trainer` script does a regular expression match on that game message "`you fire a blunt-tipped arrows with red stripe at a goblin`" to determine the kind of ammo used. In this case, it matches on the word **arrows**. Then the script tries to stow the ammo. Because the game has the typo then the script tries to `stow arrows`. Since the actual name of the item you fired is "blunt-tipped arrow" (no extra 's') then the game is confused and replies with `Stow what?`.

This can lead to exhausting or losing your ammo.

### Workaround
The workaround without this pull request is not use the bugged ammo. However, I believe players should have the choice to use the burgled ammo because it's still good, just has typo in combat messaging. So until the GameMasters fix the typo I'm proposing this code solution outlined below.

### Solution
When `combat-trainer` stows ammo, if the game responds with `Stow what?` and the ammo's name ends with an **s** then retry the action without the `s` suffix.

### Tests

**blunt-tipped arrows** (burgled)
```
[combat-trainer]>shoot

< Driving in with exacting precision, you fire a blunt-tipped arrows with absinthe-green stripe at a short forager goblin.  A short forager goblin fails to evade, mis-stepping and blundering into the blow.  
The arrow lands an apocalyptic strike (23/23) (So that's what it felt like when Grazhir shattered!) that shatters the entire left leg into a gelatinous mass.
The blunt-tipped arrow falls to the ground!
A short forager goblin collapses to the ground, shuddering and moaning until it ceases all movement.
[You're nimbly balanced]
[Roundtime 1 sec.]

> 
[combat-trainer]>stow my arrows

Stow what?  Type 'STOW HELP' for details.
> 
[combat-trainer]>stow my arrow

You pick up the arrow lying at your feet.
You put your arrow in your black quiver.
```

**cougar arrows** (store bought)
```
[combat-trainer]>shoot

< Driving in with exacting precision, you fire a cougar-claw arrow at a beady-eyed forager goblin.  A beady-eyed forager goblin attempts to dodge, taking the full blow.  
The arrow lands a cataclysmic strike (22/23) (Did the Greater Fist just erupt again?) that tears flesh and cartilage as the right leg is ripped clean below the knee (Better order that peg leg!), severely stunning it.
That would have stuck if there was anything left to stick to!
The cougar-claw arrow falls to the ground!
The forager goblin howls in pain and collapses to the ground moaning.
[You're nimbly balanced and overwhelming opponent.]
[Roundtime 1 sec.]

> 
[combat-trainer]>stow my arrow

> 
You pick up the arrow lying at your feet.
You put your arrow in your black quiver.
```