### PR TITLE
[script] [locksmithing] Train with loose lockpicks too

### DIFF
--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -27,10 +27,10 @@ class Locksmithing
     # Practice some music while use lock trainers
     start_script('performance', ['noclean']) unless Script.running?('performance')
     pause 3
-    get_lockpick unless @use_lockpick_ring
+    get_item('lockpick') unless @use_lockpick_ring
     daily_lockbox if @daily_trainer
     consumable_lockbox if @consumable_trainers
-    stow_lockpick unless @use_lockpick_ring
+    stow_item('lockpick') unless @use_lockpick_ring
   end
 
   def daily_lockbox
@@ -123,15 +123,18 @@ class Locksmithing
     end
   end
 
-  def get_lockpick
-    if DRC.bput('get my lockpick', 'You get', 'You are already holding', 'What were you') =~ /What were you/
-      DRC.message("Couldn't find your lockpick")
-      exit
+  def get_item(item, container = nil)
+    return unless item
+    return if DRCI.in_hands?(item)
+    unless DRCI.get_item(item, container)
+      DRC.message("Could not get '#{item}'!")
+      do_exit
     end
   end
 
-  def stow_lockpick
-    fput("stow my lockpick")
+  def stow_item(item, container = nil)
+    return unless item
+    DRCI.put_away_item?(item, container)
   end
 
   before_dying do

--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -7,6 +7,7 @@ custom_require.call(%w[common common-items drinfomon equipmanager])
 class Locksmithing
   include DRC
   include DRCI
+
   def initialize
     settings = get_settings
     @equipment_manager = EquipmentManager.new(settings)
@@ -17,6 +18,7 @@ class Locksmithing
     @liveboxes = settings.pick_live_boxes
     @consumable_trainers = settings.consumable_lockboxes
     @consumable_container = settings.burgle_settings['loot_container']
+    @use_lockpick_ring = settings.use_lockpick_ring
     @sell_loot = settings.sell_loot
     @safe_room = settings.safe_room
     @equipment_manager.empty_hands
@@ -25,23 +27,25 @@ class Locksmithing
     # Practice some music while use lock trainers
     start_script('performance', ['noclean']) unless Script.running?('performance')
     pause 3
+    get_lockpick unless @use_lockpick_ring
     daily_lockbox if @daily_trainer
     consumable_lockbox if @consumable_trainers
+    stow_lockpick unless @use_lockpick_ring
   end
 
   def daily_lockbox
     if DRSkill.getxp('Locksmithing') < 34
       if @worn_lockbox
-        case bput("remove my #{@box}", 'You take', 'Remove what', "You aren't wearing that", 'You sling','You remove', 'You detach')
+        case DRC.bput("remove my #{@box}", 'You take', 'Remove what', "You aren't wearing that", 'You sling', 'You remove', 'You detach')
         when 'Remove what', "You aren't wearing that"
-          echo('Lockbox is not worn but you declared it is in your yaml, exiting')
+          DRC.message('Lockbox is not worn but you declared it is in your yaml, exiting')
           return
         end
-        bput("close my #{@box}", 'You close', 'That is already',"You can't close that")
+        DRC.bput("close my #{@box}", 'You close', 'That is already', "You can't close that")
       else
-        case bput("get my #{@box}", 'You get a', 'What were')
+        case DRC.bput("get my #{@box}", 'You get a', 'What were')
         when 'What were'
-          echo('Daily Trainer not found! Where is it?')
+          DRC.message('Daily Trainer not found! Where is it?')
           return
         end
       end
@@ -49,32 +53,32 @@ class Locksmithing
       pick_box(@box)
 
       if @worn_lockbox
