### PR TITLE
Base-recipes clean-up and additional recipes added. 

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -1,14 +1,19 @@
 ---
 crafting_recipes:
-- name: a metal ring vest
-  noun: vest
-  volume: 18
+##### Page numbers are as of 2/20/2021 15:48 ET #####
+##################################
+##### Forging section begins #####
+##################################
+# Armorsmithing Chapter 1 recipes
+- name: a metal ring aventail #Page 1
+  noun: aventail
+  volume: 5
   type: armorsmithing
-  work_order: false
+  work_order: true
   chapter: 1
   part:
-  - large padding
-- name: a metal ring mask
+  - small padding
+- name: a metal ring mask #Page 2
   noun: mask
   volume: 3
   type: armorsmithing
@@ -16,7 +21,23 @@ crafting_recipes:
   chapter: 1
   part:
   - small padding
-- name: a metal chain mask
+- name: a metal chain aventail #Page 3
+  noun: aventail
+  volume: 6
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring cap #Page 4
+  noun: cap
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain mask #Page 5
   noun: mask
   volume: 4
   type: armorsmithing
@@ -24,7 +45,23 @@ crafting_recipes:
   chapter: 1
   part:
   - small padding
-- name: a metal ring helm
+- name: some metal ring gloves #Page 6
+  noun: gloves
+  volume: 6
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal ring greaves #Page 7
+  noun: greaves
+  volume: 12
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring helm #Page 8
   noun: helm
   volume: 12
   type: armorsmithing
@@ -32,171 +69,2215 @@ crafting_recipes:
   chapter: 1
   part:
   - small padding
