### PR TITLE
[script] [corn-maze] fix args use, mistake in my prior change

### DIFF
--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -196,6 +196,7 @@ class CornMaze
     @searching = false if args.restart
     @looting = false if args.noloot
     @slow_movement = args.slow || !['profanity', 'stormfront'].include?($frontend)
+    DRCI.stow_hands
     manual_loot if args.manual
 
     if args.short
@@ -285,7 +286,6 @@ class CornMaze
 
     Flags.add('maze_done', 'leads you through the twisting passages and brings you to the exit')
     Flags.add('task_done', '10 of 10', '10 of the 10', '5 of the 5', '5 of 5', 'return to one of the Halflings and ASK HALFLING ABOUT TASK again')
-    DRCI.stow_hands
     find_start
     get_task
   end

--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -193,6 +193,10 @@ class CornMaze
       DRC.message('- duffel bag')
       pause 2
     end
+    @searching = false if args.restart
+    @looting = false if args.noloot
+    @slow_movement = args.slow || !['profanity', 'stormfront'].include?($frontend)
+    manual_loot if args.manual
 
     if args.short
       run_short_maze
@@ -281,11 +285,7 @@ class CornMaze
 
     Flags.add('maze_done', 'leads you through the twisting passages and brings you to the exit')
     Flags.add('task_done', '10 of 10', '10 of the 10', '5 of the 5', '5 of 5', 'return to one of the Halflings and ASK HALFLING ABOUT TASK again')
-    @searching = false if args.restart
-    @looting = false if args.noloot
-    @slow_movement = args.slow || !['profanity', 'stormfront'].include?($frontend)
     DRCI.stow_hands
-    manual_loot if args.manual
     find_start
     get_task
   end


### PR DESCRIPTION
Apologies, I introduced break in the long maze with my prior change.

### Changes
* In creating the `run_long_maze` method, I mistakenly left code that needs access to the `args` from `initialize` method. This moves the init code where it should be.