### PR TITLE
[script] [common] Play song on configured instrument

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -470,8 +470,12 @@ module DRC
     UserVars.song = song_list.first.first unless UserVars.song
     UserVars.climbing_song = song_list.first.first unless UserVars.climbing_song
     song_to_play = climbing ? UserVars.climbing_song : UserVars.song
+    play_command = "play #{song_to_play}"
+    if instrument
+      play_command = play_command + " on my #{instrument}"
+    end
     fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
-    result = bput("play #{song_to_play}", 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
+    result = bput(play_command, 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
     case result
     when 'Play on what instrument'
       snapshot = "#{right_hand}#{left_hand}"


### PR DESCRIPTION
## Background
* The `play_song?` function does not specify which instrument to begin playing
* If you are wearing multiple instruments then the script may try to use the wrong instrument or choose an instrument that's not able to be played at the moment when another one is.

## Changes
* If an instrument is specified in your yaml config, the play song command will say `on my <instrument>`.

_Note, the script already looks up your desired instrument from settings but wasn't specifying it with the `play` command_
```ruby
instrument = worn ? settings.worn_instrument : settings.instrument
```

## Example (ambiguity)
My character is wearing two instruments, a large brass whistle dangling from a beaded metal chain (part of their themed outfit) but when training performance use some worn zills that are hidden from the LOOK via an item hider.

When the `performance` script plays a song, the song is specified but not the instrument so there's ambiguity on which instrument the game will attempt to use. In the case of the whistle, your right hand must be empty, which conflicts with tasks I'm doing with my right hand.

```
[performance]>play scales halt
You must free up your right hand to play the brass whistle.
```

## Example (specificity)
With the change in this pull request, if your yaml specifies an instrument then the play command will use it specifically, avoiding the above ambiguity.

```
[performance]>play scales halt on my zills
You begin a halting ruff on your thin-edged zills.
```