-        bput("pick my #{@box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm')
-        bput("wear my #{@box}", 'You put', 'You sling','You attach')
+        DRC.bput("pick my #{@box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm')
+        DRC.bput("wear my #{@box}", 'You put', 'You sling', 'You attach')
       else
         @equipment_manager.empty_hands
       end
     end
-    bput("open my #{@box}", 'You open',"You can't open that", 'It is locked')
+    DRC.bput("open my #{@box}", 'You open',"You can't open that", 'It is locked')
   end
 
   def consumable_lockbox
     consumables = @consumable_trainers
     if DRSkill.getxp('Locksmithing') < 34
       consumables.each do | consumable |
-        case bput("get my #{consumable} from my #{@consumable_container}", 'You get', 'What were',"But you aren't holding")
+        case DRC.bput("get my #{consumable} from my #{@consumable_container}", 'You get', 'What were', "But you aren't holding")
         when /But you aren't holding/
           echo('#{consumable} may not be specific enough - catching interference from another item')
         when /You get/
           @box = consumable
           pick_box(@box)
-          bput("put my #{@box} in my #{@consumable_container}", 'You put', 'What were') if DRC.right_hand
+          DRC.bput("put my #{@box} in my #{@consumable_container}", 'You put', 'What were') if DRC.right_hand
         when /What were/
           echo("#{consumable} NOT found!  If you're really out of them, trim or rearrange your yaml to avoid spam.")
         end
       end
     end
-    bput("put my #{@box} in my #{@consumable_container}", 'You put', 'What were') if DRC.right_hand
+    DRC.bput("put my #{@box} in my #{@consumable_container}", 'You put', 'What were') if DRC.right_hand
   end
 
   def live_boxes
@@ -90,33 +94,44 @@ class Locksmithing
 
   def pick_box(trainer)
     while (DRSkill.getxp('Locksmithing') < 34 && DRC.right_hand)
-      case bput("pick my #{trainer}", 'Maybe you should close', 'not making any progress', "why bother", "it opens.", "isn't locked", 'The lock feels warm', 'The lock looks weak', 'Pick what', 'You need some type of tool to pick', "But you aren't holding")
+      case DRC.bput("pick my #{trainer}", 'Maybe you should close', 'not making any progress', "why bother", "it opens.", "isn't locked", 'The lock feels warm', 'The lock looks weak', 'Pick what', 'You need some type of tool to pick', "But you aren't holding")
       when /You need some type of tool to pick/
-        echo ('YOU HAVE NO LOCKPICKS ON YOUR LOCKPICK RING/BELT.  SORT THAT OUT!')
+        DRC.message('YOU HAVE NO LOCKPICKS ON YOUR LOCKPICK RING/BELT.  SORT THAT OUT!')
         exit
       when /(you should close)|(it opens)|(isn't locked)/
-        bput("close my #{trainer}", 'You close', 'already closed', "You can't close that")
-        bput("lock my #{trainer}", 'You quickly lock', 'already locked')
+        DRC.bput("close my #{trainer}", 'You close', 'already closed', "You can't close that")
+        DRC.bput("lock my #{trainer}", 'You quickly lock', 'already locked')
       when /The lock feels warm/
-        echo('Charges Burned!, checking for other settings.')
+        DRC.message('Charges Burned!, checking for other settings.')
         return
       when /The lock looks weak/
-        case bput("study my #{trainer}", /0 more times/,/risk breaking the lock/,'Study what')
+        case DRC.bput("study my #{trainer}", /0 more times/, /risk breaking the lock/, 'Study what')
         when /0 more times/
-          bput("drop my #{trainer}", 'You drop')
+          DRC.bput("drop my #{trainer}", 'You drop')
           consumable_lockbox
         end
       when /But you aren't holding/
-          echo("Description: '#{trainer}' may not be specific enough or is in a wrong container - something is interfering.")
+          DRC.message("Description: '#{trainer}' may not be specific enough or is in a wrong container - something is interfering.")
           exit
       when /why bother/
-        echo ("The #{trainer} is not a valid option but shares a noun - move it out of your burgle bag to avoid hangups.")
-        bput('stow', 'You')
+        DRC.message("The #{trainer} is not a valid option but shares a noun - move it out of your burgle bag to avoid hangups.")
+        DRC.bput('stow', 'You')
         consumable_lockbox
       when /Pick what/
         return
       end
     end
+  end
+
+  def get_lockpick
+    if DRC.bput('get my lockpick', 'You get', 'You are already holding', 'What were you') =~ /What were you/
+      DRC.message("Couldn't find your lockpick")
+      exit
+    end
+  end
+
+  def stow_lockpick
+    fput("stow my lockpick")
   end
 
   before_dying do

--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -28,10 +28,10 @@ class Locksmithing
     # Practice some music while use lock trainers
     start_script('performance', ['noclean']) unless Script.running?('performance')
     pause 3
-    get_item('lockpick', @lockpick_container) unless @use_lockpick_ring
+    DRCI.get_item_if_not_held?('lockpick', @lockpick_container) unless @use_lockpick_ring
     daily_lockbox if @daily_trainer
     consumable_lockbox if @consumable_trainers
-    stow_item('lockpick', @lockpick_container) unless @use_lockpick_ring
+    DRCI.put_away_item?('lockpick', @lockpick_container) unless @use_lockpick_ring
   end
 
   def daily_lockbox
@@ -122,20 +122,6 @@ class Locksmithing
         return
       end
     end
-  end
-
-  def get_item(item, container = nil)
-    return unless item
-    return if DRCI.in_hands?(item)
-    unless DRCI.get_item(item, container)
-      DRC.message("Could not get '#{item}'!")
-      do_exit
-    end
-  end
-
-  def stow_item(item, container = nil)
-    return unless item
-    DRCI.put_away_item?(item, container)
   end
 
   before_dying do

--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -19,6 +19,7 @@ class Locksmithing
     @consumable_trainers = settings.consumable_lockboxes
     @consumable_container = settings.burgle_settings['loot_container']
     @use_lockpick_ring = settings.use_lockpick_ring
+    @lockpick_container = settings.lockpick_container
     @sell_loot = settings.sell_loot
     @safe_room = settings.safe_room
     @equipment_manager.empty_hands
@@ -27,10 +28,10 @@ class Locksmithing
     # Practice some music while use lock trainers
     start_script('performance', ['noclean']) unless Script.running?('performance')
     pause 3
-    get_item('lockpick') unless @use_lockpick_ring
+    get_item('lockpick', @lockpick_container) unless @use_lockpick_ring
     daily_lockbox if @daily_trainer
     consumable_lockbox if @consumable_trainers
-    stow_item('lockpick') unless @use_lockpick_ring
+    stow_item('lockpick', @lockpick_container) unless @use_lockpick_ring
   end
 
   def daily_lockbox

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -804,6 +804,10 @@ stop_pick_on_mindlock: true
 pick_blind: false
 use_lockpick_ring: true
 skip_lockpick_ring_refill: false
+# If you set 'use_lockpick_ring: false' then specify
+# the container that holds your loose lockpicks.
+# If you set 'use_lockpick_ring: true' then specify
+# the container that serves as your lockpick ring.
 lockpick_container: lockpick ring
 lockpick_type: ordinary
 # If you harvest traps when disarming boxes


### PR DESCRIPTION
### Background
* I'm setting up a new character who didn't have a lockpick ring yet and noticed `locksmithing` script got hung up
* Thought there might be people who don't have or don't want to use a lockpick ring but do have loose lockpicks around

### Changes
* If user doesn't use a lockpick ring then try to get a loose lockpick (lines 21-22, 31, 127-134)
* If no loose lockpick is able to be found then script exits because nothing to pick with (lines 130-133)
* Stows lockpick when done; see `STORE HELP` for setting a default location for loose lockpicks if don't set `lockpick_container:` (lines 21-22, 34, 136-139)
* Qualifies method calls with `DRC` prefix
* Uses `DRC.message()` to emphasize errors and action items to user

## Example Configs

### base.yaml

```yaml
use_lockpick_ring: true

# If you set 'use_lockpick_ring: false' then specify
# the container that holds your loose lockpicks.
# If you set 'use_lockpick_ring: true' then specify
# the container that serves as your lockpick ring.
lockpick_container: lockpick ring
````

### Using a custom lockpick ring

```yaml
# Set to false if you use loose lockpicks instead
use_lockpick_ring: true

# If you set 'use_lockpick_ring: false' then specify
# the container that holds your loose lockpicks.
# If you set 'use_lockpick_ring: true' then specify
# the container that serves as your lockpick ring.
lockpick_container: lockpick wristcuff
```

### Using loose lockpicks

```yaml
# Set to false if you use loose lockpicks instead
use_lockpick_ring: false

# If you set 'use_lockpick_ring: false' then specify
# the container that holds your loose lockpicks.
# If you set 'use_lockpick_ring: true' then specify
# the container that serves as your lockpick ring.
lockpick_container: hitman backpack
```