### PR TITLE
Restock improvements for ritual foci

### DIFF
--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -60,6 +60,7 @@ class Outdoorsmanship
 
     bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
     bput('release mana', 'You release all', "You aren't harnessing any mana")
+    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 end
 

--- a/restock.lic
+++ b/restock.lic
@@ -87,8 +87,8 @@ class Restock
         count += count_nonstackable_item(item)
         break
 	  when /has about \d+ uses of/
-	    amount = count_msg.match(/has about (\d+) uses of/).captures.first		
-		count += amount.to_i
+        amount = count_msg.match(/has about (\d+) uses of/).captures.first		
+        count += amount.to_i
       else
         count_txt = count_msg.match(/and see there \w+ (.+) left./).captures.first.tr('-', ' ')
         count += text2num(count_txt)

--- a/restock.lic
+++ b/restock.lic
@@ -78,7 +78,7 @@ class Restock
   def count_stackable_item(item)
     count = 0
     $ORDINALS.each do |ordinal|
-      count_msg = bput("count my #{ordinal} #{item}", 'I could not find what you were referring to.', 'tell you much of anything.', 'and see there \w+ .+ left.')
+      count_msg = bput("count my #{ordinal} #{item}", 'I could not find what you were referring to.', 'tell you much of anything.', /has about \d+ uses of/, 'and see there \w+ .+ left.')
       case count_msg
       when 'I could not find what you were referring to.'
         break
@@ -86,6 +86,9 @@ class Restock
         echo "#{item} is marked as stackable but is not!"
         count += count_nonstackable_item(item)
         break
+	  when /has about \d+ uses of/
+	    amount = count_msg.match(/has about (\d+) uses of/).captures.first		
+		count += amount.to_i
       else
         count_txt = count_msg.match(/and see there \w+ (.+) left./).captures.first.tr('-', ' ')
         count += text2num(count_txt)

--- a/restock.lic
+++ b/restock.lic
@@ -86,8 +86,8 @@ class Restock
         echo "#{item} is marked as stackable but is not!"
         count += count_nonstackable_item(item)
         break
-	  when /has about \d+ uses of/
-        amount = count_msg.match(/has about (\d+) uses of/).captures.first		
+      when /has about \d+ uses of/
+        amount = count_msg.match(/has about (\d+) uses of/).captures.first      
         count += amount.to_i
       else
         count_txt = count_msg.match(/and see there \w+ (.+) left./).captures.first.tr('-', ' ')


### PR DESCRIPTION
I wasn't satisfied with the fact that restock can only replace ritual foci when they completely run out, due to the order in which I run things.  I made it so that it would work for Moon Mages, but I have NOT tested it for the other limited-use ritual foci.

(Also yes, I know I screwed up this PR by accidentally bundling my outdoorsmanship changes into it.  I'm not sure how I can best separate that change without starting a new repo, since I accidentally committed it to my own master.)