### PR TITLE
Adding missed dependency for DRCI

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-arcana
 =end
 
-custom_require.call(%w[common events spellmonitor drinfomon])
+custom_require.call(%w[common common-items events spellmonitor drinfomon])
 
 $MANA_MAP = {
   'weak' => %w[dim glowing bright],


### PR DESCRIPTION
Not having this explicit dependency in DRCA seems to create an ordering/race condition for some scripts - buff, magic trainer, etc. - when used right at login. Looks like the DRCI dependencies are mostly around runestone handling.

Curious about peoples' thoughts here, or if there's a reason to avoid the common-arcana to common-items dependency.