### PR TITLE
[script] [summoning] New script to train summoning

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -387,6 +387,10 @@ exp_timers:
 # until you've increased by this many mind states,
 # or until you've reached crossing_training_max_threshold.
 attunement_target_increment: 17
+# The summoning script will continuously train
+# until you've increased by this many mind states,
+# or until you've reached crossing_training_max_threshold.
+summoning_target_increment: 17
 # Listen to classes in your safe-room
 listen: false
 listen_observe: false

--- a/summoning.lic
+++ b/summoning.lic
@@ -15,6 +15,10 @@ class Summoning
     @exp_target_increment = settings.summoning_target_increment
     @exp_start_mindstate = DRSkill.getxp('Summoning')
     @exp_stop_mindstate = get_target_mindstate(@exp_start_mindstate, @exp_target_increment, @exp_max_threshold)
+    # To break summoned weapons then you must
+    # hold it in one hand and the other hand empty
+    # so start with nothing in our hands yet.
+    DRC.stow_hands
     train_summoning
   end
 

--- a/summoning.lic
+++ b/summoning.lic
@@ -1,0 +1,46 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#summoning
+=end
+
+custom_require.call(%w[common common-arcana common-summoning drinfomon])
+
+class Summoning
+  include DRC
+  include DRCA
+  include DRCS
+
+  def initialize
+    settings = get_settings
+    @summon_target_increment = settings.summon_target_increment
+    @exp_max_threshold = settings.crossing_training_max_threshold
+    @exp_target_increment = settings.summoning_target_increment
+    @exp_start_mindstate = DRSkill.getxp('Summoning')
+    @exp_stop_mindstate = get_target_mindstate(@exp_start_mindstate, @exp_target_increment, @exp_max_threshold)
+    train_summoning
+  end
+
+  # Determines the target mind state to train to
+  # based on the starting value of `mindstate` and
+  # a target goal of increasing by `increment` without
+  # exceeding a max mind state of `threshold`.
+  def get_target_mindstate(mindstate, increment, threshold)
+    mindstate + [increment, [threshold - mindstate, 0].max].min
+  end
+
+  def done_training?
+    DRSkill.getxp('Summoning') >= @exp_stop_mindstate
+  end
+
+  def train_summoning
+    until done_training?
+      DRCS.summon_weapon
+      DRCS.break_summoned_weapon(right_hand)
+      # Use any remaining elemental charge to train Summoning
+      fput('pathway focus damage') if DRStats.circle >= 4
+      waitrt?
+    end
+  end
+
+end
+
+Summoning.new

--- a/summoning.lic
+++ b/summoning.lic
@@ -11,7 +11,6 @@ class Summoning
 
   def initialize
     settings = get_settings
-    @summon_target_increment = settings.summon_target_increment
     @exp_max_threshold = settings.crossing_training_max_threshold
     @exp_target_increment = settings.summoning_target_increment
     @exp_start_mindstate = DRSkill.getxp('Summoning')

--- a/summoning.lic
+++ b/summoning.lic
@@ -2,11 +2,12 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#summoning
 =end
 
-custom_require.call(%w[common common-arcana common-summoning drinfomon])
+custom_require.call(%w[common common-arcana common-items common-summoning drinfomon])
 
 class Summoning
   include DRC
   include DRCA
+  include DRCI
   include DRCS
 
   def initialize
@@ -18,7 +19,7 @@ class Summoning
     # To break summoned weapons then you must
     # hold it in one hand and the other hand empty
     # so start with nothing in our hands yet.
-    DRC.stow_hands
+    DRCI.stow_hands
     train_summoning
   end
 


### PR DESCRIPTION
* Puts the summoning training logic of `crossing-training` in its own script for easy use with t2 or one-off training
* Structured like the `attunement` script
* Adds new numeric configuration `summoning_target_increment` that mirrors `attunement_target_increment`