### PR TITLE
[script] [spellmonitor] consolidate logic and fix for barbarians

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -144,6 +144,7 @@ spell_action = proc do |server_string|
       spell = Regexp.last_match(1)
       duration = UNKNOWN_DURATION
     end
+    spell.strip!
     if spell
       DRSpells.active_spells[spell] = duration
       DRSpells.refresh_data[spell] = true

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -119,24 +119,24 @@ spell_action = proc do |server_string|
     spell = nil
     duration = nil
     case data
-    when /(?<spell>[^<>]+?)\s+\((?:\D*)(?<duration>\d+)\s*(?:%|roisae?n)\)/
+    when /(?<spell>[^<>]+?)\s+\((?:\D*)(?<duration>\d+)\s*(?:%|roisae?n)\)/i
       # Spell with known duration remaining
       spell = Regexp.last_match[:spell]
       duration = Regexp.last_match[:duration].to_i
-    when /(?<spell>[^<>]+?)\s+\(Fading\)/
+    when /(?<spell>[^<>]+?)\s+\(fading\)/i
       # Spell fading away
       spell = Regexp.last_match[:spell]
       duration = 0
-    when /(?<spell>[^<>]+?)\s+\(Indefinite|OM\)/
+    when /(?<spell>[^<>]+?)\s+\(indefinite|OM\)/i
       # Cyclic spell or Osrel Meraud cyclic spell
       spell = Regexp.last_match[:spell]
       duration = UNKNOWN_DURATION
-    when /(?<spell>[^<>]+?)\s+\(.+\)/
+    when /(?<spell>[^<>]+?)\s+\(.+\)/i
       # Spells with inexact duration verbiage, such as with
       # Barbarians without knowledge of Power Monger mastery
       spell = Regexp.last_match[:spell]
       duration = UNKNOWN_DURATION
-    when /.*orbiting sliver.*/
+    when /.*orbiting sliver.*/i
       # Moon Mage slivers
       DRSpells.slivers = true
     when /^(.*)$/

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -1,15 +1,12 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_development#spellmonitor
 =end
 
-custom_require.call %w[drinfomon]
+custom_require.call(%w[drinfomon])
 no_kill_all
 no_pause_all
-# hide_me
-setpriority(0)
 
-$CYCLICAL = 1001
+setpriority(0)
 
 class DRSpells
   @@active_spells = {}
@@ -43,139 +40,121 @@ class DRSpells
   end
 end
 
