### PR TITLE
Update base-items.yaml

### DIFF
--- a/data/base-items.yaml
+++ b/data/base-items.yaml
@@ -28,6 +28,7 @@ lootables:
 - package
 - permit
 - profile
+- title scroll #F2P item
 - writ
 - lump
 - shard


### PR DESCRIPTION
added title scroll since it is ignored by all the other adjective scroll pairs.