### PR TITLE
validate - Added missing training_abilities

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -442,7 +442,7 @@ class DRYamlValidator
     return unless settings.training_abilities
 
     settings.training_abilities
-            .reject { |skill, _cooldown| ['PercMana', 'Perc', 'Perc Health', 'Astro', 'App', 'App Quick', 'App Careful', 'Tactics', 'Hunt', 'Pray', 'Scream', 'Khri Prowess', 'Ret Stealth', 'Stealth', 'Ambush Stun', 'Ambush Choke', 'Favor Orb', 'Charged Maneuver', 'Meraud', 'Recall', 'Barb Research Debilitation', 'Barb Research Augmentation', 'Barb Research Warding', 'Collect', 'Analyze', 'Flee', 'PrayerMat', 'Smite', 'Locks', 'Teach', 'Almanac', 'Herbs', 'App Pouch'].include?(skill) }
+            .reject { |skill, _cooldown| ['PercMana', 'Perc', 'Perc Health', 'Astro', 'App', 'App Quick', 'App Careful', 'Tactics', 'Hunt', 'Pray', 'Scream', 'Khri Prowess', 'Ret Stealth', 'Stealth', 'Ambush Stun', 'Ambush Choke', 'Favor Orb', 'Charged Maneuver', 'Meraud', 'Recall', 'Barb Research Debilitation', 'Barb Research Augmentation', 'Barb Research Warding', 'Collect', 'Analyze', 'Flee', 'PrayerMat', 'Smite', 'Locks', 'Teach', 'Almanac', 'Herbs', 'App Pouch', 'App Bundle', 'Tessera'].include?(skill) }
             .each_key { |skill| error("Ability in training_abilities is not valid: #{skill}") }
   end
 


### PR DESCRIPTION
App Bundle and Tessera weren't listed in the section that checks against the training_abilities in your yaml.  I've added them so that it doesn't give an error when you validate yamls containing them.