### PR TITLE
[script] [combat-trainer] choose stance by sorting skills by learning rate then by ranks

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -228,13 +228,12 @@ class SetupProcess
     points = override || previous.values.inject(&:+)
 
     priority = if game_state.current_weapon_stance
-                 game_state.current_weapon_stance[0..1].sort_by { |skill| [DRSkill.getxp(skill), skill] } + [game_state.current_weapon_stance.last]
+                 game_state.sort_by_rate_then_rank(game_state.current_weapon_stance[0..1]) + [game_state.current_weapon_stance.last]
                elsif @priority_defense
                  rest = ['Evasion', 'Parry Ability', 'Shield Usage'] - [@priority_defense]
-                 rest.sort_by! { |skill| [DRSkill.getxp(skill), skill] }
-                 [@priority_defense] + rest
+                 [@priority_defense] + game_state.sort_by_rate_then_rank(rest)
                else
-                 ['Evasion', 'Parry Ability', 'Shield Usage'].sort_by { |skill| [DRSkill.getxp(skill), skill] }
+                 game_state.sort_by_rate_then_rank(['Evasion', 'Parry Ability', 'Shield Usage'])
                end
 
     game_state.parrying = priority.index('Parry Ability') < 2
@@ -3847,6 +3846,23 @@ class GameState
 
   def use_stealth?
     DRSkill.getxp('Stealth') < @combat_training_abilities_target
+  end
+
+  # Given an array of skills, sorts them first by
+  # their learning rate and then by their rank.
+  # For example, if two skills have the same learning rate (e.g. 12/34)
+  # then the skill with fewer ranks will be sorted first.
+  # This avoids repeatedly picking a high rank skill whose learn rate
+  # will be 0/34 because not being challenged and consequently
+  # starving lower rank skills from being chosen.
+  def sort_by_rate_then_rank(skills)
+    skills.sort do |skillA, skillB|
+      compare = DRSkill.getxp(skillA) <=> DRSkill.getxp(skillB)
+      if compare == 0
+        compare = DRSkill.getrank(skillA) <=> DRSkill.getrank(skillB)
+      end
+      compare
+    end
   end
 
   attr_reader :aiming_trainables, :summoned_weapons


### PR DESCRIPTION
### Background
* Choosing a stance based on which skill has 0 learning rate can cause other defensive skills to be starved.
* For example, if the skill with 0 learning rate is too high of rank for the critter you're hunting / backtraining but the other defensive skills could be learning.

### Changes
* When sorting which defensive skill to prioritize in a stance, if the learning rates are the same then choose based on which has fewer ranks.

### Example Scenario
Consider a character with 20 ranks in Parry and 50 ranks in Shield. This character is hunting field goblins that teach between 20-40 ranks. Since the Shield skill's learning rate will be 0/34, or 1/34 at best, then it's repeatedly chosen as the skill to stance into in hopes of increasing its learning rate. However, this can have the unintended consequence of starving out the Parry skill from being chosen. And in doing so, the Parry skill, with far fewer ranks and which needs to be trained, remains at 0/34 learning rate, too.

I actually ran into this issue while trying to train defenses with my non-combat empath. I originally had my `weapon_training:` set to use `Offhand Weapon: kite shield` but later realized that my stances weren't ever changing. That's because in `base.yaml` there's a `stances:` property and the `Offhand Weapon` skill has a specific stance it always uses. This led to my Parry skill falling way behind my Shield skill. I updated my YAML to override `stances:` to avoid a static stance, but then noticed combat-trainer not actually ever switching to Parry stance. That's when I noticed that choosing a stance based on learning rate alone is insufficient to help characters get out of a rut like this.

### Sample Config for Non-Combat Empath
```yaml
# For a non-combat empath that wants to train a held shield,
# list Offhand Weapon as the skill to train and your shield
# as the "weapon". This ensures you hold the shield in your left hand.
# You will not try to block if shield is in your right hand.
weapon_training:
  Offhand Weapon: kite shield

# Override the stances: property so that
# combat-trainer won't use a static stance.
# We want combat-trainer to dynamically
# set our stance to train Evasion, Parry, and Shield.
stances:
```