### PR TITLE
[script] [wand-watcher] fix #4722, if hidden then retry wands later

### DIFF
--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -24,7 +24,8 @@ class WandWatcher
                                     /^This is not a good place for that/,
                                     /^You shouldn't disrupt the area/,
                                     /^You really shouldn't be loitering in here/,
-                                    /^As you begin to do that an assistant scowls at you and motions for you to stop/]
+                                    /^As you begin to do that an assistant scowls at you and motions for you to stop/,
+                                    /^You cannot .* while maintaining the effort to stay hidden/]
     UserVars.wand_watcher_timers = {} unless UserVars.wand_watcher_timers
 
     # Don't allow users to make foolish mistakes, always prevent use during go2/burgle
@@ -147,6 +148,11 @@ class WandWatcher
         redo unless redo_count > count
         # If you run out of wands to try, set next attempt to be 1/2 the cooldown time
         UserVars.wand_watcher_timers[wand] = Time.now + (cooldown / 2)
+      when /^You cannot .* while maintaining the effort to stay hidden/
+        # Activation failed due to being invisible or hidden.
+        # Message the user and push out the retry time a little bit.
+        message "Failed to activate due to being hidden or invisible."
+        UserVars.wand_watcher_timers[wand] = Time.now + 60
       when *@activation_blocked_messages
         # Activation failed due to null-magic room or silenced room
         # Message the user and add the current room to the @no_use_rooms


### PR DESCRIPTION
### Background
* Some wands won't let you activate them if you are hidden or invisible.
* Attempting to do so yields, `You cannot use the <wand> while maintaining the effort to stay hidden.`
* The current script does not handle this match string and the script asks the player to open an issue so that it can be handled.

### Changes
* Fixes #4722, add match string when unable to activate wand due to being hidden or invisible; re-enqueues the wand to be retried a minute later

### FYI
@vtcifer, in case you have feedback about this change, thanks