### PR TITLE
[script] [combat-trainer] Configure barrage attacks per spell

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1364,7 +1364,7 @@ class SpellProcess
     end
 
     # Warrior Mage's "elemental barrage" attack
-    if @prep == 'target' && game_state.can_use_barrage_attack?
+    if @prep == 'target' && @barrage && game_state.can_use_barrage_attack?
       @custom_cast = "barrage #{game_state.melee_attack_verb}"
     end
 
@@ -1379,6 +1379,7 @@ class SpellProcess
     end
     @custom_cast = nil
     @symbiosis = nil
+    @barrage = nil
     @before = nil
     @after = nil
     @skill = nil
@@ -1782,6 +1783,7 @@ class SpellProcess
     end
     @custom_cast = data['cast']
     @symbiosis = data['symbiosis']
+    @barrage = data['barrage']
     @after = data['after']
     @skill = data['skill']
     @prep = data['prep']
@@ -3431,9 +3433,6 @@ class GameState
     @cambrinth_cap = settings.cambrinth_cap
     echo("  @cambrinth_cap: #{@cambrinth_cap}") if $debug_mode_ct
 
-    @use_barrage_attacks = settings.use_barrage_attacks
-    echo("  @use_barrage_attacks: #{@use_barrage_attacks}") if $debug_mode_ct
-
     @use_weak_attacks = settings.use_weak_attacks
     echo("  @use_weak_attacks: #{@use_weak_attacks}") if $debug_mode_ct
 
@@ -3458,7 +3457,7 @@ class GameState
 
     @whirlwind_trainables = settings.whirlwind_trainables
     echo("  @whirlwind_trainables: #{@whirlwind_trainables}") if $debug_mode_ct
-    
+
     @flame_inner_fire_threshold = settings.flame_inner_fire_threshold
     echo("  @flame_inner_fire_threshold: #{@flame_inner_fire_threshold}") if $debug_mode_ct
 
@@ -3940,14 +3939,10 @@ class GameState
   end
 
   def can_use_barrage_attack?
-    return false unless DRStats.warrior_mage? && use_barrage_attacks?
+    return false unless DRStats.warrior_mage?
     return false unless melee_skill? && !brawling?
     return false unless DRCA.check_elemental_charge >= 5
     true
-  end
-
-  def use_barrage_attacks?
-    @use_barrage_attacks
   end
 
   def use_weak_attacks?

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -217,15 +217,6 @@ performance_monitor_weapons:
 retreat_threshold:
 # avoid damaging attacks in combat - useful when training against mobs that don't spawn well.  Doesn't work right with whirlwind.
 use_weak_attacks: false
-# Warrior Mage only.
-# If wielding a melee weapon and casting a targeted magic spell
-# and you have sufficient elemental charge then combat-trainer
-# will use `barrage <attack verb>` when casting the spell.
-# Trains summoning, weapons, and TM skills at the same time.
-# Leave false unless you know the Elemental Barrage ability.
-# You may not want to do any `pathway focus <type>` in your
-# buff_nonspells to avoid dispensing your charge too early.
-use_barrage_attacks: false
 # loot bodies after killing them
 loot_bodies: true
 # Delay for looting bodies, in seconds

--- a/validate.lic
+++ b/validate.lic
@@ -853,6 +853,13 @@ class DRYamlValidator
     warn('You have a prehunt_buffs waggle set without a room defined, you will buff in place!')
   end
 
+  def assert_that_use_barrage_attacks_is_deprecated(settings)
+    return unless settings.use_barrage_attacks
+    return unless DRStats.warrior_mage?
+
+    warn('use_barrage_attacks is deprecated, please specify "barrage: true" in the spell configurations for the TM spells you want to ues barrage attacks with.')
+  end
+
   private
 
   def warn(message)


### PR DESCRIPTION
### Background
* In testing, not every TM spell can be used for barrage attacks, and your elemental charge should align to the kind of spell being used.
* Players suggested a redesign to specify `barrage: true` on their offensive spells they want to attempt barrage attacks on for greater control.

### Changes
* Deprecate `use_barrage_attacks` setting and remove it from base.yaml
* Check if spell data has `barrage: true` to attempt to use a barrage attack if all other conditions are met