### PR TITLE
[script] [drinfomon] Update DRStats when use "encumbrance" verb

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -914,6 +914,9 @@ while line = script.gets
         end
       end
       CharSettings['Stats'] = DRStats.serialize
+    elsif line =~ /(Encumbrance)\s:\s(.*)/
+      DRStats.send("#{Regexp.last_match(1).downcase}=", Regexp.last_match(2))
+      CharSettings['Stats'] = DRStats.serialize
     elsif line =~ /You have (\d+) TDPs\./
       DRStats.tdps = Regexp.last_match(1).to_i
     elsif line =~ /The clerk slides a small metal box across the counter into which you drop (\d+) (\w+) (?:Kronars|Lirums|Dokoras)/


### PR DESCRIPTION
### Background
* When user sends `info` command then this script parses the output to update `DRStats` properties
* One of the properties updated is `DRStats.encumbrance` (the in-character value, not the number)
* You can check your encumbrance with the `encumbrance` verb but `DRStats.encumbrance` won't be updated
* Future plans, I want to add an encumbrance threshold to hunting_buddy to stop hunting if you become too encumbered -- I've recently been getting too encumbered where I hunt and my characters go from doing fine to suddenly stunned and exiting due to low health. Exiting based on encumbrance may help keep characters alive and give them time to go sell heavy bundles, pick boxes, etc then come back to hunt. But, to get there then need a simple way to ensure DRStats.encumbrance gets updated.

### Changes
* Update `DRStats.encumbrance` when the `encumbrance` verb is used

## Tests

### original logic, not responding to `encumbrance` verb
```
> ,e echo DRStats.encumbrance

--- Lich: exec1 active.

[exec1: Burdened]

--- Lich: exec1 has exited.

> withdraw 10000 copper
The clerk counts out 10000 copper Kronars (1.0 plat) and hands them over, making a notation in her ledger.

> ,e echo DRStats.encumbrance

--- Lich: exec1 active.

[exec1: Burdened]

--- Lich: exec1 has exited.

> enc
  Encumbrance : It's amazing you aren't squashed! (11/11)

> ,e echo DRStats.encumbrance

--- Lich: exec1 active.

[exec1: Burdened]

--- Lich: exec1 has exited.
```

### new logic, responding to `encumbrance` verb
```
> ,e echo DRStats.encumbrance

--- Lich: exec1 active.

[exec1: Burdened]

--- Lich: exec1 has exited.

> withdraw 10000 copper
The clerk counts out 10000 copper Kronars (1.0 plat) and hands them over, making a notation in her ledger.

> ,e echo DRStats.encumbrance

--- Lich: exec1 active.

[exec1: Burdened]

--- Lich: exec1 has exited.

> enc
  Encumbrance : It's amazing you aren't squashed! (11/11)

> ,e echo DRStats.encumbrance

--- Lich: exec1 active.

[exec1: It's amazing you aren't squashed!]

--- Lich: exec1 has exited.
```