### PR TITLE
Fixed a small circular logic error.

### DIFF
--- a/invoke-rune.lic
+++ b/invoke-rune.lic
@@ -105,14 +105,11 @@ class Runestone
       waitrt?
       DRCI.dispose_trash(@rune)
       return
-    when 'backfire','The spell pattern resists'
+    when 'backfire','The spell pattern resists', 'Invoke what?'
       return
     when 'You strain, but are too mentally fatigued to finish the pattern'
       DRC.message("Cannot cast this spell currently!")
       out_beep
-    when 'Invoke what?'
-      buy_runestone
-      runestone_cast
     end
     waitcastrt?
     bput("harn #{@harness}", 'You tap into the mana')


### PR DESCRIPTION
The buy_runestone did not abide by the logic of `purchase_runestone.` In thinking about that, just having it return to the unless loop made more sense as it could try the logic again: get another runestone out from the container, purchase a runestone, or exit. 