### PR TITLE
[script] [combat-trainer] Add Elemental Barrage casting support

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1332,6 +1332,11 @@ class SpellProcess
       end
     end
 
+    # If you're a warrior mage casting a TM spell while wielding a melee weapon and you have sufficient elemental charge
+    if DRStats.warrior_mage? && (@prep == 'target') && game_state.use_barrage_attacks? && game_state.melee_skill? && (DRCA.check_elemental_charge >= 5)
+      @custom_cast = "barrage #{game_state.melee_attack_verb}"
+    end
+
     snapshot = DRSkill.getxp(@skill)
     success = cast?(@custom_cast, @symbiosis, @before, @after)
     if @symbiosis && @use_auto_mana
@@ -3377,6 +3382,9 @@ class GameState
     @cambrinth_cap = settings.cambrinth_cap
     echo("  @cambrinth_cap: #{@cambrinth_cap}") if $debug_mode_ct
 
+    @use_barrage_attacks = settings.use_barrage_attacks
+    echo("  @use_barrage_attacks: #{@use_barrage_attacks}") if $debug_mode_ct
+
     @use_weak_attacks = settings.use_weak_attacks
     echo("  @use_weak_attacks: #{@use_weak_attacks}") if $debug_mode_ct
 
@@ -3644,6 +3652,10 @@ class GameState
     $aim_skills.include?(weapon_skill)
   end
 
+  def melee_skill?
+    !$ranged_skills.include?(weapon_skill)
+  end
+
   def offhand?
     weapon_skill == 'Offhand Weapon'
   end
@@ -3859,6 +3871,10 @@ class GameState
 
   def can_ambush_stun?
     !npcs.empty? && !aimed_skill?
+  end
+
+  def use_barrage_attacks?
+    @use_barrage_attacks
   end
 
   def use_weak_attacks?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1335,8 +1335,8 @@ class SpellProcess
       end
     end
 
-    # If you're a warrior mage casting a TM spell while wielding a melee weapon and you have sufficient elemental charge
-    if DRStats.warrior_mage? && (@prep == 'target') && game_state.use_barrage_attacks? && game_state.melee_skill? && (DRCA.check_elemental_charge >= 5)
+    # Warrior Mage's "elemental barrage" attack
+    if @prep == 'target' && game_state.can_use_barrage_attack?
       @custom_cast = "barrage #{game_state.melee_attack_verb}"
     end
 
@@ -3910,6 +3910,13 @@ class GameState
 
   def can_ambush_stun?
     !npcs.empty? && !aimed_skill?
+  end
+
+  def can_use_barrage_attack?
+    return false unless DRStats.warrior_mage? && game_state.use_barrage_attacks?
+    return false unless game_state.melee_skill? && !game_state.brawling?
+    return false unless DRCA.check_elemental_charge >= 5
+    true
   end
 
   def use_barrage_attacks?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3913,8 +3913,8 @@ class GameState
   end
 
   def can_use_barrage_attack?
-    return false unless DRStats.warrior_mage? && game_state.use_barrage_attacks?
-    return false unless game_state.melee_skill? && !game_state.brawling?
+    return false unless DRStats.warrior_mage? && use_barrage_attacks?
+    return false unless melee_skill? && !brawling?
     return false unless DRCA.check_elemental_charge >= 5
     true
   end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -188,7 +188,7 @@ module DRCA
     before.each { |action| DRC.bput(action['message'], action['matches']) }
 
     Flags.add('unknown-command', "Please rephrase that command")
-    Flags.add('barrage-fail', "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that")
+    Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that")
     Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -202,6 +202,7 @@ cast_messages:
 # If don't know the cast command, like 'barrage'
 - Please rephrase that command
 # Elemental Barrage cast failures
+- That was an invalid attack choice.
 - Wouldn't it be better if you used a melee weapon?
 - You'll need to be using a weapon to BARRAGE your target.
 - You must have a fully developed target matrix to make a barrage attack.

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -217,6 +217,15 @@ performance_monitor_weapons:
 retreat_threshold:
 # avoid damaging attacks in combat - useful when training against mobs that don't spawn well.  Doesn't work right with whirlwind.
 use_weak_attacks: false
