### PR TITLE
[script] [attunement] Add "health walk" option to train attunement + empathy

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -12,16 +12,24 @@ class Attunement
   LUNAR_PERCEIVE_COMMANDS = ['mana', 'moons', 'planets']
 
   def initialize
+    arg_definitions = [
+      [
+        { name: 'health', regex: /health/, optional: true, description: 'As an Empath, will do PERCEIVE HEALTH instead of PERCEIVE to train empathy.' },
+      ]
+    ]
+    args = parse_args(arg_definitions, true)
     settings = get_settings
     @stationary_skills_only = settings.crossing_training_stationary_skills_only
     @hometown = settings.hometown
     @attunement_rooms = settings.attunement_rooms
+    @perceive_health_rooms = settings.perceive_health_rooms
+    @skill_to_train = (DRStats.empath? && args.health) ? 'Empathy' : 'Attunement'
     @exp_max_threshold = settings.crossing_training_max_threshold
     @exp_target_increment = settings.attunement_target_increment
-    @exp_start_mindstate = DRSkill.getxp('Attunement')
+    @exp_start_mindstate = DRSkill.getxp(@skill_to_train)
     @exp_stop_mindstate = get_target_mindstate(@exp_start_mindstate, @exp_target_increment, @exp_max_threshold)
     @lunar_perceive_index = -1
-    train_attunement(settings)
+    train_skill(settings)
   end
 
   # Determines the target mind state to train to
@@ -36,6 +44,10 @@ class Attunement
     DRStats.moon_mage? || DRStats.trader?
   end
 
+  def is_health_walk?
+    @skill_to_train == 'Empathy'
+  end
+
   def get_next_lunar_perceive_index
     @lunar_perceive_index = (@lunar_perceive_index + 1) % LUNAR_PERCEIVE_COMMANDS.length
   end
@@ -43,36 +55,67 @@ class Attunement
   def get_perceive_command
     if is_lunar_mage?
       "perceive #{LUNAR_PERCEIVE_COMMANDS[get_next_lunar_perceive_index]}"
+    elsif is_health_walk?
+      "perceive health"
     else
       "perceive"
     end
   end
 
   def get_rooms
+    rooms = []
     if @stationary_skills_only || is_lunar_mage?
-      [Room.current.id]
-    elsif !@attunement_rooms.empty?
-      @attunement_rooms
+      rooms = [Room.current.id]
+    elsif is_health_walk?
+      rooms = @perceive_health_rooms
+      rooms = get_data('town')[@hometown]['perceive_health_rooms'] if rooms.empty?
     else
-      get_data('town')[@hometown]['attunement_rooms']
+      rooms = @attunement_rooms
+      rooms = get_data('town')[@hometown]['attunement_rooms'] if rooms.empty?
     end
+    rooms
   end
 
   def done_training?
-    DRSkill.getxp('Attunement') >= @exp_stop_mindstate
+    DRSkill.getxp(@skill_to_train) >= @exp_stop_mindstate
   end
 
-  def train_attunement(settings)
+  def train_skill(settings)
     room_list = get_rooms
     until done_training?
       # If we keep looping, ensure buffs stay active
       DRCA.do_buffs(settings, 'attunement')
       room_list.each do |room_id|
-        walk_to(room_id)
-        bput(get_perceive_command, 'You reach out', 'Roundtime')
-        waitrt?
+        train_skill_in_room(room_id)
         break if done_training?
       end
+    end
+  end
+
+  def train_skill_in_room(room_id)
+    DRCT.walk_to(room_id)
+    # When health walking, you may fail to perceive your first time.
+    # Either from lack of skill or waiting on the timer between perceive health attempts.
+    # When health walking, will retry a few times before moving on.
+    # When power walking, will be successful first try and move on like normal.
+    5.times do
+      break if perceived?
+      # There is a 60 second timer between successful 'perceive health' commands.
+      # So if doing a health walk then pause a little bit between retries to avoid
+      # spamming the room (and yourself) with failed attempts. For normal attunement
+      # training then the wait is only as long as the perceive command takes.
+      pause (is_health_walk? ? 10 : 0)
+      waitrt?
+    end
+    waitrt?
+  end
+
+  def perceived?
+    case bput(get_perceive_command, "You fail to sense", "You're not ready to do that again, yet", "You reach out", "You sense:", "Roundtime")
+    when "You reach out", "You sense:"
+      true
+    else
+      false
     end
   end
 

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -57,6 +57,7 @@ empty_values:
   attack_overrides: {}
   astrology_training: []
   attunement_rooms: []
