### PR TITLE
[script] [common-items] match strings when stow hands

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -311,7 +311,19 @@ module DRCI
 
   def stow_hand(hand)
     braid_regex = /The braided (.+) is too long/
-    result = DRC.bput("stow #{hand}", 'You put', braid_regex, 'is too long', '^As you open your hand to release the', 'You easily strap','You hold out')
+    result = DRC.bput(
+      "stow #{hand}",
+      "You put",
+      braid_regex,
+      "close the fan",
+      "You .* unload",
+      "There isn't any more room",
+      "is too small to hold that",
+      "is too long",
+      "As you open your hand to release the",
+      "You easily strap",
+      "You hold out"
+    )
     dispose_trash(DRC.get_noun(Regexp.last_match(1))) if braid_regex.match(result)
   end
 


### PR DESCRIPTION
### Background
* The script `gosafe` uses `EquipmentManager.new.empty_hands` which uses `DRCI.stow_hands`.
* Lack of match strings causes `DRCI.stow_hands` to hang which causes `gosafe` to hang which disrupts travel, especially if you're trying to get out of a sticky situation.

### Changes
* Handle when default container can't hold what's in your hands
* Handle when holding a loaded weapon
* Format a very long line to a match string argument per line.

The new match strings:
* "close the fan"
* "You .* unload"
* "There isn't any more room"
* "is too small to hold that"