### PR TITLE
[script] [healme] [healme 2.0] Optimize triage and healing

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -251,18 +251,18 @@ module DRCH
   def bind_wound(body_part, person = 'my')
     # Either you tended it or it already has bandages on. Good job!
     tend_success = [
-      'You work carefully at tending',
-      'That area has already been tended to',
-      'That area is not bleeding'
+      /You work carefully at tending/,
+      /That area has already been tended to/,
+      /That area is not bleeding/
     ]
     # Yeouch, you couldn't tend the wound. Might have made it worse!
     tend_failure = [
-      'You fumble',
-      'too injured for you to do that'
+      /You fumble/,
+      /too injured for you to do that/
     ]
     # You dislodged ammo or a parasite, discard it.
     tend_dislodge = [
-      'You \w+ remove'
+      /You \w+ remove/
     ]
     snap = [DRC.left_hand, DRC.right_hand]
     result = DRC.bput("tend #{person} #{body_part}", *tend_success, *tend_failure, *tend_dislodge)

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -249,13 +249,34 @@ module DRCH
   end
 
   def bind_wound(body_part, person = 'my')
+    # Either you tended it or it already has bandages on. Good job!
+    tend_success = [
+      'You work carefully at tending',
+      'That area has already been tended to',
+      'That area is not bleeding'
+    ]
+    # Yeouch, you couldn't tend the wound. Might have made it worse!
+    tend_failure = [
+      'You fumble',
+      'too injured for you to do that'
+    ]
+    # You dislodged ammo or a parasite, discard it.
+    tend_dislodge = [
+      'You \w+ remove'
+    ]
     snap = [DRC.left_hand, DRC.right_hand]
-    if /You \w+ remove/ =~ DRC.bput("tend #{person} #{body_part}", 'You work carefully at tending', 'That area has already been tended to', 'That area is not bleeding', 'You fumble', 'too injured for you to do that', 'You \w+ remove')
+    result = DRC.bput("tend #{person} #{body_part}", *tend_success, *tend_failure, *tend_dislodge)
+    waitrt?
+    case result
+    when *tend_dislodge
       DRCI.dispose(DRC.left_hand) if DRC.left_hand != snap.first
       DRCI.dispose(DRC.right_hand) if DRC.right_hand != snap.last
       bind_wound(body_part, person)
+    when *tend_failure
+      false
+    else
+      true
     end
-    waitrt?
   end
 
   def unwrap_wound(body_part, person = 'my')

--- a/healme.lic
+++ b/healme.lic
@@ -29,7 +29,7 @@ class HealMe
     @use_heal_over_time_spells = @body_parts_not_to_heal.empty?
     echo "use_heal_over_time_spells = #{@use_heal_over_time_spells}" if $debug_mode_hm
 
-    @wound_severity_threshold = @settings['healme']['severity_threshold'] || args.severity.to_i || 0
+    @wound_severity_threshold = (@settings['healme']['severity_threshold'] || args.severity || 0).to_i
     echo "wound_severity_threshold = #{@wound_severity_threshold}" if $debug_mode_hm
 
     @health_data = {}

--- a/healme.lic
+++ b/healme.lic
@@ -134,8 +134,8 @@ class HealMe
           )
           .reject { |wound| wound_tended?(wound) }
           .select { |wound| !wound.bleeding? || bleeder_tendable?(wound) }
-        wound = wounds.first
-        tend_wound(wound) if wound
+          .first(1)
+          .each { |wound| tend_wound(wound) }
       when 'pre-cast'
         if /^(hw|hs)$/i =~ spell_data['abbrev']
           wounds = @health_data['wounds']

--- a/healme.lic
+++ b/healme.lic
@@ -21,7 +21,7 @@ class HealMe
     ]
     args = parse_args(arg_definitions)
 
-    $debug_mode_hm = UserVars.healme_debug || args.debug
+    $debug_mode_hm = UserVars.healme_debug || args.debug || @settings['healme']['debug']
 
     @body_parts_not_to_heal = args.keep.split(',').map(&:strip).map(&:downcase) || []
     echo "body_parts_not_to_heal = #{@body_parts_not_to_heal}" if $debug_mode_hm

--- a/healme.lic
+++ b/healme.lic
@@ -21,7 +21,7 @@ class HealMe
     $debug_mode_hm = UserVars.healme_debug || args.debug
     @spells = load_healing_waggle_set
     @body_parts_not_to_heal = args.keep.split(',').map(&:strip) || []
-    ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.add("hm-#{x}-#{y}-healed", "The #{x} #{y} on your (.+) appear completely healed") } }
+    add_health_flags
     heal_self
   end
 
@@ -77,6 +77,7 @@ class HealMe
       self_health = get_self_health
       perc_health = get_perc_health
       break unless wounds_to_heal?(self_health, perc_health)
+      reset_health_flags
       attend_vitals
       flush_poisons if self_health['poisoned']
       cure_diseases if self_health['diseased']
@@ -136,7 +137,8 @@ class HealMe
   def attend_vitals
     heal_vitality if health < [50, @settings.health_threshold].max
     stop_bleeding if bleeding?
-    regenerate if @spells['Regenerate']
+    cast_regenerate if @spells['Regenerate']
+    cast_heal if @spells['Heal']
   end
 
   # Returns wounds list without the ones
@@ -189,8 +191,14 @@ class HealMe
 
   # If your 'healing' waggle set contains 'Regenerate' spell
   # then casts it to boost your healing rate.
-  def regenerate
+  def cast_regenerate
     cast_spell('Regenerate')
+  end
+
+  # If your 'healing' waggle set contains 'Heal' spell
+  # then casts it to boost your healing rate.
+  def cast_heal
+    cast_spell('Heal')
   end
 
   # Heal all the wounds of the highest severity, then returns
@@ -225,10 +233,11 @@ class HealMe
     wounds.sort_by { |severity, wounds| severity }.reverse.first[1].each do |wound|
       wound_location = wound.internal? ? 'internal' : 'external'
       wound_type = wound.scar? ? 'scars' : 'wounds'
-      next if healed_body_parts[wound_location][wound_type].include?(wound.body_part)
-      ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.reset("hm-#{x}-#{y}-healed") } }
-      heal_wound(wound)
+      # Before we try to heal a wound, check if it's already been healed either
+      # from a previous, potent cast or from heal over time spells like Heal or Regenerate.
       ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| healed_body_parts[x][y] << wound.body_part if Flags["hm-#{x}-#{y}-healed"] } }
+      next if healed_body_parts[wound_location][wound_type].include?(wound.body_part)
+      heal_wound(wound)
       attend_vitals
     end
   end
@@ -259,6 +268,7 @@ class HealMe
     end
   end
 
+  # For tending bleeders, dislodging ammo, or removing parasites.
   def tend_wound(wound)
     echo "Tending wound: #{wound.inspect}" if $debug_mode_hm
     DRCH.bind_wound(wound.body_part)
@@ -292,6 +302,7 @@ class HealMe
     end
   end
 
+  # Cast a spell if it's not active.
   def cast_spell(spell_name)
     if DRSpells.active_spells[spell_name]
       echo "Skipping casting spell #{spell_name} because already active" if $debug_mode_hm
@@ -306,6 +317,14 @@ class HealMe
     DRC.message(message) if message
     DRC.message("The spell '#{spell_name}' is neither configured in the 'healing' waggle set nor 'empath_healing:' setting")
     DRC.message("You may need to seek the help from another healer or remedy")
+  end
+
+  def add_health_flags
+    ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.add("hm-#{x}-#{y}-healed", "The #{x} #{y} on your (.+) appear completely healed") } }
+  end
+
+  def reset_health_flags
+    ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.reset("hm-#{x}-#{y}-healed") } }
   end
 
   # Returns true if the argument is nil or empty.

--- a/healme.lic
+++ b/healme.lic
@@ -116,43 +116,32 @@ class HealMe
       reset_health_flags
       # Using these variable names to not conflict with
       # implicit 'health' variable that tells your vitality.
-      self_health = get_self_health
-      perc_health = get_perc_health
-      break unless wounds_to_heal?(self_health, perc_health)
+      health_data = get_health_data
+      break unless wounds_to_heal?(health_data)
       attend_vitals
-      flush_poisons if self_health['poisoned']
-      cure_diseases if self_health['diseased']
+      flush_poisons if health_data['poisoned']
+      cure_diseases if health_data['diseased']
       # Address the most severe wounds for a given category each loop iteration.
       # This heals the most severe bleeders first, then restarts the loop.
       # If there are more bleeders, it heals the next severity level, then restarts the loop.
       # This continues until no more bleeders and then it begins to triage the next wound types.
       # This ensures minor scratches aren't attended to before bleeders, lodged items, parasites, etc.
-      if self_health['bleeders'].length > 0
-        heal_wounds(self_health['bleeders'])
-      elsif self_health['lodged'].length > 0
-        tend_wounds(self_health['lodged'])
-      elsif self_health['parasites'].length > 0
-        tend_wounds(self_health['parasites'])
-      elsif perc_health['wounds'].length > 0
-        heal_wounds(perc_health['wounds'])
+      if health_data['bleeders'].length > 0
+        heal_wounds(health_data['bleeders'])
+      elsif health_data['lodged'].length > 0
+        tend_wounds(health_data['lodged'])
+      elsif health_data['parasites'].length > 0
+        tend_wounds(health_data['parasites'])
+      elsif health_data['wounds'].length > 0
+        heal_wounds(health_data['wounds'])
       elsif health < 100
         heal_vitality
       end
     end
   end
 
-  # Get wounds inferred from HEALTH command.
-  def get_self_health
-    echo 'Checking for visible wounds, bleeders, parasites, and lodged items' if $debug_mode_hm
-    health_data = DRCH.check_health
-    remove_wounds_to_keep(health_data['bleeders'])
-    health_data
-  end
-
-  # Get wounds inferred from PERCEIVE HEALTH SELF.
-  def get_perc_health
-    return if @settings.permashocked
-    echo 'Perceiving internal and external wounds and scars' if $debug_mode_hm
+  def get_health_data
+    echo 'Checking internal and external wounds and scars, bleeders, parasites, and lodged items' if $debug_mode_hm
     health_data = DRCH.perceive_health
     remove_wounds_to_keep(health_data['wounds'])
     remove_wounds_to_keep(health_data['bleeders'])
@@ -163,7 +152,7 @@ class HealMe
   # Designed to be called frequently so that low vitality
   # and bleeding can be addressed immediately.
   def attend_vitals
-    heal_vitality if health < [50, @settings.health_threshold].max
+    heal_vitality if DRStats.health < [50, @settings.health_threshold].max
     stop_bleeding if bleeding?
     if @use_heal_over_time_spells
       cast_regenerate if @spells['Regenerate']
@@ -227,15 +216,15 @@ class HealMe
   end
 
   # Determines if there are any wounds, poisons, etc to heal.
