### PR TITLE
[script] [wand-watcher] Add match string "This is not the best place to be doing that"

### DIFF
--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -22,6 +22,7 @@ class WandWatcher
     @activation_failure_messages = [/^The .* remains inert/]
     @activation_blocked_messages = [/^Something in the area is interfering/,
                                     /^This is not a good place for that/,
+                                    /^This is not the best place to be doing that/,
                                     /^You shouldn't disrupt the area/,
                                     /^You really shouldn't be loitering in here/,
                                     /^As you begin to do that an assistant scowls at you and motions for you to stop/,


### PR DESCRIPTION
### Background
* When in the Crossing Paladin Guild, `wand-watcher` began to activate my wands and failed because it's a non-magic room.
* The script errored about unmatched patterns.

```
[wand-watcher]>shake my eyelash viper

This is not the best place to be doing that.
...
[wand-watcher: *** No match was found after 15 seconds, dumping info]
...
[wand-watcher: message: This is not the best place to be doing that.]

[wand-watcher: checked against [/You feel yourself swaying to an internal beat/i, /^The .* remains inert/, /^Something in the area is interfering/, /^This is not a good place for that/, /^You shouldn't disrupt the area/, /^You really shouldn't be loitering in here/, /^As you begin to do that an assistant scowls at you and motions for you to stop/, /^You cannot .* while maintaining the effort to stay hidden/]]

[wand-watcher: for command shake my eyelash viper]

| Unrecognized error when trying to activate wand.

| Please open an issue on github with the details: https://github.com/rpherbig/dr-scripts/issues
```

### Changes
* Add "This is not the best place to be doing that" to activation blocked messages

## Tests

### try to activate wand in no-magic room
_Tested in Crossing Paladin Guild. This time the output clearly recognizes wands can't be used in this room and recommends user to update their configuration rather than hanging for 15 seconds._
```
[wand-watcher]>shake my eyelash viper

This is not the best place to be doing that.
> 
| Failed to activate due to room settings.

| Recommend you add room number: 7891 to wand_watcher_no_use_rooms in your yaml.

[wand-watcher]>put my eyelash viper in my watery portal
```