### PR TITLE
[script] [combat-trainer] Improve barb buff activations (round 3)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1968,21 +1968,21 @@ class AbilityProcess
         next if game_state.danger && DRCA.kneel_for_khri?(@kneel_khri, name)
         timer = game_state.cooldown_timers[name]
         next unless !timer || (Time.now - timer).to_i > 30
-        game_state.cooldown_timers[name] = Time.now if DRCA.activate_khri?(@kneel_khri, name)
+        if DRCA.activate_khri?(@kneel_khri, name)
+          game_state.cooldown_timers[name] = Time.now
+          echo "Activated khri #{name}" if $debug_mode_ct
+        else
+          echo "Did not activate khri #{name}" if $debug_mode_ct
+        end
       end
     @barb_buffs
       .select { |name| Flags["ap-#{name}-expired"] }
       .each do |name|
         if DRStats.mana < @barb_buffs_inner_fire_threshold
           echo "Not activating barb_buff #{name} until have at least #{@barb_buffs_inner_fire_threshold} inner fire. You currently have #{DRStats.mana}." if $debug_mode_ct
-        elsif DRCA.activate_barb_buff?(name)
+        elsif DRCA.activate_barb_buff?(name, { 'meditation_pause_timer' => @meditation_pause_timer })
           Flags.reset("ap-#{name}-expired")
           echo "Activated barb_buff #{name}" if $debug_mode_ct
-          waitrt?
-          if get_data('spells').barb_abilities[name]['type'].eql?('meditation')
-            echo "Waiting #{@meditation_pause_timer} seconds for meditation to take effect." if $debug_mode_ct
-            pause @meditation_pause_timer
-          end
         else
           echo "Did not activate barb_buff #{name}" if $debug_mode_ct
         end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1864,6 +1864,12 @@ class AbilityProcess
     @barb_buffs = @buffs.delete('barb_buffs') || []
     echo("  @barb_buffs: #{@barb_buffs}") if $debug_mode_ct
 
+    @barb_buffs_inner_fire_threshold = settings.barb_buffs_inner_fire_threshold
+    echo("  @barb_buffs_inner_fire_threshold: #{@barb_buffs_inner_fire_threshold}") if $debug_mode_ct
+
+    @meditation_pause_timer = settings.meditation_pause_timer
+    echo("  @meditation_pause_timer: #{@meditation_pause_timer}") if $debug_mode_ct
+
     setup_barb_buff_flags
 
     @paladin_use_badge = settings.paladin_use_badge
@@ -1934,6 +1940,11 @@ class AbilityProcess
     echo 'Used Glyph of Mana!' if $debug_mode_ct
   end
 
+  # Barbarians without knowledge of the Power meditation won't
+  # see their activated abilities in the spell window.
+  # This means we can't always rely on DRSpells.active_spells
+  # to know if an ability is active or not for those characters.
+  # As a workaround, we monitor for the expiry messages.
   def setup_barb_buff_flags
     @barb_buffs.each do |name|
       ability_data = get_data('spells').barb_abilities[name]
@@ -1954,19 +1965,27 @@ class AbilityProcess
     @khri
       .map { |name| "Khri #{name}" }
       .each do |name|
-        next if game_state.danger && kneel_for_khri?(@kneel_khri, name)
+        next if game_state.danger && DRCA.kneel_for_khri?(@kneel_khri, name)
         timer = game_state.cooldown_timers[name]
         next unless !timer || (Time.now - timer).to_i > 30
-        game_state.cooldown_timers[name] = Time.now if activate_khri?(@kneel_khri, name)
+        game_state.cooldown_timers[name] = Time.now if DRCA.activate_khri?(@kneel_khri, name)
       end
     @barb_buffs
       .select { |name| Flags["ap-#{name}-expired"] }
       .each do |name|
-        Flags.reset("ap-#{name}-expired")
-        activate_barb_buff?(name)
-        echo "Activated barb_buff #{name}!" if $debug_mode_ct
-        waitrt?
-        pause 6 if get_data('spells').barb_abilities[name]['type'].eql? 'meditation'
+        if DRStats.mana < @barb_buffs_inner_fire_threshold
+          echo "Not activating barb_buff #{name} until have at least #{@barb_buffs_inner_fire_threshold} inner fire. You currently have #{DRStats.mana}." if $debug_mode_ct
+        elsif DRCA.activate_barb_buff?(name)
+          Flags.reset("ap-#{name}-expired")
+          echo "Activated barb_buff #{name}" if $debug_mode_ct
+          waitrt?
+          if get_data('spells').barb_abilities[name]['type'].eql?('meditation')
+            echo "Waiting #{@meditation_pause_timer} seconds for meditation to take effect." if $debug_mode_ct
+            pause @meditation_pause_timer
+          end
+        else
+          echo "Did not activate barb_buff #{name}" if $debug_mode_ct
+        end
       end
   end
 end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1980,7 +1980,7 @@ class AbilityProcess
       .each do |name|
         if DRStats.mana < @barb_buffs_inner_fire_threshold
           echo "Not activating barb_buff #{name} until have at least #{@barb_buffs_inner_fire_threshold} inner fire. You currently have #{DRStats.mana}." if $debug_mode_ct
