### PR TITLE
[script] [combat-trainer] Fix #4649 - add 'you turn to face' match string

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2727,7 +2727,7 @@ class AttackProcess
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip')
     end
 
     pause


### PR DESCRIPTION
### Changes
* Fixes #4649
* Add 'You turn to face' as a match string when attacking at melee