### PR TITLE
[script] [combat-trainer] Stow ammo after 'maneuver powershot'

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3063,16 +3063,32 @@ class AttackProcess
 
   def use_charged_maneuver(action, game_state)
     game_state.cooldown_timers[action] = Time.now
+
+    # Monitor for ammo falling to ground after powershot maneuver.
+    # The regular expression is important because we need a capturing group
+    # of the ammo so that we can stow it after the powershot.
+    # We are not interested in ammo that lodges, we will get that when looting the critter.
+    Flags.add('ct-powershot-ammo', "The (.*) (?:falls to the ground|lands nearby)!") if action == 'powershot'
+
     attempt = bput("maneuver #{action}", 'You raise your', 'You brace your', 'balanced and', 'Taking a full step back', 'You take a step back', 'You lower your shoulders', 'You angle to the side and ', 'rest a bit longer', 'You square up your feet', 'You crouch down', 'You step to the side')
     return if attempt == 'rest a bit longer'
 
     # Maneuvers have extra non-RT delays
     pause 7
     waitrt?
+
+    if Flags['ct-powershot-ammo']
+      # When the flag matches game output then the value of the flag
+      # is the regular expression matches. This is how we know the ammo to stow.
+      stow_ammo(Flags['ct-powershot-ammo'][1])
+      Flags.reset('ct-powershot-ammo')
+    end
+
     game_state.use_charged_maneuvers = false
   end
 
   def stow_ammo(ammo = nil, quantity = 1)
+    echo "Stowing ammo: #{ammo}, #{quantity}" if $debug_mode_ct
     return unless ammo
     return unless quantity > 0
     case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
@@ -4047,6 +4063,7 @@ before_dying do
   Flags.delete('ct-regalia-expired')
   Flags.delete('ct-starlight-depleted')
   Flags.delete('ct-regalia-succeeded')
+  Flags.delete('ct-powershot-ammo')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new


### PR DESCRIPTION
### Background
* Maneuvers have a non-roundtime delay between the command and the output.
* The current implementation of `use_charged_maneuver` generically performs an action but doesn't handle picking up ammo.
* Fallen ammo, such as from missed shots or using blunt-tipped ammo, will land at your feet slot and should be picked up because it won't be seen as loot on the ground and automatically picked up by other steps in combat-trainer.
* Leaving a bunch of ammo at your feet can lead to running out of ammo in general, and be disruptive when trying to move to another room.

### Changes
* Set a flag to monitor for ammo falling to your atfeet slot when performing a powershot maneuver.

## Tests

### Stow fallen ammo after powershot
```
[combat-trainer]>load

You reach into your quiver to load the assassin's bow with your last lemon-striped arrow.
Roundtime 2 sec.
> 
[combat-trainer]>maneuver powershot

You square up your feet and arch your back while searching for an engaged enemy to target.
> 
* As if fumbling muscle flab were natural, a ship's rat bites at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're solidly balanced and opponent has slight advantage.]
> 
With a loud twang, you let fly your arrow!

Your lemon-striped arrow lands a devastating hit (17/22) to a ship's rat's chest!
The lemon-striped arrow falls to the ground!
The ship's rat falls to the ground and lies still.
With expert skill you end the attack and maneuver into a better position.

> 
[combat-trainer]>stow my lemon-striped arrow

> 
You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

### Ignore lodged ammo after powershot
_Lodged ammo can't be picked up, so it's ignored._
```
[combat-trainer]>maneuver powershot

> 
You square up your feet and arch your back while searching for an engaged enemy to target.
> 
A musk hog hisses viciously and lunges at you!
* Looking as if this were a bad idea, a musk hog claws, swiping with its hooves at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're nimbly balanced with opponent in better position.]
> 
With a loud twang, you let fly your arrow!

Your boar-tusk arrow lands an awesome strike (12/22) to a musk hog's right foreleg!
The musk hog is lightly stunned!

The boar-tusk arrow lodges itself shallowly into the musk hog!
With expert skill you end the attack and maneuver into a better position.
>

[combat-trainer]>load

You reach into your quiver to load the assassin's bow with a boar-tusk arrow.
Roundtime 2 sec.
```