### PR TITLE
[script] [common-arcana] Abort invoking magical tattoo in quiet rooms 

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -128,7 +128,7 @@ module DRCA
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
       return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
-    when 'Something in the area interferes with your spell preparations'
+    when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now'
       DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
       return false
     when 'Well, that was fun'

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -53,6 +53,7 @@ prep_messages:
 - The wailing of lost souls accompanies your preparation
 - You briskly utter a few sharp words
 - Something in the area interferes with your spell preparations
+- You shouldn't disrupt the area right now
 - You mutter incoherently
 - You are already preparing
 - You have already fully prepared


### PR DESCRIPTION
### Background
* Missing match string for "You shouldn't disrupt the area right now", which happens when trying to invoke a magical tattoo in quiet rooms (e.g. Dokt at Knife Clan)
* This leads to script hanging for 15 seconds, failing to prepare, but still trying to charge cambrinth.

```
--- Lich: buff active.
[buff]>invoke my tattoo 5
>
You shouldn't disrupt the area right now.
> 
[buff: *** No match was found after 15 seconds, dumping info]
```

### Changes
* Add "You shouldn't disrupt the area right now" match string to `base-spells.yaml`
* Check for match string in `prepare?` method and abort spell casting

## Tests

### abort spell casting when invoke magical tattoo in quiet room (new logic)
```
[buff]>invoke my tattoo 5
>
You shouldn't disrupt the area right now.
> 
--- Lich: buff has exited.
```

### abort spell casting when prepare spell in quiet room (regression test)
```
[buff]>prep BS 5
> 
Something in the area interferes with your spell preparations.
> 
--- Lich: buff has exited.
```

