### PR TITLE
[script] [common-healing] [healme 2.0] Use common-healing-data; refactor check_health and perceive_health

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1513,7 +1513,7 @@ class SpellProcess
 
     if Time.now - @perc_health_timer > 30 && @empath_spells['FOC'] || @empath_spells['HEAL']
       @perc_health_timer = Time.now
-      @wounds = check_perc_health
+      @wounds = DRCH.perceive_health['wounds']
     end
 
     echo('Healing') if $debug_mode_ct

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -140,6 +140,7 @@ module DRCH
     bleeders = Hash.new { |h, k| h[k] = [] }
     if health_lines.grep(/^Bleeding|^\s*\bArea\s+Rate\b/).any?
       health_lines
+        .drop_while { |line| /^You have a dormant infection|^Your wounds are infected|^Your body is covered in open oozing sores/ =~ line }
         .take_while { |line| /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/ =~ line }
         .drop_while { |line| /^Bleeding|^\s*\bArea\s+Rate\b/ =~ line }
         .each do |line|

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -140,7 +140,7 @@ module DRCH
     bleeders = Hash.new { |h, k| h[k] = [] }
     if health_lines.grep(/^Bleeding|^\s*\bArea\s+Rate\b/).any?
       health_lines
-        .drop_while { |line| /^You have a dormant infection|^Your wounds are infected|^Your body is covered in open oozing sores/ =~ line }
+        .drop_while { |line| /^You have .* poison(?:ed)?|^You feel somewhat tired and seem to be having trouble breathing|^You have a dormant infection|^Your wounds are infected|^Your body is covered in open oozing sores/ =~ line }
         .take_while { |line| /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/ =~ line }
         .drop_while { |line| /^Bleeding|^\s*\bArea\s+Rate\b/ =~ line }
         .each do |line|

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -131,7 +131,7 @@ module DRCH
     # Return same response as `check_health`
     # but with wound details per perceive health.
     health_data = check_health
-    health_data[:wounds] = wounds
+    health_data['wounds'] = wounds
     return health_data
   end
 

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -2,1089 +2,135 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-healing
 =end
 
