### PR TITLE
[script] [feed-cloak] DR fixed their typo, so we can too

### DIFF
--- a/feed-cloak.lic
+++ b/feed-cloak.lic
@@ -31,7 +31,7 @@ class FeedCloak
 
   def fed_cloak?
     no_food_in_room = [
-      /unable penetrate and procure nourishment/,
+      /unable to penetrate and procure nourishment/,
       /You shouldn't disturb the silence here/,
       /You really shouldn't be loitering in here/,
       /but find nothing of interest/


### PR DESCRIPTION
### Background
* When the vine cloaks were first released, there was a typo in their messaging.
* The GMs "[fixed the glitch](https://www.youtube.com/watch?v=BUE0PPQI3is)"

### Changes
* Update verbiage to match when a cloak can't feed in a room