### PR TITLE
[script] [faskinner] Alert user they need to wear a skinning knife or hold a blade

### DIFF
--- a/faskinner.lic
+++ b/faskinner.lic
@@ -45,13 +45,16 @@ class FaSkinner
   end
 
   def train_skills
-    case bput("skin my #{@trainer}",'You skillfully','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears')
+    case bput("skin my #{@trainer}",'You skillfully','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears','need to have a bladed instrument')
     when /You must be holding/
       get_fred
     when /The leather looks frayed/
       echo ("No Charges!  Try again later.")
       exit
-    end 
+    when /need to have a bladed instrument/
+      echo ("You need to either wear a skinning knife or hold a bladed weapon")
+      exit
+    end
 
     case bput("repair my #{@trainer}",'With some needle and thread','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears')
     when /You must be holding/

--- a/faskinner.lic
+++ b/faskinner.lic
@@ -22,8 +22,8 @@ class FaSkinner
 
     EquipmentManager.new.empty_hands
 
-    get_item(@trainer, @trainer_container)
-    get_item(@knife, @knife_container)
+    get_item(@trainer, @trainer_container) if @trainer
+    get_item(@knife, @knife_container) if @knife
 
     if @priority == 'First Aid' && DRSkill.getxp('First Aid') < 34
       until DRSkill.getxp('First Aid') > 32
@@ -52,8 +52,8 @@ class FaSkinner
   end
 
   def do_exit
-    stow_item(@trainer, @trainer_container)
-    stow_item(@knife, @knife_container)
+    DRCI.put_away_item?(@trainer, @trainer_container) if @trainer
+    DRCI.put_away_item?(@knife, @knife_container) if @knife
     exit
   end
 
@@ -79,17 +79,10 @@ class FaSkinner
   end
 
   def get_item(item, container = nil)
-    return unless item
-    return if DRCI.in_hands?(item)
-    unless DRCI.get_item(item, container)
+    unless DRCI.get_item_if_not_held?(item, container)
       DRC.message("Could not get '#{item}'!")
       do_exit
     end
-  end
-
-  def stow_item(item, container = nil)
-    return unless item
-    DRCI.put_away_item?(item, container)
   end
 
 end

--- a/faskinner.lic
+++ b/faskinner.lic
@@ -2,24 +2,28 @@
 Elanthipedia: https://elanthipedia.play.net/Lich_script_repository#faskinner
 
 # trainer noun should match exactly
-fa_skinning_trainer: crocodile 
+fa_skinning_trainer: crocodile
 
 # Options:  First Aid, Skinning, Both or leave blank for whichever happens first
-fa_skinning_priority: Skinning 
+fa_skinning_priority: Skinning
 =end
 custom_require.call(%w[common events drinfomon equipmanager])
 
 class FaSkinner
   include DRC
-  include DRCA
 
   def initialize
     @settings = get_settings
-    @trainer = @settings.fa_skinning_trainer
     @priority = @settings.fa_skinning_priority
-    
+    @trainer = @settings.fa_skinning_trainer
+    @trainer_container = @settings.fa_skinning_trainer_container
+    @knife = @settings.fa_skinning_knife
+    @knife_container = @settings.fa_skinning_knife_container
+
     EquipmentManager.new.empty_hands
-    get_fred
+
+    get_item(@trainer, @trainer_container)
+    get_item(@knife, @knife_container)
 
     if @priority == 'First Aid' && DRSkill.getxp('First Aid') < 34
       until DRSkill.getxp('First Aid') > 32
@@ -34,7 +38,7 @@ class FaSkinner
     elsif @priority == 'Both' || @priority == 'both'
       until DRSkill.getxp('First Aid') > 32  && DRSkill.getxp('Skinning') > 32
         train_skills
-      end 
+      end
       echo ("Exiting because First Aid AND Skinning locked!")
     else
       until DRSkill.getxp('First Aid') > 32  || DRSkill.getxp('Skinning') > 32
@@ -42,6 +46,15 @@ class FaSkinner
       end
       echo ("Exiting because First Aid OR Skinning locked!")
     end
