### PR TITLE
[script] [transfer-items] Add match strings for "hold anything" containers

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -29,8 +29,8 @@ class ItemTransfer
         case DRC.bput("get #{item} from my #{source}", "You get", "What were you referring to", "You need a free hand", "magical force keeps you from")
         when "You get"
           # Attempt to put the item in the destination container.
-          case DRC.bput("put #{item} in my #{destination}", "You put", "There isn't any more room", "is too long, even after stuffing it", "is too long to fit", "is too small to hold that", "too heavy to go in there", "You just can't get")
-          when "There isn't any more room", "is too long, even after stuffing it", "is too long to fit", "is too small to hold that", "too heavy to go in there", "You just can't get"
+          case DRC.bput("put #{item} in my #{destination}", "You put", "There isn't any more room", "is too long, even after stuffing it", "is too long to fit", "is too small to hold that", "too heavy to go in there", "You just can't get", "There's no room", "Containers can't be placed in")
+          when "There isn't any more room", "is too long, even after stuffing it", "is too long to fit", "is too small to hold that", "too heavy to go in there", "You just can't get", "There's no room", "Containers can't be placed in"
             DRC.message("The #{item} doesn't fit in your #{destination}. The container may be full or too small to hold the item.")
             # Return item to source container.
             # Loop will try to transfer the next item in the list.


### PR DESCRIPTION
### Changes
* Add match strings for "There's no room" and "Containers can't be placed in" to indicate item can't be moved to the new container

## Tests

### try to put a container in a "hold anything" container
```
> ,transfer backpack thigh.bag

--- Lich: transfer-items active.

[transfer-items]>look in backpack

In the hitman's backpack you see a black gem pouch and a sanowret crystal.
> 

[transfer-items]>get pouch from my backpack

You get a black gem pouch from inside your hitman's backpack.
> 
[transfer-items]>put pouch in my thigh.bag

> 
Weirdly, you can't manage to get the black gem pouch to fit.
[Containers can't be placed in the thigh bag, sorry!]
> 
| The pouch doesn't fit in your thigh.bag. The container may be full or too small to hold the item.

[transfer-items]>put pouch in my backpack

You put your pouch in your hitman's backpack.
> 
[transfer-items]>get crystal from my backpack

You get a sanowret crystal from inside your hitman's backpack.
> 
[transfer-items]>put crystal in my thigh.bag

You put your crystal in your thigh bag.

--- Lich: transfer-items has exited.
```