### PR TITLE
[data] [base-towns] Add 'perceive_health_rooms' for Shard

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -277,6 +277,16 @@ Shard:
     - 2802
     - 2803
   perceive_health_rooms:
+    - 9575   # Engineering Society, clerk
+    - 8013   # Forging Society, clerk
+    - 10935  # Outfitting Society, clerk
+    - 8187   # Empath Guild Leader K'miriel Lystrandoniel
+    - 8222   # Paladin Guild Leader Snow
+    - 2608   # Halfling vendor
+    - 2506   # stick collector Twillan
+    - 8209   # sandy blonde Halfling bartender
+    - 10035  # Carousel Desk, Secretary Zables
+    - 2780   # uniformed representative (portal)
     - 2544   # Sentinel Neharon
     - 2525   # Sentinel Esharis
     - 2516   # Sentinel Kureta

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -276,6 +276,14 @@ Shard:
     - 2801
     - 2802
     - 2803
+  perceive_health_rooms:
+    - 2544   # Sentinel Neharon
+    - 2525   # Sentinel Esharis
+    - 2516   # Sentinel Kureta
+    - 2560   # Sentinel Janeros
+    - 2640   # Sentinel Lyle
+    - 9741   # surly clerk sitting behind a counter
+    - 2512   # outside bank, sly-eyed Elothean newsman
   strength:
     outer_room: 9573
     inner_room:

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -287,6 +287,7 @@ Shard:
     - 8209   # sandy blonde Halfling bartender
     - 10035  # Carousel Desk, Secretary Zables
     - 2780   # uniformed representative (portal)
+    - 8908   # healer Quentin
     - 2544   # Sentinel Neharon
     - 2525   # Sentinel Esharis
     - 2516   # Sentinel Kureta


### PR DESCRIPTION
### Background
* Reported by [Kryptos](https://discord.com/channels/745675889622384681/745678251250417674/830660645921357834) in the Lich discord.
* To train Empathy via `perceive health` command, you must be in a room with PCs or NPCs.
* The `attunement` script uses the `perceive_health_rooms` property to know which rooms to visit.
* There are no `perceive_health_rooms` configured for Shard.

### Changes
* Add `perceive_heatlh_rooms` to Shard's town data. These rooms have NPCs that are always around.

### Considerations
* The NPCs in the crafting societies, as well as a handful of NPCs on the streets, were not used because they wander to different rooms. For "health walk" training, the NPCs need to be in a static position.

### Credits
* Thanks to Kryptos, Melindhra, Corgar, Kiriawen, B-Money42 for helping crowdsource this data