-  def wounds_to_heal?(observed_health, perceived_health)
+  def wounds_to_heal?(health_data)
     wounds_to_heal = (
-      !empty?(perceived_health['wounds']) ||
-      !empty?(observed_health['bleeders']) ||
-      !empty?(observed_health['parasites']) ||
-      !empty?(observed_health['lodged']) ||
-      observed_health['poisoned'] ||
-      observed_health['diseased'] ||
-      health < 100
+      !empty?(health_data['wounds']) ||
+      !empty?(health_data['bleeders']) ||
+      !empty?(health_data['parasites']) ||
+      !empty?(health_data['lodged']) ||
+      health_data['poisoned'] ||
+      health_data['diseased'] ||
+      DRStats.health < 100
     )
     echo "Wounds to heal? #{wounds_to_heal}" if $debug_mode_hm
     wounds_to_heal

--- a/healme.lic
+++ b/healme.lic
@@ -32,6 +32,9 @@ class HealMe
     @wound_severity_threshold = (@settings['healme']['severity_threshold'] || args.severity || 0).to_i
     echo "wound_severity_threshold = #{@wound_severity_threshold}" if $debug_mode_hm
 
+    @max_wounds_to_tend_while_prep_spells = (@settings['healme']['max_wounds_to_tend_while_prep_spells'] || 1).to_i
+    echo "max_wounds_to_tend_while_prep_spells = #{@max_wounds_to_tend_while_prep_spells}" if $debug_mode_hm
+
     @health_data = {}
     @spells = load_healing_waggle_set
     @cast_spell_lambda = build_cast_spell_lambda
@@ -59,6 +62,10 @@ class HealMe
             composite_key = build_wound_composite_key(body_part, wound_location, wound_type)
             @healed_wounds[composite_key] = true
             echo "@healed_wounds[#{composite_key}] = #{@healed_wounds[composite_key]}" if $debug_mode_hm
+            # If external wound is fully healed then flag that it's been tended, too.
+            if wound_location == 'external' && wound_type == 'wounds'
+              @tended_wounds[body_part] = true
+            end
           end
       end
       if server_string =~ /The bandages binding your (?<body_parts>.*) become useless and fall apart./
@@ -134,7 +141,7 @@ class HealMe
           )
           .reject { |wound| wound_tended?(wound) }
           .select { |wound| !wound.bleeding? || bleeder_tendable?(wound) }
-          .first(1) # TODO make configurable in yaml
+          .first(@max_wounds_to_tend_while_prep_spells)
           .each { |wound| tend_wound(wound) }
       when 'pre-cast'
         if /^(hw|hs)$/i =~ spell_data['abbrev']

--- a/healme.lic
+++ b/healme.lic
@@ -387,7 +387,7 @@ class HealMe
       echo "wound_needs_tending? #{!wound_is_tended}"
       echo "wound_is_bleeding? #{wound.bleeding?}"
       echo "wound_is_external? #{!wound.internal?}"
-      echo "skilled_to_tend? #{skill_to_tend}"
+      echo "skilled_to_tend? #{skilled_to_tend}"
       echo "bleeder_tendable? #{tendable}"
     end
     tendable

--- a/healme.lic
+++ b/healme.lic
@@ -11,18 +11,31 @@ class HealMe
 
   def initialize
     @settings = get_settings
+
     arg_definitions = [
       [
         { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug output' },
-        { name: 'keep', regex: /^[\w\s,]+$/i, variable: true, optional: true, description: 'Comma separated list of wounds to keep. Example: "right arm, chest, back"' }
+        { name: 'keep', regex: /^[a-zA-Z\s,]+$/i, variable: true, optional: true, description: 'Comma separated list of wounds to keep. Example: "right arm, chest, back"' },
+        { name: 'severity', regex: /^\d+$/i, optional: true, description: 'If specified, script will not proactively try to heal wounds whose numerical severity is at or below this value. Range is 0-13. Default is 0. Also see https://elanthipedia.play.net/Damage#Wound_Severity_Levels'}
       ]
     ]
     args = parse_args(arg_definitions)
+
     $debug_mode_hm = UserVars.healme_debug || args.debug
+
     @spells = load_healing_waggle_set
+
     @body_parts_not_to_heal = args.keep.split(',').map(&:strip) || []
+    echo "body_parts_not_to_heal = #{@body_parts_not_to_heal}" if $debug_mode_hm
+
     @use_heal_over_time_spells = @body_parts_not_to_heal.empty?
+    echo "use_heal_over_time_spells = #{@use_heal_over_time_spells}" if $debug_mode_hm
+
+    @wound_severity_threshold = args.severity.to_i || 0
+    echo "wound_severity_threshold = #{@wound_severity_threshold}" if $debug_mode_hm
+
     add_health_flags
+
     heal_self
   end
 
@@ -73,12 +86,12 @@ class HealMe
   def heal_self
     loop do
       echo 'Checking health' if $debug_mode_hm
+      reset_health_flags
       # Using these variable names to not conflict with
       # implicit 'health' variable that tells your vitality.
       self_health = get_self_health
       perc_health = get_perc_health
       break unless wounds_to_heal?(self_health, perc_health)
-      reset_health_flags
       attend_vitals
       flush_poisons if self_health['poisoned']
       cure_diseases if self_health['diseased']
@@ -144,18 +157,43 @@ class HealMe
     end
   end
 
-  # Returns wounds list without the ones
-  # that are for body parts we want to keep.
-  def remove_wounds_to_keep(wounds)
-    echo "All wounds: #{wounds}" if $debug_mode_hm
-    echo "Wounds to keep: #{@body_parts_not_to_heal}" if $debug_mode_hm
-    wounds = wounds.select do |wound|
-      !@body_parts_not_to_heal.any? do |body_part|
-        body_part.downcase == wound.body_part.downcase
-      end
+  # Removes wounds from health data that are
+  # either for body parts or severities we want to keep.
+  def remove_wounds_to_keep(health_data)
+    ['wounds', 'bleeders'].each do |type|
+      health_data[type].each { |severity, wounds| wounds.reject! { |wound| wound_to_keep?(wound) } }
+      health_data[type].select! { |severity, wounds| wounds.length > 0 }
     end
-    echo "Wounds to heal: #{wounds}" if $debug_mode_hm
-    wounds
+    health_data
+  end
+
+  # Should we keep the wound and NOT heal it?
+  def wound_to_keep?(wound)
+    should_heal_severity = should_heal_severity?(wound)
+    should_heal_body_part = should_heal_body_part?(wound)
+    wound_to_keep = !(should_heal_severity && should_heal_body_part)
+    if $debug_mode_hm
+      echo "severity = #{wound.severity}, body_part = #{wound.body_part}"
+      echo "should_heal_severity? = #{should_heal_severity}"
+      echo "should_heal_body_part? = #{should_heal_body_part}"
+      echo "wound_to_keep? = #{wound_to_keep}"
+      echo "---"
+    end
+    wound_to_keep
+  end
+
+  # Is the wound's severity greater than the threshold to keep?
+  # We won't try to heal wounds that are below the threshold.
+  def should_heal_severity?(wound)
+    wound.severity > @wound_severity_threshold
+  end
+
+  # Is the wound's body part NOT in the exclusion list?
+  # We won't try to heal wounds for body parts to keep injured.
+  def should_heal_body_part?(wound)
+    !@body_parts_not_to_heal.any? do |body_part|
+      body_part.downcase == wound.body_part.downcase
+    end
   end
 
   # Determines if there are any wounds, poisons, etc to heal.
@@ -209,7 +247,7 @@ class HealMe
   # The 'wounds' argument is a map whose keys are severity numbers (1,2,3...)
   # and the values are a list of wounds. So this only heals the wounds
   # for the map key that is the highest severity at the time.
-  def heal_wounds(wounds)
+  def heal_wounds(wounds_by_severity)
     # While iterating the wounds to heal,
     # track if any body parts become completely healed
     # so that we can avoid unnecessary spell casting.
@@ -233,10 +271,24 @@ class HealMe
         'scars' => []
       }
     }
-    wounds.sort_by { |severity, wounds| severity }.reverse.first[1].each do |wound|
+    # Convert map of "severity" => array_of_wounds to a list of wounds sorted by most severe first.
+    wounds = wounds_by_severity.sort_by { |severity, wounds| severity }.reverse.map { |arr| arr[1] }.flatten
+    return if wounds.empty?
+    # Heal over time spells, like Heal and Regenerate, try to heal the worst wounds automatically.
+    # To avoid the healing effects of those spells clashing with this script targeting the same
+    # wounds then if one of those spells is active then the script will target less severe wounds.
+    # Since we have a list of all wounds sorted by severity, we'll use an offset start index.
+    wounds_to_heal_offset = heal_over_time_spells_active? ? 4 : 0
+    # How many wounds to heal this method call before returning to main loop to re-assess your health?
+    wounds_to_heal_limit = 3
+    # Compute the array indices for which wounds we'll try to heal.
+    start_index = [wounds.length - 1, wounds_to_heal_offset].min
+    end_index = [wounds.length - 1, start_index + wounds_to_heal_limit].min
+    # Heal the needful
+    wounds.values_at(start_index..end_index).each do |wound|
       wound_location = wound.internal? ? 'internal' : 'external'
       wound_type = wound.scar? ? 'scars' : 'wounds'
-      # Before we try to heal a wound, check if it's already been healed either
+      # Before we try to heal a wound, check if it's already been healed, either
       # from a previous, potent cast or from heal over time spells like Heal or Regenerate.
       ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| healed_body_parts[x][y] << wound.body_part if Flags["hm-#{x}-#{y}-healed"] } }
       next if healed_body_parts[wound_location][wound_type].include?(wound.body_part)
@@ -249,6 +301,7 @@ class HealMe
   # If it's an internal wound then casts <spell> reverse.
   def heal_wound(wound)
     echo "Healing wound: #{wound.inspect}" if $debug_mode_hm
+    # Don't bleed out while we prepare spell.
     stop_bleeding(wound) if wound.bleeding?
     spell_name = wound.scar? ? 'Heal Scars' : 'Heal Wounds'
     # If an internal wound then focus healing power there,
@@ -320,6 +373,10 @@ class HealMe
     DRC.message(message) if message
     DRC.message("The spell '#{spell_name}' is neither configured in the 'healing' waggle set nor 'empath_healing:' setting")
     DRC.message("You may need to seek the help from another healer or remedy")
+  end
+
+  def heal_over_time_spells_active?
+    ['Heal', 'Regenerate'].any? { |spell_name| DRSpells.active_spells[spell_name] }
   end
 
   def add_health_flags

--- a/healme.lic
+++ b/healme.lic
@@ -21,7 +21,7 @@ class HealMe
     ]
     args = parse_args(arg_definitions)
 
