### PR TITLE
[script] [healme] case-insensitive check on body parts

### DIFF
--- a/healme.lic
+++ b/healme.lic
@@ -263,7 +263,7 @@ class HealMe
   # Is the wound's body part NOT in the exclusion list?
   # We won't try to heal wounds for body parts to keep injured.
   def should_heal_body_part?(wound)
-    !@body_parts_not_to_heal.any? { |body_part| body_part == wound.body_part }
+    !@body_parts_not_to_heal.any? { |body_part| body_part.downcase == wound.body_part.downcase }
   end
 
   # Determines if there are any wounds, poisons, etc to heal.


### PR DESCRIPTION
### Background
* This check excludes wounds for body parts you don't want to heal, like pet bleeders
* The parser is now returning wound body parts as UPPER CASE which may not match the script argument given, and so still healing body parts you wanted excluded.

### Changes
* Case insensitive comparison on body parts in list to keep vs. what was parsed from perceived health

## Tests

[healme-test.txt](https://github.com/rpherbig/dr-scripts/files/6178477/healme-test.txt) - correctly excludes healing a body part listed in the exclusions list, case-insensitive