-pause 5 # kludge fix for simu's bullshit until they fix it.
-spell_action = if DRStats.barbarian?
-                 proc do |server_string|
-                   if server_string =~ %r{<clearStream id="percWindow"/>}
-                     DRSpells.slivers = false
-                     DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
-                     begin
-                       Thread.new do
-                         sleep 0.5
-                         DRSpells.refresh_data.each do |key, state|
-                           unless state
-                             DRSpells.active_spells.delete(key)
-                             DRSpells.refresh_data.delete(key)
-                           end
-                         end
-                       end
-                     rescue => e
-                       echo(e)
-                       echo('Error in spell monitor')
-                     end
-                   elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisaen\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\((\d+) roisan\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>\s([^<>]+)\s\s\(Fading\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = 0
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisaen\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \((\d+) roisan\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Indefinite\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = $CYCLICAL # is there a better solution?
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(OM\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{<pushStream id="percWindow"/>.*orbiting sliver.*}
-                     DRSpells.slivers = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s*$}
-                     DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>\s+\((\d+)%\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{pushStream id="percWindow"/>(.+)<popStream/><pushStream id="percWindow"/>  \(Fading\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = 0
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{<pushStream id="percWindow"/> (.*) \((\d+) roisaen\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   elsif server_string =~ %r{<popStream/><pushStream id="percWindow"/> (.+) \((\d+) roisaen\)}
-                     DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                     DRSpells.refresh_data[Regexp.last_match(1)] = true
-                   end
+# Some spells may last for an unknown duration,
+# such as cyclic spells that last as long as
+# the caster can harness mana for it.
+# Or, barbarian abilities when the character
+# doesn't have Power Monger mastery to see true
+# durations but only vague guestimates.
+# In those situations, we set use this value.
+UNKNOWN_DURATION = 1000
 
-                   server_string
-                 end
-               else
-                 proc do |server_string|
-                   if server_string =~ %r{<clearStream id="percWindow"/>}
-                     DRSpells.slivers = false
-                     DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
-                     begin
-                       Thread.new do
-                         sleep 0.5
-                         DRSpells.refresh_data.each do |key, state|
-                           unless state
-                             DRSpells.active_spells.delete(key)
-                             DRSpells.refresh_data.delete(key)
-                           end
-                         end
-                       end
-                     rescue => e
-                       echo(e)
-                       echo('Error in spell monitor')
-                     end
+# This method receives a line of data from DragonRealms
+# and determines if it refers to active spells on the character.
+# It keeps the global class DRSpells updated with such data
+# that then other scripts can take advantage of.
+#
+# The XML stream for DragonRealms is whack at best.
+#
+# Examples of the data we're looking for:
+#     <clearStream id="percWindow"/>
+#     <pushStream id="percWindow"/> Wildfire (thoroughly inflamed)
+#     <popStream/><pushStream id="percWindow"/> Avalanche (thoroughly inflamed)
+#     <popStream/><pushStream id="percWindow"/>Righteous Wrath  (8 roisaen)
+#     Rage of the Clans  (4 roisaen)
+#     <popStream/><prompt time="1609379003">&gt;</prompt>
+#
+# <clearStream> indicates that the following tags are the latest active spells snapshot.
+#
+# <pushStream id="percWindow"> indicates a spell or spells that are active and their duration.
+#
+# <popStream/> indicates the end of content for the prior listed spell or spells for the <pushStream> tag.
+#
+# One or more spells may be listed between a <pushStream/> <popStream/> pair,
+# but only one spell and its duration are ever listed per line.
+#
+spell_action = proc do |server_string|
+  # New information about active spells, reset our cached data.
+  if server_string =~ %r{<clearStream id="percWindow"/>}
+    DRSpells.slivers = false
+    DRSpells.refresh_data.each_key { |k| DRSpells.refresh_data[k] = false }
+    begin
+      Thread.new do
+        sleep 0.5
+        DRSpells.refresh_data.each do |key, state|
+          unless state
+            DRSpells.active_spells.delete(key)
+            DRSpells.refresh_data.delete(key)
+          end
+        end
+      end
+    rescue StandardError => e
+      echo(e)
+      echo('Error in spell monitor')
+    end
+    next server_string
+  end
 
-                     next server_string
-                   end
+  # Abilities may be prefixed or suffixed by
+  # a control character that appears like whitespace
+  # but isn't whitespace so 'strip' doesn't remove it.
+  # Replace all instances of codepoint 32 with ' '.
+  data = server_string.dup.gsub(32.chr, ' ').strip
 
-                   data = server_string.dup
-                   if server_string =~ %r{pushStream id="percWindow"/>}
-                     DRSpells.grabbing_spell_data = true
-                     data.slice!(0, 29)
-                   end
+  # Indicates we're done with the prior <pushStream/> tag.
+  # However, the next characters in the line might be
+  # another <pushStream/> or something else, so keep going.
+  if data =~ %r{^<popStream/>}
+    DRSpells.grabbing_spell_data = false
+    data.slice!(0, 12).strip!
+  end
 
-                   if DRSpells.grabbing_spell_data
-                     if server_string =~ %r{popStream/}
-                       DRSpells.grabbing_spell_data = false
-                       next server_string
-                     end
+  # The start of one or more active spells!
+  if data =~ %r{^<pushStream id="percWindow"/>}
+    DRSpells.grabbing_spell_data = true
+    data.slice!(0, 29).strip!
+  end
 
-                     case data
-                     when /([^<>]+)\s\s\((\d+) roisaen\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /([^<>]+)\s\s\((\d+) roisan\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /([^<>]+)\s\s\(.+\s(\d+) roisaen\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /([^<>]+)\s\s\(.+\s(\d+) roisan\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /([^<>]+)\s\s\(Fading\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = 0
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /(.+)  \(Indefinite\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = $CYCLICAL # is there a better solution?
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /(.+)  \(OM\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /.*orbiting sliver.*/
-                       DRSpells.slivers = true
-                     when /(.+)  \((\d+)%\)/
-                       DRSpells.active_spells[Regexp.last_match(1)] = Regexp.last_match(2).to_i
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     when /^*$/
-                       DRSpells.active_spells[Regexp.last_match(1)] = 1000 # is there a better solution?
-                       DRSpells.refresh_data[Regexp.last_match(1)] = true
-                     end
-                   end
+  if DRSpells.grabbing_spell_data
+    spell = nil
+    duration = nil
+    case data
+    when /(?<spell>[^<>]+?)\s+\((?:\D*)(?<duration>\d+)\s*(?:%|roisae?n)\)/
+      # Spell with known duration remaining
+      spell = Regexp.last_match[:spell]
+      duration = Regexp.last_match[:duration].to_i
+    when /(?<spell>[^<>]+?)\s+\(Fading\)/
+      # Spell fading away
+      spell = Regexp.last_match[:spell]
+      duration = 0
+    when /(?<spell>[^<>]+?)\s+\(Indefinite|OM\)/
+      # Cyclic spell or Osrel Meraud cyclic spell
+      spell = Regexp.last_match[:spell]
+      duration = UNKNOWN_DURATION
+    when /(?<spell>[^<>]+?)\s+\(.+\)/
+      # Spells with inexact duration verbiage, such as with
+      # Barbarians without knowledge of Power Monger mastery
+      spell = Regexp.last_match[:spell]
+      duration = UNKNOWN_DURATION
+    when /.*orbiting sliver.*/
+      # Moon Mage slivers
+      DRSpells.slivers = true
+    when /^(.*)$/
+      # No idea what we received, just a general catch all
+      spell = Regexp.last_match(1)
+      duration = UNKNOWN_DURATION
+    end
+    if spell
+      DRSpells.active_spells[spell] = duration
+      DRSpells.refresh_data[spell] = true
+    end
+  end
+  server_string
+end
 
-                   server_string
-                 end
-               end
+# Unsure the historical significance of this pause
+# https://github.com/rpherbig/dr-scripts/commit/04b7474b21c809d960ccb0c720808b44ae0f1ff8
+pause 5
 
 DownstreamHook.remove('spell_action')
 DownstreamHook.add('spell_action', spell_action)
@@ -185,4 +164,6 @@ before_dying do
 end
 
 until script.gets.nil?
+  # Keep script alive while game is connected
+  # so that we continue to receive and parse data.
 end


### PR DESCRIPTION
### Background
* While playing a barbarian without the [Powermonger](https://elanthipedia.play.net/Powermonger) mastery, noticed that `DRSpells.active_spells` was empty despite having multiple abilities and buffs on.
* Prompted [this](https://discord.com/channels/745675889622384681/745675890242879671/794012967652950017) Discord question.
* Which led to [this](https://discord.com/channels/745675889622384681/745696628714897508/794040128308903977) Discord journey.
* Upon review, the regular expressions for the barbarian and non-barbarian code paths weren't really that different and the XML stream received as a Barbarian, Warrior Mage, Paladin, Moon Mage, and Ranger -- with and without cyclics, and with and without buffs from wands or self-cast buffs -- were consistent.

### Changes
* Consolidate the logic for parsing spells -- there are no longer guild specific code paths
* Use named groups in regular expressions to simplify extracting matches (e.g. spell name and duration)
* Handle oddity where DragonRealms uses unicode codepoint 32 as "whitespace" before/within/after spell names and could not be trimmed via Ruby's [String.strip](https://ruby-doc.org/core-2.5.5/String.html#method-i-strip) method
* Document the XML data that's being parsed and scenarios that each regular expression is matching for