### PR TITLE
[script] [common-items] Support backup containers to put item away in

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -292,7 +292,14 @@ module DRCI
   end
 
   def put_away_item?(item, container)
-    put_away_item_safe?(item, container)
+    if container.is_a?(Array)
+        container.each do |c|
+            return true if put_away_item_safe?(item, c)
+        end
+        return false
+    else
+        put_away_item_safe?(item, container)
+    end
   end
 
   def put_away_item_safe?(item, container)

--- a/common-items.lic
+++ b/common-items.lic
@@ -297,9 +297,8 @@ module DRCI
             return true if put_away_item_safe?(item, c)
         end
         return false
-    else
-        put_away_item_safe?(item, container)
     end
+    put_away_item_safe?(item, container)
   end
 
   def put_away_item_safe?(item, container)

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -92,3 +92,4 @@ empty_values:
   craft_overrides: {}
   pattern_hues: {}
   holy_weapon: {}
+  hollow_eve_loot_container: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1232,7 +1232,13 @@ boggle_cash_on_hand: 50 platinum
 dice_money_on_hand: 10 platinum
 dice_bet_amount: 10
 dice_withdraw: true
-hollow_eve_loot_container: backpack
+
+# When playing the hollow eve games,
+# this is where you'll put your prizes.
+# You can specify one or more containers
+# like you would for storage_containers.
+hollow_eve_loot_container:
+- backpack
 
 # HE script
 grave_junk:


### PR DESCRIPTION
### Changes
* Update `put_away_item?(item, container)` to support `container` being either an Array or a String
* If `container` is an Array then if the item can't be put into the first container, it will try the next one in the array until one works or exhausts all options

This is inspired by how `corn-maze.lic` handles `cornmaze_containers:` property and to enable the Hollow Eve game scripts to support users specifying one or more containers in `hollow_eve_container:`. See this [discord thread](https://discord.com/channels/745675889622384681/771867662551744534/777984985609011220).

### Tests

**First container is full, so tries the second container**
```
> ,e echo DRCI.put_away_item?('vault book', ['scarf', 'pouch', 'thigh bag', 'backpack'])

--- Lich: exec1 active.

[exec1]>put my vault book in my scarf

There isn't any more room in the scarf for that.
> 
[exec1]>put my vault book in my pouch

You put your book in your wrist pouch.
> 
[exec1: true]
```

**All containers full**
```
> ,e echo DRCI.put_away_item?('vault book', ['scarf', 'pants'])

--- Lich: exec1 active.

[exec1]>put my vault book in my scarf

There isn't any more room in the scarf for that.
> 
[exec1]>put my vault book in my pants

There isn't any more room in the pants for that.
> 
[exec1: false]

--- Lich: exec1 has exited.
```

**Single container, original logic**
```
> ,e echo DRCI.put_away_item?('vault book', 'backpack')

--- Lich: exec1 active.

[exec1]>put my vault book in my backpack

You put your book in your hitman's backpack.
> 
[exec1: true]

--- Lich: exec1 has exited.
```