### PR TITLE
[script] [equipmanager] Stow ammo when unload weapon

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -346,9 +346,26 @@ class EquipmentManager
   end
 
   def unload_weapon(name)
-    result = bput("unload my #{name}", 'You unload', 'Your .* fall.* from', 'As you release the string', 'You .* unloading')
+    # Phrases to match:
+    #   (hidden) You remain concealed by your surroundings, convinced that your unloading of the <weapon> went unobserved.
+    #   (hidden) You unload your <weapon> while blended in with your surroundings, but cannot shake the feeling that you drew attention to yourself.
+    #   (one hand empty) You unload the <weapon>.
+    #   (hands full) Your <ammo> falls from your <weapon> to your feet.
+    case bput("unload my #{name}", 'You unload', 'Your .* fall.*', 'As you release the string', 'You .* unloading')
+    when /^(?:Your .*?\b(?<ammo>[\w]+)\b fall.* from your .* to your feet.)$/
+      # Ammo fell to ground because hands are full.
+      # Lower weapon, stow ammo, then pick it back up.
+      ammo = Regexp.last_match[:ammo]
+      bput("lower ground left", "You lower") if DRCI.in_left_hand?(name)
+      bput("lower ground right", "You lower") if DRCI.in_right_hand?(name)
+      DRCI.put_away_item?(ammo)
+      bput("get my #{name}", "You get", "You pick")
+    when /(You unload|You .* unloading)/
+      # Ammo is in hand, stow whichever hand isn't holding the weapon.
+      bput("stow left", "You put") unless DRCI.in_left_hand?(name)
+      bput("stow right", "You put") unless DRCI.in_right_hand?(name)
+    end
     waitrt?
-    bput('stow left', 'You put') if result == 'You unload' || result =~ /You .* unloading/
   end
 
   def stow_weapon(description = nil)

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -351,7 +351,7 @@ class EquipmentManager
     #   (hidden) You unload your <weapon> while blended in with your surroundings, but cannot shake the feeling that you drew attention to yourself.
     #   (one hand empty) You unload the <weapon>.
     #   (hands full) Your <ammo> falls from your <weapon> to your feet.
-    case bput("unload my #{name}", 'You unload', 'Your .* fall.*', 'As you release the string', 'You .* unloading')
+    case bput("unload my #{name}", 'You unload', 'Your .* fall.*', 'As you release the string', 'You .* unloading', 'But your .* isn\'t loaded')
     when /^(?:Your .*?\b(?<ammo>[\w]+)\b fall.* from your .* to your feet.)$/
       # Ammo fell to ground because hands are full.
       # Lower weapon, stow ammo, then pick it back up.


### PR DESCRIPTION
### Background
* Reported by [MulletByNature](https://discord.com/channels/745675889622384681/745675890242879671/827892325416960000) in Lich discord.
* combat-trainer may decide to swap weapons you're training and your current weapon may by a loaded bow/crossbow.
* combat-trainer uses equipment-manager to unload and stow the weapon.
* equipment-manager does not stow unloaded ammo if that ammo falls to your feet rather than going in to your hand.
* By not stowing your ammo then eventually combat-trainer will skip training your ranged weapon due to out of ammunition.

### Changes
* When unload weapon, check if the ammo fell to the ground and react accordingly.

## Tests

### unload crossbow with left hand empty
_Stows ammo from hand_
```
You glance down to see a weatherbeaten battle stonebow with a pitted iron windlass in your right hand and nothing in your left hand.
> ,e em = EquipmentManager.new ; em.unload_weapon('stonebow')

--- Lich: exec1 active.

[exec1]>unload my stonebow

You unload the stonebow.
Roundtime: 3 seconds.
> 
[exec1]>stow left

You put your shard in your warrior's pack.
> 
--- Lich: exec1 has exited.
```

### unload crossbow with left hand full
_Lowers item to ground, stows ammo, picks item back up_
```
You glance down to see a weatherbeaten battle stonebow with a pitted iron windlass in your right hand and a tarnished razaksel throwing hammer embellished with niello in your left hand.
> ,e em = EquipmentManager.new ; em.unload_weapon('stonebow')

--- Lich: exec1 active.

[exec1]>unload my stonebow

Your stone shard falls from your battle stonebow to your feet.
> 
[exec1]>lower ground right

You lower the stonebow and place it on the ground at your feet.
> 
[exec1]>stow my shard

> 
You pick up the shard lying at your feet.
You put your shard in your warrior's pack.
> 
[exec1]>get my stonebow

You pick up the stonebow lying at your feet.
> 
--- Lich: exec1 has exited.
```