### PR TITLE
Removed nopause_all from script. Could cause capture in burgle if triggered while burgle running.

### DIFF
--- a/pattern-hues.lic
+++ b/pattern-hues.lic
@@ -3,7 +3,6 @@
 =end
 
 custom_require.call(%w(common))
-no_pause_all
 
 class PatternHues
   include DRC
@@ -49,11 +48,10 @@ class PatternHues
     DRC.pause_all
     bput("prep cantrip pattern hues", "You are now prepared to cast the Pattern Hues cantrip.","You already have", "You should stop practicing")
     if @settings.pattern_hues['gesture'] == "random"
-      bput("gesture #{adj.sample} #{color.sample}", "You trace the complex sigils of the Pattern Hues cantrip around yourself.", "You already have", "You gesture", "Something in the area is interfering", "You try, but the dolphin choose")
+      bput("gesture #{adj.sample} #{color.sample}", "You trace the complex sigils of the Pattern Hues cantrip around yourself.", "You already have", "You gesture", "Something in the area is interfering", "You try, but the dolphin choose", 'You should stop practicing')
     else
-      bput("gesture #{@settings.pattern_hues['gesture']}", "You trace the complex sigils of the Pattern Hues cantrip around yourself.", "You already have", "You gesture", "Something in the area is interfering", "You try, but the dolphin choose")
+      bput("gesture #{@settings.pattern_hues['gesture']}", "You trace the complex sigils of the Pattern Hues cantrip around yourself.", "You already have", "You gesture", "Something in the area is interfering", "You try, but the dolphin choose", 'You should stop practicing')
     end
-    bput("hide", "You melt") if Script.running?('burgle')
     DRC.unpause_all
   end
 


### PR DESCRIPTION
**Background:**
A situation arose where pattern-hues triggered while burgle script was running. This trigger added a little time to the burgle limiit and the unlucky participant was caught by the guards. This participant lost his hand from this unfortunate timing.

**Solution:**
Removed `no_pause_all` from script so burgle can pause it during its routine. 

**Bonus:**
Added another catch string for when pattern-hues triggers and one is too busy jamming out on zills (or other instruments). 