### PR TITLE
[script] [combat-trainer] don't hang when try to stow ammo that's lodged

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3014,7 +3014,7 @@ class AttackProcess
   def stow_ammo(ammo = nil, quantity = 1)
     return unless ammo
     return unless quantity > 0
-    case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what')
+    case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
     when 'You pick up', 'You put your'
       stow_ammo(ammo, quantity - 1)
     when 'Stow what'


### PR DESCRIPTION
### Changes
* fixes #4711
* add match string when `stow <ammo>` defaults to ammo that's lodged in you so script won't hang

combat-trainer will eventually detect that you've been shot and will dislodge the ammo, at which point the next time you try to stow ammo should work unless you got shot again

If you run out of ammo, this way or otherwise, combat-trainer is smart enough to move on to the next weapon so you don't hang that way, either.