### PR TITLE
[script] [wait] New script designed for 'multi' to wait N seconds

### DIFF
--- a/wait.lic
+++ b/wait.lic
@@ -1,0 +1,6 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#wait
+=end
+
+pause (script.vars[0].to_f || 0)
+waitrt?


### PR DESCRIPTION
### Background
* `multi` script is a great utility for cobbling together commands and scripts to perform on the fly, often in repitition.
* Although `multi` has built-in waits for RT, it doesn't allow for arbitrary pauses if you want to perform a command periodically.

### Changes
* Add new script `wait` that accepts zero or one argument, the number of seconds to pause.

### Usage Examples
`,multi 20,:wait 100,:funscript` - Runs 'funscript' 20 times with a 100 second interval between each run

`,multi 1,cough,:wait 5,sneeze,:wait 5,hiccup` - Coughs, waits 5 seconds, sneezes, waits 5 seconds, then hiccups