-- name: a shallow metal cup
-  noun: cup
+- name: a metal mail aventail #Page 9
+  noun: aventail
+  volume: 7
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain cap #Page 10
+  noun: cap
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal mail mask #Page 11
+  noun: mask
+  volume: 5
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain gloves #Page 12
+  noun: gloves
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal mail gloves #Page 13
+  noun: gloves
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring tasset #Page 14
+  noun: tasset
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal ring vambraces #Page 15
+  noun: vambraces
+  volume: 19
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain greaves #Page 16
+  noun: greaves
+  volume: 15
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring balaclava #Page 17
+  noun: balaclava
+  volume: 16
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain helm #Page 18
+  noun: helm
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal mail cap #Page 19
+  noun: cap
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring lorica #Page 20
+  noun: lorica
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+- name: a metal ring mantle #Page 21
+  noun: mantle
+  volume: 21
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal ring vest #Page 22
+  noun: vest
+  volume: 18
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+- name: a metal chain tasset #Page 23
+  noun: tasset
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal ring sleeves #Page 24
+  noun: sleeves
+  volume: 21
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain vambraces #Page 25
+  noun: vambraces
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal mail greaves #Page 26
+  noun: greaves
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain balaclava #Page 27
+  noun: balaclava
+  volume: 20
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal mail helm #Page 28
+  noun: helm
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a mail balaclava #Page 29
+  noun: balaclava
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small backing
+- name: a metal ring shirt #Page 30
+  noun: shirt
+  volume: 43
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal ring robe #Page 31
+  noun: robe
+  volume: 38
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal chain lorica #Page 32
+  noun: lorica
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal chain mantle #Page 33
+  noun: mantle
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal chain vest #Page 34
+  noun: vest
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal mail tasset #Page 35
+  noun: tasset
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain sleeves #Page 36
+  noun: sleeves
+  volume: 26
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal mail vambraces #Page 37
+  noun: vambraces
+  volume: 23
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring hauberk #Page 38
+  noun: hauberk
+  volume: 70
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal chain shirt #Page 39
+  noun: shirt
+  volume: 50
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal chain robe #Page 40
+  noun: robe
+  volume: 45
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal mail lorica #Page 41
+  noun: lorica
+  volume: 34
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+- name: a metal mail mantle #Page 42
+  noun: mantle
+  volume: 27
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal mail vest #Page 43
+  noun: vest
+  volume: 22
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: some metal mail sleeves #Page 44
+  noun: sleeves
+  volume: 31
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain hauberk #Page 45
+  noun: hauberk
+  volume: 80
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal mail shirt #Page 46
+  noun: shirt
+  volume: 57
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal mail robe #Page 47
+  noun: robe
+  volume: 52
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal mail hauberk #Page 48
+  noun: hauberk
+  volume: 90
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal bar-mail hauberk #Page 49
+  noun: hauberk
+  volume: 90
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+# Armorsmithing Chapter 2 recipes
+- name: a metal scale aventail #Page 1
+  noun: aventail
+  volume: 9
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale mask #Page 2
+  noun: mask
+  volume: 5
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale cap #Page 3
+  noun: cap
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine aventail #Page 4
+  noun: aventail
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine mask #Page 5
+  noun: mask
+  volume: 6
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some metal scale gloves #Page 6
+  noun: gloves
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale helm #Page 7
+  noun: helm
+  volume: 21
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine cap #Page 8
+  noun: cap
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal lamellar aventail #Page 9
+  noun: aventail
+  volume: 11
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: a metal lamellar mask #Page 10
+  noun: mask
+  volume: 7
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some metal scale greaves #Page 11
+  noun: greaves
+  volume: 15
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: some brigandine gloves #Page 12
+  noun: gloves
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale tasset #Page 13
+  noun: tasset
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some metal scale vambraces #Page 14
+  noun: vambraces
+  volume: 22
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale balaclava #Page 15
+  noun: balaclava
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine helm #Page 16
+  noun: helm
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal lamellar cap #Page 17
+  noun: cap
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some brigandine greaves #Page 18
+  noun: greaves
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some metal lamellar gloves #Page 19
+  noun: gloves
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: a metal brigandine tasset #Page 20
+  noun: tasset
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some brigandine vambraces #Page 21
+  noun: vambraces
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a brigandine balaclava #Page 22
+  noun: balaclava
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal lamellar helm #Page 23
+  noun: helm
+  volume: 27
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some lamellar greaves #Page 24
+  noun: greaves
+  volume: 18
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: some metal scale sleeves #Page 25
+  noun: sleeves
+  volume: 30
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale lorica #Page 26
+  noun: lorica
+  volume: 34
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale mantle #Page 27
+  noun: mantle
+  volume: 33
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale vest #Page 28
+  noun: vest
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal lamellar tasset #Page 29
+  noun: tasset
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: some lamellar vambraces #Page 30
+  noun: vambraces
+  volume: 28
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: a metal lamellar balaclava #Page 31
+  noun: balaclava
+  volume: 34
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some brigandine sleeves #Page 32
+  noun: sleeves
+  volume: 35
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale shirt #Page 33
+  noun: shirt
+  volume: 56
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale robe #Page 34
+  noun: robe
+  volume: 49
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+- name: a metal brigandine lorica #Page 35
+  noun: lorica
+  volume: 38
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal brigandine mantle #Page 36
+  noun: mantle
+  volume: 36
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal brigandine vest #Page 37
+  noun: vest
+  volume: 26
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: some lamellar sleeves #Page 38
+  noun: sleeves
+  volume: 40
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: a brigandine robe #Page 39
+  noun: robe
+  volume: 56
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+- name: a brigandine shirt #Page 40
+  noun: shirt
+  volume: 63
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale hauberk #Page 41
+  noun: hauberk
+  volume: 80
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal lamellar lorica #Page 42
+  noun: lorica
+  volume: 42
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+- name: a metal lamellar mantle #Page 43
+  noun: mantle
+  volume: 39
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+- name: a metal lamellar vest #Page 44
+  noun: vest
+  volume: 28
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+- name: a metal lamellar robe #Page 45
+  noun: robe
+  volume: 63
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+  - small backing
+- name: a brigandine hauberk #Page 46
+  noun: hauberk
+  volume: 90
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal lamellar shirt #Page 47
+  noun: shirt
+  volume: 70
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a lamellar hauberk #Page 48
+  noun: hauberk
+  volume: 100
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+  - small backing
+  - small backing
+- name: a laminar hauberk #Page 49
+  noun: hauberk
+  volume: 100
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+  - small backing
+  - small backing
+# Armorsmithing Chapter 3 recipes
+- name: a light plate aventail #Page 1
+  noun: aventail
+  volume: 12
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a light plate mask #Page 2
+  noun: mask
+  volume: 7
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some light plate gauntlets #Page 3
+  noun: gauntlets
+  volume: 13
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a plate aventail #Page 4
+  noun: aventail
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal dome helm #Page 5
+  noun: helm
+  volume: 16
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a plate mask #Page 6
+  noun: mask
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a metal bascinet #Page 7
+  noun: bascinet
+  volume: 23
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some plate gauntlets #Page 8
+  noun: gauntlets
+  volume: 15
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a heavy plate aventail #Page 9
+  noun: aventail
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal morion #Page 10
+  noun: morion
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a heavy plate mask #Page 11
+  noun: mask
+  volume: 9
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a light plate fauld #Page 12
+  noun: fauld
+  volume: 13
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small padding
+- name: a light backplate #Page 13
+  noun: backplate
+  volume: 10
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some light plate vambraces #Page 14
+  noun: vambraces
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a metal visored helm #Page 15
+  noun: helm
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: heavy plate gauntlets #Page 16
+  noun: gauntlets
+  volume: 17
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: a metal barbute #Page 17
+  noun: barbute
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: some light plate greaves #Page 18
+  noun: greaves
+  volume: 19
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a metal sallet #Page 19
+  noun: sallet
+  volume: 35
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a light breastplate #Page 20
+  noun: breastplate
+  volume: 16
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a plate fauld #Page 21
+  noun: fauld
+  volume: 15
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal backplate #Page 22
+  noun: backplate
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: some light plate sleeves #Page 23
+  noun: sleeves
+  volume: 39
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some plate vambraces #Page 24
+  noun: vambraces
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: some plate greaves #Page 25
+  noun: greaves
+  volume: 22
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal armet #Page 26
+  noun: armet
+  volume: 40
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: a metal closed helm #Page 27
+  noun: helm
+  volume: 29
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a light plate cuirass #Page 28
+  noun: cuirass
+  volume: 39
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - large padding
+- name: a metal breastplate #Page 29
+  noun: breastplate
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a heavy plate fauld #Page 30
+  noun: fauld
+  volume: 17
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: a metal heavy backplate #Page 31
+  noun: backplate
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some plate sleeves #Page 32
+  noun: sleeves
+  volume: 45
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some heavy plate vambraces #Page 33
+  noun: vambraces
+  volume: 34
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some heavy plate greaves #Page 34
+  noun: greaves
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal great helm #Page 35
+  noun: helm
+  volume: 45
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some light half plate #Page 36
+  noun: plate
+  volume: 65
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+  - large padding
+- name: some light field plate #Page 37
+  noun: plate
+  volume: 58
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+  - large padding
+- name: a plate cuirass #Page 38
+  noun: cuirass
+  volume: 45
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+- name: a heavy breastplate #Page 39
+  noun: breastplate
+  volume: 20
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some heavy plate sleeves #Page 40
+  noun: sleeves
+  volume: 51
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some light full plate #Page 41
+  noun: plate
+  volume: 100
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+  - small padding
+  - large padding
+- name: some half plate #Page 42
+  noun: plate
+  volume: 75
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+  - large backing
+- name: some field plate #Page 43
+  noun: plate
+  volume: 67
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+  - large backing
+- name: a heavy plate cuirass #Page 44
+  noun: cuirass
+  volume: 51
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - large backing
+- name: some heavy half plate #Page 45
+  noun: plate
+  volume: 85
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large padding
+  - small padding
+- name: some full plate #Page 46
+  noun: plate
+  volume: 110
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+  - small backing
+- name: some heavy field plate #Page 47
+  noun: plate
+  volume: 76
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+- name: some heavy full plate #Page 48
+  noun: plate
+  volume: 120
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+  - small backing
+- name: some heavy fluted plate #Page 49
+  noun: plate
+  volume: 120
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+  - small backing
+# Armorsmithing Chapter 4 recipes
+- name: a metal shield handle #Page 1
+  noun: handle
+  volume: 2
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+- name: a metal shield boss #Page 2
+  noun: boss
+  volume: 3
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+- name: a metal target shield #Page 3
+  noun: shield
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal round sipar #Page 4
+  noun: sipar
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal ordinary shield #Page 5
+  noun: shield
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal targe #Page 6
+  noun: targe
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal triangular sipar #Page 7
+  noun: sipar
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal medium shield #Page 8
+  noun: shield
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal ceremonial shield #Page 9
+  noun: shield
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal curved shield #Page 10
+  noun: shield
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal circular buckler #Page 11
+  noun: buckler
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal medium buckler #Page 12
+  noun: buckler
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal oval shield #Page 13
+  noun: shield
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a simple parry stick #Page 14
+  noun: stick
+  volume: 7
+  type: armorsmithing
+  work_order: false
+  chapter: 4
+  part:
+  - small backing
+- name: a metal jousting shield #Page 15
+  noun: shield
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal skirmisher's shield #Page 16
+  noun: shield
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal kite shield #Page 17
+  noun: shield
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal warrior's shield #Page 18
+  noun: shield
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal valnik shield #Page 19
+  noun: shield
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal tower shield #Page 20
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal battle shield #Page 21
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal heater shield #Page 22
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal aegis #Page 23
+  noun: aegis
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal war shield #Page 24
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+# Blacksmithing Chapter 2 recipes
+- name: a diagonal-peen mallet #Page 1
+  noun: mallet
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a curved metal shovel #Page 2
+  noun: shovel
+  volume: 8
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - long pole
+- name: a diagonal-peen hammer #Page 3
+  noun: hammer
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - short pole
+- name: a stout metal pickaxe #Page 4
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some straight metal tongs #Page 5
+  noun: tongs
+  volume: 10
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+- name: a metal cross-peen hammer #Page 6
+  noun: hammer
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a narrow metal pickaxe #Page 7
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: a square metal shovel #Page 8
+  noun: shovel
+  volume: 8
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - long pole
+- name: some curved metal tongs #Page 9
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: some flat-bladed tongs #Page 10
+  noun: tongs
+  volume: 10
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+- name: a tapered metal shovel #Page 11
+  noun: shovel
+  volume: 8
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - long pole
+- name: some angular metal tongs #Page 12
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: a straight-peen hammer #Page 13
+  noun: hammer
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a straight-peen mallet #Page 14
+  noun: mallet
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - short pole
+- name: a slender metal pickaxe #Page 15
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some metal bolt tongs #Page 16
+  noun: tongs
+  volume: 10
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+- name: a flat-headed metal pickaxe #Page 17
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: a sturdy metal shovel #Page 18
+  noun: shovel
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: a ball-peen hammer #Page 19
+  noun: hammer
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a wide metal shovel #Page 20
+  noun: shovel
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some segmented tongs #Page 21
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: a weighted metal pickaxe #Page 22
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some box-jaw tongs #Page 23
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: some articulated tongs #Page 24
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: a ball-peen mallet #Page 25
+  noun: mallet
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - short pole
+# Blacksmithing Chapter 3 recipes
+- name: a short metal drawknife #Page 1
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: some short metal chisels #Page 2
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: a long metal drawknife #Page 3
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: a metal straight wood saw #Page 4
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal straight bone saw #Page 5
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a thin metal rasp #Page 6
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some square metal rifflers #Page 7
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: some long metal chisels #Page 8
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: a flat metal shaper #Page 9
+  noun: shaper
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: some plain metal pliers #Page 10
+  noun: pliers
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: some squat metal rifflers #Page 11
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: thin metal tinker's tools #Page 12
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: a rough metal wood shaper #Page 13
+  noun: shaper
+  volume: 4
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a sturdy metal drawknife #Page 14
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: a metal curved wood saw #Page 15
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal curved bone saw #Page 16
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some curved metal pliers #Page 17
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a coarse metal rasp #Page 18
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some sturdy metal chisels #Page 19
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: curved metal tinker's tools #Page 20
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: some curved metal rifflers #Page 21
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: some reinforced chisels #Page 22
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: a sharpened metal drawknife #Page 23
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: a metal slender wood saw #Page 24
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal slender bone saw #Page 25
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some rough metal pliers #Page 26
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a textured metal rasp #Page 27
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal beveled wood shaper #Page 28
+  noun: shaper
+  volume: 4
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: some thick metal pliers #Page 29
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a flat metal rasp #Page 30
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some elongated rifflers #Page 31
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: some sharpened chisels #Page 32
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: thick metal tinker's tools #Page 33
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: a metal tapered wood saw #Page 34
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal tapered bone saw #Page 35
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some hooked metal pliers #Page 36
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a tapered metal rasp #Page 37
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal jagged wood shaper #Page 38
+  noun: shaper
+  volume: 4
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a metal serrated wood saw #Page 39
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal serrated bone saw #Page 40
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: precise metal tinker's tools #Page 41
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+# Blacksmithing Chapter 4 recipes
+- name: a stout metal yardstick #Page 1
+  noun: yardstick
+  volume: 6
+  chapter: 4
+  type: blacksmithing
+  work_order: false
+- name: some smooth knitting needles #Page 2
+  noun: needles
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a metal hide scraper #Page 3
+  noun: scraper
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some straight metal scissors #Page 4
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some plain sewing needles #Page 5
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some curved metal scissors #Page 6
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a flat metal yardstick #Page 7
+  noun: yardstick
+  volume: 6
+  chapter: 4
+  type: blacksmithing
+  work_order: false
+- name: some tapered knitting needles #Page 8
+  noun: needles
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a pointed metal awl #Page 9
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a curved hide scraper #Page 10
+  noun: scraper
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some ribbed sewing needles #Page 11
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some bent metal scissors #Page 12
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a rectangular yardstick #Page 13
+  noun: yardstick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 4
+- name: some knobby sewing needles #Page 14
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some squat knitting needles #Page 15
+  noun: needles
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a narrow metal awl #Page 16
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some polished knitting needles #Page 17
+  noun: needles
+  volume: 4
+  chapter: 4
+  type: blacksmithing
+  work_order: true
+- name: a compact metal awl #Page 18
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a serrated hide scraper #Page 19
+  noun: scraper
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some serrated scissors #Page 20
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a detailed yardstick #Page 21
+  noun: yardstick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 4
+- name: a slender metal awl #Page 22
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some thin sewing needles #Page 23
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+# Blacksmithing Chapter 5 recipes
+- name: a small metal brazier #Page 1
+  noun: brazier
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a tapered pestle #Page 2
+  noun: pestle
   volume: 1
   type: blacksmithing
   work_order: true
