### PR TITLE
[script] [first-aid] Add more 'study' verb matches

### DIFF
--- a/first-aid.lic
+++ b/first-aid.lic
@@ -65,7 +65,7 @@ class FirstAid
       .each do |info|
         case bput("turn my #{@booktype} to #{info['index']}", 'You turn', 'That section does not exist', 'Turn what?','almost impossible to do')
         when 'You turn'
-          case bput("study my #{@booktype}", 'gradually absorbing', 'difficult time comprehending the advanced text', 'suddenly makes sense to you', '^Why ', 'You need to be holding', 'discerned all you can')
+          case bput("study my #{@booktype}", 'You attempt to study', 'find it almost impossible to do', 'gradually absorbing', 'difficult time comprehending the advanced text', 'suddenly makes sense to you', '^Why ', 'You need to be holding', 'discerned all you can')
           when 'gradually absorbing'
             3.times{ message = bput("study my #{@booktype}", /Roundtime/, /makes sense/, /discerned all you can/ ); break if message == 'makes sense' || 'discerned all you can'}
           when 'You need to be holding'
@@ -88,7 +88,7 @@ class FirstAid
       when skill <= 150
         skill - 30
       when skill <= 200
-        skill - 50      
+        skill - 50
       when skill <= 400
         skill - 100
       when skill <= 600


### PR DESCRIPTION
## Changes
* Add **You attempt to study** and **find it almost impossible to do** to the match strings for `study my <textbook>`

## Scenario
```
[first-aid]>study my tome
> 
You attempt to study the chart, but find it almost impossible to do.
Roundtime: 10 seconds.
> 
[first-aid: *** No match was found after 15 seconds, dumping info]

[first-aid: messages seen length: 9]

[first-aid: message: Swirling Winds  (10 roisaen)]

[first-aid: message: Manifest Force  (7 roisaen)]

[first-aid: message: Ethereal Shield  (13 roisaen)]

[first-aid: message: You continue playing on your thin-edged zills.]

[first-aid: message: Roundtime: 10 seconds.]

[first-aid: message: You attempt to study the chart, but find it almost impossible to do.]

[first-aid: message: Swirling Winds  (10 roisaen)]

[first-aid: message: Manifest Force  (7 roisaen)]

[first-aid: message: Ethereal Shield  (13 roisaen)]

[first-aid: checked against [/gradually absorbing/i, /difficult time comprehending the advanced text/i, /suddenly makes sense to you/i, /^Why /i, /You need to be holding/i, /discerned all you can/i]]

[first-aid: for command study my tome]
```