### PR TITLE
Changed unpause to unpause_script.

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -299,7 +299,7 @@ class HuntingBuddy
         message('***STATUS*** heading back to room - familiar drug while stunned')
         pause_script('combat-trainer') if Script.running?('combat-trainer')
         DRCT.walk_to(hunting_room)
-        unpause('combat-trainer') if Script.running?('combat-trainer')
+        unpause_script('combat-trainer') if Script.running?('combat-trainer')
         Flags.reset('familiar_drag')
       end
       if (counter % 60).zero?


### PR DESCRIPTION
Found `unpause` did not work. Threw an error:

```2020-11-28 16:27:46 -0500:--- Lich: error: undefined method `unpause' for #<HuntingBuddy:0x0000000003405558>
2020-11-28 16:27:46 -0500:Did you mean?  pause
2020-11-28 16:27:46 -0500:	hunting-buddy:302:in `block in hunt'
2020-11-28 16:27:46 -0500:	hunting-buddy:257:in `loop'```