### PR TITLE
base.yaml - Added flying_mount setting

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1527,3 +1527,8 @@ use_tessera_during_crossing_training: false
 # then the script will move to your `safe_room`.
 # Example: 992 # Crossing, [Northeast Wilds, Outside Northeast Gate]
 feed_cloak_room: 
+
+#Flying mount setting
+#Currently only used by bescort for the Faldesu and Segoltha.
+#Example: flying_mount: silk carpet
+flying_mount: 


### PR DESCRIPTION
Added `flying_mount: ` to base.yaml
Currently it's only used in bescort.