### PR TITLE
Fix to the github comms deprecation.

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -448,13 +448,12 @@ class ScriptManager
 
   def make_request(raw_uri)
     uri = URI.parse(raw_uri)
-    args = { access_token: @git_token }
-    uri.query = URI.encode_www_form(args)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
     request = Net::HTTP::Get.new(uri.request_uri)
+    request['Authorization'] = "token #{@git_token}"
 
     response = http.request(request)
     JSON.parse(response.body)


### PR DESCRIPTION
Tested the fix with a clean install of Lich.

1. Made change to dependency.lic within `make_request` method.
2. Commented out the update for dependency.lic from within itself...
```
  def download_script(filename, force = false)
    return if filename.nil? || filename.empty?
    echo("downloading:#{filename}") if @debug
    info = get_file_status(filename)
    return unless info
    return if @developer
    return if get_versions[filename] == info['sha'] && !force
    if filename == 'dependency.lic'
      echo "Skipping dependency.lic update..."
      return
    end
```
3. The above step requirement actually confirms it works, but moved on for further testing.
4.  Made changes to the top of a few scripts like combat-trainer. 
5. Re-ran dependency.lic, files updated and were overwritten successfully. 
6. The args and uri.query seem to be unnecessary, removed.

Let me know if you all believe any more testing is required.

Resolves #4478