### PR TITLE
[script] [hunting-buddy] Enter watchdog loop immediately

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -257,7 +257,6 @@ class HuntingBuddy
     message("***STATUS*** beginning hunt '#{args}' for '#{duration}' minutes")
     verify_script('combat-trainer')
     start_script('combat-trainer', args)
-    pause until $COMBAT_TRAINER.running
     counter = 0
     loop do
       clear


### PR DESCRIPTION
### Background
* If `combat-trainer` script fails to start for any reason, line 260 that pauses until the scripts starts will never stop.
* Sitting in combat taking no actions and no watchdog to bail if you get hurt leads to you dying. womp womp

### Changes
* Don't pause and wait for `combat-trainer` to start, immediately begin watchdog loop to monitor your vitals.