### PR TITLE
[script] [charge-holy-weapon] fix typo "fainly" => "faintly"

### DIFF
--- a/charge-holy-weapon.lic
+++ b/charge-holy-weapon.lic
@@ -28,7 +28,7 @@ class HolyWeapon
   def check_charge_level(hw_settings)
     @em.wield_weapon(hw_settings['weapon_name'])
 
-    case bput("look my #{hw_settings['weapon_name']}", 'barely detectable', 'flickering', 'barely glowing', 'fainly', 'shining', 'emanating', 'blinding')
+    case bput("look my #{hw_settings['weapon_name']}", 'barely detectable', 'flickering', 'barely glowing', 'faintly', 'shining', 'emanating', 'blinding')
     when 'barely detectable', 'flickering'
       complete_ritual(hw_settings)
     when 'barely glowing'


### PR DESCRIPTION
### Background
* Reported by Madigan in [Lich discord](https://discord.com/channels/745675889622384681/745678209449853049/795364131951345704)

```
[charge-holy-weapon]>look my glaes greatsword
Your greatsword is faintly glowing with holy power.
 
The extra long hilt of this blade is capped with a heavy steel pommel designed to counter balance the length of the weapon.  Forming the protective crossguard, a pair of sinuous silver dragons, wings outstretched, mirror each other clasping a pristine white Therengian rose between the them.
>

[charge-holy-weapon: *** No match was found after 15 seconds, dumping info]
[charge-holy-weapon: messages seen length: 14]
[charge-holy-weapon: message: Your greatsword is faintly glowing with holy power.]
[charge-holy-weapon: checked against [/barely detectable/i, /flickering/i, /barely glowing/i, /fainly/i, /shining/i, /emanating/i, /blinding/i]]
[charge-holy-weapon: for command look my glaes greatsword]
[charge-holy-weapon]>sheath my glaes.greatsword
You put your greatsword in your claymore sheath.
You sheathe the glaes greatsword in your claymore sheath.
--- Lich: charge-holy-weapon has exited.
```

### Changes
* Fix typo "fainly" => "faintly"