### PR TITLE
Added an exit of current mine location if returning from safe-room

### DIFF
--- a/mine.lic
+++ b/mine.lic
@@ -56,7 +56,9 @@ class Mine
       store_mining_tool
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)
-      exit unless DRRoom.npcs.empty?
+      if @mining_skip_populated && !DRRoom.npcs.empty?
+        DRC.message("Returned from healing and another player is in the room. Returning to mining-buddy to move on!")
+      end
       get_mining_tool
     end
 
@@ -134,6 +136,7 @@ class Mine
               'enormous quantity \(5/5\) remains to be found', 'substantial quantity \(4/5\) remains to be found', 'good quantity \(3/5\) remains to be found',
               'decent quantity \(2/5\) remains to be found', 'small quantity \(1/5\) remains to be found', 'scattering of resources \(0/5\) remains to be found')
     settings = get_settings
+    @mining_skip_populated = settings.mining_skip_populated
     @mining_implement = settings.mining_implement
     @forging_belt = settings.forging_belt
     @loot_list = settings.mining_buddy_vein_list

--- a/mine.lic
+++ b/mine.lic
@@ -56,7 +56,7 @@ class Mine
       store_mining_tool
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)
-      if @mining_skip_populated && !DRRoom.npcs.empty?
+      if @mining_skip_populated && !DRRoom.pcs.empty?
         DRC.message("Returned from healing and another player is in the room. Returning to mining-buddy to move on!")
       end
       get_mining_tool

--- a/mine.lic
+++ b/mine.lic
@@ -56,6 +56,7 @@ class Mine
       store_mining_tool
       wait_for_script_to_complete('safe-room')
       walk_to(snapshot)
+      exit unless DRRoom.npcs.empty?
       get_mining_tool
     end
 


### PR DESCRIPTION
 while in danger comes up to the room now having a pc.

Basically, people go heal, snapshot room is taken, they return and begin to mine again, and someone else is there. We should exit mine and move on. This needs testing to make sure mining-buddy recovers correctly. 