### PR TITLE
Use own brazier by default if you have one assigned.

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -43,7 +43,7 @@ class Enchant
 
     @use_own_brazier = true
     DRRoom.room_objs.each do |obj|
-      if obj.include?("enchanter's brazier")
+      if obj.include?("enchanter's brazier") and not @brazier
         @brazier = "enchanter's brazier"
         @use_own_brazier = false
       end


### PR DESCRIPTION
Previously the script preferred the society brazier.