### PR TITLE
[script] [burgle] trash non-empty burgled items

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -500,6 +500,7 @@ class Burgle
   def pawn_item(item)
     case bput("sell my #{item}",
       'You sell your',                        # success
+      "You'll want to empty that first",      # non-empty container
       /shakes (his|her) head and says/,       # not worth enough (generic)
       'Relf briefly glances at your',         # not worth enough (hib - special messaging)
       'Oweede growls and says,',              # not worth enough (Mer'Kresh)


### PR DESCRIPTION
### Background
Per [Sexylumberjack](https://discord.com/channels/745675889622384681/745678330933805157/809060928905674882) in the Lich discord, some new [burgle items](https://elanthipedia.play.net/Post:Tuesday_Tidings_-_50_-_New_Breaking_and_Entering_Loot_-_02/02/2021_-_18:03) are non-empty containers and unable to be sold as-is. There is no match string for this response and the script hangs.

```
[burgle]>sell my recipe box
Aelik scowls and says, "You'll want to empty that first.  For all I know you've put some curse on the contents or stuffed it full of stolen goods!"
```

### Changes
* [Kiriawen](https://discord.com/channels/745675889622384681/745678330933805157/809119370277290074)'s suggestion is add match string for non-empty burgled container and drop it

### Notes
[VTCifer](https://discord.com/channels/745675889622384681/745678330933805157/809119034586955797) was consulted in Discord and said that he's not currently subscribed to the game to test or submit the script changes. I'm submitting on their behalf.