### PR TITLE
[script] [common-healing] Support unwrapping others' wounds

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -240,19 +240,18 @@ module DRCH
     wounds
   end
 
-  def bind_wound(part, person = 'my')
+  def bind_wound(body_part, person = 'my')
     snap = [DRC.left_hand, DRC.right_hand]
-    if /You \w+ remove/ =~ DRC.bput("tend #{person} #{part}", 'You work carefully at tending', 'That area has already been tended to', 'That area is not bleeding', 'You fumble', 'too injured for you to do that', 'You \w+ remove')
+    if /You \w+ remove/ =~ DRC.bput("tend #{person} #{body_part}", 'You work carefully at tending', 'That area has already been tended to', 'That area is not bleeding', 'You fumble', 'too injured for you to do that', 'You \w+ remove')
       DRCI.dispose(DRC.left_hand) if DRC.left_hand != snap.first
       DRCI.dispose(DRC.right_hand) if DRC.right_hand != snap.last
-      bind_wound(part, person)
+      bind_wound(body_part, person)
     end
     waitrt?
   end
 
-  def unwrap_wound(part)
-    DRC.bput("unwrap my #{part}", 'You unwrap your bandages') # Are there other messages?
-    pause 5
-    bind_wound(part)
+  def unwrap_wound(body_part, person = 'my')
+    DRC.bput("unwrap #{person} #{body_part}", 'You unwrap .* bandages')
+    waitrt?
   end
 end

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -251,7 +251,7 @@ module DRCH
   end
 
   def unwrap_wound(body_part, person = 'my')
-    DRC.bput("unwrap #{person} #{body_part}", 'You unwrap .* bandages')
+    DRC.bput("unwrap #{person} #{body_part}", 'You unwrap .* bandages', 'That area is not tended')
     waitrt?
   end
 end


### PR DESCRIPTION
### Changes
* `unwrap_wound` now accepts argument for which person's bandages you're unwrapping to match style of `bind_wound`
* Rename `part` variable to `body_part` to be a bit more explicit (it'll align with naming convention of other updates I'll be submitting)
* Use `waitrt?` instead of pausing
* `unwrap_wound` no longer rebinds the wounds, which doesn't make sense considering there is a separate function for that.
  - The only place I noticed `unwrap_wound` being called was the `tendme.lic` script, and it [binds the wound afterwards already](https://github.com/rpherbig/dr-scripts/blob/4dea14b1e38c13be95882914945597a7193efc49/tendme.lic#L80). So of the code we're aware of in this project, there should not be impact with this change.