### PR TITLE
[script] [burgle] Don't need to sneak if you're invisible

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -449,7 +449,7 @@ class Burgle
 
   #specialized move routine - sneaks when in hiding, when needed, moves when not to speed up script
   def burgle_move(direction)
-    if hidden? and @search_count < @burgle_settings['max_search_count'] and !(Flags['burgle-footsteps'])
+    if !invisible? && hidden? and @search_count < @burgle_settings['max_search_count'] and !(Flags['burgle-footsteps'])
       result = bput("sneak #{direction}","Someone Else's Home",'Sneaking is an',"You can't",'In YOUR condition')
       return if /Someone Else's Home/ =~ result
     end


### PR DESCRIPTION
### Background
* Sneaking room-to-room while burgling incurs extra roundtime
* With a finite amount of time to visit rooms and search, every second counts
* While invisible, a character can move rooms and search without extra roundtime of sneaking or hiding

### Changes
* When moving rooms, if you're invisible then don't try to sneak to avoid unnecessary round time
* If a player wants to **sneak** while burgling then they just ensure they aren't invisible
* If a player wants to increase chances of visiting more rooms by reducing roundtime, they just ensure they are invisible

## Tests

### Moon Mage using Refractive Field
_Note, does not sneak and does not incur extra roundtime._
```
[burgle]>burgle

You make short work of the lock on the window and slip inside.

[Someone Else's Home, Kitchen]
Hickory floors lie beneath cloth-of-silver rugs.  A long almiris counter fills the center of the room.
You also see the kitchen window.
Obvious exits: southeast, southwest.

I> 
[burgle]>southwest

You go southwest.
```

### Thief using Khri Silence
_Note, does not sneak and does not incur extra roundtime._
``` 
[burgle]>burgle

You scale up the side of a wall, quickly slipping inside.

[Someone Else's Home, Kitchen]
Flamewood floors lie beneath samite rugs.  A long pumice counter fills the center of the room.
You also see the kitchen window.
Obvious exits: southwest, west.

I> 
[burgle]>southwest

I>
You drift southwest.
```

### When not invisible, but hidden
_Note, does sneak and does incur extra roundtime._
```
[burgle]>burgle

You scale up the side of a wall, quickly slipping inside.

[Someone Else's Home, Kitchen]
Mahogany floors lie beneath wool rugs.  A long shale counter fills the center of the room.
You also see the kitchen window.
Obvious exits: southeast.

H> 
[burgle]>sneak southeast

Roundtime: 6 sec.

You sneak southeast...
```