### PR TITLE
[script] [bescort] flying mount updates

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -305,15 +305,23 @@ class Bescort
     mode = mode.downcase
     case mode
     when 'mount'
-      bput("get my #{type}", /You get /, /You are already holding/)
+      bput("get my #{type}", /You get/, /You pick up/, /You are already holding/, /What were you referring/)
       case type
-      when /broom/i, /dirigible/i
-        bput("mount my #{type}", /You mount your/)
+      when /broom|dirigible/i
+        case bput("mount my #{type}", /You mount your/, /You are already mounted/, /What were you referring/)
+        when /What were you referring/
+          message("Can't mount your #{type}, where is it?")
+          exit
+        end
         bput("command #{type} to #{speed}", /You command your/)
-      when /carpet/i
-        bput(right_hand == type ? "lower ground right" : "lower ground left", /You lower/)
-        bput("unroll #{type}", /You carefully unroll/)
-        bput("mount #{type}", /You step onto your carpet which comes to life and slowly raises up off of the ground/)
+      when /carpet|rug/i
+        bput(right_hand == type ? "lower ground right" : "lower ground left", /You lower/, /But you aren't holding/)
+        bput("unroll #{type}", /You carefully unroll/, /You can't unroll/, /What were you referring/)
+        case bput("mount #{type}", /You step onto your .* which comes to life and slowly raises up off of the ground/, /You are already mounted/, /What were you referring/)
+        when /What were you referring/
+          message("Can't mount your #{type}, where is it?")
+          exit
+        end
         bput("command #{type} to #{speed}", /You command your/)
       else
         message("#{type} is not a valid type of flying mount.")
@@ -321,13 +329,13 @@ class Bescort
       end
     when 'dismount'
       case type
-      when /broom/i, /dirigible/i
-        bput('dismount', /Your (broom|dirigible) floats down to the ground/)
+      when /broom|dirigible/i
+        bput('dismount', /Your .* floats down to the ground/, /You climb off/)
         EquipmentManager.new.empty_hands
-      when /carpet/i
-        bput('dismount', /Your carpet floats down to the ground/)
-        bput("roll #{type}", /You roll up/)
-        bput("stow my #{type}", /You pick up/)
+      when /carpet|rug/i
+        bput('dismount', /Your .* floats down to the ground/, /You climb off/)
+        bput("roll #{type}", /You roll up/, /You can't roll/)
+        bput("stow my #{type}", /You put/, /You pick up/, /Stow what?/)
       else
         message("#{type} is not a valid type of flying mount.")
         exit


### PR DESCRIPTION
### Changes
* When mounting, don't exit unless unable to mount -- handle scenarios where you're already mounted, or item is in various phases of being held or at your feet, etc
* When dismounting, handle scenarios when you're already dismounted, or item is in various phases of being held or at your feet, etc
* Support "rug" noun like "carpet"

## Tests

In addition to the unit tests below, I also confirmed that this version of `bescort` used my flying mount to bypass the Faldesu river to travel from Crossing to Leth.

### Mount
```
[bescort]>get my barkcloth rug

You get a braided barkcloth rug shaded in earthy tones from inside your hitman's backpack.
> 
[bescort]>lower ground right

You lower the rug and place it on the ground at your feet.
> 
[bescort]>unroll barkcloth rug

You carefully unroll the barkcloth rug.

> 
[bescort]>mount barkcloth rug

You step onto your rug which comes to life and slowly raises up off of the ground.

> 
[bescort]>command barkcloth rug to fly

You command your rug to move as swift as a hawk pursuing prey.
```

### Attempt to mount when already mounted
```
[bescort]>get my barkcloth rug

What were you referring to?
> 
[bescort]>lower ground left

But you aren't holding anything in your left hand!
> 
[bescort]>unroll barkcloth rug

You can't unroll that!
> 
[bescort]>mount barkcloth rug

You are already mounted.
> 
[bescort]>command barkcloth rug to fly

You command your rug to move as swift as a hawk pursuing prey.
```

### Attempt to mount but item can't be found
```
[bescort]>get my foo

What were you referring to?
> 
[bescort]>lower ground left

> 
But you aren't holding anything in your left hand!
> 
[bescort]>unroll foo

What were you referring to?
> 
[bescort]>mount foo

What were you referring to?
> 
| Can't mount your foo, where is it?

--- Lich: bescort has exited.
```

### Dismount
```
[bescort]>dismount

Your rug floats down to the ground then you step off of it.

> 
[bescort]>roll barkcloth rug

You roll up your rug.

> 
[bescort]>stow my barkcloth rug

You pick up the rug lying at your feet.
You put your rug in your hitman's backpack.
```

### Attempt to dismount when already dismounted
```
[bescort]>dismount

You climb off your high horse and assume a more friendly demeanor.
```

### Attempt to dismount but item can't be found
```
[bescort]>dismount

You climb off your high horse and assume a more friendly demeanor.
> 
[bescort]>roll barkcloth rug

You can't roll that.
> 
[bescort]>stow my barkcloth rug

Stow what?  Type 'STOW HELP' for details.
> 
--- Lich: bescort has exited.
```

### FYI
@BinuDR as a recent contributer and original author of the `use_flying_mount` method, would appreciate your feedback on my proposal, thanks