-  chapter: 6
-- name: a metal rod
+  chapter: 5
+- name: a flat mixing stick #Page 3
+  noun: stick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a square wire sieve #Page 4
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a tapered mixing stick #Page 5
+  noun: stick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a flat pestle #Page 6
+  noun: pestle
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a metal brazier #Page 7
+  noun: brazier
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a triangular wire sieve #Page 8
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a round mixing stick #Page 9
+  noun: stick
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a round pestle #Page 10
+  noun: pestle
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a grooved pestle #Page 11
+  noun: pestle
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: an oblong wire sieve #Page 12
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a grooved mixing stick #Page 13
+  noun: stick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a trapezoidal wire sieve #Page 14
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+# Blacksmithing Chapter 6 recipes
+- name: a metal rod #Page 1
   noun: rod
   volume: 1
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a tall metal mug
-  noun: mug
+- name: a shallow metal cup #Page 2
+  noun: cup
   volume: 1
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a short metal mug
-  noun: mug
-  volume: 1
+- name: a metal horseshoe #Page 3
+  noun: horseshoe
+  volume: 4
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a soft metal keyblank
+- name: a soft metal keyblank #Page 4
   noun: keyblank
   volume: 2
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a metal horseshoe
+- name: a short metal mug #Page 5
+  noun: mug
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a tall metal mug #Page 6
+  noun: mug
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a large metal horseshoe #Page 7
   noun: horseshoe
-  volume: 4
+  volume: 12
   type: blacksmithing
-  work_order: true
+  work_order: false
   chapter: 6
-- name: a back scratcher
-  noun: scratcher
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: some metal barbells
+- name: some metal barbells #Page 8
   noun: barbells
   volume: 80
   type: blacksmithing
   work_order: false
   chapter: 6
-- name: a large metal horseshoe
-  noun: horseshoe
+- name: a back scratcher #Page 9
+  noun: scratcher
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal bolt box #Page 10
+  noun: box
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal origami case #Page 11
+  noun: case
   volume: 12
   type: blacksmithing
   work_order: false
   chapter: 6
-- name: a small metal flask
-  noun: flask
-  volume: 5
+- name: a metal lockpick case #Page 12
+  noun: case
+  volume: 12
   type: blacksmithing
-  work_order: true
+  work_order: false
   chapter: 6
-- name: a metal ankle band
+- name: a metal ankle band #Page 13
   noun: band
   volume: 4
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a metal lockpick case
-  noun: case
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal origami case
-  noun: case
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal bolt box
-  noun: box
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal talisman case
-  noun: case
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal flask
+- name: a small metal flask #Page 14
   noun: flask
   volume: 5
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a metal oil lantern
-  noun: lantern
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal lockpick ring
-  noun: ring
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal herbal case
+- name: a metal talisman case #Page 15
   noun: case
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal jewelry box
-  noun: box
-  volume: 4
+  volume: 5
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a metal flights box
-  noun: box
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal razor
+- name: a metal razor #Page 16
   noun: razor
   volume: 2
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a large metal flask
-  noun: flask
-  volume: 7
+- name: a metal flights box #Page 17
+  noun: box
+  volume: 10
   type: blacksmithing
   work_order: false
   chapter: 6
-- name: a metal armband
-  noun: armband
+- name: a metal jewelry box #Page 18
+  noun: box
   volume: 4
   type: blacksmithing
   work_order: true
   chapter: 6
-- name: a metal instrument case
+- name: a metal herbal case #Page 19
   noun: case
   volume: 8
   type: blacksmithing
   work_order: false
   chapter: 6
-- name: a metal chest
+- name: a metal lockpick ring #Page 20
+  noun: ring
+  volume: 2
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal oil lantern #Page 21
+  noun: lantern
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal flask #Page 22
+  noun: flask
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal chest #Page 23
   noun: chest
   volume: 12
   type: blacksmithing
   work_order: false
   chapter: 6
-- name: a metal backtube
-  noun: backtube
-  volume: 10
+- name: a metal instrument case #Page 24
+  noun: case
+  volume: 8
   type: blacksmithing
   work_order: false
   chapter: 6
-  part:
-  - long cord
-- name: a metal starchart tube
+- name: a metal armband #Page 25
+  noun: armband
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a large metal flask #Page 26
+  noun: flask
+  volume: 7
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: some metal clippers #Page 27
+  noun: clippers
+  volume: 2
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal starchart tube #Page 28
   noun: tube
   volume: 8
   type: blacksmithing
@@ -204,25 +2285,21 @@ crafting_recipes:
   chapter: 6
   part:
   - short cord
-- name: some metal clippers
-  noun: clippers
-  volume: 2
+- name: a metal backtube #Page 29
+  noun: backtube
+  volume: 10
   type: blacksmithing
-  work_order: true
+  work_order: false
   chapter: 6
-- name: a metal crown
+  part:
+  - long cord
+- name: a metal crown #Page 30
   noun: crown
   volume: 10
   type: blacksmithing
   work_order: false
   chapter: 6
-- name: a metal torque
-  noun: torque
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal mask
+- name: a metal mask #Page 31
   noun: mask
   volume: 5
   type: blacksmithing
@@ -230,690 +2307,1524 @@ crafting_recipes:
   chapter: 6
   part:
   - short cord
-- name: a metal headdress
+- name: a metal torque #Page 32
+  noun: torque
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal headdress #Page 33
   noun: headdress
   volume: 10
   type: blacksmithing
   work_order: false
   chapter: 6
