### PR TITLE
[data] [base-picking] fix #4631 missing match in disarm_quick message list

### DIFF
--- a/data/base-picking.yaml
+++ b/data/base-picking.yaml
@@ -82,8 +82,7 @@ picking:
 
   disarm_quick:
   - trivially constructed gadget which you can take down any time
-  - This trap is a laughable matter, you could do it blindfolded
-  - This trap is a laughable matter -- you could do it blindfolded
+  - This trap is a laughable matter
   - An aged grandmother could defeat this trap in her sleep
 
   disarm_normal:

--- a/data/base-picking.yaml
+++ b/data/base-picking.yaml
@@ -83,6 +83,7 @@ picking:
   disarm_quick:
   - trivially constructed gadget which you can take down any time
   - This trap is a laughable matter, you could do it blindfolded
+  - This trap is a laughable matter -- you could do it blindfolded
   - An aged grandmother could defeat this trap in her sleep
 
   disarm_normal:


### PR DESCRIPTION
### Changes
* Add new (or modified) match string to fix #4631 

The phrasing change may be related to TOGGLE APPRAISAL or other setting or is a permanent game change that occurred recently.