### PR TITLE
[script] [combat-trainer] Move to next weapon to train when out of ammo

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -197,9 +197,15 @@ class SetupProcess
       echo('skipping summoned weapons because no moonblade available') if $debug_mode_ct
       weapon_training = weapon_training.reject { |skill, _| game_state.summoned_info(skill) }
     end
-    new_weapon_skill = weapon_training.min_by { |skill, _| [DRSkill.getxp(skill), @priority_weapons.include?(skill) ? -1 : 0, DRSkill.getrank(skill)] }.first
-    game_state.update_weapon_info(new_weapon_skill)
 
+    # Exclude current skill so that a new one is selected.
+    new_weapon_skill = weapon_training
+      .reject { |skill, _| skill == game_state.weapon_skill }
+      .min_by { |skill, _| [DRSkill.getxp(skill), @priority_weapons.include?(skill) ? -1 : 0, DRSkill.getrank(skill)] }.first
+
+    # Update weapon skill to train next, if a new one was chosen.
+    # If you're training exactly one weapon then won't change.
+    game_state.update_weapon_info(new_weapon_skill) if new_weapon_skill
     game_state.update_target_weapon_skill
   end
 
@@ -2883,11 +2889,21 @@ class AttackProcess
         end
       else
         fput('load')
-        pause 0.5 until bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand') != ''
+        case bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition")
+        when "As you try to reach", "You don't have the proper ammunition"
+          DRC.message("Out of ammunition for #{game_state.weapon_name}, dancing until can switch to next weapon")
+          game_state.loaded = false
+          game_state.clear_aim_queue
+          dance(game_state)
+          # Increment action count so that the script
+          # will eventually progress to next skill to train.
+          game_state.action_taken(99)
+        else
+          game_state.loaded = true
+        end
       end
 
       waitrt?
-      game_state.loaded = true
       unless game_state.selected_maneuver
         game_state.set_aim_queue
         aim(game_state)
@@ -2935,6 +2951,8 @@ class AttackProcess
       when 'You attempt to ready your repeating arbalest'
         game_state.loaded = false
       end
+    when "isn't loaded"
+      game_state.loaded = false
     when 'Face what?'
       game_state.clear_aim_queue
     when 'Strangely, you don\'t feel like fighting right now'
@@ -3610,12 +3628,12 @@ class GameState
     @action_count = 0
   end
 
-  def action_taken
-    @action_count += 1
+  def action_taken(count = 1)
+    @action_count += count
   end
 
-  def action_reduce
-    @action_count -= 1
+  def action_reduce(count = 1)
+    @action_count -= count
   end
 
   def set_aim_queue


### PR DESCRIPTION
### Background
* If you run out of ammunition, combat-trainer gets stuck in a loop trying to load your weapon.
* Result is your character standing still, getting pommeled by the enemy, possibly resulting in your death.

```
[combat-trainer]>load

You don't have the proper ammunition readily available for your riot crossbow.
> 
* Awkwardly, a copperhead viper coils up and strikes at you.  You dodge, bending aside easily.  
[You're badly hurt, solidly balanced and in better position.]
....
> 
[combat-trainer: *** No match was found after 15 seconds, dumping info]

[combat-trainer: messages seen length: 12]

[combat-trainer: message: [You're solidly balanced and in dominating position.]]

[combat-trainer: message: * Awkwardly, a copperhead viper coils up and strikes at you.  You dodge, bending aside easily.   ]

[combat-trainer: message: [You're badly hurt, solidly balanced and in better position.]]

[combat-trainer: message: You don't have the proper ammunition readily available for your riot crossbow.]

[combat-trainer: checked against [/You reach into/i, /You carefully load/i, /already loaded/i, /in your hand/i]]

[combat-trainer: for command load]

[combat-trainer]>load

You don't have the proper ammunition readily available for your riot crossbow.
```
That repeats until you die or combat-trainer ends, womp womp...

### Changes
* Detect when you're out of ammunition and prompt combat-trainer to switch to the next weapon.
* This ensures you continue to hunt and train your other weapons (and stay alive!).

```
[combat-trainer]>load

* In a weak and directionless display of aggression, a copperhead viper coils up and strikes suddenly at you.  You dodge, leaping aside like a cunning cat.  
[You're solidly balanced and in strong position.]
> 
[combat-trainer]>load

You don't have the proper ammunition readily available for your blackwood latchbow.
> 
You don't have the proper ammunition readily available for your blackwood latchbow.
> 
| Out of ammunition for blackwood latchbow, dancing until can switch to next weapon

[combat-trainer]>circle

* As if fumbling muscle flab were natural, a copperhead viper coils up and strikes suddenly at you.  You block with a gleaming steel Grey Raven guard's shield.  
[You're solidly balanced with opponent in better position.]
> 
You fake a copperhead viper, first moving one way and then another, leaving it off balance.
[You're nimbly balanced and in dominating position.]
Roundtime: 4 sec.
> 
* As if effort and skill were a bad thing, a copperhead viper coils up and strikes suddenly at you.  You dodge, moving cleanly out of the way.  
[You're nimbly balanced and in good position.]
> 
[combat-trainer]>aim

Your blackwood latchbow isn't loaded!

[combat-trainer]>wear my blackwood.latchbow

You sling a blackwood latchbow with with a steelsilk wrapped stock over your shoulder.
> 
[combat-trainer]>stance set 100 82 0

Setting your Evasion stance to 100%, your Parry stance to 82%, and your Shield stance to 0%.  You have 0 stance points left.

...
```
With the updated code, once detect you're out of ammo and the ranged attack cycle ends then you switch to a new weapon and keep on hunting. Woot!

### Workarounds
* Keep a healthy stock of ammunition on  you before hunting, more than you think you'll burn through/lose. The `restock` script can help with this.
* If you use a repeating crossbow, ensure you carry more ammo than can be loaded into it otherwise combat-trainer will try to load your weapon and get stuck in the loop because it doesn't find any loose ammo (it's all loaded in your repeater).