### PR TITLE
[script] [multi] Update code style, move waitrt?, fix whitespace bug

### DIFF
--- a/multi.lic
+++ b/multi.lic
@@ -13,21 +13,26 @@ class Multi
     elsif args[0] == "help"
       show_help
     else
-      args[0] = args[0] =~ /,/ ? args[0] : args[0].gsub(';',',')
-      indiv = args[0].split(',')
+      # Support either ',' or ';' as command delimiter
+      # because Genie can't use semicolons, but normalize on ',' for parsing.
+      args[0] = args[0] =~ /,/ ? args[0] : args[0].gsub(';', ',')
+      commands = args[0].split(',').map(&:strip)
       # in case the user puts the num of times at the end instead of the beginning
-      num = indiv[0] =~/^\d+$/ ? indiv.shift.to_i : indiv.pop.to_i
+      num = commands[0] =~ /^\d+$/ ? commands.shift.to_i : commands.pop.to_i
       num.times {
-        indiv.each{ |thing|
+        commands.each { |command|
           # To run a script, prefix its name with either a semicolon ; or a colon :
           # Genie users will need to use a colon : because smicolons ; are stripped.
           # To specify arguments for the script, include a spaces between them.
-          if thing !~ /^[;:]/ then
-            fput thing
-            waitrt?
+          waitrt?
+          if command !~ /^[;:]/ then
+            fput(command)
           else
-            scriptything = thing[1..-1].split(' ')
-            wait_for_script_to_complete(scriptything[0], scriptything[1..-1])
+            # Identify the name and arguments of the script to call.
+            script_name_and_args = command[1..-1].split(' ')
+            script_name = script_name_and_args[0]
+            script_args = script_name_and_args[1..-1]
+            DRC.wait_for_script_to_complete(script_name, script_args)
           end
         }
       }


### PR DESCRIPTION
### Changes
* Rename variables to be more descriptive.
* Do `waitrt?` before attempting any command/script.
* Fix issue where if whitespace exists appear between the `,` and `:` characters then script isn't started but treated as a literal game command.

## Tests

### Prior to change, spaces treat script commands literally
_Note the "Please rephrase that command."_
```
> ,multi 1, exp evasion , :sanowret-crystal , hiccup

--- Lich: multi active.

[multi]> exp evasion 

          SKILL: Rank/Percent towards next rank/Amount learning/Mindstate fraction
          ...snip...

> 
[multi]> :sanowret-crystal 

Please rephrase that command.
> 
[multi]> hiccup

You hiccup.
> 
--- Lich: multi has exited.
```

### With update, whitespaces are trimmed and don't cause issue
```
> ,multi 1, hiccup, :transfer-items boots backpack, smile

--- Lich: multi active.

[multi]>hiccup

You hiccup.
> 
--- Lich: transfer-items active.

[transfer-items]>look in my boots

In the demonscale boots you see a chamois cloth.
> 
[transfer-items]>get cloth from my boots

You get a chamois cloth from inside your demonscale boots.
> 
[transfer-items]>put my cloth in my backpack

You put your cloth in your hitman's backpack.
> 
--- Lich: transfer-items has exited.

> 
[multi]>smile

You smile.
> 
--- Lich: multi has exited.
```