-custom_require.call(%w[common common-items])
-
-# Maps bleed rates from `health` command to severity number.
-# A partially tended wound is considered more severe than
-# its non-tended counterpart because once the bandages come off
-# then the wound is much worse so they should be triaged first.
-# https://elanthipedia.play.net/Damage#Bleeding_Levels
-#
-# As of December 2020, the skill needed to tend bleeders are guestimates.
-# I was not aware of any definitive data.
-# A 'nil' value means that can't be tended because already is tended or isn't bleeding.
-# Please adjust skill needed as appropriate, and be conservative.
-$DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
-  'tended' => {
-    severity: 1,            # lower numbers are less severe than higher numbers
-    bleeding: false,        # is it actively bleeding and causing vitality loss?
-    skill_to_tend: nil      # ranks in First Aid needed to tend this wound
-  },
-  '(tended)' => {
-    severity: 1,
-    bleeding: false,
-    skill_to_tend: nil
-  },
-  'clotted' => {
-    severity: 2,
-    bleeding: false,
-    skill_to_tend: nil
-  },
-  'clotted(tended)' => {
-    severity: 3,
-    bleeding: false,
-    skill_to_tend: nil
-  },
-  'slight' => {
-    severity: 3,
-    bleeding: true,
-    skill_to_tend: 25
-  },
-  'slight(tended)' => {
-    severity: 4,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'light' => {
-    severity: 4,
-    bleeding: true,
-    skill_to_tend: 50
-  },
-  'light(tended)' => {
-    severity: 5,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'moderate' => {
-    severity: 5,
-    bleeding: true,
-    skill_to_tend: 75
-  },
-  'moderate(tended)' => {
-    severity: 6,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'bad' => {
-    severity: 6,
-    bleeding: true,
-    skill_to_tend: 100
-  },
-  'bad(tended)' => {
-    severity: 7,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'very bad' => {
-    severity: 7,
-    bleeding: true,
-    skill_to_tend: 200
-  },
-  'very bad(tended)' => {
-    severity: 8,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'heavy' => {
-    severity: 8,
-    bleeding: true,
-    skill_to_tend: 300
-  },
-  'heavy(tended)' => {
-    severity: 9,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'very heavy' => {
-    severity: 9,
-    bleeding: true,
-    skill_to_tend: 400
-  },
-  'very heavy(tended)' => {
-    severity: 10,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'severe' => {
-    severity: 10,
-    bleeding: true,
-    skill_to_tend: 500
-  },
-  'severe(tended)' => {
-    severity: 11,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'very severe' => {
-    severity: 11,
-    bleeding: true,
-    skill_to_tend: 600
-  },
-  'very severe(tended)' => {
-    severity: 12,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'profuse' => {
-    severity: 12,
-    bleeding: true,
-    skill_to_tend: 700
-  },
-  'profuse(tended)' => {
-    severity: 13,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'very profuse' => {
-    severity: 13,
-    bleeding: true,
-    skill_to_tend: 800
-  },
-  'very profuse(tended)' => {
-    severity: 14,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'gushing' => {
-    severity: 14,
-    bleeding: true,
-    skill_to_tend: 900
-  },
-  'gushing(tended)' => {
-    severity: 15,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'massive stream' => {
-    severity: 15,
-    bleeding: true,
-    skill_to_tend: 1000
-  },
-  'massive stream(tended)' => {
-    severity: 16,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'uncontrollable' => {
-    severity: 16,
-    bleeding: true,
-    skill_to_tend: 1100
-  },
-  'uncontrollable(tended)' => {
-    severity: 17,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'unbelievable' => {
-    severity: 17,
-    bleeding: true,
-    skill_to_tend: 1200
-  },
-  'unbelievable(tended)' => {
-    severity: 18,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'beyond measure' => {
-    severity: 18,
-    bleeding: true,
-    skill_to_tend: 1300
-  },
-  'beyond measure(tended)' => {
-    severity: 19,
-    bleeding: true,
-    skill_to_tend: nil
-  },
-  'death awaits' => {
-    severity: 19,
-    bleeding: true,
-    skill_to_tend: 1400
-  },
-}
-
-# https://elanthipedia.play.net/Damage#Lodged_Items
-$DRCH_LODGED_TO_SEVERITY_MAP = {
-  'loosely hanging' => 1,
-  'shallowly' => 2,
-  'firmly' => 3,
-  'deeply' => 4,
-  'savagely' => 5
-}
-
-# https://elanthipedia.play.net/Damage#Wound_Severity_Levels
-$DRCH_WOUND_TO_SEVERITY_MAP = {
-  'insignificant' => 1,
-  'negligible' => 2,
-  'minor' => 3,
-  'more than minor' => 4,
-  'harmful' => 5,
-  'very harmful' => 6,
-  'damaging' => 7,
-  'very damaging' => 8,
-  'severe' => 9,
-  'very severe' => 10,
-  'devastating' => 11,
-  'very devastating' => 12,
-  'useless' => 13
-}
-
-# https://elanthipedia.play.net/Damage#Parasites
-$DRCH_PARASITES_REGEX_LIST = [
-  /(?:small|large) (?:black|red) blood mite/,
-  /(?:black|red|albino) (sand|forest) leech/,
-  /(?:green|red) blood worm/,
-  /retch maggot/
-]
-
-# Parses the severity number out of the wound line from 'perceive health self'.
-# For example, the 'negligible' in "Fresh External:  light scratches -- negligible"
-$DRCH_PERCEIVE_HEALTH_SEVERITY_REGEX = /(?<freshness>Fresh|Scars) (?<location>External|Internal).+--\s+(?<severity>insignificant|negligible|minor|more than minor|harmful|very harmful|damaging|very damaging|severe|very severe|devastating|very devastating|useless)\b/
-
-$DRCH_BODY_PART_REGEX = /(?<part>(?:l\.|r\.|left|right)?\s?(?:\w+))/
-
-# Matches body parts in the `health` line for wounds and bleeders.
-$DRCH_WOUND_BODY_PART_REGEX = /(?:inside)?\s?#{$DRCH_BODY_PART_REGEX}/
-
-# Matches body parts in the `health` line for lodged items.
-$DRCH_LODGED_BODY_PART_REGEX = /lodged .* into your #{$DRCH_BODY_PART_REGEX}/
-
-# Matches body parts in the `health` line for parasites.
-$DRCH_PARASITE_BODY_PART_REGEX = /on your #{$DRCH_BODY_PART_REGEX}/
-
-# https://elanthipedia.play.net/Damage#Wounds
-$DRCH_WOUND_SEVERITY_REGEX_MAP = {
-  # insignificant
-  /minor abrasions to the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 1,
-    internal: false,
-    scar: false
-  },
-  /a few nearly invisible scars along the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 1,
-    internal: false,
-    scar: true
-  },
-  # negligible
-  /some tiny scars (?:across|along) the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 2,
-    internal: false,
-    scar: true
-  },
-  /(?:light|tiny) scratches to the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 2,
-    internal: false,
-    scar: false
-  },
-  # minor / more than minor
-  /a bruised (?<part>head)/ => {
-    severity: 3,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>a small skin rash)/ => {
-    severity: 3,
-    internal: false,
-    scar: false
-  },
-  /(?<skin>loss of skin tone)/ => {
-    severity: 3,
-    internal: false,
-    scar: true
-  },
-  /(?<skin>some minor twitching)/ => {
-    severity: 3,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>slight difficulty moving your fingers and toes)/ => {
-    severity: 3,
-    internal: true,
-    scar: true
-  },
-  /cuts and bruises about the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 3,
-    internal: false,
-    scar: false
-  },
-  /minor scar\w+ (?:about|along|across) the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 3,
-    internal: false,
-    scar: true
-  },
-  /minor swelling and bruising (?:around|in) the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 3,
-    internal: true,
-    scar: false
-  },
-  /occasional twitch\w* (?:on|in) the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 3,
-    internal: true,
-    scar: true
-  },
-  /a black and blue #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 3,
-    internal: false,
-    scar: false
-  },
-  # harmful / very harmful
-  /a deeply bruised (?<part>head)/ => {
-    severity: 4,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>a large skin rash)/ => {
-    severity: 4,
-    internal: false,
-    scar: false
-  },
-  /(?<skin>minor skin discoloration)/ => {
-    severity: 4,
-    internal: false,
-    scar: true
-  },
-  /(?<skin>some severe twitching)/ => {
-    severity: 4,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>slight numbness in your arms and legs)/ => {
-    severity: 4,
-    internal: true,
-    scar: true
-  },
-  /deep cuts (?:about|across) the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 4,
-    internal: false,
-    scar: false
-  },
-  /severe scarring (?:across|along|about) the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 4,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen and\s?(?:deeply)? bruised #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 4,
-    internal: true,
-    scar: false
-  },
-  /(?:occasional|constant) twitch\w* (?:on|in) the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 4,
-    internal: true,
-    scar: true
-  },
-  /a bruised and swollen (?<part>(?:right|left) (?:eye))/ => {
-    severity: 4,
-    internal: false,
-    scar: false
-  },
-  # damaging / very damaging
-  /some deep slashes and cuts about the (?<part>head)/ => {
-    severity: 5,
-    internal: false,
-    scar: false
-  },
-  /severe scarring and ugly gashes about the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: false,
-    scar: true
-  },
-  /major swelling and bruising around the (?<part>head)/ => {
-    severity: 5,
-    internal: true,
-    scar: false
-  },
-  /an occasional twitch on the fore(?<part>head)/ => {
-    severity: 5,
-    internal: true,
-    scar: true
-  },
-  /a bruised,* swollen and bleeding #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: false,
-    scar: false
-  },
-  /deeply scarred gashes across the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen, bruised and crossed #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: true,
-    scar: false
-  },
-  /a constant twitching in the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: true,
-    scar: true
-  },
-  /deep slashes across the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: false,
-    scar: false
-  },
-  /a severely swollen and deeply bruised #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: true,
-    scar: false
-  },
-  /severely swollen and bruised #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 5,
-    internal: true,
-    scar: false
-  },
-  /a constant twitching in the (?<part>chest) area and difficulty breathing/ => {
-    severity: 5,
-    internal: true,
-    scar: true
-  },
-  /(?<abdomen>a somewhat emaciated look)/ => {
-    severity: 5,
-    internal: true,
-    scar: true
-  },
-  /a constant twitching in the #{$DRCH_WOUND_BODY_PART_REGEX} and difficulty moving in general/ => {
-    severity: 5,
-    internal: true,
-    scar: true
-  },
-  /(?<skin>a body rash)/ => {
-    severity: 5,
-    internal: false,
-    scar: false
-  },
-  /severe (?<part>skin) discoloration/ => {
-    severity: 5,
-    internal: false,
-    scar: true
-  },
-  /(?<skin>difficulty controlling actions)/ => {
-    severity: 5,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>numbness in your fingers and toes)/ => {
-    severity: 5,
-    internal: true,
-    scar: true
-  },
-  # severe / very severe
-  /(?<head>a cracked skull with deep slashes)/ => {
-    severity: 6,
-    internal: false,
-    scar: false
-  },
-  /missing chunks out of the (?<part>head)/ => {
-    severity: 6,
-    internal: false,
-    scar: true
-  },
-  /a ghastly bloated (?<part>head) with bleeding from the ears/ => {
-    severity: 6,
-    internal: true,
-    scar: false
-  },
-  /a confused look with sporadic twitching of the fore(?<part>head)/ => {
-    severity: 6,
-    internal: true,
-    scar: true
-  },
-  /a bruised, swollen and slashed #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: false,
-    scar: false
-  },
-  /a punctured and shriveled #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen,* bruised and cloudy #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: true,
-    scar: false
-  },
-  /a clouded #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: true,
-    scar: true
-  },
-  /gaping holes in the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: false,
-    scar: false
-  },
-  /a broken #{$DRCH_WOUND_BODY_PART_REGEX} with gaping holes/ => {
-    severity: 6,
-    internal: false,
-    scar: false
-  },
-  /severe scarring and ugly gashes about the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: false,
-    scar: true
-  },
-  /severe scarring and chunks of flesh missing from the #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen and deeply bruised #{$DRCH_WOUND_BODY_PART_REGEX} with odd protrusions under the skin/ => {
-    severity: 6,
-    internal: true,
-    scar: false
-  },
-  /a severely swollen and deeply bruised (?<part>chest) area with odd protrusions under the skin/ => {
-    severity: 6,
-    internal: true,
-    scar: false
-  },
-  /a partially paralyzed #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 6,
-    internal: true,
-    scar: true
-  },
-  /a painful #{$DRCH_WOUND_BODY_PART_REGEX} and difficulty moving without pain/ => {
-    severity: 6,
-    internal: true,
-    scar: true
-  },
-  /a painful (?<part>chest) area and difficulty getting a breath without pain/ => {
-    severity: 6,
-    internal: true,
-    scar: true
-  },
-  /a severely bloated and discolored #{$DRCH_WOUND_BODY_PART_REGEX} with strange round lumps under the skin/ => {
-    severity: 6,
-    internal: true,
-    scar: false
-  },
-  /(?<abdomen>a definite greenish pallor and emaciated look)/ => {
-    severity: 6,
-    internal: true,
-    scar: true
-  },
-  /(?<skin>a painful,* inflamed body rash)/ => {
-    severity: 6,
-    internal: false,
-    scar: false
-  },
-  /(?<skin>a painful,* enflamed body rash)/ => {
-    severity: 6,
-    internal: false,
-    scar: false
-  },
-  /some shriveled and oddly folded (?<part>skin)/ => {
-    severity: 6,
-    internal: false,
-    scar: true
-  },
-  /(?<skin>partial paralysis of the entire body)/ => {
-    severity: 6,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>numbness in your arms and legs)/ => {
-    severity: 6,
-    internal: true,
-    scar: true
-  },
-  # devastating / very devastating
-  /(?<head>a crushed skull with horrendous wounds)/ => {
-    severity: 7,
-    internal: false,
-    scar: false
-  },
-  /a mangled and malformed (?<part>head)/ => {
-    severity: 7,
-    internal: false,
-    scar: true
-  },
-  /a ghastly bloated (?<part>head) with bleeding from the ears/ => {
-    severity: 7,
-    internal: true,
-    scar: false
-  },
-  /a confused look with sporadic twitching of the fore(?<part>head)/ => {
-    severity: 7,
-    internal: true,
-    scar: true
-  },
-  /a bruised,* swollen and shattered #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 7,
-    internal: false,
-    scar: false
-  },
-  /a painfully mangled and malformed #{$DRCH_WOUND_BODY_PART_REGEX} in a shattered eye socket/ => {
-    severity: 7,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen,* bruised and blind #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 7,
-    internal: true,
-    scar: false
-  },
-  /severely scarred,* mangled and malformed #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 7,
-    internal: false,
-    scar: true
-  },
-  /a completely clouded #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 7,
-    internal: true,
-    scar: true
-  },
-  /a shattered #{$DRCH_WOUND_BODY_PART_REGEX} with gaping wounds/ => {
-    severity: 7,
-    internal: false,
-    scar: false
-  },
-  /shattered (?<part>chest) area with gaping wounds/ => {
-    severity: 7,
-    internal: false,
-    scar: false
-  },
-  /a severely swollen and deeply bruised #{$DRCH_WOUND_BODY_PART_REGEX} with bones protruding out from the skin/ => {
-    severity: 7,
-    internal: true,
-    scar: false
-  },
-  /a severely swollen and deeply bruised #{$DRCH_WOUND_BODY_PART_REGEX} with ribs or vertebrae protruding out from the skin/ => {
-    severity: 7,
-    internal: true,
-    scar: false
-  },
-  /a severely paralyzed #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 7,
-    internal: true,
-    scar: true
-  },
-  /a severely painful #{$DRCH_WOUND_BODY_PART_REGEX} with significant problems moving/ => {
-    severity: 7,
-    internal: true,
-    scar: true
-  },
-  /a severely painful (?<part>chest) area with significant problems breathing/ => {
-    severity: 7,
-    internal: true,
-    scar: true
-  },
-  /#{$DRCH_WOUND_BODY_PART_REGEX} deeply gouged with gaping wounds/ => {
-    severity: 7,
-    internal: false,
-    scar: false
-  },
-  /a severely bloated and discolored #{$DRCH_WOUND_BODY_PART_REGEX} with strange round lumps under the skin/ => {
-    severity: 7,
-    internal: true,
-    scar: false
-  },
-  /(?<abdomen>a severely yellow pallor and a look of starvation)/ => {
-    severity: 7,
-    internal: true,
-    scar: true
-  },
-  /a shattered #{$DRCH_WOUND_BODY_PART_REGEX} with gaping wounds/ => {
-    severity: 7,
-    internal: false,
-    scar: false
-  },
-  /boils and sores around the (?<part>skin)/ => {
-    severity: 7,
-    internal: false,
-    scar: false
-  },
-  /severely stiff and shriveled (?<part>skin) that seems to be peeling off the body/ => {
-    severity: 7,
-    internal: false,
-    scar: true
-  },
-  /(?<skin>severe paralysis of the entire body)/ => {
-    severity: 7,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>general numbness all over)/ => {
-    severity: 7,
-    internal: true,
-    scar: true
-  },
-  # useless
-  /pulpy stump for a (?<part>head)/ => {
-    severity: 8,
-    internal: false,
-    scar: false
-  },
-  /a stump for a (?<part>head)/ => {
-    severity: 8,
-    internal: false,
-    scar: true
-  },
-  /an ugly stump for a #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 8,
-    internal: false,
-    scar: false
-  },
-  /a grotesquely bloated (?<part>head) with bleeding from the eyes and ears/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /(?<head>a blank stare)/ => {
-    severity: 8,
-    internal: true,
-    scar: true
-  },
-  /a pulpy cavity for a #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 8,
-    internal: false,
-    scar: false
-  },
-  /an empty #{$DRCH_WOUND_BODY_PART_REGEX} socket overgrown with bits of odd shaped flesh/ => {
-    severity: 8,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen,* bruised and blind #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /a blind #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 8,
-    internal: true,
-    scar: true
-  },
-  /a completely useless #{$DRCH_WOUND_BODY_PART_REGEX} with nearly all flesh and bone torn away/ => {
-    severity: 8,
-    internal: false,
-    scar: false
-  },
-  /a completely destroyed #{$DRCH_WOUND_BODY_PART_REGEX} with nearly all flesh and bone torn away revealing a gaping hole/ => {
-    severity: 8,
-    internal: false,
-    scar: false
-  },
-  /an ugly flesh stump for a #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 8,
-    internal: false,
-    scar: true
-  },
-  /an ugly flesh stump for a #{$DRCH_WOUND_BODY_PART_REGEX} with little left to support the head/ => {
-    severity: 8,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen and shattered #{$DRCH_WOUND_BODY_PART_REGEX} which appears completely useless/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /a severely swollen and shattered #{$DRCH_WOUND_BODY_PART_REGEX} which appears useless to hold up the head/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /a completely paralyzed #{$DRCH_WOUND_BODY_PART_REGEX}/ => {
-    severity: 8,
-    internal: true,
-    scar: true
-  },
-  /a mostly non-existent #{$DRCH_WOUND_BODY_PART_REGEX} filled with ugly chunks of scarred flesh/ => {
-    severity: 8,
-    internal: false,
-    scar: true
-  },
-  /a severely swollen (?<part>chest) area with a shattered rib cage/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /an extremely painful #{$DRCH_WOUND_BODY_PART_REGEX} while gasping for breath in short shallow bursts/ => {
-    severity: 8,
-    internal: true,
-    scar: true
-  },
-  /a severely bloated and discolored #{$DRCH_WOUND_BODY_PART_REGEX} which appears oddly rearranged/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /(?<abdomen>a death pallor and extreme loss of weight)/ => {
-    severity: 8,
-    internal: true,
-    scar: true
-  },
-  /a severely swollen #{$DRCH_WOUND_BODY_PART_REGEX} with a shattered spinal cord/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /an extremely painful and bizarrely twisted #{$DRCH_WOUND_BODY_PART_REGEX} making it nearly impossible to move/ => {
-    severity: 8,
-    internal: true,
-    scar: true
-  },
-  /open and bleeding sores all over the (?<part>skin)/ => {
-    severity: 8,
-    internal: false,
-    scar: false
-  },
-  /severe (?<part>skin) loss exposing bone and internal organs/ => {
-    severity: 8,
-    internal: false,
-    scar: true
-  },
-  /(?<skin>complete paralysis of the entire body)/ => {
-    severity: 8,
-    internal: true,
-    scar: false
-  },
-  /(?<skin>general numbness all over and have difficulty thinking)/ => {
-    severity: 8,
-    internal: true,
-    scar: true
-  }
-}
-
-# https://elanthipedia.play.net/Damage#Wounds
-$DRCH_WOUND_COMMA_SEPARATOR = /(?<=swollen|bruised|scarred|painful),(?=\s(?:swollen|bruised|mangled|inflamed))/
-
-$wound_map = {
-  'insignificant' => 1,
-  'negligible' => 2,
-  'minor' => 3,
-  'more than minor' => 4,
-  'harmful' => 5,
-  'very harmful' => 6,
-  'damaging' => 7,
-  'very damaging' => 8,
-  'severe' => 9,
-  'very severe' => 10,
-  'devastating' => 11,
-  'very devastating' => 12,
-  'useless' => 13
-}
-
-$all_parasites = [
-  /(?:small|large) (?:black|red) blood mite/,
-  /red sand leech/,
-  /albino forest leech/,
-  /(?:green|red) blood worm/,
-  /Retch maggot/
-]
-
-re_part = /(?<part>(?:left|right)?\s?(?:\w+))/
-$severity_to_text = {
-  1 => [
-    /minor abrasions to the #{re_part}/,
-    /a few nearly invisible scars along the #{re_part}/
-  ],
-  2 => [
-    /some tiny scars (?:across|along) the #{re_part}/,
-    /(?:light|tiny) scratches to the #{re_part}/
-  ],
-  3 => [
-    /a bruised (?<part>head)/,
-    /(?<skin>a small skin rash)/,
-    /(?<skin>loss of skin tone)/,
-    /(?<skin>some minor twitching)/,
-    /(?<skin>slight difficulty moving your fingers and toes)/,
-    /cuts and bruises about the #{re_part}/,
-    /minor scar\w+ (?:about|along|across) the #{re_part}/,
-    /minor swelling and bruising (?:around|in) the #{re_part}/,
-    /occasional twitch\w* (?:on|in) the #{re_part}/,
-    /a black and blue #{re_part}/
-  ],
-  4 => [
-    /a deeply bruised (?<part>head)/,
-    /(?<skin>a large skin rash)/,
-    /(?<skin>minor skin discoloration)/,
-    /(?<skin>some severe twitching)/,
-    /(?<skin>slight numbness in your arms and legs)/,
-    /deep cuts (?:about|across) the #{re_part}/,
-    /severe scarring (?:across|along|about) the #{re_part}/,
-    /a severely swollen and\s?(?:deeply)? bruised #{re_part}/,
-    /(?:occasional|constant) twitch\w* (?:on|in) the #{re_part}/,
-    /a bruised and swollen (?<part>(?:right|left) (?:eye))/
-  ],
-  5 => [
-    /some deep slashes and cuts about the (?<part>head)/,
-    /severe scarring and ugly gashes about the #{re_part}/,
-    /major swelling and bruising around the (?<part>head)/,
-    /an occasional twitch on the fore(?<part>head)/,
-    /a bruised,* swollen and bleeding #{re_part}/,
-    /deeply scarred gashes across the #{re_part}/,
-    /a severely swollen, bruised and crossed #{re_part}/,
-    /a constant twitching in the #{re_part}/,
-    /deep slashes across the #{re_part}/,
-    /a severely swollen and deeply bruised #{re_part}/,
-    /severely swollen and bruised #{re_part}/,
-    /a constant twitching in the (?<part>chest) area and difficulty breathing/,
-    /(?<abdomen>a somewhat emaciated look)/,
-    /a constant twitching in the #{re_part} and difficulty moving in general/,
-    /(?<skin>a body rash)/,
-    /severe (?<part>skin) discoloration/,
-    /(?<skin>difficulty controlling actions)/,
-    /(?<skin>numbness in your fingers and toes)/
-  ],
-  6 => [
-    /(?<head>a cracked skull with deep slashes)/,
-    /missing chunks out of the (?<part>head)/,
-    /a ghastly bloated (?<part>head) with bleeding from the ears/,
-    /a confused look with sporadic twitching of the fore(?<part>head)/,
-    /a bruised, swollen and slashed #{re_part}/,
-    /a punctured and shriveled #{re_part}/,
-    /a severely swollen,* bruised and cloudy #{re_part}/,
-    /a clouded #{re_part}/,
-    /gaping holes in the #{re_part}/,
-    /a broken #{re_part} with gaping holes/,
-    /severe scarring and ugly gashes about the #{re_part}/,
-    /severe scarring and chunks of flesh missing from the #{re_part}/,
-    /a severely swollen and deeply bruised #{re_part} with odd protrusions under the skin/,
-    /a severely swollen and deeply bruised (?<part>chest) area with odd protrusions under the skin/,
-    /a partially paralyzed #{re_part}/,
-    /a painful #{re_part} and difficulty moving without pain/,
-    /a painful (?<part>chest) area and difficulty getting a breath without pain/,
-    /a severely bloated and discolored #{re_part} with strange round lumps under the skin/,
-    /(?<abdomen>a definite greenish pallor and emaciated look)/,
-    /(?<skin>a painful,* inflamed body rash)/,
-    /(?<skin>a painful,* enflamed body rash)/,
-    /some shriveled and oddly folded (?<part>skin)/,
-    /(?<skin>partial paralysis of the entire body)/,
-    /(?<skin>numbness in your arms and legs)/
-  ],
-  7 => [
-    /(?<head>a crushed skull with horrendous wounds)/,
-    /a mangled and malformed (?<part>head)/,
-    /a ghastly bloated (?<part>head) with bleeding from the ears/,
-    /a confused look with sporadic twitching of the fore(?<part>head)/,
-    /a bruised,* swollen and shattered #{re_part}/,
-    /a painfully mangled and malformed #{re_part} in a shattered eye socket/,
-    /a severely swollen,* bruised and blind #{re_part}/,
-    /severely scarred,* mangled and malformed #{re_part}/,
-    /a completely clouded #{re_part}/,
-    /a shattered #{re_part} with gaping wounds/,
-    /shattered (?<part>chest) area with gaping wounds/,
-    /a severely swollen and deeply bruised #{re_part} with bones protruding out from the skin/,
-    /a severely swollen and deeply bruised #{re_part} with ribs or vertebrae protruding out from the skin/,
-    /a severely paralyzed #{re_part}/,
-    /a severely painful #{re_part} with significant problems moving/,
-    /a severely painful (?<part>chest) area with significant problems breathing/,
-    /#{re_part} deeply gouged with gaping wounds/,
-    /a severely bloated and discolored #{re_part} with strange round lumps under the skin/,
-    /(?<abdomen>a severely yellow pallor and a look of starvation)/,
-    /a shattered #{re_part} with gaping wounds/,
-    /boils and sores around the (?<part>skin)/,
-    /severely stiff and shriveled (?<part>skin) that seems to be peeling off the body/,
-    /(?<skin>severe paralysis of the entire body)/,
-    /(?<skin>general numbness all over)/
-  ],
-  8 => [
-    /pulpy stump for a (?<part>head)/,
-    /a stump for a (?<part>head)/,
-    /an ugly stump for a #{re_part}/,
-    /a grotesquely bloated (?<part>head) with bleeding from the eyes and ears/,
-    /(?<head>a blank stare)/,
-    /a pulpy cavity for a #{re_part}/,
-    /an empty #{re_part} socket overgrown with bits of odd shaped flesh/,
-    /a severely swollen,* bruised and blind #{re_part}/,
-    /a blind #{re_part}/,
-    /a completely useless #{re_part} with nearly all flesh and bone torn away/,
-    /a completely destroyed #{re_part} with nearly all flesh and bone torn away revealing a gaping hole/,
-    /an ugly flesh stump for a #{re_part}/,
-    /an ugly flesh stump for a #{re_part} with little left to support the head/,
-    /a severely swollen and shattered #{re_part} which appears completely useless/,
-    /a severely swollen and shattered #{re_part} which appears useless to hold up the head/,
-    /a completely paralyzed #{re_part}/,
-    /a mostly non-existent #{re_part} filled with ugly chunks of scarred flesh/,
-    /a severely swollen (?<part>chest) area with a shattered rib cage/,
-    /an extremely painful #{re_part} while gasping for breath in short shallow bursts/,
-    /a severely bloated and discolored #{re_part} which appears oddly rearranged/,
-    /(?<abdomen>a death pallor and extreme loss of weight)/,
-    /a severely swollen #{re_part} with a shattered spinal cord/,
-    /an extremely painful and bizarrely twisted #{re_part} making it nearly impossible to move/,
-    /open and bleeding sores all over the (?<part>skin)/,
-    /severe (?<part>skin) loss exposing bone and internal organs/,
-    /(?<skin>complete paralysis of the entire body)/,
-    /(?<skin>general numbness all over and have difficulty thinking)/
-  ]
-}
-$comma_detector = /(?<=swollen|bruised|scarred|painful),(?=\s(?:swollen|bruised|mangled|inflamed))/
+custom_require.call(%w[common common-items common-healing-data])
 
 module DRCH
   module_function
 
