### PR TITLE
[script] [faux-atmo] Randomize item/verb selection

### DIFF
--- a/faux-atmo.lic
+++ b/faux-atmo.lic
@@ -19,11 +19,15 @@ class FauxAtmo
     @no_use_scripts = settings.faux_atmo_no_use_scripts
     @no_use_rooms = settings.faux_atmo_no_use_rooms
     @interval = settings.faux_atmo_interval * 60
-    @randomize = settings.faux_atmo_random
     @items = settings.faux_atmo_items.select { |item| item_is_valid?(item) }
     if @items.empty?
       DRC.message("No items to check.  Ending script.  Double check your settings.")
       exit
+    end
+    if settings.faux_atmo_random
+      @items.shuffle!
+      @items.each { |item| item['verbs'].shuffle! }
+      echo "shuffled items and verbs: #{@items}" if @debug
     end
     passive_run
   end
@@ -67,18 +71,24 @@ class FauxAtmo
   end
 
   def do_item
-    do_verb(get_next(@items))
+    do_verb(get_then_rotate(@items))
   end
 
   def do_verb(item)
     waitrt?
-    verb = get_next(item['verbs'])
+    verb = get_then_rotate(item['verbs'])
     fput("#{verb} my #{item['name']}")
     waitrt?
   end
 
-  def get_next(list)
-    @randomize ? list.sample : list.rotate!.first
+  def get_then_rotate(list)
+    # This ensures that the first time
+    # this method is called on a list
+    # we indeed return the first item,
+    # not rotate and return the second item.
+    item = list.first
+    list.rotate!
+    item
   end
 
 end

--- a/faux-atmo.lic
+++ b/faux-atmo.lic
@@ -19,6 +19,7 @@ class FauxAtmo
     @no_use_scripts = settings.faux_atmo_no_use_scripts
     @no_use_rooms = settings.faux_atmo_no_use_rooms
     @interval = settings.faux_atmo_interval * 60
+    @randomize = settings.faux_atmo_random
     @items = settings.faux_atmo_items.select { |item| item_is_valid?(item) }
     if @items.empty?
       DRC.message("No items to check.  Ending script.  Double check your settings.")
@@ -66,14 +67,18 @@ class FauxAtmo
   end
 
   def do_item
-    do_verb(@items.rotate!.first)
+    do_verb(get_next(@items))
   end
 
   def do_verb(item)
     waitrt?
-    verb = item['verbs'].rotate!.first
+    verb = get_next(item['verbs'])
     fput("#{verb} my #{item['name']}")
     waitrt?
+  end
+
+  def get_next(list)
+    @randomize ? list.sample : list.rotate!.first
   end
 
 end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1452,6 +1452,10 @@ tarantula_debug: false
 # Number of minutes to wait between performing a verb on an item.
 faux_atmo_interval: 15
 
+# Set to true to randomly select an item and verb to perform.
+# Set to false to round-robin select items and verbs to perform.
+faux_atmo_random: true
+
 # Items that don't have an inherent atmo effect
 # but whose verbs if done periodically would.
 # faux_atmo_items:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1458,7 +1458,7 @@ faux_atmo_random: true
 
 # Items that don't have an inherent atmo effect
 # but whose verbs if done periodically would.
-faux_atmo_items: []
+faux_atmo_items:
 #   - name: blue basilisk
 #     verbs:
 #     - pet

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1458,7 +1458,7 @@ faux_atmo_random: true
 
 # Items that don't have an inherent atmo effect
 # but whose verbs if done periodically would.
-# faux_atmo_items:
+faux_atmo_items: []
 #   - name: blue basilisk
 #     verbs:
 #     - pet


### PR DESCRIPTION
### Changes
* Per [feedback](https://github.com/rpherbig/dr-scripts/pull/4488#pullrequestreview-488143353), uncommented `faux_atmo_items` in `base.yaml`
* Per [feedback](https://github.com/rpherbig/dr-scripts/pull/4488#pullrequestreview-488144288), support random or round-robin selection of items/verbs via `faux_atmo_random`