### PR TITLE
[script] [attunement] Add warning if no rooms to train in

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -68,10 +68,22 @@ class Attunement
       rooms = [Room.current.id]
     elsif is_health_walk?
       rooms = @perceive_health_rooms
-      rooms = get_data('town')[@hometown]['perceive_health_rooms'] if rooms.empty?
+      if rooms.nil? || rooms.empty?
+        rooms = get_data('town')[@hometown]['perceive_health_rooms']
+      end
+      if rooms.nil? || rooms.empty?
+        DRC.message("No room ids defined for 'perceive_health_rooms' in your yaml nor in base-town.yaml for #{@hometown}.")
+        exit
+      end
     else
       rooms = @attunement_rooms
-      rooms = get_data('town')[@hometown]['attunement_rooms'] if rooms.empty?
+      if rooms.nil? || rooms.empty?
+        rooms = get_data('town')[@hometown]['attunement_rooms']
+      end
+      if rooms.nil? || rooms.empty?
+        DRC.message("No room ids defined for 'attunement_rooms' in your yaml nor in base-town.yaml for #{@hometown}.")
+        exit
+      end
     end
     rooms
   end


### PR DESCRIPTION
### Background
* Reported by [Kryptos](https://discord.com/channels/745675889622384681/745678251250417674/830645175712874516) in Lich discord.
* The `attunement` script enters an infinite loop of doing nothing if no rooms are defined in your yaml nor in base-town.yaml for `perceive_health_rooms` or `attunement_rooms`.

### Changes
* Add check that rooms to train in aren't empty, and if so then warn the user.
* In another PR, ensure as many towns as reasonable have both `perceive_health_rooms` and `attunement_rooms` defined.

## Tests

### no perceive_health_rooms defined
```
> ,attunement health

--- Lich: attunement active.

| No room ids defined for 'perceive_health_rooms' in your yaml nor in base-town.yaml for Shard.

--- Lich: attunement has exited.
```

### no attunement_rooms defined
```
> ,attunement

--- Lich: attunement active.

| No room ids defined for 'attunement_rooms' in your yaml nor in base-town.yaml for Shard.

--- Lich: attunement has exited.
```