### PR TITLE
[script] [common] add match string when fail to collect rocks

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -217,7 +217,8 @@ module DRC
         'You forage around but are unable to find anything',
         'You manage to collect a pile',
         'You survey the area and realize that any collecting efforts would be futile',
-        'You wander around and poke your fingers'
+        'You wander around and poke your fingers',
+        'You forage around for a while and manage to stir up a small mound of fire ants!'
     ]
     case bput("collect #{item}", messages)
     when 'The room is too cluttered'


### PR DESCRIPTION
### Background
* Encountered this new failure message when collecting rocks in Ship Rats on a new character with 4 ranks of Outdoorsmanship

```
[combat-trainer]>collect rock

You forage around for a while and manage to stir up a small mound of fire ants!  Removing your hands from the pile, you feel the ants crawling all over your skin.  Swinging you arms around wildly, you manage to fling them to the ground.
Roundtime: 4 sec.

...

[combat-trainer: *** No match was found after 15 seconds, dumping info]
```

### Changes
* Add new match string so `bput` doesn't hang for 15 seconds

