### PR TITLE
weave-cloth - Clear off thread from loom

### DIFF
--- a/weave-cloth.lic
+++ b/weave-cloth.lic
@@ -13,6 +13,13 @@ loop do
   pause 30
 end
 
+case DRC.bput('look on loom', /loom is loaded with some \w+ thread\.$/, /loom is loaded with some \w+ thread and some \w+ thread\.$/, /loom is not loaded/)
+when /loom is loaded with some/
+  while DRC.bput('pull loom', /You pull some (\w+) thread off from/, /You see nothing to pull/) =~ /You pull some (\w+) thread off from/
+    DRC.bput("drop my #{Regexp.last_match(1)} thread", /You drop/)
+  end
+end
+
 fput('get my thread')
 fput('put my thread on loom')
 fput('drop thread') if checkright || checkleft


### PR DESCRIPTION
This update is to deal with thread that's already on the loom when you go to use it.
Related Issue:
https://github.com/rpherbig/dr-scripts/issues/1402