### PR TITLE
[script] [common-healing] Standardize on downcase

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -308,11 +308,11 @@ module DRCH
       # Is this a scar (true) or fresh wound (false)?
       is_scar: false
     )
-      @body_part = body_part
+      @body_part = body_part.downcase
       @severity = severity
-      @bleeding_rate = bleeding_rate
-      @is_internal = is_internal
-      @is_scar = is_scar
+      @bleeding_rate = bleeding_rate.downcase
+      @is_internal = !!is_internal
+      @is_scar = !!is_scar
     end
 
     def bleeding?


### PR DESCRIPTION
### Background
* To add predictability on how values on the DRCH.Wound object are stored regardless of where the values were parsed or derived from.
* Somewhat related to https://github.com/rpherbig/dr-scripts/pull/4830

### Changes
* Force body_part and bleeding_rate to be stored as lower case
* Force is_internal and is_scar to be stored as booleans

## Tests

### use mixed case and psuedo booleans 
_The wound object's string properties should be lower case and the predicates as booleans.
```
> ,e echo DRCH::Wound.new(body_part: 'LEFT EyE', severity: 4, bleeding_rate: 'HeaVy', is_internal: 'a', is_scar: false).inspect

--- Lich: exec1 active.

[exec1: #<DRCH::Wound:0x0431e788 
  @body_part="left eye", 
  @severity=4, 
  @bleeding_rate="heavy", 
  @is_internal=true, 
  @is_scar=false>
]

--- Lich: exec1 has exited.
```