### PR TITLE
[script] [t2] Removed unused variables

### DIFF
--- a/t2.lic
+++ b/t2.lic
@@ -16,8 +16,6 @@ class T2
 
     @counter = 0
     @settings = get_settings
-    @repair_timer = @settings.repair_timer
-    UserVars.repair_timer_snap ||= Time.now
     UserVars.t2_timers ||= {}
 
     t2_avoids = @settings.t2_avoids


### PR DESCRIPTION
### Background
* The assignments to `@repair_timer` and `UserVars.repair_timer_snap` were in the original commit of this script years ago, but were never used. The assignments may have been part of some copy/paste.

### Changes
* Remove assignments to `@repair_timer` and `UserVars.repair_timer_snap` as those variables are not used in this script