### PR TITLE
Targeted Tattoo Support

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -92,7 +92,7 @@ module DRCA
     end
   end
 
-  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_type = 'buff')
+  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false)
     return false unless abbrev
     
     DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
@@ -101,13 +101,13 @@ module DRCA
     case match
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
-      return prepare?(abbrev, mana, symbiosis, command, tattoo_type)
+      return prepare?(abbrev, mana, symbiosis, command, tattoo_tm)
     when 'Something in the area interferes with your spell preparations'
       DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
       return false
     end
 
-    DRC.bput("target", 'You begin to weave mana lines') if tattoo_type.include?("targ")
+    DRC.bput("target", 'You begin to weave mana lines') if tattoo_tm
 
     match
   end
@@ -458,10 +458,7 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    tattoo_type = 'buff'
-    tattoo_type = data['tattoo_type']
-
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_type)
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'])
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -458,7 +458,10 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'])
+    tm_tattoo = false
+    tm_tattoo = data['tattoo_tm'] if data['tattoo_tm']
+
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tm_tattoo)
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -94,7 +94,7 @@ module DRCA
 
   def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false)
     return false unless abbrev
-    
+
     DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 
     match = DRC.bput("#{command} #{abbrev} #{mana}", get_data('spells').prep_messages)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -107,7 +107,7 @@ module DRCA
       return false
     end
 
-    DRC.bput("target", 'You begin to weave mana lines') if tattoo_tm
+    DRC.bput("target", get_data('spells').prep_messages) if tattoo_tm
 
     match
   end
@@ -458,10 +458,10 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    tm_tattoo = false
-    tm_tattoo = data['tattoo_tm'] if data['tattoo_tm']
+    tattoo_tm = false
+    tattoo_tm = data['tattoo_tm'] if data['tattoo_tm']
 
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tm_tattoo)
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_tm)
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -458,10 +458,7 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    tattoo_tm = false
-    tattoo_tm = data['tattoo_tm'] if data['tattoo_tm']
-
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_tm)
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'])
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -92,20 +92,22 @@ module DRCA
     end
   end
 
-  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare')
+  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_type = 'buff')
     return false unless abbrev
-
+    
     DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 
     match = DRC.bput("#{command} #{abbrev} #{mana}", get_data('spells').prep_messages)
     case match
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
-      return prepare?(abbrev, mana, symbiosis, command)
+      return prepare?(abbrev, mana, symbiosis, command, tattoo_type)
     when 'Something in the area interferes with your spell preparations'
       DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
       return false
     end
+
+    DRC.bput("target", 'You begin to weave mana lines') if tattoo_type.include?("targ")
 
     match
   end
@@ -456,7 +458,10 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
+    tattoo_type = 'buff'
+    tattoo_type = data['tattoo_type']
+
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_type)
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']
@@ -621,6 +626,7 @@ module DRCA
     command = 'prep'
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
+
     prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
   end
 


### PR DESCRIPTION
Added a setting to the spells to prepare and target if setting is true.

```
- skill: Sorcery
  prep: invoke tattoo
  tattoo_tm: true
  cast_only_to_train: true
  mana: 25
  cambrinth:
  - 25
```
