### PR TITLE
[script] [common] Add 'wput' method, a variant of 'bput' with a timeout arg

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -91,7 +91,17 @@ module DRC
 
   module_function
 
+  # Like `fput` but better because will wait for RT
+  # before performing command and do smart retries.
+  # Will wait for matching text up to 15 seconds then timeout.
   def bput(message, *matches)
+    wput(message, 15, matches)
+  end
+
+  # Like `fput` but better because will wait for RT
+  # before performing command and do smart retries.
+  # Will wait for matching text up til the given timeout in seconds.
+  def wput(message, timeout, *matches)
     waitrt?
     log = []
     matches.flatten!
@@ -99,7 +109,7 @@ module DRC
     clear
     put message
     timer = Time.now
-    while (response = get?) || (Time.now - timer < 15)
+    while (response = get?) || (Time.now - timer < timeout)
 
       if response.nil?
         pause 0.1
@@ -144,7 +154,7 @@ module DRC
         end
       end
     end
-    echo '*** No match was found after 15 seconds, dumping info'
+    echo "*** No match was found after #{timeout} seconds, dumping info"
     echo "messages seen length: #{log.length}"
     log.reverse.each { |logged_response| echo "message: #{logged_response}" }
     echo "checked against #{matches}"


### PR DESCRIPTION
## Changes
* Move logic of `bput` into new method, `wput` ('w' is for "wait")
* `wput` accepts 3 arguments:
  * the message to send
  * a timeout in seconds
  * list of match strings
* The original `bput` method delegates to the new `wput` method, passing in the original 15 second timeout

## Why
* To let scripts leverage the magic of `bput` in scenarios when you know it may take longer than 15 seconds to receive an expected match in the game output.

## Use Cases
An example of this need is discussed at https://discordapp.com/channels/745675889622384681/745696628714897508/765743464343928843

**Summarized here:**

> [Katoak] Kali and I introduced a new script yesterday, feed-cloak to well, um, feed those vine cloaks! Thanks blackheart for the merge. Today, I'm noticing that my cloak is taking like 30 seconds to feed, longer than the default timer for bput command and so the script is outputting the error about "didn't match" stuff.

>  [Dartellum] if it is always 30 seconds, pause 30

> [Kali] its not
can be 10 or up to a minute
and its not visible RT
just whenever it feels full