### PR TITLE
[script] [common-arcana] Handle when cast offensive spell and there's nothing else to face

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -194,7 +194,7 @@ module DRCA
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
 
     case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
-    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/
+    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
       DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     when /You gesture/

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -189,7 +189,7 @@ module DRCA
 
     Flags.add('unknown-command', "Please rephrase that command")
     Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that")
-    Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell')
+    Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell', 'There is nothing else to face')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
 

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -202,6 +202,8 @@ cast_messages:
 - ^You trace the complex sigils
 - ^The air around you becomes
 - wave of light ripples outward from you
+# You tried to cast an offensive spell and the target no longer exists
+- There is nothing else to face
 # If don't know the cast command, like 'barrage'
 - Please rephrase that command
 # Elemental Barrage cast failures


### PR DESCRIPTION
### Background
* As a Warrior Mage casting TM spells with elemental barrage attack, by the time you're ready to `barrage <attack>` the targeted enemy may be dead or gone.
* When this happens, the game response is `There is nothing else to face!`, which is not currently one of common-arcana's match strings when casting.
* This causes the script to hang for a bit before proceeding.

```
[combat-trainer]>barrage feint
There is nothing else to face!
>
Your concentration lapses and you lose your targeting pattern.
Your watersilk bag thrums softly as it discharges all its power to maintain your spell.
>
[combat-trainer: *** No match was found after 15 seconds, dumping info]
```

### Changes
* Add match string for "There is nothing else to face" and treat as a cast failure.