### PR TITLE
[script] [combat-trainer] Fixes #4490

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2768,8 +2768,8 @@ class AttackProcess
       game_state.action_taken
       ammo = Regexp.last_match(2)
       @firing_check = 0
-      stow_ammo(ammo)
-      stow_ammo(ammo) if game_state.dual_load?
+      quantity = game_state.dual_load? ? 2 : 1
+      stow_ammo(ammo, quantity)
     when 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire'
       pause 1
       shoot_aimed(command, game_state)
@@ -2954,14 +2954,18 @@ class AttackProcess
     game_state.use_charged_maneuvers = false
   end
 
-  def stow_ammo(ammo)
+  def stow_ammo(ammo = nil, quantity = 1)
     return unless ammo
-    if bput("stow my #{ammo}", 'You pick up', 'Stow what') == 'Stow what'
+    return unless quantity > 0
+    case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what')
+    when 'You pick up', 'You put your'
+      stow_ammo(ammo, quantity - 1)
+    when 'Stow what'
       # Bug fix for typo with burgled arrows.
       # Messaging will say "you fire a blunt-tipped arrows" (note the trailing 's')
       # when you actually only shot a singular arrow and the item itself
       # only responds to 'stow arrow' (no 's').
-      stow_ammo(ammo.delete_suffix('s')) if ammo.end_with?('s')
+      stow_ammo(ammo.slice(0..-2), quantity) if ammo.end_with?('s')
     end
   end
 end


### PR DESCRIPTION
### Changes
* Builds upon https://github.com/rpherbig/dr-scripts/pull/4489
* Fixes #4490 to replace delete_suffix() with slice() to support Ruby 2.0
* [Optimize](https://github.com/rpherbig/dr-scripts/pull/4489#issuecomment-692035147) number of stows for dual loading
* Specify quantity for how much ammo you want to pick up
* Supports if the ammo is in your hand or at your feet

### Tests

_Optimizes the number of stows for dual loading by only computing "arrows => arrow" once._

[exec1]>stow arrows

Stow what?  Type 'STOW HELP' for details.
> 
[exec1]>stow arrow

> 
You pick up the arrow lying at your feet.
You put your arrow in your black quiver.
> 
[exec1]>stow arrow

You pick up the arrow lying at your feet.
You put your arrow in your black quiver.