### PR TITLE
athletics.lic - Removed automatic xalas climbing

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -217,10 +217,10 @@ class Athletics
       end
     elsif UserVars.athletics < 450
       override_location_and_practice('segoltha_bank')
-    elsif UserVars.athletics < 600
+    else
+      message("The xalas argument will train faster at 650+ athletics.  Be aware that it's potentially dangerous.") if UserVars.athletics > 650
       override_location_and_practice('arthelun_rocks')
-    elsif UserVars.athletics
-      climb_xalas
+      message("The xalas argument will train faster at 650+ athletics.  Be aware that it's potentially dangerous.") if UserVars.athletics > 650
     end
   end
 


### PR DESCRIPTION
Script will no longer automatically climb xalas at 600+ athletics with Crossing as hometown.  It will now message the user that xalas is a dangerous option that will train better.