### PR TITLE
[script] [common-items] Add get_inventory_by_type method

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -173,14 +173,15 @@ module DRCI
     # Unless you're looking for items at your feet, this is noise.
     items_at_feet = snapshot.grep(/(^Lying at your feet)/).any?
     # If the snapshot found all the inventory then begin processing.
-    if snapshot.grep(/(^All of your (#{type}|items))|(^You aren't wearing anything like that)/).any? && snapshot.grep(/Use INVENTORY HELP/).any?
+    if snapshot.grep(/^All of your (#{type}|items)|^You aren't wearing anything like that|Both of your hands are empty/).any? && snapshot.grep(/Use INVENTORY HELP/).any?
       snapshot
       .map(&:strip)
       .reverse
-      .take_while { |line| [/^All of your (#{type}|items)/, /^You aren't wearing anything like that/].none? { |phrase| phrase =~ line } }
-      .drop_while { |line| items_at_feet ? !line.start_with?('Lying at your feet') : !line.start_with?('[Use INVENTORY HELP for more options.]') }
+      .take_while { |line| [/^All of your (#{type}|items)/, /^You aren't wearing anything like that/, /Both of your hands are empty/].none? { |phrase| phrase =~ line } }
+      .drop_while { |line| !line.start_with?('[Use INVENTORY HELP for more options.]') }
       .drop(1)
       .reverse
+      .take_while { |line| !items_at_feet || !line.start_with?('Lying at your feet') }
       .map { |item| item.gsub(/^(a|an|some)\s+/, '').gsub(/\s+\(closed\)/, '') }
     else
       # Otherwise, retry the command. Other actions may have flooded the game window.

--- a/common-items.lic
+++ b/common-items.lic
@@ -158,6 +158,36 @@ module DRCI
     end
   end
 
+  # Returns a list of item descriptions from the `INVENTORY <type|slot>` verb output.
+  # Where <type> can be armor, weapon, fluff, container, or combat.
+  # Where <slot> can be any phrase from INV SLOTS LIST command.
+  def get_inventory_by_type(type = 'combat', line_count = 40)
+    case DRC.bput("inventory #{type}", "Use INVENTORY HELP for more options.", "The INVENTORY command is the best way")
+    when "The INVENTORY command is the best way"
+      DRC.message("Unrecognized inventory type: #{type}. Valid options are ARMOR, WEAPON, FLUFF, CONTAINER, COMBAT, or any slot from INVENTORY SLOTS LIST.")
+      return []
+    end
+    # Multiple lines may have been printed to the game window,
+    # grab the last several lines for analysis.
+    snapshot = reget(line_count)
+    # Unless you're looking for items at your feet, this is noise.
+    items_at_feet = snapshot.grep(/(^Lying at your feet)/).any?
+    # If the snapshot found all the inventory then begin processing.
+    if snapshot.grep(/(^All of your (#{type}|items))|(^You aren't wearing anything like that)/).any? && snapshot.grep(/Use INVENTORY HELP/).any?
+      snapshot
+      .map(&:strip)
+      .reverse
+      .take_while { |line| [/^All of your (#{type}|items)/, /^You aren't wearing anything like that/].none? { |phrase| phrase =~ line } }
+      .drop_while { |line| items_at_feet ? !line.start_with?('Lying at your feet') : !line.start_with?('[Use INVENTORY HELP for more options.]') }
+      .drop(1)
+      .reverse
+      .map { |item| item.gsub(/^(a|an|some)\s+/, '').gsub(/\s+\(closed\)/, '') }
+    else
+      # Otherwise, retry the command. Other actions may have flooded the game window.
+      get_inventory_by_type(type, line_count + 40)
+    end
+  end
+
   def exists?(description)
     result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You thump your fingers', 'The orb is delicate')
     result =~ /You tap|You thump|The orb is delicate/


### PR DESCRIPTION
### Background
* This is part of a larger effort (https://github.com/rpherbig/dr-scripts/pull/4484) for identifying items and their `<adjective> <noun>` tap word combinations.
* Inspired by `get_combat_items` in the `equipmanager.lic` script, with plan to refactor that method to use this new utility method in a future PR.

### Changes
* New method that returns a list of item descriptions from the `inventory <type>` verb output.
* Supported `<type>`s include `armor`, `weapon`, `fluff`, `container`, `combat`, and any slot from `INVENTORY SLOTS LIST`.

### Usage

```
> ,e echo DRCI.get_inventory_by_type('atfeet')

--- Lich: exec1 active.

[exec1]>inventory atfeet

> 
All of your items lying at your feet:

  a hickory branch
  a leaf
  a rock
[Use INVENTORY HELP for more options.]
> 
[exec1: ["hickory branch", "leaf", "rock"]]

--- Lich: exec1 has exited.
```

```
> ,e echo DRCI.get_inventory_by_type('armor')

--- Lich: exec1 active.

[exec1]>inventory armor

> 
All of your armor:

  a sleek diacan brigandine balaclava with twisted black gold edging
  some shadowleaf assassin's leathers tinged somber black
  a small demonscale shield pyrographed with a map of the Blasted Plains
  some diacan mail gloves crafted with sleek lines
Lying at your feet are a hickory branch.

[Use INVENTORY HELP for more options.]
> 
[exec1: ["sleek diacan brigandine balaclava with twisted black gold edging", "shadowleaf assassin's leathers tinged somber black", "small demonscale shield pyrographed with a map of the Blasted Plains", "diacan mail gloves crafted with sleek lines"]]

--- Lich: exec1 has exited.
```

```
> ,e echo DRCI.get_inventory_by_type('back')

--- Lich: exec1 active.

[exec1]>inventory back

All of your items worn on the back:

  a worn grey hitman's backpack with fraying straps
[Use INVENTORY HELP for more options.]
> 
[exec1: ["worn grey hitman's backpack with fraying straps"]]

--- Lich: exec1 has exited.
```