### PR TITLE
[data] [spells] match string when try to do unknown ritual

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -2473,6 +2473,7 @@ rituals:
   construct: Rituals do not work upon constructs
   butcher: Making several deep cuts with your knife
   failures:
+  - You do not have the knowledge required to perform this ritual
   - don't have enough thanatological
   - You cannot harvest
   - Rituals do not work upon the undead


### PR DESCRIPTION
### Background
* As a Necromancer, if you have `thanatology:` property set in your YAML then combat-trainer will try to perform rituals on killed critters.
* As a new Necromancer without knowledge of any rituals, the combat script would hang when trying to perform thanatology for unknown rituals.

### Changes
* Add match string for when try ritual that you don't know.