### PR TITLE
[script] [sell-loot] Sell component pouches of harvested traps

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -231,6 +231,7 @@ Shard:
     id: 8908
   locksmithing:
     id: 9817
+    name: Kilam
   debt_office:
     id: 2477
   guard_house:
@@ -394,6 +395,7 @@ Riverhaven:
     name: Unspiek
   locksmithing:
     id: 19096
+    name: Ss'Thran
   metal_repair:
     id: 8737
     name: Unspiek
@@ -1125,6 +1127,7 @@ Muspar'i:
     << : *northern_favor_puzzle    
   locksmithing:
     id: 7613
+    name: Hekipe
   debt_office:
     id: 54
   guard_house:
@@ -1162,6 +1165,7 @@ Ain Ghazal:
     << : *hib_exchange
   locksmithing:
     id: 13190
+    name: Sephina
   guild_leaders:
     Thief:
       name: Ivitha

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -41,6 +41,7 @@ Crossing:
     id: 6218
   locksmithing:
     id: 19125
+    name: Ragge
   theurgy_supplies:
     id: 19073
   favor_altar: &zoluren_favor_altar

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -787,7 +787,11 @@ use_lockpick_ring: true
 skip_lockpick_ring_refill: false
 lockpick_container: lockpick ring
 lockpick_type: ordinary
+# If you harvest traps when disarming boxes
+# and you set the component_container property
+# then you might also want to set sell_loot_traps: true
 harvest_traps: true
+# When harvesting traps from boxes, this is where you store the traps.
 component_container:
 picking_box_source: duffel bag
 # Keep this empty to drop too-hard boxes on the ground
@@ -812,6 +816,9 @@ bankbot_enabled: false
 sell_loot: true
 sell_loot_pouch: true
 sell_loot_bundle: true
+# For thieves to sell their component pouch of harvested traps.
+# If set to true, you likely also want to set harvest_traps and component_container.
+sell_loot_traps: false
 sell_loot_money_on_hand: 3 silver
 sell_loot_skip_bank: false
 sell_loot_skip_exchange: false

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -29,11 +29,14 @@ class SellLoot
     skip_bank = @settings.sell_loot_skip_bank
     skip_exchange = @settings.sell_loot_skip_exchange
     keep_money_by_currency = @settings.sell_loot_money_on_hand
+    @sort_auto_head = @settings.sort_auto_head
 
     sell_gems("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}") if @settings.sell_loot_pouch
     check_spare_pouch(@settings.spare_gem_pouch_container, @settings.gem_pouch_adjective) if @settings.spare_gem_pouch_container
 
     sell_bundle if @settings.sell_loot_bundle
+
+    sell_traps(@settings.component_container) if @settings.sell_loot_traps
 
     return if skip_bank && !@bankbot_enabled
     return if @bankbot_enabled && (@bankbot_name.nil? || @bankbot_room_id.nil?)
@@ -73,24 +76,24 @@ class SellLoot
   end
 
   def exchange_coins
