### PR TITLE
[script] [combat-trainer] Fix 'smite' routine to handle when no other creatures to attack

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2200,7 +2200,7 @@ class TrainerProcess
     return if game_state.brawling? || game_state.offhand? || game_state.aimed_skill?
     return if right_hand.nil?
 
-    bput('smite', 'Drawing strength from your conviction', 'You aren\'t close enough')
+    bput("smite", "Drawing strength from your conviction", "You aren't close enough", "What are you trying to attack")
   end
 
   def meraud_commune(game_state)


### PR DESCRIPTION
### Background
Reported on Discord at https://discordapp.com/channels/745675889622384681/745696628714897508/756020830705811587

### Changes
* Adds `What are you trying to attack` to `bput` matches so script doesn't stall