### PR TITLE
Stage 1 of runestones working with buff and combat-trainer.

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -109,22 +109,31 @@ module DRCA
     end
   end
 
-  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false)
+  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false, runestone_name = '', runestone_tm = false)
     return false unless abbrev
 
     DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 
-    match = DRC.bput("#{command} #{abbrev} #{mana}", get_data('spells').prep_messages)
+    if runestone_name.nil?
+      match = DRC.bput("#{command} #{abbrev} #{mana}", get_data('spells').prep_messages)
+    else
+      match = DRC.bput("#{command} my #{runestone_name}", get_data('spells').invoke_messages)
+    end
     case match
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
-      return prepare?(abbrev, mana, symbiosis, command, tattoo_tm)
+      return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
     when 'Something in the area interferes with your spell preparations'
       DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
       return false
+    when 'Well, that was fun'
+      DRCI.dispose_trash(runestone_name)
+      return false
+    when 'You\'ll have to hold it'
+      return false
     end
 
-    DRC.bput("target", get_data('spells').prep_messages) if tattoo_tm
+    DRC.bput("target", get_data('spells').prep_messages) if tattoo_tm || runestone_tm
 
     match
   end
@@ -138,7 +147,7 @@ module DRCA
     command = spell['prep'] if spell['prep']
     command = spell['prep_type'] if spell['prep_type']
 
-    return unless prepare?(spell['abbrev'], spell['mana'], spell['symbiosis'], command)
+    return unless prepare?(spell['abbrev'], spell['mana'], spell['symbiosis'], command, tattoo_tm = false, spell['runestone_name'], spell['runestone_tm'])
     find_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'], spell['sheathed_focus'])
 
     invoke(spell['focus'], nil, nil)
@@ -148,6 +157,26 @@ module DRCA
     waitcastrt?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
     DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
+  end
+
+  def prepare_to_cast_runestone?(spell, settings)
+    if DRCI.inside?("#{spell['runestone_name']}", settings.runestone_storage)
+      return false if !get_runestone?(spell['runestone_name'], settings)
+    else
+      DRC.message("*** Out of #{spell['runestone_name']}! ***")
+      return false
+    end
+    return true
+  end
+
+  def get_runestone?(runestone, settings)
+    return true if DRCI.in_hands?(runestone)
+    DRCI.get_item(runestone, settings.runestone_storage)
+    if reget(3, "You get a useless #{runestone}")
+      DRCI.dispose_trash(runestone)
+      return false
+    end
+    return true
   end
 
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])
@@ -377,7 +406,6 @@ module DRCA
         echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
         pause 15
       end
-
       cast_spell(data, settings, force_cambrinth)
     end
   end
@@ -475,7 +503,14 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'])
+    if data['runestone_name']
+      if !prepare_to_cast_runestone?(data, settings)
+        return
+      end
+    end
+
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_tm = false, data['runestone_name'], data['runestone_tm'])
+    DRCI.put_away_item?(data['runestone_name'], settings.runestone_storage) if DRCI.in_hands?(data['runestone_name'])
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']
@@ -641,7 +676,7 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
+    prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_tm = false, data['runestone_name'], data['runestone_tm'])
   end
 
   def crafting_magic_routine(settings)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -21,6 +21,10 @@ invoke_messages:
 - You make sweeping gestures through the air
 - You lift your \w+ (?:toward|reverently)
 - You reach for their centers
+- Closing your eyes
+- Well, that was fun
+- Invoke what
+- You'll have to hold it
 
 prep_messages:
 - You lick the tip of your finger and trace a sigil in the air
@@ -107,6 +111,7 @@ prep_messages:
 - You focus your thoughts on the immolation of the skies.
 - You are now prepared to cast
 - You already have a cantrip prepared!
+- Invoke what
 
 cast_messages:
 - You clench your fists


### PR DESCRIPTION
Stage 1 of runestone casting in buff and combat-trainer. This commit needs to go first.

All work, testing, and reviews are here: https://github.com/rpherbig/dr-scripts/pull/4644.

`;buff <runestone spell>` works. 

Format for spell is:
```yaml
Refresh:
    mana: 0
    prep_type: invoke
    symbiosis: false
    runestone_exists: true
    runestone: quartz runestone
    cambrinth:
    - - 10
```
For TM spell:
```yaml
- name: Eagle's Cry
  prep_type: invoke
  cambrinth:
  - 20
  runestone_name: electrum runestone
  runestone_tm: true
```
For restock:
```yaml
restock:
  Refresh:
    hometown: Shard
    name: quartz runestone
    room: 13105
    price: 8118
    size: 1
    stackable: false
    quantity: 4
```
```yaml
##########################
### Runestone settings ###
##########################
runestone_storage: *zill_pouch
runestone_harness: 60 # Only used for ;invoke-runestone script.
### Setting runestone_purchase to true means you must have access to **Shard**.
### These runestones are only purchasable there and maybe Ratha.
### Uses restock section.
runestone_purchase: true
```
Can still use (or not use) `runestone_harness:` setting. 

**Do not use `use_auto_mana: true` for runestone casting. You cannot discern the spell since you do not know it.**

**Use cambrinth settings as in the example.**

 **`runestone_harness:` is shared between `invoke-rune.lic` and `combat-trainer.lic`. `invoke-rune.lic` does not use cambrinth at this time.** 