### PR TITLE
[scripts] [locksmithing] More updates to handle closeable training boxes

### DIFF
--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -90,14 +90,15 @@ class Locksmithing
 
   def pick_box(trainer)
     while (DRSkill.getxp('Locksmithing') < 34 && DRC.right_hand)
-      case bput("pick my #{trainer}", 'Maybe you should close', 'not making any progress', "why bother", "it opens.", "isn't locked", 'The lock feels warm',/The lock looks weak/, 'Pick what','You need some type of tool to pick',"But you aren't holding")
+      case bput("pick my #{trainer}", 'Maybe you should close', 'not making any progress', "why bother", "it opens.", "isn't locked", 'The lock feels warm', 'The lock looks weak', 'Pick what', 'You need some type of tool to pick', "But you aren't holding")
       when /Maybe you should close/
-        bput("close my #{trainer}", 'You close')
+        bput("close my #{trainer}", 'You close', 'already closed', "You can't close that")
         bput("lock my #{trainer}", 'You quickly lock', 'already locked')
       when /You need some type of tool to pick/
         echo ('YOU HAVE NO LOCKPICKS ON YOUR LOCKPICK RING/BELT.  SORT THAT OUT!')
         exit
       when /it opens|isn't locked/
+        bput("close my #{trainer}", 'You close', 'already closed', "You can't close that")
         bput("lock my #{trainer}", 'You quickly lock', 'already locked')
       when /The lock feels warm/
         echo('Charges Burned!, checking for other settings.')


### PR DESCRIPTION
### Changes
* This is a continuation of https://github.com/rpherbig/dr-scripts/pull/4559
* Adds more match strings for `close my <box>`
* Will close the box if it's not locked
* Will close the box if picking it causes it to become open

### Background
I had a burgled keepsake box from before the "open/close" changes came into effect. Not sure if that is related or not, but the locksmithing script got hung up for me trying to lock my box after picking it and the game told me that I needed to close the box but there was no step to close the box for the `/it opens|isn't locked/` case.