+
+    do_exit
+
+  end
+
+  def do_exit
+    stow_item(@trainer, @trainer_container)
+    stow_item(@knife, @knife_container)
+    exit
   end
 
   def train_skills
@@ -49,32 +62,40 @@ class FaSkinner
     when /You must be holding/
       get_fred
     when /The leather looks frayed/
-      echo ("No Charges!  Try again later.")
-      exit
+      DRC.message("No Charges!  Try again later.")
+      do_exit
     when /need to have a bladed instrument/
-      echo ("You need to either wear a skinning knife or hold a bladed weapon")
-      exit
+      DRC.message("You need to either wear a skinning knife or hold a bladed weapon")
+      do_exit
     end
 
     case bput("repair my #{@trainer}",'With some needle and thread','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears')
     when /You must be holding/
       get_fred
     when /The leather looks frayed/
-      echo ("No Charges!  Try again later.")
-      exit
-    end 
-  end   
-
-  def get_fred
-    case bput("get my #{@trainer}",'You get','What were you referring')
-    when /What were you referring/
-      echo "OH MY DAMN - WHERE IS FRED!?"
+      DRC.message("No Charges!  Try again later.")
+      do_exit
     end
   end
+
+  def get_item(item, container = nil)
+    return unless item
+    return if DRCI.in_hands?(item)
+    unless DRCI.get_item(item, container)
+      DRC.message("Could not get '#{item}'!")
+      do_exit
+    end
+  end
+
+  def stow_item(item, container = nil)
+    return unless item
+    DRCI.put_away_item?(item, container)
+  end
+
 end
 
 before_dying do
   EquipmentManager.new.empty_hands
 end
 
-FaSkinner.new  
+FaSkinner.new

--- a/faskinner.lic
+++ b/faskinner.lic
@@ -60,7 +60,7 @@ class FaSkinner
   def train_skills
     case bput("skin my #{@trainer}",'You skillfully','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears','need to have a bladed instrument')
     when /You must be holding/
-      get_fred
+      get_item(@trainer, @trainer_container)
     when /The leather looks frayed/
       DRC.message("No Charges!  Try again later.")
       do_exit
@@ -71,7 +71,7 @@ class FaSkinner
 
     case bput("repair my #{@trainer}",'With some needle and thread','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears')
     when /You must be holding/
-      get_fred
+      get_item(@trainer, @trainer_container)
     when /The leather looks frayed/
       DRC.message("No Charges!  Try again later.")
       do_exit

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -469,8 +469,16 @@ firstaid_scholarship_modifier:
 
 # trainer noun should match exactly
 fa_skinning_trainer:
+# Container where you store your trainer, if it's not worn.
+fa_skinning_trainer_container:
 # Options:  First Aid, Skinning, Both or leave blank for whichever happens first
 fa_skinning_priority:
+# If you don't wear a skinning knife, this is the
+# bladed weapon you want to use to skin with.
+fa_skinning_knife:
+# If you specify 'fa_skinning_knife:' then this is
+# the container where that bladed weapon is stored.
+fa_skinning_knife_container:
 
 dedicated_camb_use:
 symbiosis_learning_threshold: 2


### PR DESCRIPTION
### Background
* If you choose not to wear a skinning knife, then you must ensure you have a bladed weapon in your hand otherwise you can't practice skinning.
* The current version of the script will hang and error on the `bput` command when trying to skin the trainer.

```
[faskinner]>skin my caracal
You'll need to have a bladed instrument to skin with.
> 
[faskinner: *** No match was found after 15 seconds, dumping info]
[faskinner: messages seen length: 4]
l
[faskinner: message: You'll need to have a bladed instrument to skin with.]
[faskinner: checked against [/You skillfully/i, /A small blue-belly crocodile with prominently/i, /You must be holding/i, /The leather looks frayed/i, /A small fuzzy caracal with tufted ears/i]]
[faskinner: for command skin my caracal]
```

### Changes
* Add match for "You'll need to have a bladed instrument to skin with" so can message user what they need to do, and exit the script gracefully.
* Add new optional config options for specifying a skinning knife/container if a knife isn't worn
* Add new optional config option for trainer container