### PR TITLE
[script] [common-moonmage] Simplify logic for 'hold_moon_weapon?'

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -170,35 +170,18 @@ module DRCMM
   end
 
   # Try to hold a moon weapon.
-  # If one isn't already in your hands then will look to see if
-  # one is floating around you and hold it.
   # If you end up not holding a moon weapon then returns false.
   def hold_moon_weapon?
     return true if holding_moon_weapon?
-    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
-    moon_floating_regex = /((black|red-hot|blue-white) moon[\w]+) bobs lazily in the air next to you/
-    moon_hold_messages = ["You grab", "You aren't wearing", "Hold hands with whom?"]
-    held_it = false
-    # Look at yourself to see if you're wearing a moon weapon.
-    # This regex specifically checks for the messaging that it's in the air next to you
-    # so that we avoid false positives like wearing a "black moonsilk shirt".
-    # Known caveat, this won't work if you're wearing a shadowsilk cloak or something that hides all worn items.
-    look_result = DRC.bput("look #{Char.name}", moon_floating_regex, "You are wearing", "You are wrapped", "I could not find")
-    # Now try to extract just the moon weapon name from what we saw.
-    scan_result = look_result.scan(moon_weapon_regex)
-    # If a match was found then grab it from the captured groups per the regex.
-    if scan_result.length > 0 && scan_result[0].length > 0
-      moon_weapon = scan_result[0][0]
-      held_it = DRC.bput("hold #{moon_weapon}", *moon_hold_messages) == "You grab"
-    else
-      # At this point you're neither holding a moon weapon nor did we see one
-      # hovering around you. In case you're wearing a shadowsilk cloak or other
-      # item that hides all your features then we will brute force try to hold
-      # all known moon weapon types as a last ditch effort.
-      held_it = held_it || DRC.bput("hold moonblade", *moon_hold_messages) == "You grab"
-      held_it = held_it || DRC.bput("hold moonstaff", *moon_hold_messages) == "You grab"
+    return false if [DRC.left_hand, DRC.right_hand].compact.length >= 2
+    ['moonblade', 'moonstaff'].each do |weapon|
+      glance = DRC.bput("glance my #{weapon}", "You glance at a .* #{weapon}", "I could not find")
+      case glance
+      when /You glance/
+        return DRC.bput("hold my #{weapon}", "You grab", "You aren't wearing", "Hold hands with whom?", "You need a free hand") == "You grab"
+      end
     end
-    return held_it
+    false
   end
 
 end


### PR DESCRIPTION
### Background
* I introduced the `hold_moon_weapon?` in https://github.com/rpherbig/dr-scripts/pull/4470
* At the time, I didn't fully understand how the Moonblade and Shape Moonblade spells worked and thought there could be all sorts of variants of moon* (moonblade, moonstaff, moonkatar, etc).
* Also, I was not aware of the simplicty of using the `glance` command over the `look` command.
* I came back to this method while investigating https://github.com/rpherbig/dr-scripts/pull/4732 and while fixing https://github.com/rpherbig/dr-scripts/pull/4744
* Related to https://github.com/rpherbig/dr-scripts/pull/4744 and https://github.com/rpherbig/dr-scripts/pull/4746, and this and those PRs can be merged in any order of each other, and all 3 supercede https://github.com/rpherbig/dr-scripts/pull/4732

### Changes
* Atone for my sins and simplify the `hold_moon_weapon?` method, inspired by https://github.com/rpherbig/dr-scripts/pull/4744

## Tests

### Not holding or wearing a moonblade
```
> ,e echo DRCMM.hold_moon_weapon?

--- Lich: exec1 active.

[exec1]>glance my moonblade

I could not find what you were referring to.
> 
[exec1]>glance my moonstaff

I could not find what you were referring to.
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### Holding a moonblade
```
> ,e echo DRCMM.hold_moon_weapon?

--- Lich: exec1 active.

[exec1: true]

--- Lich: exec1 has exited.
```

### Holding a moonstaff
```
> ,e echo DRCMM.hold_moon_weapon?

--- Lich: exec1 active.

[exec1: true]

--- Lich: exec1 has exited.
```

### Wearing a moonblade
```
> ,e echo DRCMM.hold_moon_weapon?

--- Lich: exec1 active.

[exec1]>glance my moonblade

> 
You glance at a cold blue-white moonblade.
> 
[exec1]>hold my moonblade

You grab your blue-white moonblade from the air.

> 
[exec1: true]

--- Lich: exec1 has exited.
```

### Wearing a moonstaff
```
> ,e echo DRCMM.hold_moon_weapon?

--- Lich: exec1 active.

[exec1]>glance my moonblade

I could not find what you were referring to.
> 
[exec1]>glance my moonstaff

You glance at a long blue-white moonstaff.
> 
[exec1]>hold my moonstaff

You grab your blue-white moonstaff from the air.

> 
[exec1: true]

--- Lich: exec1 has exited.
```

### Hands are full
```
> ,e echo DRCMM.hold_moon_weapon?

--- Lich: exec1 active.

[exec1: false]

--- Lich: exec1 has exited.
```