### PR TITLE
[script] [multi] Point players to wiki for usage

### DIFF
--- a/multi.lic
+++ b/multi.lic
@@ -8,10 +8,8 @@ class Multi
   include DRC
 
   def initialize(args = nil)
-    if args.nil? || args.empty?
+    if args.nil? || args.empty? || args[0] == "help"
       show_usage
-    elsif args[0] == "help"
-      show_help
     else
       # Support either ',' or ';' as command delimiter
       # because Genie can't use semicolons, but normalize on ',' for parsing.
@@ -40,28 +38,8 @@ class Multi
 
   end
 
-  def show_help
-    respond "Use a comma to separate number of times,command 1,command 2,etc"
-    respond " "
-    respond "For example:"
-    respond ";multi 2,order 1,buy,stow amulet"
-    respond "Will do the specified commands 2 times: order 1, buy, stow"
-    respond " "
-    respond "It will launch a script for you, too:"
-    respond ";multi 2,get diamond in pouch,;loresing,put diamond in sack"
-    respond " "
-  end
-
   def show_usage
-    respond "Use a comma to separate number of times,command 1,command 2,etc"
-    respond " "
-    respond "For example:"
-    respond ";multi 2,order 1,buy,stow amulet"
-    respond "Will do the specified commands 2 times: order 1, buy, stow"
-    respond " "
-    respond "It will launch a script for you, too:"
-    respond ";multi 2,get diamond in pouch,;purify,put diamond in sack"
-    respond " "
+    DRC.message("For usage, see https://elanthipedia.play.net/Lich_script_repository#multi")
   end
 
 end


### PR DESCRIPTION
### Background
* When `multi` is called without arguments or with the "help" argument then it displays some basic usage.
* For Genie clients, semicolons (`;`) are stripped and are not shown in the echoed response, so the examples as rendered don't work.

### Changes
* Remove `show_help` method which is redundant of `show_usage`.
* Update `show_usage` to point players to the wiki.

## Tests

### call multi with no arguments
```
> ,multi

--- Lich: multi active.

| For usage, see https://elanthipedia.play.net/Lich_script_repository#multi

--- Lich: multi has exited.
```

### call multi with 'help' argument
```
> ,multi help

--- Lich: multi active.

| For usage, see https://elanthipedia.play.net/Lich_script_repository#multi

--- Lich: multi has exited.
```

### call multi with correct arguments
```
,multi 2,hiccup
--- Lich: multi active.

[multi]>hiccup

You hiccup.
> 
[multi]>hiccup

You hiccup.
> 
--- Lich: multi has exited.
```