### PR TITLE
[script] [combat-trainer] Add match string for 'manipulate friendship'

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2071,7 +2071,7 @@ class ManipulateProcess
       index = npc_occurrences[npc]
       ordinal_string = $ORDINALS[index]
 
-      case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence')
+      case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence', 'Manipulate what')
       when 'does not seem to have a life essence' then
         game_state.construct(npc)
       else


### PR DESCRIPTION
### Background
* Fixes #4846

### Changes
* Adds `Manipulate what` as match string to `manipulate friendship` command

## Tests

### bput command doesn't hang on 'Manipulate what'
```
> ,e echo DRC.bput("manipulate friendship minstrel", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence', 'Manipulate what')

--- Lich: exec1 active.

[exec1]>manipulate friendship minstrel

Manipulate what?
> 
[exec1: Manipulate what]

--- Lich: exec1 has exited.
```