### PR TITLE
Mining Buddy: Call Buff instead of DRCA directly

### DIFF
--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -27,7 +27,7 @@ class MiningBuddy
         fput('stow my packet')
       end
     end
-    DRCA.do_buffs(@settings, 'mining')
+    wait_for_script_to_complete('buff', ['mining'])
     bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end


### PR DESCRIPTION
Switching from direct use of DRCA to sub-scripting to 'buff', to make it easier to sync with sanowret crystals (which are fine to use during the normal mining loop, but can interfere with the buffing portion of the script).

This is a semantic minor change, interface stays the same, behavior changes slightly in ways that should align with user expectations.