### PR TITLE
[script] [spellmonitor] Fix: add parens to support OR expression

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -127,7 +127,7 @@ spell_action = proc do |server_string|
       # Spell fading away
       spell = Regexp.last_match[:spell]
       duration = 0
-    when /(?<spell>[^<>]+?)\s+\((?:indefinite|om)\)/i
+    when /(?<spell>[^<>]+?)\s+\((?<duration>indefinite|om)\)/i
       # Cyclic spell or Osrel Meraud cyclic spell
       spell = Regexp.last_match[:spell]
       duration = UNKNOWN_DURATION

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -127,7 +127,7 @@ spell_action = proc do |server_string|
       # Spell fading away
       spell = Regexp.last_match[:spell]
       duration = 0
-    when /(?<spell>[^<>]+?)\s+\(indefinite|OM\)/i
+    when /(?<spell>[^<>]+?)\s+\((?:indefinite|om)\)/i
       # Cyclic spell or Osrel Meraud cyclic spell
       spell = Regexp.last_match[:spell]
       duration = UNKNOWN_DURATION


### PR DESCRIPTION
### Background
* The recent update to spellmonitor per https://github.com/rpherbig/dr-scripts/pull/4679 introduced a bug for Clerics using the Osrel Meraud spell -- the regex was not performing an OR between `indefinite|om` because the parens in that expression were actually escaped to match literally, not as a "either this or that" expression.
* This caused combat-trainer to repeatedly try to cast buffs because it didn't realize the spells were active.

### Changes
* Add () around `indefinite|om` regex to be an OR expression

## Tests

_[Koujia](https://discord.com/channels/745675889622384681/745676326190579843/796257768154726432) in the Lich discord tested the change._

```
--- Lich: exec1 active.

[exec1: {"Osrel Meraud"=>75, "Benediction"=>1000, "Shield of Light"=>1000, "Minor Physical Protection"=>1000, "Persistence of Mana"=>1000}]
```

