### PR TITLE
[script] [common-items] add match string when fade into view to get item

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -318,8 +318,8 @@ module DRCI
   def get_item_unsafe(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
-    result = DRC.bput("get #{item} #{from}", 'You get', 'You pluck', 'I could not', 'What were you', 'Get what', 'You are already holding', 'You need a free hand')
-    result =~ /^You get|^You pluck|^You are already holding/
+    result = DRC.bput("get #{item} #{from}", 'You get', 'You pluck', 'You are already holding', 'You fade in for a moment as you get', 'I could not', 'What were you', 'Get what', 'You need a free hand')
+    result =~ /^(You get|You pluck|You are already holding|You fade in for a moment as you get)/
   end
 
   # Gets a list of items found in a container.


### PR DESCRIPTION
### Background
* While invisible, there is different messaging when you reach out to get something than just "You get..."
* This phrase is not matched and can cause scripts to hang.

### Changes
* Add match string `You fade in for a moment as you get` to detect when temporarily phasing out of invisibility to get an item.
* Update the order of the match strings on line 321 to match line 322

## Tests

### without match string
```
[wand-watcher]>get second indurium phoenix from my watery portal

You fade in for a moment as you get an indurium phoenix with eyes of canary diamond from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame.
I> 
| Could not find correct number of wands for indurium phoenix in watery portal.

| Double check your wand name, count, and container settings.

| Removing this wand from the list.
```

### with match string
```
Your spell subtly alters the corruption around you, creating a blind spot once more.

I> ,e DRCI.get_item('indurium phoenix', 'watery portal')

--- Lich: exec1 active.

[exec1]>get indurium phoenix from my watery portal

You fade in for a moment as you get an indurium phoenix with eyes of canary diamond from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame.
I> 
--- Lich: exec1 has exited.
```