### PR TITLE
[script] [equipmanager] Fix success/failure match strings for transforms

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -292,6 +292,7 @@ class EquipmentManager
     snapshot = [left_hand, right_hand]
     waitrt?
     response = bput("#{data[:verb]} my #{item.short_name}", *data[:matches])
+    waitrt?
     case response
     when *data[:exhausted]
       return false

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -363,7 +363,7 @@ class EquipmentManager
     if weapon.wield
       stow_helper("sheath my #{weapon.short_name}", weapon.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'close the fan', 'You secure your', 'You slip', 'You hang', 'You strap', "You don't seem to be able to move", 'You easily strap', 'is too small to hold that', 'With a flick of your wrist you stealthily sheathe', '^The .* slides easily')
     elsif weapon.worn
-      stow_helper("wear my #{weapon.short_name}", weapon.short_name, 'You sling', 'You attach', 'You .* unload', 'You slide', 'You place', 'close the fan', 'You hang', 'You spin', 'You strap', 'You put', 'You carefully loop', "You don't seem to be able to move")
+      stow_helper("wear my #{weapon.short_name}", weapon.short_name, 'You sling', 'You attach', 'You .* unload', 'You slide', 'You place', 'close the fan', 'You hang', 'You spin', 'You strap', 'You put', 'You carefully loop', "You don't seem to be able to move", "You are already wearing")
     elsif !weapon.tie_to.nil?
       stow_helper("tie my #{weapon.short_name} to #{weapon.tie_to}", weapon.short_name, 'You attach', 'close the fan', 'you tie', 'You are a little too busy', "You don't seem to be able to move", 'Your wounds hinder your ability to do that')
     elsif weapon.transforms_to

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -274,8 +274,8 @@ class EquipmentManager
       },
       transform: {
         verb: item.transform_verb,
-        matches: [item.transform_text, "You'll need a free hand to do that!", "You don't seem to be holding"],
-        failures: [item.transform_text, "You'll need a free hand to do that!", "You don't seem to be holding"],
+        matches: [item.transform_text],
+        failures: ["You'll need a free hand to do that!", "You don't seem to be holding"],
         failure_recovery: proc do |noun|
                             fput('stow left') if left_hand && left_hand !~ /#{noun}/i
                             fput('stow right') if right_hand && right_hand !~ /#{noun}/i


### PR DESCRIPTION
### Background
In get_item_helper, it checks for exhausted then failures then successes match strings, in that order. Since the name of the transformed weapon was in the failures list then on successful transformation the script thought it failed and went through the failure recovery logic. I'm surprised more people haven't run into this issue before. Maybe rare to use transform items?

### Changes
* Remove failure messages from the "matches" list, which is only for successful actions
* Remove success messages from the "failures" list, which is only for unsuccessful actions
* `stow_weapon` to handle that a transformed weapon may already become auto-worn when its transformed to jewelry again
* `get_item_helper` waits for any RT after "getting" the item, such as RT incurred transforming weapon <=> item

## Tests

For each test, assume this config:
```yaml
gear:
- :adjective: carapace
  :name: armband
  :skip_repair: true
  :is_worn: true
  :transforms_to: exoskeletal axe
  :transform_verb: tap
  :transform_text: Your armband breaks apart
  :container: dergatine backpack

- :adjective: exoskeletal
  :name: axe
  :transforms_to: carapace armband
  :transform_verb: shake
  :transform_text: You shake your exoskeletal axe
  :container: dergatine backpack
```

### demonstrate error with current logic when transform item => weapon
```
> ,e EquipmentManager.new.wield_weapon("exoskeletal axe")

--- Lich: exec1 active.

[exec1]>remove my carapace.armband

You remove a thick armband formed by joined segments of blackened carapace from your upper arm.
> 
[exec1]>tap my carapace.armband

You tap your carapace armband.
Your armband breaks apart explosively into thousands of swarming spiders, which scuttle down your arm in a frenzy!  The arachnid wave flows as one, moving with an apparent collective consciousness.  Your hand is covered with twisting and writhing legs, but only briefly as the spiders resolidify into a deep ebony exoskeletal axe.
Roundtime: 3 seconds.

> 
[exec1]>stow right

...wait 3 seconds.
> 
[exec1]>stow right

You put your axe in your dergatine backpack.
> 
[exec1]>remove my armband

You remove a braided cambrinth armband from your upper arm.
> 
[exec1]>tap my carapace.armband

I could not find what you were referring to.
> 
--- Lich: exec1 has exited.
```

### demonstrate fixed logic when transform item => weapon
```
> ,e EquipmentManager.new.wield_weapon("exoskeletal axe")

--- Lich: exec1 active.

[exec1]>remove my carapace.armband

You remove a thick armband formed by joined segments of blackened carapace from your upper arm.
> 
[exec1]>tap my carapace.armband

You tap your carapace armband.
Your armband breaks apart explosively into thousands of swarming spiders, which scuttle down your arm in a frenzy!  The arachnid wave flows as one, moving with an apparent collective consciousness.  Your hand is covered with twisting and writhing legs, but only briefly as the spiders resolidify into a deep ebony exoskeletal axe.
Roundtime: 3 seconds.

> 
--- Lich: exec1 has exited.
```

### demonstrate error with current logic when transform weapon => item
```
> ,e EquipmentManager.new.stow_weapon("exoskeletal axe")

--- Lich: exec1 active.

[exec1]>shake my exoskeletal.axe

You shake your exoskeletal axe, causing it to break apart into thousands of live spiders.  The swarm of arachnids scuttles quickly up your arm, nestling themselves on your person until they finally melt and coagulate into a thick armband formed by joined segments of blackened carapace.
Roundtime: 3 sec.

> 
[exec1]>wear my carapace.armband

> 
You are already wearing that.
>
[exec1: *** No match was found after 15 seconds, dumping info]

[exec1: messages seen length: 1]

[exec1: message: You are already wearing that.]

[exec1: checked against [/You sling/i, /You attach/i, /You .* unload/i, /You slide/i, /You place/i, /close the fan/i, /You hang/i, /You spin/i, /You strap/i, /You put/i, /You carefully loop/i, /You don't seem to be able to move/i]]

[exec1: for command wear my carapace.armband]

--- Lich: exec1 has exited.
```

### demonstrate fixed logic when transform weapon => item
```
> ,e EquipmentManager.new.stow_weapon("exoskeletal axe")

--- Lich: exec1 active.

[exec1]>shake my exoskeletal.axe

You shake your exoskeletal axe, causing it to break apart into thousands of live spiders.  The swarm of arachnids scuttles quickly up your arm, nestling themselves on your person until they finally melt and coagulate into a thick armband formed by joined segments of blackened carapace.
Roundtime: 3 sec.

> 
[exec1]>wear my carapace.armband

You are already wearing that.
> 
--- Lich: exec1 has exited.
```