### PR TITLE
[script] [feed-cloak] Handle really hungry cloaks slow at eating

### DIFF
--- a/feed-cloak.lic
+++ b/feed-cloak.lic
@@ -42,9 +42,9 @@ class FeedCloak
     cant_feed = /You can't feed/
     # Seconds to wait for a message before raise error.
     # If a cloak successfully feeds, it may take a variable
-    # amount of time between 10 and 60 seconds or so.
+    # amount of time depending on how hungry it is. A few seconds to minutes.
     # Therefore we use `wput` instead of `bput` which is a 15 second timeout.
-    timeout = 90
+    timeout = 300
     case DRC.wput("feed my cloak", timeout, *no_food_in_room, not_hungry, done_eating, no_cloak, cant_feed)
     when no_cloak, cant_feed
       DRC.message("You aren't wearing a cloak that can be fed.")


### PR DESCRIPTION
### Changes
* Increase wait timeout from 90 seconds to 300 seconds

### Problem
* It took over 2 minutes for me to feed a cloak I hadn't fed in a couple days. Not sure if "how hungry" the cloak was, or "where" I was feeding, or just "random timers" is the culprit.