### PR TITLE
[script] [equipmanager] remove redundant call to get_item

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -179,7 +179,6 @@ class EquipmentManager
 
     if [left_hand, right_hand].grep(weapon.short_regex).any?
       stow_weapon
-      get_item?(weapon)
     end
 
     get_item?(weapon)


### PR DESCRIPTION
### Background
* When calling `wield_weapon(name)`, if you have the weapon in question in your hands, the original logic will stow it then wield it, then at line 184 try to wield it _again_ and the script will hang because it doesn't recognize the second time that it already has the weapon in hand.

```
,e EquipmentManager.new.wield_weapon('broadaxe')
--- Lich: exec1 active.

[exec1]>sheath my broadaxe

You sheathe the broadaxe in your dirt-covered backpack.
> 
[exec1]>wield my broadaxe

You draw out your broadaxe from the dirt-covered backpack, gripping it firmly in your right hand and balancing with your left.
> 
[exec1]>wield my broadaxe

You're already holding a steel broadaxe!
> 
[exec1: *** No match was found after 15 seconds, dumping info]

[exec1: message: You're already holding a steel broadaxe!]

[exec1: checked against [/You draw/i, /You deftly remove/i, /You slip/i, /Wield what/i, /With a flick of your wrist you stealthily unsheathe/i]]

[exec1: for command wield my broadaxe]

--- Lich: exec1 has exited.
```

### Changes
* Remove the seemingly redundant call to `get_item?` at line 182 and defer to the one at line 184

## Tests

### empty hands, wield weapon
```
> ,e EquipmentManager.new.wield_weapon('broadaxe')

--- Lich: exec1 active.

[exec1]>wield my broadaxe

You draw out your broadaxe from the dirt-covered backpack, gripping it firmly in your right hand and balancing with your left.
> 
--- Lich: exec1 has exited.
```

### holding weapon, wield weapon
```
> ,e EquipmentManager.new.wield_weapon('broadaxe')

--- Lich: exec1 active.

[exec1]>sheath my broadaxe

You sheathe the broadaxe in your dirt-covered backpack.
> 
[exec1]>wield my broadaxe

You draw out your broadaxe from the dirt-covered backpack, gripping it firmly in your right hand and balancing with your left.
> 
--- Lich: exec1 has exited.
```