-    $debug_mode_hm = UserVars.healme_debug || args.debug || @settings['healme']['debug']
+    $debug_mode_hm =  @settings['healme']['debug'] || UserVars.healme_debug || args.debug
 
     @body_parts_not_to_heal = args.keep.split(',').map(&:strip).map(&:downcase) || []
     echo "body_parts_not_to_heal = #{@body_parts_not_to_heal}" if $debug_mode_hm
@@ -29,7 +29,7 @@ class HealMe
     @use_heal_over_time_spells = @body_parts_not_to_heal.empty?
     echo "use_heal_over_time_spells = #{@use_heal_over_time_spells}" if $debug_mode_hm
 
-    @wound_severity_threshold = args.severity.to_i || 0
+    @wound_severity_threshold = @settings['healme']['severity_threshold'] || args.severity.to_i || 0
     echo "wound_severity_threshold = #{@wound_severity_threshold}" if $debug_mode_hm
 
     @health_data = {}

--- a/healme.lic
+++ b/healme.lic
@@ -134,7 +134,7 @@ class HealMe
           )
           .reject { |wound| wound_tended?(wound) }
           .select { |wound| !wound.bleeding? || bleeder_tendable?(wound) }
-          .first(1)
+          .first(1) # TODO make configurable in yaml
           .each { |wound| tend_wound(wound) }
       when 'pre-cast'
         if /^(hw|hs)$/i =~ spell_data['abbrev']

--- a/healme.lic
+++ b/healme.lic
@@ -23,9 +23,7 @@ class HealMe
 
     $debug_mode_hm = UserVars.healme_debug || args.debug
 
-    @spells = load_healing_waggle_set
-
-    @body_parts_not_to_heal = args.keep.split(',').map(&:strip) || []
+    @body_parts_not_to_heal = args.keep.split(',').map(&:strip).map(&:downcase) || []
     echo "body_parts_not_to_heal = #{@body_parts_not_to_heal}" if $debug_mode_hm
 
     @use_heal_over_time_spells = @body_parts_not_to_heal.empty?
@@ -33,6 +31,10 @@ class HealMe
 
     @wound_severity_threshold = args.severity.to_i || 0
     echo "wound_severity_threshold = #{@wound_severity_threshold}" if $debug_mode_hm
+
+    @health_data = {}
+    @spells = load_healing_waggle_set
+    @cast_spell_lambda = build_cast_spell_lambda
 
     reset_health_flags
     register_wounds_healed_hook
@@ -42,8 +44,8 @@ class HealMe
   def register_wounds_healed_hook
     wounds_healed_hook = lambda do |server_string|
       # Do regex then look for the wound location, type, and body part matches.
-      if server_string =~ /The (?<location>internal|external) (?<type>wounds|scars) (?:on|to) your (?<parts>.*) (?:are fully healed|appear completely healed)/
-        body_parts = Regexp.last_match[:parts].to_s
+      if server_string =~ /The (?<location>internal|external) (?<type>wounds|scars) (?:on|to) your (?<body_parts>.*) (?:are fully healed|appear completely healed)/
+        body_parts = Regexp.last_match[:body_parts].to_s
         wound_location = Regexp.last_match[:location].to_s
         wound_type = Regexp.last_match[:type].to_s
         echo "Detected fully healed wounds: body_parts=#{body_parts}, wound_location=#{wound_location}, wound_type=#{wound_type}" if $debug_mode_hm
@@ -57,6 +59,20 @@ class HealMe
             composite_key = build_wound_composite_key(body_part, wound_location, wound_type)
             @healed_wounds[composite_key] = true
             echo "@healed_wounds[#{composite_key}] = #{@healed_wounds[composite_key]}" if $debug_mode_hm
+          end
+      end
+      if server_string =~ /The bandages binding your (?<body_parts>.*) become useless and fall apart./
+        body_parts = Regexp.last_match[:body_parts].to_s
+        echo "Detected bandages fall off: body_parts=#{body_parts}" if $debug_mode_hm
+        # One or more body parts lost their bandages.
+        # Split the string to identify each one.
+        body_parts
+          .gsub(' and ', ' , ')
+          .split(',')
+          .map { |value| value.strip.downcase }
+          .each do |body_part|
+            @tended_wounds[body_part] = false
+            echo "@tended_wounds[#{body_part}] = #{@tended_wounds[body_part]}" if $debug_mode_hm
           end
       end
       server_string
@@ -106,6 +122,32 @@ class HealMe
     waggle_set
   end
 
+  def build_cast_spell_lambda
+    lambda do |phase, spell_data, settings|
+      wound = nil
+      case phase
+      when 'post-prep'
+        wounds = @health_data['bleeders'].values.flatten.select { |wound| bleeder_tendable?(wound) }
+        wounds = wounds + @health_data['parasites'] + @health_data['lodged']
+        wounds = wounds.values.flatten.reject { |wound| wound_tended?(wound) }
+        wound = wounds.first
+        tend_wound(wound)
+      when 'pre-cast'
+        if /^(hw|hs)$/i =~ spell_data['abbrev']
+          wounds = @health_data['wounds']
+          wounds = wounds.values.flatten.reject { |wound| wound_is_healed?(wound) }
+          case spell_data['abbrev'].downcase
+          when 'hw'
+            wound = wounds.find { |wound| !wound.scar? }
+          when 'hs'
+            wound = wounds.find { |wound| wound.scar? }
+          end
+          spell_data['cast'] = get_cast_command_for_wound(wound)
+        end
+      end
+    end
+  end
+
   # This method triages your wounds and heals the most severe first.
   # After a round of healing, it rechecks your wounds to determine
   # which are now the most severe, and then heals them. In this manner,
@@ -116,24 +158,24 @@ class HealMe
       reset_health_flags
       # Using these variable names to not conflict with
       # implicit 'health' variable that tells your vitality.
-      health_data = get_health_data
-      break unless wounds_to_heal?(health_data)
+      @health_data = get_health_data
+      break unless wounds_to_heal?(@health_data)
       attend_vitals
-      flush_poisons if health_data['poisoned']
-      cure_diseases if health_data['diseased']
+      flush_poisons if @health_data['poisoned']
+      cure_diseases if @health_data['diseased']
       # Address the most severe wounds for a given category each loop iteration.
       # This heals the most severe bleeders first, then restarts the loop.
       # If there are more bleeders, it heals the next severity level, then restarts the loop.
       # This continues until no more bleeders and then it begins to triage the next wound types.
       # This ensures minor scratches aren't attended to before bleeders, lodged items, parasites, etc.
-      if health_data['bleeders'].length > 0
-        heal_wounds(health_data['bleeders'])
-      elsif health_data['lodged'].length > 0
-        tend_wounds(health_data['lodged'])
-      elsif health_data['parasites'].length > 0
-        tend_wounds(health_data['parasites'])
-      elsif health_data['wounds'].length > 0
-        heal_wounds(health_data['wounds'])
+      if @health_data['bleeders'].length > 0
+        heal_wounds(@health_data['bleeders'])
+      elsif @health_data['lodged'].length > 0
+        tend_wounds(@health_data['lodged'])
+      elsif @health_data['parasites'].length > 0
+        tend_wounds(@health_data['parasites'])
+      elsif @health_data['wounds'].length > 0
+        heal_wounds(@health_data['wounds'])
       elsif health < 100
         heal_vitality
       end
@@ -145,6 +187,10 @@ class HealMe
     health_data = DRCH.perceive_health
     remove_wounds_to_keep(health_data['wounds'])
     remove_wounds_to_keep(health_data['bleeders'])
+
+    echo health_data['bleeders'].values.flatten.select { |wound| bleeder_tendable?(wound) }
+    exit
+
     health_data
   end
 
@@ -210,9 +256,7 @@ class HealMe
   # Is the wound's body part NOT in the exclusion list?
   # We won't try to heal wounds for body parts to keep injured.
   def should_heal_body_part?(wound)
-    !@body_parts_not_to_heal.any? do |body_part|
-      body_part.downcase == wound.body_part.downcase
-    end
+    !@body_parts_not_to_heal.any? { |body_part| body_part == wound.body_part }
   end
 
   # Determines if there are any wounds, poisons, etc to heal.
@@ -234,6 +278,12 @@ class HealMe
   # then casts it to try and restore vitality.
   def heal_vitality
     cast_spell_or_warn('Vitality Healing', "You're vitality is low!")
+  end
+
+  # If your 'healing' waggle set contains 'Blood Staunching' spell
+  # then casts it to stop blood loss.
+  def stop_bleeding
+    cast_spell_or_warn('Blood Staunching', "You're bleeding!")
   end
 
   # If your 'healing' waggle set contains 'Flush Poisons' spell
@@ -265,32 +315,20 @@ class HealMe
   # The 'wounds' argument is a map whose keys are severity numbers (1,2,3...)
   # and the values are a list of wounds. So this only heals the wounds
   # for the map key that is the highest severity at the time.
-  def heal_wounds(wounds_by_severity)
+  def heal_wounds(wounds_by_severity, max_wounds_to_heal = 3)
     # Convert map of "severity" => array_of_wounds to a list of wounds sorted by most severe first.
     wounds = wounds_by_severity.sort_by { |severity, wounds| severity }.reverse.map { |arr| arr[1] }.flatten
     return if wounds.empty?
-    # Heal over time spells, like Heal and Regenerate, try to heal the worst wounds automatically.
-    # To avoid the healing effects of those spells clashing with this script targeting the same
-    # wounds then if one of those spells is active then the script will target less severe wounds.
-    # Since we have a list of all wounds sorted by severity, we'll use an offset start index.
-    wounds_to_heal_offset = heal_over_time_spells_active? ? 4 : 0
-    # How many wounds to heal this method call before returning to main loop to re-assess your health?
-    wounds_to_heal_limit = 3
-    # Compute the array indices for which wounds we'll try to heal.
-    start_index = [wounds.length - 1, wounds_to_heal_offset].min
-    end_index = [wounds.length - 1, start_index + wounds_to_heal_limit].min
     # Heal the needful
-    wounds.values_at(start_index..end_index).each do |wound|
-      wound_location = wound.internal? ? 'internal' : 'external'
-      wound_type = wound.scar? ? 'scars' : 'wounds'
+    count_of_wounds_healed = 0
+    wounds.each do |wound|
       # Before we try to heal a wound, check if it's already been healed, either
       # from a previous, potent cast or from heal over time spells like Heal or Regenerate.
-      composite_key = build_wound_composite_key(wound.body_part, wound_location, wound_type)
-      wound_is_healed = @healed_wounds[composite_key]
-      echo "wound_is_healed = #{wound_is_healed}, composite_key = #{composite_key}" if $debug_mode_hm
-      next if wound_is_healed
+      next if wound_healed?(wound)
       heal_wound(wound)
       attend_vitals
+      count_of_wounds_healed = count_of_wounds_healed + 1
+      break if count_of_wounds_healed >= max_wounds_to_heal
     end
   end
 
