### PR TITLE
Remedy script update - lower ground

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -178,7 +178,8 @@ class Remedy
     end
     get_item(@container)
 
-    bput("lower my #{@container} to ground", 'You lower') # lower to count and combine herbs
+    bput('swap', 'You move', 'You have nothing') unless right_hand =~ /#{@container}/i #lower ground only works if the container is in the right hand.
+    bput("lower ground", 'You lower') # lower to count and combine herbs. Switched to just lower ground so it works with all containers.
 
     # count herb, less than 25 get more herbs, otherwise stow and continue
     # added to handle herb containers, and modified to combine up to 25
@@ -196,7 +197,8 @@ class Remedy
           stow_item(@container)
           bput("get my #{@herb1}", 'You get', 'What were you referring to?', 'You are already holding that.') # using bput instead of get_item to keep script running when it cannot get the herb
           get_item(@container)
-          bput("lower my #{@container} ground", 'You lower')
+          bput('swap', 'You move', 'You have nothing') unless right_hand =~ /#{@container}/i #lower ground only works if the container is in the right hand.
+          bput("lower ground", 'You lower') # lower to count and combine herbs. Switched to just lower ground so it works with all containers.
           bput("get #{@herb1} from #{@container}", 'You get', 'What were you referring to?')
           if bput("combine my #{@herb1}", 'You combine', 'too large to add', 'You must be holding both') == 'You must be holding both'
             @count = 25 # 25 used to break loops


### PR DESCRIPTION
Changed lower my #{container} to just lower ground. I had several people in Discord confirm `lower ground` works for their containers where `lower my #{@container} to ground` did not. Also, put in a check to make sure the container is in the right hand.

Opening this in draft mode because I have a question. 

:question: Should I go through and put DRC. in front of all the bputs? 

@KatoakDR 