### PR TITLE
Changed the handling of items when removed from a wound.

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -2,7 +2,7 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-healing
 =end
-custom_require.call(%w[common])
+custom_require.call(%w[common common-items])
 
 $wound_map = {
   'insignificant' => 1,

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -243,8 +243,8 @@ module DRCH
   def bind_wound(part, person = 'my')
     snap = [DRC.left_hand, DRC.right_hand]
     if /You \w+ remove/ =~ DRC.bput("tend #{person} #{part}", 'You work carefully at tending', 'That area has already been tended to', 'That area is not bleeding', 'You fumble', 'too injured for you to do that', 'You \w+ remove')
-      DRC.bput("drop my #{DRC.left_hand}", 'You drop', 'What were you') if DRC.left_hand != snap.first
-      DRC.bput("drop my #{DRC.right_hand}", 'You drop', 'What were you') if DRC.right_hand != snap.last
+      DRCI.dispose(DRC.left_hand) if DRC.left_hand != snap.first
+      DRCI.dispose(DRC.right_hand) if DRC.right_hand != snap.last
       bind_wound(part, person)
     end
     waitrt?


### PR DESCRIPTION
This change will use the standard dispose function found in common-items to put the tended items (shards, fragments, arrows, bolts, etc) into a trash receptacle or will drop (current method) item if none found in the room.