### PR TITLE
[script] [transfer-items] Refactor to use existing utilities

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -2,41 +2,32 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#transfer-items
 =end
 
+custom_require.call %w[common common-items]
+
 class ItemTransfer
+  include DRC
+  include DRCI
+
   def initialize
     arg_definitions = [
       [
-        { name: 'source', regex: /^[A-z\s\-]+$/i, variable: true, description: 'Source container' },
-        { name: 'destination', regex: /^[A-z\s\-]+$/i, variable: true, description: 'Destination container' }
+        { name: 'source', regex: /^[A-z\.\s\-]+$/i, variable: true, description: 'Source container' },
+        { name: 'destination', regex: /^[A-z\.\s\-]+$/i, variable: true, description: 'Destination container' }
       ]
     ]
     args = parse_args(arg_definitions)
-    @source = args.source
-    @destination = args.destination
-
-    transfer_items
+    transfer_items(args.source, args.destination)
   end
 
-  def transfer_items
-    fput("look in my #{@source}")
-
-    while line = get
-      if line =~ /In the .*#{@source} you see/
-        items = line
-        break
-      end
-    end
-
-    items
-      .sub(' and ', ',')
-      .split(',')
-      .map { |full_name| full_name.split(' ') }
-      .map { |parts| parts.last.sub('.', '') }
+  def transfer_items(source, destination)
+    DRCI.get_item_list(source)
+      .map { |full_name| full_name.split(' ').last }
       .each do |item|
-        fput("get #{item} from my #{@source}")
-        fput("put #{item} in my #{@destination}")
+        fput("get #{item} from my #{source}")
+        fput("put #{item} in my #{destination}")
       end
   end
+
 end
 
 ItemTransfer.new


### PR DESCRIPTION
### Changes
* `source` and `destination` container names don't have to be full `<adj> <noun>`.
  * Examples: "blue backpack", "blue.back", "backpack", "back"
  * Previously only "blue backpack" (full adj. and noun) or "backpack" (full noun) would work.
* Refactor `transfer_items` method to accept source and destination container names as parameters; removed need for class properties for the same.
* Leverage `DRCI.get_item_list` existing method; able to remove duplicate code.

### Example Usage
```ruby
> ,transfer blue.back thorn.loots

--- Lich: transfer-items active.

[transfer-items]>look in blue.back

In the blue backpack you see a black blindfold, a foo, a bar, and a baz.
> 
[transfer-items]>get blindfold from my blue.back

You get a black blindfold from inside a rugged blue backpack which is in your hitman's backpack.
> 
[transfer-items]>put blindfold in my thorn.loots

You put your blindfold in your thornweave lootsack.

...

--- Lich: transfer-items has exited.
```