### PR TITLE
[script] [combat-trainer] option: train appraisal in combat via bundles (low-level character friendly)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2004,7 +2004,7 @@ class TrainerProcess
                    'Scream' => 'Bardic Lore', 'Perc Health' => 'Empathy', 'Khri Prowess' => 'Debilitation', 'Teach' => 'Scholarship',
                    'Stealth' => 'Stealth', 'Ambush Stun' => settings.stun_skill, 'Ambush Choke' => 'Debilitation', 'App Pouch' => 'Appraisal',
                    'Favor Orb' => 'Anything', 'Charged Maneuver' => 'Expertise', 'Meraud' => 'Theurgy', 'Recall' => 'Scholarship',
-                   'Barb Research Warding' => 'Warding', 'Barb Research Augmentation' => 'Augmentation',
+                   'Barb Research Warding' => 'Warding', 'Barb Research Augmentation' => 'Augmentation', 'App Bundle' => 'Appraisal',
                    'Barb Research Debilitation' => 'Debilitation', 'Collect' => 'Outdoorsmanship', 'Smite' => 'Conviction', 'Locks' => 'Locksmithing', 'Tessera' => 'Trading' }
 
     @skill_map['Hunt'] = %w[Perception Scouting] if DRStats.ranger?
@@ -2108,6 +2108,9 @@ class TrainerProcess
     when 'App Pouch'
       retreat
       bput("app my #{@gem_pouch_adjective} pouch quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
+    when 'App Bundle'
+      retreat
+      bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
     when 'Tactics'
       bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
     when 'Analyze'


### PR DESCRIPTION
### Background
* combat-trainer supports training appraisal in combat through its `training_abilities:` setting.
  * You can appraise a gem pouch via `App Pouch` option.
  * You can appraise a critter via `App Quick|Careful`... but only if you have [at least 76 ranks](https://github.com/rpherbig/dr-scripts/blob/d76711834b94cd0e095b5bfe3aab4d1230961367/combat-trainer.lic#L2460).
* As a new character starting out in Ship Rats and without either gems or sufficient appraisal ranks, training appraisal in combat is not possible with combat-trainer (to my knowledge).

### Changes
* Add new option to `training_abilities` called `App Bundle` mirroring the existing option `App Pouch`.
* When `App Bundle` is configured and `Appraisal` is the skill to train then retreat from combat and do `app my bundle quick` mirroring appraising a gem pouch.

### Example Config
```yaml
training_abilities:
  App Bundle: 60
```

In total, this provides characters 3 easy ways to train appraisal in combat: critter, gem pouch, bundle. Each has their merits depending on the context (e.g. have sufficient skill or have gems or have bundle).
```yaml
# All appraisal options (need use only one)
training_abilities:
  App Bundle: 60    # appraisal: bundle (don't use on non-skinnable critters)
  App Pouch: 60     # appraisal: gem pouch (don't use with empty pouch)
  App Quick: 60     # appraisal: critter (can't use below 76 ranks)
```

## Tests

### appraise bundle quick
```
[combat-trainer]>retreat

You retreat back to pole range.
> 
[combat-trainer]>retreat

You retreat from combat.
> 
[combat-trainer]>app my bundle quick

It appears that the tight bundle can be worn around the waist.
The bundle appears to be tied off.
The bundle appears to be loosened a little, allowing for quick fitting of additional skins.
Taking careful count, it looks like there are 5 items in the bundle.
You scan through the tight bundle and finally decide that they're worth a total of about 493 Kronars.
Roundtime: 3 sec.

...

[combat-trainer]>feint

You aren't close enough to attack.
You are already advancing on a ship's rat.
> 
[combat-trainer]>engage
```

## FYI
@Dartellum @jayRyan24 I'd appreciate your all's review and feedback, thanks