### PR TITLE
Add Twohanded Whirlwinding

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3273,7 +3273,7 @@ class GameState
     @analyze_combo_array = []
     @currently_whirlwinding = false
     @avtalia_cambrinth = {}
-    @analyze_map = { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }
+    @barb_analyzes = { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }
 
     @left_hand_free = settings.left_hand_free
     echo("  @left_hand_free: #{@left_hand_free}") if $debug_mode_ct
@@ -4023,9 +4023,9 @@ class GameState
   def update_analyze_array(type = nil)
     if DRStats.barbarian?
       # Try to perform the desired combo, and if successful then return.
-      return if type && perform_analyze?(type, @analyze_map[type])
+      return if type && perform_analyze?(type, @barb_analyzes[type])
       # Otherwise, let system try to decide which combo to perform based on your expertise ranks.
-      @analyze_map.each do |combo, expertise|
+      @barb_analyzes.each do |combo, expertise|
         break if perform_analyze?(combo, expertise)
       end
     else

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -192,6 +192,9 @@ class SetupProcess
     echo('new skill needed for training') if $debug_mode_ct
 
     game_state.reset_action_count
+    # Moved this here from check_weapon based on order of operations and sheathing logic returning  
+    # if current weapon skill is twohanded.
+    game_state.sheath_whirlwind_offhand
 
     # If you're training with summoned moon weapons but you haven't cast the moonblade spell yet
     # then skip those weapon skills and train something else while we wait for moonblade spell to be cast.
@@ -268,7 +271,6 @@ class SetupProcess
     # Clean up the previous weapon
     if !last_summoned
       @equipment_manager.stow_weapon(game_state.last_weapon_name)
-      game_state.sheath_whirlwind_offhand
     elsif !next_summoned && !DRStats.moon_mage?
       break_summoned_weapon(game_state.last_weapon_name)
     elsif !next_summoned && DRStats.moon_mage?
@@ -297,7 +299,8 @@ class SetupProcess
   end
 
   def determine_whirlwind_weapon(game_state)
-    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill]).first
+    return if game_state.weapon_skill.include?'Twohanded'
+    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill] - ['Twohanded Edged'] - ['Twohanded Blunt']).first
     game_state.update_whirlwind_weapon_info(offhand_skill)
     game_state.wield_whirlwind_offhand
   end
@@ -3401,6 +3404,16 @@ class GameState
 
     @whirlwind_trainables = settings.whirlwind_trainables
     echo("  @whirlwind_trainables: #{@whirlwind_trainables}") if $debug_mode_ct
+    
+    @flame_inner_fire_threshold = settings.barb_combat_inner_fire_threshold
+    echo("  @flame_inner_fire_threshold: #{@flame_inner_fire_threshold}") if $debug_mode_ct
+
+    if @whirlwind_trainables && @charged_maneuvers
+      @flame_for_expertise = false
+    else
+      @flame_for_expertise = true
+    end
+    echo("  @flame_for_expertise: #{@flame_for_expertise}") if $debug_mode_ct
 
     @avtalia_array = settings.avtalia_array
     echo("  @avtalia_array: #{@avtalia_array}") if $debug_mode_ct
@@ -3501,6 +3514,7 @@ class GameState
   end
 
   def sheath_whirlwind_offhand
+    return if weapon_skill.include?'Twohanded'
     return unless currently_whirlwinding
     @equipment_manager.stow_weapon(whirlwind_offhand_name)
   end
@@ -3530,13 +3544,17 @@ class GameState
   end
 
   def wield_whirlwind_offhand
+    return if weapon_skill.include?'Twohanded'
     return unless currently_whirlwinding
     @equipment_manager.wield_weapon_offhand(whirlwind_offhand_name)
   end
 
   def determine_whirlwind_action
-    if @use_weak_attacks && Flags['ct-accuracy-ready']
-      update_analyze_array(true) if @analyze_combo_array.empty?
+    if @flame_for_expertise == true && ( (DRStats.mana < @flame_inner_fire_threshold) || (DRSkill.getxp('Expertise') < 15) )
+      update_analyze_array('flame')
+      @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
+    elsif Flags['ct-accuracy-ready']
+      update_analyze_array('accuracy') if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif (npcs.length > 2) && !balance_low?
       'whirlwind'
@@ -3891,7 +3909,7 @@ class GameState
     # !offhand & !brawling are there because you can't use a weapon for brawling commands
     # This issue will cause problems with the combo array system
     elsif @use_analyze_combos && !offhand? && !brawling?
-      update_analyze_array(false) if @analyze_combo_array.empty?
+      update_analyze_array() if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else
       'attack'
@@ -4000,8 +4018,14 @@ class GameState
     true
   end
 
