### PR TITLE
Update tarantula.lic - add skip alternate setting

### DIFF
--- a/tarantula.lic
+++ b/tarantula.lic
@@ -15,6 +15,7 @@ class Tarantula
     @startup_delay = settings.tarantula_startup_delay || 15
     @tarantula_noun = settings.tarantula_noun.nil? ? 'biomechanical tarantula' : settings.tarantula_noun
     @exclude = settings.tarantula_excluded_skills
+    @skip_alternate = settings.tarantula_skip_alternate
     UserVars.tarantula_last_use ||= Time.now - 600
     @last = UserVars.tarantula_last_skillset
     @last ||= check_last
@@ -91,6 +92,8 @@ class Tarantula
     if skill
       return unless turn_tarantula?(skill)
     else
+      _respond( bold("*** Skipping alternate skills due to user setting. ***") ) if @skip_alternate && @debug
+      return if @skip_alternate
       _respond( bold("*** No preferred skills available.  Trying others. ***") ) if @debug
       alt = choose_alternate
       if alt


### PR DESCRIPTION
I've added a setting that allows you to skip the alternate skill being chosen so that it's not necessary to exclude so many skills if you just don't want the alternate to happen.
With this set to true, the script will only pick skills you list under `tarantula:`
`tarantula_skip_alternate: true`