### PR TITLE
Updated regex to fix when overlap in names occur. 

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -319,7 +319,7 @@ module DRC
     end
 
     def short_regex
-      @adjective ? /#{adjective}.*\b#{@name}/i : /\b#{@name}/i
+      @adjective ? /\b#{adjective}.*\b#{@name}/i : /\b#{@name}/i
     end
   end
 

--- a/test/test_items.rb
+++ b/test/test_items.rb
@@ -30,7 +30,7 @@ class TestItems < Minitest::Test
   def test_short_regex
     @test = run_script_with_proc('common', proc do
       actual = DRC::Item.new(name: 'sword', adjective: 'steel')
-      assert_equal(/#{'steel'}.*\b#{'sword'}/i, actual.short_regex)
+      assert_equal(/\b#{'steel'}.*\b#{'sword'}/i, actual.short_regex)
     end)
   end
 end


### PR DESCRIPTION
Example is demonscale gloves and scale gloves. Tested with Altair on Discord. 
https://discord.com/channels/745675889622384681/745678330933805157/779511256243503144

