### PR TITLE
[script] [combat-trainer] add decay messages when try to loot non-stowable items

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -488,7 +488,7 @@ class LootProcess
       return
     end
 
-    case bput("stow #{item}", 'You pick up', 'You get', 'You need a free hand', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything')
+    case bput("stow #{item}", 'You pick up', 'You get', 'You need a free hand', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
     when 'already in your inventory'
       if @gem_nouns.include?(item)
         bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')


### PR DESCRIPTION
### Background
* combat-trainer tries to loot things on the ground that match nouns in `base-items.yaml` `lootables:` property or in a user's `loot_additions:` property.
* The Ranger spell [Deadfall](https://elanthipedia.play.net/Deadfall) summons random nature objects to fall on its victim, such as **rocks** or **branches**.
* These summoned objects fall to the ground and combat-trainer identifies the rocks as lootable ammunition.

### Problem
* You cannot actually pick up the magically summoned rocks or branches created by the Deadfall spell, and combat-trainer is missing match strings to detect this and so the script hangs for 15 seconds waiting for a message that'll never come.
* During this time, you could lose your attention to targeting with a spell or aiming with a bow, or just sit there being pommeled by the enemy.

### Changes
* Add "rapidly decays away" and "cracks and rots away" as match strings when combat-trainer's LootableProcess tries to stow "lootable" items on the ground

## Tests

### Without Fix
```
[combat-trainer]>cast

Your inventory is now arranged in head-to-toe order.
> 
You gesture at a muscular spotted bobcat.
Your cambrinth armband emits a loud *snap* as it discharges all its power to aid your spell.
Small globes of blue and orange light appear and dart upward like fireflies.
Creating an ominous shadow, a large limestone rock falls from above!
Unfortunately, a muscular spotted bobcat manages to avoid the rock.

Roundtime: 2 sec.

> > 
* In a weak and directionless display of aggression, a muscular spotted bobcat claws at you.  You partially block with a blackened target shield displaying a metallochitin tomiek-iguji broodling.  
[You're nimbly balanced and in good position.]
> 
[combat-trainer]>stow rock

The limestone rock rapidly decays away.
 
...

[combat-trainer: *** No match was found after 15 seconds, dumping info]

...

[combat-trainer: message: The limestone rock rapidly decays away.]

[combat-trainer: checked against [/You pick up/i, /You get/i, /You need a free hand/i, /There isn't any more room/i, /You just can't/i, /push you over the item limit/i, /You stop as you realize the .* is not yours/i, /Stow what/i, /already in your inventory/i, /The .* is not designed to carry anything/i]]

[combat-trainer: for command stow rock]

You stop concentrating on aiming your weapon.
```

### With Fix
```
[combat-trainer]>cast

Your inventory is now arranged in head-to-toe order.
> 
You gesture at a muscular spotted bobcat.
Your cambrinth armband emits a loud *snap* as it discharges all its power to aid your spell.
Small globes of blue and orange light appear and dart upward like fireflies.
Creating an ominous shadow, a large limestone rock falls from above!
The rock slams heavily into a muscular spotted bobcat, stunning it!

Roundtime: 2 sec.

> 
You feel fully attuned to the mana streams again.
> 
[combat-trainer]>stow rock

The limestone rock rapidly decays away.

> 
The spotted bobcat begins to advance on you!
The spotted bobcat advances from nearby and is closing steadily.
> 
[combat-trainer]>retreat
```