### PR TITLE
[script] [common-arcana] ignore cambrinth when cambrinth_num_charges = 0

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -552,17 +552,20 @@ module DRCA
         'stored' => settings.stored_cambrinth
       }]
     end
-    total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+)
+    # Ignore cambrinth if charges to use is nil or 0
+    settings.cambrinth_num_charges ||= 0
+    settings.cambrinth_items = [] if settings.cambrinth_num_charges == 0
+    total_cambrinth_cap = settings.cambrinth_items.map { |x| x['cap'] }.inject(&:+) || 0
     charges_count_floor = remaining >= settings.cambrinth_num_charges ? settings.cambrinth_num_charges : 1
     settings.cambrinth_items.each do |item|
       item['charges'] = ((item['cap'].to_f / total_cambrinth_cap) * charges_count_floor).ceil
     end
-    total_cambrinth_charges = settings.cambrinth_items.map { |x| x['charges'] }.inject(&:+)
+    total_cambrinth_charges = settings.cambrinth_items.map { |x| x['charges'] }.inject(&:+) || 0
     if remaining > total_cambrinth_cap
       discern_data['mana'] = discern_data['mana'] + (remaining - total_cambrinth_cap)
       remaining = total - discern_data['mana']
     end
-    if cyclic
+    if cyclic || total_cambrinth_charges == 0
       discern_data['cambrinth'] = nil
       discern_data['mana'] = discern_data['mana'] + remaining
     elsif remaining > 0


### PR DESCRIPTION
### Background
* While testing https://github.com/rpherbig/dr-scripts/pull/4718, I wanted to burn through my mana quickly by not using cambrinth and instead prepping for higher amounts.
* When I set `cambrinth_num_charges` to nil or 0 then got "divide by zero" error in the `calculate_mana` function.

### Changes
* Avoid "divide by zero" when `cambrinth_num_charges` is nil or 0
* If `cambrinth_num_charges` is nil then default to 0
* Ignore cambrinth items when generating discerns if `cambrinth_num_charges` is 0

### Example Config

```yaml
# The next time discerns are calculated for spells with 'use_auto_mana: true'
# then no cambrinth will be considered. Set this to a positive value to use cambrinth.
cambrinth_num_charges: 0
```

### FYI
@jandersson, friendly ping if you're interested in this PR as the [commit history](https://github.com/rpherbig/dr-scripts/commit/f0785783a57ab0932f63ff9560e8ca294d520e5e) shows you were last developer to commit to `calculate_mana` function a couple years ago.