@@ -298,25 +336,19 @@ class HealMe
   # If it's an internal wound then casts <spell> reverse.
   def heal_wound(wound)
     echo "Healing wound: #{wound.inspect}" if $debug_mode_hm
-    # Don't bleed out while we prepare spell.
-    stop_bleeding(wound) if wound.bleeding?
-    spell_name = wound.scar? ? 'Heal Scars' : 'Heal Wounds'
-    # If an internal wound then focus healing power there,
-    # with any remaining healing power going to the external wound.
-    # If an external wound then the opposite will occur.
-    # Healing power focused on the external wound and any remaining
-    # will be directed to the internal wound.
-    # However, if the wound is for a body part the player wants to keep,
-    # which is usually a pet bleeder, then only focus the healing power
-    # on the location for the wound we are given. Often this means
-    # we're healing the internal damage but keeping the external pet bleeder.
-    if should_heal_body_part?(wound)
-      spell_location = wound.internal? ? 'reverse' : ''
-    else
-      spell_location = wound.internal? ? 'internal' : 'external'
-    end
-    @spells[spell_name]['cast'] = "cast #{wound.body_part} #{spell_location}"
+    # Determine spell to cast to heal this wound.
+    spell_name = get_spell_name_for_wound(wound)
+    @spells[spell_name]['cast'] = get_cast_command_for_wound(wound)
     cast_spell_or_warn(spell_name)
+  end
+
+  def wound_healed?(wound)
+    wound_location = wound.internal? ? 'internal' : 'external'
+    wound_type = wound.scar? ? 'scars' : 'wounds'
+    composite_key = build_wound_composite_key(wound.body_part, wound_location, wound_type)
+    wound_is_healed = @healed_wounds[composite_key]
+    echo "Wound already healed? #{wound_is_healed}, wound = #{wound.inspect}" if $debug_mode_hm
+    wound_is_healed
   end
 
   # Similar to 'heal_wounds' except instead of casting a spell on the wound
@@ -331,25 +363,37 @@ class HealMe
 
   # For tending bleeders, dislodging ammo, or removing parasites.
   def tend_wound(wound)
-    echo "Tending wound: #{wound.inspect}" if $debug_mode_hm
-    DRCH.bind_wound(wound.body_part)
+    if !wound_tended?(wound) && (!wound.bleeding? || bleeder_tendable?(wound))
+      echo "Tending wound: #{wound.inspect}" if $debug_mode_hm
+      @tended_wounds[wound.body_part] = DRCH.bind_wound(wound.body_part)
+    else
+      echo "Wound doesn't meet criteria to be tended: #{wound.inspect}" if $debug_mode_hm
+    end
   end
 
-  # If your 'healing' waggle set contains 'Blood Staunching' spell
-  # then casts it to stop blood loss.
-  # If given a wound that is a simple enough bleeder, tends it, too.
-  def stop_bleeding(wound = nil)
-    DRCH.bind_wound(wound.body_part) if wound_tendable?(wound)
-    cast_spell_or_warn('Blood Staunching', "You're bleeding!") if bleeding?
+  # Have we tended the wound already?
+  # If yes then we don't need to retry until the bandages fall off.
+  def wound_tended?(wound)
+    wound_is_tended = @tended_wounds[wound.body_part]
+    echo "Wound already tended? #{wound_is_tended}, wound = #{wound.inspect}" if $debug_mode_hm
+    wound_is_tended
   end
 
   # If the wound is an easy to tend external bleeder, then tend it.
   # May want this to be configurable, also to attempt to tend
   # more severe wounds based on First Aid skill.
-  def wound_tendable?(wound)
-    return false unless wound
-    tendable = wound.bleeding? && !wound.internal? && DRCH.skilled_to_tend_wound?(wound.severity)
-    echo "Wound tendable? #{tendable} #{wound.inspect}" if $debug_mode_hm
+  def bleeder_tendable?(wound)
+    wound_is_tended = wound_tended?(wound)
+    skilled_to_tend = DRCH.skilled_to_tend_wound?(wound.severity)
+    tendable = !wound_is_tended && wound.bleeding? && !wound.internal? && skilled_to_tend
+    if $debug_mode_hm
+      echo "wound = #{wound.inspect}"
+      echo "wound_needs_tending? #{!wound_is_tended}"
+      echo "wound_is_bleeding? #{wound.bleeding?}"
+      echo "wound_is_external? #{!wound.internal?}"
+      echo "skilled_to_tend? #{skill_to_tend}"
+      echo "bleeder_tendable? #{tendable}"
+    end
     tendable
   end
 
@@ -370,7 +414,7 @@ class HealMe
     else
       echo "Casting spell: #{spell_name}" if $debug_mode_hm
       DRCA.check_discern(@spells[spell_name], @settings) if @spells[spell_name]['use_auto_mana']
-      DRCA.cast_spells({ spell_name: @spells[spell_name] }, @settings)
+      DRCA.cast_spells({ spell_name: @spells[spell_name] }, @settings, @settings.waggle_force_cambrinth, @cast_spell_lambda)
     end
   end
 
@@ -378,6 +422,30 @@ class HealMe
     DRC.message(message) if message
     DRC.message("The spell '#{spell_name}' is neither configured in the 'healing' waggle set nor 'empath_healing:' setting")
     DRC.message("You may need to seek the help from another healer or remedy")
+  end
+
+  def get_spell_name_for_wound(wound)
+    spell_name = wound.scar? ? 'Heal Scars' : 'Heal Wounds'
+  end
+
+  def get_cast_command_for_wound(wound)
+    # Default, the cast command must specify a body part.
+    return 'cast skin' unless wound
+    if should_heal_body_part?(wound)
+      # If an internal wound then focus healing power there,
+      # with any remaining healing power going to the external wound.
+      # If an external wound then the opposite will occur.
+      # Healing power focused on the external wound and any remaining
+      # will be directed to the internal wound.
+      spell_location = wound.internal? ? 'reverse' : ''
+    else
+      # However, if the wound is for a body part the player wants to keep,
+      # which is usually a pet bleeder, then only focus the healing power
+      # on the location for the wound we are given. Often this means
+      # we're healing the internal damage but keeping the external pet bleeder.
+      spell_location = wound.internal? ? 'internal' : 'external'
+    end
+    cast_command = "cast #{wound.body_part} #{spell_location}"
   end
 
   def heal_over_time_spells_active?
@@ -406,6 +474,7 @@ class HealMe
     # because a body part might be fully healed one moment but
     # becomes worse the next due to disease, poison, or other cause.
     @healed_wounds = Hash.new { |h, k| h[k] = false }
+    @tended_wounds = Hash.new { |h, k| h[k] = false }
   end
 
   # Returns true if the argument is nil or empty.

--- a/healme.lic
+++ b/healme.lic
@@ -176,7 +176,7 @@ class HealMe
     # Exclude wounds that are below the threshold.
     should_heal_severity = should_heal_severity?(wound)
     # Exclude wounds for body parts not to heal.
-    should_heal_body_part = should_heal_body_part?(wound)
+    should_heal_body_part = wound.internal? || wound.scar? || should_heal_body_part?(wound)
     # Exclude bleeders that are '(tended)' because
     # they aren't causing immediate loss of vitality
     # and, more technically, once the body part is
@@ -191,7 +191,7 @@ class HealMe
     # If any one of the conditions is false then we'll keep the wound (not heal it).
     should_keep_wound = !(should_heal_severity && should_heal_body_part && should_heal_bleeder)
     if $debug_mode_hm
-      echo "severity = #{wound.severity}, body_part = #{wound.body_part}, bleeding_rate = #{wound.bleeding_rate}"
+      echo "#{wound.inspect}"
       echo "should_heal_severity? = #{should_heal_severity}"
       echo "should_heal_body_part? = #{should_heal_body_part}"
       echo "should_heal_bleeder? = #{should_heal_bleeder}"
@@ -306,7 +306,15 @@ class HealMe
     # If an external wound then the opposite will occur.
     # Healing power focused on the external wound and any remaining
     # will be directed to the internal wound.
-    spell_location = wound.internal? ? 'reverse' : ''
+    # However, if the wound is for a body part the player wants to keep,
+    # which is usually a pet bleeder, then only focus the healing power
+    # on the location for the wound we are given. Often this means
+    # we're healing the internal damage but keeping the external pet bleeder.
+    if should_heal_body_part?(wound)
+      spell_location = wound.internal? ? 'reverse' : ''
+    else
+      spell_location = wound.internal? ? 'internal' : 'external'
+    end
     @spells[spell_name]['cast'] = "cast #{wound.body_part} #{spell_location}"
     cast_spell_or_warn(spell_name)
   end

--- a/healme.lic
+++ b/healme.lic
@@ -380,7 +380,7 @@ class HealMe
   # more severe wounds based on First Aid skill.
   def bleeder_tendable?(wound)
     wound_is_tended = wound_tended?(wound)
-    skilled_to_tend = DRCH.skilled_to_tend_wound?(wound.severity)
+    skilled_to_tend = DRCH.skilled_to_tend_wound?(wound.bleeding_rate)
     tendable = !wound_is_tended && wound.bleeding? && !wound.internal? && skilled_to_tend
     if $debug_mode_hm
       echo "wound = #{wound.inspect}"

--- a/healme.lic
+++ b/healme.lic
@@ -108,8 +108,6 @@ class HealMe
         tend_wounds(self_health['parasites'])
       elsif perc_health['wounds'].length > 0
         heal_wounds(perc_health['wounds'])
-      elsif self_health['wounds'].length > 0
-        heal_wounds(self_health['wounds'])
       elsif health < 100
         heal_vitality
       end
@@ -119,30 +117,19 @@ class HealMe
   # Get wounds inferred from HEALTH command.
   def get_self_health
     echo 'Checking for visible wounds, bleeders, parasites, and lodged items' if $debug_mode_hm
-    self_health = DRCH.check_health
-    # Exclude bleeders that are '(tended)' because
-    # they aren't causing immediate loss of vitality
-    # and, more technically, once the body part is
-    # healed the wound will still be listed in HEALTH
-    # as '(tended)' giving the impression you have a bleeder
-    # when in reality you don't. We have to wait for the
-    # bandages to fall off or removed explicitly in order
-    # to no longer see a bleeder in the HEALTH output.
-    # Without this workaround, the script loops repeatedly
-    # trying to heal a body part that's not injured.
-    self_health['bleeders'].each do |severity, wounds|
-      wounds.select! { |wound| wound.bleeding_rate != '(tended)' }
-    end
-    # Now, remove any keys from the map if no wounds left after filtering.
-    self_health['bleeders'].select! { |severity, wounds| wounds.length > 0 }
-    remove_wounds_to_keep(self_health)
+    health_data = DRCH.check_health
+    remove_wounds_to_keep(health_data['bleeders'])
+    health_data
   end
 
   # Get wounds inferred from PERCEIVE HEALTH SELF.
   def get_perc_health
     return if @settings.permashocked
     echo 'Perceiving internal and external wounds and scars' if $debug_mode_hm
