### PR TITLE
Add pick.lic method to balance the lockpick container.

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -41,6 +41,7 @@ class LockPicker
         echo '***STOPPING DUE TO MINDLOCK***'
         break
       end
+      balance_lockpick_container
       attempt_open(box)
       break if @make_pets && @pet_count >= @pet_goal
     end
@@ -205,6 +206,11 @@ class LockPicker
         bput("meditate #{med}", 'You feel a jolt as your vision snaps shut', 'Your inner fire lacks the strength')
       end
     end
+  end
+
+  def balance_lockpick_container
+    return unless @settings.balance_lockpick_container
+    bput("turn my #{@settings.lockpick_container} to best", "You fiddle with", "You think about it")
   end
 
   def refill_ring


### PR DESCRIPTION
The purpose of this is to evenly wear picks so they can be repaired by a Thief. Playing with the idea of using a flag for this, see code for example settings flag.