### PR TITLE
[script] [multi] Port 'multi' script for Lich built-in repo to GitHub

### DIFF
--- a/multi.lic
+++ b/multi.lic
@@ -1,0 +1,64 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#multi
+=end
+
+custom_require.call(%w[common])
+
+class Multi
+  include DRC
+
+  def initialize(args = nil)
+    if args.nil? || args.empty?
+      show_usage
+    elsif args[0] == "help"
+      show_help
+    else
+      args[0] = args[0] =~ /,/ ? args[0] : args[0].gsub(';',',')
+      indiv = args[0].split(',')
+      # in case the user puts the num of times at the end instead of the beginning
+      num = indiv[0] =~/^\d+$/ ? indiv.shift.to_i : indiv.pop.to_i
+      num.times {
+        indiv.each{ |thing|
+          # To run a script, prefix its name with either a semicolon ; or a colon :
+          # Genie users will need to use a colon : because smicolons ; are stripped.
+          # To specify arguments for the script, include a spaces between them.
+          if thing !~ /^[;:]/ then
+            fput thing
+            waitrt?
+          else
+            scriptything = thing[1..-1].split(' ')
+            wait_for_script_to_complete(scriptything[0], scriptything[1..-1])
+          end
+        }
+      }
+    end
+
+  end
+
+  def show_help
+    respond "Use a comma to separate number of times,command 1,command 2,etc"
+    respond " "
+    respond "For example:"
+    respond ";multi 2,order 1,buy,stow amulet"
+    respond "Will do the specified commands 2 times: order 1, buy, stow"
+    respond " "
+    respond "It will launch a script for you, too:"
+    respond ";multi 2,get diamond in pouch,;loresing,put diamond in sack"
+    respond " "
+  end
+
+  def show_usage
+    respond "Use a comma to separate number of times,command 1,command 2,etc"
+    respond " "
+    respond "For example:"
+    respond ";multi 2,order 1,buy,stow amulet"
+    respond "Will do the specified commands 2 times: order 1, buy, stow"
+    respond " "
+    respond "It will launch a script for you, too:"
+    respond ";multi 2,get diamond in pouch,;purify,put diamond in sack"
+    respond " "
+  end
+
+end
+
+Multi.new(script.vars)


### PR DESCRIPTION
### Background
* This script is downloadable from Lich's built-in repository but isn't part of our GitHub cannon.
* People use the `multi` script and it's a good candidate to begin managing in version control.

### Changes
* Code is inside of a class now, aptly called `Multi`
* If one of the things you want executed is a script, will wait for that script to complete before moving on to next item in your commands list