-  def update_analyze_array(only_accuracy)
-    return perform_analyze?('accuracy', 50) if only_accuracy # Barb only setting
+  def update_analyze_array(type = '')
+    # Force overrides during whirlwinding, barb only
+    if currently_whirlwinding
+      return perform_analyze?('accuracy', 50) if type == 'accuracy'
+      return perform_analyze?('flame', 0) if type == 'flame'
+    end
+
+    # Let system decide, not whirlwinding
     if DRStats.barbarian?
       { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }.each do |type, expertise|
         break if perform_analyze?(type, expertise)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3910,7 +3910,7 @@ class GameState
     # !offhand & !brawling are there because you can't use a weapon for brawling commands
     # This issue will cause problems with the combo array system
     elsif @use_analyze_combos && !offhand? && !brawling?
-      update_analyze_array() if @analyze_combo_array.empty?
+      update_analyze_array if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else
       'attack'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3547,7 +3547,7 @@ class GameState
   end
 
   def determine_whirlwind_action
-    if (DRStats.mana < @flame_inner_fire_threshold) || (@flame_for_expertise && DRSkill.getxp('Expertise') < 15)
+    if ( (DRStats.mana < @flame_inner_fire_threshold) && @use_analyze_combos ) || ( @flame_for_expertise && (DRSkill.getxp('Expertise') < 15) )
       update_analyze_array('flame')
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif Flags['ct-accuracy-ready']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3406,7 +3406,7 @@ class GameState
     @whirlwind_trainables = settings.whirlwind_trainables
     echo("  @whirlwind_trainables: #{@whirlwind_trainables}") if $debug_mode_ct
     
-    @flame_inner_fire_threshold = settings.barb_combat_inner_fire_threshold
+    @flame_inner_fire_threshold = settings.flame_inner_fire_threshold
     echo("  @flame_inner_fire_threshold: #{@flame_inner_fire_threshold}") if $debug_mode_ct
 
     @flame_for_expertise = !(@whirlwind_trainables && @charged_maneuvers)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3705,7 +3705,7 @@ class GameState
   end
 
   def charged_maneuver
-    return @charged_maneuvers['Dual Wield'] if currently_whirlwinding
+    return @charged_maneuvers['Dual Wield'] if currently_whirlwinding && !twohanded_weapon_skill?
     @charged_maneuvers[weapon_skill]
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3408,11 +3408,7 @@ class GameState
     @flame_inner_fire_threshold = settings.barb_combat_inner_fire_threshold
     echo("  @flame_inner_fire_threshold: #{@flame_inner_fire_threshold}") if $debug_mode_ct
 
-    if @whirlwind_trainables && @charged_maneuvers
-      @flame_for_expertise = false
-    else
-      @flame_for_expertise = true
-    end
+    @flame_for_expertise = !(@whirlwind_trainables && @charged_maneuvers)
     echo("  @flame_for_expertise: #{@flame_for_expertise}") if $debug_mode_ct
 
     @avtalia_array = settings.avtalia_array
@@ -3550,7 +3546,7 @@ class GameState
   end
 
   def determine_whirlwind_action
-    if @flame_for_expertise == true && ( (DRStats.mana < @flame_inner_fire_threshold) || (DRSkill.getxp('Expertise') < 15) )
+    if @flame_for_expertise && ( (DRStats.mana < @flame_inner_fire_threshold) || (DRSkill.getxp('Expertise') < 15) )
       update_analyze_array('flame')
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif Flags['ct-accuracy-ready']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3929,7 +3929,7 @@ class GameState
     # !offhand & !brawling are there because you can't use a weapon for brawling commands
     # This issue will cause problems with the combo array system
     elsif @use_analyze_combos && !offhand? && !brawling?
-      update_analyze_array(false) if @analyze_combo_array.empty?
+      update_analyze_array if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else
       'attack'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -299,8 +299,8 @@ class SetupProcess
   end
 
   def determine_whirlwind_weapon(game_state)
-    return if game_state.weapon_skill.include?'Twohanded'
-    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill] - ['Twohanded Edged'] - ['Twohanded Blunt']).first
+    return if game_state.twohanded_weapon_skill?
+    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill, 'Twohanded Edged', 'Twohanded Blunt']).first
     game_state.update_whirlwind_weapon_info(offhand_skill)
     game_state.wield_whirlwind_offhand
   end
@@ -3510,7 +3510,7 @@ class GameState
   end
 
   def sheath_whirlwind_offhand
-    return if weapon_skill.include?'Twohanded'
+    return if twohanded_weapon_skill?
     return unless currently_whirlwinding
     @equipment_manager.stow_weapon(whirlwind_offhand_name)
   end
@@ -3540,7 +3540,7 @@ class GameState
   end
 
   def wield_whirlwind_offhand
-    return if weapon_skill.include?'Twohanded'
+    return if twohanded_weapon_skill?
     return unless currently_whirlwinding
     @equipment_manager.wield_weapon_offhand(whirlwind_offhand_name)
   end
