### PR TITLE
[script] [multi] Simplify logic to strip double quotes

### DIFF
--- a/multi.lic
+++ b/multi.lic
@@ -40,7 +40,7 @@ class Multi
     # That breaks the parsing logic so if we detect that situation
     # we strip the leading and trailing double quote.
     if args =~ /^\"(.*)\"$/
-      args = args.slice(1..args.length - 1)
+      args = Regexp.last_match[1]
     end
     # Support either ',' or ';' as command delimiter
     # because Genie can't use semicolons, but normalize on ',' for parsing.


### PR DESCRIPTION
### Background
* Responding to feedback https://github.com/rpherbig/dr-scripts/pull/4880#discussion_r611218372

### Changes
* In `clean_arguments` method, refactor use of `slice(..)` with getting the regex captured group

## Tests

### regression test, should still execute multi programmatically
```
> ,e DRC.wait_for_script_to_complete('multi', ['1, close haversack, open haversack'])

--- Lich: exec1 active.

--- Lich: multi active.

[multi]>close haversack

You close your yellow haversack.
> 
[multi]>open haversack

You open your yellow haversack.
> 
--- Lich: multi has exited.

--- Lich: exec1 has exited.
```

### regression test, should still execute multi explicitly
```
> ,multi 1, close haversack, open haversack

> 
--- Lich: multi active.

[multi]>close haversack

You close your yellow haversack.
> 
[multi]>open haversack

You open your yellow haversack.
> 
--- Lich: multi has exited.
```