### PR TITLE
[script] [common-arcana] Match strings to retry activating barb ability

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -81,14 +81,21 @@ module DRCA
 
   def activate_barb_buff(name)
     ability_data = get_data('spells').barb_abilities[name]
-    case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting')
+    case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
+    when 'You must be unengaged'
+      DRC.retreat
+      activate_barb_buff(name)
     when 'You must be sitting'
       DRC.retreat
-      DRC.bput('sit', 'You sit', 'You are already', 'You rise')
+      DRC.bput('sit', 'You sit', 'You are already', 'You rise', 'While swimming?')
       activate_barb_buff(name)
     when 'You should stand'
       DRC.fix_standing
       activate_barb_buff(name)
+    when ability_data['activated_message']
+      true
+    else
+      false
     end
   end
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -72,26 +72,36 @@ module DRCA
     skills
       .reject { |name| DRSpells.active_spells[name] }
       .each do |name|
-        activate_barb_buff(name)
+        activate_barb_buff?(name)
         waitrt?
         pause settings.meditation_pause_timer.to_i if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'
         DRC.fix_standing
       end
   end
 
+  # Deprecated, will be removed in a future update
+  # Use 'activate_babr_buff?' instead.
   def activate_barb_buff(name)
+    activate_barb_buff?(name)
+  end
+
+  def activate_barb_buff?(name)
     ability_data = get_data('spells').barb_abilities[name]
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
     when 'You must be unengaged'
       DRC.retreat
-      activate_barb_buff(name)
+      activate_barb_buff?(name)
     when 'You must be sitting'
       DRC.retreat
-      DRC.bput('sit', 'You sit', 'You are already', 'You rise', 'While swimming?')
-      activate_barb_buff(name)
+      case DRC.bput('sit', 'You sit', 'You are already', 'You rise', 'While swimming?')
+      when 'While swimming?'
+        false # can't sit here, water is too deep
+      else
+        activate_barb_buff?(name)
+      end
     when 'You should stand'
       DRC.fix_standing
-      activate_barb_buff(name)
+      activate_barb_buff?(name)
     when ability_data['activated_message']
       true
     else


### PR DESCRIPTION
### Changes
* Add match string for `While swimming?` when you fail to meditate in water
* Add match string for `You must be unengaged` when you fail to meditate while engaged
* Return `true` if ability activated, `false` otherwise so calling scripts can respond accordingly
* Renamed method to include question mark to indicate it's a predicate, which matches format for `activate_khri?` too