### PR TITLE
[script] [charge-holy-weapon] Code style updates: DRC module prefixes, use DRCI to get/stow items

### DIFF
--- a/charge-holy-weapon.lic
+++ b/charge-holy-weapon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#charge-holy-weapon
 =end
 
-custom_require.call(%w[drinfomon common common-travel equipmanager])
+custom_require.call(%w[common common-travel drinfomon equipmanager])
 
 class HolyWeapon
   include DRC
@@ -18,7 +18,7 @@ class HolyWeapon
     @em = EquipmentManager.new(settings)
 
     unless hw_settings
-      message "No paladin settings found, please check your YAML settings. Exiting..."
+      DRC.message("No paladin settings found, please check your YAML settings. Exiting...")
       exit
     end
 
@@ -28,19 +28,19 @@ class HolyWeapon
   def check_charge_level(hw_settings)
     @em.wield_weapon(hw_settings['weapon_name'])
 
-    case bput("look my #{hw_settings['weapon_name']}", 'barely detectable', 'flickering', 'barely glowing', 'faintly', 'shining', 'emanating', 'blinding')
+    case DRC.bput("look my #{hw_settings['weapon_name']}", 'barely detectable', 'flickering', 'barely glowing', 'faintly', 'shining', 'emanating', 'blinding')
     when 'barely detectable', 'flickering'
       complete_ritual(hw_settings)
     when 'barely glowing'
-      message "200 estimated charges remain, skipping..."
+      DRC.message("200 estimated charges remain, skipping...")
     when 'faintly'
-      message "350 estimated charges remain, skipping..."
+      DRC.message("350 estimated charges remain, skipping...")
     when 'shining'
-      message "500 estimated charges remain, skipping..."
+      DRC.message("500 estimated charges remain, skipping...")
     when 'emanating'
-      message "1000 estimated charges remain, skipping..."
+      DRC.message("1000 estimated charges remain, skipping...")
     when 'blinding'
-      message "1500 estimated charges remain, skipping..."
+      DRC.message("1500 estimated charges remain, skipping...")
     end
 
     @em.stow_weapon(hw_settings['weapon_name'])
@@ -55,65 +55,54 @@ class HolyWeapon
     @em.stow_weapon(weapon)
 
     unless name
-      message "No icon found, using #{@hometown}'s chapel to complete the ritual!"
+      DRC.message("No icon found, using #{@hometown}'s chapel to complete the ritual!")
       altar_room_ritual(weapon, @altar_room)
     else
-      message "Icon -#{name}- found, moving to room #{room} to complete the ritual!"
+      DRC.message("Icon -#{name}- found, moving to room #{room} to complete the ritual!")
       icon_ritual(weapon, name, room, container)
     end
   end
 
   def altar_room_ritual(weapon, room)
-    walk_to(room)
+    DRCT.walk_to(room)
 
-    case bput('pray chadatru', 'not cleared enough to pay proper respect to Chadatru', 'You decide to wait awhile longer')
+    case DRC.bput('pray chadatru', 'not cleared enough to pay proper respect to Chadatru', 'You decide to wait awhile longer')
     when 'not cleared enough to pay proper respect to Chadatru'
-      message "Waiting for the prayer to finish (should take no longer than 2 minutes)..."
+      DRC.message("Waiting for the prayer to finish (should take no longer than 2 minutes)...")
       waitfor('soothing sensation washes over your soul.')
-
       glyph_of_renew(weapon)
     when 'You decide to wait awhile longer'
-      message "You're not ready to recharge yet, exiting!"
+      DRC.message("You're not ready to recharge yet, exiting!")
     end
 
     exit
   end
 
   def icon_ritual(weapon, name, room = @altar_room, container)
-    walk_to(room)
+    DRCT.walk_to(room)
 
-    command = "get my #{name}"
-    if container
-      bput("open my #{container}", 'You open', 'That is already')
-      command << " in my #{container}"
-    end
-    
-    case bput(command, 'You get', 'What were')
-    when 'You get'
-      icon_routine(name)
-      if container
-        bput("put my #{name} in my #{container}", 'You put')
-      else
-        bput("stow my #{name}", 'You put')
-      end
-      glyph_of_renew(weapon)
-    when 'What were'
-      message "Icon not found! Exiting..."
+    DRCI.open_container?(container)
+    unless DRCI.get_item_if_not_held?(name, container)
+      DRC.message("Icon not found! Exiting...")
       exit
     end
+
+    icon_routine(name)
+    DRCI.put_away_item?(name, container)
+    glyph_of_renew(weapon)
   end
 
   def icon_routine(name)
     3.times{DRC.bput("clean my #{name}", 'You carefully', 'You turn', 'You inspect')}
-    bput("hug my #{name}", 'You drop')
-    bput("focus my #{name}", 'Unaware of what')
-    bput("pray my #{name}", 'You breathe out')
-    fix_standing
+    DRC.bput("hug my #{name}", 'You drop')
+    DRC.bput("focus my #{name}", 'Unaware of what')
+    DRC.bput("pray my #{name}", 'You breathe out')
+    DRC.fix_standing
   end
 
   def glyph_of_renew(weapon)
     @em.wield_weapon(weapon)
-    bput("glyph renew my #{weapon}", 'You trace')
+    DRC.bput("glyph renew my #{weapon}", 'You trace')
     @em.stow_weapon(weapon)
   end
 end


### PR DESCRIPTION
### Background
* As the team works on scripts, we've been updating the code style to ensure use of DRC module prefixes to clarify where those methods come from, and consolidating logic for get/stow items to use common-items utility.

### Changes
* Adds `DRC` module prefix to methods such as `bput`, and `message`
* Refactored the get/stow of the holy icon to use `DRCI.open_container?`, `DRCI.get_item_if_not_held?`, and `DRCI.put_away_item?`

## Tests
_[Madigan](https://discord.com/channels/745675889622384681/745678209449853049/795799741039902732) in the Lich discord tested the changes._

### charge holy weapon
```
;charge-holy-weapon working like a charm with my icon FYI.

The only change I would recommend is removing the two lower "checks".  Once you get down below 200 strikes, you really need to re-charge. I have manually changed that for my version, but that is probably a global change that would be useful IMO.

I still need to check if it charges without an icon.  I will do that this evening.
```

### skip when holy weapon has all charges
```
>;charge-holy-weapon
--- Lich: charge-holy-weapon active.
[charge-holy-weapon]>wield my glaes.greatsword
You draw out your glaes greatsword from the claymore sheath, gripping it firmly in your right hand and balancing with your left.
>
[charge-holy-weapon]>look my glaes greatsword
Your greatsword is blinding you with holy power.
 
The extra long hilt of this blade is capped with a heavy steel pommel designed to counter balance the length of the weapon.  Forming the protective crossguard, a pair of sinuous silver dragons, wings outstretched, mirror each other clasping a pristine white Therengian rose between the them.
>
| 1500 estimated charges remain, skipping...
[charge-holy-weapon]>sheath my glaes.greatsword
You put your greatsword in your claymore sheath.
You sheathe the glaes greatsword in your claymore sheath.
>
--- Lich: charge-holy-weapon has exited.
```