### PR TITLE
[script] [common-items] 'get_item_list' handles empty container

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -253,7 +253,9 @@ module DRCI
   end
 
   def get_item_list(container)
-    container_contents = DRC.bput("look in #{container}",'In the .* you see (.*)\.').match(/In the .* you see (?:a|an|some) (?<items>.*)\./)[:items].split(/(?:, | and )?(?:a|an|some) /)
+    container_contents = DRC.bput("look in #{container}", 'In the .* you see (.*)\.', 'There is nothing')
+      .match(/In the .* you see (?:a|an|some) (?<items>.*)\./)[:items]
+      .split(/(?:, | and )?(?:a|an|some) /)
   end
 
   def put_away_item?(item, container)


### PR DESCRIPTION
### Changes
* Add `bput` string match for `There is nothing` (empty container) so that an empty array is returned rather than a `bput` error about unmatched string.
* Moved `.match` and `.split` calls to their own lines; the original line was very long.