### PR TITLE
[script] [common-arcana] activate_barb_buff? pause argument

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -77,34 +77,32 @@ module DRCA
     # for your active abilities to be detected by DRSpells.
     abilities
       .reject { |name| DRSpells.active_spells[name] }
-      .each { |name| activate_barb_buff?(name, settings) }
+      .each { |name| activate_barb_buff?(name, settings.meditation_pause_timer) }
   end
 
-  def activate_barb_buff?(name, settings = nil)
+  def activate_barb_buff?(name, meditation_pause_timer = 0)
     activated = false
     ability_data = get_data('spells').barb_abilities[name]
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
     when 'You must be unengaged'
       DRC.retreat
-      activated = activate_barb_buff?(name, settings)
+      activated = activate_barb_buff?(name, meditation_pause_timer)
     when 'You must be sitting'
       DRC.retreat
       case DRC.bput('sit', 'You sit', 'You are already', 'You rise', 'While swimming?')
       when 'While swimming?'
         activated = false # can't sit here, water is too deep
       else
-        activated = activate_barb_buff?(name, settings)
+        activated = activate_barb_buff?(name, meditation_pause_timer)
       end
     when 'You should stand'
       DRC.fix_standing
-      activated = activate_barb_buff?(name, settings)
+      activated = activate_barb_buff?(name, meditation_pause_timer)
     when /#{ability_data['activated_message']}/
       # Pause at least for the preferred amount of time
       # to let the meditation take effect else it may fail.
-      # Note, we use bracket notation to reference settings here
-      # because this method may be invoked with either JSON or an OpenStruct.
-      if ability_data['type'].eql?('meditation') && settings['meditation_pause_timer']
-        pause settings['meditation_pause_timer'].to_i
+      if ability_data['type'].eql?('meditation') && meditation_pause_timer
+        pause meditation_pause_timer
       end
       # Wait for any remaining RT before proceeding
       waitrt?

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -80,7 +80,7 @@ module DRCA
       .each { |name| activate_barb_buff?(name, settings.meditation_pause_timer) }
   end
 
-  def activate_barb_buff?(name, meditation_pause_timer = 0)
+  def activate_barb_buff?(name, meditation_pause_timer = 20)
     activated = false
     ability_data = get_data('spells').barb_abilities[name]
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')


### PR DESCRIPTION
### Background
* Responding to feedback per https://github.com/rpherbig/dr-scripts/pull/4762#discussion_r585164162
* This builds upon https://github.com/rpherbig/dr-scripts/pull/4772

### Changes
* Refactor second argument (that was just introduced) from being a settings object to just the number of seconds to pause for meditation to take effect.
* If no second argument is provided then default seconds to pause is `20` to match `base.yaml` per https://github.com/rpherbig/dr-scripts/pull/4762

## Tests

```
> ,e echo DRCA.activate_barb_buff?('Tenacity', 15)

--- Lich: exec1 active.

[exec1]>med tenacity

> 
You must be sitting to properly reinforce your physical resistance.
> 
[exec1]>retreat

You are already as far away as you can get!
> 
[exec1]>sit

> 
You sit down.

s> 
[exec1]>med tenacity

You begin to meditate upon the chakrel amulet, your inner fire swelling as you center your mind, body, and spirit.
Roundtime: 9 sec.

(script pauses for 15 seconds, this is in parallel to any RT, not additive)
(after the pause, then script waits for any remaining RT; in this case there is no extra)

s> 
Peering into the flame you visualize swords, teeth and worse all rending your flesh.
s> 
You draw the flames close and bring forth a physical hardening to your body.
s> 
The flame infuses your flesh, reinforcing it against physical damage!
You feel a jolt as your vision snaps shut.

s> 
[exec1]>stand

You stand back up.

> 
[exec1: true]

--- Lich: exec1 has exited.
```