### PR TITLE
[data] [base-picking] Hopefully fixes #4662

### DIFF
--- a/data/base-picking.yaml
+++ b/data/base-picking.yaml
@@ -59,6 +59,8 @@ picking:
 
   disarm_retry:
   - You work with the trap for a while but are unable to make any progress
+  - Thanks to an instinct provided by your sense of security, you barely avoid
+  - You doubt you'll be this lucky every time
 
   disarm_identify_failed:
   - fails to reveal to you what type of trap protects it


### PR DESCRIPTION
### Changes
* Fixes #4662
* Add disarm messages when [Khri Safe](https://elanthipedia.play.net/Khri_Safe) saves you from blowing a trap, but it still needs to be disarmed

This change is based on review of the `disarm_speed?` method in `pick.lic` script. The method has the [following case statement](https://github.com/rpherbig/dr-scripts/blob/master/pick.lic#L440):

```ruby
    case bput("disarm my #{box} #{speed}", @disarm_failed, @disarm_retry, 'Roundtime')
    when *@disarm_failed
      beep
      beep
      echo('**SPRUNG TRAP**')

      check_danger

      return false
    when *@disarm_retry
      new_speed = reget(10, 'something to shift') ? 'careful' : speed
      return disarm_speed?(box, new_speed)
    end
```

Unless the game output matches `@disarm_failed` or `@disarm_retry`  then the script assumes success. Per #4462, neither a failed nor retry message was found so the script proceeded to pick an armed box and KABOOM.