### PR TITLE
Hollow eve games update

### DIFF
--- a/crowns.lic
+++ b/crowns.lic
@@ -22,7 +22,7 @@ class Dice
     @dice_bet_amount = settings.dice_bet_amount || args.bet
     @dice_money_on_hand = settings.dice_money_on_hand
     @withdraw = settings.dice_withdraw
-    @dice_loot_container = settings.dice_loot_container
+    @dhollow_eve_loot_container = settings.hollow_eve_loot_container
 
     @dice = ["anchor", "crown", "heart", "lightning", "ship", "trident"]
 
@@ -128,7 +128,7 @@ class Dice
           if /\brope\b/ =~ in_hand
             fput("coil my #{in_hand}")
           end
-          case DRC.bput("stow #{in_hand} in my #{@dice_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+          case DRC.bput("stow #{in_hand} in my #{@hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
           when 'to fit in the'
             DRC.message("*** Item is too big to fit in your stow container! ***")
             exit

--- a/crowns.lic
+++ b/crowns.lic
@@ -19,7 +19,6 @@ class Dice
 
     settings = get_settings
     @trash_items = settings.hollow_eve_junk.map { |x| /#{x}/i }
-    #@trash_items = settings.hollow_eve_junk
     @dice_bet_amount = settings.dice_bet_amount || args.bet
     @dice_money_on_hand = settings.dice_money_on_hand
     @withdraw = settings.dice_withdraw

--- a/crowns.lic
+++ b/crowns.lic
@@ -18,11 +18,12 @@ class Dice
     ]
 
     settings = get_settings
-    #@junk_list = settings.darkbox_junk.map { |x| /#{x}/i }
-    @trash_items = settings.darkbox_junk
+    @trash_items = settings.hollow_eve_junk.map { |x| /#{x}/i }
+    #@trash_items = settings.hollow_eve_junk
     @dice_bet_amount = settings.dice_bet_amount || args.bet
     @dice_money_on_hand = settings.dice_money_on_hand
     @withdraw = settings.dice_withdraw
+    @dice_loot_container = settings.dice_loot_container
 
     @dice = ["anchor", "crown", "heart", "lightning", "ship", "trident"]
 
@@ -35,7 +36,6 @@ class Dice
 
   def dice_game
     loop do
-      check_money
       walk_to_table
       play_dice
       check_prize
@@ -117,28 +117,28 @@ class Dice
   end
 
   def check_prize
-    if @trash_items.any? { |item| Regexp.new(item) =~ right_hand }
-      bput("put my #{righthand} in bucket", 'You put', 'You drop')
-    else
-      case bput("stow #{righthand}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-      when 'to fit in the'
-        message("*** Item is too big to fit in your stow container! ***")
-        exit
+    [left_hand, right_hand]
+    .compact
+    .each do |in_hand|
+      if in_hand
+        case in_hand
+        when *@trash_items
+          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
+        else
+          # Coil rope so we can store it
+          if /\brope\b/ =~ in_hand
+            fput("coil my #{in_hand}")
+          end
+          case DRC.bput("stow #{in_hand} in my #{@dice_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+          when 'to fit in the'
+            DRC.message("*** Item is too big to fit in your stow container! ***")
+            exit
+          end
+        end
       end
-      pause
-    end
-    # Check left hand as well. On lag may have items in both hands.
-    if @trash_items.any? { |item| Regexp.new(item) =~ left_hand }
-      bput("put my #{lefthand} in bucket", 'You put', 'You drop')
-    else
-      case bput("stow #{lefthand}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-      when 'to fit in the'
-        message("*** Item is too big to fit in your stow container! ***")
-        exit
-      end
-      pause
     end
   end
+
 end
 
 before_dying do

--- a/crowns.lic
+++ b/crowns.lic
@@ -12,9 +12,9 @@ class Dice
 
   def initialize
     arg_definitions = [
-      [
-        { name: 'bet', regex: /\d+/, optional: true, description: 'Optional override for betting amount.' }
-      ]
+    [
+      { name: 'bet', regex: /\d+/, optional: true, description: 'Optional override for betting amount.' }
+    ]
     ]
 
     settings = get_settings
@@ -118,25 +118,17 @@ class Dice
 
   def check_prize
     [left_hand, right_hand]
-<<<<<<< HEAD
     .compact
     .each do |in_hand|
       if in_hand
         case in_hand
         when *@trash_items
           DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
-=======
-      .compact
-      .each do |in_hand|
-        if @trash_items.any? { |item| Regexp.new(item) =~ in_hand }
-          bput("put my #{in_hand} in bucket", 'You put', 'You drop')
->>>>>>> master
         else
           # Coil rope so we can store it
           if /\brope\b/ =~ in_hand
             fput("coil my #{in_hand}")
           end
-<<<<<<< HEAD
           case DRC.bput("stow #{in_hand} in my #{@dice_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
           when 'to fit in the'
             DRC.message("*** Item is too big to fit in your stow container! ***")
@@ -145,17 +137,6 @@ class Dice
         end
       end
     end
-=======
-          case bput("stow #{in_hand}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-          when 'to fit in the'
-            message("*** Item is too big to fit in your stow container! ***")
-            exit
-          end
-          pause
-        end
-      end
-    pause
->>>>>>> master
   end
 
 end

--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -13,12 +13,12 @@ arg_definitions = [
 ]
 
 args = parse_args(arg_definitions)
-@override = args.override
-
-trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
-darkbox_stop_on_wounded = get_settings.darkbox_stop_on_wounded
-he_use_herbs_remedies = get_settings.he_use_herbs_remedies
-hollow_eve_loot_container = get_settings.hollow_eve_loot_container
+override = args.override
+settings = get_settings
+trash_items = settings.hollow_eve_junk.map { |x| /#{x}/i }
+darkbox_stop_on_wounded = settings.darkbox_stop_on_wounded
+he_use_herbs_remedies = settings.he_use_herbs_remedies
+hollow_eve_loot_container = settings.hollow_eve_loot_container
 
 if Script.running?('roomnumbers')
   stop_script('roomnumbers')
@@ -78,7 +78,7 @@ loop do
   end
 
   if reget(10, 'your wounds make it impossible') && he_use_herbs_remedies
-    if @override
+    if override
       DRC.wait_for_script_to_complete('heal-remedy', ['quick', 'override'])
     else
       DRC.wait_for_script_to_complete('heal-remedy', ['quick'])

--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -15,9 +15,10 @@ arg_definitions = [
 args = parse_args(arg_definitions)
 @override = args.override
 
-junk_list = get_settings.darkbox_junk.map { |x| /#{x}/i }
+junk_list = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
 darkbox_stop_on_wounded = get_settings.darkbox_stop_on_wounded
 he_use_herbs_remedies = get_settings.he_use_herbs_remedies
+darkbox_loot_container = get_settings.darkbox_loot_container
 
 if Script.running?('roomnumbers')
   stop_script('roomnumbers')
@@ -89,23 +90,26 @@ loop do
     pause 65 # Gives time for herbs to work so you do not receive the feel nasua message
   end
 
-  thing = DRC.right_hand || DRC.left_hand
-  waitrt?
-  if thing
-    fput("get #{thing}") if Flags['darkbox-drop']
-    case thing
-    when /pouch/
-      fput('open my pouch')
-      fput('get my tickets from my pouch')
-      fput('put pouch in bucket')
-      fput('drop pouch')
-      fput('ticket')
-    when *junk_list
-      fput("put #{thing} in bucket")
-    else
-      fput("stow #{thing}")
+  [DRC.left_hand, DRC.right_hand]
+    .compact
+    .each do |in_hand|
+      if in_hand
+        case in_hand
+        when *junk_list
+          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
+        else
+          # Coil rope so we can store it
+          if /\brope\b/ =~ in_hand
+            fput("coil my #{in_hand}")
+          end
+          case DRC.bput("stow #{in_hand} in my #{darkbox_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+          when 'to fit in the'
+            DRC.message("*** Item is too big to fit in your stow container! ***")
+            exit
+          end
+        end
+      end
     end
-  end
   waitrt?
 end
 

--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -15,7 +15,7 @@ arg_definitions = [
 args = parse_args(arg_definitions)
 @override = args.override
 
-junk_list = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
+trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
 darkbox_stop_on_wounded = get_settings.darkbox_stop_on_wounded
 he_use_herbs_remedies = get_settings.he_use_herbs_remedies
 darkbox_loot_container = get_settings.darkbox_loot_container
@@ -95,7 +95,7 @@ loop do
     .each do |in_hand|
       if in_hand
         case in_hand
-        when *junk_list
+        when *trash_items
           DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
         else
           # Coil rope so we can store it

--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -18,7 +18,7 @@ args = parse_args(arg_definitions)
 trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
 darkbox_stop_on_wounded = get_settings.darkbox_stop_on_wounded
 he_use_herbs_remedies = get_settings.he_use_herbs_remedies
-darkbox_loot_container = get_settings.darkbox_loot_container
+hollow_eve_loot_container = get_settings.hollow_eve_loot_container
 
 if Script.running?('roomnumbers')
   stop_script('roomnumbers')
@@ -102,7 +102,7 @@ loop do
           if /\brope\b/ =~ in_hand
             fput("coil my #{in_hand}")
           end
-          case DRC.bput("stow #{in_hand} in my #{darkbox_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+          case DRC.bput("stow #{in_hand} in my #{hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
           when 'to fit in the'
             DRC.message("*** Item is too big to fit in your stow container! ***")
             exit

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -20,7 +20,7 @@ class Lamprey
   end
 
   def walk_to_lamprey
-    message("*** Heading to Lamprey! ***")
+    message("*** Heading to get a Lamprey! ***")
     walk_to(16_173)
   end
 

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -33,7 +33,7 @@ class Lamprey
   end
 
   def check_prize
-    lamprey_loot_container = get_settings.lamprey_loot_container
+    hollow_eve_loot_container = get_settings.hollow_eve_loot_container
     trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
     [left_hand, right_hand]
     .compact
@@ -48,7 +48,7 @@ class Lamprey
         when *trash_items
           bput("put #{in_hand} in bucket", 'You drop')
         else
-          case bput("stow #{in_hand} in my #{lamprey_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+          case bput("stow #{in_hand} in my #{hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
           when 'to fit in the'
             message("*** Item is too big to fit in your stow container! ***")
             exit

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#lamprey
 =end
 
-custom_require.call(%w[events common-travel common common-items])
+custom_require.call(%w[common-travel common common-items])
 
 class Lamprey
   include DRC
@@ -11,9 +11,11 @@ class Lamprey
 
   def initialize
     walk_to_lamprey
+    stow_hands
     loop do
       play_lamprey
       check_prize
+      walk_to_lamprey
     end
   end
 
@@ -31,26 +33,28 @@ class Lamprey
   end
 
   def check_prize
-    junk_list = get_settings.darkbox_junk.map { |x| /#{x}/i }
-    prize = DRC.right_hand
-    waitrt?
-    if prize
-      walk_to(16_169)
-      case prize
-      when /lamprey/
-        bput("put lamprey in bucket", 'You drop')
-        message("*** Retrieved a Lamprey! You will need to wait 10 minutes to play again! ***")
-        exit # Can only play once every 10 minutes if you get a lamprey.
-      when *junk_list
-        bput("put #{prize} in bucket", 'You drop')
-      else
-        case bput("stow #{prize}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-        when 'to fit in the'
-          message("*** Item is too big to fit in your stow container! ***")
-          exit
+    lamprey_loot_container = get_settings.lamprey_loot_container
+    junk_list = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
+    [left_hand, right_hand]
+    .compact
+    .each do |in_hand|
+      if in_hand
+        walk_to(16_169)
+        case in_hand
+        when /lamprey/
+          bput("put lamprey in bucket", 'You drop')
+          message("*** Retrieved a Lamprey or Prize! You will need to wait 10 minutes to play again! ***")
+          exit # Can only play once every 10 minutes if you get a lamprey.
+        when *junk_list
+          bput("put #{in_hand} in bucket", 'You drop')
+        else
+          case bput("stow #{in_hand} in my #{lamprey_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+          when 'to fit in the'
+            message("*** Item is too big to fit in your stow container! ***")
+            exit
+          end
         end
       end
-     pause
     end
   end
 end

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -34,7 +34,7 @@ class Lamprey
 
   def check_prize
     lamprey_loot_container = get_settings.lamprey_loot_container
-    junk_list = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
+    trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
     [left_hand, right_hand]
     .compact
     .each do |in_hand|
@@ -45,7 +45,7 @@ class Lamprey
           bput("put lamprey in bucket", 'You drop')
           message("*** Retrieved a Lamprey or Prize! You will need to wait 10 minutes to play again! ***")
           exit # Can only play once every 10 minutes if you get a lamprey.
-        when *junk_list
+        when *trash_items
           bput("put #{in_hand} in bucket", 'You drop')
         else
           case bput("stow #{in_hand} in my #{lamprey_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -990,8 +990,8 @@ lockpick_buff_bot:
 slack_username:
 
 # HE script
-darkbox_junk:
-pumpkin_junk:
+darkbox_junk: # depreciated - consolidated into hollow_eve_junk
+pumpkin_junk: # depreciated - consololidated into hollow_eve_junk
 hollow_eve_junk:
 - socks
 - seeds

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -990,50 +990,7 @@ lockpick_buff_bot:
 slack_username:
 
 # HE script
-darkbox_junk:
-- sharkskin
-- root
-- rockweed
-- kelp
-- flowers
-- apple
-- strawberry
-- root
-- snake
-- cobra
-- coin
-- belt
-- powder
-- sundress
-- earcuff
-- armband
-- anklet
-- sash
-- ascot
-- shirt
-- cap
-- cape
-- ocarina
-- tooth
-- cloak
-- pants
-- headscarf
-- belt
-- boots
-- tobacco
-- trousers
-- moccasins
-- viper
-- armband
-- ring
-- peach
-- sandwich
-- plum
-
-darkbox_stop_on_wounded: false
-
-# HE script
-pumpkin_junk:
+hollow_eve_junk:
 - socks
 - seeds
 - muffin
@@ -1086,72 +1043,152 @@ pumpkin_junk:
 - green bracelet
 - cambrinth peach
 - cambrinth turnip
-- pouch
+- cambrinth ring
 - fangs
 - band
 - eyeballs
-
-# HE script
-boggle_junk:
+- meat
 - robe
-- blouse
-- pajamas
-- cambrinth armband
-- pants
-- anklet
-- towel
-- keyblank
-- blossom
-- amulet
-- greatcloak
-- cloak
-- coat
-- shirt
-- pumpkins
-- mirror
-- globe
-- earrings
-- wings
-- compass
-- cambrinth pumpkin
-- spectacles
-- jar
-- clay
-- fabric
-- strands
-- flamewood case
-- leather boots
-- tomiek-rimmed goggles
-- scarecrow doll
-- boggle doll
-- heart
-- garnet
+- skinning knife
+- card
+- cookie tin
+- tin
+- yo-yo
+- otter
 - comb
-- wooden earcuff
-- orange hat
-- wooden armband
-- gem pouch
-- sling
-- seeds
-- purse
-- simple necklace
-- electrum charm
-- glass pestle
-- cookie
-- candy
-- pumpkin pie
-- mortar
-- ring
-- statuette
-- lollipop
+- razor
+- octopus
+- dice
+- kaleidoscope
+- Alamhif
+- Albreda
+- Aliesa
+- Aluna
+- Aniek
+- Asketi
+- Be'ort
+- Berengaria
+- Botolf
+- Chadatru
+- Coshivi
+- Damaris
+- Demrris
+- Dergati
+- Divyaush
+- Drogor
+- Eimeuz
+- Eluned
+- Enelne
+- Everild
+- Eylhaar
+- Faenella
+- Firulf
+- Glythtide
+- Harawep
+- Hav'roth
+- Hodierna
+- Huldah
+- Idon
+- Kerenhappuch
+- Kertigen
+- Kuniyo
+- Lemicus
+- Meraud
+- Merion
+- Misiumos
+- Mrod
+- Murrula
+- Orisas
+- Peri'el
+- Phelim
+- Rutilor
+- Saemaus
+- Sieben
+- Sraxaec
+- Tamsine
+- Tenemlor
+- Tieheq
+- Truffenyi
+- Urrem'tier
+- Ushnish
+- Xosiurion
+- Zachriedek
+- sharkskin
+- root
+- rockweed
+- kelp
+- flowers
+- apple
+- strawberry
+- root
+- snake
+- cobra
+- coin
+- belt
+- powder
+- sundress
+- earcuff
+- armband
+- anklet
+- sash
+- ascot
+- shirt
+- cap
+- cape
+- ocarina
+- tooth
+- cloak
+- pants
+- headscarf
+- belt
+- boots
+- tobacco
 - trousers
-- rocks
-- carving knife
-- beer
-- pendant
-- torque
-- rose
-- wallet
+- moccasins
+- viper
+- armband
+- cambrinth ring
+- peach
+- sandwich
+- plum
+- wheel
+- ocarina
+- coyote
+- soap
+- hat
+- patch
+- eel skin
+- kaleidoscope
+- silk cloth
+- pewter bar
+- robe
+- boots
+- dagger
+- bobblehead
+- yo-yo
+- turtle
+- bracelet
+- razor
+- tunic
+- dice
+- kelp
+- tunic
+- towel
+- comb
+- meat
+- fan
+- whistle
+- cowbell
+- puppet
+- jar
+- toy sword
+- eraser
+- haversack
+- fedora
+- abacus
+- skirt
+- quill
+- pinwheel
 
 maze_junk:
 - earrings
@@ -1178,6 +1215,8 @@ maze_junk:
 - sweet corn
 - sweater
 
+darkbox_stop_on_wounded: false
+darkbox_loot_container: backpack
 # Define a list of containers like you would for storage_containers.  All the bags you could shove stuff into for the cornmaze
 cornmaze_containers:
 boggle_withdraw: true
@@ -1188,6 +1227,9 @@ boggle_cash_on_hand: 50 platinum
 dice_money_on_hand: 10 platinum
 dice_bet_amount: 10
 dice_withdraw: true
+dice_loot_container: backpack
+smash_shells_loot_container: backpack
+lamprey_loot_container: backpack
 
 # HE script
 grave_junk:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -990,6 +990,8 @@ lockpick_buff_bot:
 slack_username:
 
 # HE script
+darkbox_junk:
+pumpkin_junk:
 hollow_eve_junk:
 - socks
 - seeds

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1220,7 +1220,6 @@ maze_junk:
 - sweater
 
 darkbox_stop_on_wounded: false
-darkbox_loot_container: backpack
 # Define a list of containers like you would for storage_containers.  All the bags you could shove stuff into for the cornmaze
 cornmaze_containers:
 boggle_withdraw: true
@@ -1231,9 +1230,7 @@ boggle_cash_on_hand: 50 platinum
 dice_money_on_hand: 10 platinum
 dice_bet_amount: 10
 dice_withdraw: true
-dice_loot_container: backpack
-smash_shells_loot_container: backpack
-lamprey_loot_container: backpack
+hollow_eve_loot_container: backpack
 
 # HE script
 grave_junk:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1189,6 +1189,10 @@ hollow_eve_junk:
 - skirt
 - quill
 - pinwheel
+- globe
+- medal
+- rope
+- traveler's pack
 
 maze_junk:
 - earrings

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -9,7 +9,7 @@ Flags.add('shell-fragments', 'shell explodes')
 trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
 smash_shells_loot_container = get_settings.smash_shells_loot_container
 
-DRC.message("** Heading to grab a shell ***")
+DRC.message("*** Heading to grab a shell ***")
 DRCT.walk_to(16_236)
 loop do
   break if checkbleeding

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -9,6 +9,7 @@ Flags.add('shell-fragments', 'shell explodes')
 trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
 smash_shells_loot_container = get_settings.smash_shells_loot_container
 
+DRC.message("** Heading to grab a shell ***")
 DRCT.walk_to(16_236)
 loop do
   break if checkbleeding

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -6,7 +6,8 @@ custom_require.call(%w[events common-items common-travel common])
 
 Flags.add('shell-fragments', 'shell explodes')
 
-trash_items = get_settings.pumpkin_junk
+trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
+smash_shells_loot_container.get_settings.smash_shells_loot_container
 
 DRCT.walk_to(16_236)
 loop do
@@ -41,16 +42,28 @@ loop do
   end
   pause
 
-  if trash_items.any? { |item| Regexp.new(item) =~ DRC.right_hand }
-    DRC.bput("put my #{righthand} in bucket", 'You put', 'You drop')
-  else
-    case DRC.bput("stow #{righthand}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-    when 'to fit in the'
-      DRC.message("*** Item is too big to fit in your stow container! ***")
-      exit
+  [left_hand, right_hand]
+    .compact
+    .each do |in_hand|
+      if in_hand
+        case in_hand
+        when *trash_items
+          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
+        else
+          # Coil rope so we can store it
+          if /\brope\b/ =~ in_hand
+            fput("coil my #{in_hand}")
+          end
+          case DRC.bput("stow #{in_hand}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+          when 'to fit in the'
+            DRC.message("*** Item is too big to fit in your stow container! ***")
+            exit
+          end
+        end
+      end
     end
-    pause
   end
+  waitrt?
   DRCT.walk_to(16_236)
   next unless Flags['shell-fragments']
   pause 4

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -7,7 +7,7 @@ custom_require.call(%w[events common-items common-travel common])
 Flags.add('shell-fragments', 'shell explodes')
 
 trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
-smash_shells_loot_container.get_settings.smash_shells_loot_container
+smash_shells_loot_container = get_settings.smash_shells_loot_container
 
 DRCT.walk_to(16_236)
 loop do
@@ -42,27 +42,27 @@ loop do
   end
   pause
 
-  [left_hand, right_hand]
-    .compact
-    .each do |in_hand|
-      if in_hand
-        case in_hand
-        when *trash_items
-          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
-        else
-          # Coil rope so we can store it
-          if /\brope\b/ =~ in_hand
-            fput("coil my #{in_hand}")
-          end
-          case DRC.bput("stow #{in_hand}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-          when 'to fit in the'
-            DRC.message("*** Item is too big to fit in your stow container! ***")
-            exit
-          end
+  [DRC.left_hand, DRC.right_hand]
+  .compact
+  .each do |in_hand|
+    if in_hand
+      case in_hand
+      when *trash_items
+        DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
+      else
+        # Coil rope so we can store it
+        if /\brope\b/ =~ in_hand
+          fput("coil my #{in_hand}")
+        end
+        case DRC.bput("stow #{in_hand} in #{smash_shells_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+        when 'to fit in the'
+          DRC.message("*** Item is too big to fit in your stow container! ***")
+          exit
         end
       end
     end
   end
+
   waitrt?
   DRCT.walk_to(16_236)
   next unless Flags['shell-fragments']

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -7,7 +7,7 @@ custom_require.call(%w[events common-items common-travel common])
 Flags.add('shell-fragments', 'shell explodes')
 
 trash_items = get_settings.hollow_eve_junk.map { |x| /#{x}/i }
-smash_shells_loot_container = get_settings.smash_shells_loot_container
+hollow_eve_loot_container = get_settings.hollow_eve_loot_container
 
 DRC.message("*** Heading to grab a shell ***")
 DRCT.walk_to(16_236)
@@ -55,7 +55,7 @@ loop do
         if /\brope\b/ =~ in_hand
           fput("coil my #{in_hand}")
         end
-        case DRC.bput("stow #{in_hand} in #{smash_shells_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
+        case DRC.bput("stow #{in_hand} in #{hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
         when 'to fit in the'
           DRC.message("*** Item is too big to fit in your stow container! ***")
           exit


### PR DESCRIPTION
Made all the game scripts this year use the same logic for handling junk that @KatoakDR put in for crowns.lic. Added loot storage containers with defaults in `base.yaml.` Made one list for junk/trash items as the games use the same pool now. The name is `hollow_eve_junk.` Made all these scripts use `trash_items:` for consistency. 

For the loot containers, should I just make one, `hollow_eve_loot_container:,` or keep the individual ones I have created? 