### PR TITLE
[script] [common-arcana] Use 'DRStats.mana' instead of 'mana' implicit variable

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -373,7 +373,7 @@ module DRCA
     infuse_om(!settings.osrel_no_harness, settings.osrel_amount)
     spells.each do |name, data|
       next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
-      while (mana < settings.waggle_spells_mana_threshold || DRStats.concentration < settings.waggle_spells_concentration_threshold)
+      while (DRStats.mana < settings.waggle_spells_mana_threshold || DRStats.concentration < settings.waggle_spells_concentration_threshold)
         echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
         pause 15
       end
@@ -647,7 +647,7 @@ module DRCA
   def crafting_magic_routine(settings)
     training_spells = settings.crafting_training_spells
     return if training_spells.empty?
-    return if mana <= 40
+    return if DRStats.mana <= settings.waggle_spells_mana_threshold
 
     if !XMLData.prepared_spell.eql?('None') && checkcastrt == 0
       spell = XMLData.prepared_spell
@@ -694,7 +694,7 @@ module DRCA
     return unless Script.running?('avtalia')
 
     invoke(cambrinth, dedicated_camb_use, invoke_amount)
-    UserVars.avtalia[cambrinth]['mana'] -= [mana, invoke_amount].min
+    UserVars.avtalia[cambrinth]['mana'] -= [DRStats.mana, invoke_amount].min
   end
 
   def charge_avtalia(cambrinth, charge_amount)


### PR DESCRIPTION
### Background
* [formayor](https://discord.com/channels/745675889622384681/745678251250417674/795102520187027476) and I were testing an Empath healing script and noticed that common-arcana's logic to pause casting and wait for mana or concentration to regenerate when below `waggle_spells_mana_threshold` and `waggle_spells_concentration_threshold` respectively only was waiting for concentration, and never waiting on mana.
* This caused the healing script to exhaust the character's mana.
* Upon investigation and testing, it seemed to be an issue between relying on the implicit `mana` variable vs. `DRStats.mana` variable. I can't explain _why_, but this one change resolved the issue.

### Changes
* Replace references to `mana` implicit variable with `DRStats.mana`
* In `crafting_magic_routine` method, replace hard coded mana threshold of 40 with `settings.waggle_spells_mana_threshold`

### FYI
@BinuDR, friendly ping if you're interested in this PR as the [commit history](https://github.com/rpherbig/dr-scripts/commit/183a46b7ca938ef219421626f8f325fa72a478d7) shows you were last developer to commit to `crafting_magic_routine` function a couple years ago.

## Tests

### when mana is below threshold then common-arcana will wait

![image](https://user-images.githubusercontent.com/68095633/104893068-93582480-5938-11eb-96ee-946d8cfd6376.png)
