### PR TITLE
Spells added

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1605,6 +1605,7 @@ spell_data:
     abbrev: p h
     prep_type: prep cantrip
     prep_time: 0
+    cast: gesture phosphorescent emerald green
     mana:
     harmless: true
     expire: The faint .* aura fades from around you.

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1046,6 +1046,7 @@ spell_data:
   Flame Shockwave:
     abbrev: FLS
     prep_time: 0
+    cast: gesture
     harmless: true
     expire: Your attention wanders, the dream of skies alight gone with it.
     mana:

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1601,16 +1601,6 @@ spell_data:
     abbrev: PD
     mana: 2
     mana_type: lunar
-  Pattern Hues:
-    abbrev: p h
-    prep_type: prep cantrip
-    prep_time: 0
-    cast: gesture phosphorescent emerald green
-    mana:
-    harmless: true
-    expire: The faint .* aura fades from around you.
-    recast: 1
-    mana_type: elemental
   Perseverance of Peri'el:
     skill: Warding
     abbrev: POP

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1045,7 +1045,11 @@ spell_data:
     mana_type: lunar
   Flame Shockwave:
     abbrev: FLS
+    prep_time: 0
     harmless: true
+    expire: Your attention wanders, the dream of skies alight gone with it.
+    mana:
+    recast: 1
     mana_type: elemental
   Fluoresce:
     abbrev: fluoresce
@@ -1596,6 +1600,15 @@ spell_data:
     abbrev: PD
     mana: 2
     mana_type: lunar
+  Pattern Hues:
+    abbrev: p h
+    prep_type: prep cantrip
+    prep_time: 0
+    mana:
+    harmless: true
+    expire: The faint .* aura fades from around you.
+    recast: 1
+    mana_type: elemental
   Perseverance of Peri'el:
     skill: Warding
     abbrev: POP


### PR DESCRIPTION
Messages were added in PR #4499. This PR fleshes out the spells in the file to work as expected. Tested since September 19, 2020; date of PR to add cast messages. 

Usage in your yaml:
```
  Pattern Hues:
    cast: gesture custom
  Flame Shockwave:

```
You can gesture whatever color is available to you. Custom is for those lucky enough to obtain a specific color many, many years ago. You need to add cast: gesture to your yaml. Or, do I just assign a color in base-spells and let the user override?

`cast: gesture` in FLS is so you do not have the `You do not have a spell prepared message`. 

This would keep Pattern Hues up during hunting if one desires.