### PR TITLE
[script] [schedule] Refactor to be a class and to delegate to 'multi' script

### DIFF
--- a/schedule.lic
+++ b/schedule.lic
@@ -1,63 +1,50 @@
 =begin
-
-Lets you set an interval for how often the commands are allowed to run (only when called with schedule)
-
-    author: SuperPowers
-    game:   any
-    tags:   schedule,multi,multifput, input, buy, repeating, multiple command entry, empty jars, etc
-
-    Changelog: 
-          Version 1.0 - initial release. Copied from multi V1.1   22 May 2020
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#schedule
 =end
 
-if script.vars[0] == "help" or not script.vars[0]
-	respond "Schedule will run a sequence of commands at set time intervals"
-  respond " The first argument is an index for that specific time set - you can have many timers"
-  respond " The second argument is the time in minutes before allowing the commands to run again"
-  respond " The third argument is used to repeat the command sequence multiple times"
-  respond " "
-  respond "For example:"
-	respond ";schedule 1,5,2,collect rock,kick pile"
-  respond "  Will collect and kick rocks twice, if 5 minutes have passed since the last time"
-  respond " "
-  respond "It will launch a script for you, too:"
-  respond ";schedule 1,720,1,;crossing-repair"
-  respond " Will run the script crossing-repair if 6 hours have passed"
-  respond " "
-else
+custom_require.call(%w[common])
 
-#Mister Xanlin's contribution to make it better:
- #in case the user uses a semicolon
-  script.vars[0] = script.vars[0] =~ /,/ ? script.vars[0] : script.vars[0].gsub(';',',')
-  indiv = script.vars[0].split(',')
-  echo indiv
-  #in case the user puts the num of times at the end instead of the beginning
-#scheduling bit
-  UserVars.schedule ||= {}
-  index = indiv[0] =~/^\d+$/ ? indiv.shift.to_i : indiv.pop.to_i
-  minutes = indiv[0] =~/^\d+$/ ? indiv.shift.to_i : indiv.pop.to_i
-  num = indiv[0] =~/^\d+$/ ? indiv.shift.to_i : indiv.pop.to_i
-  if UserVars.schedule[index].nil? || Time.now > UserVars.schedule[index]
-    echo Time.now + 60 * minutes
-    UserVars.schedule[index] = Time.now + 60 * minutes
-    #num.times {multifput indiv}
-    num.times{
-      indiv.each{ |thing|
-        waitrt?
-        pause 0.25
-        if thing !~ /^[;:]/
-          fput thing
-        else 
-          scriptything = thing[1..-1].split(' ')
-          Script.run(scriptything[0], scriptything[1..-1].join(" "))
-        end
-        }
-    }
-  else
-    echo "Scheduler: Action skipped"
-    echo UserVars.schedule[index]
+class Schedule
+  include DRC
+
+  def initialize(args = nil)
+    UserVars.schedule ||= {}
+    if args.nil? || args.empty? || args[0] == 'help'
+      show_usage
+    else
+      commands = clean_arguments(args[0]).split(',').map(&:strip)
+      timer_label = commands.shift.to_s
+      timer_minutes = commands.shift.to_i
+      if UserVars.schedule[timer_label].nil? || Time.now > UserVars.schedule[timer_label]
+        next_time = Time.now + (60 * timer_minutes)
+        UserVars.schedule[timer_label] = next_time
+        # The multi script expects a single argument with details comma separated.
+        # This is why we rejoin the commands together and send as one argument.
+        DRC.wait_for_script_to_complete('multi', [commands.join(',')])
+      else
+        echo "Action for timer label #{timer_label} will be skipped until #{UserVars.schedule[timer_label]}"
+      end
+    end
   end
-##
 
-  
+  def clean_arguments(args)
+    # If this script is invoked from DRC.wait_for_script_to_complete
+    # then the arguments may be enclosed in literal double quotes.
+    # That breaks the parsing logic so if we detect that situation
+    # we strip the leading and trailing double quote.
+    if args =~ /^\"(.*)\"$/
+      args = args.slice(1..args.length - 1)
+    end
+    # Support either ',' or ';' as command delimiter
+    # because Genie can't use semicolons, but normalize on ',' for parsing.
+    args = args =~ /,/ ? args : args.gsub(';', ',')
+    return args
+  end
+
+  def show_usage
+    DRC.message("For usage, see https://elanthipedia.play.net/Lich_script_repository#schedule")
+  end
+
 end
+
+Schedule.new(script.vars)

--- a/schedule.lic
+++ b/schedule.lic
@@ -9,7 +9,7 @@ class Schedule
 
   def initialize(args = nil)
     UserVars.schedule ||= {}
-    if args.nil? || args.empty? || args[0] == 'help'
+    if args.nil? || args.empty? || args[0] == "help"
       show_usage
     else
       commands = clean_arguments(args[0]).split(',').map(&:strip)

--- a/schedule.lic
+++ b/schedule.lic
@@ -33,7 +33,7 @@ class Schedule
     # That breaks the parsing logic so if we detect that situation
     # we strip the leading and trailing double quote.
     if args =~ /^\"(.*)\"$/
-      args = args.slice(1..args.length - 1)
+      args = Regexp.last_match[1]
     end
     # Support either ',' or ';' as command delimiter
     # because Genie can't use semicolons, but normalize on ',' for parsing.


### PR DESCRIPTION
### Dependencies
* ~~Depends on https://github.com/rpherbig/dr-scripts/pull/4880~~

### Background
* The `schedule` script was imported from the Lnet repository and it enforces a minimum time to wait before executing a command sequence.
* The `schedule` script was mirrored after the original `multi` script, which also was refactored and imported into this repo.

### Changes
* Refactor the script in the style of `multi` that's now in the Lich repo.
* Delegate to `multi` to remove duplicative code for executing commands.
* Use the new `clean_arguments(args)` method that was added to `multi` for parsing their csv single argument.
* Update `show_usage` to point players to the wiki. 
* Timer labels (first argument to `schedule`) can be any words for more descriptive values. Previously it was limited to only numbers.

### Usage
```
;schedule [label], [interval], [arguments for multi script]
```
Example:
  - `;schedule repairs, 15, 1, :crossing-repair`
    - calls the crossing-repair script once if at least 15 minutes have elapsed since the last 'schedule' script execution for the 'repairs' label
  - `;schedule 1, 20, 2, hiccup, smile`
    - Performs the sequence twice: hiccup then smile, if at least 20 minutes have elapsed since thte last 'schedule' script execution for the '1' label

## Tests

### calling schedule without arguments shows new usage message
```
> ,schedule

--- Lich: schedule active.

| For usage, see https://elanthipedia.play.net/Lich_script_repository#schedule

--- Lich: schedule has exited.
```

### calling schedule once will set timer and run the commands using multi
```
,schedule my-timer-label,1,2,hiccup
--- Lich: schedule active.

--- Lich: multi active.
> 
[multi]>hiccup

You hiccup.
> 
[multi]>hiccup
> 
--- Lich: multi has exited.

You hiccup.
> 
--- Lich: schedule has exited.
```

### calling schedule with same label before timer expires will not run command sequence
```
,schedule my-timer-label,1,2,hiccup
--- Lich: schedule active.

[schedule: Action for timer label my-timer-label will be skipped until 2021-04-10 22:11:26 -0500]

--- Lich: schedule has exited.
```