-- name: a diagonal-peen mallet
+# Weaponsmithing Chapter 1 recipes
+- name: a metal briquet #Page 1
+  noun: briquet
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal carving knife #Page 2
+  noun: knife
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal dagger #Page 3
+  noun: dagger
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal misericorde #Page 4
+  noun: misericorde
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal katar #Page 5
+  noun: katar
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal short sword #Page 6
+  noun: sword
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal pugio #Page 7
+  noun: pugio
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal poignard #Page 8
+  noun: poignard
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal stiletto #Page 9
+  noun: stiletto
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal dart #Page 10
+  noun: dart
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+- name: a metal throwing dagger #Page 11
+  noun: dagger
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal falcata #Page 12
+  noun: falcata
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal nehlata #Page 13
+  noun: nehlata
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal telek #Page 14
+  noun: telek
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal leaf blade sword #Page 15
+  noun: sword
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal jambiya #Page 16
+  noun: jambiya
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal takouba #Page 17
+  noun: takouba
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal kris #Page 18
+  noun: kris
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal thrusting blade #Page 19
+  noun: blade
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal pasabas #Page 20
+  noun: pasabas
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal rapier #Page 21
+  noun: rapier
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal koummya #Page 22
+  noun: koummya
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal oben #Page 23
+  noun: oben
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal kythe #Page 24
+  noun: kythe
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal dao #Page 25
+  noun: dao
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal kasai #Page 26
+  noun: kasai
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal sunblade #Page 27
+  noun: sunblade
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal foil #Page 28
+  noun: foil
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal baselard #Page 29
+  noun: baselard
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal gladius #Page 30
+  noun: gladius
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal mambeli #Page 31
+  noun: mambeli
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal sashqa #Page 32
+  noun: sashqa
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal adze #Page 33
+  noun: adze
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal curlade #Page 34
+  noun: curlade
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal parang #Page 35
+  noun: parang
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal hanger #Page 36
+  noun: hanger
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal sabre #Page 37
+  noun: sabre
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal scimitar #Page 38
+  noun: scimitar
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal shotel #Page 39
+  noun: shotel
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal cutlass #Page 40
+  noun: cutlass
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal hatchet #Page 41
+  noun: hatchet
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal hand axe #Page 42
+  noun: axe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - haft
+- name: a light throwing axe #Page 43
+  noun: axe
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - haft
+- name: a metal iltesh #Page 44
+  noun: iltesh
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+# Weaponsmithing Chapter 2 recipes
+- name: a metal condottiere #Page 1
+  noun: condottiere
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal nehdalata #Page 2
+  noun: nehdalata
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal round axe #Page 3
+  noun: axe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - haft
+- name: a metal longsword #Page 4
+  noun: longsword
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal spatha #Page 5
+  noun: spatha
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal kudalata #Page 6
+  noun: kudalata
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal arzfilt #Page 7
+  noun: arzfilt
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal broadsword #Page 8
+  noun: broadsword
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal schiavona #Page 9
+  noun: schiavona
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal falchion #Page 10
+  noun: falchion
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal robe sword #Page 11
+  noun: sword
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal battle axe #Page 12
+  noun: axe
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - haft
+- name: a metal recade #Page 13
+  noun: recade
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal back-sword #Page 14
+  noun: back-sword
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal nimsha #Page 15
+  noun: nimsha
+  volume: 8
+  type: weaponsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - hilt
+- name: a metal hunting sword #Page 16
+  noun: sword
+  volume: 8
+  type: weaponsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - hilt
+- name: a metal namkomba #Page 17
+  noun: namkomba
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal dagesse #Page 18
+  noun: dagesse
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal abassi #Page 19
+  noun: abassi
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal cinquedea #Page 20
+  noun: cinquedea
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal hurling axe #Page 21
+  noun: axe
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - haft
+# Weaponsmithing Chapter 3 recipes
+- name: a metal twin-point axe #Page 1
+  noun: axe
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal karambit #Page 2
+  noun: karambit
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal claymore #Page 3
+  noun: claymore
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal greataxe #Page 4
+  noun: greataxe
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal marauder blade #Page 5
+  noun: blade
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal warring axe #Page 6
+  noun: axe
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal two-handed sword #Page 7
+  noun: sword
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal double axe #Page 8
+  noun: axe
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal periperiu sword #Page 9
+  noun: sword
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal flamberge #Page 10
+  noun: flamberge
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal greatsword #Page 11
+  noun: greatsword
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal shh'oi'ata #Page 12
+  noun: shh'oi'ata
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal kaskara #Page 13
+  noun: kaskara
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal igorat axe #Page 14
+  noun: axe
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+# Weaponsmithing Chapter 4 recipes
+- name: a metal gavel #Page 1
+  noun: gavel
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal cosh #Page 2
+  noun: cosh
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal prod #Page 3
+  noun: prod
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal cudgel #Page 4
+  noun: cudgel
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal zubke #Page 5
+  noun: zubke
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal scepter #Page 6
+  noun: scepter
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal hand mallet #Page 7
   noun: mallet
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
   part:
-  - short pole
-- name: a straight-peen mallet
+  - haft
+- name: a metal bludgeon #Page 8
+  noun: bludgeon
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal garz #Page 9
+  noun: garz
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a ridged metal gauntlet #Page 10
+  noun: gauntlet
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal hand mace #Page 11
+  noun: mace
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal club #Page 12
+  noun: club
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a short metal hammer #Page 13
+  noun: hammer
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal gauntlet #Page 14
+  noun: gauntlet
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal bulhawf #Page 15
+  noun: bulhawf
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal cuska #Page 16
+  noun: cuska
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal bola #Page 17
+  noun: bola
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - long cord
+- name: a metal throwing club #Page 18
+  noun: club
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal mallet #Page 19
   noun: mallet
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
   part:
-  - short pole
-- name: a ball-peen mallet
+  - haft
+- name: a metal war club #Page 20
+  noun: club
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal boko #Page 21
+  noun: boko
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal boomerang #Page 22
+  noun: boomerang
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal war hammer #Page 23
+  noun: hammer
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal belaying pin #Page 24
+  noun: pin
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal mace #Page 25
+  noun: mace
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal marlingspike #Page 26
+  noun: marlingspike
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal mace #Page 27
+  noun: mace
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal hammer #Page 28
+  noun: hammer
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal club #Page 29
+  noun: club
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal hhr'tami #Page 30
+  noun: hhr'tami
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal komno #Page 31
+  noun: komno
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal k'trinni sha-tai #Page 32
+  noun: sha-tai
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a flanged metal mace #Page 33
+  noun: mace
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+# Weaponsmithing Chapter 5 recipes
+- name: a metal imperial war hammer #Page 1
+  noun: hammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a heavy metal mace #Page 2
+  noun: mace
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal greathammer #Page 3
+  noun: greathammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal ball and chain #Page 4
+  noun: chain
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a heavy metal chain #Page 5
+  noun: chain
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+- name: a metal horseman's flail #Page 6
+  noun: flail
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal ukabi #Page 7
+  noun: ukabi
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a spiked ball and chain #Page 8
+  noun: ukabi
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a spiked metal hara #Page 9
+  noun: hara
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal morning star #Page 10
+  noun: star
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal sledgehammer #Page 11
+  noun: sledgehammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a heavy metal mallet #Page 12
   noun: mallet
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
   part:
-  - short pole
-- name: a diagonal-peen hammer
+  - haft
+- name: a metal hara #Page 13
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a double-headed hammer #Page 14
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal hhr'ata #Page 15
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a hurlable war hammer #Page 16
   noun: hammer
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
   part:
-  - short pole
-- name: a metal cross-peen hammer
+  - haft
+- name: a metal throwing mallet #Page 17
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal throwing hammer #Page 18
   noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
   part:
-  - short pole
-- name: a straight-peen hammer
+  - haft
+# Weaponsmithing Chapter 6 recipes
+- name: a metal vilks kodur #Page 1
+  noun: kodur
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal war mattock #Page 2
+  noun: mattock
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: double-sided ball and chain #Page 3
+  noun: chain
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal akabo #Page 4
+  noun: akabo
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal footman's flail #Page 5
+  noun: flail
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal dire mace #Page 6
+  noun: mace
+  volume: 16
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a heavy sledgehammer #Page 7
+  noun: sledgehammer
+  volume: 16
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal maul #Page 8
+  noun: maul
+  volume: 16
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal two-headed hammer #Page 9
   noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
   part:
-  - short pole
-- name: a ball-peen hammer
+  - haft
+- name: a giant metal mallet #Page 10
   noun: hammer
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+# Weaponsmithing Chapter 7 recipes
+- name: a light metal spear #Page 1
+  noun: spear
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal javelin #Page 2
+  noun: javelin
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal spear #Page 3
+  noun: spear
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal allarh #Page 4
+  noun: allarh
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal hunthsleg #Page 5
+  noun: hunthsleg
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal awgravet ava #Page 6
+  noun: ava
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal coresca #Page 7
+  noun: coresca
   volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal tzece #Page 8
