### PR TITLE
[data] [base-spells] Add Warrior Mage Cantrips

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -431,12 +431,30 @@ spell_data:
     cyclic: true
     mana: 4
     mana_type: elemental
+  Aether Spheres:
+    skill: cantrip
+    abbrev: C AE S
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Aether Wolves:
     skill: Debilitation
     harmless: true
     abbrev: AEWO
     cyclic: true
     mana: 2
+    mana_type: elemental
+  Aethereal Image:
+    skill: cantrip
+    abbrev: C AE I
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
     mana_type: elemental
   Aethrolysis:
     skill: Targeted Magic
@@ -456,6 +474,15 @@ spell_data:
     mana: 5
     recast: 1
     mana_type: life
+  Air Blast:
+    skill: cantrip
+    abbrev: C AI B
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Air Bubble:
     skill: Utility
     abbrev: AB
@@ -655,6 +682,15 @@ spell_data:
     abbrev: burn
     mana: 7
     mana_type: lunar
+  Burning Touch:
+    skill: cantrip
+    abbrev: C B T
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Butcher's Eye:
     skill: Augmentation
     abbrev: BUE
@@ -777,6 +813,15 @@ spell_data:
     mana: 2
     starlight_threshold: 0
     mana_type: lunar
+  Crystalize Ice:
+    skill: cantrip
+    abbrev: C Crystalize Ice
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Crusader's Challenge:
     skill: Augmentation # Also Utility
     abbrev: CRC
@@ -942,6 +987,15 @@ spell_data:
     recast: 1
     starlight_threshold: 0
     mana_type: lunar
+  Electric Charge:
+    skill: cantrip
+    abbrev: C E C
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Electrostatic Eddy:
     skill: Debilitation
     harmless: true
@@ -1050,6 +1104,15 @@ spell_data:
     cast: gesture
     harmless: true
     expire: Your attention wanders, the dream of skies alight gone with it.
+    mana:
+    recast: 1
+    mana_type: elemental
+  Flash Point:
+    skill: cantrip
+    abbrev: C F
+    prep_time: 0
+    cast: gesture
+    harmless: true
     mana:
     recast: 1
     mana_type: elemental
@@ -1164,6 +1227,15 @@ spell_data:
     prep_type: prepare
     mana: 5
     mana_type: life
+  Gust of Wind:
+    skill: cantrip
+    abbrev: C G O W
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Halo:
     skill: Debilitation # Also warding
     abbrev: HALO
@@ -1602,6 +1674,15 @@ spell_data:
     abbrev: PD
     mana: 2
     mana_type: lunar
+  Pattern Hues:
+    skill: cantrip
+    abbrev: C P H
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Perseverance of Peri'el:
     skill: Warding
     abbrev: POP
@@ -1679,6 +1760,15 @@ spell_data:
     abbrev: RAGE
     recast: 1
     mana_type: elemental
+  Raincloud:
+    skill: cantrip
+    abbrev: C Raincloud
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Raise Power:
     skill: Utility
     abbrev: RP
@@ -1735,6 +1825,15 @@ spell_data:
     cyclic: true
     mana: 5
     mana_type: life
+  Reinforce Stone:
+    skill: cantrip
+    abbrev: C R S
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Rejuvenation:
     skill: Utility
     abbrev: REJUV
@@ -2064,6 +2163,15 @@ spell_data:
     cyclic: true
     invisibility: true
     mana_type: lunar
+  Stone Seat:
+    skill: cantrip
+    abbrev: C S S
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Stone Strike:
     skill: Targeted Magic
     abbrev: STS
@@ -2275,6 +2383,15 @@ spell_data:
     abbrev: WB
     mana: 1
     mana_type: elemental
+  Water Globe:
+    skill: cantrip
+    abbrev: C Water Globe
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
   Whispers of the Muse:
     skill: Augmentation
     abbrev: WOTM
@@ -2293,6 +2410,15 @@ spell_data:
     abbrev: WILL
     mana: 150
     ritual: true
+    mana_type: elemental
+  Will O Wisp:
+    skill: cantrip
+    abbrev: C W O W
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
     mana_type: elemental
   Wisdom of the Pack:
     skill: Augmentation


### PR DESCRIPTION
## Changes
* Adds [Warrior Mage Cantrips](https://elanthipedia.play.net/Category:Cantrips#Warrior_Mage_cantrips) to `base-spells.yaml` data file.

## Why?
* So that they can be defined simply as waggle sets
* So that `validate` script doesn't complain about unknown spells in your config

## Defining Cantrips without them in base-spells
Is verbose and player has to override the `abbrev` and `cast` properties for each cantrip spell they want to use.
```yaml
waggle_sets:
    Air Blast:
      abbrev: cantrip air blast
      cast: gesture
```

## Validation Errors
And since cantrips are not known in lich data then the `validate` script complains.
```
--- Lich: validate active.

  Checking 90 different potential errors

[validate: WARNING:< waggle_sets contains the following spell names not found in data/base_spells, ["Air Blast"] Check spelling and capitalization.  >]

  WARNINGS:1 ERRORS:0

  All done!

--- Lich: validate has exited.
```

## Usage
Define a waggle set with your desired spells and cantrips:
```yaml
waggle_sets:
  dry:
    Air Blast:
      skill: cantrip
```
Use with buff script, such as to dry yourself after swimming: `;buff dry`
```
> ;buff dry

--- Lich: buff active.

[buff]>release mana

You aren't harnessing any mana.
> 
[buff]>prep C AI B 

You are now prepared to cast the Air Blast cantrip.
> 
[buff]>gesture

You gesture, and a strong warm breeze swirls around you, quickly drying your feet.
> 
--- Lich: buff has exited.
```

### Simpler Config
To avoid redundantly specifying cantrip attributes defined in `base-spells.yaml`, you could use empty `{}`
```yaml
waggle_sets:
  dry:
    Air Blast: {}
```

### Simplest Config
But `{}` feels a bit unintuitive. If we really wanted to leverage all the defaults, it'd be nice to just do this:
```yaml
waggle_sets:
  dry:
    Air Blast:
```
However, this last example throws an error in `dependency` trying to merge a null object:
```
--- Lich: buff active.

*** ERROR MODIFYING DATA IN DEPENDENCY ***

*** Commonly this is malformed spell or loot entries in your yaml file ***

can't convert NilClass to Hash (NilClass#to_hash gives NilClass)

dependency:925:in `merge'

dependency:925:in `block (3 levels) in transform_settings'

dependency:925:in `each'

dependency:925:in `block (2 levels) in transform_settings'

dependency:925:in `select'

dependency:925:in `block in transform_settings'

dependency:925:in `select'

dependency:925:in `transform_settings'

dependency:865:in `load_settings'

dependency:775:in `run_queue'

dependency:1332:in `block in _script'

dependency:1325:in `loop'

dependency:1325:in `_script'

lich.rbw:2524:in `eval'

lich.rbw:2524:in `block (2 levels) in <class:Script>'

--- Lich: buff has exited.
```
Not addressed in this pull request, but I believe end of line 925 of `dependency.lic` needs to change from:
```ruby
s.waggle_sets[set_name][spell_name] = spells[spell_name].merge(spell_data)
```
to
```ruby
s.waggle_sets[set_name][spell_name] = (spell_data ? spells[spell_name].merge(spell_data) : spells[spell_name])
```
so that it only tries to merge configs if something exists.