### PR TITLE
[script] [common-items] Add match strings to open/close containers

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -5,22 +5,56 @@
 
 $TRASH_STORAGE = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot]
 
-$PUT_AWAY_ITEM_SUCCESS_PATTERNS = [/^You put your .* in/,
-                                   /^You hold out/,
-                                   /^You tuck your/]
-$PUT_AWAY_ITEM_OPEN_PATTERNS = [/^But that's closed/]
-$PUT_AWAY_ITEM_FAILURE_PATTERNS = [/^What were you referring to/,
-                                   /to fit in the/,
-                                  /^There isn't any more room in/]
+$PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
+  /^You put your .* in/,
+  /^You hold out/,
+  /^You tuck your/
+]
 
-$OPEN_CONTAINER_SUCCESS_PATTERNS = [/^You open/,
-                                    /^That is already open/]
-$OPEN_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
+$PUT_AWAY_ITEM_OPEN_PATTERNS = [
+  /^But that's closed/
+]
 
+$PUT_AWAY_ITEM_FAILURE_PATTERNS = [
+  /^Please rephrase that command/,
+  /^What were you referring to/,
+  /^I could not find what you were referring to/,
+  /to fit in the/,
+  /^There isn't any more room in/
+]
 
-$CLOSE_CONTAINER_SUCCESS_PATTERNS = [/^You close/,
-                                     /^That is already closed/]
-$CLOSE_CONTAINER_FAILURE_PATTERNS = [/^What were you referring to/]
+$OPEN_CONTAINER_SUCCESS_PATTERNS = [
+  /^You open/,
+  /^That is already open/,
+  /^You spread your arms, carefully holding your bag well away from your body/
+]
+
+$OPEN_CONTAINER_FAILURE_PATTERNS = [
+  /^Please rephrase that command/,
+  /^What were you referring to/,
+  /^I could not find what you were referring to/,
+  /^You don't want to ruin your spell just for that do you/,
+  /^It would be a shame to disturb the silence of this place for that/,
+  /^This is probably not the time nor place for that/,
+  /^There is no way to do that/,
+  /^You can't do that/
+]
+
+$CLOSE_CONTAINER_SUCCESS_PATTERNS = [
+  /^You close/,
+  /^That is already closed/
+]
+
+$CLOSE_CONTAINER_FAILURE_PATTERNS = [
+  /^Please rephrase that command/,
+  /^What were you referring to/,
+  /^I could not find what you were referring to/,
+  /^You don't want to ruin your spell just for that do you/,
+  /^It would be a shame to disturb the silence of this place for that/,
+  /^This is probably not the time nor place for that/,
+  /^There is no way to do that/,
+  /^You can't do that/
+]
 
 custom_require.call(%w[common common-travel])
 
@@ -372,21 +406,15 @@ module DRCI
     case DRC.bput("open #{container}", $OPEN_CONTAINER_SUCCESS_PATTERNS, $OPEN_CONTAINER_FAILURE_PATTERNS)
     when *$OPEN_CONTAINER_SUCCESS_PATTERNS
       return true
-    when *$OPEN_CONTAINER_FAILURE_PATTERNS
-      return false
-    else
-      return false
     end
+    return false
   end
 
   def close_container?(container)
     case DRC.bput("close #{container}", $CLOSE_CONTAINER_SUCCESS_PATTERNS, $CLOSE_CONTAINER_FAILURE_PATTERNS)
     when *$CLOSE_CONTAINER_SUCCESS_PATTERNS
       return true
-    when *$CLOSE_CONTAINER_FAILURE_PATTERNS
-      return false
-    else
-      return false
     end
+    return false
   end
 end


### PR DESCRIPTION
### Changes
* Add more match strings for successful/failure attempts to open/close containers
* Some rooms don't let you take these actions on certain containers, like in banks, or if you have certain spells active
* Format arrays to left-align in the file to not waste space and to not require horizontal scroll

## Tests (some)

### Try to open container in bank
```
> ,e echo DRCI.open_container?('backpack')

--- Lich: exec1 active.

[exec1]>open backpack

This is probably not the time nor place for that.
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### Try to open container outside bank
```
> ,e echo DRCI.open_container?('backpack')

--- Lich: exec1 active.

[exec1]>open backpack

You open the backpack, the soft material moving soundlessly.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### Try to open an already open container
```
> ,e echo DRCI.open_container?('backpack')

--- Lich: exec1 active.

[exec1]>open backpack

That is already open.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### Try to open a non-existant container
```
> ,e echo DRCI.open_container?('basket')

--- Lich: exec1 active.

[exec1]>open basket

What were you referring to?
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### Try to open an unopenable container
```
> ,e echo DRCI.open_container?('boots')

--- Lich: exec1 active.

[exec1]>open boots

You can't do that.
> 
[exec1: false]

--- Lich: exec1 has exited.
```