### PR TITLE
athletics.lic - pause fix

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -71,7 +71,8 @@ class Athletics
     walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
     stow_athletics_items
     wait_for_script_to_complete('outdoorsmanship', [n])
-    pause (n*15) - (Time.now - start)
+    remaining_pause = ((n*15) - (Time.now - start))
+    pause remaining_pause if remaining_pause > 0
     get_athletics_items
   end
 


### PR DESCRIPTION
Pause time must be positive.   Added in a check to make sure it doesn't pause if it's negative.