### PR TITLE
Hollow eve games update #3

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -8,7 +8,9 @@ $TRASH_STORAGE = %w[basket bin gloop barrel bucket urn log arms stump tree statu
 $PUT_AWAY_ITEM_SUCCESS_PATTERNS = [/^You put your .* in/,
                                    /^You hold out/]
 $PUT_AWAY_ITEM_OPEN_PATTERNS = [/^But that's closed/]
-$PUT_AWAY_ITEM_FAILURE_PATTERNS = [/^What were you referring to/]
+$PUT_AWAY_ITEM_FAILURE_PATTERNS = [/^What were you referring to/,
+                                   /to fit in the/,
+                                  /^There isn't any more room in/]
 
 $OPEN_CONTAINER_SUCCESS_PATTERNS = [/^You open/,
                                     /^That is already open/]

--- a/crowns.lic
+++ b/crowns.lic
@@ -122,20 +122,28 @@ class Dice
       if in_hand
         case in_hand
         when *@trash_items
-          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
+          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop', 'What were', 'Stow what?')
         else
           # Coil rope so we can store it
           if /\brope\b/ =~ in_hand
             fput("coil my #{in_hand}")
           end
-          case DRC.bput("stow #{in_hand} in my #{@hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-          when 'to fit in the'
-            DRC.message("*** Item is too big to fit in your stow container! ***")
-            exit
+          DRCI.put_away_item?(in_hand, @hollow_eve_loot_container)
+          if reget(5, /to fit in the/)
+            DRC.message("*** Item is too big to fit in your container! ***")
+            beep_exit
+          elsif reget(5, /There isn't any more room in/)
+            DRC.message("*** No more room in your container! ***")
+            beep_exit
           end
         end
       end
     end
+  end
+
+  def beep_exit
+    DRC.beep
+    exit
   end
 
 end

--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -100,7 +100,7 @@ loop do
       if in_hand
         case in_hand
         when *trash_items
-          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
+          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop', 'What were', 'Stow what?')
         else
           # Coil rope so we can store it
           if /\brope\b/ =~ in_hand

--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -4,7 +4,7 @@
 =end
 
 
-custom_require.call(%w[events common-travel common])
+custom_require.call(%w[events common-travel common common-items])
 
 arg_definitions = [
   [
@@ -106,9 +106,14 @@ loop do
           if /\brope\b/ =~ in_hand
             fput("coil my #{in_hand}")
           end
-          case DRC.bput("stow #{in_hand} in my #{hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-          when 'to fit in the'
-            DRC.message("*** Item is too big to fit in your stow container! ***")
+          DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
+          if reget(5, /to fit in the/)
+            DRC.message("*** Item is too big to fit in your container! ***")
+            DRC.beep
+            exit
+          elsif reget(5, /There isn't any more room in/)
+            DRC.message("*** No more room in your container! ***")
+            DRC.beep
             exit
           end
         end

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -48,7 +48,7 @@ class Lamprey
           message("*** Retrieved a Lamprey or Prize! You will need to wait 10 minutes to play again! ***")
           exit # Can only play once every 10 minutes if you get a lamprey.
         when *@trash_items
-          bput("put #{in_hand} in bucket", 'You drop')
+          bput("put #{in_hand} in bucket", 'You drop', 'What were', 'Stow what?')
         else
           DRCI.put_away_item?(in_hand, @hollow_eve_loot_container)
           if reget(5, /to fit in the/)

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -10,6 +10,10 @@ class Lamprey
   include DRCT
 
   def initialize
+    settings = get_settings
+    @hollow_eve_loot_container = settings.hollow_eve_loot_container
+    @trash_items = settings.hollow_eve_junk.map { |x| /\b#{x}\b/i }
+
     walk_to_lamprey
     stow_hands
     loop do
@@ -33,8 +37,6 @@ class Lamprey
   end
 
   def check_prize
-    hollow_eve_loot_container = get_settings.hollow_eve_loot_container
-    trash_items = get_settings.hollow_eve_junk.map { |x| /\b#{x}\b/i }
     [left_hand, right_hand]
     .compact
     .each do |in_hand|
@@ -45,17 +47,26 @@ class Lamprey
           bput("put lamprey in bucket", 'You drop')
           message("*** Retrieved a Lamprey or Prize! You will need to wait 10 minutes to play again! ***")
           exit # Can only play once every 10 minutes if you get a lamprey.
-        when *trash_items
+        when *@trash_items
           bput("put #{in_hand} in bucket", 'You drop')
         else
-          case bput("stow #{in_hand} in my #{hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-          when 'to fit in the'
-            message("*** Item is too big to fit in your stow container! ***")
-            exit
+          DRCI.put_away_item?(in_hand, @hollow_eve_loot_container)
+          if reget(5, /to fit in the/)
+            DRC.message("*** Item is too big to fit in your container! ***")
+            beep_exit
+          elsif reget(5, /There isn't any more room in/)
+            DRC.message("*** No more room in your container! ***")
+            beep_exit
           end
         end
       end
     end
   end
+
+  def beep_exit
+    DRC.beep
+    exit
+  end
+
 end
 Lamprey.new

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -50,7 +50,7 @@ loop do
     if in_hand
       case in_hand
       when *trash_items
-        DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop')
+        DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop', 'What were', 'Stow what?')
       else
         # Coil rope so we can store it
         if /\brope\b/ =~ in_hand

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -6,8 +6,9 @@ custom_require.call(%w[events common-items common-travel common])
 
 Flags.add('shell-fragments', 'shell explodes')
 
-trash_items = get_settings.hollow_eve_junk.map { |x| /\b#{x}\b/i }
-hollow_eve_loot_container = get_settings.hollow_eve_loot_container
+settings = get_settings
+trash_items = settings.hollow_eve_junk.map { |x| /\b#{x}\b/i }
+hollow_eve_loot_container = settings.hollow_eve_loot_container
 
 DRC.message("*** Heading to grab a shell ***")
 DRCT.walk_to(16_236)
@@ -55,9 +56,14 @@ loop do
         if /\brope\b/ =~ in_hand
           fput("coil my #{in_hand}")
         end
-        case DRC.bput("stow #{in_hand} in #{hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')
-        when 'to fit in the'
-          DRC.message("*** Item is too big to fit in your stow container! ***")
+        DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
+        if reget(5, /to fit in the/)
+          DRC.message("*** Item is too big to fit in your container! ***")
+          DRC.beep
+          exit
+        elsif reget(5, /There isn't any more room in/)
+          DRC.message("*** No more room in your container! ***")
+          DRC.beep
           exit
         end
       end


### PR DESCRIPTION
Following up on a comment that stow, in `case DRC.bput("stow #{in_hand} in my #{@hollow_eve_loot_container}", 'You put', 'to fit in the', 'What were', 'Stow what?')` was changing store default if one had that item defined. Found the common-items function `DRCI.put_away_item?` works well. Yes, I could have just changed the stow to put but we already have a function so I decided to use it. 

I experimented with result = DRCI.... then case result but it did not work. The reget function (or are these methods?) grabbed what I needed to find. In the scripts I could, I made a function for beeping and exiting. I also fixed how the scripts were getting the settings. I made it so settings = get_settings was used instead of each setting reaching back to the yaml. 

Also added another catch for the disposal of the junk item for those instances one emptied their hands or another script did before this line was called.