### PR TITLE
[script] [corn-maze] Support fast 10-task 'short' maze

### DIFF
--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -176,7 +176,8 @@ class CornMaze
       [
         { name: 'noloot', regex: /noloot/i, optional: true, description: 'Do tasks and run through the maze only picking up passes.' },
         { name: 'restart', regex: /restart/i, optional: true, description: 'Do tasks, but no searching for loot at all, not even passes.' },
-        { name: 'slow', regex: /slow/i, optional: true, description: 'Move through the maze one room at a time, useful for a slow connection.' }
+        { name: 'slow', regex: /slow/i, optional: true, description: 'Move through the maze one room at a time, useful for a slow connection.' },
+        { name: 'short', regex: /short/i, optional: true, description: 'Do the short 10-task maze run with the harried Halfling.' }
       ],
       [
         { name: 'manual', regex: /manual/i, optional: false, description: 'Walk around the maze on your own, however it will search and loot any incidental points you see.' }
@@ -193,6 +194,89 @@ class CornMaze
       pause 2
     end
 
+    if args.short
+      run_short_maze
+    else
+      run_long_maze
+    end
+  end
+
+  # --- SHORT MAZE --- #
+
+  def run_short_maze
+    Flags.add('maze_done',   "Thanks for all the hard work.  Here's a little something to show my appreciation.")
+    Flags.add('task_build',  "find a good spot and BUILD")
+    Flags.add('task_search', "I'd like you to SEARCH")
+    Flags.add('task_touch',  "I'd like you to find and TOUCH")
+    Flags.add('task_forage', "I'd like you to FORAGE")
+    Flags.add('task_scream', "let out a good SCREAM")
+    Flags.add('task_pull',   "I'd like you to go PULL")
+    Flags.add('task_wave',   "You just have to WAVE your hands")
+    Flags.add('task_disarm', "I'd like you to DISARM")
+    Flags.add('task_poke',   "I'd like you to go find and POKE EMPLOYEEs")
+
+    join_harried_halfling
+
+    until Flags['maze_done'] do
+        do_short_task('build')  if Flags['task_build']
+        do_short_task('search') if Flags['task_search']
+        do_short_task('touch')  if Flags['task_touch']
+        do_short_task('forage') if Flags['task_forage']
+        do_short_task('scream') if Flags['task_scream']
+        do_short_task('pull')   if Flags['task_pull']
+        do_short_task('wave')   if Flags['task_wave']
+        do_short_task('disarm') if Flags['task_disarm']
+        do_short_task('poke')   if Flags['task_poke']
+        pause 1
+    end
+
+  end
+
+  def join_harried_halfling
+    halfling_room = 13245 # harried Halfling
+    DRCT.walk_to(halfling_room)
+    join_confirm = [
+        "Are you SURE you want to do the FAST version",
+    ]
+    join_success = [
+        "A harried Halfling escorts you"
+    ]
+    join_failure = [
+        "What were you referring to?",
+    ]
+    join_need_pass = [
+        "Sorry, I'm quite busy"
+    ]
+    case DRC.bput("join harried halfling", *join_confirm, *join_success, *join_failure, *join_need_pass)
+    when *join_failure
+      DRC.message("Unable to join a harried Halfling. Is one here?")
+      exit
+    when *join_need_pass
+      DRC.message("You need to REDEEM a corn maze pass first, then retry this script.")
+      exit
+    when *join_confirm
+        join_harried_halfling
+    end
+  end
+
+  def do_short_task(task)
+    Flags.reset("task_#{task}")
+    case task
+    when 'poke'
+        task = 'poke employee'
+    when 'disarm'
+        waitrt?
+        fput("search")
+        task = 'disarm trap'
+    end
+    waitrt?
+    fput("#{task}")
+    waitrt?
+  end
+
+  # --- LONG MAZE --- #
+
+  def run_long_maze
     DRC.message("WARNING! THE CORN MAZE IS DIFFICULT TO NAVIGATE, AND IT'S ALWAYS POSSIBLE FOR LAG TO BREAK THE SCRIPT. BE MINDFUL OF YOUR PASSES, AND WATCH IT IN CASE YOU NEED TO TAKE CONTROL.")
 
     Flags.add('maze_done', 'leads you through the twisting passages and brings you to the exit')
@@ -589,6 +673,7 @@ class CornMaze
   end
 
   def reset_flags
+    # Long maze flags
     Flags.reset('scarecrow')
     Flags.reset('mice')
     Flags.reset('weeds')
@@ -600,6 +685,16 @@ class CornMaze
     Flags.reset('corn')
     Flags.reset('halflings')
     Flags.reset('loot')
+    # Short maze flags
+    Flags.reset('task_build')
+    Flags.reset('task_search')
+    Flags.reset('task_touch')
+    Flags.reset('task_forage')
+    Flags.reset('task_scream')
+    Flags.reset('task_pull')
+    Flags.reset('task_wave')
+    Flags.reset('task_disarm')
+    Flags.reset('task_poke')
   end
 
   def custom_move(dir, fast=false)
@@ -636,6 +731,7 @@ class CornMaze
 end
 
 before_dying do
+  # Long maze flags
   Flags.delete('scarecrow')
   Flags.delete('mice')
   Flags.delete('weeds')
@@ -652,6 +748,16 @@ before_dying do
   Flags.delete('already_built')
   Flags.delete('scarecrow_done')
   Flags.delete('task_done')
+  # Short maze flags
+  Flags.delete('task_build')
+  Flags.delete('task_search')
+  Flags.delete('task_touch')
+  Flags.delete('task_forage')
+  Flags.delete('task_scream')
+  Flags.delete('task_pull')
+  Flags.delete('task_wave')
+  Flags.delete('task_disarm')
+  Flags.delete('task_poke')
 end
 
 CornMaze.new


### PR DESCRIPTION
### Changes
* Add new argument `short` to run the fast 10-task run
* Moves to and joins the harried Halfling

### Usage
* Redeem a corn maze pass
* `;corn-maze short`

