### PR TITLE
[script] [common-items] Remove unused variables, don't double up on "my my <container>"

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -10,12 +10,12 @@ $PUT_AWAY_ITEM_SUCCESS_PATTERNS = [/^You put your .* in/,
 $PUT_AWAY_ITEM_OPEN_PATTERNS = [/^But that's closed/]
 $PUT_AWAY_ITEM_FAILURE_PATTERNS = [/^What were you referring to/]
 
-$OPEN_CONTAINER_SUCCESS_PATTERNS = [/^You open/, 
+$OPEN_CONTAINER_SUCCESS_PATTERNS = [/^You open/,
                                     /^That is already open/]
 $OPEN_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
 
 
-$CLOSE_CONTAINER_SUCCESS_PATTERNS = [/^You close/, 
+$CLOSE_CONTAINER_SUCCESS_PATTERNS = [/^You close/,
                                      /^That is already closed/]
 $CLOSE_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
 
@@ -253,18 +253,18 @@ module DRCI
   end
 
   def get_item_list(container)
-    container_contents = DRC.bput("look in #{container}", 'In the .* you see (.*)\.', 'There is nothing')
+    DRC.bput("look in #{container}", 'In the .* you see (.*)\.', 'There is nothing')
       .match(/In the .* you see (?:a|an|some) (?<items>.*)\./)[:items]
       .split(/(?:, | and )?(?:a|an|some) /)
   end
 
   def put_away_item?(item, container)
-    result = put_away_item_safe?(item, container)
+    put_away_item_safe?(item, container)
   end
 
   def put_away_item_safe?(item, container)
-    container = "my " + container
-    result = put_away_item_unsafe?(item, container)
+    container = "my #{container}" unless container =~ /^my /i
+    put_away_item_unsafe?(item, container)
   end
 
   def put_away_item_unsafe?(item, container)


### PR DESCRIPTION
### Changes
* Continuation of https://github.com/rpherbig/dr-scripts/pull/4565
* Remove unused variables
* Trim trailing whitespace
* Update `put_away_item_safe?` to only prefix container with "my" if it doesn't already start with that word to avoid "my my <container>" snafus