### PR TITLE
[script] [combat-trainer] Rename to activate_barb_buff? predicate

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1963,7 +1963,7 @@ class AbilityProcess
       .select { |name| Flags["ap-#{name}-expired"] }
       .each do |name|
         Flags.reset("ap-#{name}-expired")
-        activate_barb_buff(name)
+        activate_barb_buff?(name)
         echo "Activated barb_buff #{name}!" if $debug_mode_ct
         waitrt?
         pause 6 if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'


### PR DESCRIPTION
### Background
* With the reversion of https://github.com/rpherbig/dr-scripts/pull/4759, combat-trainer is now trying to call `activate_barb_buff` but a method by that name no longer exists per https://github.com/rpherbig/dr-scripts/pull/4754

```
--- Lich: error: undefined method `activate_barb_buff' for #<AbilityProcess:0x08aebb60>
Did you mean?  activate_barb_buff?
	combat-trainer:1966:in `block in check_nonspell_buffs'
	combat-trainer:1964:in `each'
```

### Changes
* Update `activate_barb_buff` to be `activate_barb_buff?` to match the new name