### PR TITLE
[script] [pick] New argument to override picking_box_source

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -114,7 +114,8 @@ class LockPicker
       [
         { name: 'pets', regex: /pets/, optional: true, description: 'Disarm boxes and place them in the pet box container.' },
         { name: 'count', regex: /\d+/, optional: true, description: 'How many pet boxes to make.' },
-        { name: 'refill', regex: /refill/, optional: true, description: 'Refills your lockpick ring.' }
+        { name: 'refill', regex: /refill/, optional: true, description: 'Refills your lockpick ring.' },
+        { name: 'source', regex: /(source=(\w+))/, optional: true, description: 'Container with boxes to pick.'}
       ]
     ]
 
@@ -125,6 +126,11 @@ class LockPicker
     @pet_count = 0
 
     @settings = get_settings(args.flex)
+
+    if args.source
+      source = args.source.split('=')[1]
+      @settings.picking_box_source = source
+    end
 
     if @make_pets && @pet_goal < 1
       if @settings.pet_boxes_on_hand > 0


### PR DESCRIPTION
## Scenario
I loot boxes into an "autoloot" container. Sometimes it's full and I have an overflow of boxes in a regular container, like a backpack. Sometimes the `pick` script stops or is exited and I still have a locked box in my hands. Since my `picking_box_source` in my yaml points to my autoloot container and since I can't put the box in my hand back in the autoloot container, I either have to pick the box manually (eww) or discard the box (womp womp) or update my yaml to point to a different container then re-run the script (boo!).

## Changes
Add new script argument `source` you can specify at runtime to override the `picking_box_source` in your yaml.

```ruby
;pick source=backpack
;pick source=haversack
```

## Benefits
If I have an overflow of boxes in a secondary container that aren't "pet boxes", I can re-run the script from within the game `;pick source=backpack` without updating my yaml.