### PR TITLE
Optional DRCA Lambda Callbacks [Healme 2.0]

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -415,7 +415,7 @@ module DRCA
     aura
   end
 
-  def cast_spells(spells, settings, force_cambrinth = false)
+  def cast_spells(spells, settings, force_cambrinth = false, wait_lambda = nil, cast_lambda = nil)
     infuse_om(!settings.osrel_no_harness, settings.osrel_amount)
     spells.each do |name, data|
       next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
@@ -423,7 +423,7 @@ module DRCA
         echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
         pause 15
       end
-      cast_spell(data, settings, force_cambrinth)
+      cast_spell(data, settings, force_cambrinth, wait_lambda, cast_lambda)
     end
   end
 
@@ -496,7 +496,7 @@ module DRCA
     pause 0.5 while UserVars.moons.empty?
   end
 
-  def cast_spell(data, settings, force_cambrinth = false)
+  def cast_spell(data, settings, force_cambrinth = false, wait_lambda = nil, cast_lambda = nil)
     return unless data
     return unless settings
 
@@ -550,10 +550,18 @@ module DRCA
       end
     end
 
+    if wait_lambda != nil
+      wait_lambda.call(data, settings)
+    end
+
     if data['prep_time']
       pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
     else
       waitcastrt?
+    end
+
+    if cast_lambda != nil
+      cast_lambda.call(data, settings)
     end
 
     cast?(data['cast'], data['symbiosis'], data['before'], data['after'])

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -415,7 +415,7 @@ module DRCA
     aura
   end
 
-  def cast_spells(spells, settings, force_cambrinth = false, wait_lambda = nil, cast_lambda = nil)
+  def cast_spells(spells, settings, force_cambrinth = false, cast_lifecycle_lambda = nil)
     infuse_om(!settings.osrel_no_harness, settings.osrel_amount)
     spells.each do |name, data|
       next if DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast'])
@@ -423,7 +423,7 @@ module DRCA
         echo("Waiting on mana over #{settings.waggle_spells_mana_threshold} or concentration over #{settings.waggle_spells_concentration_threshold}...")
         pause 15
       end
-      cast_spell(data, settings, force_cambrinth, wait_lambda, cast_lambda)
+      cast_spell(data, settings, force_cambrinth, cast_lifecycle_lambda)
     end
   end
 
@@ -496,7 +496,7 @@ module DRCA
     pause 0.5 while UserVars.moons.empty?
   end
 
-  def cast_spell(data, settings, force_cambrinth = false, wait_lambda = nil, cast_lambda = nil)
+  def cast_spell(data, settings, force_cambrinth = false, cast_lifecycle_lambda = nil)
     return unless data
     return unless settings
 
@@ -526,6 +526,8 @@ module DRCA
       end
     end
 
+    cast_lifecycle_lambda.call('pre-prep', data, settings) if cast_lifecycle_lambda != nil
+
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
     DRCI.put_away_item?(data['runestone_name'], settings.runestone_storage) if DRCI.in_hands?(data['runestone_name'])
     prepare_time = Time.now
@@ -550,15 +552,17 @@ module DRCA
       end
     end
 
-    wait_lambda.call(data, settings) if wait_lambda != nil
+    cast_lifecycle_lambda.call('post-prep', data, settings) if cast_lifecycle_lambda != nil
+
     if data['prep_time']
       pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
     else
       waitcastrt?
     end
 
-    cast_lambda.call(data, settings) if cast_lambda != nil
+    cast_lifecycle_lambda.call('pre-cast', data, settings) if cast_lifecycle_lambda != nil
     cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
+    cast_lifecycle_lambda.call('post-cast', data, settings) if cast_lifecycle_lambda != nil
   end
 
   def check_discern(data, settings)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -550,20 +550,14 @@ module DRCA
       end
     end
 
-    if wait_lambda != nil
-      wait_lambda.call(data, settings)
-    end
-
+    wait_lambda.call(data, settings) if wait_lambda != nil
     if data['prep_time']
       pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
     else
       waitcastrt?
     end
 
-    if cast_lambda != nil
-      cast_lambda.call(data, settings)
-    end
-
+    cast_lambda.call(data, settings) if cast_lambda != nil
     cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
   end
 


### PR DESCRIPTION
DRCA.cast_spells / .cast_spell optional lambda callback hooks to make writing interleaved commands easier.

These are being added primarily for use in the revamped 'healme' that is in the works, but should be useful for many other situations.

The 'wait_lambda' lets you provide a script specific block of code to execute while the spell preps [like tending a wound while your heals prep].
The 'cast_lambda' gives you just-in-time access to the spell block to either take required actions, or change targeting criteria [which we need for hw/hs targeting - because it fights with heal over time effects like heal and regen].