-    remove_wounds_to_keep(DRCH.perceive_health)
+    health_data = DRCH.perceive_health
+    remove_wounds_to_keep(health_data['wounds'])
+    remove_wounds_to_keep(health_data['bleeders'])
+    health_data
   end
 
   # Takes a pulse on vitality then takes action accordingly.
@@ -157,25 +144,41 @@ class HealMe
     end
   end
 
-  # Removes wounds from health data that are
+  # Removes wounds from the wounds map that are
   # either for body parts or severities we want to keep.
-  def remove_wounds_to_keep(health_data)
-    ['wounds', 'bleeders'].each do |type|
-      health_data[type].each { |severity, wounds| wounds.reject! { |wound| should_keep_wound?(wound) } }
-      health_data[type].select! { |severity, wounds| wounds.length > 0 }
-    end
-    health_data
+  # This modifies the map directly.
+  def remove_wounds_to_keep(wounds_map)
+    wounds_map.each { |severity, wounds| wounds.reject! { |wound| should_keep_wound?(wound) } }
+    # Now, remove any keys from the map if no wounds left after filtering.
+    wounds_map.select! { |severity, wounds| wounds.length > 0 }
+    # Return the modified map for convenient api design
+    wounds_map
   end
 
   # Should we keep the wound and NOT heal it?
   def should_keep_wound?(wound)
+    # Exclude wounds that are below the threshold.
     should_heal_severity = should_heal_severity?(wound)
+    # Exclude wounds for body parts not to heal.
     should_heal_body_part = should_heal_body_part?(wound)
-    should_keep_wound = !(should_heal_severity && should_heal_body_part)
+    # Exclude bleeders that are '(tended)' because
+    # they aren't causing immediate loss of vitality
+    # and, more technically, once the body part is
+    # healed the wound will still be listed in HEALTH
+    # as '(tended)' giving the impression you have a bleeder
+    # when in reality you don't. We have to wait for the
+    # bandages to fall off or removed explicitly in order
+    # to no longer see a bleeder in the HEALTH output.
+    # Without this workaround, the script loops repeatedly
+    # trying to heal a body part that's not injured.
+    should_heal_bleeder = wound.bleeding_rate != '(tended)'
+    # If any one of the conditions is false then we'll keep the wound (not heal it).
+    should_keep_wound = !(should_heal_severity && should_heal_body_part && should_heal_bleeder)
     if $debug_mode_hm
-      echo "severity = #{wound.severity}, body_part = #{wound.body_part}"
+      echo "severity = #{wound.severity}, body_part = #{wound.body_part}, bleeding_rate = #{wound.bleeding_rate}"
       echo "should_heal_severity? = #{should_heal_severity}"
       echo "should_heal_body_part? = #{should_heal_body_part}"
+      echo "should_heal_bleeder? = #{should_heal_bleeder}"
       echo "should_keep_wound? = #{should_keep_wound}"
       echo "---"
     end
@@ -200,7 +203,6 @@ class HealMe
   def wounds_to_heal?(observed_health, perceived_health)
     wounds_to_heal = (
       !empty?(perceived_health['wounds']) ||
-      !empty?(observed_health['wounds']) ||
       !empty?(observed_health['bleeders']) ||
       !empty?(observed_health['parasites']) ||
       !empty?(observed_health['lodged']) ||

--- a/healme.lic
+++ b/healme.lic
@@ -21,6 +21,7 @@ class HealMe
     $debug_mode_hm = UserVars.healme_debug || args.debug
     @spells = load_healing_waggle_set
     @body_parts_not_to_heal = args.keep.split(',').map(&:strip) || []
+    @use_heal_over_time_spells = @body_parts_not_to_heal.empty?
     add_health_flags
     heal_self
   end
@@ -137,8 +138,10 @@ class HealMe
   def attend_vitals
     heal_vitality if health < [50, @settings.health_threshold].max
     stop_bleeding if bleeding?
-    cast_regenerate if @spells['Regenerate']
-    cast_heal if @spells['Heal']
+    if @use_heal_over_time_spells
+      cast_regenerate if @spells['Regenerate']
+      cast_heal if @spells['Heal']
+    end
   end
 
   # Returns wounds list without the ones

--- a/healme.lic
+++ b/healme.lic
@@ -139,7 +139,7 @@ class HealMe
       when 'pre-cast'
         if /^(hw|hs)$/i =~ spell_data['abbrev']
           wounds = @health_data['wounds']
-          wounds = wounds.values.flatten.reject { |wound| wound_is_healed?(wound) }
+          wounds = wounds.values.flatten.reject { |wound| wound_healed?(wound) }
           case spell_data['abbrev'].downcase
           when 'hw'
             wound = wounds.find { |wound| !wound.scar? }

--- a/healme.lic
+++ b/healme.lic
@@ -161,25 +161,25 @@ class HealMe
   # either for body parts or severities we want to keep.
   def remove_wounds_to_keep(health_data)
     ['wounds', 'bleeders'].each do |type|
-      health_data[type].each { |severity, wounds| wounds.reject! { |wound| wound_to_keep?(wound) } }
+      health_data[type].each { |severity, wounds| wounds.reject! { |wound| should_keep_wound?(wound) } }
       health_data[type].select! { |severity, wounds| wounds.length > 0 }
     end
     health_data
   end
 
   # Should we keep the wound and NOT heal it?
-  def wound_to_keep?(wound)
+  def should_keep_wound?(wound)
     should_heal_severity = should_heal_severity?(wound)
     should_heal_body_part = should_heal_body_part?(wound)
-    wound_to_keep = !(should_heal_severity && should_heal_body_part)
+    should_keep_wound = !(should_heal_severity && should_heal_body_part)
     if $debug_mode_hm
       echo "severity = #{wound.severity}, body_part = #{wound.body_part}"
       echo "should_heal_severity? = #{should_heal_severity}"
       echo "should_heal_body_part? = #{should_heal_body_part}"
-      echo "wound_to_keep? = #{wound_to_keep}"
+      echo "should_keep_wound? = #{should_keep_wound}"
       echo "---"
     end
-    wound_to_keep
+    should_keep_wound
   end
 
   # Is the wound's severity greater than the threshold to keep?

--- a/healme.lic
+++ b/healme.lic
@@ -34,9 +34,36 @@ class HealMe
     @wound_severity_threshold = args.severity.to_i || 0
     echo "wound_severity_threshold = #{@wound_severity_threshold}" if $debug_mode_hm
 
-    add_health_flags
-
+    reset_health_flags
+    register_wounds_healed_hook
     heal_self
+  end
+
+  def register_wounds_healed_hook
+    wounds_healed_hook = lambda do |server_string|
+      # Do regex then look for the wound location, type, and body part matches.
+      if server_string =~ /The (?<location>internal|external) (?<type>wounds|scars) (?:on|to) your (?<parts>.*) (?:are fully healed|appear completely healed)/
+        body_parts = Regexp.last_match[:parts].to_s
+        wound_location = Regexp.last_match[:location].to_s
+        wound_type = Regexp.last_match[:type].to_s
+        echo "Detected fully healed wounds: body_parts=#{body_parts}, wound_location=#{wound_location}, wound_type=#{wound_type}" if $debug_mode_hm
+        # One or more body parts may have been fully healed.
+        # Split the string to identify each one.
+        body_parts
+          .gsub(' and ', ' , ')
+          .split(',')
+          .map { |value| value.strip.downcase }
+          .each do |body_part|
+            composite_key = build_wound_composite_key(body_part, wound_location, wound_type)
+            @healed_wounds[composite_key] = true
+            echo "@healed_wounds[#{composite_key}] = #{@healed_wounds[composite_key]}" if $debug_mode_hm
+          end
+      end
+      server_string
+    end
+
+    DownstreamHook.remove('wounds_healed_hook')
+    DownstreamHook.add('wounds_healed_hook', wounds_healed_hook)
   end
 
   # The original version of the 'healme' script used
@@ -250,29 +277,6 @@ class HealMe
   # and the values are a list of wounds. So this only heals the wounds
   # for the map key that is the highest severity at the time.
   def heal_wounds(wounds_by_severity)
-    # While iterating the wounds to heal,
-    # track if any body parts become completely healed
-    # so that we can avoid unnecessary spell casting.
-    # For example, a cast to heal an external chest wound
-    # could spill over and fully heal the internal wound, too.
-    # If the internal chest wound is in the wounds-to-heal list
-    # we'll waste time/mana overhealing an already healed wound.
-    # This is designed to only optimize healing the list of wounds
-    # given to this method with the understanding that your
-    # health and any remaining wounds will be re-assesed
-    # in the loop that called 'heal_wounds' to begin with.
-    # Also means that if some other cause reintroduces a wound
-    # then we won't mistakenly consider it still healed.
-    healed_body_parts = {
-      'internal' => {
-        'wounds' => [],
-        'scars' => []
-      },
-      'external' => {
-        'wounds' => [],
-        'scars' => []
-      }
-    }
     # Convert map of "severity" => array_of_wounds to a list of wounds sorted by most severe first.
     wounds = wounds_by_severity.sort_by { |severity, wounds| severity }.reverse.map { |arr| arr[1] }.flatten
     return if wounds.empty?
@@ -292,8 +296,10 @@ class HealMe
       wound_type = wound.scar? ? 'scars' : 'wounds'
       # Before we try to heal a wound, check if it's already been healed, either
       # from a previous, potent cast or from heal over time spells like Heal or Regenerate.
-      ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| healed_body_parts[x][y] << wound.body_part if Flags["hm-#{x}-#{y}-healed"] } }
-      next if healed_body_parts[wound_location][wound_type].include?(wound.body_part)
+      composite_key = build_wound_composite_key(wound.body_part, wound_location, wound_type)
+      wound_is_healed = @healed_wounds[composite_key]
+      echo "wound_is_healed = #{wound_is_healed}, composite_key = #{composite_key}" if $debug_mode_hm
+      next if wound_is_healed
       heal_wound(wound)
       attend_vitals
     end
@@ -381,12 +387,28 @@ class HealMe
     ['Heal', 'Regenerate'].any? { |spell_name| DRSpells.active_spells[spell_name] }
   end
 
-  def add_health_flags
-    ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.add("hm-#{x}-#{y}-healed", "The #{x} #{y} on your (.+) appear completely healed") } }
+  # Generate a key for use with @healed_wounds map.
+  def build_wound_composite_key(body_part, wound_location, wound_type)
+    "#{body_part}|#{wound_location}|#{wound_type}".downcase
   end
 
   def reset_health_flags
