### PR TITLE
[script] [transfer-items] more "can't touch" or "can't put" messages

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -26,11 +26,11 @@ class ItemTransfer
       .select { |item| noun ? /\b#{noun}\b/ =~ item : true }
       .each do |item|
         # Attempt to get the item from the source container.
-        case DRC.bput("get #{item} from my #{source}", "You get", "What were you referring to", "You need a free hand")
+        case DRC.bput("get #{item} from my #{source}", "You get", "What were you referring to", "You need a free hand", "magical force keeps you from")
         when "You get"
           # Attempt to put the item in the destination container.
-          case DRC.bput("put #{item} in my #{destination}", "You put", "There isn't any more room", "is too long to fit", "is too small to hold that", "too heavy to go in there")
-          when "There isn't any more room", "is too long to fit", "is too small to hold that", "too heavy to go in there"
+          case DRC.bput("put #{item} in my #{destination}", "You put", "There isn't any more room", "is too long, even after stuffing it", "is too long to fit", "is too small to hold that", "too heavy to go in there", "You just can't get")
+          when "There isn't any more room", "is too long, even after stuffing it", "is too long to fit", "is too small to hold that", "too heavy to go in there", "You just can't get"
             DRC.message("The #{item} doesn't fit in your #{destination}. The container may be full or too small to hold the item.")
             # Return item to source container.
             # Loop will try to transfer the next item in the list.


### PR DESCRIPTION
### Changes
* Handle "magical force keeps you from" getting an item, such as a bonded item not for your character.
* Handle "is too long, even after stuffing it" messaging as a failure to put item in destination container.