### PR TITLE
workorders.lic - fix clamp check

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -355,11 +355,11 @@ class WorkOrders
         end
         stow_tool('wood stain')
 
-        case bput('get my clamps', 'What were', 'You get')
-        when 'What were'
+        case bput('tap my clamps', 'I could not find', 'You tap some')
+        when 'I could not find'
           order_item(info['tool-room'], info['clamps-number'])
+          stow_tool('clamps')
         end
-        stow_tool('clamps')
 
         buy_parts(recipe['part'], info['part-room'])
         find_shaping_room(@hometown, @engineering_room)


### PR DESCRIPTION
Currently the script tries to get clamps to check if you have them but it doesn't have a match for if they're tied to a toolbelt.  It then tries to put them away and fails at that too.
I updated it to try and tap clamps instead of getting them out and stowing them.

[workorders]>get my clamps
You should untie the orange clamps from the engineer's belt first.
>
[workorders: *** No match was found after 15 seconds, dumping info]
[workorders: messages seen length: 12]
[workorders: message: Aegis of Granite  (21 roisaen)]
[workorders: message: Swirling Winds  (8 roisaen)]
[workorders: message: Righteous Wrath  (9 roisaen)]
[workorders: message: Y'ntrel Sechra  (9 roisaen)]
[workorders: message: Sure Footing  (8 roisaen)]
[workorders: message:  * Dancer Mendira Huns just wandered into another adventure.]
[workorders: message: Aegis of Granite  (21 roisaen)]
[workorders: message: Swirling Winds  (8 roisaen)]
[workorders: message: Righteous Wrath  (9 roisaen)]
[workorders: message: Y'ntrel Sechra  (9 roisaen)]
[workorders: message: Sure Footing  (8 roisaen)]
[workorders: message: You should untie the orange clamps from the engineer's belt first.]
[workorders: checked against [/What were/i, /You get/i]]
[workorders: for command get my clamps]
[workorders]>tie my clamps to my engi belt
You must be holding the orange clamps to tie to the belt.
>
[workorders: *** No match was found after 15 seconds, dumping info]
[workorders: messages seen length: 6]
[workorders: message: Aegis of Granite  (21 roisaen)]
[workorders: message: Swirling Winds  (8 roisaen)]
[workorders: message: Righteous Wrath  (9 roisaen)]
[workorders: message: Y'ntrel Sechra  (9 roisaen)]
[workorders: message: Sure Footing  (8 roisaen)]
[workorders: message: You must be holding the orange clamps to tie to the belt.]
[workorders: checked against [/you attach/i, /Your wounds hinder/i]]
[workorders: for command tie my clamps to my engi belt]