### PR TITLE
[script] [common-arcana] activate barb abilities

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -72,35 +72,42 @@ module DRCA
     end
   end
 
-  def start_barb_abilities(skills, settings)
-    skills
+  def start_barb_abilities(abilities, settings)
+    # Note, you must know Power meditation or Powermonger mastery
+    # for your active abilities to be detected by DRSpells.
+    abilities
       .reject { |name| DRSpells.active_spells[name] }
-      .each do |name|
-        activate_barb_buff?(name)
-        waitrt?
-        pause settings.meditation_pause_timer.to_i if get_data('spells').barb_abilities[name]['type'].eql?('meditation')
-        DRC.fix_standing
-      end
+      .each { |name| activate_barb_buff?(name, settings) }
+    DRC.fix_standing
   end
 
-  def activate_barb_buff?(name)
+  def activate_barb_buff?(name, settings = nil)
     ability_data = get_data('spells').barb_abilities[name]
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
     when 'You must be unengaged'
       DRC.retreat
-      activate_barb_buff?(name)
+      activate_barb_buff?(name, settings)
     when 'You must be sitting'
       DRC.retreat
       case DRC.bput('sit', 'You sit', 'You are already', 'You rise', 'While swimming?')
       when 'While swimming?'
         false # can't sit here, water is too deep
       else
-        activate_barb_buff?(name)
+        activate_barb_buff?(name, settings)
       end
     when 'You should stand'
       DRC.fix_standing
-      activate_barb_buff?(name)
-    when ability_data['activated_message']
+      activate_barb_buff?(name, settings)
+    when /#{ability_data['activated_message']}/
+      # Pause at least for the preferred amount of time
+      # to let the meditation take effect else it may fail.
+      # Note, we use bracket notation to reference settings here
+      # because this method may be invoked with either JSON or an OpenStruct.
+      if ability_data['type'].eql?('meditation') && settings['meditation_pause_timer']
+        pause settings['meditation_pause_timer'].to_i
+      end
+      # Wait for any remaining RT before proceeding
+      waitrt?
       true
     else
       false


### PR DESCRIPTION
### Background
* Inspired by testing #4762
* The logic for pausing after activating a meditation was responsibility of code that called `activate_barb_buff?`, which appeared in multiple places and in multiple scripts: combat-trainer and common-arcana

### Changes
* Consolidate the logic for pausing after activating a meditation to the `activate_barb_buff?` method so calling code doesn't need to repeat the logic.
* Update `activate_barb_buff?` to accept an optional second argument, `settings`, to reference if need to pause after activating a meditation.
* Add comments about why the pause is necessary.
* In `start_barb_abilities` method, renamed `skills` variable to `abilities` to disambiguate from experience skills you train.
* Fix bug where the case statement for `ability_data['activated_message']` is not matched because it's value was structured like a regular expression in `data/base-spells.yaml` but was treated literally in the code.

## Tests

### Pause then wait out any remaining RT
```
> ,e echo DRCA.activate_barb_buff?('Tenacity', { 'meditation_pause_timer' => 5 })

--- Lich: exec1 active.

[exec1]>med tenacity

You must be sitting to properly reinforce your physical resistance.
> 
[exec1]>sit

You sit down.

s> 
[exec1]>med tenacity

You begin to meditate upon the chakrel amulet, your inner fire swelling as you center your mind, body, and spirit.
Roundtime: 9 sec.
s> 

(script pauses for 5 seconds, the value of meditation_pause_timer)

Peering into the flame you visualize swords, teeth and worse all rending your flesh.
s> 
You draw the flames close and bring forth a physical hardening to your body.
s> 
The flame infuses your flesh, reinforcing it against physical damage!
You feel a jolt as your vision snaps shut.
s> 

(script waits for any remaining RT, of which there is 4 seconds)

(then script terminates)

[exec1: true]

--- Lich: exec1 has exited.
```