### PR TITLE
[script] [combat-trainer] Fix dynamic dance for use with sort_by_rate_then_rank

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3488,7 +3488,7 @@ class GameState
 
   def dance
     if @dynamic_dance_skill
-      filtered_skills = weapon_training.reject { |skill, _| $non_dance_skills.include?(skill) }
+      filtered_skills = weapon_training.keys.reject { |skill| $non_dance_skills.include?(skill) }
       @dance_skill = sort_by_rate_then_rank(filtered_skills).first
     end
     update_weapon_info(@dance_skill)


### PR DESCRIPTION
### Background
* If you have `dynamic_dance_skill` configured in your YAML then https://github.com/rpherbig/dr-scripts/pull/4686 inadvertently introduced a bug that will fail to select a weapon skill.

```
[combat-trainer: failed to match a weapon for :["Small Blunt", "throwing club"]]
```

### Changes
* Use `weapon_training.keys`  to process the skill names.