### PR TITLE
[script] [equipmanager] Fixes #4633 to match string "There's no room"

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -361,16 +361,18 @@ class EquipmentManager
     weapon = item_by_desc(description)
     return unless weapon
     if weapon.wield
-      stow_helper("sheath my #{weapon.short_name}", weapon.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'close the fan', 'You secure your', 'You slip', 'You hang', 'You strap', "You don't seem to be able to move", 'You easily strap', 'is too small to hold that', 'With a flick of your wrist you stealthily sheathe', '^The .* slides easily')
+      stow_helper("sheath my #{weapon.short_name}", weapon.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'close the fan', 'You secure your', 'You slip', 'You hang', 'You strap', "You don't seem to be able to move", 'You easily strap', 'is too small to hold that', 'With a flick of your wrist you stealthily sheathe', '^The .* slides easily', "There's no room")
     elsif weapon.worn
       stow_helper("wear my #{weapon.short_name}", weapon.short_name, 'You sling', 'You attach', 'You .* unload', 'You slide', 'You place', 'close the fan', 'You hang', 'You spin', 'You strap', 'You put', 'You carefully loop', "You don't seem to be able to move")
     elsif !weapon.tie_to.nil?
-      stow_helper("tie my #{weapon.short_name} to #{weapon.tie_to}", weapon.short_name, 'You attach', 'close the fan', 'you tie', 'You are a little too busy', "You don't seem to be able to move", 'Your wounds hinder your ability to do that')
+      stow_helper("tie my #{weapon.short_name} to my #{weapon.tie_to}", weapon.short_name, 'You attach', 'close the fan', 'you tie', 'You are a little too busy', "You don't seem to be able to move", 'Your wounds hinder your ability to do that')
     elsif weapon.transforms_to
       stow_helper("#{weapon.transform_verb} my #{weapon.short_name}", weapon.short_name, weapon.transform_text)
       stow_weapon(weapon.transforms_to)
+    elsif weapon.container
+      stow_helper("put my #{weapon.short_name} in my #{weapon.container}", weapon.short_name, "You put .*#{weapon.name}", 'You .* unload', 'close the fan', 'You easily strap', "You don't seem to be able to move", 'You secure', 'is too small to hold that', 'You hang', '^The .* slides easily', "There's no room")
     else
-      stow_helper("stow my #{weapon.short_name}", weapon.short_name, "You put .*#{weapon.name}", 'You .* unload', 'close the fan', 'You easily strap', "You don't seem to be able to move", 'You secure', 'is too small to hold that', 'You hang', '^The .* slides easily')
+      stow_helper("stow my #{weapon.short_name}", weapon.short_name, "You put .*#{weapon.name}", 'You .* unload', 'close the fan', 'You easily strap', "You don't seem to be able to move", 'You secure', 'is too small to hold that', 'You hang', '^The .* slides easily', "There's no room")
     end
   end
 


### PR DESCRIPTION
### Changes
* Fixes #4633
* `stow_weapon` method now matches "There's no room" when it put/stow/sheathe
* `stow_weapon` method now respects `:container:` property on gear
* `stow_weapon` method uses "my" qualifier with tie item's storage


## Tests

### put away loaded weapon in "hold anything" container

GIVEN:
A "hold anything" container with one empty slot left and this config:
```yaml
gear:
- :adjective: assassin's
  :name: longbow
  :container: thigh bag
```

THEN:
```
> ,e echo EquipmentManager.new.stow_weapon

--- Lich: exec1 active.

[exec1]>put my assassin's.longbow in my thigh bag

There's no room in the bag.
> 
[exec1: ]
```

### tie weapon to "my" tie container

GIVEN:
This config:
```yaml
gear:
- :adjective: slender
  :name: quarterstaff
  :tie_to: thornweave lootsack
```

THEN:
```
> ,e EquipmentManager.new.stow_weapon

--- Lich: exec1 active.

[exec1]>tie my slender.quarterstaff to my thornweave lootsack

You attach a slender quarterstaff carved from smokewood and reinforced with audrualm tips to a strap on your thornweave lootsack.
> 
--- Lich: exec1 has exited.
```