### PR TITLE
Update herb stock and trade money calls

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -128,7 +128,7 @@ module DRCM
   def deposit_coins(keep_copper, settings, hometown = nil)
     return if settings.skip_bank
     hometown = settings.hometown if hometown == nil
-    
+
     DRCT.walk_to(get_data('town')[hometown]['deposit']['id'])
     DRC.release_invisibility
     DRC.bput('wealth', 'Wealth:')
@@ -142,22 +142,5 @@ module DRCM
 
   def town_currency(town)
     get_data('town')[town]['currency']
-  end
-
-  def get_money_from_specific_bank?(amount_as_string, town)
-    DRCT.walk_to(get_data('town')[town]['deposit']['id'])
-    DRC.release_invisibility
-    loop do
-      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account')
-      when 'The clerk counts', 'You count out'
-        break true
-      when 'The clerk glares at you.', 'Hey!  Slow down!'
-        pause 15
-      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account'
-        break false
-      else
-        break false
-      end
-    end
   end
 end

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -33,8 +33,8 @@ class Herbstock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-    get_money_bank("#{coin_needed / 1000} gold", "#{town_currency(town)}", "#{town}") if (coin_needed / 1000) > 0
-    get_money_bank("#{coin_needed % 1000} copper", "#{town_currency(town)}", "#{town}") if coin_needed > 0
+    get_money_from_bank("#{coin_needed / 1000} gold", "#{town_currency(town)}", "#{town}") if (coin_needed / 1000) > 0
+    get_money_from_bank("#{coin_needed % 1000} copper", "#{town_currency(town)}", "#{town}") if coin_needed > 0
     items_to_restock.each do |item|
       item['buy_num'].times do
         stow_hands

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -52,6 +52,8 @@ class Herbstock
     @settings = get_settings
     @restock = @settings.herbs
     @hometown = @settings.hometown
+    amount, denom = @settings.sell_loot_money_on_hand.split(' ')
+    @keep_copper = convert_to_copper(amount, denom)
     get_settings.storage_containers.each { |container| fput("open my #{container}") }
   end
 

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -33,8 +33,8 @@ class Herbstock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-    get_money_from_specific_bank?("#{coin_needed / 1000} gold #{town_currency(town)}", town) if (coin_needed / 1000) > 0
-    get_money_from_specific_bank?("#{coin_needed % 1000} copper #{town_currency(town)}", town) if coin_needed > 0
+    get_money_bank("#{coin_needed / 1000} gold", "#{town_currency(town)}", "#{town}") if (coin_needed / 1000) > 0
+    get_money_bank("#{coin_needed % 1000} copper", "#{town_currency(town)}", "#{town}") if coin_needed > 0
     items_to_restock.each do |item|
       item['buy_num'].times do
         stow_hands
@@ -45,6 +45,7 @@ class Herbstock
         stow_hands
       end
     end
+    deposit_coins(@keep_copper, @settings, "#{town}")
   end
 
   def setup

--- a/trade.lic
+++ b/trade.lic
@@ -1298,7 +1298,6 @@ class Trade
     return unless time_to_room(Room.current.id, @trading_towns[near_town]['deposit']['id']) < 20.0
 
     walk_to(@town_data[near_town]['deposit']['id'])
-    #minimize_coins(withdraw_amt).each { |amount| get_money_from_specific_bank?(amount, near_town) }
     minimize_coins(withdraw_amt).each { |amount| withdraw_exact_amount?(amount, @settings, "#{near_town}") }
   end
 

--- a/trade.lic
+++ b/trade.lic
@@ -125,7 +125,7 @@ class Trade
       echo 'WAITING FOR BESCORT TO FINISH'
       pause 1 while Script.running?('bescort')
     end
-    
+
     if Room.current.id.nil?
       DRC.message("The script doesn't know what room it's in!  Manually move one room away and return, then everything should resume automatically!")
       pause 1 while Room.current.id.nil?
@@ -1298,7 +1298,8 @@ class Trade
     return unless time_to_room(Room.current.id, @trading_towns[near_town]['deposit']['id']) < 20.0
 
     walk_to(@town_data[near_town]['deposit']['id'])
-    minimize_coins(withdraw_amt).each { |amount| get_money_from_specific_bank?(amount, near_town) }
+    #minimize_coins(withdraw_amt).each { |amount| get_money_from_specific_bank?(amount, near_town) }
+    minimize_coins(withdraw_amt).each { |amount| withdraw_exact_amount?(amount, @settings, "#{near_town}") }
   end
 
   def debugging?


### PR DESCRIPTION
This update removes `def get_money_from_specific_bank?()` as it provides duplicate of `def get_money_from_bank()`. From my updates with other scripts, it appears when restock, herb-stock, and trade were updated or created the creator did not notice one could put the town they wanted in the call from the other scripts and the def only reverts to `settings.hometown` if none was passed in. This update brings these remaining two scripts inline with the way this was to work.

**Dependant on PR 4652: https://github.com/rpherbig/dr-scripts/pull/4652/files.**

**~~I need someone to test the `trade` script to make sure it is working as intended.~~** I have tested the `herb-stock` script. 