### PR TITLE
[script] [common-items] Update `get_item` to support an array of containers, too

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -297,12 +297,12 @@ module DRCI
   # Can provide an array of containers to try, too, in case some might be empty.
   def get_item(item, container = nil)
     if container.is_a?(Array)
-        container.each do |c|
-          return true if get_item_safe(item, c)
-        end
-        return false
+      container.each do |c|
+        return true if get_item_safe(item, c)
       end
-      get_item_safe(item, container)
+      return false
+    end
+    get_item_safe(item, container)
   end
 
   # Same as 'get_item_unsafe' but ensures that

--- a/common-items.lic
+++ b/common-items.lic
@@ -294,11 +294,26 @@ module DRCI
 
   # Gets an item, optionally from a specific container.
   # If no container specified then generically grabs from the room/your person.
+  # Can provide an array of containers to try, too, in case some might be empty.
   def get_item(item, container = nil)
+    if container.is_a?(Array)
+        container.each do |c|
+          return true if get_item_safe(item, c)
+        end
+        return false
+      end
+      get_item_safe(item, container)
+  end
+
+  # Same as 'get_item_unsafe' but ensures that
+  # the container argument is prefixed with ' my '.
+  def get_item_safe(item, container = nil)
     container = "my #{container}" if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
     get_item_unsafe(item, container)
   end
 
+  # Gets an item, optionally from a specific container.
+  # If no container specified then generically grabs from the room/your person.
   def get_item_unsafe(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
@@ -306,6 +321,7 @@ module DRCI
     result =~ /^You get|^You are already holding/
   end
 
+  # Gets a list of items found in a container.
   def get_item_list(container)
     DRC.bput("look in #{container}", 'In the .* you see (.*)\.', 'There is nothing')
       .match(/In the .* you see (?:a|an|some) (?<items>.*)\./)[:items]


### PR DESCRIPTION
### Changes
* Update `get_item` to support an array of containers, too, which mirrors `put_away_item` behavior
* Based on this [Discord](https://discord.com/channels/745675889622384681/745696628714897508/783183586698330162) conversation
* The other "get" methods are unchanged, but for completeness I've included regression test results below

## Tests

### NEW: get item (array, eventually found)
```
> ,e echo DRCI.get_item('lockpick', ['kit', 'my boots', 'from my haversack'])

--- Lich: exec1 active.

[exec1]>get lockpick from my kit

What were you referring to?
> 
[exec1]>get lockpick from my boots

What were you referring to?
> 
[exec1]>get lockpick from my haversack

You get an ordinary lockpick from inside your yellow haversack.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### NEW: get item (array, not found)
```
> ,e echo DRCI.get_item('lockpick', ['kit', 'boots', 'haversack'])

--- Lich: exec1 active.

[exec1]>get lockpick from my kit

What were you referring to?
> 
[exec1]>get lockpick from my boots

What were you referring to?
> 
[exec1]>get lockpick from my haversack

What were you referring to?
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### get item (string, found)
```
> ,e echo DRCI.get_item('lockpick', 'haversack')

--- Lich: exec1 active.

[exec1]>get lockpick from my haversack

You get an ordinary lockpick from inside your yellow haversack.
> 
[exec1: 0]

--- Lich: exec1 has exited.
```

### get item (string, not found)
```
> ,e echo DRCI.get_item('lockpick', 'kit')

--- Lich: exec1 active.

[exec1]>get lockpick from my kit

What were you referring to?
> 
[exec1: ]

--- Lich: exec1 has exited.
```

### get item (generic, found)
```
> ,e echo DRCI.get_item('lockpick')

--- Lich: exec1 active.

[exec1]>get lockpick 

You get an ordinary lockpick from inside your yellow haversack.
> 
[exec1: 0]

--- Lich: exec1 has exited.
```

### get item (generic, not found)
```
> ,e echo DRCI.get_item('lockpick')

--- Lich: exec1 active.

[exec1]>get lockpick 

What were you referring to?
> 
[exec1: ]

--- Lich: exec1 has exited.
```