### PR TITLE
create_remedies.lic

### DIFF
--- a/create_remedies.lic
+++ b/create_remedies.lic
@@ -1,0 +1,59 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#create_remedies
+=end
+
+custom_require.call(%w[common common-crafting])
+
+class Create_remedies
+  include DRC
+  include DRCC
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'target', regex: /\w+/, description: 'Recipe.' },
+        { name: 'catalyst', regex: /\w+/i, optional: true, description: 'Catalyst to use. Default is coal.' },
+        { name: 'tools', regex: /tools/i, optional: true },
+        { name: 'debug', regex: /debug/i, optional: true }
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
+    settings = get_settings
+    crafting_data = get_data('crafting')
+    hometown = settings.hometown
+    info = crafting_data['remedies'][hometown]
+    catalyst = args.catalyst || info['catalyst']
+
+    # Get recipe
+    recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /#{args.target}/i }
+    echo("Recipe is: #{recipe}.") if debug
+    # Gather first herb section based on settings
+    get_prep_herb(recipe['herb1'])
+    # Gather second herb if necessary
+    get_prep_herb(recipe['herb2']) unless recipe['herb2'].nil?
+    # Get tools?
+    get_store_tools("get") if args.tools
+    # Craft call section
+    if recipe['herb2'].nil?
+      herb2_needed = 'na'
+      wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], herb2_needed, catalyst, recipe['container'], recipe['noun']])
+    else
+      wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], recipe['herb2'], catalyst, recipe['container'], recipe['noun']])
+    end
+    # Store tools?
+    get_store_tools("store") if args.tools
+  end
+
+  def get_prep_herb(herb)
+    wait_for_script_to_complete('alchemy', [herb, 'forage', 25])
+    wait_for_script_to_complete('alchemy', [herb, 'prepare'])
+  end
+
+  def get_store_tools(option)
+    echo("Option for tools is: {option}.") if debug
+    wait_for_script_to_complete('clerk-tools',['alchemy', 'get']) if option == "get"
+    wait_for_script_to_complete('clerk-tools',['alchemy', 'store']) if option == "store"
+  end
+end
+Create_remedies.new


### PR DESCRIPTION
This script uses the new alchemy forage and process method then will create the remedy. All one needs to do is enter the product - ;create_remedies "limb ungent" "pewter ingot" tools. The script will do the rest. The pewter ingot is an optional catalyst to use and tools will retrieve and store the tools with the Clerk.

This script will not purchase the herbs from the Society. The assumption in using this script is you have adequate Outdoorsmanship skill to forage the herbs and the remedy is not for `workorders` or skill increase only, aka `;craft`.