### PR TITLE
Add craft overrides and sew for outfitting

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -29,6 +29,7 @@ class Craft
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.enchanting_belt
+    @overrides = @settings.craft_overrides
 
     if args.craft == 'engineering'
       exit if DRSkill.getxp('Engineering') > @craft_max_mindstate
@@ -58,21 +59,32 @@ class Craft
 
   def train_outfitting
     rank = DRSkill.getrank('Outfitting')
+    info = @overrides['Outfitting']
 
-    if rank <= 25 # Tier 1  Extremely Easy
-      sew(5, 'some knitted socks', 'socks')
+    if !info.empty?
+      if info['type'].downcase.eql? 'sew'
+        sew(info['chapter'], info['item'], info['item'].split.last, info['volumes'])
+      else
+        knit(info['chapter'], info['item'], info['item'].split.last)
+      end
+    elsif rank <= 25 # Tier 1  Extremely Easy
+      knit(5, 'some knitted socks', 'socks')
     elsif rank <= 50 # Tier 2 Very Easy
-      sew(5, 'some knitted mittens', 'mittens')
+      knit(5, 'some knitted mittens', 'mittens')
     elsif rank <= 100 # Tier 3  Easy
-      sew(5, 'a knitted hat', 'hat')
+      knit(5, 'a knitted hat', 'hat')
     elsif rank <= 175 # Tier 4  Simple
-      sew(5, 'some knitted gloves', 'gloves')
+      knit(5, 'some knitted gloves', 'gloves')
     elsif rank <= 300 # Tier 5  Basic
-      sew(5, 'some knitted hose', 'hose')
+      knit(5, 'some knitted hose', 'hose')
     elsif rank <= 425 # Tier 6  Somewhat Challenging
-      sew(5, 'a knitted cloak', 'cloak')
+      knit(5, 'a knitted cloak', 'cloak')
     elsif rank <= 650 # Tier 7  Challenging
-      sew(5, 'a knitted blanket', 'blanket')
+      knit(5, 'a knitted blanket', 'blanket')
+    elsif rank <= 750 # Tier 8, Complicated
+      sew(3, 'a small cloth rucksack', 'rucksack', 7)
+    elsif rank <= 850 # Tier 10, difficult
+      sew(3, 'a cloth rucksack', 'rucksack', 8)
     else # Tier 12  Extremely Difficult
       echo('*** NOT YET IMPLEMENTED ***')
     end
@@ -80,8 +92,11 @@ class Craft
 
   def train_engineering
     rank = DRSkill.getrank('Engineering')
+    info = @overrides['Engineering']
 
-    if rank <= 25 # Tier 1  Extremely Easy
+    if !info.empty?
+      shape(info['chapter'], info['item'], info['item'].split.last)
+    elsif rank <= 25 # Tier 1  Extremely Easy
       shape(7, 'a wood band', 'band')
     elsif rank <= 50 # Tier 2 Very Easy
       shape(7, 'a wood bracelet', 'bracelet')
@@ -110,7 +125,11 @@ class Craft
 
   def train_forging
     rank = DRSkill.getrank('Forging')
-    if rank <= 25 # Tier 1 - Extremely Easy
+    info = @overrides['Forging']
+
+    if !info.empty?
+      smith(info['item'])
+    elsif rank <= 25 # Tier 1 - Extremely Easy
       smith('a shallow metal cup')
     elsif rank <= 50 # Tier 2 - Very Easy
       smith('a short metal mug')
@@ -140,7 +159,7 @@ class Craft
   def train_enchanting
     crafting_data = get_data('crafting')
     rank = DRSkill.getrank('Enchanting')
-
+    
     if rank <= 25 # Tier 1  Extremely Easy
       # Buy an abolution sigil and wood totem
       ensure_copper_on_hand(2000, @settings)
@@ -266,7 +285,7 @@ class Craft
     end
   end
 
-  def sew(chapter, unique_name, item)
+  def knit(chapter, unique_name, item)
     check_yarn
 
     walk_to(@training_room)
@@ -276,6 +295,19 @@ class Craft
     wait_for_script_to_complete('sew', ['trash', 'knitting', chapter, unique_name, item, 'wool'])
 
     bput('stow my yarn', 'You put', 'Stow what')
+  end
+
+  def sew(chapter, unique_name, item, fabric_volumes)
+    check_thread
+    check_fabric(fabric_volumes)
+    
+    walk_to(@training_room)
+    check_listening
+    check_teaching
+
+    wait_for_script_to_complete('sew', ['trash', 'sewing', chapter, unique_name, item, 'burlap'])
+
+    bput('stow my thread', 'You put', 'Stow what')
   end
 
   def shape(chapter, unique_name, item)
