### PR TITLE
[script] [transfer-items] Handle when item doesn't fit, hands are full, and other scenarios

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -23,8 +23,21 @@ class ItemTransfer
     DRCI.get_item_list(source)
       .map { |full_name| full_name.split(' ').last }
       .each do |item|
-        fput("get #{item} from my #{source}")
-        fput("put #{item} in my #{destination}")
+        # Attempt to get the item from the source container.
+        case DRC.bput("get #{item} from my #{source}", "You get", "What were you referring to", "You need a free hand")
+        when "You get"
+          # Attempt to put the item in the destination container.
+          case DRC.bput("put #{item} in my #{destination}", "You put", "There isn't any more room", "is too long to fit", "is too small to hold that", "too heavy to go in there")
+          when "There isn't any more room", "is too long to fit", "is too small to hold that", "too heavy to go in there"
+            DRC.message("The #{item} doesn't fit in your #{destination}. The container may be full or too small to hold the item.")
+            # Return item to source container.
+            # Loop will try to transfer the next item in the list.
+            DRC.bput("put #{item} in my #{source}", "You put")
+          end
+        when "You need a free hand"
+          DRC.message("Can't transfer items because your hands are full.")
+          exit
+        end
       end
   end
 


### PR DESCRIPTION
### Changes
* This is a continuation of https://github.com/rpherbig/dr-scripts/pull/4566
* Use `bput` instead of `fput`
* If item doesn't fit in the destination container then shows a message to the user and returns the item to the source container then tries to transfer the next item.
* If hands are full then shows message to the user and exits the script.