### PR TITLE
Update game put logic because put_away_item? logic is now an array.

### DIFF
--- a/crowns.lic
+++ b/crowns.lic
@@ -128,13 +128,10 @@ class Dice
           if /\brope\b/ =~ in_hand
             fput("coil my #{in_hand}")
           end
-          DRCI.put_away_item?(in_hand, @hollow_eve_loot_container)
-          if reget(5, /to fit in the/)
-            DRC.message("*** Item is too big to fit in your container! ***")
-            beep_exit
-          elsif reget(5, /There isn't any more room in/)
-            DRC.message("*** No more room in your container! ***")
-            beep_exit
+          if !DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
+            DRC.message("*** The item is either too big to fit or no more room in the container(s)! ***")
+            DRC.beep
+            exit
           end
         end
       end

--- a/crowns.lic
+++ b/crowns.lic
@@ -130,8 +130,7 @@ class Dice
           end
           if !DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
             DRC.message("*** The item is either too big to fit or no more room in the container(s)! ***")
-            DRC.beep
-            exit
+            beep_exit
           end
         end
       end

--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -106,13 +106,8 @@ loop do
           if /\brope\b/ =~ in_hand
             fput("coil my #{in_hand}")
           end
-          DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
-          if reget(5, /to fit in the/)
-            DRC.message("*** Item is too big to fit in your container! ***")
-            DRC.beep
-            exit
-          elsif reget(5, /There isn't any more room in/)
-            DRC.message("*** No more room in your container! ***")
+          if !DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
+            DRC.message("*** The item is either too big to fit or no more room in the container(s)! ***")
             DRC.beep
             exit
           end

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -43,20 +43,17 @@ class Lamprey
       if in_hand
         walk_to(16_169)
         case in_hand
-        when /lamprey/
-          bput("put lamprey in bucket", 'You drop')
+        when /lamprey/,/slime/
+          bput("put #{in_hand} in bucket", 'You drop', 'You put')
           message("*** Retrieved a Lamprey or Prize! You will need to wait 10 minutes to play again! ***")
           exit # Can only play once every 10 minutes if you get a lamprey.
         when *@trash_items
           bput("put #{in_hand} in bucket", 'You drop', 'What were', 'Stow what?')
         else
-          DRCI.put_away_item?(in_hand, @hollow_eve_loot_container)
-          if reget(5, /to fit in the/)
-            DRC.message("*** Item is too big to fit in your container! ***")
-            beep_exit
-          elsif reget(5, /There isn't any more room in/)
-            DRC.message("*** No more room in your container! ***")
-            beep_exit
+          if !DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
+            DRC.message("*** The item is either too big to fit or no more room in the container(s)! ***")
+            DRC.beep
+            exit
           end
         end
       end

--- a/lamprey.lic
+++ b/lamprey.lic
@@ -52,8 +52,7 @@ class Lamprey
         else
           if !DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
             DRC.message("*** The item is either too big to fit or no more room in the container(s)! ***")
-            DRC.beep
-            exit
+            beep_exit
           end
         end
       end

--- a/smash-shells.lic
+++ b/smash-shells.lic
@@ -56,13 +56,8 @@ loop do
         if /\brope\b/ =~ in_hand
           fput("coil my #{in_hand}")
         end
-        DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
-        if reget(5, /to fit in the/)
-          DRC.message("*** Item is too big to fit in your container! ***")
-          DRC.beep
-          exit
-        elsif reget(5, /There isn't any more room in/)
-          DRC.message("*** No more room in your container! ***")
+        if !DRCI.put_away_item?(in_hand, hollow_eve_loot_container)
+          DRC.message("*** The item is either too big to fit or no more room in the container(s)! ***")
           DRC.beep
           exit
         end


### PR DESCRIPTION
With the update to the common-items put_away_item? function to include an array, the reget method for outputting the error was causing the script to exit even on successful put. I thought about dropping the reget down to 1, and even tried that with success but the game was not crowded. I am concerned reget would miss the message if lots of scroll (unless it is only getting our output). I figure checking for false is the best way to go. I still output a message.

Example: 
```
2020-11-21 10:24:29 -0500:[smash-shells]>put my dolphin-shaped bolts in my watery portal
2020-11-21 10:24:29 -0500:[Assuming you mean a swirling eddy of incandescent light bound by a gold-striated coralite frame.]
2020-11-21 10:24:29 -0500:[Assuming you mean a swirling eddy of incandescent light bound by a gold-striated coralite frame.]
2020-11-21 10:24:29 -0500:There isn't any more room in the eddy for that.
2020-11-21 10:24:30 -0500:[smash-shells]>put my dolphin-shaped bolts in my blue backpack
2020-11-21 10:24:30 -0500:Gneme just arrived.
2020-11-21 10:24:31 -0500:You put your bolts in the blue backpack which is inside your embroidered backpack.
2020-11-21 10:24:31 -0500:| *** No more room in your container! ***
2020-11-21 10:24:31 -0500:[smash-shells: ]
2020-11-21 10:24:31 -0500:--- Lich: smash-shells has exited.
```

With the change:
```
2020-11-21 10:27:43 -0500:[smash-shells]>put my green sack in my watery portal
2020-11-21 10:27:43 -0500:[Assuming you mean a swirling eddy of incandescent light bound by a gold-striated coralite frame.]
2020-11-21 10:27:43 -0500:[Assuming you mean a swirling eddy of incandescent light bound by a gold-striated coralite frame.]
2020-11-21 10:27:43 -0500:There isn't any more room in the eddy for that.
2020-11-21 10:27:44 -0500:[smash-shells]>put my green sack in my blue backpack
2020-11-21 10:27:44 -0500:You put your sack in the blue backpack which is inside your embroidered backpack.
2020-11-21 10:27:44 -0500:--- Lich: go2 active.
2020-11-21 10:27:44 -0500:[go2: ETA: 0:00:00 (1 rooms to move through)]
2020-11-21 10:27:44 -0500:[go2]>west
2020-11-21 10:27:44 -0500:Roundtime: 1 sec.
2020-11-21 10:27:44 -0500:You wade west, moving with the light current.
2020-11-21 10:27:44 -0500:[Sea Otter Smash, Den]
2020-11-21 10:27:44 -0500:Obvious exits: east.
2020-11-21 10:27:44 -0500:Room Number: 16236
2020-11-21 10:27:45 -0500:[go2: travel time: 0:00:01]
2020-11-21 10:27:45 -0500:--- Lich: go2 has exited.
2020-11-21 10:27:46 -0500:[smash-shells]>grab box
```

