### PR TITLE
[script] [hunting-buddy] Exit game if below health threshold

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -256,6 +256,10 @@ class HuntingBuddy
     counter = 0
     loop do
       clear
+      if health < @settings.health_threshold
+        message('***STATUS*** exiting due to low health')
+        fput('exit')
+      end
       if @settings.stop_hunting_if_bleeding && bleeding?
         message('***STATUS*** stopping due to bleeding')
         @stopped_for_bleeding = true


### PR DESCRIPTION
 ### Background
* In the safety process of `combat-trainer`, it will [exit the game](https://github.com/rpherbig/dr-scripts/blob/master/combat-trainer.lic#L889) if your health is below a threshold you set in your YAML.
* The safety process can fail to activate in a timely manner if you are stunned because combat-trainer never proceeds through enough actions to get back to the safety process step of the combat loop or you incur roundtime trying to tend bleeders via the tendme script that gets auto-started, resulting in your death.
* The safety process can fail to activate if [you are bleeding](https://github.com/rpherbig/dr-scripts/blob/master/hunting-buddy.lic#L261) and hunting-buddy [stops combat-trainer script](https://github.com/rpherbig/dr-scripts/blob/master/hunting-buddy.lic#L319) on its own. And if you continue to be stunned and hit by the enemy then hunting-buddy can fail to retreat and get you to a safe room in a timely manner, resulting in your death.

### Changes
* In the event loop, if detect that you're below your health threshold then exit the game (mirror behavior of combat-trainer script)