### PR TITLE
[script] [feed-cloak] New script to feed those vine cloaks

### DIFF
--- a/feed-cloak.lic
+++ b/feed-cloak.lic
@@ -1,0 +1,55 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#feed-cloak
+=end
+
+custom_require.call(%w[common common-travel])
+
+class FeedCloak
+  include DRC
+  include DRCT
+
+  def initialize
+    settings = get_settings
+    @feed_rooms = [settings.feed_cloak_room, settings.safe_room].compact.uniq
+    main
+  end
+
+  def main
+    # Try to feed in the current room.
+    # If unsuccessful then move to designated feed room.
+    loop do
+      break if fed_cloak?
+      room = @feed_rooms.shift
+      if room && Room.current.id != room
+        DRCT.walk_to(room)
+      else
+        DRC.message("Unable to find a room to feed your cloak. Check your config.")
+        exit
+      end
+    end
+  end
+
+  def fed_cloak?
+    no_food_in_room = [
+      /unable penetrate and procure nourishment/,
+      /You shouldn't disturb the silence here/,
+      /You really shouldn't be loitering in here/
+    ]
+    not_hungry = /The vines seem uninterested/
+    done_eating = /They rapidly slither back up around your body/
+    no_cloak = /What were you referring to?/
+    cant_feed = /You can't feed/
+    case bput("feed my cloak", *no_food_in_room, not_hungry, done_eating, no_cloak, cant_feed)
+    when no_cloak, cant_feed
+      DRC.message("You aren't wearing a cloak that can be fed.")
+      exit
+    when *no_food_in_room
+      false
+    when not_hungry, done_eating
+      true
+    end
+  end
+
+end
+
+FeedCloak.new

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1511,3 +1511,11 @@ faux_atmo_no_use_rooms:
 
 # Will attempt to invoke a tessera during crossing-training between activities, 10 minute cooldown.
 use_tessera_during_crossing_training: false
+
+# Feed-cloak settings
+# If your cloak can't feed in your current room
+# then feed-cloak will move to this specified room id.
+# If not specified, or if the cloak can't feed here either,
+# then the script will move to your `safe_room`.
+# Example: 992 # Crossing, [Northeast Wilds, Outside Northeast Gate]
+feed_cloak_room: 


### PR DESCRIPTION
In collaboration with @Hiinky, developed a script we can work in to our training routines to keep those new vine cloaks fed and refreshed 🌱 

## New Config Variable
```yaml
# If your cloak can't feed in your current room
# then feed-cloak will move to this specified room.
# If not specified, or if the cloak can't feed here either,
# then the script will move to your `safe_room`.
feed_cloak_room: 992 # Crossing, [Northeast Wilds, Outside Northeast Gate]
```