### PR TITLE
Add toggle to stop releasing cyclics at the end of combat

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -30,6 +30,8 @@ class SetupProcess
     echo("  @cycle_regalia: #{@cycle_regalia}") if $debug_mode_ct
     @default_armor = settings.default_armor_type
     echo("  @default_armor: #{@default_armor}") if $debug_mode_ct
+    @release_cyclic = settings.release_combat_cyclic
+   echo("  @release_cyclic: #{@release_cyclic}") if $debug_mode_ct 
 
     @gearsets = settings.gear_sets
     @warhorn = settings.warhorn
@@ -3889,7 +3891,7 @@ class GameState
 end
 
 before_dying do
-  DRCA.release_cyclics unless get_settings.do_not_release_combat_cyclic
+  DRCA.release_cyclics unless @release_cyclic
   DRCA.shatter_regalia?
   fput('close fissure') if DRStats.warrior_mage? && DRRoom.room_objs.any? { |x| /fissure/ =~x }
   Flags.delete('using-corpse')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3889,7 +3889,7 @@ class GameState
 end
 
 before_dying do
-  DRCA.release_cyclics
+  DRCA.release_cyclics unless get_settings.do_not_release_combat_cyclic
   DRCA.shatter_regalia?
   fput('close fissure') if DRStats.warrior_mage? && DRRoom.room_objs.any? { |x| /fissure/ =~x }
   Flags.delete('using-corpse')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -30,8 +30,6 @@ class SetupProcess
     echo("  @cycle_regalia: #{@cycle_regalia}") if $debug_mode_ct
     @default_armor = settings.default_armor_type
     echo("  @default_armor: #{@default_armor}") if $debug_mode_ct
-    @release_cyclic = settings.release_combat_cyclic
-   echo("  @release_cyclic: #{@release_cyclic}") if $debug_mode_ct 
 
     @gearsets = settings.gear_sets
     @warhorn = settings.warhorn
@@ -3891,7 +3889,7 @@ class GameState
 end
 
 before_dying do
-  DRCA.release_cyclics unless @release_cyclic
+  DRCA.release_cyclics if get_settings.release_combat_cyclic
   DRCA.shatter_regalia?
   fput('close fissure') if DRStats.warrior_mage? && DRRoom.room_objs.any? { |x| /fissure/ =~x }
   Flags.delete('using-corpse')

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -123,6 +123,10 @@ offensive_spells:
 # offensive_spell_cycle is a list of offensive_spells names in the order you want to cast them.  Most useful if you have multiple TM or DEBIL spells to cast
 offensive_spell_cycle:
 # list of actions to take while aiming when stealth still needs to be trained
+
+# toggle to not release cyclic spells at the end of combat.  USE WITH CAUTION as most combat cyclics will get you arrested in a hurry.
+do_not_release_combat_cyclic: false
+
 aim_fillers_stealth:
 # some non-spell buffs. Khris/Barbarian buffs/WM pathways, etc.  See Dartellum-setup, Chuno-setup, or Evissam-setup
 buff_nonspells:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -125,7 +125,7 @@ offensive_spell_cycle:
 # list of actions to take while aiming when stealth still needs to be trained
 
 # toggle to not release cyclic spells at the end of combat.  USE WITH CAUTION as most combat cyclics will get you arrested in a hurry.
-do_not_release_combat_cyclic: false
+release_combat_cyclic: true
 
 aim_fillers_stealth:
 # some non-spell buffs. Khris/Barbarian buffs/WM pathways, etc.  See Dartellum-setup, Chuno-setup, or Evissam-setup


### PR DESCRIPTION
While most cyclics are dangerous, some are not such as necro SO mitigation, empath cylics, bard buffs, etc.  This allows a toggle to forego that release.  This is a frequently asked question and there is much grumbling over being told to recast before moving.