@@ -3562,6 +3562,10 @@ class GameState
 
   def weapon_skill
     @current_weapon_skill
+  end
+
+  def twohanded_weapon_skill?
+    weapon_skill.include?'Twohanded'
   end
 
   def dance

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -300,7 +300,7 @@ class SetupProcess
 
   def determine_whirlwind_weapon(game_state)
     return if game_state.twohanded_weapon_skill?
-    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill] - $twohanded_skills).first
+    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill] - [$twohanded_skills]).first
     game_state.update_whirlwind_weapon_info(offhand_skill)
     game_state.wield_whirlwind_offhand
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3919,7 +3919,7 @@ class GameState
   def melee_attack_verb
     if currently_whirlwinding
       determine_whirlwind_action
-    else lacking_inner_fire? || need_expertise?
+    elsif lacking_inner_fire? || need_expertise?
       update_analyze_array('flame')    
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif attack_override

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -300,7 +300,7 @@ class SetupProcess
 
   def determine_whirlwind_weapon(game_state)
     return if game_state.twohanded_weapon_skill?
-    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill, 'Twohanded Edged', 'Twohanded Blunt']).first
+    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill] - $twohanded_skills).first
     game_state.update_whirlwind_weapon_info(offhand_skill)
     game_state.wield_whirlwind_offhand
   end
@@ -3215,6 +3215,7 @@ class GameState
   include DRC
 
   $thrown_skills = ['Heavy Thrown', 'Light Thrown']
+  $twohanded_skills = ['Twohanded Edged', 'Twohanded Blunt']
   $aim_skills = %w[Bow Slings Crossbow]
   $tactics_actions = %w[bob weave circle]
   $ranged_skills = $thrown_skills + $aim_skills

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3273,6 +3273,7 @@ class GameState
     @analyze_combo_array = []
     @currently_whirlwinding = false
     @avtalia_cambrinth = {}
+    @analyze_map = { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }
 
     @left_hand_free = settings.left_hand_free
     echo("  @left_hand_free: #{@left_hand_free}") if $debug_mode_ct
@@ -4019,17 +4020,13 @@ class GameState
     true
   end
 
-  def update_analyze_array(type = '')
-    # Force overrides during whirlwinding, barb only
-    if currently_whirlwinding
-      return perform_analyze?('accuracy', 50) if type == 'accuracy'
-      return perform_analyze?('flame', 0) if type == 'flame'
-    end
-
-    # Let system decide, not whirlwinding
+  def update_analyze_array(type = nil)
     if DRStats.barbarian?
-      { 'accuracy' => 50, 'damage' => 125, 'balance' => 600, 'flame' => 0 }.each do |type, expertise|
-        break if perform_analyze?(type, expertise)
+      # Try to perform the desired combo, and if successful then return.
+      return if type && perform_analyze?(type, @analyze_map[type])
+      # Otherwise, let system try to decide which combo to perform based on your expertise ranks.
+      @analyze_map.each do |combo, expertise|
+        break if perform_analyze?(combo, expertise)
       end
     else
       perform_analyze?('', 0)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3410,8 +3410,11 @@ class GameState
     @flame_inner_fire_threshold = settings.flame_inner_fire_threshold
     echo("  @flame_inner_fire_threshold: #{@flame_inner_fire_threshold}") if $debug_mode_ct
 
-    @flame_for_expertise = !(@whirlwind_trainables && @charged_maneuvers)
-    echo("  @flame_for_expertise: #{@flame_for_expertise}") if $debug_mode_ct
+    @flame_for_ww_expertise = !(@whirlwind_trainables && @charged_maneuvers)
+    echo("  @flame_for_ww_expertise: #{@flame_for_ww_expertise}") if $debug_mode_ct
+
+    @flame_expertise_training_threshold = settings.flame_expertise_training_threshold
+    echo("  @flame_expertise_training_threshold: #{@flame_expertise_training_threshold}") if $debug_mode_ct
 
     @avtalia_array = settings.avtalia_array
     echo("  @avtalia_array: #{@avtalia_array}") if $debug_mode_ct
@@ -3548,7 +3551,7 @@ class GameState
   end
 
   def determine_whirlwind_action
-    if ( (DRStats.mana < @flame_inner_fire_threshold) && @use_analyze_combos ) || ( @flame_for_expertise && (DRSkill.getxp('Expertise') < 15) )
+    if lacking_inner_fire? || (@flame_for_ww_expertise && need_expertise?)
       update_analyze_array('flame')
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif Flags['ct-accuracy-ready']
@@ -3901,9 +3904,24 @@ class GameState
     Flags.reset('ct-damage-ready')
   end
 
