### PR TITLE
[script] [sanowret-crystal] handle more sanowret crystals taps

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -48,8 +48,8 @@ class SanowretCrystal
     if @worn_crystal
       use_crystal
     else
-      case DRC.bput("tap my #{@adjective} crystal", /^You tap (?:a|an) .*sanowret crystal inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal that you are holding.$/, 'I could not find what you were referring to.', 'Not here, ', 'a wave of Corruption magic')
-      when /You tap (?:a|an) .*sanowret crystal inside your/
+      case DRC.bput("tap my #{@adjective} crystal", /^You tap (?:a|an) .*sanowret crystal.* inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are holding.$/, 'I could not find what you were referring to.', 'Not here, ', 'a wave of Corruption magic')
+      when /You tap (?:a|an) .*sanowret crystal.* inside your/
         # We need to retrieve the crystal but if it's not in your hands and your hands are full then wait
         pause 1 until DRCI.in_hands?("#{@adjective} crystal") || DRC.left_hand.nil? || DRC.right_hand.nil?
         DRC.bput("get my #{@adjective} crystal", 'You get', 'What were you referring to', "You need a free hand")
@@ -58,7 +58,7 @@ class SanowretCrystal
       when /^You tap (?:a|an) .*sanowret crystal.* that you are wearing\.$/
         @worn_crystal = true
         use_crystal
-      when /^You tap (?:a|an) .*sanowret crystal that you are holding\.$/
+      when /^You tap (?:a|an) .*sanowret crystal.* that you are holding\.$/
         use_crystal
         DRC.bput("stow my #{@adjective} crystal", 'You put', 'Stow what')
       when /Not here, /, /a wave of Corruption magic/


### PR DESCRIPTION
### Background
* Hollows Eve introduces [sanowret crystals](https://elanthipedia.play.net/Sanowret_crystal) that include more adjectives and words than just `sanowret crystal`. For example, `void-black sanowret crystal` or `argent sanowret crystal set within a silversteel blade spider`.
* Some match strings when tapping to check for the existence of a crystal don't handle the descriptive words that come after 'crystal', preventing script from running.

### Changes
* Update the match strings when tapping the sanowret crystal to include the `.*` regex pattern after the word `crystal` as is done before `sanowret`. 

## Tests

### Original match strings (fails)
```
--- Lich: sanowret-crystal active.

[sanowret-crystal]>tap my sanowret crystal

You tap an argent sanowret crystal set within a silversteel blade spider inside your hunting pack.
> 

[sanowret-crystal: *** No match was found after 15 seconds, dumping info]

[sanowret-crystal: messages seen length: 3]

[sanowret-crystal: message: You tap an argent sanowret crystal set within a silversteel blade spider inside your hunting pack.]

[sanowret-crystal: checked against [/^You tap (?:a|an) .*sanowret crystal inside your .*.$/, /^You tap (?:a|an) .*sanowret crystal.* that you are wearing.$/, /^You tap (?:a|an) .*sanowret crystal that you are holding.$/, /I could not find what you were referring to./i, /Not here, /i, /a wave of Corruption magic/i]]

[sanowret-crystal: for command tap my sanowret crystal]

| Sanowret crystal not found, exiting!

--- Lich: sanowret-crystal has exited.
```

### Updated match strings (successful)
```
--- Lich: sanowret-crystal active.

[sanowret-crystal]>tap my sanowret crystal

You tap an argent sanowret crystal set within a silversteel blade spider inside your hunting pack.
> 
[sanowret-crystal]>get my sanowret crystal

You get an argent sanowret crystal set within a silversteel blade spider from inside your hunting pack.
> 
[sanowret-crystal]>exhale my sanowret crystal

You exhale softly on your sanowret crystal, and scintillating sparks of light dance across its surface.
You hear in your mind a quiet recollection of wisdom.  Though you think that you could get more knowledge if you were to GAZE into the crystal, you come away from the experience with a further understanding of Arcana as the scintillating lights fade again.
> 
[sanowret-crystal]>stow my sanowret crystal

You put your crystal in your hunting pack.
```

### FYI
Hi @BinuDR, as a recent previous committer to this script, I wanted to let you know about an update I've proposed. Feel free to comment on this pull request or ignore it, no pressure!