### PR TITLE
[script] [combat-trainer] Fix: dual load arrows to support when out of ammo

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2882,7 +2882,8 @@ class AttackProcess
     else
       dual_load = game_state.dual_load?
 
-      if dual_load
+        # Occasionally, there may be no game output after loading.
+        # To be on the safe side, we do two attempts to get output.
         fput('load arrows')
         case bput('load arrows', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')
         when "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands'
@@ -2894,6 +2895,8 @@ class AttackProcess
       end
 
       unless dual_load
+        # Occasionally, there may be no game output after loading.
+        # To be on the safe side, we do two attempts to get output.
         fput('load')
         case bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition")
         when "As you try to reach", "You don't have the proper ammunition"

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2883,6 +2883,7 @@ class AttackProcess
       dual_load = game_state.dual_load?
 
       if dual_load
+        fput('load arrows')
         case bput('load arrows', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')
         when "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands'
           dual_load = false # fallback to single load
@@ -2893,6 +2894,7 @@ class AttackProcess
       end
 
       unless dual_load
+        fput('load')
         case bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition")
         when "As you try to reach", "You don't have the proper ammunition"
           DRC.message("Out of ammunition for #{game_state.weapon_name}, dancing until can switch to next weapon")

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2882,6 +2882,7 @@ class AttackProcess
     else
       dual_load = game_state.dual_load?
 
+      if dual_load
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
         fput('load arrows')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2880,14 +2880,19 @@ class AttackProcess
         waitrt?
       end
     else
-      if game_state.dual_load?
-        fput('load arrows')
-        pause 0.5 until (load_return = bput('load arrows', 'You reach into', 'already loaded', 'in your hand', 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')) != ''
-        if ['but are unable to draw upon its majesty', 'without steadier hands', 'Such a feat would be impossible without the winds to guide'].include?(load_return)
-          pause 0.5 until bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand') != ''
+      dual_load = game_state.dual_load?
+
+      if dual_load
+        case bput('load arrows', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')
+        when "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands'
+          dual_load = false # fallback to single load
+          game_state.loaded = false
+        else
+          game_state.loaded = true
         end
-      else
-        fput('load')
+      end
+
+      unless dual_load
         case bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition")
         when "As you try to reach", "You don't have the proper ammunition"
           DRC.message("Out of ammunition for #{game_state.weapon_name}, dancing until can switch to next weapon")


### PR DESCRIPTION
### Background
* Reported by Galtha in [Lich discord](https://discord.com/channels/745675889622384681/745675890242879671/795444494421852221) that they were repeatedly trying to dual load arrows.

### Changes
* Update the dual load logic to handle when out of ammo like previously done for single load
* If lack the buff or skill to dual load, falls back to single load
* Remove redundant `fput` and looping of `bput` 

### Tests
* Fix confirmed by Galtha (I don't have dual load ability yet)