### PR TITLE
fixing a Ratha climbing infinite loop

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -248,6 +248,10 @@ class Athletics
         override_location_and_practice('ratha_rock_gorge')
       elsif DRSkill.getrank('Stealth') >= 130
         override_location_and_practice('ratha_deep_crack')
+      else
+        # stops in infinte loop when > 185 ranks in athletics and < 130 ranks in stealth
+        echo "!! You don't meet current requirements for ratha climbing, exiting. !!"
+        break
       end
     end
   end


### PR DESCRIPTION
Under certain conditions of >180 athletics and <130 stealth. Athletics will enter an infinite loop and never exit. Adding logic to the if statement to prevent this.