+# Warrior Mage only.
+# If wielding a melee weapon and casting a targeted magic spell
+# and you have sufficient elemental charge then combat-trainer
+# will use `barrage <attack verb>` when casting the spell.
+# Trains summoning, weapons, and TM skills at the same time.
+# Leave false unless you know the Elemental Barrage ability.
+# You may not want to do any `pathway focus <type>` in your
+# buff_nonspells to avoid dispensing your charge too early.
+use_barrage_attacks: false
 # loot bodies after killing them
 loot_bodies: true
 # Delay for looting bodies, in seconds


### PR DESCRIPTION
### Dependencies
* ~Depends on https://github.com/rpherbig/dr-scripts/pull/4801~
* ~Depends on https://github.com/rpherbig/dr-scripts/pull/4802~

### Background
* Warrior Mages can use [Elemental Barrage](https://elanthipedia.play.net/Elemental_barrage) to amplify a melee attack via a TM spell.
* I think it'd be a neat way to train a bit of summoning and introduce a unique attack by supporting this ability.

### Changes
* Add new setting `use_barrage_attacks` (true|false) that defaults to false.
* If false, or if the conditions to use barrage aren't met, no change to how TM spells are cast.
* If true, combat-trainer will change the cast command to `barrage <melee attack verb>` if you're casting a TM spell, wielding a melee weapon, and have sufficient elemental charge.
* The melee attack verb defers to `game_state.melee_attack_verb` so it respects other settings such as attack overrides and weak attacks.
* Add match string "That was an invalid attack choice." if try to barrage a brawling attack.

### Example Config
```yaml
# Warrior Mage only.
# If wielding a melee weapon and casting a targeted magic spell
# and you have sufficient elemental charge then combat-trainer
# will use `barrage <attack verb>` when casting the spell.
# Trains summoning, weapons, and TM skills at the same time.
# Leave false unless you know the Elemental Barrage ability.
# You may not want to do any `pathway focus <type>` in your
# buff_nonspells to avoid dispensing your charge too early.
use_barrage_attacks: false
```

## Tests

### TM spell with sufficient charge, use barrage
```
[combat-trainer]>invoke my watersilk bag

The watersilk bag is dim, almost magically null.  A very faint pattern indicates its readiness to absorb Elemental energy.
Roundtime: 5 sec.
> 
[combat-trainer]>wear my watersilk bag

You put on a dark watersilk bag bearing a detailed cambrinth medallion.
> 
[combat-trainer: *** DRStats.warrior_mage? = true]

[combat-trainer: *** @prep = target]

[combat-trainer: *** game_state.melee_skill? = true]

[combat-trainer]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
Elemental essence floats freely within your body, leaving little untouched.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
> 
[combat-trainer: *** DRCA.check_elemental_charge = 6]

[combat-trainer: *** @custom_cast = barrage feint]

[combat-trainer]>barrage feint

Heatless orange flames climb your fan before winking out of existance.
< Moving with dominating grace, you feint an uthamar-bladed dreamweave fan dangling scattered star charms at a copperhead viper.  A copperhead viper attempts to evade, failing miserably.  
The fan lands a solid hit (4/22) to the viper's right leg.
[You're incredibly balanced and overwhelming opponent.]
[Roundtime 1 sec.]
You gesture at a copperhead viper.
Several shards of elemental flame fly at a copperhead viper!

The fire shard smacks into it, leaving a circular burn on its back.
The copperhead viper is lightly stunned!
The shard hits a copperhead viper squarely in the belly, sending it reeling and scorching the skin.
The complementary nature of the spell empowers you.

Roundtime: 1 sec.
```

### Non TM spell or insufficient charge, no barrage
```
[combat-trainer]>invoke my watersilk bag

The watersilk bag pulses with Elemental energy.  You reach for its center and forge a magical link to it, readying all of its mana for your use.
Roundtime: 1 sec.
> 
> 
[combat-trainer]>wear my watersilk bag

You put on a dark watersilk bag bearing a detailed cambrinth medallion.
> 
> 
[combat-trainer: *** DRStats.warrior_mage? = true]

[combat-trainer: *** @prep = ]

[combat-trainer: *** game_state.melee_skill? = true]

[combat-trainer]>pathway sense

You turn your perceptions inward, assessing the elemental influences over your body.
A small charge lingers within your body.
Your body is aligned with the Elemental Plane of Fire and opposed to the Elemental Plane of Water.
> 
[combat-trainer: *** DRCA.check_elemental_charge = 2]

[combat-trainer: *** @custom_cast = ]

[combat-trainer]>cast
```