### PR TITLE
[script] [sanowret-crystal] For non-worn crystals, wait until hands can hold crystal

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -2,9 +2,12 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#sanowret-crystal
 =end
 
-custom_require.call(%w[common drinfomon])
+custom_require.call(%w[common common-items drinfomon])
 
 class SanowretCrystal
+  include DRC
+  include DRCI
+
   def initialize
     arg_definitions = [
       [
@@ -47,7 +50,9 @@ class SanowretCrystal
     else
       case DRC.bput("tap my #{@adjective} crystal", /^You tap (?:a|an) .*sanowret crystal inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal that you are holding.$/, 'I could not find what you were referring to.', 'Not here, ', 'a wave of Corruption magic')
       when /You tap (?:a|an) .*sanowret crystal inside your/
-        DRC.bput("get my #{@adjective} crystal", 'You get', 'What were you referring to')
+        # We need to retrieve the crystal but if it's not in your hands and your hands are full then wait
+        pause 1 until DRCI.in_hands?("#{@adjective} crystal") || DRC.left_hand.nil? || DRC.right_hand.nil?
+        DRC.bput("get my #{@adjective} crystal", 'You get', 'What were you referring to', "You need a free hand")
         use_crystal
         DRC.bput("stow my #{@adjective} crystal", 'You put', 'Stow what')
       when /^You tap (?:a|an) .*sanowret crystal.* that you are wearing\.$/


### PR DESCRIPTION
### Changes
* If your sanowret crystal is stored and needs to be taken out of a container, and if your hands are full, then the script will now wait until at least one hand is empty to avoid "No match was found after 15 seconds" error

### Problem
```
[sanowret-crystal]>tap my sanowret crystal

You tap a blood-red sanowret crystal inside your hitman's backpack.
> 
[sanowret-crystal]>get my sanowret crystal

You need a free hand to pick that up.
> 
[sanowret-crystal: *** No match was found after 15 seconds, dumping info]
```