### PR TITLE
[script] [faux-atmo] fix logic for matching room names/ids

### DIFF
--- a/faux-atmo.lic
+++ b/faux-atmo.lic
@@ -50,7 +50,7 @@ class FauxAtmo
   end
 
   def no_use_room?
-    @no_use_rooms.any? { |room| room === DRRoom.title.to_s()[2..-3] || room == Room.current.id }
+    @no_use_rooms.any? { |name| /#{name}/ =~ DRRoom.title || name.to_s == Room.current.id.to_s }
   end
 
   def ready_to_use_item?


### PR DESCRIPTION
### Background
* Noticed script was trying to perform a verb while at the Crossing bank window and would get the "don't disturb the silence" messaging. Noticed that my yaml already had "Teller" in its no use list but obviously wasn't having an effect.

### Changes
* Now uses same syntax as `sanowret-crystal` script for detecting you're in a "no use" room
