### PR TITLE
[script] [enchant] Remove redundant 'find_charge_invoke_stow' call

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -124,7 +124,6 @@ class Enchant
       crafting_prepare_spell(imbue_data, @settings)
       castrt = checkcastrt - (imbue_data['cambrinth'].size * 3)
       pause castrt
-      find_charge_invoke_stow(@settings.cambrinth, @settings.stored_cambrinth, @settings.cambrinth_cap, @settings.dedicated_camb_use, imbue_data['cambrinth'], true)
       waitcastrt?
       crafting_cast_spell(imbue_data, @settings)
     else


### PR DESCRIPTION
### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/4843
* Tested by ubiquitous42, https://github.com/rpherbig/dr-scripts/issues/4843#issuecomment-815423758

### Changes
* Remove the call to `find_charge_invoke_stow` because it will be done again in the `crafting_cast_spell` function of common-arcana

FYI @dr-leustyin @Dartellum @Hiinky, as previous committers to this script, would appreciate your review/approval of this change I've submitted on behalf of ubiquitous42. Thanks