### PR TITLE
[script] [common-arcana] Add `check_elemental_charge` method

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -772,4 +772,28 @@ module DRCA
 
     return camb_to_use ? camb_to_use : {}
   end
+
+  # Determine the numerical range of a Warrior Mage's elemental charge.
+  # This can be used to know if the mage is ready to perform certain abilities, like barrage.
+  # Returns a number between 0 (no charge) and 11 (max charge).
+  # https://elanthipedia.play.net/Summoning_skill#Charge_levels
+  def check_elemental_charge
+    return 0 unless DRStats.warrior_mage?
+    charge_levels = [
+        /^You sense nothing out of the ordinary.  Only magic could detect the useless trace of .* still in your system.$/,
+        /^A small charge lingers within your body, just above the threshold of perception.$/,
+        /^A small charge lingers within your body.$/,
+        /^A charge dances through your body.$/,
+        /^A charge dances just below the threshold of discomfort.$/,
+        /^A charge circulates through your body, causing a low hum to vibrate through your bones.$/,
+        /^Elemental essence floats freely within your body, leaving little untouched.$/,
+        /^Elemental essence has infused every inch of your body.  While you could contain more, you'd do so at the risk of your health.$/,
+        /^Extraplanar power crackles within your body, leaving you feeling mildly feverish.$/,
+        /^Extraplanar power crackles within your body, leaving you feeling acutely ill.$/,
+        /^Your body sings and crackles with a barely contained charge, destroying what little cenesthesia you had left.$/,
+        /^You have reached the limits of your body's capacity to store a charge.  The laws of the Elemental Plane of .* scream demands upon your physiology, threatening your life.$/
+    ]
+    result = DRC.bput("pathway sense", *charge_levels)
+    charge_levels.find_index { |pattern| pattern =~ result }
+  end
 end


### PR DESCRIPTION
### Background
* Warrior Mages can use [Elemental Barrage](https://elanthipedia.play.net/Elemental_barrage) to amplify a melee attack via a TM spell.
* However, you must have sufficient elemental charge to use the ability.
* I did not readily see an existing method for checking a Warrior Mage's elemental charge.
* This is one of a series of pull requests to add Elemental Barrage support to combat-trainer. Also see https://github.com/rpherbig/dr-scripts/pull/4802.
* Prerequisite for https://github.com/rpherbig/dr-scripts/pull/4803

### Changes
* Add new method `check_elemental_charge` that uses `pathway sense` command to determine how much elemental charge a Warrior Mage has built up.
* This can be used in other scripts, such as planned updates to combat-trainer to support using the [Elemental Barrage](https://elanthipedia.play.net/Elemental_barrage) ability.
* Match strings came from https://elanthipedia.play.net/Summoning_skill#Charge_levels

## Tests

### Non-Warrior Mage
```
> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1: 0]

--- Lich: exec1 has exited.
```

### Level 0
```
s> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
You sense nothing out of the ordinary.  Only magic could detect the useless trace of fire still in your system.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 0]

--- Lich: exec1 has exited.
```

### Level 1
```
s> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
A small charge lingers within your body, just above the threshold of perception.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 1]

--- Lich: exec1 has exited.
```

### Level 2
```
s> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

s> 
[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
A small charge lingers within your body.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 2]

--- Lich: exec1 has exited.
```

### Level 3
```
s> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

s> 
[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
A charge dances through your body.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 3]

--- Lich: exec1 has exited.
```

### Level 4
_I never reached this level, always hit above/below it._

### Level 5
```
,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
A charge circulates through your body, causing a low hum to vibrate through your bones.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 5]

--- Lich: exec1 has exited.
```

### Level 6
```
s> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
Elemental essence floats freely within your body, leaving little untouched.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 6]

--- Lich: exec1 has exited.
```

### Level 7
```
,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
Elemental essence has infused every inch of your body.  While you could contain more, you'd do so at the risk of your health.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 7]

--- Lich: exec1 has exited.
```

### Level 8
```
s> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
Extraplanar power crackles within your body, leaving you feeling mildly feverish.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 8]

--- Lich: exec1 has exited.
```

### Level 9
_I never reached this level, always hit above/below it._

### Level 10
```
s> ,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
Your body sings and crackles with a barely contained charge, destroying what little cenesthesia you had left.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 10]

--- Lich: exec1 has exited.
```

### Level 11
```
,e echo DRCA.check_elemental_charge

--- Lich: exec1 active.

[exec1]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
You have reached the limits of your body's capacity to store a charge.  The laws of the Elemental Plane of Fire scream demands upon your physiology, threatening your life.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
s> 
[exec1: 11]

--- Lich: exec1 has exited.
```