### PR TITLE
[script] [combat-trainer] Add missing match strings when stow loot

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -494,7 +494,7 @@ class LootProcess
       return
     end
 
-    case bput("stow #{item}", 'You pick up', 'You get', 'You need a free hand', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
+    case bput("stow #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
     when 'already in your inventory'
       if @gem_nouns.include?(item)
         bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
@@ -502,7 +502,7 @@ class LootProcess
         item_reg = item.split.join('.*')
         return stow_loot(DRRoom.room_objs.grep(/\b#{item_reg}$/).first.split.last(2).join(' '), game_state)
       else
-        bput("stow other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+        bput("stow other #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
       end
     when 'You pick up', 'You get'
       @current_box_count += 1 if @box_loot_limit && @box_nouns.include?(item)


### PR DESCRIPTION
### Background
* Reported by [Sagadin](https://discord.com/channels/745675889622384681/745675890242879671/825409075927187476) who shared [this log](https://pastebin.com/zTyrcQRH)
* If ammo is lodged in you and you try to `stow <ammo>` then the game tries to get the lodged ammo instead of ammo on the ground. You will fail because you must `tend` the wound to dislodge the ammo.
* The stowing of loot (in contrast to the stowing of ammo) routine is missing match strings for this scenario.

### Changes
* When stowing loot, add match string for `needs to be tended to be removed`
* Make the match strings for `stow <item>` and `stow other <item>` be consistent

### Notes
* A more comprehensive refactoring of how loot is stowed is forthcoming that will use DRCI methods for better code reusability and maintenance.