+  perceive_health_rooms: []
   restock: {}
   athletics_outdoorsmanship_rooms: []
   combat_spell_training: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -503,7 +503,17 @@ full_pouch_container:
 classes_to_teach:
 avoid_athletics_in_justice: false
 athletics_outdoorsmanship_rooms:
+# Used by 'attunement' script.
+# These override the default rooms where magic users will visit to
+# train attunement via 'perceive' command.
+# If not defined then the rooms are taken from base-towns.yaml.
+# This is ignored for lunar mages and instead they train in their current room.
 attunement_rooms:
+# Used by 'attunement' script when called with the 'health' option.
+# These override the default rooms where Empaths will visit to
+# train empathy via 'perceive health' command.
+# If not defined then the rooms are taken from base-towns.yaml.
+perceive_health_rooms:
 training_rooms:
 journal_noun: journal
 


### PR DESCRIPTION
### Background
* Deneri in the empaths lich channel [asked](https://discord.com/channels/745675889622384681/745678251250417674/794988805525471252) if there was a script to do a "health walk" with T2.
* Kiriawen [answered](https://discord.com/channels/745675889622384681/745678251250417674/795021486854242315) that there wasn't, that `crossing-training` script trains empathy via its own code.
* Further discussion ensued about tweaking this script to support "health walks" in addition to "power walks".

### Changes
* Add optional `health` argument that will do a "health walk" for Empaths
* Add new setting `perceive_health_rooms` to override the base-towns.yaml rooms for a "health walk" (analogous to existing `attunement_rooms` setting)

### Sample Config
```yaml
# Used by 'attunement' script.
# These override the default rooms where magic users will visit to
# train attunement via 'perceive' command.
# If not defined then the rooms are taken from base-towns.yaml.
# This is ignored for lunar mages and instead they train in their current room.
attunement_rooms:

# Used by 'attunement' script when called with the 'health' option.
# These override the default rooms where Empaths will visit to
# train empathy via 'perceive health' command.
# If not defined then the rooms are taken from base-towns.yaml.
perceive_health_rooms:
- 100
- 200
- 300
```

### Credits
Kiriawen was very helpful in outlining how to add "health walk" to the attunement script and nuances around how to train empathy in this manner.

## Tests

### Health Walk (new feature)
```
> ,attunement health

--- Lich: attunement active.

--- Lich: go2 active.

[go2: ETA: 0:00:02 (14 rooms to move through)]

...

[attunement]>perceive health

You're not ready to do that again, yet.
> 
[attunement]>perceive health

You close your eyes, drawing all your thoughts inward, and then slowly reach out to sense the life essences of those around you...

You fail to sense anything, however.
Roundtime: 11 seconds
> 
[attunement]>perceive health

You close your eyes, drawing all your thoughts inward, and then slowly reach out to sense the life essences of those around you...

You sense:
    The presence of a monk.
Roundtime: 11 seconds

...
```

### Power Walk (regression test)
```
> ,attunement

--- Lich: attunement active.

--- Lich: go2 active.

[go2: ETA: 0:00:00 (1 rooms to move through)]

[go2]>s

You limp south.

[go2: travel time: 0:00:03]

--- Lich: go2 has exited.

[attunement]>perceive

You reach out with your senses and see shimmering (9/21) streams of vibrant blue and white Life mana flowing through the area.
You sense the Gift of Life spell upon you, which will last for about thirteen roisaen.
You sense the Manifest Force spell surrounding you, which will last for sixteen roisaen or until it has endured six more blows.
You sense the Refresh spell upon you, which will last for about seventeen roisaen.
Roundtime: 7 sec.

...

--- Lich: attunement has exited.
```