-    walk_to @hometown['exchange']['id']
+    DRCT.walk_to(@hometown['exchange']['id'])
     release_invisibility
     exchange_to = @hometown['currency']
     $CURRENCIES
       .reject { |currency| currency =~ /#{exchange_to}/i }
-      .each { |currency| fput "exchange all #{currency} for #{exchange_to}" }
+      .each { |currency| fput("exchange all #{currency} for #{exchange_to}") }
   end
 
   def deposit_coins(keep_copper)
-    walk_to @hometown['deposit']['id']
+    DRCT.walk_to(@hometown['deposit']['id'])
     release_invisibility
-    bput('wealth', 'Wealth:')
-    case bput('deposit all', 'you drop all your', 'drop your coins inside', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit', "We don't serve necromancers or sorcerers here.")
+    DRC.bput('wealth', 'Wealth:')
+    case DRC.bput('deposit all', 'you drop all your', 'drop your coins inside', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit', "We don't serve necromancers or sorcerers here.")
     when 'There is no teller here', "We don't serve necromancers or sorcerers here."
       return
     end
     minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, @settings) }
-    bput('check balance', 'your current balance is', 'As expected, there are')
+    DRC.bput('check balance', 'your current balance is', 'As expected, there are')
   end
 
   def give_money_to_bankbot(currency, keep)
@@ -98,13 +101,13 @@ class SellLoot
     deposit_amount = copper_on_hand - keep
     return if deposit_amount <= 0
 
-    walk_to @bankbot_room_id
+    DRCT.walk_to(@bankbot_room_id)
     return unless DRRoom.pcs.include?(@bankbot_name)
 
     Flags.reset('tip-accepted')
     Flags.reset('tip-expired')
     Flags.reset('tip-declined')
-    case bput("tip #{@bankbot_name} #{deposit_amount} #{currency}", 'You offer', "I don't know who", 'you really should keep every bronze you can get your hands on', 'You already have a tip offer outstanding', 'already has a tip offer pending', "But you don't have that much!")
+    case DRC.bput("tip #{@bankbot_name} #{deposit_amount} #{currency}", 'You offer', "I don't know who", 'you really should keep every bronze you can get your hands on', 'You already have a tip offer outstanding', 'already has a tip offer pending', "But you don't have that much!")
     when "I don't know who"
       echo '***Bankbot not found, skipping deposit***'
       return
@@ -128,18 +131,18 @@ class SellLoot
   def sell_bundle
     return unless exists?('bundle')
 
-    return unless walk_to @hometown['tannery']['id']
+    return unless DRCT.walk_to(@hometown['tannery']['id'])
 
-    return if bput('remove my bundle', 'You remove', 'You sling', 'Remove what','You take') == 'Remove what'
+    return if DRC.bput('remove my bundle', 'You remove', 'You sling', 'Remove what','You take') == 'Remove what'
     release_invisibility
-    bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle')
-    bput('stow rope', 'You put')
+    DRC.bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle')
+    DRC.bput('stow rope', 'You put')
   end
 
   def check_spare_pouch(container, adj)
     fput("open my #{container}")
     return if inside?("#{adj} pouch", container)
-    walk_to @hometown['gemshop']['id']
+    DRCT.walk_to(@hometown['gemshop']['id'])
     clerk = which_clerk(@hometown['gemshop']['name'])
     release_invisibility
     fput("ask #{clerk} for #{adj} pouch")
@@ -152,24 +155,59 @@ class SellLoot
 
   def sell_gems(container)
     release_invisibility
-    case bput("open my #{container}", 'You open your', 'You open a', 'has been tied off', 'What were you referring to', 'That is already open')
+    case DRC.bput("open my #{container}", 'You open your', 'You open a', 'has been tied off', 'What were you referring to', 'That is already open')
     when 'has been tied off', 'What were you referring to'
       return
     end
 
     gems = get_gems(container)
     unless gems.empty?
-      return unless walk_to @hometown['gemshop']['id']
+      return unless DRCT.walk_to(@hometown['gemshop']['id'])
       clerk = which_clerk(@hometown['gemshop']['name'])
 
       gems.each do |gem|
-        fput "get my #{gem} from my #{container}"
-        fput "sell my #{gem} to #{clerk}"
+        fput("get my #{gem} from my #{container}")
+        fput("sell my #{gem} to #{clerk}")
       end
     end
 
-    fput "close my #{container}" unless @settings.sell_loot_skip_pouch_close
+    fput("close my #{container}") unless @settings.sell_loot_skip_pouch_close
   end
+
+  # Sells traps harvested from disarmed boxes.
+  def sell_traps(container)
+    release_invisibility
+    case DRC.bput("remove my #{container}", "You remove", "What were you referring to", "You aren't wearing that", "Remove what")
+    when "What were you referring to", "You aren't wearing that", "Remove what"
+      return
+    end
+
+    if DRCT.walk_to(@hometown['locksmithing']['id'])
+      clerk = which_clerk(@hometown['locksmithing']['name'])
+      # The locksmith won't accept your component container
+      # as long as other players are in the same room.
+      # Once the room is empty then try to give it to them.
+      wait_counter = 0
+      while !DRRoom.pcs.empty? do
+        break if wait_counter >= 5
+        wait_counter = wait_counter + 1
+        echo "Waiting for other players to leave the room..."
+        pause 5
+      end
+      unless DRC.bput("give my #{container} to #{clerk}",
+        "hands it back to you along with some coins",     # success!
+        "There is nothing in there",                      # empty container
+        "What is it you're trying to give",               # no container or no npc
+        "I don't have that in stock right now"            # players in room, try again later
+      ) == "hands it back to you along with some coins"
+        DRC.message("Unable to sell #{container} at this time. Try again later.")
+      end
+    end
+
+    DRC.bput("wear my #{container}", "You attach", "Wear what", "You are already wearing")
+    fput("sort auto head") if @sort_auto_head
+  end
+
 end
 
 before_dying do

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -174,8 +174,16 @@ class SellLoot
     fput("close my #{container}") unless @settings.sell_loot_skip_pouch_close
   end
 
-  # Sells traps harvested from disarmed boxes.
+  # Thief only.
+  # Sells traps harvested from disarmed boxes to the locksmith.
+  # Not going to try to sell to a pawnshop because too great of risk of
+  # selling something valuable that found its way into this container.
+  # Bulk selling a component pouch is safest option because it works like
+  # bulk selling a bundle of skins or a trader bulk selling a gem pouch.
   def sell_traps(container)
+    return unless DRStats.thief?
+    return unless DRC.bput("look in my #{container}", "There is nothing in there", "you see") == "you see"
+
     DRC.release_invisibility
     case DRC.bput("remove my #{container}", "You remove", "What were you referring to", "You aren't wearing that", "Remove what")
     when "What were you referring to", "You aren't wearing that", "Remove what"
@@ -194,13 +202,20 @@ class SellLoot
         echo "Waiting for other players to leave the room..."
         pause 5
       end
-      unless DRC.bput("give my #{container} to #{clerk}",
+      case DRC.bput("give my #{container} to #{clerk}",
         "hands it back to you along with some coins",     # success!
         "There's nothing in there",                       # empty container
         "What is it you're trying to give",               # no container or no npc
+        "not interested in",                              # non-traps in container
+        "doesn't appear to be interested in your offer"   # not a thief
         "I don't have that in stock right now"            # players in room, try again later
-      ) == "hands it back to you along with some coins"
-        DRC.message("Unable to sell #{container} at this time. Try again later.")
+      )
+      when "not interested in"
+        DRC.message("Remove non-trap components from #{container} then try again.")
+      when "doesn't appear to be interested in your offer"
+        DRC.message("Only thieves can sell trap components in bulk to locksmiths. Try selling them individually at the pawnshop.")
+      when "I don't have that in stock right now"
+        DRC.message("Unable to sell #{container} at this time. Try again later when no one else is in the shop with you.")
       end
     end
 

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -207,7 +207,7 @@ class SellLoot
         "There's nothing in there",                       # empty container
         "What is it you're trying to give",               # no container or no npc
         "not interested in",                              # non-traps in container
-        "doesn't appear to be interested in your offer"   # not a thief
+        "doesn't appear to be interested in your offer",  # not a thief
         "I don't have that in stock right now"            # players in room, try again later
       )
       when "not interested in"

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -196,7 +196,7 @@ class SellLoot
       end
       unless DRC.bput("give my #{container} to #{clerk}",
         "hands it back to you along with some coins",     # success!
-        "There is nothing in there",                      # empty container
+        "There's nothing in there",                       # empty container
         "What is it you're trying to give",               # no container or no npc
         "I don't have that in stock right now"            # players in room, try again later
       ) == "hands it back to you along with some coins"

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -77,7 +77,7 @@ class SellLoot
 
   def exchange_coins
     DRCT.walk_to(@hometown['exchange']['id'])