+  def lacking_inner_fire?
+    return false unless DRStats.barbarian? && @use_analyze_combos
+    return false unless DRStats.mana < @flame_inner_fire_threshold
+    true
+  end
+
+  def need_expertise?
+    return false unless DRStats.barbarian? && @use_analyze_combos
+    return false unless DRStats.getxp('Expertise') < @flame_expertise_training_threshold
+    true
+  end
+
   def melee_attack_verb
     if currently_whirlwinding
       determine_whirlwind_action
+    else lacking_inner_fire? || need_expertise?
+      update_analyze_array('flame')    
+      @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif attack_override
       attack_override
     elsif @use_weak_attacks
@@ -3911,7 +3929,7 @@ class GameState
     # !offhand & !brawling are there because you can't use a weapon for brawling commands
     # This issue will cause problems with the combo array system
     elsif @use_analyze_combos && !offhand? && !brawling?
-      update_analyze_array if @analyze_combo_array.empty?
+      update_analyze_array(false) if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else
       'attack'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3547,7 +3547,7 @@ class GameState
   end
 
   def determine_whirlwind_action
-    if @flame_for_expertise && ( (DRStats.mana < @flame_inner_fire_threshold) || (DRSkill.getxp('Expertise') < 15) )
+    if (DRStats.mana < @flame_inner_fire_threshold) || (@flame_for_expertise && DRSkill.getxp('Expertise') < 15)
       update_analyze_array('flame')
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif Flags['ct-accuracy-ready']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -300,7 +300,7 @@ class SetupProcess
 
   def determine_whirlwind_weapon(game_state)
     return if game_state.twohanded_weapon_skill?
-    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill] - [$twohanded_skills]).first
+    offhand_skill = game_state.sort_by_rate_then_rank(game_state.whirlwind_trainables - [game_state.weapon_skill] - $twohanded_skills).first
     game_state.update_whirlwind_weapon_info(offhand_skill)
     game_state.wield_whirlwind_offhand
   end
@@ -3552,7 +3552,7 @@ class GameState
 
   def determine_whirlwind_action
     if lacking_inner_fire? || (@flame_for_ww_expertise && need_expertise?)
-      update_analyze_array('flame')
+      update_analyze_array('flame') if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif Flags['ct-accuracy-ready']
       update_analyze_array('accuracy') if @analyze_combo_array.empty?
@@ -3919,8 +3919,8 @@ class GameState
   def melee_attack_verb
     if currently_whirlwinding
       determine_whirlwind_action
-    elsif lacking_inner_fire? || need_expertise?
-      update_analyze_array('flame')    
+    elsif (lacking_inner_fire? || need_expertise?) && !brawling?
+      update_analyze_array('flame') if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     elsif attack_override
       attack_override
@@ -4041,7 +4041,7 @@ class GameState
   def update_analyze_array(type = nil)
     if DRStats.barbarian?
       # Try to perform the desired combo, and if successful then return.
-      return if type && perform_analyze?(type, @barb_analyzes[type])
+      return if type && (perform_analyze?(type, @barb_analyzes[type]) || currently_whirlwinding)
       # Otherwise, let system try to decide which combo to perform based on your expertise ranks.
       @barb_analyzes.each do |combo, expertise|
         break if perform_analyze?(combo, expertise)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3912,7 +3912,7 @@ class GameState
 
   def need_expertise?
     return false unless DRStats.barbarian? && @use_analyze_combos
-    return false unless DRStats.getxp('Expertise') < @flame_expertise_training_threshold
+    return false unless DRSkill.getxp('Expertise') < @flame_expertise_training_threshold
     true
   end
 

--- a/profiles/Mozof-setup.yaml
+++ b/profiles/Mozof-setup.yaml
@@ -1,10 +1,4 @@
 ---
-# Understanding Backstab, Ambush, & use_stealth_attacks
-# Backstab: weapon skill, used for thieves to backstab with only specific weapon
-# ambush: true, used to train backstab with all weapons while stealthed
-# use_stealth_attacks: true, used by all guilds to train stealth, does not teach backstab
-# use_stealth_ranged: true, used to train stealth using ranged attacks
-
 hometown: Shard
 repair_town: Hibarnhvidar
 slack_username: blackheart
@@ -20,65 +14,20 @@ repair_every: .inf # Infinite
 dump_junk: true
 integrate_shit_list_with_textsubs: true
 bescort_hide: false
-sell_loot_money_on_hand: 3 silver
+sell_loot_money_on_hand: 5 platinum
+default_stance: 100 0 88
 
-default_stance: 100 0 87
-
+##################################################################
+#                                                                #
+############################################# Hunting Buddies ####
 find_empty_room_first: true
 hunting_buddies:
 - #####
 - #####
 