-    ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.reset("hm-#{x}-#{y}-healed") } }
+    # Track when a wound becomes fully healed.
+    # When 'heal over time' spells or herbs are in effect
+    # then a wound might become fully healed while
+    # you're preparing HW/HS spell, which will lead
+    # to a wasted cast on a now non-injury. Knowing
+    # if we're about to do this allows us to dynamically
+    # change which body part to cast HW/HS on at cast time.
+    #
+    # The keys in the map are in format '<body_part>|<wound_location>|<wound_type>'
+    # such as 'head|external|scar' or 'left arm|internal|wound'.
+    # A true value means that wound is fully healed, don't waste a HW/HS on it.
+    #
+    # This map gets re-created each time we perceive our health
+    # because a body part might be fully healed one moment but
+    # becomes worse the next due to disease, poison, or other cause.
+    @healed_wounds = Hash.new { |h, k| h[k] = false }
   end
 
   # Returns true if the argument is nil or empty.
@@ -396,7 +418,7 @@ class HealMe
 end
 
 before_dying do
-  ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.delete("hm-#{x}-#{y}-healed") } }
+  DownstreamHook.remove('wounds_healed_hook')
 end
 
 HealMe.new

--- a/healme.lic
+++ b/healme.lic
@@ -34,7 +34,7 @@ class HealMe
   # Returns the spell data in a waggle format, regardless the configuration used.
   def load_healing_waggle_set
     waggle_set = @settings.waggle_sets['healing']
-    if empty?(waggle_set) || empty?(@settings.empath_healing)
+    if empty?(waggle_set) && empty?(@settings.empath_healing)
       DRC.message("Neither waggle set 'healing' nor setting 'empath_healing:' are configured")
       DRC.message("See https://elanthipedia.play.net/Lich_script_development#healme")
       exit

--- a/healme.lic
+++ b/healme.lic
@@ -127,9 +127,13 @@ class HealMe
       wound = nil
       case phase
       when 'post-prep'
-        wounds = @health_data['bleeders'].values.flatten.select { |wound| bleeder_tendable?(wound) }
-        wounds = wounds + @health_data['parasites'] + @health_data['lodged']
-        wounds = wounds.values.flatten.reject { |wound| wound_tended?(wound) }
+        wounds = (
+            @health_data['bleeders'].values.flatten +
+            @health_data['parasites'].values.flatten +
+            @health_data['lodged'].values.flatten
+          )
+          .reject { |wound| wound_tended?(wound) }
+          .select { |wound| !wound.bleeding? || bleeder_tendable?(wound) }
         wound = wounds.first
         tend_wound(wound)
       when 'pre-cast'

--- a/healme.lic
+++ b/healme.lic
@@ -2,13 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#healme
 =end
 
-# ***BEGIN USER CONFIG***
-
-UserVars.healme_debug ||= false # turn on echos in the script
-
-# ***END USER CONFIG***
-
-custom_require.call(%w[common common-arcana common-healing events])
+custom_require.call(%w[common common-arcana common-healing events spellmonitor])
 
 class HealMe
   include DRC
@@ -16,184 +10,312 @@ class HealMe
   include DRCH
 
   def initialize
-    @deadly_wounds = %w[SKIN HEAD NECK CHEST ABDOMEN BACK]
     @settings = get_settings
-
     arg_definitions = [
       [
-        { name: 'bleeders', regex: /^[\w\s,]+$/i, variable: true, optional: true, description: 'comma separated list of bleeders to keep. "right arm, chest, back"' }
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug output' },
+        { name: 'keep', regex: /^[\w\s,]+$/i, variable: true, optional: true, description: 'Comma separated list of wounds to keep. Example: "right arm, chest, back"' }
       ]
     ]
-
     args = parse_args(arg_definitions)
-    @using_waggle = false
-
-    heal_self(args.bleeders)
+    $debug_mode_hm = UserVars.healme_debug || args.debug
+    @spells = load_healing_waggle_set
+    @body_parts_not_to_heal = args.keep.split(',').map(&:strip) || []
+    ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.add("hm-#{x}-#{y}-healed", "The #{x} #{y} on your (.+) appear completely healed") } }
+    heal_self
   end
 
-  def severity(wounds)
-    wounds.map { |wound| wound['level'] }.inject(&:+)
-  end
-
-  def spam_heal(base, camb)
-    loop do
-      unless DRSpells.active_spells['Heal']
-        pause 1 while mana < 25
-        prepare?('heal', base)
-        charge_and_invoke(@settings.cambrinth, @settings.dedicated_camb_use, camb, @settings.cambrinth_invoke_exact_amount) unless camb.empty?
-        waitcastrt?
-        cast?
-        pause 0.5
-      end
-      case bput('perceive health self', '...no injuries to speak of', 'Roundtime')
-      when '...no injuries to speak of'
-        break
-      else
-        pause 1
-        end
-      pause 21
+  # The original version of the 'healme' script used
+  # the 'empath_healing:' setting to configure the spells to cast.
+  # Later, the script added support for waggle sets.
+  # This method checks for how the player has specified their
+  # healing spells, using the waggle set by default if defined.
+  # Returns the spell data in a waggle format, regardless the configuration used.
+  def load_healing_waggle_set
+    waggle_set = @settings.waggle_sets['healing']
+    if empty?(waggle_set) || empty?(@settings.empath_healing)
+      DRC.message("Neither waggle set 'healing' nor setting 'empath_healing:' are configured")
+      DRC.message("See https://elanthipedia.play.net/Lich_script_development#healme")
+      exit
     end
-  end
-
-  def cast_spell(spell, preps, part, internal = false)
-    pause 1 while mana < 25
-    prepare?(spell, preps.first)
-    charge_and_invoke(@settings.cambrinth, @settings.dedicated_camb_use, preps[1..-1], @settings.cambrinth_invoke_exact_amount) unless preps[1..-1].empty?
-    waitcastrt?
-    Flags.reset('hm-partial-heal')
-    cast?("cast #{part} #{internal ? 'internal' : ''}")
-    pause 0.5
-    echo "partial: #{Flags['hm-partial-heal']}" if UserVars.healme_debug
-    Flags['hm-partial-heal']
-  end
-
-  def heal_wound(spells, part, internal)
-    if @using_waggle
-      spells['Heal Wounds']['cast'] = "cast #{part}"
-      spells['Heal Wounds']['cast'] = "cast #{part} internal" if internal
-      check_discern(spells['Heal Wounds'], @settings) if spells['Heal Wounds']['use_auto_mana']
-      loop do
-        Flags.reset('hm-partial-heal')
-        DRCA.cast_spell(spells['Heal Wounds'], @settings, true)
-        echo "partial: #{Flags['hm-partial-heal']}" if UserVars.healme_debug
-        break unless Flags['hm-partial-heal']
-      end
+    if waggle_set
+      echo "Using 'healing' waggle set to define healing spells" if $debug_mode_hm
     else
-      pause 0.5 while cast_spell('HW', @settings.empath_healing['HW'], part, internal)
-    end
-  end
-
-  def heal_scar(spells, part)
-    if @using_waggle
-      spells['Heal Scars']['cast'] = "cast #{part}"
-      check_discern(spells['Heal Scars'], @settings) if spells['Heal Scars']['use_auto_mana']
-      loop do
-        Flags.reset('hm-partial-heal')
-        DRCA.cast_spell(spells['Heal Scars'], @settings, true)
-        echo "partial: #{Flags['hm-partial-heal']}" if UserVars.healme_debug
-        break unless Flags['hm-partial-heal']
+      echo "Using empath_healing setting to define healing spells" if $debug_mode_hm
+      # The 'empath_healing' setting is a map where the keys are spell abbreviations
+      # and the values are a list of mana to use.
+      # For example, definition for Heal Wounds spell with prep of 5 and cambrinth of 10:
+      #   empath_healing:
+      #     'HW':
+      #     - 5
+      #     - 10
+      waggle_set = {}
+      spell_data = get_data('spells')['spell_data']
+      @settings.empath_healing.each do |abbrev, manas|
+        spells = spell_data.select { |name, data| data['abbrev'].downcase == abbrev.downcase }
+        name, data = spells.to_a.first.dup
+        # Modify the base spell data with the user's config.
+        # The first value in the manas list is the prep, rest are for cambrinth.
+        data['mana'] = manas.first if manas.length > 0
+        data['cambrinth'] = manas[1..-1] if manas.length > 1
+        waggle_set[name] = data
       end
-    else
-      pause 0.5 while cast_spell('HS', @settings.empath_healing['HS'], part)
     end
+    echo "Healing spells: #{waggle_set}" if $debug_mode_hm
+    waggle_set
   end
 
-  def heal_wounds(spells, wounds, skip_parts)
-    echo "healing: #{wounds}" if UserVars.healme_debug
-
-    return if skip_parts.include?(wounds.first['part']) && wounds.size == 1
-
-    if wounds.count { |wound| wound['type'] == 'Fresh' } > 0
-      heal_wound(spells, wounds.first['part'], skip_parts.include?(wounds.first['part']))
-    end
-    heal_scar(spells, wounds.first['part'])
-  end
-
-  def cure_disease(spells, health)
-    return unless health['diseased']
-    return unless spells['Cure Disease']
-    Flags.add('hm-disease', 'You feel completely cured of all disease', 'you don.t seem to be so afflicted')
+  # This method triages your wounds and heals the most severe first.
+  # After a round of healing, it rechecks your wounds to determine
+  # which are now the most severe, and then heals them. In this manner,
+  # you're always trying to heal the most severe wounds in the moment.
+  def heal_self
     loop do
-      if Flags['hm-disease']
-        Flags.delete('hm-disease')
-        return
-      else
-        unless DRSpells.active_spells['Cure Disease']
-          DRCA.cast_spell(spells['Cure Disease'], @settings, true)
-        end
+      echo 'Checking health' if $debug_mode_hm
+      # Using these variable names to not conflict with
+      # implicit 'health' variable that tells your vitality.
+      self_health = get_self_health
+      perc_health = get_perc_health
+      break unless wounds_to_heal?(self_health, perc_health)
+      attend_vitals
+      flush_poisons if self_health['poisoned']
+      cure_diseases if self_health['diseased']
+      # Address the most severe wounds for a given category each loop iteration.
+      # This heals the most severe bleeders first, then restarts the loop.
+      # If there are more bleeders, it heals the next severity level, then restarts the loop.
+      # This continues until no more bleeders and then it begins to triage the next wound types.
+      # This ensures minor scratches aren't attended to before bleeders, lodged items, parasites, etc.
+      if self_health['bleeders'].length > 0
+        heal_wounds(self_health['bleeders'])
+      elsif self_health['lodged'].length > 0
+        tend_wounds(self_health['lodged'])
+      elsif self_health['parasites'].length > 0
+        tend_wounds(self_health['parasites'])
+      elsif perc_health['wounds'].length > 0
+        heal_wounds(perc_health['wounds'])
+      elsif self_health['wounds'].length > 0
+        heal_wounds(self_health['wounds'])
+      elsif health < 100
+        heal_vitality
       end
     end
   end
 