+  noun: tzece
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal halberd #Page 9
+  noun: halberd
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal guisarme #Page 10
+  noun: guisarme
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal lochaber axe #Page 11
+  noun: axe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal bardiche #Page 12
+  noun: bardiche
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal scythe #Page 13
+  noun: scythe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal duraka skefne #Page 14
+  noun: skefne
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal military fork #Page 15
+  noun: fork
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal partisan #Page 16
+  noun: partisan
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal khuj #Page 17
+  noun: khuj
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a two-pronged halberd #Page 18
+  noun: halberd
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal glaive #Page 19
+  noun: glaive
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal ngalio #Page 20
+  noun: ngalio
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal fauchard #Page 21
+  noun: fauchard
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal pole axe #Page 22
+  noun: axe
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal ilglaiks skefne #Page 23
+  noun: skefne
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal ranseur #Page 24
+  noun: ranseur
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal spetum #Page 25
+  noun: spetum
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal lance #Page 26
+  noun: lance
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal pike #Page 27
+  noun: pike
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal voulge #Page 28
+  noun: voulge
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a short-hafted halberd #Page 29
+  noun: halberd
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
   part:
   - short pole
-- name: some straight metal tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: some flat-bladed tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: some curved metal tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some angular metal tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some metal bolt tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: some segmented tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some box-jaw tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some articulated tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: a curved metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: a square metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: a tapered metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: a sturdy metal shovel
-  noun: shovel
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a wide metal shovel
-  noun: shovel
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a stout metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a narrow metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a slender metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a flat-headed metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a weighted metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a short metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
+- name: a metal awl pike #Page 30
+  noun: pike
+  volume: 15
+  type: weaponsmithing
   work_order: true
-  chapter: 3
+  chapter: 7
   part:
-  - short pole
-- name: a long metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
+  - long pole
+# Weaponsmithing Chapter 8 recipes
+- name: a metal nightstick #Page 1
+  noun: nightstick
+  volume: 7
+  type: weaponsmithing
   work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a sturdy metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a sharpened metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: some square metal rifflers
-  noun: rifflers
+  chapter: 8
+- name: a metal cane #Page 2
+  noun: cane
   volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: a metal quarterstaff #Page 3
+  noun: quarterstaff
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: a metal pike staff #Page 4
+  noun: staff
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some metal knuckles #Page 5
+  noun: knuckles
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some weighted metal footwraps #Page 6
+  noun: footwraps
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some metal knee spikes #Page 7
+  noun: spikes
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
   part:
   - short cord
-- name: some squat metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+- name: some metal elbow spikes #Page 8
+  noun: spikes
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
   part:
   - short cord
-- name: some curved metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+- name: some spiked metal footwraps #Page 9
+  noun: footwraps
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some spiked metal knuckles #Page 10
+  noun: knuckles
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: a weighted staff #Page 11
+  noun: staff
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some metal hand claws #Page 12
+  noun: claws
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
   part:
   - short cord
-- name: some elongated rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+# Weaponsmithing Chapter 9 recipes
+- name: a metal throwing spike #Page 1
+  noun: spike
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+- name: a metal bar mace #Page 2
+  noun: mace
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
   part:
-  - short cord
-- name: some short metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+  - haft
+- name: a metal broadaxe #Page 3
+  noun: broadaxe
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
   part:
-  - short cord
-- name: some long metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+  - haft
+- name: a metal war sword #Page 4
+  noun: sword
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
   part:
-  - short cord
-- name: some sturdy metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+  - hilt
+- name: a metal bastard sword #Page 5
+  noun: sword
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
   part:
-  - short cord
-- name: some reinforced chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+  - hilt
+- name: a metal boarding axe #Page 6
+  noun: axe
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
   part:
-  - short cord
-- name: some sharpened chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
+  - hilt
+- name: a metal splitting maul #Page 7
+  noun: maul
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
   part:
-  - short cord
-- name: a metal straight bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal curved bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal slender bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal tapered bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal serrated bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a thin metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a coarse metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a textured metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a flat metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a tapered metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a flat metal shaper
-  noun: shaper
+  - haft
+- name: a thin-bladed metal fan #Page 8
+  noun: fan
   volume: 4
-  type: blacksmithing
+  type: weaponsmithing
   work_order: true
-  chapter: 3
-- name: a rough metal wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
+  chapter: 9
+- name: a metal half-handled riste #Page 9
+  noun: riste
+  volume: 7
+  type: weaponsmithing
   work_order: true
-- name: a metal beveled wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a metal jagged wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: some plain metal pliers
-  noun: pliers
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some thick metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: some curved metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: some rough metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: some hooked metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a metal straight wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal curved wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal slender wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal tapered wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal serrated wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: thin metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: curved metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: thick metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: precise metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some smooth knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some tapered knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some squat knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some polished knitting needles
-  noun: needles
-  volume: 4
-  chapter: 4
-  type: blacksmithing
-  work_order: true
-- name: a metal hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a curved hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a serrated hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some plain sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some ribbed sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some knobby sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some thin sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some straight metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some curved metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some bent metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some serrated scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a stout metal yardstick
-  noun: yardstick
+  chapter: 9
+  part:
+  - hilt
+- name: a thick-bladed metal fan #Page 10
+  noun: fan
   volume: 6
-  chapter: 4
-  type: blacksmithing
-  work_order: false
-- name: a flat metal yardstick
-  noun: yardstick
-  volume: 6
-  chapter: 4
-  type: blacksmithing
-  work_order: false
-- name: rectangular yardstick
-  noun: yardstick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 4
-- name: detailed yardstick
-  noun: yardstick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 4
-- name: a pointed metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
+  type: weaponsmithing
   work_order: true
-  chapter: 4
-- name: a narrow metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
+  chapter: 9
+- name: a metal riste #Page 11
+  noun: riste
+  volume: 9
+  type: weaponsmithing
   work_order: true
-  chapter: 4
-- name: a compact metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a slender metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a square wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a triangular wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: an oblong wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a trapezoidal wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a flat mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a tapered mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a round mixing stick
-  noun: stick
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a grooved mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a tapered pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a flat pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a round pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a grooved pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a small metal brazier
-  noun: brazier
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a metal brazier
-  noun: brazier
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 5
+  chapter: 9
+  part:
+  - hilt
+###############################
+##### Forging section end #####
+###############################
+######################################
+##### Engineering section begins #####
+######################################
+# Carving Chapter 1 recipes
 - name: a small stone block
   noun: block
   volume: 3
@@ -1536,6 +4447,7 @@ crafting_recipes:
   work_order: true
   chapter: 8
   material: bone
+# Carving Chapter 9 recipes
 - name: a bone toe ring
   noun: ring
   volume: 1
@@ -1717,7 +4629,379 @@ crafting_recipes:
   work_order: true
   chapter: 9
   material: bone
-- name: a wood pendant
+# Shaping Chapter 2 recipes
+- name: a toy bow #Page 1
+  noun: bow
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a practice shortbow #Page 2
+  noun: shortbow
+  volume: 4
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a simple shortbow #Page 3
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a light shortbow #Page 4
+  noun: shortbow
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a farmer's bow #Page 5
+  noun: bow
+  volume: 4
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a shortbow #Page 6
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a sturdy shortbow #Page 7
+  noun: shortbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: an alpine shortbow #Page 8
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a saddle bow #Page 9
+  noun: bow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a flight bow #Page 10
+  noun: bow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a steppe bow #Page 11
+  noun: bow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a battle shortbow #Page 12
+  noun: shortbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a forester's shortbow #Page 13
+  noun: shortbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a Nisha shortbow #Page 14
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+- name: a competition shortbow #Page 15
+  noun: shortbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
+    - bow string
+# Shaping Chapter 3 recipes
+- name: a simple longbow #Page 1
+  noun: longbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
+    - bow string
+- name: a practice longbow #Page 2
+  noun: longbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
+    - bow string
+- name: a longbow #Page 3
+  noun: longbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
+    - bow string
+- name: a sturdy longbow #Page 4
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
+    - bow string
+- name: a flatbow #Page 5
+  noun: flatbow
+  volume: 7
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
+    - bow string
+- name: a skirmisher's bow #Page 6
+  noun: bow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
+    - bow string
+- name: a reflex longbow #Page 7
+  noun: longbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
+    - bow string
+- name: a self bow #Page 8
+  noun: bow
+  volume: 7
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
+    - bow string
+- name: a recurve longbow #Page 9
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
+    - bow string
+- name: a forester's longbow #Page 10
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
+    - bow string
+- name: a battle longbow #Page 11
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
+    - bow string
+- name: a competition longbow #Page 12
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
+    - bow string
+# Shaping Chapter 4 recipes
+- name: a composite bow #Page 1
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a double-backed bow #Page 2
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a recurve bow #Page 3
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a forester's bow #Page 4
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a reflex bow #Page 5
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a savannah bow #Page 6
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a footman's bow #Page 7
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: false
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a horseman's bow #Page 8
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: false
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a battle bow #Page 9
+  noun: bow
+  volume: 10
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+- name: a competition bow #Page 10
+  noun: bow
+  volume: 10
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
+    - bow string
+    - bone backer
+# Shaping Chapter 5 recipes are arrows and covered with the arrows.lic script.
+# Shaping Chapter 6 recipes are Enhancements and Materials.
+# Shaping Chapter 7 recipes
+- name: a wood band #Page 1
+  noun: band
+  volume: 1
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood nose ring #Page 2
+  noun: ring
+  volume: 1
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood toe ring #Page 3
+  noun: ring
+  volume: 1
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood bracelet #Page 4
+  noun: bracelet
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood anklet #Page 5
+  noun: anklet
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood pin #Page 6
+  noun: pin
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood cloak pin #Page 7
+  noun: pin
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a shallow wood cup #Page 8
+  noun: cup
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood hairpin #Page 9
+  noun: hairpin
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood tailband #Page 10
+  noun: tailband
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood pendant #Page 11
   noun: pendant
   volume: 1
   type: shaping
