### PR TITLE
Added rummage to get_item_list for those with lots of stuff.

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -323,7 +323,7 @@ module DRCI
 
   # Gets a list of items found in a container.
   def get_item_list(container)
-    DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'There is nothing')
+    DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'there is nothing')
     .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
     .split(/(?:, | and )?(?:a|an|some) /)
   end

--- a/common-items.lic
+++ b/common-items.lic
@@ -326,6 +326,11 @@ module DRCI
     DRC.bput("look in #{container}", 'In the .* you see (.*)\.', 'There is nothing')
       .match(/In the .* you see (?:a|an|some) (?<items>.*)\./)[:items]
       .split(/(?:, | and )?(?:a|an|some) /)
+    if reget(5, 'a lot of other stuff')
+      DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'There is nothing')
+      .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
+      .split(/(?:, | and )?(?:a|an|some) /)
+    end
   end
 
   # Puts away an item, optionally into a specific container.

--- a/common-items.lic
+++ b/common-items.lic
@@ -323,14 +323,9 @@ module DRCI
 
   # Gets a list of items found in a container.
   def get_item_list(container)
-    DRC.bput("look in #{container}", 'In the .* you see (.*)\.', 'There is nothing')
-      .match(/In the .* you see (?:a|an|some) (?<items>.*)\./)[:items]
-      .split(/(?:, | and )?(?:a|an|some) /)
-    if reget(5, 'a lot of other stuff')
-      DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'There is nothing')
-      .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
-      .split(/(?:, | and )?(?:a|an|some) /)
-    end
+    DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'There is nothing')
+    .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
+    .split(/(?:, | and )?(?:a|an|some) /)
   end
 
   # Puts away an item, optionally into a specific container.


### PR DESCRIPTION
Found an instance that `transfer-items` was not working because of too many items in the container. I have it set to move my runestones to a specific container for counting and restocking. For restock to work properly one needs all the items in the same container for the count to work otherwise you end up with too many of that item.

```2020-12-30 01:25:44 -0500:>inv search runestone
2020-12-30 01:25:44 -0500:You rummage about your person, looking for something...
2020-12-30 01:25:44 -0500:  Your quartz runestone is in an embroidered backpack depicting a large town by the side of a river.
2020-12-30 01:25:44 -0500:  Your quartz runestone is in an extraordinary zillinen pouch with perfect proportions.
2020-12-30 01:25:44 -0500:  Your quartz runestone is in an extraordinary zillinen pouch with perfect proportions.
2020-12-30 01:25:44 -0500:  Your quartz runestone is in an extraordinary zillinen pouch with perfect proportions.
2020-12-30 01:25:44 -0500:  Your quartz runestone is in an extraordinary zillinen pouch with perfect proportions.

2020-12-30 01:25:59 -0500:>;transfer backpack "zill pouch" runestone
2020-12-30 01:25:59 -0500:--- Lich: transfer-items active.
2020-12-30 01:25:59 -0500:[transfer-items]>look in backpack
2020-12-30 01:25:59 -0500:--- Lich: transfer-items has exited.
2020-12-30 01:26:00 -0500:In the embroidered backpack:
2020-12-30 01:26:00 -0500:armor (3): 
...
2020-12-30 01:26:00 -0500:    **lot of other stuff**
...
```
No transfer occurred because of the bolded lot of other stuff. I added in the code below and the results were:
```2020-12-30 01:46:44 -0500:>;transfer backpack "zill pouch" runestone
2020-12-30 01:46:44 -0500:--- Lich: transfer-items active.
2020-12-30 01:46:44 -0500:[transfer-items]>look in backpack
2020-12-30 01:46:44 -0500:[transfer-items]>rummage my backpack
2020-12-30 01:46:45 -0500:In the embroidered backpack:
2020-12-30 01:46:45 -0500:armor (3): 
...
2020-12-30 01:46:45 -0500:    lot of other stuff

2020-12-30 01:46:45 -0500:[transfer-items]>get runestone from my backpack
2020-12-30 01:46:45 -0500:You get a quartz runestone from inside your embroidered backpack.
2020-12-30 01:46:45 -0500:[transfer-items]>put runestone in my zill pouch
2020-12-30 01:46:46 -0500:You rummage through an embroidered backpack depicting a large town by the side of a river:
2020-12-30 01:46:46 -0500:armor (3): 
...
2020-12-30 01:46:46 -0500:You put your runestone in your zillinen pouch.
2020-12-30 01:46:46 -0500:--- Lich: transfer-items has exited.
```
The transfer of the runestone completed.