### PR TITLE
Clumsy Arcana Check Matches

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-arcana
 =end
 
-custom_require.call(%w[common common-items events spellmonitor drinfomon])
+custom_require.call(%w[common events spellmonitor drinfomon])
 
 $MANA_MAP = {
   'weak' => %w[dim glowing bright],

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -8,6 +8,7 @@ charge_messages:
 - lack the mental stamina to charge
 - resists your efforts to charge it
 - You fail to channel
+- you find it too clumsy to charge
 
 invoke_messages:
 - Images of streaking stars falling from the heavens flash
@@ -25,6 +26,7 @@ invoke_messages:
 - Well, that was fun
 - Invoke what
 - You'll have to hold it
+- you find it too clumsy to invoke
 
 prep_messages:
 - You lick the tip of your finger and trace a sigil in the air


### PR DESCRIPTION
Adding matches for when you aren't able to use cambrinth while worn (due to arcana penalties, etc.)

These changes alone will make scripts that use DRCA to charge cambrinth no longer hang when the current arcana skill isn't good enough to use a cambrinth without removing it. This doesn't address harnessing instead, or any other handling we might want to do with this edge case; it just lets scripts keep going as normal instead of waiting for the 'no match was seen' timeout.

I tested this with a misconfigured YAML (marking an item's capacity lower than it is), in several scripts (combat-trainer, buff, etc.)

@Hiinky, @KatoakDR or anyone else - thoughts?