-###############
-# Athletics
-###############
-athletics_outdoorsmanship_rooms: 
-- #####
-- #####
-- #####
-- #####
-- #####
-#- 9517
-- #####
-held_athletics_items:
-  - bolts
-  - arrows
-
-###############
-# Safe Room
-###############
-#safe_room: &safe_room #####
-safe_room: &safe_room #####
-repair_wait_room: #####
-safe_room_empaths:
-- name: #####
-  id: #####
-# - name: #####
-#   id: #####
-gem_pouch_adjective: suede
-spare_gem_pouch_container: backpack
-full_pouch_container: haversack
-listen: true
-listen_observe: false
-
-###############
-# Hunting Buddy
-###############
-hunting_info:
-- :zone:
-  - storm_bulls
-  - black_apes
-  - zombie_maulers 
-  args:
-  - d0
-  :duration: 60
-  stop_on_low:
-  #- Stealth
-  - Athletics
-
-###############
-# T2
-###############
+##################################################################
+#                                                                #
+########################################################## T2 ####
 training_list:
 - skill: Athletics
   start: 12
@@ -98,14 +47,14 @@ training_list:
   - get2 #####
   - rem
   - safe-room
-  - sell-loot shard
+  - sell-loot
   - restock
 - skill: Forging
   start: 26
   scripts:
   - burgle start
   - craft forging
-  - sell-loot shard
+  - sell-loot
 - skill: First Aid
   start: 2
   scripts:
@@ -117,50 +66,55 @@ training_list:
   scripts:
   - burgle start
   - craft outfitting
-  - sell-loot shard
+  - sell-loot
 
-###############
-# Barb Majiks
-###############
-waggle_sets:
-  default: &default
-  #- Contemplation
-  #- Tenacity
-  - Python
-  - Piranha
-  - Eagle
-  - Dragon
-  - Monkey
-  #- Tornado
-  pre: *default
-  stealth:
-  #- Panther
-  #- Tornado
-  #- Python
-  pick:
-  #- Focus
-  #- Owl
-  #- Wildfire
+##################################################################
+#                                                                #
+################################################### Safe Room ####
+#safe_room: &safe_room ####
+safe_room: &safe_room ####
+repair_wait_room: ####
+safe_room_empaths:
+- name: ####
+  id: ####
+- name: ####
+  id: ####
+gem_pouch_adjective: suede
+spare_gem_pouch_container: backpack
+full_pouch_container: haversack
+listen: true
+listen_observe: false
 
-###############
-# Combat Trainer
-###############
-combat_trainer_target_increment: 3
-combat_trainer_action_count: 10
+##################################################################
+#                                                                #
+################################################### Athletics ####
+athletics_outdoorsmanship_rooms: 
+- ####
+- ####
+- ####
+- ####
+- ####
+#- ####
+- ####
+held_athletics_items:
+  - rocks
+  - arrows
+
+##################################################################
+#                                                                #
+############################## Hunting Buddy & Combat Trainer ####
 priority_defense: Parry Ability
-skip_last_kill: true
-use_weak_attacks: false
-using_light_crossbow: true
-aiming_trainables:
-- Brawling
-- Small Edged
-- Large Edged
-- Small Blunt
-- Large Blunt
-- Light Thrown
-- Heavy Thrown
-- Staves
-- Polearms
+hunting_info:
+- :zone:
+  - storm_bulls
+  - black_apes
+  - zombie_maulers 
+  args:
+  - d0
+  :duration: 45
+  stop_on_low:
+  - Stealth
+  - Athletics
 
 buff_nonspells:
   roar wail: 60
@@ -180,13 +134,13 @@ buff_nonspells:
   - Tornado
   - Landslide
   #- Tsunami
-  #- Earthquake
+  - Earthquake
   #- Wildfire
   #- Flashflood
 #meditations
   #- Serenity
-  #- Contemplation
-  #- Tenacity
+  - Contemplation
+  - Tenacity
 
 training_abilities:
   Hunt: 180
@@ -199,14 +153,69 @@ ambush: false
 stealth_attack_aimed_action: poach
 use_stealth_attacks: false
 use_stealth_ranged: false
+skip_last_kill: true
 
-###############
-# Barb Specific
-###############
+cycle_armors:
+  Brigandine:
+  - scale greaves
+  Plate Armor:
+  - light greaves
+  Chain Armor:
+  - ring greaves
+  # Light Armor:
+  # - quilted pants
+
+ignored_npcs:
+- student
+- leopard
+- owl
+- Taala
+- foal
+- warrior
+- thrall # sanyu lyba
+- watchsoul # sanyu lyba
+- appraiser # Dwarven appraiser
+- shadowling
+- Servant # Shadow Servant
+- guard # Town guard
+- zombie # necromancer pet
+- lynx
+- panther
+
+##################################################################
+#                                                                #
+################################################ Barb Majicks ####
+waggle_sets:
+  default: &default
+  - Contemplation
+  - Tenacity
+  - Python
+  - Piranha
+  - Eagle
+  - Dragon
+  - Monkey
+  - Tornado
+  - Famine
+  pre: *default
+  stealth:
+  #- Panther
+  #- Tornado
+  #- Python
+  pick:
+  #- Focus
+  #- Owl
+  #- Wildfire
+
+##################################################################
+#                                                                #
+################################################### Barbarian ####
 meditation_pause_timer: 6
 use_barb_combos: true
 dual_load: true
