### PR TITLE
[script] [dependency] Hydrate spells defined in necromancer_healing

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -920,6 +920,12 @@ class SetupFiles
              .each_value { |data| s.lockpick_buffs['spells'][i] = data.merge(spell) }
      end
 
+    s.necromancer_healing
+     .each do |key, value|
+       spells.select { |name, _data| key.downcase == name.downcase }
+             .each_value { |data| s.necromancer_healing[key] = data.merge(value) }
+     end
+
     s.waggle_sets
      .select { |set_name, set_spells| set_spells.select { |spell_name, spell_data| spells[spell_name].each { s.waggle_sets[set_name][spell_name] = spells[spell_name].merge(spell_data) } } }
 


### PR DESCRIPTION
### Background
* Dependency embellishes waggle sets and other properties that define spells with missing data from base-spells.yaml
* Dependency does not do this for `necromancer_healing` property, which requires players to redundantly specify spell data in their yaml.

For example, given the below config:
```yaml
necromancer_healing:
  wound_level_threshold: 2
  Consume Flesh:
    use_auto_mana: true
```
then when combat-trainer performs necro healing and passes the above defined spell data to common-arcana, common-arcana will fail to discern because it assumes the `abbrev` spell property is defined (which I don't have listed in my yaml, only `use_auto_mana`). But I'm so used to those things being handled automatically for buffs I assumed it worked here, too. Turns out that magical convenience is done in dependency when loading the settings.

### Changes
* Just as with waggle sets and other buff lists defined in yaml, embellish spells listed in `necromancer_healing` with base spell data.

## Tests

### Output necromancer_healing without this change
```
> ,e echo get_settings.necromancer_healing
{
  "wound_level_threshold" => 2, 
  "Consume Flesh" => {
    "use_auto_mana" => true
  }, 
  "Siphon Vitality" => {
    "use_auto_mana" => true
  }
}
```

### Output necromancer_healing with this change
```
> ,e echo get_settings.necromancer_healing
{
  "wound_level_threshold" => 2, 
  "Consume Flesh" => {
    "skill" => "Utility", "abbrev" => "CF", "mana" => 15, "recast" => 1, "mana_type" => "arcane", "use_auto_mana" => true
  }, 
  "Siphon Vitality" => {
    "skill" => "Targeted Magic", "abbrev" => "SV", "mana" => 10, "mana_type" => "arcane", "use_auto_mana" => true
  }
}
```

### Reviewers
* @jayRyan24, you were mentioned as author of the necro healing for combat-trainer. Would like your review of these proposed changes to dependency. I don't think there's any negative impact.