@@ -1725,129 +5009,55 @@ crafting_recipes:
   chapter: 7
   part:
   - short cord
-- name: a wood amulet
+- name: a wood amulet #Page 12
   noun: amulet
   volume: 2
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood medallion
+- name: a wood medallion #Page 13
   noun: medallion
   volume: 2
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood toe ring
-  noun: ring
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood nose ring
-  noun: ring
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood band
-  noun: band
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood pin
-  noun: pin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood anklet
-  noun: anklet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood bracelet
-  noun: bracelet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood cloak pin
-  noun: pin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a shallow wood cup
-  noun: cup
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood hairpin
-  noun: hairpin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood tailband
-  noun: tailband
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a pair of wood earrings
+- name: a pair of wood earrings #Page 14
   noun: earrings
   volume: 2
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood walking cane
-  noun: cane
-  volume: 6
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood quarterstaff
-  noun: quarterstaff
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood crook
-  noun: crook
-  volume: 5
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood bo staff
-  noun: staff
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 9
-  part:
-  - leather strip
-- name: a wood earcuff
+- name: a wood earcuff #Page 15
   noun: earcuff
   volume: 2
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood brooch
+- name: a wood brooch #Page 16
   noun: brooch
   volume: 2
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood belt buckle
+- name: a wood armband #Page 17
+  noun: armband
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood belt buckle #Page 18
   noun: buckle
   volume: 2
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood locket
+- name: a wood choker #Page 19
+  noun: choker
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood locket #Page 20
   noun: locket
   volume: 2
   type: shaping
@@ -1855,7 +5065,25 @@ crafting_recipes:
   chapter: 7
   part:
   - short cord
-- name: a wood circlet
+- name: some wood bangles #Page 21
+  noun: bangles
+  volume: 5
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood tiara #Page 22
+  noun: tiara
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: an articulated wood bracelet #Page 23
+  noun: bracelet
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood circlet #Page 24
   noun: circlet
   volume: 3
   type: shaping
@@ -1863,37 +5091,19 @@ crafting_recipes:
   chapter: 7
   part:
   - short cord
-- name: a wood armband
-  noun: armband
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood tiara
-  noun: tiara
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood choker
-  noun: choker
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: an articulated wood bracelet
-  noun: bracelet
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: an articulated wood necklace
+- name: an articulated wood necklace #Page 25
   noun: necklace
   volume: 3
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood mask
+- name: a wood crown #Page 26
+  noun: crown
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood mask #Page 27
   noun: mask
   volume: 3
   type: shaping
@@ -1901,24 +5111,281 @@ crafting_recipes:
   chapter: 7
   part:
   - short cord
-- name: a wood crown
-  noun: crown
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood comb
+- name: a wood comb #Page 28
   noun: comb
   volume: 2
   type: shaping
   work_order: true
   chapter: 7
-- name: a wood haircomb
+- name: a wood haircomb #Page 29
   noun: haircomb
   volume: 3
   type: shaping
   work_order: true
   chapter: 7
+# Shaping Chapter 8 recipes
+- name: a wood bead #Page 1
+  noun: bead
+  volume: 1
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood bead #Page 2
+  noun: bead
+  volume: 1
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood totem #Page 3
+  noun: totem
+  volume: 2
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood totem #Page 4
+  noun: totem
+  volume: 2
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood figurine #Page 5
+  noun: figurine
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood wand #Page 6
+  noun: wand
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood rod #Page 7
+  noun: rod
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood figurine #Page 8
+  noun: figurine
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood statuette #Page 9
+  noun: statuette
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood statuette #Page 10
+  noun: statuette
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood statue #Page 11
+  noun: statue
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood statue #Page 12
+  noun: statue
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 8
+# Shaping Chapter 9 recipes
+- name: a wood cane #Page 1
+  noun: cane
+  volume: 7
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood nightstick #Page 2
+  noun: nightstick
+  volume: 6
+  type: shaping
+  work_order: true
+  chapter: 9
+  part:
+  - leather strip
+- name: a wood quarterstaff #Page 3
+  noun: quarterstaff
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood walking cane #Page 4
+  noun: cane
+  volume: 6
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood crook #Page 5
+  noun: crook
+  volume: 5
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood bo staff #Page 6
+  noun: staff
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 9
+  part:
+  - leather strip
+- name: a weighted staff #Page 7
+  noun: staff
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 9
+  part:
+  - leather strip
+# Shaping Chapter 10 recipes
+- name: a rough wood table #Page 1
+  noun: table
+  volume: 15
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a low wood table #Page 2
+  noun: table
+  volume: 18
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - short pole
+  - short pole
+  - short pole
+  - short pole
+- name: a high wood table #Page 3
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a round wood table #Page 4
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a square wood table #Page 5
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a long wood table #Page 6
+  noun: table
+  volume: 25
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: an oval wood table #Page 7
+  noun: table
+  volume: 25
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood dining table #Page 8
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood buffet table #Page 9
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood refectory table #Page 10
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood parquet table #Page 11
+  noun: table
+  volume: 32
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood meditation table #Page 12
+  noun: table
+  volume: 32
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+# Tinkering requires mechanism made from metal or ingot.
+####################################
+##### Engineering section ends #####
+####################################
+####################################
+##### Outfitting section ends  #####
+####################################
+# Tailoring Chapter 2 recipes
 - name: a cloth shaman's robe
   noun: robe
   volume: 9
@@ -3563,1252 +7030,13 @@ crafting_recipes:
   part:
   - shield handle
   - long cord
