### PR TITLE
Revert "Stage 1 of runestones working with buff and combat-trainer."

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -109,31 +109,22 @@ module DRCA
     end
   end
 
-  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false, runestone_name = '', runestone_tm = false)
+  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false)
     return false unless abbrev
 
     DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 
-    if runestone_name.nil?
-      match = DRC.bput("#{command} #{abbrev} #{mana}", get_data('spells').prep_messages)
-    else
-      match = DRC.bput("#{command} my #{runestone_name}", get_data('spells').invoke_messages)
-    end
+    match = DRC.bput("#{command} #{abbrev} #{mana}", get_data('spells').prep_messages)
     case match
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
-      return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
+      return prepare?(abbrev, mana, symbiosis, command, tattoo_tm)
     when 'Something in the area interferes with your spell preparations'
       DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
       return false
-    when 'Well, that was fun'
-      DRCI.dispose_trash(runestone_name)
-      return false
-    when 'You\'ll have to hold it'
-      return false
     end
 
-    DRC.bput("target", get_data('spells').prep_messages) if tattoo_tm || runestone_tm
+    DRC.bput("target", get_data('spells').prep_messages) if tattoo_tm
 
     match
   end
@@ -147,7 +138,7 @@ module DRCA
     command = spell['prep'] if spell['prep']
     command = spell['prep_type'] if spell['prep_type']
 
-    return unless prepare?(spell['abbrev'], spell['mana'], spell['symbiosis'], command, tattoo_tm = false, spell['runestone_name'], spell['runestone_tm'])
+    return unless prepare?(spell['abbrev'], spell['mana'], spell['symbiosis'], command)
     find_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'], spell['sheathed_focus'])
 
     invoke(spell['focus'], nil, nil)
@@ -157,26 +148,6 @@ module DRCA
     waitcastrt?
     return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
     DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
-  end
-
-  def prepare_to_cast_runestone?(spell, settings)
-    if DRCI.inside?("#{spell['runestone_name']}", settings.runestone_storage)
-      return false if !get_runestone?(spell['runestone_name'], settings)
-    else
-      DRC.message("*** Out of #{spell['runestone_name']}! ***")
-      return false
-    end
-    return true
-  end
-
-  def get_runestone?(runestone, settings)
-    return true if DRCI.in_hands?(runestone)
-    DRCI.get_item(runestone, settings.runestone_storage)
-    if reget(3, "You get a useless #{runestone}")
-      DRCI.dispose_trash(runestone)
-      return false
-    end
-    return true
   end
 
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])
@@ -406,6 +377,7 @@ module DRCA
         echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
         pause 15
       end
+
       cast_spell(data, settings, force_cambrinth)
     end
   end
@@ -503,14 +475,7 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    if data['runestone_name']
-      if !prepare_to_cast_runestone?(data, settings)
-        return
-      end
-    end
-
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_tm = false, data['runestone_name'], data['runestone_tm'])
-    DRCI.put_away_item?(data['runestone_name'], settings.runestone_storage) if DRCI.in_hands?(data['runestone_name'])
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'])
     prepare_time = Time.now
 
     unless settings.cambrinth_items[0]['name']
@@ -676,7 +641,7 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, tattoo_tm = false, data['runestone_name'], data['runestone_tm'])
+    prepare?(data['abbrev'], data['mana'], data['symbiosis'], command)
   end
 
   def crafting_magic_routine(settings)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -21,10 +21,6 @@ invoke_messages:
 - You make sweeping gestures through the air
 - You lift your \w+ (?:toward|reverently)
 - You reach for their centers
-- Closing your eyes
-- Well, that was fun
-- Invoke what
-- You'll have to hold it
 
 prep_messages:
 - You lick the tip of your finger and trace a sigil in the air
@@ -111,7 +107,6 @@ prep_messages:
 - You focus your thoughts on the immolation of the skies.
 - You are now prepared to cast
 - You already have a cantrip prepared!
-- Invoke what
 
 cast_messages:
 - You clench your fists


### PR DESCRIPTION
Reverts rpherbig/dr-scripts#4695 

@rpherbig  Could you revert https://github.com/rpherbig/dr-scripts/pull/4695? Two reasons: First, without the updated combat-trainer it is not preparing properly, and two, seems some are getting into the else match with crossing-training and I am not sure how (line 117-121 common-arcana.