-  def flush_poisons(spells, health)
-    return unless health['poisoned']
-    return unless spells['Flush Poisons']
-    Flags.add('hm-poison', '^A sudden wave of heat washes over you as your spell attempts to flush poison from your body but finds no toxins', '^A sudden wave of heat washes over you as your spell flushes all poison from your body')
-    loop do
-      if Flags['hm-poison']
-        Flags.delete('hm-poison')
-        return
-      else
-        unless DRSpells.active_spells['Flush Poisons']
-          DRCA.cast_spell(spells['Flush Poisons'], @settings, true)
-        end
+  # Get wounds inferred from HEALTH command.
+  def get_self_health
+    echo 'Checking for visible wounds, bleeders, parasites, and lodged items' if $debug_mode_hm
+    self_health = DRCH.check_health
+    # Exclude bleeders that are '(tended)' because
+    # they aren't causing immediate loss of vitality
+    # and, more technically, once the body part is
+    # healed the wound will still be listed in HEALTH
+    # as '(tended)' giving the impression you have a bleeder
+    # when in reality you don't. We have to wait for the
+    # bandages to fall off or removed explicitly in order
+    # to no longer see a bleeder in the HEALTH output.
+    # Without this workaround, the script loops repeatedly
+    # trying to heal a body part that's not injured.
+    self_health['bleeders'].each do |severity, wounds|
+      wounds.select! { |wound| wound.bleeding_rate != '(tended)' }
+    end
+    # Now, remove any keys from the map if no wounds left after filtering.
+    self_health['bleeders'].select! { |severity, wounds| wounds.length > 0 }
+    remove_wounds_to_keep(self_health)
+  end
+
+  # Get wounds inferred from PERCEIVE HEALTH SELF.
+  def get_perc_health
+    return if @settings.permashocked
+    echo 'Perceiving internal and external wounds and scars' if $debug_mode_hm
+    remove_wounds_to_keep(DRCH.perceive_health)
+  end
+
+  # Takes a pulse on vitality then takes action accordingly.
+  # Designed to be called frequently so that low vitality
+  # and bleeding can be addressed immediately.
+  def attend_vitals
+    heal_vitality if health < [50, @settings.health_threshold].max
+    stop_bleeding if bleeding?
+    regenerate if @spells['Regenerate']
+  end
+
+  # Returns wounds list without the ones
+  # that are for body parts we want to keep.
+  def remove_wounds_to_keep(wounds)
+    echo "All wounds: #{wounds}" if $debug_mode_hm
+    echo "Wounds to keep: #{@body_parts_not_to_heal}" if $debug_mode_hm
+    wounds = wounds.select do |wound|
+      !@body_parts_not_to_heal.any? do |body_part|
+        body_part.downcase == wound.body_part.downcase
       end
+    end
+    echo "Wounds to heal: #{wounds}" if $debug_mode_hm
+    wounds
+  end
+
+  # Determines if there are any wounds, poisons, etc to heal.
+  def wounds_to_heal?(observed_health, perceived_health)
+    wounds_to_heal = (
+      !empty?(perceived_health['wounds']) ||
+      !empty?(observed_health['wounds']) ||
+      !empty?(observed_health['bleeders']) ||
+      !empty?(observed_health['parasites']) ||
+      !empty?(observed_health['lodged']) ||
+      observed_health['poisoned'] ||
+      observed_health['diseased'] ||
+      health < 100
+    )
+    echo "Wounds to heal? #{wounds_to_heal}" if $debug_mode_hm
+    wounds_to_heal
+  end
+
+  # If your 'healing' waggle set contains 'Vitality Healing' spell
+  # then casts it to try and restore vitality.
+  def heal_vitality
+    cast_spell_or_warn('Vitality Healing', "You're vitality is low!")
+  end
+
+  # If your 'healing' waggle set contains 'Flush Poisons' spell
+  # then casts it to try and remove poisons.
+  def flush_poisons
+    cast_spell_or_warn('Flush Poisons', "You're poisoned!")
+  end
+
+  # If your 'healing' waggle set contains 'Cure Disease' spell
+  # then casts it to try and cure diseases.
+  def cure_diseases
+    cast_spell_or_warn('Cure Disease', "You're diseased!")
+  end
+
+  # If your 'healing' waggle set contains 'Regenerate' spell
+  # then casts it to boost your healing rate.
+  def regenerate
+    cast_spell('Regenerate')
+  end
+
+  # Heal all the wounds of the highest severity, then returns
+  # so that the main healing loop can triage the next wounds to heal.
+  # The 'wounds' argument is a map whose keys are severity numbers (1,2,3...)
+  # and the values are a list of wounds. So this only heals the wounds
+  # for the map key that is the highest severity at the time.
+  def heal_wounds(wounds)
+    # While iterating the wounds to heal,
+    # track if any body parts become completely healed
+    # so that we can avoid unnecessary spell casting.
+    # For example, a cast to heal an external chest wound
+    # could spill over and fully heal the internal wound, too.
+    # If the internal chest wound is in the wounds-to-heal list
+    # we'll waste time/mana overhealing an already healed wound.
+    # This is designed to only optimize healing the list of wounds
+    # given to this method with the understanding that your
+    # health and any remaining wounds will be re-assesed
+    # in the loop that called 'heal_wounds' to begin with.
+    # Also means that if some other cause reintroduces a wound
+    # then we won't mistakenly consider it still healed.
+    healed_body_parts = {
+      'internal' => {
+        'wounds' => [],
+        'scars' => []
+      },
+      'external' => {
+        'wounds' => [],
+        'scars' => []
+      }
+    }
+    wounds.sort_by { |severity, wounds| severity }.reverse.first[1].each do |wound|
+      wound_location = wound.internal? ? 'internal' : 'external'
+      wound_type = wound.scar? ? 'scars' : 'wounds'
+      next if healed_body_parts[wound_location][wound_type].include?(wound.body_part)
+      ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.reset("hm-#{x}-#{y}-healed") } }
+      heal_wound(wound)
+      ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| healed_body_parts[x][y] << wound.body_part if Flags["hm-#{x}-#{y}-healed"] } }
+      attend_vitals
     end
   end
 
-  def heal_self(skip_parts)
-    return unless DRStats.empath?
+  # Casts either Heal Wounds or Heal Scars for the given wound.
+  # If it's an internal wound then casts <spell> reverse.
+  def heal_wound(wound)
+    echo "Healing wound: #{wound.inspect}" if $debug_mode_hm
+    stop_bleeding(wound) if wound.bleeding?
+    spell_name = wound.scar? ? 'Heal Scars' : 'Heal Wounds'
+    # If an internal wound then focus healing power there,
+    # with any remaining healing power going to the external wound.
+    # If an external wound then the opposite will occur.
+    # Healing power focused on the external wound and any remaining
+    # will be directed to the internal wound.
+    spell_location = wound.internal? ? 'reverse' : ''
+    @spells[spell_name]['cast'] = "cast #{wound.body_part} #{spell_location}"
+    cast_spell_or_warn(spell_name)
+  end
 
-    Flags.delete('hm-partial-heal')
-    Flags.add('hm-partial-heal',
-              'appear very slightly improved\.',
-              'appear slightly improved\.',
-              'appear better\.',
-              'appear greatly improved\.',
-              'appear almost completely healed\.',
-              'but it is ineffective\.',
-              'appear somewhat better\.',
-              'appear considerably better\.')
+  # Similar to 'heal_wounds' except instead of casting a spell on the wound
+  # this method tends the wound to remove parasites or lodged items.
+  # This method is not intended for bleeders, use `heal_wound` method for those.
+  def tend_wounds(wounds)
+    wounds.sort_by { |severity, wounds| severity }.reverse.first[1].each do |wound|
+      tend_wound(wound)
+      attend_vitals
+    end
+  end
 
-    wounds = check_perc_health
-    return if wounds.empty?
+  def tend_wound(wound)
+    echo "Tending wound: #{wound.inspect}" if $debug_mode_hm
+    DRCH.bind_wound(wound.body_part)
+  end
 
-    spells = if @settings.waggle_sets['healing']
-               @using_waggle = true
-               @settings.waggle_sets['healing']
-             else
-               @settings.empath_healing
-             end
-    find_cambrinth(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap)
-    health = check_health
-    cure_disease(spells, health)
-    flush_poisons(spells, health)
+  # If your 'healing' waggle set contains 'Blood Staunching' spell
+  # then casts it to stop blood loss.
+  # If given a wound that is a simple enough bleeder, tends it, too.
+  def stop_bleeding(wound = nil)
+    DRCH.bind_wound(wound.body_part) if wound_tendable?(wound)
+    cast_spell_or_warn('Blood Staunching', "You're bleeding!") if bleeding?
+  end
 
-    DRCA.cast_spell(spells['Regenerate'], @settings) if spells['Regenerate'] && !DRSpells.active_spells.include?('Regenerate')
+  # If the wound is an easy to tend external bleeder, then tend it.
+  # May want this to be configurable, also to attempt to tend
+  # more severe wounds based on First Aid skill.
+  def wound_tendable?(wound)
+    return false unless wound
+    tendable = wound.bleeding? && !wound.internal? && DRCH.skilled_to_tend_wound?(wound.severity)
+    echo "Wound tendable? #{tendable} #{wound.inspect}" if $debug_mode_hm
+    tendable
+  end
 
-    if spells['Heal'] && @using_waggle && skip_parts.nil?
-      spam_heal(@settings.waggle_sets['healing']['Heal']['mana'], @settings.waggle_sets['healing']['Heal']['cambrinth'])
-    elsif @settings.empath_healing['HEAL'] && skip_parts.nil?
-      spam_heal(@settings.empath_healing['HEAL'].first, @settings.empath_healing['HEAL'][1..-1])
+  # If the spell is configured in your 'healing' waggle set then casts it.
+  # Otherwise displays a warning message that you're wounded without ability to heal it.
+  def cast_spell_or_warn(spell_name, message = nil)
+    if @spells[spell_name]
+      cast_spell(spell_name)
     else
-
-      skip_parts = skip_parts.split(',').map(&:upcase).map(&:strip)
-
-      echo("skip: #{skip_parts}") if UserVars.healme_debug
-      echo("wounds: #{wounds}") if UserVars.healme_debug
-      echo("dw: #{@deadly_wounds}") if UserVars.healme_debug
-      danger_wounds = wounds.select { |part, _| @deadly_wounds.include?(part) }.sort_by { |_, val| severity(val) }.reverse
-
-      echo("bad wounds: #{danger_wounds}") if UserVars.healme_debug
-
-      danger_wounds.each do |(part, _)|
-        heal_wounds(spells, wounds[part], skip_parts)
-        wounds.delete(part)
-      end
-
-      wounds.sort_by { |_, val| severity(val) }.reverse_each { |_, wound| heal_wounds(spells, wound, skip_parts) }
+      warn_no_spell(spell_name, message)
     end
