### PR TITLE
[script] [common] Add match strings when playing/cleaning instrument

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -493,7 +493,7 @@ module DRC
       play_command = play_command + " on my #{instrument}"
     end
     fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
-    result = bput(play_command, 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
+    result = bput(play_command, 'too damaged to play', 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
     case result
     when 'Play on what instrument'
       snapshot = "#{right_hand}#{left_hand}"
@@ -543,7 +543,7 @@ module DRC
   def clean_instrument(settings, worn = true)
     cloth = settings.cleaning_cloth
     instrument = worn ? settings.worn_instrument : settings.instrument
-    case bput("get my #{cloth}", 'You get', 'What were you')
+    case bput("get my #{cloth}", 'You get', 'You are already holding', 'What were you')
     when 'What were you'
       echo('You have no chamois cloth -- this could cause problems with playing an instrument!')
       beep


### PR DESCRIPTION
### Changes
* Add match string if instrument is too damaged to play
* Add match string if you're already holding a cleaning cloth

With all the weather-resistant zills and cowbells out there, I'm not surprised the "too damaged to play" hasn't come up more often. I hit that using a flute that got wet from rain.

And I ran into the "already holding" a cleaning cloth when I stopped and restarted the script midway through trying to clean the instrument.

❓ What I'm not sure about is whether `'too damaged to play'` should be another case when you clean your instrument as with `'dirtiness may affect your performance'`. I've since switched back to weather resistant zills myself.