### PR TITLE
[script] [common-items] Add 'look_in_container' for transfer-items script

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -29,6 +29,7 @@ $PUT_AWAY_ITEM_FAILURE_PATTERNS = [
   /You just can't get/,
   /You can't put items/,
   /You can only take items out/,
+  /Perhaps you should be holding that first/,
   /Containers can't be placed in/
 ]
 

--- a/common-items.lic
+++ b/common-items.lic
@@ -19,8 +19,15 @@ $PUT_AWAY_ITEM_FAILURE_PATTERNS = [
   /^Please rephrase that command/,
   /^What were you referring to/,
   /^I could not find what you were referring to/,
+  /even after stuffing it/,
+  /is too long to fit/,
+  /is too small to hold that/,
+  /There isn't any more room in/,
+  /There's no room/,
   /to fit in the/,
-  /^There isn't any more room in/
+  /too heavy to go in there/,
+  /You just can't get/,
+  /Containers can't be placed in/
 ]
 
 $OPEN_CONTAINER_SUCCESS_PATTERNS = [
@@ -364,15 +371,33 @@ module DRCI
   def get_item_unsafe(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
-    result = DRC.bput("get #{item} #{from}", 'You get', 'You pluck', 'You are already holding', 'You fade in for a moment as you get', 'I could not', 'What were you', 'Get what', 'You need a free hand')
-    result =~ /^(You get|You pluck|You are already holding|You fade in for a moment as you get)/
+    result = DRC.bput("get #{item} #{from}", 'You get', 'You pick', 'You pluck', 'You are already holding', 'You fade in for a moment as you get', 'I could not', 'What were you', 'Get what', 'You need a free hand')
+    result =~ /^(You get|You pick|You pluck|You are already holding|You fade in for a moment as you get)/
   end
 
-  # Gets a list of items found in a container.
-  def get_item_list(container)
+  # Gets a list of items found in a container via RUMMAGE or LOOK.
+  # Default is 'rummage' which returns the full item tap descriptions (e.g. some grey ice skates with black laces)
+  # You can pass in 'LOOK' to get back the short item names, which is easier to parse to know the adjective and noun (e.g. some grey ice skates)
+  def get_item_list(container, verb = 'rummage')
+    case verb
+    when /^(r|rummage)$/i
+      rummage_container(container)
+    when /^(l|look)$/i
+      look_in_container(container)
+    end
+  end
+
+  def rummage_container(container)
     DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'there is nothing')
     .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
     .split(/(?:, | and )?(?:a|an|some) /)
+  end
+
+  def look_in_container(container)
+    DRC.bput("look in my #{container}", 'In the .* you see (.*)\.', 'there is nothing')
+    .match(/In the .* you see (?:some|an|a) (?<items>.*)\./)[:items]
+    .split(/(?:,|and) (?:some|an|a)/)
+    .map(&:strip)
   end
 
   # Puts away an item, optionally into a specific container.

--- a/common-items.lic
+++ b/common-items.lic
@@ -27,6 +27,8 @@ $PUT_AWAY_ITEM_FAILURE_PATTERNS = [
   /to fit in the/,
   /too heavy to go in there/,
   /You just can't get/,
+  /You can't put items/,
+  /You can only take items out/,
   /Containers can't be placed in/
 ]
 


### PR DESCRIPTION
### Background
* A while ago, `get_item_list` was refactored from using LOOK to RUMMAGE to ensure it listed all items in a container.
* LOOK has a limit and will say "and a lot of other stuff" but RUMMAGE will list everything.
* `transfer-items` script relied on the output from `LOOK` to parse the exact item noun when moving things between containers.
* The current use of RUMMAGE breaks `transfer-items` script.
* [Rohk in lich discord](https://discord.com/channels/745675889622384681/771867662551744534/822913913548046376) raised this as a concern because they are trying to use `transfer-items` to move prize loot won at Droughtman's.
* This is a prerequisite for a future pull request to update `transfer-items` to take advantage of these changes.

### Changes
* Add `rummage_container` and `look_in_container` methods so we have options how to get item lists.
* Update `get_item_list` to default to using `rummage_container` (current behavior) but can easily toggle over to the LOOK behavior.

## Tests

### get_item_list defaults to 'rummage'
```
> ,e echo DRCI.get_item_list('thigh.bag')

--- Lich: exec1 active.

[exec1]>rummage my thigh.bag

You rummage through a leather thigh bag heavily-beaded in cambrinth with the image of a fierce scorpion and see a length of spidersilk fabric, a pristine white healer's apron with herb embroidered pockets and a pocket-sized steel kaleidoscope engraved with crocus blooms.
> 
[exec1: ["length of spidersilk fabric", "pristine white healer's apron with herb embroidered pockets", "pocket-sized steel kaleidoscope engraved with crocus blooms"]]

--- Lich: exec1 has exited.
```

### get_item_list explicitly uses 'rummage'
```
> ,e echo DRCI.get_item_list('thigh.bag', 'rummage')

--- Lich: exec1 active.

[exec1]>rummage my thigh.bag

You rummage through a leather thigh bag heavily-beaded in cambrinth with the image of a fierce scorpion and see a length of spidersilk fabric, a pristine white healer's apron with herb embroidered pockets and a pocket-sized steel kaleidoscope engraved with crocus blooms.
> 
[exec1: ["length of spidersilk fabric", "pristine white healer's apron with herb embroidered pockets", "pocket-sized steel kaleidoscope engraved with crocus blooms"]]

--- Lich: exec1 has exited.
```

### get_item_list explicitly uses 'look'
```
> ,e echo DRCI.get_item_list('thigh.bag', 'look')

--- Lich: exec1 active.

[exec1]>look in my thigh.bag

In the thigh bag you see a length of spidersilk fabric, a white apron and a pocket-sized kaleidoscope.
> 
[exec1: ["length of spidersilk fabric", "white apron", "pocket-sized kaleidoscope"]]

--- Lich: exec1 has exited.
```

### rummage_container uses 'rummage'
```
> ,e echo DRCI.rummage_container('thigh.bag')

--- Lich: exec1 active.

[exec1]>rummage my thigh.bag

You rummage through a leather thigh bag heavily-beaded in cambrinth with the image of a fierce scorpion and see a length of spidersilk fabric, a pristine white healer's apron with herb embroidered pockets and a pocket-sized steel kaleidoscope engraved with crocus blooms.
> 
[exec1: ["length of spidersilk fabric", "pristine white healer's apron with herb embroidered pockets", "pocket-sized steel kaleidoscope engraved with crocus blooms"]]

--- Lich: exec1 has exited.
```

### look_in_container uses 'look'
```
> ,e echo DRCI.look_in_container('thigh.bag')

--- Lich: exec1 active.

[exec1]>look in my thigh.bag

In the thigh bag you see a length of spidersilk fabric, a white apron and a pocket-sized kaleidoscope.
> 
[exec1: ["length of spidersilk fabric", "white apron", "pocket-sized kaleidoscope"]]

--- Lich: exec1 has exited.
```