### PR TITLE
athletics.lic - added outdoorsmanship method

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -66,6 +66,15 @@ class Athletics
     stow_athletics_items
   end
 
+  def outdoorsmanship_waiting(n)
+    start = Time.now
+    walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
+    stow_athletics_items
+    wait_for_script_to_complete('outdoorsmanship', [n])
+    pause (n*15) - (Time.now - start)
+    get_athletics_items
+  end
+
   def get_athletics_items
     return if @settings.held_athletics_items.empty?
 
@@ -337,10 +346,7 @@ class Athletics
         walk_to(11_126)
         walk_to(9515)
         break if done_training?
-        walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
-        stow_athletics_items
-        wait_for_script_to_complete('outdoorsmanship', ['4'])
-        get_athletics_items
+        outdoorsmanship_waiting(4)
       end
     else
       climb_wyvern
@@ -354,10 +360,7 @@ class Athletics
       walk_to(9607)
       walk_to(2900)
       break if done_training?
-      walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
-      stow_athletics_items
-      wait_for_script_to_complete('outdoorsmanship', ['4'])
-      get_athletics_items
+      outdoorsmanship_waiting(4)
     end
   end
 
@@ -373,10 +376,7 @@ class Athletics
       walk_to(13_117)
       walk_to(6443)
       break if done_training?
-      walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
-      stow_athletics_items
-      wait_for_script_to_complete('outdoorsmanship', ['3'])
-      get_athletics_items
+      outdoorsmanship_waiting(3)
     end
   end
 
@@ -386,10 +386,7 @@ class Athletics
       walk_to(12_838)
       walk_to(6154)
       break if done_training?
-      walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
-      stow_athletics_items
-      wait_for_script_to_complete('outdoorsmanship', ['4'])
-      get_athletics_items
+      outdoorsmanship_waiting(4)
     end
   end
 end


### PR DESCRIPTION
Added a method to call outdoorsmanship between climbing runs.
It consolidates the code and also fixes the issue where your outdoorsmanship is already over 29/34 which stops the outdoorsmanship script, causing you to start the climbing loop again immediately.  This will now pause the remainder of the time so that you don't make a climbing loop and learn nothing.