### PR TITLE
[script] [drinfomon] Add support for Fang Cove banks/vaults

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -558,38 +558,38 @@ lirum_banks = ["Aesry Surlaenis'a", "Hara'jaal", "Mer'Kresh", "Muspar'i", "Ratha
 dokora_banks = ["Ain Ghazal", "Boar Clan", "Chyolvea Tayeu'a", "Hibarnhvidar", "Fang Cove", "Raven's Point", "Shard"]
 
 bank_titles = {
+  "Aesry Surlaenis'a"  => ["[[Tona Kertigen, Deposit Window]]"],
   "Ain Ghazal"         => ["Unknown Description"],
   "Boar Clan"          => ["Unknown Description"],
+  "Chyolvea Tayeu'a"   => ["[[Chyolvea Tayeu'a, Teller]]"],
   "Crossings"          => ["[[Provincial Bank, Teller]]"],
   "Dirge"              => ["[[Dirge, Traveller's Bank]]"],
   "Fang Cove"          => ["[[First Council Banking, Vault]]"],
+  "Hara'jaal"          => ["Unknown Description"],
   "Hibarnhvidar"       => ["[[Second Provincial Bank of Hibarnhvidar, Teller]]", "[[Hibarnhvidar, Teller Windows]]", "[[First Arachnid Bank, Lobby]]"],
   "Ilaya Taipa"        => ["Unknown Description"],
   "Leth Deriel"        => ["[[Imperial Depository, Domestic Branch]]"],
-  "Ratha"              => ["[[Lower Bank of Ratha, Cashier]]", "[[Sshoi-sson Palace, Grand Provincial Bank, Bursarium]]"],
-  "Riverhaven"         => ["[[Bank of Riverhaven, Teller]]"],
-  "Shard"              => ["[[First Bank of Ilithi, Teller's Windows]]"],
-  "Therenborough"      => ["[[Bank of Therenborough, Teller]]"],
-  "Throne City"        => ["[[Faldesu Exchequer, Teller]]"],
-  "Aesry Surlaenis'a"  => ["[[Tona Kertigen, Deposit Window]]"],
-  "Chyolvea Tayeu'a"   => ["[[Chyolvea Tayeu'a, Teller]]"],
-  "Hara'jaal"          => ["Unknown Description"],
   "Mer'Kresh"          => ["[[Harti Clemois Bank, Teller's Window]]"],
   "Muspar'i"           => ["[[Old Lata'arna Keep, Teller Windows]]"],
+  "Ratha"              => ["[[Lower Bank of Ratha, Cashier]]", "[[Sshoi-sson Palace, Grand Provincial Bank, Bursarium]]"],
   "Raven's Point"      => ["[[Bank of Raven's Point, Depository]]"],
-  "Rossman's Landing"  => ["Unknown Description"]
+  "Riverhaven"         => ["[[Bank of Riverhaven, Teller]]"],
+  "Rossman's Landing"  => ["Unknown Description"],
+  "Shard"              => ["[[First Bank of Ilithi, Teller's Windows]]"],
+  "Therenborough"      => ["[[Bank of Therenborough, Teller]]"],
+  "Throne City"        => ["[[Faldesu Exchequer, Teller]]"]
 }
 
 vault_titles = {
   "Crossings"          => ["[[Crossing, Carousel Chamber]]"],
   "Fang Cove"          => ["[[Fang Cove, Carousel Chamber]]"],
   "Leth Deriel"        => ["[[Leth Deriel, Carousel Chamber]]"],
+  "Mer'Kresh"          => ["[[Mer'Kresh, Carousel Square]]"],
+  "Muspar'i"           => ["[[Muspar'i, Carousel Square]]"],
   "Ratha"              => ["[[Ratha, Carousel Square]]"],
   "Riverhaven"         => ["[[Riverhaven, Carousel Chamber]]"],
   "Shard"              => ["[[Shard, Carousel Square]]"],
-  "Therenborough"      => ["[[Therenborough, Carousel Square]]"],
-  "Mer'Kresh"          => ["[[Mer'Kresh, Carousel Square]]"],
-  "Muspar'i"           => ["[[Muspar'i, Carousel Square]]"]
+  "Therenborough"      => ["[[Therenborough, Carousel Square]]"]
 }
 #
 # Register ;banks ;vault commands

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -553,41 +553,43 @@ sleep(0.1) until Char.name && !Char.name.empty?
 CharSettings['bank_accounts'] = {} unless CharSettings['bank_accounts'].class == Hash
 CharSettings['vault_info'] = {} unless CharSettings['vault_info'].class == Hash
 
-kronar_banks = ['Crossings', 'Dirge', 'Leth Deriel', 'Ilaya Taipa']
-lirum_banks = ["Aesry Surlaenis'a", "Hara'jaal", "Mer'Kresh", "Muspar'i", 'Ratha', 'Riverhaven', "Rossman's Landing", 'Therenborough', 'Throne City']
-dokora_banks = ['Ain Ghazal', 'Boar Clan', "Chyolvea Tayeu'a", 'Hibarnhvidar', 'Shard', "Raven's Point"]
+kronar_banks = ['Crossings', 'Dirge', 'Ilaya Taipa', 'Leth Deriel']
+lirum_banks = ["Aesry Surlaenis'a", "Hara'jaal", "Mer'Kresh", "Muspar'i", "Ratha", "Riverhaven", "Rossman's Landing", "Therenborough", "Throne City"]
+dokora_banks = ["Ain Ghazal", "Boar Clan", "Chyolvea Tayeu'a", "Hibarnhvidar", "Fang Cove", "Raven's Point", "Shard"]
 
 bank_titles = {
-  "Aesry Surlaenis'a" => ['[[Tona Kertigen, Deposit Window]]'],
-  'Ain Ghazal'				=> ['Unknown Description'],
-  'Boar Clan'					=> ['Unknown Description'],
-  "Chyolvea Tayeu'a"	=> ["[[Chyolvea Tayeu'a, Teller]]"],
-  'Crossings'					=> ['[[Provincial Bank, Teller]]'],
-  'Dirge'						  => ["[[Dirge, Traveller's Bank]]"],
-  "Hara'jaal"					=> ['Unknown Description'],
-  'Hibarnhvidar'			=> ['[[Second Provincial Bank of Hibarnhvidar, Teller]]', '[[Hibarnhvidar, Teller Windows]]', '[[First Arachnid Bank, Lobby]]'],
-  'Ilaya Taipa'				=> ['Unknown Description'],
-  'Leth Deriel'				=> ['[[Imperial Depository, Domestic Branch]]'],
-  "Mer'Kresh"					=> ["[[Harti Clemois Bank, Teller's Window]]"],
-  "Muspar'i"					=> ["[[Old Lata'arna Keep, Teller Windows]]"],
-  'Ratha'						  => ['[[Lower Bank of Ratha, Cashier]]', '[[Sshoi-sson Palace, Grand Provincial Bank, Bursarium]]'],
-  "Raven's Point"				=> ["[[Bank of Raven's Point, Depository]]"],
-  'Riverhaven'				=> ['[[Bank of Riverhaven, Teller]]'],
-  "Rossman's Landing"	=> ['Unknown Description'],
-  'Shard'						  => ["[[First Bank of Ilithi, Teller's Windows]]"],
-  'Therenborough'			=> ['[[Bank of Therenborough, Teller]]'],
-  'Throne City'				=> ['[[Faldesu Exchequer, Teller]]']
+  "Ain Ghazal"         => ["Unknown Description"],
+  "Boar Clan"          => ["Unknown Description"],
+  "Crossings"          => ["[[Provincial Bank, Teller]]"],
+  "Dirge"              => ["[[Dirge, Traveller's Bank]]"],
+  "Fang Cove"          => ["[[First Council Banking, Vault]]"],
+  "Hibarnhvidar"       => ["[[Second Provincial Bank of Hibarnhvidar, Teller]]", "[[Hibarnhvidar, Teller Windows]]", "[[First Arachnid Bank, Lobby]]"],
+  "Ilaya Taipa"        => ["Unknown Description"],
+  "Leth Deriel"        => ["[[Imperial Depository, Domestic Branch]]"],
+  "Ratha"              => ["[[Lower Bank of Ratha, Cashier]]", "[[Sshoi-sson Palace, Grand Provincial Bank, Bursarium]]"],
+  "Riverhaven"         => ["[[Bank of Riverhaven, Teller]]"],
+  "Shard"              => ["[[First Bank of Ilithi, Teller's Windows]]"],
+  "Therenborough"      => ["[[Bank of Therenborough, Teller]]"],
+  "Throne City"        => ["[[Faldesu Exchequer, Teller]]"],
+  "Aesry Surlaenis'a"  => ["[[Tona Kertigen, Deposit Window]]"],
+  "Chyolvea Tayeu'a"   => ["[[Chyolvea Tayeu'a, Teller]]"],
+  "Hara'jaal"          => ["Unknown Description"],
+  "Mer'Kresh"          => ["[[Harti Clemois Bank, Teller's Window]]"],
+  "Muspar'i"           => ["[[Old Lata'arna Keep, Teller Windows]]"],
+  "Raven's Point"      => ["[[Bank of Raven's Point, Depository]]"],
+  "Rossman's Landing"  => ["Unknown Description"]
 }
 
 vault_titles = {
-  'Crossings'					=> ['[[Crossing, Carousel Chamber]]'],
-  'Leth Deriel'				=> ['[[Leth Deriel, Carousel Chamber]]'],
-  "Muspar'i"					=> ["[[Muspar'i, Carousel Square]]"],
-  'Ratha'						=> ['[[Ratha, Carousel Square]]'],
-  'Riverhaven'				=> ['[[Riverhaven, Carousel Chamber]]'],
-  'Shard'						=> ['[[Shard, Carousel Square]]'],
-  "Mer'Kresh"					=> ["[[Mer'Kresh, Carousel Square]]"],
-  'Therenborough'				=> ['[[Therenborough, Carousel Square]]']
+  "Crossings"          => ["[[Crossing, Carousel Chamber]]"],
+  "Fang Cove"          => ["[[Fang Cove, Carousel Chamber]]"],
+  "Leth Deriel"        => ["[[Leth Deriel, Carousel Chamber]]"],
+  "Ratha"              => ["[[Ratha, Carousel Square]]"],
+  "Riverhaven"         => ["[[Riverhaven, Carousel Chamber]]"],
+  "Shard"              => ["[[Shard, Carousel Square]]"],
+  "Therenborough"      => ["[[Therenborough, Carousel Square]]"],
+  "Mer'Kresh"          => ["[[Mer'Kresh, Carousel Square]]"],
+  "Muspar'i"           => ["[[Muspar'i, Carousel Square]]"]
 }
 #
 # Register ;banks ;vault commands
@@ -857,15 +859,15 @@ while line = script.gets
       if CharSettings['vault_info'].empty?
         respond 'No vault info recorded.'
       else
-        respond "					Your vault is located in #{CharSettings['vault_info']['location']}"
-        respond '					---------------------------------------'
-        respond "					#{CharSettings['vault_info']['contents']}"
+        respond "          Your vault is located in #{CharSettings['vault_info']['location']}"
+        respond "          ---------------------------------------"
+        respond "          #{CharSettings['vault_info']['contents']}"
       end
       respond
     elsif line =~ /(?:In the secure vault you see|You rummage through a secure vault and see)\s(.*)\./
       vault_titles
         .select { |_town, titles| titles.include?(checkroom) }
-        .each do |_town, _titles|
+        .each do |town, _titles|
           contents = Regexp.last_match(1)
           line.scan(/a.*?(?:(\w+ (?:shelf|rack|box|case|tree))) with some stuff (on|in) it/).each do |noun, location|
             fput 'look ' + location + ' ' + noun
@@ -873,7 +875,7 @@ while line = script.gets
               contents += Regexp.last_match(1).sub(/ and(.*)/, ',\1,')
             end
           end
-          CharSettings['vault_info']['location'] = checkarea.slice(/\w+/)
+          CharSettings['vault_info']['location'] = town
           CharSettings['vault_info']['contents'] = contents.sub(/,$/, '')
         end
     elsif line =~ /^Circle: (\d+)/
@@ -914,7 +916,7 @@ while line = script.gets
       CharSettings['Stats'] = DRStats.serialize
     elsif line =~ /You have (\d+) TDPs\./
       DRStats.tdps = Regexp.last_match(1).to_i
-    elsif line =~ /The clerk slides a small metal box across the counter into which you drop (\d+) (\w+) (?:Kronars|Lirums|Dokoras)./
+    elsif line =~ /The clerk slides a small metal box across the counter into which you drop (\d+) (\w+) (?:Kronars|Lirums|Dokoras)/
       # you deposited a portion of your money
       bank_titles
         .select { |_town, titles| titles.include?(checkroom) }
@@ -923,10 +925,10 @@ while line = script.gets
           CharSettings['bank_accounts'][town] = CharSettings['bank_accounts'][town].to_i + copper
           break
         end
-    elsif line =~ /^The clerk slides a small metal box across the counter into which you drop all your (?:Kronars|Lirums|Dokoras).  She counts them carefully and records the deposit in her ledger\./
+    elsif line =~ /^The clerk slides a small metal box across the counter into which you drop all your (?:Kronars|Lirums|Dokoras).  She counts them carefully and records the deposit in her ledger|You cross through the old balance on the label and update it to reflect your new balance/
       # you deposited all your money
       fput 'balance'
-    elsif line =~ /^The clerk counts out ([0-9]+) (platinum|gold|silver|bronze|copper) (?:Kronars|Lirums|Dokoras) and hands them over, making a notation in her ledger\./
+    elsif line =~ /(?:The clerk counts|You count) out ([0-9]+) (platinum|gold|silver|bronze|copper) (?:Kronars|Lirums|Dokoras) (?:and hands them over, making a notation in her ledger|and quickly pocket them, updating the notation on your jar)/
       # you withdrew some money
       bank_titles
         .select { |_town, titles| titles.include?(checkroom) }
@@ -935,7 +937,7 @@ while line = script.gets
           CharSettings['bank_accounts'][town] = CharSettings['bank_accounts'][town].to_i - copper
           break
         end
-    elsif line =~ /^The clerk counts out all your (?:Kronars|Lirums|Dokoras) and hands them over, making a notation in her ledger\./
+    elsif line =~ /(?:The clerk counts out all your|You count out all of your) (?:Kronars|Lirums|Dokoras) (?:and hands them over, making a notation in her ledger|and quickly pocket them)/
       # you withdrew all your money
       bank_titles.each do |town, titles|
         if titles.include?(checkroom)
@@ -943,10 +945,9 @@ while line = script.gets
           break
         end
       end
-    elsif line =~ /[it looks like|\"Here we are.]\s[y]our current balance is (.*)\s(?:Kronars|Lirums|Dokoras)\.\"/i
+    elsif line =~ /(?:(?:it looks like|\"Here we are.)\s[y]our current balance is|As expected, there are) (.*)\s(?:Kronars|Lirums|Dokoras)/i
       # you checked your balance
       copper = 0
-      # echo $1
       Regexp.last_match(1).each_line(', ') do |m|
         m.to_s
         a = m.match(/([0-9]+).[a-z]+/)
@@ -958,7 +959,7 @@ while line = script.gets
           break
         end
       end
-    elsif line =~ /you do not seem to have an account with us/
+    elsif line =~ /you do not seem to have an account with us|you should find a new deposit jar for your financial needs/
       # you have no account
       bank_titles.each do |town, titles|
         if titles.include?(checkroom)


### PR DESCRIPTION
### Background
* I was spelunking in drinfomon script and came across the `;bank` and `;vault` commands
* I use Fang Cove and noticed the bank/vault command was not registering when I rummaged the vault or modified my balances.
* I don't use nor plan to use these commands, but if they're here then they might as well work :)

### Changes
* Add Fang Cove to bank_titles and vault_titles list to track balances and inventory when you rummage your vault
* Sorted the enties in bank_titles and vault_titles
* In the great war of tabs vs. spaces, spaces wins
* In the great battle of mixed use of single and double quotes, double-quoted strings wins

### Tests
* I tested these changes in Crossing and Fang Cove
* For `;banks`, I withdraw some, withdrew all, deposited some, deposited all, checked balance
* For `;vault`, I rummaged my vault in Fang Cove

### FYI
@jandersson heads up on some incoming changes to drinfomon script. I saw you worked on it most recently a few months ago