### PR TITLE
[script] [common-summoning] Revert and fix logic for 'glancing' at moon weapon

### DIFF
--- a/common-summoning.lic
+++ b/common-summoning.lic
@@ -73,16 +73,21 @@ module DRCS
   end
 
   def moon_used_to_summon_weapon
-    case "#{DRC.left_hand}|#{DRC.right_hand}"
-    when /black moon[\w]+/
-      return 'katamba'
-    when /red-hot moon[\w]+/
-      return 'yavash'
-    when /blue-white moon[\w]+/
-      return 'xibar'
-    else
-      return nil
+    # Note, if you have more than one weapon summoned at a time
+    # then the results of this method are non-deterministic.
+    # For example, if you have 2+ moonblades/staffs cast on different moons.
+    ['moonblade', 'moonstaff'].each do |weapon|
+      glance = DRC.bput("glance my #{weapon}", "You glance at a .* (black|red-hot|blue-white) moon(blade|staff)", "I could not find")
+      case glance
+      when /black moon[\w]+/
+        return 'katamba'
+      when /red-hot moon[\w]+/
+        return 'yavash'
+      when /blue-white moon[\w]+/
+        return 'xibar'
+      end
     end
+    return nil
   end
 
   def turn_summoned_weapon


### PR DESCRIPTION
### Background
* While investigating https://github.com/rpherbig/dr-scripts/pull/4732, @rpherbig [recalled](https://github.com/rpherbig/dr-scripts/pull/4732#issuecomment-779256517) this method had changed and likely introduced the reported issue.
* Related to https://github.com/rpherbig/dr-scripts/pull/4746 and https://github.com/rpherbig/dr-scripts/pull/4745, and this and those PRs can be merged in any order of each other, and all 3 supercede https://github.com/rpherbig/dr-scripts/pull/4732

### Changes
* Fix logic flaw that I introduced in https://github.com/rpherbig/dr-scripts/pull/4473 that assumes you'll be holding a summoned moon weapon when checking it. In combat-trainer, it's likely you'll be wearing it if you're training a different weapon skill.
* Avoids ambiguity of items whose nouns start with "moon" by checking explicitly for `moonblade` or `moonstaff`.

## Tests

### Identify worn moonstaff
```
> wear moonstaff

You gently suspend your blue-white moonstaff on currents of telekinetic force.

> ,e echo DRCS.moon_used_to_summon_weapon

--- Lich: exec1 active.

[exec1]>glance my moonblade

I could not find what you were referring to.
> 
[exec1]>glance my moonstaff

You glance at a long blue-white moonstaff.
> 
[exec1: xibar]

--- Lich: exec1 has exited.
```

### Identify held moonblade
```
--- Lich: exec1 active.

[exec1]>glance my moonblade

You glance at a fiery red-hot moonblade.
> 
[exec1: yavash]

--- Lich: exec1 has exited.
```

### No summoned moon weapon 
```
> ,e echo DRCS.moon_used_to_summon_weapon

--- Lich: exec1 active.

[exec1]>glance my moonblade

I could not find what you were referring to.
> 
[exec1]>glance my moonstaff

I could not find what you were referring to.
> 
[exec1: ]

--- Lich: exec1 has exited.
```