+barb_combat_inner_fire_threshold: 5
 whirlwind_trainables:
+  - Twohanded Edged
+  - Twohanded Blunt
   - Large Edged
   - Small Edged
   - Large Blunt
@@ -217,15 +226,18 @@ barb_famine_healing:
   health_threshold: 75
   inner_fire_threshold: 10
 
-###############
-# Favors
-###############
+##################################################################
+#                                                                #
+###################################################### Favors ####
 favor_god: Everild
 favor_goal: 40
 
-###############
-# Weapons
-###############
+##################################################################
+#                                                                #
+##################################################### Weapons ####
+combat_trainer_target_increment: 3
+combat_trainer_action_count: 10
+use_weak_attacks: false
 weapon_training:
   Brawling: ''
   Small Edged: throwing axe
@@ -243,9 +255,21 @@ weapon_training:
   Slings: sling
 dance_skill: Small Edged
 
-###############
-# Looting
-###############
+using_light_crossbow: true
+aiming_trainables:
+- Brawling
+- Small Edged
+- Large Edged
+- Small Blunt
+- Large Blunt
+- Light Thrown
+- Heavy Thrown
+- Staves
+- Polearms
+
+##################################################################
+#                                                                #
+##################################################### Looting ####
 storage_containers:
 - backpack
 - haversack
@@ -255,6 +279,8 @@ loot_subtractions:
 - arrows
 - rock
 - rocks
+- bolt
+- bolts
 - coffer
 - strongbox
 - chest
@@ -265,8 +291,6 @@ loot_subtractions:
 - crate
 - box
 loot_additions:
-- bolt
-- bolts
 - smooth rock
 - smooth rocks
 - long arrow
@@ -306,56 +330,35 @@ skinning:
   arrange_count: 0
   tie_bundle: true
 
-###############                                                       ##########
-# Hunting Buddy                                                                #
-###############                                                       ##########
-ignored_npcs:
-- student
-- leopard
-- owl
-- Taala
-- foal
-#- warrior
-- thrall # sanyu lyba
-- watchsoul # sanyu lyba
-- appraiser # Dwarven appraiser
-- shadowling
-- Servant # Shadow Servant
-- guard # Town guard
-- zombie # necromancer pet
-- lynx
-#- silverfish
-- panther
-
-###############
-# Script Gear
-###############
+##################################################################
+#                                                                #
+################################################# Script Gear ####
 warhorn: warhorn
 footwear: black boots
 #textbook: true
 #textbook_type: weathered textbook
 hand_armor: gloves
 
-###############
-# Burgle
-###############
+##################################################################
+#                                                                #
+###################################################### Burgle ####
 burgle_settings:
-  room: ##### # Shard
-  #room: ##### # Crossing
+  room: 2622 # Shard
+  #room: 8257 # Crossing
   entry_type: lockpick
   use_lockpick_ring: true
   lockpick_container: lockpick ring
   loot_container: backpack
   loot: pawn
-  max_search_count: 2
+  max_search_count: 3
   item_whitelist:
   - memory orb
   - keepsake box
   #- liquor cabinet
 
-###############
-# Locksmithing
-###############
+##################################################################
+#                                                                #
+################################################ Locksmithing ####
 lockpick_room_id: *safe_room
 use_lockpick_ring: true
 lockpick_container: lockpick ring
@@ -382,11 +385,11 @@ picking_worn_lockbox: false
 # list as many as you want - though it will try from the top down.
 consumable_lockboxes:
 - keepsake box
-#- liquor cabinet
+- liquor cabinet
 
-###############
-# Crafting
-###############
+##################################################################
+#                                                                #
+#################################################### Crafting ####
 engineering_room: *safe_room
 outfitting_room: *safe_room
 alchemy_room: *safe_room
@@ -407,9 +410,9 @@ forging_tools:
 outfitting_tools:
 - needles
 
-###############
-# Gear
-###############
+##################################################################
+#                                                                #
+######################################################## Gear ####
 gear_sets:
   standard: &std
   - target shield
@@ -425,16 +428,6 @@ gear_sets:
   - knuckles
   - parry stick
   naked: []
-
-cycle_armors:
-  Brigandine:
-  - scale greaves
-  Plate Armor:
-  - light greaves
-  Chain Armor:
-  - ring greaves
-  # Light Armor:
-  # - quilted pants
 
 gear:
 #ARMOR
@@ -524,9 +517,9 @@ gear:
   :is_leather: true
   :wield: true
 
-###############
-# Scrolls
-###############
+##################################################################
+#                                                                #
+##################################################### Scrolls ####
 stacker_container: backpack
 scroll_stackers:
 - brown booklet
