### PR TITLE
Update base-spells.yaml

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1800,7 +1800,6 @@ spell_data:
     harmless: true
     abbrev: RM
     mana: 15
-    recast: 1
     expire: The unnatural fog breaks apart
     mana_type: elemental
   Rite of Contrition:


### PR DESCRIPTION
Removed "recast: 1" from under Rising Mists.  Rising Mists is not displayed in the Active Spells window or even any version of the PERCEIVE command.  The only way to recast is on the expire match which is correct.