### PR TITLE
Fixing the issue for whirlwinding 2 handed.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -192,9 +192,6 @@ class SetupProcess
     echo('new skill needed for training') if $debug_mode_ct
 
     game_state.reset_action_count
-    # Moved this here from check_weapon based on order of operations and sheathing logic returning  
-    # if current weapon skill is twohanded.
-    game_state.sheath_whirlwind_offhand
 
     # If you're training with summoned moon weapons but you haven't cast the moonblade spell yet
     # then skip those weapon skills and train something else while we wait for moonblade spell to be cast.
@@ -271,6 +268,7 @@ class SetupProcess
     # Clean up the previous weapon
     if !last_summoned
       @equipment_manager.stow_weapon(game_state.last_weapon_name)
+      game_state.sheath_whirlwind_offhand
     elsif !next_summoned && !DRStats.moon_mage?
       break_summoned_weapon(game_state.last_weapon_name)
     elsif !next_summoned && DRStats.moon_mage?
@@ -3539,8 +3537,7 @@ class GameState
   end
 
   def sheath_whirlwind_offhand
-    return if twohanded_weapon_skill?
-    return unless currently_whirlwinding
+    return unless currently_whirlwinding && left_hand
     @equipment_manager.stow_weapon(whirlwind_offhand_name)
   end
 


### PR DESCRIPTION
Started over with the PR.

So, I've been using 2 handed whirlwinding for about 4 years now. The version I pushed is a bit different than what I normally had. Most of the core logic for 2 handers was the same, except the sheathing of the offhand weapon. The issue we run into is it is checking the weapon skill, but that changes before you change weapons and the logic for the sheathing is an order of operations nightmare based on the rest of the system and how it handles things like dancing. This should just flatly fix the problem, and honestly, it has worked with Chuno and Mozof for a couple thousand ranks.

This reverts the sheathing from determine_next_to_train and moves it back to check_weapon. 