### PR TITLE
Changed the attempt timer to trigger before waitrt?

### DIFF
--- a/mine.lic
+++ b/mine.lic
@@ -85,6 +85,7 @@ class Mine
     end
 
     bput('mine', 'roundtime')
+    pause @mining_attempt_timer
     waitrt?
 
     @loot_list.each do |item|
@@ -102,7 +103,6 @@ class Mine
       end
     end
 
-    pause @mining_attempt_timer
     mine(count - 1)
   end
 


### PR DESCRIPTION
I previous had it after due to not fully understanding how the system worked. Figured you'd need to loot and then wait, etc. Doesn't matter I guess, so we will just wait at least the player designated timer, and then whatever time is left for the waitrt?. I thought it was  a set time, but it varies by skill and stats, so here it is.