### PR TITLE
Adding a bit more text around the 'tools' argument

### DIFF
--- a/create_remedies.lic
+++ b/create_remedies.lic
@@ -12,7 +12,7 @@ class Create_remedies
     arg_definitions = [
       [
         { name: 'target', regex: /\w+/, description: 'Recipe.' },
-        { name: 'tools', regex: /tools/i, optional: true, description: 'Use tools.'  },
+        { name: 'tools', regex: /tools/i, optional: true, description: 'Use clerk-tools to get and store tools.'  },
         { name: 'debug', regex: /debug/i, optional: true, description: 'Debug mode.'  },
         { name: 'catalyst', regex: /\w+/i, variable: true, optional: true, description: 'Catalyst to use. Default is coal.' }
       ]


### PR DESCRIPTION
As Galli mentioned on lnet, the help string for "tools" was a bit ambiguous.  Added a bit more detail to mention the usage of clerk-tools.