### PR TITLE
[script] [common-items] get item if not held, get item unsafe

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -280,10 +280,28 @@ module DRCI
     dispose_trash(DRC.get_noun(Regexp.last_match(1))) if braid_regex.match(result)
   end
 
+  # Gets an item unless you are already hold it.
+  # Use this method to avoid having two of an item
+  # in your hands when you only want one.
+  #
+  # Returns true if the item is in your hand
+  # or we were able to get it to your hand.
+  def get_item_if_not_held?(item, container = nil)
+    return false unless item
+    return true if in_hands?(item)
+    return get_item(item, container)
+  end
+
   # Gets an item, optionally from a specific container.
   # If no container specified then generically grabs from the room/your person.
   def get_item(item, container = nil)
-    from = "in my #{container}" if container
+    container = "my #{container}" if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
+    get_item_unsafe(item, container)
+  end
+
+  def get_item_unsafe(item, container = nil)
+    from = container
+    from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
     result = DRC.bput("get #{item} #{from}", 'You get', 'I could not', 'What were you', 'You are already holding', 'You need a free hand')
     result =~ /^You get|^You are already holding/
   end


### PR DESCRIPTION
### Background
* Creating reusable methods per https://github.com/rpherbig/dr-scripts/pull/4620#pullrequestreview-537768130
* These changes are prerequisites for https://github.com/rpherbig/dr-scripts/pull/4620 and https://github.com/rpherbig/dr-scripts/pull/4619

### Changes
* Add method `get_item_if_not_held?(item, container)` that will only try to get an item if it's not already in your hands to avoid having two of the same thing in your hands.
* Support more options for specifying the "container". Optionally you can include "my" qualifier or even "in|on|under|behind|from" qualifiers.

## Tests

### Get Item (unsafe)
```
> ,e DRCI.get_item_unsafe('book')

--- Lich: exec1 active.

[exec1]>get book 

You get a leather bank book from inside your dirt-covered backpack.

--- Lich: exec1 has exited.

> stow book

You put your book in your dirt-covered backpack.

> ,e DRCI.get_item_unsafe('book', 'backpack')

--- Lich: exec1 active.

[exec1]>get book from backpack

You get a leather bank book from inside your dirt-covered backpack.

--- Lich: exec1 has exited.

> stow book

You put your book in your dirt-covered backpack.

> ,e DRCI.get_item_unsafe('book', 'my backpack')

--- Lich: exec1 active.

[exec1]>get book from my backpack

You get a leather bank book from inside your dirt-covered backpack.
 
--- Lich: exec1 has exited.

> stow book

You put your book in your dirt-covered backpack.

> ,e DRCI.get_item_unsafe('book', 'in my backpack')

--- Lich: exec1 active.

[exec1]>get book in my backpack

You get a leather bank book from inside your dirt-covered backpack.
 
--- Lich: exec1 has exited.
```

### Get Item (safe)
```
> ,e DRCI.get_item('book')

--- Lich: exec1 active.

[exec1]>get book 

You get a leather bank book from inside your dirt-covered backpack.

--- Lich: exec1 has exited.

> stow book

You put your book in your dirt-covered backpack.

> ,e DRCI.get_item('book', 'backpack')

--- Lich: exec1 active.

[exec1]>get book from my backpack

You get a leather bank book from inside your dirt-covered backpack.
 
--- Lich: exec1 has exited.

> stow book

You put your book in your dirt-covered backpack.

> ,e DRCI.get_item('book', 'my backpack')

--- Lich: exec1 active.

[exec1]>get book from my backpack

You get a leather bank book from inside your dirt-covered backpack.
 
--- Lich: exec1 has exited.

> stow book

You put your book in your dirt-covered backpack.

> ,e DRCI.get_item('book', 'in my backpack')

--- Lich: exec1 active.

[exec1]>get book in my backpack

You get a leather bank book from inside your dirt-covered backpack.
 
--- Lich: exec1 has exited.
```

### Get item if not held
```
> ,e DRCI.get_item_if_not_held?('book')

--- Lich: exec1 active.

[exec1]>get book 

You get a leather bank book from inside your dirt-covered backpack.
 
--- Lich: exec1 has exited.

> ,e DRCI.get_item_if_not_held?('book')

--- Lich: exec1 active.

--- Lich: exec1 has exited.

> stow book

You put your book in your dirt-covered backpack.

> ,e DRCI.get_item_if_not_held?('book', 'backpack')

--- Lich: exec1 active.

[exec1]>get book from my backpack

You get a leather bank book from inside your dirt-covered backpack.
> 
--- Lich: exec1 has exited.

> ,e DRCI.get_item_if_not_held?('book', 'backpack')

--- Lich: exec1 active.

--- Lich: exec1 has exited.
```