-    stow_cambrinth(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap)
+  end
+
+  def cast_spell(spell_name)
+    if DRSpells.active_spells[spell_name]
+      echo "Skipping casting spell #{spell_name} because already active" if $debug_mode_hm
+    else
+      echo "Casting spell: #{spell_name}" if $debug_mode_hm
+      DRCA.check_discern(@spells[spell_name], @settings) if @spells[spell_name]['use_auto_mana']
+      DRCA.cast_spells({ spell_name: @spells[spell_name] }, @settings)
+    end
+  end
+
+  def warn_no_spell(spell_name, message = nil)
+    DRC.message(message) if message
+    DRC.message("The spell '#{spell_name}' is neither configured in the 'healing' waggle set nor 'empath_healing:' setting")
+    DRC.message("You may need to seek the help from another healer or remedy")
+  end
+
+  # Returns true if the argument is nil or empty.
+  def empty?(x)
+    x.nil? || x.empty?
   end
 end
+
+before_dying do
+  ['internal', 'external'].each { |x| ['wounds', 'scars'].each { |y| Flags.delete("hm-#{x}-#{y}-healed") } }
+end
+
 HealMe.new

--- a/healme.lic
+++ b/healme.lic
@@ -187,10 +187,6 @@ class HealMe
     health_data = DRCH.perceive_health
     remove_wounds_to_keep(health_data['wounds'])
     remove_wounds_to_keep(health_data['bleeders'])
-
-    echo health_data['bleeders'].values.flatten.select { |wound| bleeder_tendable?(wound) }
-    exit
-
     health_data
   end
 

--- a/healme.lic
+++ b/healme.lic
@@ -135,7 +135,7 @@ class HealMe
           .reject { |wound| wound_tended?(wound) }
           .select { |wound| !wound.bleeding? || bleeder_tendable?(wound) }
         wound = wounds.first
-        tend_wound(wound)
+        tend_wound(wound) if wound
       when 'pre-cast'
         if /^(hw|hs)$/i =~ spell_data['abbrev']
           wounds = @health_data['wounds']

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -11,6 +11,7 @@ empty_values:
   necromancer_healing: {}
   zombie: {}
   empath_healing: {}
+  healme: {}
   storage_containers: []
   summoned_weapons: []
   stances: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -910,8 +910,44 @@ sale_pouches_container: backpack
 storage_containers:
 gear:
 gear_sets:
-# Spell list healme uses to heal if you don't have a waggle set defined for it.
+
+# Spell list that combat-trainer uses to heal you in combat.
+# Spell list that healme script uses to heal you if you don't have a 'healing' waggle set.
+# The keys are the spell abbreviations.
+# The values per key are a list of mana to use.
+# The first mana number is the prep amount.
+# The remaining numbers are cambrinth amounts (optional).
+# An example configuration for casting Heal Wounds is commented out below.
 empath_healing:
+#   'HW':     # Heal Wounds
+#   - 1       # prep amount
+#   - 5       # 1st cambrinth amount
+#   - 5       # 2nd cambrinth amount
+
+# healme script specific settings for empaths.
+# Highly recommend that you define a 'healing' waggle set
+# for maximum control over how you cast your healing spells.
+# If no 'healing' waggle set is defined then healme script
+# will use 'empath_healing:' settings as backup.
+healme:
+  # Toggle debug mode. Can also use `debug` script argument.
+  # Default is false.
+  debug: false
+  # Wound severities below this threshold will be ignored.
+  # Range is 0 to 13 based on 'perceive health self'.
+  # If you have HEAL or REGENERATE, then you may choose
+  # to set a low threshold (1 or 2) since those can be healed over time
+  # rather than waiting for the script to heal them all in one sitting.
+  # Default is 0.
+  severity_threshold: 1
+  # When waiting for a spell to be prepared and if you have wounds to tend,
+  # such as bleeders or lodged ammo or parasites, then this is the max
+  # number of those wounds to tend before casting to be efficient.
+  # Even if you set this to 0, healme script will tend wounds just not
+  # between preparing and casting a spell.
+  # Default is 1.
+  max_wounds_to_tend_while_prep_spells: 1
+
 # Uses a scoring based system to determine when to go get healed after combat, 0 means always. 10 is 10 minor abraisions or 5 tiny scratches, etc
 # Run ;en echo DRCH.check_health to see your current wound value
 saferoom_health_threshold: 7


### PR DESCRIPTION
### Dependencies
* ~Depends on https://github.com/rpherbig/dr-scripts/pull/4793~
* ~Depends on https://github.com/rpherbig/dr-scripts/pull/4794~

### Background
* Continuation of https://github.com/rpherbig/dr-scripts/pull/4659 and https://github.com/rpherbig/dr-scripts/pull/4664
* `healme` is a script designed for Empaths to heal themselves.
* The current version of the script heals wounds, one body part at a time to completion then heals the next wound.
  - ⚠️ Issue: you may spend time healing a less severe wound when more severe wounds could be triaged.
* The current version of the script does not check your vitality or try to stop bleeding.
  - ⚠️ Issue: you may die from preventable vitality loss, mitigateable by Blood Staunching (if known) or tending the wound (with sufficient skill) or simply prioritizing bleeding wounds over non life-threatening ones.
* The current version of the script does not always focus the cast of Heal Wounds or Heal Scars on "internal" unless it's a body part that should not be healed according to the `bleeders` runtime argument passed in to the script.
  - ⚠️ Issue: you may waste healing potential of a spell by using the brunt of its power on less severe wounds.

### Changes
* `common-healing` provides more detailed information about wounds beyond severity and body part, including if it's internal/external, fresh/scar, or bleeding.
  - ✅  This enables scripts to better triage healing and focus the casting of Heal Wounds vs. Heal Scars and whether to cast on external or internal body part.
* `DRCH.check_health` provides two new properties in its return value: **bleeders** and **lodged**.
  - ✅  This enables scripts to better triage healing and focus on vitality-loss causing wounds first, as well as remove lodged items such as arrows or crossbow bolts that not only cause periodic vitality loss but also worsen wounds to make bleeding more severe.
 * `healme` triages healing based on the new detailed information from `common-healing`.
   - ✅  Heals wounds in this order: poisons, diseases, bleeders, lodged items, parasites, all other wounds.
   - ✅  Casts Heal Wounds or Heal Scars depending on the wound type; and casts "internal" if that is the most severe area.
 * `healme` actively mitigates vitality loss.
   - ✅  Prevents vitality loss by casting Blood Staunching if your 'healing' waggle lists the spell and you're bleeding.
   - ✅  Restores vitality by casting Vitality Healing if your 'healing' waggle lists the spell and you're low on health.
   - ✅  Speeds up healing by casting Regenerate if your 'healing' waggle lists the spell and it's not active.
   - ✅  Speeds up healing by casting Heal if your 'healing' waggle lists the spell and it's not active.
 * `healme` will try to tend bleeding wounds if its within your skill level.
   - ✅  This mitigates vitality loss, especially if you don't know Blood Staunching yet or if it takes multiple casts of Heal Wounds to reduce the wound to be a non-bleeder. You also might learn a little First Aid in the process, although that's an unintended benefit.
 * `healme` always focuses on the most severe wounds.
   - ✅  At any time, if there is a more severe wound then it will be addressed.
   - ✅  Time and mana is not wasted on healing tiny scratches if you're bleeding or have more severe wound elsewhere.
   - ✅  Continuously rechecks your health to triage the next severe set of wounds to heal. This catches if poison or a lodged item cause a wound to get worse, or if bandages become untended, etc.
   - ✅  If you need to stop the script early, rest easy knowing that across the body the severity of the worst wounds has been reduced. This can help you get back in the field to heal patients because rather than having one fully healed left arm but a completely useless right arm, you could have two somewhat damaged arms and able to take wounds from both body parts again, which is even more helpful if you don't have the ability to redirect wounds.
 
### Example Config
As an Empath, define a **healing** waggle set with how you'd like to cast these spells, if you know them:
```yaml
waggle_sets:
  healing:                   # waggle name        
    # Required spells
    Heal Wounds:             # cast to heal wounds
      use_auto_mana: true
    Heal Scars:              # cast to heal scars
      use_auto_mana: true
    # Important spells (optional)
    Blood Staunching:        # cast when bleeding
      use_auto_mana: true
    Vitality Healing:        # cast when low on vitality
      use_auto_mana: true
    # Niche spells (optional)
    Flush Poisons:           # cast if you're poisoned
      use_auto_mana: true
    Cure Disease:            # cast if you're diseased
      use_auto_mana: true
    # Helpful spells (optional)
    Heal:                    # cast if not active
      use_auto_mana: true
    Regenerate:              # cast if not active
      use_auto_mana: true

# healme script specific settings for empaths.
# Highly recommend that you define a 'healing' waggle set
# for maximum control over how you cast your healing spells.
# If no 'healing' waggle set is defined then healme script
# will use 'empath_healing:' settings as backup.
healme:
  # Toggle debug mode. Can also use `debug` script argument.
  # Default is false.
  debug: false
  # Wound severities below this threshold will be ignored.
  # Range is 0 to 13 based on 'perceive health self'.
  # If you have HEAL or REGENERATE, then you may choose
  # to set a low threshold (1 or 2) since those can be healed over time
  # rather than waiting for the script to heal them all in one sitting.
  # Default is 0.
  severity_threshold: 1
  # When waiting for a spell to be prepared and if you have wounds to tend,
  # such as bleeders or lodged ammo or parasites, then this is the max
  # number of those wounds to tend before casting to be efficient.
  # Even if you set this to 0, healme script will tend wounds just not
  # between preparing and casting a spell.
  # Default is 1.
  max_wounds_to_tend_while_prep_spells: 1
```

Also backwards compatible with `empath_healing` setting which defined a spell abbreviation and the prep and cambrinth amounts:
```yaml
# The keys are the spell abbreviations.
# The values per key are a list of mana to use.
# The first mana number is the prep amount.
# The remaining numbers are cambrinth amounts.
empath_healing:
  'HW':     # Heal Wounds
  - 10
  - 5
  'HS':     # Heal Scars
  - 10
  - 5
  'BS':     # Blood Staunching
  - 10
  - 5
  'VH':     # Vitality Healing
  - 10
  - 5
  'CD':     # Cure Disease
  - 15
  - 5
  'FP':     # Flush Poisons
  - 15
  - 5
  'HEAL':   # Heal
  - 15
  - 5
```

### Reviewers
* Corgar (`will#6948`) and ubiquitous42 (`ubiquitous42#7320`) from Lich discord expressed interest in refactoring `healme` as well.