@@ -314,6 +346,23 @@ class Craft
     stow_hands
   end
 
+  def buy_thread(skipcoin = false)
+    crafting_data = get_data('crafting')
+    ensure_copper_on_hand(1000, @settings) unless skipcoin
+    order_item(crafting_data['tailoring'][@hometown]['stock-room'], 6)
+    stow_item('cotton thread')
+  end
+
+  def order_fabric(stock_room, stock_needed, stock_number, type)
+    stock_needed.times do
+      order_item(stock_room, stock_number)
+      bput("get my #{type} from my #{@bag}", 'What were', 'You get')
+      next unless left_hand && right_hand
+      bput("combine #{type} with #{type}", 'You combine')
+    end
+    stow_item('burlap cloth')
+  end
+
   def check_yarn
     case DRC.bput('get my yarn', 'You get', 'You are already', 'What were you')
     when 'What were you'
@@ -323,6 +372,31 @@ class Craft
       buy_yarn if count < @yarn_quantity
     end
     stow_hands
+  end
+
+  def check_thread
+    case DRC.bput('get my cotton thread', 'You get', 'You are already', 'What were you')
+    when 'What were you'
+      buy_thread
+    when 'You get', 'You are already'
+      count = bput('count my cotton thread', 'You count out \d+ yards').scan(/\d+/).first.to_i
+      buy_thread if count < @yarn_quantity
+    end
+    stow_hands
+  end
+
+  def check_fabric(fabric_volumes)
+    crafting_data = get_data('crafting')['tailoring'][@hometown]
+    existing = if bput("get burlap cloth from my #{@bag}", 'What were', 'You get') == 'What were'
+                 0
+               else
+                 while bput("get burlap cloth from my #{@bag}", 'What were', 'You get') == 'You get'
+                   bput("combine burlap cloth with burlap cloth", 'You combine')
+                 end
+                 bput("count my burlap cloth cloth", 'You count out \d+ yards').scan(/\d+/).first.to_i
+               end
+    stock_needed = ((fabric_volumes - existing) / 10.0).ceil
+    order_fabric(crafting_data['stock-room'], stock_needed, crafting_data['sew-stock-number'], 'burlap cloth')
   end
 
   def check_wood

--- a/craft.lic
+++ b/craft.lic
@@ -61,7 +61,7 @@ class Craft
     rank = DRSkill.getrank('Outfitting')
     info = @overrides['Outfitting']
 
-    if !info.empty?
+    if info
       if info['type'].downcase.eql? 'sew'
         sew(info['chapter'], info['item'], info['item'].split.last, info['volumes'])
       else
@@ -94,7 +94,7 @@ class Craft
     rank = DRSkill.getrank('Engineering')
     info = @overrides['Engineering']
 
-    if !info.empty?
+    if info
       shape(info['chapter'], info['item'], info['item'].split.last)
     elsif rank <= 25 # Tier 1  Extremely Easy
       shape(7, 'a wood band', 'band')
@@ -127,7 +127,7 @@ class Craft
     rank = DRSkill.getrank('Forging')
     info = @overrides['Forging']
 
-    if !info.empty?
+    if info
       smith(info['item'])
     elsif rank <= 25 # Tier 1 - Extremely Easy
       smith('a shallow metal cup')

--- a/craft.lic
+++ b/craft.lic
@@ -159,7 +159,7 @@ class Craft
   def train_enchanting
     crafting_data = get_data('crafting')
     rank = DRSkill.getrank('Enchanting')
-    
+
     if rank <= 25 # Tier 1  Extremely Easy
       # Buy an abolution sigil and wood totem
       ensure_copper_on_hand(2000, @settings)

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -89,4 +89,5 @@ empty_values:
   play_no_use_scripts: []
   barb_famine_healing: {}
   private_textsubs: {}
+  craft_overrides: {}
   

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -582,6 +582,8 @@ alcohol_container:
 water_container:
 # container used to hold herbs for remedy.lic (optional)
 herb_container:
+# override craft.lic training items
+craft_overrides:
 
 # Workorder settings
 # https://elanthipedia.play.net/Lich_script_repository#workorders


### PR DESCRIPTION
OK, you can override recipes using the below settings. It doesn't require them all. I also added the ability for higher tier outfitting, this works fine, I just need testers for all the things I can't see. 

```
craft_overrides:
  Outfitting:
    chapter: 5
    item: a knitted blanket
    volumes: 7
    type: knit
  Forging:
    item: a shallow metal cup
  Engineering:
    chapter: 7
    item: a wood bracelet
```