@@ -547,18 +540,11 @@ discard_scrolls:
 - Blood Burst
 - Obfuscation
 
-# Sorter
-sorter:
-  width: 25
-  mute_old_inventory: true
-  sort_inv_command: false
-  sort_look_others: false
-  sort_look_items_command: true
-  ignore_categories: lootables|trash 
-
+##################################################################
+#                                                                #
+##################################################### Restock ####
 restock:
   arrow:
-  bolt:
   rock:
     hometown: Hibarnhvidar
     name: smooth rocks
@@ -568,19 +554,14 @@ restock:
     stackable: true
     quantity: 30
 
-play_no_use_scripts:
-- sew
-- carve
-- tinker
-- forge
-- remedy
-- shape
-- enchant
-- outdoorsmanship
-- combat-trainer
-- buff
-- burgle
-- go2
-- theurgy
-- barb-trainer
-#- performance
+##################################################################
+#                                                                #
+######################################################## Misc ####
+# Sorter
+sorter:
+  width: 25
+  mute_old_inventory: true
+  sort_inv_command: false
+  sort_look_others: false
+  sort_look_items_command: true
+  ignore_categories: lootables|trash

--- a/profiles/Mozof-setup.yaml
+++ b/profiles/Mozof-setup.yaml
@@ -212,6 +212,7 @@ waggle_sets:
 meditation_pause_timer: 6
 use_barb_combos: true
 dual_load: true
+barb_buffs_inner_fire_threshold: 5
 barb_combat_inner_fire_threshold: 5
 flame_expertise_training_threshold: 20
 whirlwind_trainables:

--- a/profiles/Mozof-setup.yaml
+++ b/profiles/Mozof-setup.yaml
@@ -213,6 +213,7 @@ meditation_pause_timer: 6
 use_barb_combos: true
 dual_load: true
 barb_combat_inner_fire_threshold: 5
+flame_expertise_training_threshold: 20
 whirlwind_trainables:
   - Twohanded Edged
   - Twohanded Blunt

--- a/profiles/Mozof-setup.yaml
+++ b/profiles/Mozof-setup.yaml
@@ -134,16 +134,16 @@ buff_nonspells:
   - Tornado
   - Landslide
   #- Tsunami
-  - Earthquake
+  #- Earthquake
   #- Wildfire
   #- Flashflood
 #meditations
   #- Serenity
-  - Contemplation
-  - Tenacity
+  #- Contemplation
+  #- Tenacity
 
 training_abilities:
-  Charged Maneuver: 30
+  Charged Maneuver: 60
   Hunt: 180
   App Quick: 120
   Tactics: 30
@@ -182,6 +182,7 @@ ignored_npcs:
 - zombie # necromancer pet
 - lynx
 - panther
+- construct
 
 ##################################################################
 #                                                                #
@@ -253,9 +254,9 @@ weapon_training:
   Twohanded Blunt: kertig maul
   Large Blunt: throwing hammer
   Small Blunt: bola
-  #Crossbow: maple stonebow
-  #Bow: cypress bow
-  #Slings: sling
+  Crossbow: maple stonebow
+  Bow: cypress bow
+  Slings: sling
 dance_skill: Small Edged
 
 using_light_crossbow: true

--- a/profiles/Mozof-setup.yaml
+++ b/profiles/Mozof-setup.yaml
@@ -143,6 +143,7 @@ buff_nonspells:
   - Tenacity
 
 training_abilities:
+  Charged Maneuver: 30
   Hunt: 180
   App Quick: 120
   Tactics: 30
@@ -213,7 +214,7 @@ meditation_pause_timer: 6
 use_barb_combos: true
 dual_load: true
 barb_buffs_inner_fire_threshold: 5
-barb_combat_inner_fire_threshold: 5
+flame_inner_fire_threshold: 5
 flame_expertise_training_threshold: 20
 whirlwind_trainables:
   - Twohanded Edged
@@ -252,9 +253,9 @@ weapon_training:
   Twohanded Blunt: kertig maul
   Large Blunt: throwing hammer
   Small Blunt: bola
-  Crossbow: maple stonebow
-  Bow: cypress bow
-  Slings: sling
+  #Crossbow: maple stonebow
+  #Bow: cypress bow
+  #Slings: sling
 dance_skill: Small Edged
 
 using_light_crossbow: true

--- a/profiles/SampleBarbarian-setup.yaml
+++ b/profiles/SampleBarbarian-setup.yaml
@@ -265,8 +265,14 @@ meditation_pause_timer: 6
 #dual loads with eagle up
 dual_load: true
 
+# Will not activate barb buffs inner fire is under this amount
+barb_buffs_inner_fire_threshold: 5
+
 # While whirlwinding, will use analyze flame if under this threshold of IF
 flame_inner_fire_threshold: 10
