### PR TITLE
[script] [multi] Support being invoked by DRC.wait_for_script_to_complete

### DIFF
--- a/multi.lic
+++ b/multi.lic
@@ -13,11 +13,8 @@ class Multi
     elsif args[0] == "help"
       show_help
     else
-      # Support either ',' or ';' as command delimiter
-      # because Genie can't use semicolons, but normalize on ',' for parsing.
-      args[0] = args[0] =~ /,/ ? args[0] : args[0].gsub(';', ',')
-      commands = args[0].split(',').map(&:strip)
-      # in case the user puts the num of times at the end instead of the beginning
+      commands = clean_arguments(args[0]).split(',').map(&:strip)
+      # In case the user puts the number of times to execute at the end instead of the beginning
       num = commands[0] =~ /^\d+$/ ? commands.shift.to_i : commands.pop.to_i
       num.times {
         commands.each { |command|
@@ -37,7 +34,20 @@ class Multi
         }
       }
     end
+  end
 
+  def clean_arguments(args)
+    # If this script is invoked from DRC.wait_for_script_to_complete
+    # then the arguments may be enclosed in literal double quotes.
+    # That breaks the parsing logic so if we detect that situation
+    # we strip the leading and trailing double quote.
+    if args =~ /^\"(.*)\"$/
+      args = args.slice(1..args.length - 1)
+    end
+    # Support either ',' or ';' as command delimiter
+    # because Genie can't use semicolons, but normalize on ',' for parsing.
+    args = args =~ /,/ ? args : args.gsub(';', ',')
+    return args
   end
 
   def show_help


### PR DESCRIPTION
### Background
* In preparation for refactorings to `schedule` script (https://github.com/rpherbig/dr-scripts/pull/4882), want to ensure `multi` can be invoked programmatically via `DRC.wait_for_script_to_complete`
* `DRC.wait_for_script_to_complete` wraps the arguments in double quotes if the argument value contains a space.
* `multi` parses the first argument as a csv of arguments so the introduction of the double quotes breaks the parsing logic.

### Changes
* If `args[0]` is enclosed in double quotes then strip them.
* Move logic that transforms/cleans up the arguments to `clean_arguments(args)` method.

## Tests

### without stripping the leading/trailing double quotes, multi doesn't run
_Note the double quotes in the output of args[0]_
```
> ,e DRC.wait_for_script_to_complete('multi', ['1,:burgle start'])
--- Lich: exec1 active.
--- Lich: multi active.
[multi: args[0]="1,:burgle start"]
--- Lich: multi has exited.
--- Lich: exec1 has exited.
```

### stripping the leading/trailing double quotes works
```
> ,e DRC.wait_for_script_to_complete('multi', ['1,:burgle start'])
--- Lich: exec1 active.
--- Lich: multi active.
--- Lich: burgle active.
--- Lich: exec1 paused.
--- Lich: multi paused.

[burgle]>open my thornweave lootsack

That is already open.
> 
[burgle]>burgle recall

You take a moment to think, you believe...
You should wait at least 5 roisaen for the heat to die down.
> 

--- Lich: exec1 unpaused.
--- Lich: multi unpaused.
--- Lich: burgle has exited.
--- Lich: multi has exited.
--- Lich: exec1 has exited.
```