-        elsif DRCA.activate_barb_buff?(name, { 'meditation_pause_timer' => @meditation_pause_timer })
+        elsif DRCA.activate_barb_buff?(name, @meditation_pause_timer)
           Flags.reset("ap-#{name}-expired")
           echo "Activated barb_buff #{name}" if $debug_mode_ct
         else

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -225,10 +225,15 @@ loot_delay: 5
 dump_junk: false
 # items to wait for before junking
 dump_item_count: 9
-# used to set a pause timer for barbarian meditations, this number should go down with a chakrel, circles, and stats...
-# as an example, chuno currently runs it at 6 being circle 195
-# defaulting to 25, as 20 for lower skilled barbs was explained to be common
-meditation_pause_timer: 25
+# Used to set a pause timer for barbarian meditations.
+# This number should go down with a chakrel, circles, and stats...
+# When buff or combat-trainer scripts are activating meditations,
+# this is how many seconds to wait for it to activate.
+meditation_pause_timer: 6
+# The minimum inner fire needed to activate a barb_buffs: in your buff_nonspells:
+# You won't try to activate a barb buff until you have this much inner fire.
+# You need some inner fire in reserve to pay the periodic cost of abilities.
+barb_buffs_inner_fire_threshold: 15
 # Requires health_threshold (will use below this number) and inner_fire_threshold (will use if ABOVE this number) - Leave empty if unused!
 barb_famine_healing:
 # This is deprecated, instead switch to use_analyze_combos

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -229,7 +229,7 @@ dump_item_count: 9
 # This number should go down with a chakrel, circles, and stats...
 # When buff or combat-trainer scripts are activating meditations,
 # this is how many seconds to wait for it to activate.
-meditation_pause_timer: 6
+meditation_pause_timer: 20
 # The minimum inner fire needed to activate a barb_buffs: in your buff_nonspells:
 # You won't try to activate a barb buff until you have this much inner fire.
 # You need some inner fire in reserve to pay the periodic cost of abilities.


### PR DESCRIPTION
### Dependencies
* ~Depends on #4772~
* ~Depends on #4773~

### Background
* Supercedes #4752
* If combat trainer fails to activate a barb buff and that buff wasn't already active then the flag `"ap-#{name}-expired"` won't ever reset because the expiry message won't ever be seen again. This causes the ability to never be retried for the rest of that hunt.
* Just like mages need a minimum amount of mana/concentration to cast spells or maintain cyclics, so too do barbarians need sufficient inner fire.

### Changes
* Add comments why barb buffs are tracked via Flags and not DRSpells.active_spells (spoiler: it's because barbarians must know Power meditation or Powermonger mastery to see their active abilities...)
* Don't assume the barb ability was activated just because it was attempted to be activated (you may have lacked inner fire at the time or in a location that prevents the ability from being activated, such as trying to meditate in deep water).
* Only try to activate ability if you have sufficient inner fire based on new numeric setting, `barb_buffs_inner_fire_threshold`.
* If activated a meditation, use the pre-existing setting `meditation_pause_timer` to control how many seconds to wait for it to take effect.
* Set `meditation_pause_timer` in `base.yaml` to 20 seconds from 25 seconds.
  * As a 30th circle barbarian, I haven't noticed taking more than 6-10 seconds for Tenacity meditation to take effect.
  * Kali said her young barbarian takes 18 seconds to activate a meditation.
* Add `DRCA` prefix to khri activation methods

### Config Example
_Added to base.yaml_
```yaml
# The minimum inner fire needed to activate a barb_buff in your buff_nonspells.
# You won't try to activate a barb buff until you have this much inner fire.
# You need some inner fire in reserve to pay the periodic cost of abilities.
barb_buffs_inner_fire_threshold: 15
```
_Updated in base.yaml_
```yaml
# Used to set a pause timer for barbarian meditations.
# This number should go down with a chakrel, circles, and stats...
# When buff script is activating meditations,
# this is how many seconds to wait for it to activate
# before moving on to the next action.
meditation_pause_timer: 20
```

## Tests

The following abbreviated log shows that combat-trainer monitors your inner fire level to attempt activations and will re-activate an ability if it expires.

```
[combat-trainer]>form monkey

An interesting fluidity fills your muscles as you assume the movements of an agile monkey!
Roundtime: 2 sec.
> 
[combat-trainer: Activated barb_buff Monkey]

> 
[combat-trainer]>bers avalanche

The momentus rage of the avalanche replenishes your energy!
> 
[combat-trainer: Activated barb_buff Avalanche]

[combat-trainer: Not activating barb_buff Wildfire until have at least 15 inner fire. You currently have 10.]

...

> berserk stop all
The ever-building avalanche of rage within you crashes to a sudden halt!

...

[combat-trainer: Not activating barb_buff Avalanche until have at least 15 inner fire. You currently have 14.]

[combat-trainer: Not activating barb_buff Wildfire until have at least 15 inner fire. You currently have 14.]

...

[combat-trainer]>bers avalanche

The momentus rage of the avalanche replenishes your energy!
> 
[combat-trainer: Activated barb_buff Avalanche]

[combat-trainer: Not activating barb_buff Wildfire until have at least 15 inner fire. You currently have 9.]
```

### FYI
@jayRyan24 @Hiinky Would appreciate your review of my revised attempt at updating combat-trainer for barbarians. Thanks!