### PR TITLE
[script] [equipmanager] check container property to support eddy

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -194,7 +194,7 @@ class EquipmentManager
       item = item_by_desc(item.transforms_to)
       item.worn ? get_item_helper(item, :worn) : get_item_helper(item, :stowed)
       get_item_helper(item, :transform)
-    elsif (item.tie_to && get_item_helper(item, :tied)) || (item.worn && get_item_helper(item, :worn)) || get_item_helper(item, :stowed)
+    elsif (item.tie_to && get_item_helper(item, :tied)) || (item.worn && get_item_helper(item, :worn)) || (item.container && DRCI.get_item(item.short_name, item.container)) || get_item_helper(item, :stowed)
       true
     else
       echo("Could not find #{item.short_name} anywhere.")


### PR DESCRIPTION
_Note, this is an interim fix while I'm still working on an overhaul to the `get_item_helper` function per https://github.com/rpherbig/dr-scripts/pull/4683. This PR solves the problem for people now, the better fix to be part of get_item_helper is coming next._

### Background
* The `GET` command does not find items in the [eddy](https://elanthipedia.play.net/Item:Swirling_eddy_of_incandescent_light_bound_by_a_gold-striated_coralite_frame) because the items are not on your person.
* This causes [non-intuitive problems](https://discord.com/channels/745675889622384681/745675890242879671/800178361074319390) for players who choose to store their gear in their eddy because scripts like equipmanager's `get_item?` function won't find the gear.

### Changes
* Update `get_item?` function to get item from container if `:container` property is set, just like checking `:tied` and `:worn`, before falling back to generic "get <item>"

## Tests

### without this fix, does not look for item in watery portal
GIVEN:
```yaml
gear:
- :adjective: leather
  :name: cowl
  :container: watery portal
```
THEN:
```
> ,e em = EquipmentManager.new ; em.get_item?( em.item_by_desc('leather cowl') )

--- Lich: exec1 active.

[exec1]>get my leather.cowl

What were you referring to?
> 
[exec1: Could not find leather.cowl anywhere.]

--- Lich: exec1 has exited.
```

### with this fix, looks in watery portal
GIVEN:
```yaml
gear:
- :adjective: leather
  :name: cowl
  :container: watery portal
```
THEN:
```
,e em = EquipmentManager.new ; em.get_item?( em.item_by_desc('leather cowl') )
--- Lich: exec1 active.

[exec1]>get leather.cowl from my watery portal

> 
You get a lightweight leather cowl embellished with a fan of murder crow feathers from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame.
> 
--- Lich: exec1 has exited.
```

## with this fix, if item not found in container then falls back to generic "get"
GIVEN:
```yaml
gear:
- :adjective: leather
  :name: cowl
  :container: watery portal
```
THEN:
```
> ,e em = EquipmentManager.new ; em.get_item?( em.item_by_desc('leather cowl') )

--- Lich: exec1 active.

[exec1]>get leather.cowl from my watery portal

What were you referring to?
> 
[exec1]>get my leather.cowl

You get a lightweight leather cowl embellished with a fan of murder crow feathers from inside your hunting pack.
> 
--- Lich: exec1 has exited.
```