-- name: a metal carving knife
-  noun: knife
-  volume: 2
-  type: weaponsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hunting sword
-  noun: sword
-  volume: 8
-  type: weaponsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - hilt
-- name: a metal nimsha
-  noun: nimsha
-  volume: 8
-  type: weaponsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - hilt
-- name: a metal throwing dagger
-  noun: dagger
-  volume: 2
-  type: weaponsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - hilt
-- name: a metal short sword
-  noun: sword
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal foil
-  noun: foil
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal pugio
-  noun: pugio
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal thrusting blade
-  noun: blade
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal rapier
-  noun: rapier
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal stiletto
-  noun: stiletto
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal gladius
-  noun: gladius
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal parang
-  noun: parang
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal scimitar
-  noun: scimitar
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hand axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - haft
-- name: a metal adze
-  noun: adze
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal sabre
-  noun: sabre
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal cutlass
-  noun: cutlass
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal iltesh
-  noun: iltesh
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal longsword
-  noun: longsword
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal broadsword
-  noun: broadsword
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal kudalata
-  noun: kudalata
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal falchion
-  noun: falchion
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a light throwing axe
-  noun: axe
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - haft
-- name: a metal battle axe
-  noun: axe
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-- name: a metal robe sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal abassi
-  noun: abassi
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal cinquedea
-  noun: cinquedea
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal dagesse
-  noun: dagesse
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal namkomba
-  noun: namkomba
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal hurling axe
-  noun: axe
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-- name: a metal two-handed sword
-  noun: sword
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal greataxe
-  noun: greataxe
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal marauder blade
-  noun: blade
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal double axe
-  noun: axe
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal warring axe
-  noun: axe
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal greatsword
-  noun: greatsword
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal bludgeon
-  noun: bludgeon
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal boomerang
-  noun: boomerang
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal bola
-  noun: bola
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - long cord
-- name: a metal komno
-  noun: komno
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a flanged metal mace
-  noun: mace
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal dire mace
-  noun: mace
-  volume: 16
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal throwing club
-  noun: club
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: some metal hand claws
-  noun: claws
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: some metal spiked knuckles
-  noun: knuckles
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal throwing mallet
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal throwing hammer
-  noun: hammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal greathammer
-  noun: greathammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal morning star
-  noun: star
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal war mattock
-  noun: mattock
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal akabo
-  noun: akabo
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal footman's flail
-  noun: flail
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal javelin
-  noun: javelin
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a light metal spear
-  noun: spear
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal scythe
-  noun: scythe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal bardiche
-  noun: bardiche
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal lochaber axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal guisarme
-  noun: guisarme
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal halberd
-  noun: halberd
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal tzece
-  noun: tzece
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal coresca
-  noun: coresca
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal awgravet ava
-  noun: ava
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal hunthsleg
-  noun: hunthsleg
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal allarh
-  noun: allarh
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal spear
-  noun: spear
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal glaive
-  noun: glaive
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a two-pronged halberd
-  noun: halberd
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal khuj
-  noun: khuj
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal partisan
-  noun: partisan
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal military fork
-  noun: fork
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal duraka skefne
-  noun: skefne
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal pole axe
-  noun: axe
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal fauchard
-  noun: fauchard
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ngalio
-  noun: ngalio
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal pike
-  noun: pike
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal lance
-  noun: lance
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal spetum
-  noun: spetum
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ranseur
-  noun: ranseur
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ilglaiks skefne
-  noun: skefne
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal voulge
-  noun: voulge
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal awl pike
-  noun: pike
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a short-hafted halberd
-  noun: halberd
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal cane
-  noun: cane
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal nightstick
-  noun: nightstick
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal quarterstaff
-  noun: quarterstaff
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal knuckles
-  noun: knuckles
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal pike staff
-  noun: staff
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal elbow spikes
-  noun: spikes
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: some metal knee spikes
-  noun: spikes
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: some weighted metal footwraps
-  noun: footwraps
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some spiked metal knuckles
-  noun: knuckles
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some spiked metal footwraps
-  noun: footwraps
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal hand claws
-  noun: claws
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: a weighted staff
-  noun: staff
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal throwing spike
-  noun: spike
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-- name: a metal bastard sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal war sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal broadaxe
-  noun: broadaxe
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a stone armband
-  noun: armband
-  volume: 3
-  type: carving
-  work_order: true
-  chapter: 4
-- name: a metal splitting maul
-  noun: maul
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a metal bar mace
-  noun: mace
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a simple parry stick
-  noun: stick
-  volume: 7
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - small backing
-- name: a metal target shield
-  noun: shield
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal round sipar
-  noun: sipar
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal ring lorica
-  noun: lorica
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal ring shirt
-  noun: shirt
-  volume: 43
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal chain shirt
-  noun: shirt
-  volume: 50
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail lorica
-  noun: lorica
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal ring balaclava
-  noun: balaclava
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring vambraces
-  noun: vambraces
-  volume: 19
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring gloves
-  noun: gloves
-  volume: 6
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain balaclava
-  noun: balaclava
-  volume: 20
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain gloves
-  noun: gloves
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal scale mask
-  noun: mask
-  volume: 5
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: some metal scale greaves
-  noun: greaves
-  volume: 15
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: some metal scale vambraces
-  noun: vambraces
-  volume: 22
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: some lamellar sleeves
-  noun: sleeves
-  volume: 40
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: some lamellar greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: a metal lamellar tasset
-  noun: tasset
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: some lamellar vambraces
-  noun: vambraces
-  volume: 28
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: some metal scale sleeves
-  noun: sleeves
-  volume: 30
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale lorica
-  noun: lorica
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale balaclava
-  noun: balaclava
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal dome helm
-  noun: helm
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal sallet
-  noun: sallet
-  volume: 35
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some light plate gauntlets
-  noun: gauntlets
-  volume: 13
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a light plate aventail
-  noun: aventail
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: heavy plate gauntlets
-  noun: gauntlets
-  volume: 17
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal great helm
-  noun: helm
-  volume: 45
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some light plate sleeves
-  noun: sleeves
-  volume: 39
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some light half plate
-  noun: plate
-  volume: 65
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - large padding
-- name: some light plate greaves
-  noun: greaves
-  volume: 19
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a light plate mask
-  noun: mask
-  volume: 7
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a plate mask
-  noun: mask
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal bascinet
-  noun: bascinet
-  volume: 23
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some light plate vambraces
-  noun: vambraces
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some heavy plate vambraces
-  noun: vambraces
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal visored helm
-  noun: helm
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal armet
-  noun: armet
-  volume: 40
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some plate sleeves
-  noun: sleeves
-  volume: 45
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate sleeves
-  noun: sleeves
-  volume: 51
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some light field plate
-  noun: plate
-  volume: 58
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - large padding
-- name: some field plate
-  noun: plate
-  volume: 67
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-  - large backing
-- name: some half plate
-  noun: plate
-  volume: 75
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-  - large backing
-- name: some light full plate
-  noun: plate
-  volume: 100
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - small padding
-  - large padding
-- name: a metal ring cap
-  noun: cap
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring greaves
-  noun: greaves
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain greaves
-  noun: greaves
-  volume: 15
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring tasset
-  noun: tasset
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal scale gloves
-  noun: gloves
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale helm
-  noun: helm
-  volume: 21
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a light backplate
-  noun: backplate
-  volume: 10
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a light breastplate
-  noun: breastplate
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal heavy backplate
-  noun: backplate
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate fauld
-  noun: fauld
-  volume: 17
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy breastplate
-  noun: breastplate
-  volume: 20
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a light plate cuirass
-  noun: cuirass
-  volume: 39
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - large padding
-- name: a heavy plate cuirass
-  noun: cuirass
-  volume: 51
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - large backing
+####################################
+##### Outfitting section ends  #####
+####################################
+#################################
+##### Alchemy section begins#####
+#################################
+# Remedies Chapter 2 recipes
 - name: some blister cream
   noun: cream
   volume: 1
@@ -4934,6 +7162,7 @@ crafting_recipes:
   herb1_stock: 13
   herb2: dioica
   herb2_stock:
+# Remedies Chapter 3 recipes
 - name: some neck salve
   noun: salve
   volume: 1
@@ -5069,6 +7298,7 @@ crafting_recipes:
   container: mortar
   herb1: jadice
   herb1_stock: 5
+# Remedies Chapter 4 recipes
 - name: a neck potion
   noun: potion
   volume: 1
@@ -5213,6 +7443,7 @@ crafting_recipes:
   container: bowl
   herb1: yelith
   herb1_stock:
+# Remedies Chapter 5 recipes
 - name: some face ointment
   noun: ointment
   volume: 1
@@ -5323,6 +7554,7 @@ crafting_recipes:
   herb1: ojhenik
   herb1_stock: 12
   liquid: alcohol
+# Remedies Chapter 6 recipes
 - name: a face draught
   noun: draught
   volume: 1
@@ -5413,1373 +7645,10 @@ crafting_recipes:
   herb1: belradi
   herb1-stock:
   liquid: alcohol
