### PR TITLE
[script] [performance] Only remove hand armor if property is defined

### DIFF
--- a/performance.lic
+++ b/performance.lic
@@ -28,8 +28,10 @@ class Performance
     hand_armor = @settings.hand_armor
     if instrument
       bput("get my #{instrument}", 'You get')
-      bput("remove my #{hand_armor}", 'You pull off', 'Remove what')
-      bput("stow my #{hand_armor}", 'You put', 'Stow what')
+      if hand_armor
+        bput("remove my #{hand_armor}", 'You pull off', 'You tug', 'Remove what')
+        bput("stow my #{hand_armor}", 'You put', 'Stow what')
+      end
     end
 
     return unless DRC.play_song?(@settings, @song_list, is_instrument_worn, skip_clean)


### PR DESCRIPTION
## Background
* If playing a non-worn instrument then the script tries to remove your hand armor and stow it.
* The script looks at the `hand_armor` property in your yaml.
* It always tries to remove and stow the hand armor, even if it's not necessary for your instrument. For example, one of my character's doesn't _wear_ zills or a cowbell, but keeps them stored and pulls them out as needed.

## Changes
* Only try to remove hand armor if the `hand_armor` property is defined
* Add support for `some silversteel mail gloves traced with a labyrinthine pattern` which give the message "You tug at the fingers of your mail gloves and gently pull them off of your hands." when removed from some characters. This ensures the `bput` command doesn't spit out the "could not match" error and the script wait for 15 seconds.

## Config
Already defined in `base.yaml`
```yaml
hand_armor: gloves
```
To disable the attempt at removing your hand armor you can set it to nil:
```yaml
hand_armor:
```