-    release_invisibility
+    DRC.release_invisibility
     exchange_to = @hometown['currency']
     $CURRENCIES
       .reject { |currency| currency =~ /#{exchange_to}/i }
@@ -86,18 +86,18 @@ class SellLoot
 
   def deposit_coins(keep_copper)
     DRCT.walk_to(@hometown['deposit']['id'])
-    release_invisibility
+    DRC.release_invisibility
     DRC.bput('wealth', 'Wealth:')
     case DRC.bput('deposit all', 'you drop all your', 'drop your coins inside', 'You hand the clerk some coins', "You don't have any", 'There is no teller here', 'reached the maximum balance I can permit', "We don't serve necromancers or sorcerers here.")
     when 'There is no teller here', "We don't serve necromancers or sorcerers here."
       return
     end
-    minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, @settings) }
+    minimize_coins(keep_copper).each { |amount| DRCM.withdraw_exact_amount?(amount, @settings) }
     DRC.bput('check balance', 'your current balance is', 'As expected, there are')
   end
 
   def give_money_to_bankbot(currency, keep)
-    copper_on_hand = check_wealth(currency)
+    copper_on_hand = DRCM.check_wealth(currency)
     deposit_amount = copper_on_hand - keep
     return if deposit_amount <= 0
 
@@ -129,12 +129,12 @@ class SellLoot
   end
 
   def sell_bundle
-    return unless exists?('bundle')
+    return unless DRCI.exists?('bundle')
 
     return unless DRCT.walk_to(@hometown['tannery']['id'])
 
     return if DRC.bput('remove my bundle', 'You remove', 'You sling', 'Remove what','You take') == 'Remove what'
-    release_invisibility
+    DRC.release_invisibility
     DRC.bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle')
     DRC.bput('stow rope', 'You put')
   end
@@ -144,7 +144,7 @@ class SellLoot
     return if inside?("#{adj} pouch", container)
     DRCT.walk_to(@hometown['gemshop']['id'])
     clerk = which_clerk(@hometown['gemshop']['name'])
-    release_invisibility
+    DRC.release_invisibility
     fput("ask #{clerk} for #{adj} pouch")
     fput("put my pouch in my #{container}")
   end
@@ -154,7 +154,7 @@ class SellLoot
   end
 
   def sell_gems(container)
-    release_invisibility
+    DRC.release_invisibility
     case DRC.bput("open my #{container}", 'You open your', 'You open a', 'has been tied off', 'What were you referring to', 'That is already open')
     when 'has been tied off', 'What were you referring to'
       return
@@ -176,7 +176,7 @@ class SellLoot
 
   # Sells traps harvested from disarmed boxes.
   def sell_traps(container)
-    release_invisibility
+    DRC.release_invisibility
     case DRC.bput("remove my #{container}", "You remove", "What were you referring to", "You aren't wearing that", "Remove what")
     when "What were you referring to", "You aren't wearing that", "Remove what"
       return


### PR DESCRIPTION
### Changes
* Add new method `sell_traps` that tries to sell any harvested traps from disarming boxes
* Add new config property `sell_loot_traps` to `base.yaml` (default is `false`)
* Add names of locksmith NPCs to `base-town.yaml`
* Brought formatting of the code to be up to date with current conventions we've been making to scripts (e.g. include `DRC` prefixes and use parentheses around method calls)

### Where I've tested
- [x] Crossing locksmith
- [x] Riverhaven locksmith
- [x] Shard locksmith