### PR TITLE
[script] [common-arcana] harness mana, restore #4718, and cleanup

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -31,12 +31,16 @@ module DRCA
     end
   end
 
-  def harness_mana(amount)
-    amount.each do |mana|
-      result = DRC.bput("harness #{mana}", 'You tap into', 'Strain though you may')
-      pause 0.5
-      waitrt?
-      break if result =~ /Strain though you may/
+  def harness?(mana)
+    result = DRC.bput("harness #{mana}", 'You tap into', 'Strain though you may')
+    pause 0.5
+    waitrt?
+    return result =~ /You tap into/
+  end
+
+  def harness_mana(amounts)
+    amounts.each do |mana|
+      break unless harness?(mana)
     end
   end
 
@@ -74,15 +78,9 @@ module DRCA
       .each do |name|
         activate_barb_buff?(name)
         waitrt?
-        pause settings.meditation_pause_timer.to_i if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'
+        pause settings.meditation_pause_timer.to_i if get_data('spells').barb_abilities[name]['type'].eql?('meditation')
         DRC.fix_standing
       end
-  end
-
-  # Deprecated, will be removed in a future update
-  # Use 'activate_babr_buff?' instead.
-  def activate_barb_buff(name)
-    activate_barb_buff?(name)
   end
 
   def activate_barb_buff?(name)
@@ -290,7 +288,12 @@ module DRCA
     result = DRC.bput("charge my #{cambrinth} #{mana}", get_data('spells').charge_messages, 'I could not find')
     pause
     waitrt?
-    result =~ /absorbs? all of the energy/
+    case result
+    when /You are in no condition to do that/
+      harness?(mana)
+    else
+      result =~ /absorbs? all of the energy/
+    end
   end
 
   def release_cyclics
@@ -402,7 +405,7 @@ module DRCA
     infuse_om(!settings.osrel_no_harness, settings.osrel_amount)
     spells.each do |name, data|
       next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
-      while (mana < settings.waggle_spells_mana_threshold || DRStats.concentration < settings.waggle_spells_concentration_threshold)
+      while (DRStats.mana < settings.waggle_spells_mana_threshold || DRStats.concentration < settings.waggle_spells_concentration_threshold)
         echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
         pause 15
       end
@@ -685,7 +688,7 @@ module DRCA
   def crafting_magic_routine(settings)
     training_spells = settings.crafting_training_spells
     return if training_spells.empty?
-    return if mana <= 40
+    return if DRStats.mana <= settings.waggle_spells_mana_threshold
 
     if !XMLData.prepared_spell.eql?('None') && checkcastrt == 0
       spell = XMLData.prepared_spell
@@ -732,7 +735,7 @@ module DRCA
     return unless Script.running?('avtalia')
 
     invoke(cambrinth, dedicated_camb_use, invoke_amount)
-    UserVars.avtalia[cambrinth]['mana'] -= [mana, invoke_amount].min
+    UserVars.avtalia[cambrinth]['mana'] -= [DRStats.mana, invoke_amount].min
   end
 
   def charge_avtalia(cambrinth, charge_amount)


### PR DESCRIPTION
### Background
* https://github.com/rpherbig/dr-scripts/pull/4737 inadvertently reverted https://github.com/rpherbig/dr-scripts/pull/4718, this adds those changes back in
* As an Empath, I often am too injured to use my cambrinth items when trying to heal myself, harnessing as a backup ensures I cast the spell with the intended mana amount rather than min prep.

### Changes
* Re-introduce changes from https://github.com/rpherbig/dr-scripts/pull/4718
* Update `charge?` to harness mana if too injured to charge a cambrinth item
* Move the harnessing logic of `harness_mana(array_of_amounts)` to `harness?(mana)` predicate to know if were successful and to be reusable
* Remove obsolete method `activate_barb_buff` which was replaced by `activate_barb_buff?` predicate

## Tests

### If too injured to charge cambrinth, harness instead
_Example where original logic neither charged or harnessed when too injured_
```
[healme]>get my cambrinth rod

You get a twisted cambrinth rod resembling a unicorn's horn from inside your yellow haversack.
!> 
[healme]>charge my cambrinth rod 5

You are in no condition to do that.
!> 
[healme]>invoke my cambrinth rod

You are in no condition to do that.
!> 
[healme]>stow my cambrinth rod

You put your rod in your first aid kit.

[healme]>cast

You gesture.
A sudden sensation of warmth spreads through your body, focusing on your bleeding wounds.
```
_With new logic, will harness if can't charge_
```
[healme]>get my cambrinth rod

You get a twisted cambrinth rod resembling a unicorn's horn from inside your first aid kit.
> 
[healme]>charge my cambrinth rod 8

You are in no condition to do that.
> 
[healme]>harness 8

You tap into the mana from eight of the surrounding streams and attempt to keep it channeling in a stream around you.
Roundtime: 3 sec.
> 
> 
[healme]>charge my cambrinth rod 8

You are in no condition to do that.
> 
[healme]>harness 8

You tap into the mana from eight of the surrounding streams and add it to the average amount already streaming around you.
Roundtime: 3 sec.
> 
[healme]>invoke my cambrinth rod

You are in no condition to do that.
> 
[healme]>stow my cambrinth rod

> 
You put your rod in your first aid kit.
> 
> 
[healme]>cast HEAD 

You gesture.
You contribute your harnessed streams to increase the pattern's potential.
The external wounds on your head appear completely healed.
The internal wounds on your head appear completely healed.
```

### Harness multiple amounts (regression test)
```
> ,e DRCA.harness_mana([3,3])

--- Lich: exec1 active.

[exec1]>harness 3

You tap into the mana from three of the surrounding streams and attempt to keep it channeling in a stream around you.
Roundtime: 3 sec.
> 
[exec1]>harness 3

You tap into the mana from three of the surrounding streams and add it to the small amount already streaming around you.
Roundtime: 3 sec.
> 
--- Lich: exec1 has exited.
```

### FYI
@Dartellum as a recent contributor to common-arcana, wanted to let you know about this changes I'm proposing