### PR TITLE
Fixed magic_cleanup for outdoorsmanship to properly release symbiosis

### DIFF
--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -60,6 +60,7 @@ class Outdoorsmanship
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")
+    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 end
 


### PR DESCRIPTION
While using t2 with outdoorsmanship, I noticed that it wasn't releasing symbiosis, and caused me to backfire a few spells.  Easy fix.