### PR TITLE
[script] [common-arcana] Add Elemental Barrage casting support

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -187,6 +187,8 @@ module DRCA
   def cast?(cast_command = 'cast', symbiosis = false, before = [], after = [])
     before.each { |action| DRC.bput(action['message'], action['matches']) }
 
+    Flags.add('unknown-command', "Please rephrase that command")
+    Flags.add('barrage-fail', "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that")
     Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
@@ -199,6 +201,11 @@ module DRCA
       pause 0.25
     end
     waitrt?
+
+    # Warrior Mage failed to use (or doesn't know) barrage ability. Do regular cast instead.
+    if cast_command =~ /\b(barrage)\b/i && (Flags['unknown-command'] || Flags['barrage-fail'])
+      cast?('cast', symbiosis, [], after)
+    end
 
     if Flags['cyclic-too-recent'] || Flags['spell-full-prep']
       pause 1

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -199,6 +199,13 @@ cast_messages:
 - ^You trace the complex sigils
 - ^The air around you becomes
 - wave of light ripples outward from you
+# If don't know the cast command, like 'barrage'
+- Please rephrase that command
+# Elemental Barrage cast failures
+- Wouldn't it be better if you used a melee weapon?
+- You'll need to be using a weapon to BARRAGE your target.
+- You must have a fully developed target matrix to make a barrage attack.
+- You are unable to muster the energy to do that.
 
 khri_preps:
 - With deep breaths


### PR DESCRIPTION
### Background
* Warrior Mages can use [Elemental Barrage](https://elanthipedia.play.net/Elemental_barrage) to amplify a melee attack via a TM spell.
* I think it'd be a neat way to train a bit of summoning and introduce a unique attack by supporting this ability.
* This is one of a series of pull requests to add Elemental Barrage support to combat-trainer. Also see https://github.com/rpherbig/dr-scripts/pull/4801.
* Prerequisite for https://github.com/rpherbig/dr-scripts/pull/4803

### Changes
* Add `barrage` cast messages to `data/base-spells.yaml`, notably the failures so we know how to recover to do a normal cast.
* Update `cast?` method to check if a `barrage` cast failed, and if so then fallback to normal `cast` mechanics.

A `barrage` cast may fail due to lack of knowing the ability, not wielding a melee weapon in your right hand, insufficient elemental charge, or not having a TM spell fully targeted.

## Tests

### Try to barrage without spell prepared
```
> ,e DRCA.cast?('barrage feint')

--- Lich: exec1 active.

[exec1]>barrage feint

You must have a fully developed target matrix to make a barrage attack.
> 
[exec1]>cast

You don't have a spell prepared!
> 
--- Lich: exec1 has exited.
```

### Try to barrage without a complete targeting matrix
```
> ,e DRCA.cast?('barrage feint')

--- Lich: exec1 active.

[exec1]>barrage feint

You must have a fully developed target matrix to make a barrage attack.
> 
[exec1]>cast
> 
You gesture at a ship's rat.
Several shards of elemental flame fly at a ship's rat!

The fire shard glances off its right hindleg, singeing it a little.
The fire shard smacks into it, leaving a circular burn on its back.
The complementary nature of the spell empowers you.

Roundtime: 1 sec.
> 
--- Lich: exec1 has exited.
```

### Try to barrage with insufficient elemental charge
```
> ,e DRCA.cast?('barrage feint')

--- Lich: exec1 active.

[exec1]>barrage feint

You are unable to muster the energy to do that.
> 
[exec1]>cast

You gesture at a ship's rat.
Several shards of elemental flame fly at a ship's rat!

The fire shard slams into it, badly blistering its chest.
The complementary nature of the spell empowers you.
The ship's rat falls to the ground and lies still.

Roundtime: 1 sec.

> 
--- Lich: exec1 has exited.
```

### Try to barrage without holding melee weapon in right hand
```
> ,e DRCA.cast?('barrage feint')

--- Lich: exec1 active.

[exec1]>barrage feint

Wouldn't it be better if you used a melee weapon?
> 
[exec1]>cast

You gesture at a ship's rat.
Several shards of elemental flame fly at a ship's rat!

The fire shard smacks into it, leaving a circular burn on its chest.
The ship's rat is lightly stunned!
The fire shard collides with its jaw, leaving an ugly burn!
The complementary nature of the spell empowers you.
The ship's rat falls to the ground and lies still.

Roundtime: 1 sec.

> 
--- Lich: exec1 has exited.
```

### Successfully cast via barrage
```
Your formation of a targeting pattern around a ship's rat has completed.

> ,e DRCA.cast?('barrage feint')

--- Lich: exec1 active.

[exec1]>barrage feint

Heatless orange flames climb your club before winking out of existance.
< Moving as a single sinuous force, you feint a dark steel throwing club with an eagle-shaped head at a ship's rat.  A ship's rat fails to evade, failing miserably.  
The club lands an extremely heavy hit (9/22) to the rat's left leg.
[You're nimbly balanced and opponent has slight advantage.]
[Roundtime 1 sec.]
You gesture at a ship's rat.
Several shards of elemental flame fly at a ship's rat!

The shard hits a ship's rat in the right hindleg, scorching the skin.
The shard hits a ship's rat in the forehead, leaving a blistered and bleeding patch of furry skin.
The complementary nature of the spell empowers you.
The ship's rat falls to the ground and lies still.

Roundtime: 1 sec.

> 
--- Lich: exec1 has exited.
```