### PR TITLE
[script] [charge-holy-weapon] configurable holy power threshold when to recharge weapon

### DIFF
--- a/charge-holy-weapon.lic
+++ b/charge-holy-weapon.lic
@@ -14,6 +14,7 @@ class HolyWeapon
     settings = get_settings
     @hometown = settings.hometown
     hw_settings = settings.holy_weapon
+    @hw_power_levels = get_data('spells')['holy_weapon_power_levels']
     @altar_room = get_data('town')[@hometown]['holy_weapon_altar']['id']
     @em = EquipmentManager.new(settings)
 
@@ -26,24 +27,34 @@ class HolyWeapon
   end
 
   def check_charge_level(hw_settings)
-    @em.wield_weapon(hw_settings['weapon_name'])
+    weapon = hw_settings['weapon_name']
+    threshold = hw_settings['power_level_threshold'] || 3
 
-    case DRC.bput("look my #{hw_settings['weapon_name']}", 'barely detectable', 'flickering', 'barely glowing', 'faintly', 'shining', 'emanating', 'blinding')
-    when 'barely detectable', 'flickering'
-      complete_ritual(hw_settings)
-    when 'barely glowing'
-      DRC.message("200 estimated charges remain, skipping...")
-    when 'faintly'
-      DRC.message("350 estimated charges remain, skipping...")
-    when 'shining'
-      DRC.message("500 estimated charges remain, skipping...")
-    when 'emanating'
-      DRC.message("1000 estimated charges remain, skipping...")
-    when 'blinding'
-      DRC.message("1500 estimated charges remain, skipping...")
+    @em.wield_weapon(weapon)
+
+    power_matches = @hw_power_levels.map { |data| /#{data['match']}/ }
+    power_message = DRC.bput("look my #{weapon}", *power_matches)
+    power_data = @hw_power_levels.find { |data| /#{data['match']}/ =~ power_message }
+
+    unless power_data
+      DRC.message("Could not detect holy power on your '#{weapon}', is this the correct weapon?")
+      exit
     end
 
-    @em.stow_weapon(hw_settings['weapon_name'])
+    level = power_data['level']
+    charges = power_data['estimated_charges']
+
+    echo("Detected holy power level of #{level} with an estimated #{charges} charges remaining")
+    echo("Your holy power level threshold is #{threshold} or below")
+
+    if level <= threshold
+      DRC.message("At or below holy power level threshold, recharging")
+      complete_ritual(hw_settings)
+    else
+      DRC.message("Above holy power level threshold, skipping")
+    end
+
+    @em.stow_weapon(weapon)
   end
 
   def complete_ritual(hw_settings)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -2461,7 +2461,6 @@ spell_data:
     expire: the breeze fades from the area
     mana_type: elemental
 
-
 rituals:
   preserve: Unseen energies seep into the creature's fluids, suspending the corpse in unnatural stasis for a time
   harvest: a few quick, precise motions with your ritual knife
@@ -2487,3 +2486,34 @@ rituals:
   - much too battered and beat up to extract any body parts from
   - renders it useless for butchering
   - prevents a meaningful dissection
+
+# Designed for the `charge-holy-weapon` script.
+# `level` is a number, lower means less power/fewer charges
+# `match` is the text to match when looking at weapon to know its power level
+# `estimated_charges` is an estimate of the number of remaining charges
+# https://elanthipedia.play.net/Holy_weapon#Power_Levels
+holy_weapon_power_levels:
+  - level: 1
+    match: barely detectable
+    estimated_charges: 0
+  - level: 2
+    match: flickering faintly with holy power
+    estimated_charges: 10
+  - level: 3
+    match: flickering slightly with holy power
+    estimated_charges: 50
+  - level: 4
+    match: barely glowing with holy power
+    estimated_charges: 200
+  - level: 5
+    match: faintly glowing with holy power
+    estimated_charges: 350
+  - level: 6
+    match: shining with holy power
+    estimated_charges: 500
+  - level: 7
+    match: emanating a powerful sense of holiness
+    estimated_charges: 1000
+  - level: 8
+    match: blinding you with holy power
+    estimated_charges: 1500


### PR DESCRIPTION
### Dependencies
* ~~Depends on https://github.com/rpherbig/dr-scripts/pull/4692~~

### Background
* [Madigan](https://discord.com/channels/745675889622384681/745678209449853049/796807722011721748) requested more fine-grained control over when the script chooses to recharge the holy weapon.
* Taking into consideration that some people have holy icons they can use anywhere, others may have to travel to an altar, and personal preferences, people may want to recharge their weapon at different thresholds. Similar to preferences on when to refil a car's gasoline... some do it at half tank, some quarter tank, some run out of gas ;)

### Changes
* Add the 8 power level match strings and metadata to `data/base-spells.yaml`
* Support new yaml setting `holy_weapon: power_level_threshold:` (optional, number in range 1-8)
* Refactor `check_charge_level` method to compare the holy power level seen when looking at the weapon to the character's configured threshold and decide whether to recharge or not.
* If unable to detect holy power on the weapon then exits with error message -- character may have specified a non-holy weapon.

## Tests

Madigan, again, has graciously [offered to help test](https://discord.com/channels/745675889622384681/745678209449853049/797368525315899424) the script updates. Awaiting their test results.

### skips when weapon is above threshold
```
>;charge-holy-weapon
--- Lich: charge-holy-weapon active.
[charge-holy-weapon]>wield my glaes.greatsword
You draw out your glaes greatsword from the claymore sheath, gripping it firmly in your right hand and balancing with your left.
>
[charge-holy-weapon]>look my glaes greatsword
Your greatsword is emanating a powerful sense of holiness.
 
The extra long hilt of this blade is capped with a heavy steel pommel designed to counter balance the length of the weapon.  Forming the protective crossguard, a pair of sinuous silver dragons, wings outstretched, mirror each other clasping a pristine white Therengian rose between the them.
>
[charge-holy-weapon: Detected holy power level of 7 with an estimated 1000 charges remaining]
[charge-holy-weapon: Your holy power level threshold is 3 or below]
| Above holy power level threshold, skipping
[charge-holy-weapon]>sheath my glaes.greatsword
You put your greatsword in your claymore sheath.
You sheathe the glaes greatsword in your claymore sheath.
>
--- Lich: charge-holy-weapon has exited.
```