### PR TITLE
[script] [almanac] of skills not learning, choose lowest ranked skill

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -30,7 +30,7 @@ class Almanac
     unless @almanac_skills.empty?
       training_skill = @almanac_skills
                        .select { |skill| DRSkill.getxp(skill) < 18 }
-                       .sort_by { |skill| DRSkill.getxp(skill) }.first
+                       .sort_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }.first
       return unless training_skill
     end
 


### PR DESCRIPTION
### Changes
* For any two skills that could be selected for almanac that have the same learning rate, choose the one with fewer ranks.

### Explanation

Original behavior is preserved. If you have two skills with different learning rates: `Forging 20 (2/34)` and `Enchanting 10 (8/34)`, Forging would be chosen this time because it has the lowest learning rate of the two.

New behavior prioritizes lowest ranked skills as tie breaker. In the same example but this time with same learning rates, `Forging 20 (0/34)` and `Enchanting 10 (0/34)`, then Enchanting would be chosen because it has fewer ranks.

This takes some random selection out of the equation and makes skill selection more deterministic.