### PR TITLE
common-items - Add match for get_item_unsafe

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -374,8 +374,8 @@ module DRCI
   def get_item_unsafe(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
-    result = DRC.bput("get #{item} #{from}", 'You get', 'You pick', 'You pluck', 'You are already holding', 'You fade in for a moment as you get', 'I could not', 'What were you', 'Get what', 'You need a free hand')
-    result =~ /^(You get|You pick|You pluck|You are already holding|You fade in for a moment as you get)/
+    result = DRC.bput("get #{item} #{from}", 'You get', 'You pick', 'You pluck', 'You deftly remove', 'You are already holding', 'You fade in for a moment as you get', 'I could not', 'What were you', 'Get what', 'You need a free hand')
+    result =~ /^(You get|You pick|You pluck|You deftly remove|You are already holding|You fade in for a moment as you get)/
   end
 
   # Gets a list of items found in a container via RUMMAGE or LOOK.


### PR DESCRIPTION
Added a match for `You deftly remove` to the get_item_unsafe method.

This addresses issue https://github.com/rpherbig/dr-scripts/issues/4833