### PR TITLE
[script] [pick] Fixes #4654 - handle when grab loose lockpick when ring becomes empty

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -380,7 +380,13 @@ class LockPicker
     return if left_hand
     waitrt?
 
-    case bput('get my lockpick', 'referring to\?', '^You get ')
+    case bput('get my lockpick', 'referring to\?', 'You get')
+    when 'You get'
+      # If we had to find a loose lockpick then either
+      # the player isn't using a lockpick ring or
+      # the lockpick ring is now empty. Toggle setting
+      # so that script will stow the left hand.
+      @settings.use_lockpick_ring = false
     when 'referring to?'
       echo '***OUT OF LOCKPICKS***'
       beep


### PR DESCRIPTION
### Background
* If a lockpick ring becomes empty while picking then the script will try to find a loose one
* However, the setting that we're using a lockpick ring isn't set to false so the script never tries to stow the left hand
* This causes the script to hang when dismantling boxes, among other actions

### Changes
* Fixes #4654 
* If the `find_lockpick` function is invoked and we get a loose lockpick, ensure the `use_lockpick_ring` setting is `false` for remainder of the script run

## Tests

### Getting and stowing loose lockpick when ring becomes empty
GIVEN:
- A loose lockpick is in an open container
- Wearing an empty lockpick ring (or one that becomes empty while picking)
- And using the following config:
```yaml
use_lockpick_ring: true
lockpick_container: lockpick ring
```
THEN:
_The important bit is the "stow left" which wasn't happening before_
```
[pick]>pick my wooden caddy ident

Find a more appropriate tool and try again!
s> 
[pick]>get my lockpick

s> 
You get an ordinary lockpick from inside your thornweave lootsack.
s> 
[pick]>pick my wooden caddy ident

...

[pick]>stow left

You put your lockpick in your hitman's backpack.
s> 
[pick]>open my wooden caddy

...


```