### PR TITLE
Fixing lowering

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -178,7 +178,7 @@ class Remedy
     end
     get_item(@container)
 
-    bput("lower my #{@container} ground", 'You lower') # lower to count and combine herbs
+    bput("lower my #{@container} to ground", 'You lower') # lower to count and combine herbs
 
     # count herb, less than 25 get more herbs, otherwise stow and continue
     # added to handle herb containers, and modified to combine up to 25


### PR DESCRIPTION
Some adjective bowls don't seem to work with just lower <adjective> bowl ground and need the "to" added.