+  # Uses HEALTH command to check for poisons, diseases, bleeders, parasites, and lodged items.
+  # Based on this diagnostic information, you should be able to prioritize how you heal
+  # yourself with medicinal potions and salves, or healing spells.
   def check_health
-    all_parasites_re = Regexp.union($all_parasites)
+    parasites_regex = Regexp.union($DRCH_PARASITES_REGEX_LIST)
     wounds_line = nil
     parasites_line = nil
+    lodged_line = nil
     diseased = false
     poisoned = false
 
     DRC.bput('health', 'You have', 'You feel somewhat tired and seem to be having trouble breathing')
     pause 0.5
-    data = reget(50).reverse
-    data.each do |line|
+    health_lines = reget(50).map(&:strip).reverse
+
+    health_lines.each do |line|
       case line
-      when /^You have (?!no significant injuries)(?!.* lodged into your)(?!.* infection)(?!.* poison(?:ed)?)(?!.* #{all_parasites_re})/
-        wounds_line = line
       when /^Your body feels\b.*(?:strength|battered|beat up|bad shape|death's door|dead)/
+        # While iterating the game output in reverse,
+        # this line represents the start of `HEALTH` command
+        # so we can now break out of the loop and avoid
+        # parsing text prior to the latest HEALTH command.
+        # We don't need to parse this line, just use implicit `health` numeric variable.
         break
+      when /Your spirit feels\b.*(?:mighty and unconquerable|full of life|strong|wavering slightly|shaky|weak|cold|empty|lifeless|dead)/
+        # This line is your spirit health.
+        # We don't need to parse this line, just use implicit `spirit` numeric variable.
+        next
+      when /^You have (?!no significant injuries)(?!.* lodged .* into your)(?!.* infection)(?!.* poison(?:ed)?)(?!.* #{parasites_regex})/
+        wounds_line = line
+      when /^You have .* lodged .* into your/
+        lodged_line = line
+      when /^You have a .* on your/, parasites_regex
+        parasites_line = line
       when /^You have a dormant infection/, /^Your wounds are infected/, /^Your body is covered in open oozing sores/
         diseased = true
       when /^You have .* poison(?:ed)?/, /^You feel somewhat tired and seem to be having trouble breathing/
         poisoned = true
-      when /^You have a .* on your/, all_parasites_re
-        parasites_line = line
       end
     end
 
-    wounds = Hash.new { |h, k| h[k] = [] }
-    if wounds_line
-      wounds_line.gsub!($comma_detector, '') # Remove commas from individual wounds
-      part = nil
-      wounds_line.split(',').each do |wound|
-        $severity_to_text.each do |severity_level, match_text|
-          next unless wound =~ Regexp.union(match_text)
-          part = Regexp.last_match.names.find { |x| Regexp.last_match[x.to_sym] }
-          part = Regexp.last_match[:part] if part == 'part'
-          wounds[severity_level] << part
-        end
-      end
-    end
+    bleeders = parse_bleeders(health_lines)
+    wounds = parse_wounds(wounds_line)
+    parasites = parse_parasites(parasites_line)
+    lodged_items = parse_lodged_items(lodged_line)
 
-    parasites = Hash.new { |h, k| h[k] = [] }
-    if parasites_line
-      parasites_line.split(',').each do |parasite|
-        parasite =~ all_parasites_re
-        parasite_name = Regexp.last_match.to_s
-        parasite =~ /on your (?<part>(?:left|right)?\s?(?:\w+))/
-        location = Regexp.last_match[:part].to_s
-        parasites[parasite_name] << location
-      end
-    end
-
-    { 'wounds' => wounds, 'poisoned' => poisoned, 'diseased' => diseased, 'parasites' => parasites }
+    return {
+      'wounds' => wounds,
+      'bleeders' => bleeders,
+      'parasites' => parasites,
+      'lodged' => lodged_items,
+      'poisoned' => poisoned,
+      'diseased' => diseased
+    }
   end
 
-  def check_perc_health
+  # Uses PERCEIVE HEALTH SELF command to check for wounds and scars.
+  # Returns a map of any wounds where the keys
+  # are the severity and the values are the list of wounds.
+  def perceive_health
     return unless DRStats.empath?
-    DRC.bput('perc heal self', 'Roundtime')
-    data = reget 100
-    data = data.reverse.take_while { |item| item != "Your injuries include...\r" }.reverse
-    wounds = {}
-    part = nil
-    data.each do |line|
-      if line =~ /Wounds to the (.+):/
-        part = Regexp.last_match(1)
-        wounds[part] = []
-      end
-      wounds[part] += [{ 'part' => part, 'location' => Regexp.last_match(2), 'type' => Regexp.last_match(1), 'level' => $wound_map[Regexp.last_match(3)] }] if line =~ /(\w+) (\w+):.*\-\- (.*)\r/
+
+    wounds = Hash.new { |h, k| h[k] = [] }
+
+    case DRC.bput('perceive health self', 'feel only an aching emptiness', 'Roundtime')
+    when 'feel only an aching emptiness'
+      # Empath is permashocked and cannot perceive wounds.
+      return
     end
+
+    pause 0.5
+    health_lines = reget(100).map(&:strip).reverse
+
+    # Example of what we're parsing:
+    # ===
+    # Your injuries include...
+    # Wounds to the LEFT ARM:
+    # Fresh External:  cuts and bruises about the left arm -- more than minor
+    # Scars External:  severe scarring and chunks of flesh missing from the left arm -- very severe
+    # Fresh Internal:  minor swelling and bruising around the left arm -- more than minor
+    # Scars Internal:  a completely paralyzed left arm -- useless
+    # ===
+    if health_lines.grep(/^Your injuries include\b/).any?
+      perceived_wounds = Hash.new { |h, k| h[k] = [] }
+      body_part = nil
+      health_lines
+        .take_while { |line| line != 'Your injuries include...' }
+        .reverse # put back in normal order so we parse <body part> line then <wound> lines
+        .each do |line|
+          case line
+          when /^Wounds to the (.+):/
+            body_part = Regexp.last_match(1)
+            perceived_wounds[body_part] = []
+          when /^(Fresh|Scars) (External|Internal)/
+            # Do regex then grab matches for wound details.
+            line =~ $DRCH_PERCEIVE_HEALTH_SEVERITY_REGEX
+            severity = $DRCH_WOUND_TO_SEVERITY_MAP[Regexp.last_match[:severity]]
+            is_internal = Regexp.last_match[:location] == 'Internal'
+            is_scar = Regexp.last_match[:freshness] == 'Scars'
+            perceived_wounds[body_part] << Wound.new(
+              body_part: body_part,
+              severity: severity,
+              is_internal: is_internal,
+              is_scar: is_scar
+            )
+          end
+        end
+    end
+
+    # Now go through the preceived wounds map (key=body part)
+    # and bucket the wounds by severity into the 'wounds' map (key=severity).
+    perceived_wounds.values.flatten.each do |wound|
+      wounds[wound.severity] << wound
+    end
+
+    # The perceive command incurs roundtime.
+    # We delayed waiting until now so that
+    # the script can use that time to parse
+    # the output rather than waiting unnecessarily.
     waitrt?
-    wounds
+
+    return {
+      'wounds' => wounds
+    }
   end
 
   # Given lines of text from the HEALTH command output,

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -74,7 +74,7 @@ module DRCH
     case DRC.bput('perceive health self', 'feel only an aching emptiness', 'Roundtime')
     when 'feel only an aching emptiness'
       # Empath is permashocked and cannot perceive wounds.
-      return
+      return check_health
     end
 
     pause 0.5
@@ -128,9 +128,11 @@ module DRCH
     # the output rather than waiting unnecessarily.
     waitrt?
 
-    return {
-      'wounds' => wounds
-    }
+    # Return same response as `check_health`
+    # but with wound details per perceive health.
+    health_data = check_health
+    health_data[:wounds] = wounds
+    return health_data
   end
 
   # Given lines of text from the HEALTH command output,

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -229,7 +229,7 @@ class CrossingTraining
 
   def check_nerves
     wounds = DRCH.check_health['wounds']
-    return unless wounds.values.flatten.any? { |wound| wound.body_part == 'skin' }
+    return unless wounds.values.flatten.map(&:body_part).map(&:downcase).include?('skin')
 
     wait_for_script_to_complete('safe-room', ['force'])
     walk_to(@training_room)

--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -228,8 +228,8 @@ class CrossingTraining
   end
 
   def check_nerves
-    wounds = check_health['wounds']
-    return unless wounds.any? { |_k, v| v.include?('skin') }
+    wounds = DRCH.check_health['wounds']
+    return unless wounds.values.flatten.any? { |wound| wound.body_part == 'skin' }
 
     wait_for_script_to_complete('safe-room', ['force'])
     walk_to(@training_room)

--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -47,7 +47,7 @@ def wounds
   wounds = DRCH.check_health['wounds']
   pause 1
   echo wounds if $debug_mode_hr
-  hurt = wounds.select { |level, _| level >= $heal_level }.values.flatten.map(&:body_part).uniq
+  hurt = wounds.select { |level, _| level >= $heal_level }.values.flatten.map(&:body_part).map(&:downcase).uniq
   wound_grouping = { 'right arm' => 'limbs', 'left arm' => 'limbs', 'left leg' => 'limbs', 'right leg' => 'limbs', 'right hand' => 'limbs', 'left hand' => 'limbs', 'right eye' => 'eyes', 'left eye' => 'eyes' }
   scar_grouping = { 'right arm' => 'limbs', 'left arm' => 'limbs', 'left leg' => 'limbs', 'right leg' => 'limbs', 'right hand' => 'limbs', 'left hand' => 'limbs', 'head' => 'face', 'neck' => 'face', 'eyes' => 'face', 'chest' => 'body', 'abdomen' => 'body', 'back' => 'body' }
   hurt = hurt.map { |raw| wound_grouping[raw] || raw }.uniq

--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -47,7 +47,7 @@ def wounds
   wounds = DRCH.check_health['wounds']
   pause 1
   echo wounds if $debug_mode_hr
-  hurt = wounds.select { |level, _| level >= $heal_level }.values.flatten
+  hurt = wounds.select { |level, _| level >= $heal_level }.values.flatten.map(&:body_part).uniq
   wound_grouping = { 'right arm' => 'limbs', 'left arm' => 'limbs', 'left leg' => 'limbs', 'right leg' => 'limbs', 'right hand' => 'limbs', 'left hand' => 'limbs', 'right eye' => 'eyes', 'left eye' => 'eyes' }
   scar_grouping = { 'right arm' => 'limbs', 'left arm' => 'limbs', 'left leg' => 'limbs', 'right leg' => 'limbs', 'right hand' => 'limbs', 'left hand' => 'limbs', 'head' => 'face', 'neck' => 'face', 'eyes' => 'face', 'chest' => 'body', 'abdomen' => 'body', 'back' => 'body' }
   hurt = hurt.map { |raw| wound_grouping[raw] || raw }.uniq

--- a/test/test_check_health.rb
+++ b/test/test_check_health.rb
@@ -53,7 +53,7 @@ class TestCheckHealth < Minitest::Test
   def check_health_with_buffer(messages, assertions = [])
     $server_buffer = messages.dup
     $history = $server_buffer.dup
-    @test = run_script_with_proc(['common', 'common-healing'], proc do
+    @test = run_script_with_proc(['common', 'common-healing-data', 'common-healing'], proc do
       health_result = DRCH.check_health
       assertions = [assertions] unless assertions.is_a?(Array)
       assertions.each { |assertion| assertion.call(health_result) }


### PR DESCRIPTION
### Dependencies
* ~Depends on https://github.com/rpherbig/dr-scripts/pull/4793~

### Background
* Continuation of https://github.com/rpherbig/dr-scripts/pull/4659 and https://github.com/rpherbig/dr-scripts/pull/4664
* Motivation is to have more granular wound information to power `healme` and other healing scripts.
* Prerequisite for https://github.com/rpherbig/dr-scripts/pull/4795

### Changes
* Move constant declarations to `common-healing-data` per https://github.com/rpherbig/dr-scripts/pull/4793
* Refactor `check_health` to identify lodged items
* Refactor `check_perc_health` to `perceive_health`
* Both methods now return wound details structured as `DRCH.Wound` objects, which lets you know the body part, severity, is a scar or not, and is external or internal.

### Reviewers
* Corgar (`will#6948`) and ubiquitous42 (`ubiquitous42#7320`) from Lich discord expressed interest in refactoring `healme` as well.