### PR TITLE
[script] [combat-trainer] Update necro healing to use new DRCH.Wound data model

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -617,7 +617,7 @@ class LootProcess
     echo "  should_perform_ritual? #{should_perform_ritual?(game_state)}" if $debug_mode_ct
     if @last_ritual.nil?
       if @necro_heal && !game_state.necro_casting?
-        game_state.wounds = check_health['wounds']
+        game_state.wounds = DRCH.check_health['wounds']
         echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
         echo "wound_level_threshold: #{@wound_level_threshold}" if $debug_mode_ct
         unless game_state.wounds.empty?
@@ -1342,7 +1342,7 @@ class SpellProcess
 
     if game_state.casting_consume
       if @necromancer_healing.key?('Consume Flesh') && !@necromancer_healing.key?('Devour')
-        @custom_cast = "cast #{game_state.wounds[game_state.wounds.keys.max].first}"
+        @custom_cast = "cast #{game_state.wounds[game_state.wounds.keys.max].first.body_part}"
       end
     end
 


### PR DESCRIPTION
### Background
* Per https://github.com/rpherbig/dr-scripts/pull/4794, the data model returned from DRCH.check_health changed to better support a [new version of healme](https://github.com/rpherbig/dr-scripts/pull/4795).
* Although some parts of combat-trainer were [updated](https://github.com/rpherbig/dr-scripts/pull/4794/files#diff-9ae4def723db1fc18dedeb6525353643931809a12e604361ffe988f736fd30a6R1522) for empath healing, a spot was missed for necro healing.

### Changes
* Update necro healing section to get the `body_part` from the new DRCH.Wound data model for the custom cast command.

### Credits
* Thank you to Zaglis and Kiriawen for reporting the issue.
* Thank you to Corgar for identifying and proposing the fix.