### PR TITLE
[yaml] [base] Set healme.severity_threshold to 0

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -939,7 +939,7 @@ healme:
   # to set a low threshold (1 or 2) since those can be healed over time
   # rather than waiting for the script to heal them all in one sitting.
   # Default is 0.
-  severity_threshold: 1
+  severity_threshold: 0
   # When waiting for a spell to be prepared and if you have wounds to tend,
   # such as bleeders or lodged ammo or parasites, then this is the max
   # number of those wounds to tend before casting to be efficient.


### PR DESCRIPTION
I mistakenly copied my personal threshold into base.yaml; the default should be 0 (heal all wounds regardless of their severity). Players may modify this in their character's yaml.