### PR TITLE
Restock deposit fix - made it so it does not deposit if no purchases were made.

### DIFF
--- a/restock.lic
+++ b/restock.lic
@@ -21,6 +21,7 @@ class Restock
   end
 
   def restock_items(item_list, town)
+    purchased = false
     items_to_restock = []
     coin_needed = 0
 
@@ -37,10 +38,13 @@ class Restock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-    ### The following line is for the bribe to the night attendant to let you in.
-    coin_needed += 2502 if UserVars.sun['night'] && town == /\bShard\b/
-    get_money_from_bank("#{coin_needed} copper", "#{town_currency(town)}", "#{town}") if coin_needed > 0
+    if coin_needed > 0
+      ### The following line is for the bribe to the night attendant to let you in.
+      coin_needed += 2502 if UserVars.sun['night'] && town =~ /\bShard\b/
+      get_money_from_bank("#{coin_needed} copper", "#{town_currency(town)}", "#{town}")
+    end
     items_to_restock.each do |item|
+      purchased = true
       item['buy_num'].times do
         buy_item(item['room'], item['name'])
         if reget(3, 'Seeing that you are too encumbered')
@@ -49,7 +53,7 @@ class Restock
         reget(2, 'runestone') ? DRCI.put_away_item?(item['name'], @runestone_storage) : stow_hands
       end
     end
-    deposit_coins(@keep_copper, @settings, "#{town}")
+    deposit_coins(@keep_copper, @settings, "#{town}") if purchased
   end
 
   def setup

--- a/restock.lic
+++ b/restock.lic
@@ -43,8 +43,8 @@ class Restock
       coin_needed += 2502 if UserVars.sun['night'] && town =~ /\bShard\b/
       get_money_from_bank("#{coin_needed} copper", "#{town_currency(town)}", "#{town}")
     end
+    purchased = true unless items_to_restock.empty?
     items_to_restock.each do |item|
-      purchased = true
       item['buy_num'].times do
         buy_item(item['room'], item['name'])
         if reget(3, 'Seeing that you are too encumbered')


### PR DESCRIPTION
Behavior as of the last commit added in depositing the money withdrawn from the town you are in. For example, if I have restock setup for smooth rock from Hib, restock would count my arrows and determine if I had the proper number. If not, it will go purchase. However, if I have the proper number, the place deposit is now, restock runs you to Hib to deposit money even if you do not have money from that bank. 

If you have enough items or do not have restock set, no movement should happen. A lot of extra running around is now removed from the script. I was going under the assumption anyone using restock had it as a separate script. I did not see it was called by hunting-buddy. Running to the bank is not a bad thing unless you are a necro or do not have prehunt_buff room set. Hopefully, this explanation is clear.

The deposit is necessary to prevent burden. In testing, I had money left over causing a burden as I went into combat. 