### PR TITLE
[script] [train] Message user when lack coin/TDPs to train

### DIFF
--- a/train.lic
+++ b/train.lic
@@ -34,17 +34,27 @@ class CrossingTrain
       return
     end
 
-    echo args.to_s
-
     @copper = 0
 
-    to_train = [args.strength, args.stamina, args.reflex, args.agility, args.discipline, args.wisdom, args.intelligence, args.charisma].join(' ').gsub(/([A-z]+)(\d+)/, '\1 \2')
+    to_train = [
+      args.strength,
+      args.stamina,
+      args.reflex,
+      args.agility,
+      args.discipline,
+      args.wisdom,
+      args.intelligence,
+      args.charisma
+    ].join(' ').gsub(/([A-z]+)(\d+)/, '\1 \2')
 
     to_train = find_train(to_train)
 
     return unless can_train?(to_train)
 
-    return unless ensure_copper_on_hand(@copper , @settings)
+    unless DRCM.ensure_copper_on_hand(@copper, @settings)
+      DRC.message("You lack sufficient funds to train. You need #{@copper} copper.")
+      exit
+    end
 
     to_train.each { |attribute, count| train(@attributes[attribute], count) }
     pause
@@ -71,7 +81,13 @@ class CrossingTrain
 
     @tdp_total = tdp_cost
 
-    DRStats.tdps >= tdp_cost
+    have_enough_tdps = DRStats.tdps >= tdp_cost
+
+    unless have_enough_tdps
+      DRC.message("You require #{tdp_cost} TDPs to train but only have #{DRStats.tdps}.")
+    end
+
+    have_enough_tdps
   end
 
   def train(info, count)
@@ -101,7 +117,7 @@ class CrossingTrain
 
     return matches if matches.length == 1
 
-    echo "Unable to match '#{input}' to a single attribute (candidates are #{matches})"
+    DRC.message("Unable to match '#{input}' to a single attribute (candidates are #{matches})")
     exit
   end
 
@@ -109,7 +125,16 @@ class CrossingTrain
     @settings = get_settings
     hometown_data = get_data('town')[@settings.hometown]
 
-    current_stats = { 'strength' => DRStats.strength, 'agility' => DRStats.agility, 'discipline' => DRStats.discipline, 'intelligence' => DRStats.intelligence, 'reflex' => DRStats.reflex, 'charisma' => DRStats.charisma, 'wisdom' => DRStats.wisdom, 'stamina' => DRStats.stamina }
+    current_stats = {
+      'strength' => DRStats.strength,
+      'agility' => DRStats.agility,
+      'discipline' => DRStats.discipline,
+      'intelligence' => DRStats.intelligence,
+      'reflex' => DRStats.reflex,
+      'charisma' => DRStats.charisma,
+      'wisdom' => DRStats.wisdom,
+      'stamina' => DRStats.stamina
+    }
 
     @attributes = {}
     current_stats .each do |stat, current|
@@ -122,5 +147,4 @@ class CrossingTrain
   end
 end
 
-# Call this last to avoid the need for forward declarations
 CrossingTrain.new


### PR DESCRIPTION
### Background
* If you have insufficient funds or TDPs to train then the script exited but didn't tell you why, so you're left wondering what's wrong.

### Changes
* Message user when they lack coins or TDPs to train the stats requested.
* Format a couple really long lines for readability.

## Tests

### lack tdps
```
> ,train str5 agi5

--- Lich: train active.

> 
[train]>tdp

You have 26 TDPs.
> 
[train]>tdp project strength 17

It will cost you 210 TDPs to reach 17 points in Strength.
> 
[train]>tdp project agility 30

It will cost you 471 TDPs to reach 30 points in Agility.
> 
| You require 681 TDPs to train but only have 26.

--- Lich: train has exited.
```

### insufficient funds
```
| You lack sufficient funds to train. You need 1362 copper.
```