### PR TITLE
[script] [combat-trainer] Fix regex to match ammo after firing

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2894,10 +2894,11 @@ class AttackProcess
     echo("Time now: #{Time.now.to_i}") if $debug_mode_ct
     echo("@firing_timer: #{@firing_timer}") if $debug_mode_ct
     echo("@firing_delay: #{@firing_delay}") if $debug_mode_ct
-    case bput(command, 'isn\'t loaded', 'There is nothing', 'But your', /you (fire|poach|snipe) an? (?:.*\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment).* at/i, 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
+    ammo_regex = /you (fire|poach|snipe) an? (?:.*?\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|blowgun dart|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment).* at/i
+    case bput(command, ammo_regex, 'isn\'t loaded', 'There is nothing', 'But your', 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
     when /How can you (poach|snipe)/
       shoot_aimed('shoot', game_state)
-    when /you (fire|poach|snipe) an? (?:.*\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|blowgun dart|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment).* at/i
+    when ammo_regex
       game_state.action_taken
       ammo = Regexp.last_match(2)
       @firing_check = 0


### PR DESCRIPTION
### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/4868

### Changes
* Use non-greedy quantifier so regex stops at first word that would be ammo (that is: `(?:.*\s)` => `(?:.*?\s)`)
* Moved regex to variable to avoid duplication and ensure they're consistent (one was missing 'blowgun dart')

## Tests

### correctly identifies 'shard' as ammo and not 'spine' from spine-rattling strike
See and test the regular expression change at https://regex101.com/r/9bemRl/1
```
[combat-trainer]>shoot

< Moving with amazing force and guile, you fire a Sunderstone shard at a quartz gargoyle.  A quartz gargoyle fails to dodge, only slightly avoiding the blow.  
The shard lands a spine-rattling strike (16/22) that shatters bone and rends flesh of the right arm, leaving it pretty much useless.
The Sunderstone shard falls to the ground!
[You're adeptly balanced and in dominating position.]
[Roundtime 1 sec.]
> 
[combat-trainer]>stow my shard

> 
You pick up the shard lying at your feet.
You put your shard in your black quiver.
```