### PR TITLE
bescort.lic - add dirigible support to flying mounts

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -307,7 +307,7 @@ class Bescort
     when 'mount'
       bput("get my #{type}", /You get /, /You are already holding/)
       case type
-      when /broom/i
+      when /broom/i, /dirigible/i
         bput("mount my #{type}", /You mount your/)
         bput("command #{type} to #{speed}", /You command your/)
       when /carpet/i
@@ -321,8 +321,8 @@ class Bescort
       end
     when 'dismount'
       case type
-      when /broom/i
-        bput('dismount', /Your broom floats down to the ground/)
+      when /broom/i, /dirigible/i
+        bput('dismount', /Your (broom|dirigible) floats down to the ground/)
         EquipmentManager.new.empty_hands
       when /carpet/i
         bput('dismount', /Your carpet floats down to the ground/)


### PR DESCRIPTION
Added support for using the dirigible the same way brooms and carpets are used.