-- name: a toy bow
-  noun: bow
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a practice shortbow
-  noun: shortbow
-  volume: 4
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a simple shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a light shortbow
-  noun: shortbow
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a farmer's bow
-  noun: bow
-  volume: 4
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a sturdy shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: an alpine shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a saddle bow
-  noun: bow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a flight bow
-  noun: bow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a steppe bow
-  noun: bow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a battle shortbow
-  noun: shortbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a forester's shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a Nisha shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a competition shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
-    - bow string
-- name: a practice longbow
-  noun: longbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
-    - bow string
-- name: a simple longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
-    - bow string
-- name: a longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
-    - bow string
-- name: a sturdy longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
-    - bow string
-- name: a flatbow
-  noun: flatbow
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
-    - bow string
-- name: a skirmisher's bow
-  noun: bow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
-    - bow string
-- name: a reflex longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
-    - bow string
-- name: a self bow
-  noun: bow
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
-    - bow string
-- name: a recurve longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
-    - bow string
-- name: a forester's longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
-    - bow string
-- name: a battle longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
-    - bow string
-- name: a competition longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
-    - bow string
-- name: a composite bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a double-backed bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a recurve bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a forester's bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a reflex bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a savannah bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a footman's bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a horseman's bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a battle bow
-  noun: bow
-  volume: 10
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a competition bow
-  noun: bow
-  volume: 10
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
-    - bow string
-    - bone backer
-- name: a metal ring aventail
-  noun: aventail
-  volume: 5
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain aventail
-  noun: aventail
-  volume: 6
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail aventail
-  noun: aventail
-  volume: 7
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain cap
-  noun: cap
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail mask
-  noun: mask
-  volume: 5
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail gloves
-  noun: gloves
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain helm
-  noun: helm
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail cap
-  noun: cap
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring mantle
-  noun: mantle
-  volume: 21
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain tasset
-  noun: tasset
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring sleeves
-  noun: sleeves
-  volume: 21
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain vambraces
-  noun: vambraces
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail helm
-  noun: helm
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a mail balaclava
-  noun: balaclava
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small backing
-- name: a metal ring robe
-  noun: robe
-  volume: 38
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal chain lorica
-  noun: lorica
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain mantle
-  noun: mantle
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain vest
-  noun: vest
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail tasset
-  noun: tasset
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain sleeves
-  noun: sleeves
-  volume: 26
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail vambraces
-  noun: vambraces
-  volume: 23
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring hauberk
-  noun: hauberk
-  volume: 70
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal chain robe
-  noun: robe
-  volume: 45
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail mantle
-  noun: mantle
-  volume: 27
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail vest
-  noun: vest
-  volume: 22
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: some metal mail sleeves
-  noun: sleeves
-  volume: 31
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain hauberk
-  noun: hauberk
-  volume: 80
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal mail shirt
-  noun: shirt
-  volume: 57
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail robe
-  noun: robe
-  volume: 52
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal bar-mail hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal scale aventail
-  noun: aventail
-  volume: 9
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale cap
-  noun: cap
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine aventail
-  noun: aventail
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine mask
-  noun: mask
-  volume: 6
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine cap
-  noun: cap
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar aventail
-  noun: aventail
-  volume: 11
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: a metal lamellar mask
-  noun: mask
-  volume: 7
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some brigandine gloves
-  noun: gloves
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale tasset
-  noun: tasset
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine helm
-  noun: helm
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar cap
-  noun: cap
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some brigandine greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some metal lamellar gloves
-  noun: gloves
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: a metal brigandine tasset
-  noun: tasset
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some brigandine vambraces
-  noun: vambraces
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a brigandine balaclava
-  noun: balaclava
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar helm
-  noun: helm
-  volume: 27
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: a metal scale mantle
-  noun: mantle
-  volume: 33
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale vest
-  noun: vest
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal lamellar balaclava
-  noun: balaclava
-  volume: 34
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some brigandine sleeves
-  noun: sleeves
-  volume: 35
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale shirt
-  noun: shirt
-  volume: 56
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale robe
-  noun: robe
-  volume: 49
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-- name: a metal brigandine lorica
-  noun: lorica
-  volume: 38
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal brigandine mantle
-  noun: mantle
-  volume: 36
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal brigandine vest
-  noun: vest
-  volume: 26
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a brigandine robe
-  noun: robe
-  volume: 56
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-- name: a brigandine shirt
-  noun: shirt
-  volume: 63
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale hauberk
-  noun: hauberk
-  volume: 80
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal lamellar lorica
-  noun: lorica
-  volume: 42
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar mantle
-  noun: mantle
-  volume: 39
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar vest
-  noun: vest
-  volume: 28
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar robe
-  noun: robe
-  volume: 63
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-- name: a brigandine hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal lamellar shirt
-  noun: shirt
-  volume: 70
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a lamellar hauberk
-  noun: hauberk
-  volume: 100
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: a laminar hauberk
-  noun: hauberk
-  volume: 100
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: a plate aventail
-  noun: aventail
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some plate gauntlets
-  noun: gauntlets
-  volume: 15
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate aventail
-  noun: aventail
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal morion
-  noun: morion
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate mask
-  noun: mask
-  volume: 9
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a light plate fauld
-  noun: fauld
-  volume: 13
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small padding
-- name: a metal barbute
-  noun: barbute
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a plate fauld
-  noun: fauld
-  volume: 15
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal backplate
-  noun: backplate
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some plate vambraces
-  noun: vambraces
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some plate greaves
-  noun: greaves
-  volume: 22
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal closed helm
-  noun: helm
-  volume: 29
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal breastplate
-  noun: breastplate
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate greaves
-  noun: greaves
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a plate cuirass
-  noun: cuirass
-  volume: 45
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-- name: some heavy half plate
-  noun: plate
-  volume: 85
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large padding
-  - small padding
-- name: some full plate
-  noun: plate
-  volume: 110
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: some heavy field plate
-  noun: plate
-  volume: 76
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-- name: some heavy full plate
-  noun: plate
-  volume: 120
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: some heavy fluted plate
-  noun: plate
-  volume: 120
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: a metal shield handle
-  noun: handle
-  volume: 2
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-- name: a metal shield boss
-  noun: boss
-  volume: 3
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-- name: a metal ordinary shield
-  noun: shield
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal targe
-  noun: targe
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal triangular sipar
-  noun: sipar
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal medium shield
-  noun: shield
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal ceremonial shield
-  noun: shield
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal curved shield
-  noun: shield
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal circular buckler
-  noun: buckler
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal medium buckler
-  noun: buckler
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal oval shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal jousting shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal skirmisher's shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal kite shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal warrior's shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal tower shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal battle shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal heater shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal aegis
-  noun: aegis
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal war shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a rough wood table
-  noun: table
-  volume: 15
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a low wood table
-  noun: table
-  volume: 18
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - short pole
-  - short pole
-  - short pole
-  - short pole
-- name: a high wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a round wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a square wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a long wood table
-  noun: table
-  volume: 25
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: an oval wood table
-  noun: table
-  volume: 25
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a long wood table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood dining table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood buffet table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood refectory table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood parquet table
-  noun: table
-  volume: 32
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood meditation table
-  noun: table
-  volume: 32
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-#### Enchanting
+####################################
+##### Enchanting section ends #####
+####################################
+# Artificing Chapter 2 recipes
 - name: a radiant trinket
   noun: bone totem
   type: artificing
@@ -7055,6 +7924,7 @@ crafting_recipes:
   item:
   part:
   - ring
+# Artificing Chapter 3 recipes
 - name: training ritual focus
   noun: bone totem
   type: artificing
@@ -7221,6 +8091,7 @@ crafting_recipes:
   enchant_stock2:
   enchant_stock3:
   item: 6
+# Artificing Chapter 4 recipes
 - name: common material minor fount
   noun: small sphere
   type: artificing
@@ -7397,6 +8268,7 @@ crafting_recipes:
   item:
   part:
   - sphere
+# Artificing Chapter 5 recipes
 - name: an unfocused burin
   noun: burin
   type: artificing
@@ -7541,6 +8413,7 @@ crafting_recipes:
   item:
   part:
   - bobcat rod
+# Artificing Chapter 6 recipes
 - name: a bubble wand
   noun: wand
   type: artificing


### PR DESCRIPTION
The goal is to put all current discipline recipes in the file. 

**March 3, 2021** - All Forging recipes are in and confirmed. Eningeering carve and shape recipes confirmed. I am working on adding tinkering recipes and then adding to workorders. Before adding tinkering, I will verify Tailoring and Alchemy recipes. For sanity, all recipes start at the first chapter recipes start in the book and are in page order as of this time. However, it does not appear these change order or has not for me. I added a comment after each recipe indicating page number. This step is the sanity check. :smile: Example showing Chapter comment and then page number on recipe:
```yaml
# Shaping Chapter 10 recipes
- name: a rough wood table #Page 1
  noun: table
  volume: 15
  type: shaping
  work_order: false
  chapter: 10
  part:
  - long pole
  - long pole
  - long pole
  - long pole
 ```