### PR TITLE
Update pause room for Undergondola route

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -330,12 +330,12 @@ class Athletics
       override_location_and_practice('undergondola_branch')
     elsif UserVars.athletics < 850
       walk_to(9607)
-      walk_to(19_464)
+      walk_to(9515)
       until done_training?
         walk_to(2245)
         walk_to(9607)
         walk_to(11_126)
-        walk_to(19_464)
+        walk_to(9515)
         break if done_training?
         walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
         stow_athletics_items


### PR DESCRIPTION
How we've never come across this, I don't know. I suppose it must be because critter spawn in the area is sparse at best. The room where we wait between rounds and do outdoors on the "undergondola" route was in a la'tami room.  Being in combat results in not being able to collect which in turn causes the script to begin climbing before the internal cooldown on climbing gains has run down.  This means you waste time climbing when you can't learn and are also not collecting for outdoors.  New room 9515 is a safe area I've used for years and know it to be free of mobs only four rooms away from the original.