+
+# Will use analyze flame if expertise is under this threshold
+flame_expertise_training_threshold: 28
 
 # NOTE: If you are whirlwinding AND you are NOT using Combat Maneuevers to train Expertise, you will automatically use Analyze Flame for training
 # Analyze Accuracy is automatically maintained while whirlwinding.

--- a/profiles/SampleBarbarian-setup.yaml
+++ b/profiles/SampleBarbarian-setup.yaml
@@ -265,8 +265,15 @@ meditation_pause_timer: 6
 #dual loads with eagle up
 dual_load: true
 
-#weapons to use with whirlwinding, requires one handed template weapons only, two handers maintain analyzes
+# While whirlwinding, will use analyze flame if under this threshold of IF
+flame_inner_fire_threshold: 10
+
+# NOTE: If you are whirlwinding AND you are NOT using Combat Maneuevers to train Expertise, you will automatically use Analyze Flame for training
+# Analyze Accuracy is automatically maintained while whirlwinding.
+# Weapons to use with whirlwinding, requires one handed template weapons only for the offhand, twohanders now supported!
 whirlwind_trainables:
+  - Twohanded Edged
+  - Twohanded Blunt
   - Large Edged
   - Small Edged
   - Large Blunt

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -234,6 +234,8 @@ meditation_pause_timer: 20
 # You won't try to activate a barb buff until you have this much inner fire.
 # You need some inner fire in reserve to pay the periodic cost of abilities.
 barb_buffs_inner_fire_threshold: 15
+# Minimum inner fire to trigger analyze flame during whirlwinding
+barb_combat_inner_fire_threshold: 10
 # Requires health_threshold (will use below this number) and inner_fire_threshold (will use if ABOVE this number) - Leave empty if unused!
 barb_famine_healing:
 # This is deprecated, instead switch to use_analyze_combos

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -234,6 +234,8 @@ meditation_pause_timer: 20
 # You won't try to activate a barb buff until you have this much inner fire.
 # You need some inner fire in reserve to pay the periodic cost of abilities.
 barb_buffs_inner_fire_threshold: 15
+# Minimum EXP to maintain for use with analyze combos. Will Flame if your Expertise is below this threshold.
+flame_expertise_training_threshold: 28
 # Minimum inner fire to trigger analyze flame during whirlwinding
 flame_inner_fire_threshold: 10
 # Requires health_threshold (will use below this number) and inner_fire_threshold (will use if ABOVE this number) - Leave empty if unused!

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -235,7 +235,7 @@ meditation_pause_timer: 20
 # You need some inner fire in reserve to pay the periodic cost of abilities.
 barb_buffs_inner_fire_threshold: 15
 # Minimum inner fire to trigger analyze flame during whirlwinding
-barb_combat_inner_fire_threshold: 10
+flame_inner_fire_threshold: 10
 # Requires health_threshold (will use below this number) and inner_fire_threshold (will use if ABOVE this number) - Leave empty if unused!
 barb_famine_healing:
 # This is deprecated, instead switch to use_analyze_combos

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -236,7 +236,7 @@ meditation_pause_timer: 20
 barb_buffs_inner_fire_threshold: 15
 # Minimum EXP to maintain for use with analyze combos. Will Flame if your Expertise is below this threshold.
 flame_expertise_training_threshold: 28
-# Minimum inner fire to trigger analyze flame during whirlwinding
+# Minimum inner fire to trigger analyze flame use
 flame_inner_fire_threshold: 10
 # Requires health_threshold (will use below this number) and inner_fire_threshold (will use if ABOVE this number) - Leave empty if unused!
 barb_famine_healing:

--- a/validate.lic
+++ b/validate.lic
@@ -411,13 +411,6 @@ class DRYamlValidator
     error('Whirlwinding requires a minimum of two one-handed template weapons!')
   end
 
-  def assert_that_whirlwind_trainables_are_one_handed(settings)
-    return unless settings.whirlwind_trainables
-    return unless settings.whirlwind_trainables.include?('Twohanded Blunt') || settings.whirlwind_trainables.include?('Twohanded Edged')
-
-    error('Whirlwind does not support twohanded weapons at this time. We only support one-handed weapon templates.')
-  end
-
   def assert_that_whirlwind_trainables_are_in_weapon_training(settings)
     return unless settings.weapon_training && settings.whirlwind_trainables
 


### PR DESCRIPTION
Currently how I use it (and have for the last 4 years) is to only analyze to maintain the Accuracy buff. I haven't had a need for the others.  Due to the new mana being IF reading, I have added in this feature as well. 

It will analyze flame if you are below a new inner fire threshold setting, defaults to 10. 
It will analyze flame if you are NOT using Combat Maneuvers and your Expertise is below 15.

Let me know how people feel about these scenarios.

I am currently testing it in the Storm Bulls range and can use others. 

**Suggested that you use Combat Maneuvers to train Expertise, I already put in Double Strike to support it.**