### PR TITLE
[script] [crossing-repair] Migrate repair time interval logic from training-manager

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -133,7 +133,7 @@ class CrossingRepair
     ]
     args = parse_args(arg_definitions)
 
-    $debug_mode_crossing_repair = args.debug ||= UserVars.crossing_repair_debug
+    $debug_mode_crossing_repair = args.debug || UserVars.crossing_repair_debug
 
     town = args.town.capitalize
     if town.start_with?('Hib')

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -145,7 +145,7 @@ class CrossingRepair
     ]
     conditions_regex = /^You [^\.]+ and is (?<condition>#{conditions.join('|')})/
     @repair_heuristic_gear.any? do |item|
-      result = DRC.bput("appraise my #{item} quick", conditions_regex, "Appraise what", "I could not find", "What were you referring", "It's hard to appraise", "Roundtime")
+      result = DRC.bput("appraise my #{item} quick", conditions_regex, "Appraise what", "I could not find", "What were you referring", "It's hard to appraise", "You cannot appraise that", "Roundtime")
       # Do regex then grab matches for condition details.
       result =~ conditions_regex
       condition_match = Regexp.last_match[:condition]

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -98,7 +98,7 @@ class CrossingRepair
   # taking into consideration wait timers between visits
   # and any heuristics to check for gear damage.
   def should_repair?
-    return should_repair_by_time?
+    return should_repair_by_time? || should_repair_by_heuristic?
   end
 
   # Returns true if enough time has elapsed since the last time
@@ -121,6 +121,44 @@ class CrossingRepair
     end
 
     return should_repair
+  end
+
+  # Appraise one or more items and if their conditions
+  # are below a threshold then repair all gear.
+  def should_repair_by_heuristic?
+    return false if @repair_heuristic_threshold.nil?
+
+    # List of damage conditions in order of worst to best.
+    # The index position is important and is compared to the threshold.
+    # https://elanthipedia.play.net/Appraisal_skill#Condition
+    conditions = [
+      'battered and practically destroyed',
+      'badly damaged',
+      'heavily scratched and notched',
+      'several unsightly notches',
+      'a few dents and dings',
+      'some minor scratches',
+      'rather scuffed up',
+      'in good condition',
+      'practically in mint condition',
+      'in pristine condition'
+    ]
+    conditions_regex = /^You [^\.]+ and is (?<condition>#{conditions.join('|')})/
+    @repair_heuristic_gear.any? do |item|
+      result = DRC.bput("appraise my #{item} quick", conditions_regex, "Appraise what", "I could not find", "What were you referring", "It's hard to appraise the", "Roundtime")
+      # Do regex then grab matches for condition details.
+      result =~ conditions_regex
+      condition_match = Regexp.last_match[:condition]
+      condition_value = conditions.index(condition_match) + 1
+      should_repair = condition_value <= @repair_heuristic_threshold
+      if $debug_mode_crossing_repair
+        echo "item: #{item}"
+        echo "condition: #{condition_value} (#{condition_match})"
+        echo "threshold: #{@repair_heuristic_threshold}"
+        echo "should repair? #{should_repair}"
+      end
+      should_repair
+    end
   end
 
   def setup
@@ -147,6 +185,8 @@ class CrossingRepair
 
     settings['hometown'] = town if town
 
+    @repair_heuristic_gear = settings.repair_heuristic_gear
+    @repair_heuristic_threshold = settings.repair_heuristic_threshold
     @repair_timer = settings.repair_timer
     UserVars.repair_timer_snap ||= Time.now
 

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -145,7 +145,7 @@ class CrossingRepair
     ]
     conditions_regex = /^You [^\.]+ and is (?<condition>#{conditions.join('|')})/
     @repair_heuristic_gear.any? do |item|
-      result = DRC.bput("appraise my #{item} quick", conditions_regex, "Appraise what", "I could not find", "What were you referring", "It's hard to appraise the", "Roundtime")
+      result = DRC.bput("appraise my #{item} quick", conditions_regex, "Appraise what", "I could not find", "What were you referring", "It's hard to appraise", "Roundtime")
       # Do regex then grab matches for condition details.
       result =~ conditions_regex
       condition_match = Regexp.last_match[:condition]

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -145,7 +145,20 @@ class CrossingRepair
     ]
     conditions_regex = /^You [^\.]+ and is (?<condition>#{conditions.join('|')})/
     @repair_heuristic_gear.any? do |item|
-      result = DRC.bput("appraise my #{item} quick", conditions_regex, "Appraise what", "I could not find", "What were you referring", "It's hard to appraise", "You cannot appraise that", "Roundtime")
+      result = DRC.bput("appraise my #{item} quick",
+        # Damage conditions, what we hope to see
+        conditions_regex,
+        # Can't find the item to appraise
+        "Appraise what",
+        "I could not find",
+        "What were you referring",
+        # Item is in a container
+        "It's hard to appraise",
+        # You're in combat or otherwise busy
+        "You cannot appraise that",
+        # Catchall in case none of the other strings are matched
+        "Roundtime"
+      )
       # Do regex then grab matches for condition details.
       result =~ conditions_regex
       condition_match = Regexp.last_match[:condition]

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -13,18 +13,23 @@ class CrossingRepair
     settings = setup
 
     start_script('performance', ['noclean']) unless settings.instrument
+
     @repair_info.each do |repairer, items|
-      echo "Repairing at #{repairer}" if UserVars.crossing_repair_debug
+      echo "Repairing at #{repairer}" if $debug_mode_crossing_repair
       repair_at(repairer['name'], repairer['id'], items)
     end
 
-    deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
+    DRCM.deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
 
     @repair_info.to_a.reverse.each do |(repairer, _items)|
       while tickets_left?(repairer)
       end
     end
 
+    # update when last repair completed
+    UserVars.repair_timer_snap = Time.now
+
+    # don't wear your boots on your head, silly
     fput('sort auto head') if settings.sort_auto_head
   end
 
@@ -32,7 +37,7 @@ class CrossingRepair
     return unless repairer
     return unless item
 
-    release_invisibility
+    DRC.release_invisibility
     if repeat
       fput('swap') unless right_hand
       command = "give #{repairer}"
@@ -59,7 +64,7 @@ class CrossingRepair
       return false
     end
 
-    walk_to(repairer['id'])
+    DRCT.walk_to(repairer['id'])
     turn_in_ticket(repairer['name'])
     @equipment_manager.empty_hands
     true
@@ -84,18 +89,51 @@ class CrossingRepair
 
   def repair_at(repairer, target_room, items)
     return if items.nil? || items.empty?
-    return unless walk_to target_room
+    return unless DRCT.walk_to(target_room)
 
     items.each { |item| repair(repairer, item) }
+  end
+
+  # Determines if you should go repair your gear,
+  # taking into consideration wait timers between visits
+  # and any heuristics to check for gear damage.
+  def should_repair?
+    return should_repair_by_time?
+  end
+
+  # Returns true if enough time has elapsed since the last time
+  # you went to repair your gear, else false.
+  # Designed to be called from 'should_repair?'
+  def should_repair_by_time?
+    return false if @repair_timer.nil?
+
+    last_repair_time = UserVars.repair_timer_snap
+    current_repair_time = Time.now
+    elapsed_time = (current_repair_time - last_repair_time).to_i
+    should_repair = elapsed_time >= @repair_timer
+
+    if $debug_mode_crossing_repair
+      echo "last repair time: #{last_repair_time}"
+      echo "current time: #{current_repair_time}"
+      echo "elapsed time (seconds): #{elapsed_time}"
+      echo "repair timer (seconds): #{@repair_timer}"
+      echo "does elapsed time exceed repair timer? #{should_repair}"
+    end
+
+    return should_repair
   end
 
   def setup
     arg_definitions = [
       [
-        { name: 'town', regex: /Crossing|River.*|Theren.*|Shard|Hib.*|Ratha/i, optional: true, description: 'Town to sell in' }
+        { name: 'town', regex: /Crossing|River.*|Theren.*|Shard|Hib.*|Ratha/i, optional: true, description: 'Town to sell in' },
+        { name: 'force', regex: /force/i, optional: true, description: 'Force repair gear, ignoring any wait timers' },
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug mode' }
       ]
     ]
     args = parse_args(arg_definitions)
+
+    $debug_mode_crossing_repair = args.debug ||= UserVars.crossing_repair_debug
 
     town = args.town.capitalize
     if town.start_with?('Hib')
@@ -109,6 +147,14 @@ class CrossingRepair
 
     settings['hometown'] = town if town
 
+    @repair_timer = settings.repair_timer
+    UserVars.repair_timer_snap ||= Time.now
+
+    unless args.force || should_repair?
+      echo "Skipping repair" if $debug_mode_crossing_repair
+      exit
+    end
+
     @equipment_manager = EquipmentManager.new
     @equipment_manager.wear_equipment_set?('standard')
     @equipment_manager.empty_hands
@@ -116,11 +162,11 @@ class CrossingRepair
     @hometown = settings.hometown
     @skip_bank = settings.sell_loot_skip_bank
     amount, denom = settings.sell_loot_money_on_hand.split(' ')
-    @keep_copper = convert_to_copper(amount, denom)
+    @keep_copper = DRCM.convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
     hometown_data = get_data('town')[settings.hometown]
 
-    ensure_copper_on_hand(@repair_withdrawal_amount, settings)
+    DRCM.ensure_copper_on_hand(@repair_withdrawal_amount, settings)
 
     # Merge, do not overwrite
     @repair_info = { hometown_data['leather_repair'] => @equipment_manager.items.select(&:leather).reject(&:skip_repair) }

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -100,3 +100,4 @@ empty_values:
   wand_watcher_no_use_scripts: []
   wand_watcher_no_use_rooms: []
   noheal_empathylink: []
+  repair_heuristic_gear: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -336,13 +336,56 @@ hunting_file_list:
 stop_on_low_threshold: 2
 
 
-# Repair settings
+## Repair settings
+# Amount of coin to withdraw to cover repair costs.
 repair_withdrawal_amount: 10_000
-# skip repairs in training_manager
+
+# If using training-manager script, skips reparing your gear.
 skip_repair: false
-# repair_timer repairs every X seconds and repair_every repairs every Y hunts
-repair_timer: 600
+
+# If using training-manager script, repairs your gear after this many hunts.
 repair_every: 1
+
+# Used by crossing-repair script.
+# Use this to control how frequently you repair your gear based on
+# the amount of elapsed time since you last repaired them.
+# The value is specified in seconds.
+# 60 = 1 minute
+# 3600 = 1 hour
+# 86400 = 1 day
+# Define variable but leave value blank to disable this check.
+repair_timer: 600
+
+# Used by crossing-repair script.
+# Which item(s) to appraise that if
+# any of their conditions are at or below
+# the heuristic threshold then run crossing-repair.
+# Shields and/or parry sticks are good choices.
+# Use this repair scheduling option to only
+# try to repair all your gear if some key items show wear and tear.
+repair_heuristic_gear:
+# - shield
+# - parry stick
+
+# Used by crossing-repair script.
+# Specify the condition of your gear listed in `repair_heuristic_gear`
+# for when to run crossing-repair to repair your gear.
+# Define variable but leave value blank to disable this check.
+#
+# --- NO REPAIRS NEEDED ---
+# 10 = in pristine condition
+# --- GEAR IS EFFECTIVE BUT STARTING TO DING UP ---
+#  9 = practically in mint condition
+#  8 = in good condition
+# --- GEAR IS LESS EFFECTIVE BELOW THIS LINE, YOU SHOULD REPAIR ---
+#  7 = rather scuffed up
+#  6 = some minor scratches
+#  5 = a few dents and dings
+#  4 = several unsightly notches
+#  3 = heavily scratched and notched
+#  2 = badly damaged
+#  1 = battered and practically destroyed
+repair_heuristic_threshold: 8
 
 
 
@@ -992,9 +1035,6 @@ theurgy_supply_container: backpack
 #    min: 3
 #    target: 4
 theurgy_supply_levels:
-
-# For better-book.lic
-writing_instrument:
 
 tithe: false
 tithe_almsbox:

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -98,17 +98,15 @@ class TrainingManager
   # Otherwise, lets crossing-repair decide if it should run or not.
   def check_repair
     return false if @skip_repair
+    repair_args = []
     if @repair_every
       UserVars.repair_every_counter += 1
       if UserVars.repair_every_counter >= @repair_every
         UserVars.repair_every_counter = 0
-        wait_for_script_to_complete('crossing-repair', ['force'])
-      else
-        wait_for_script_to_complete('crossing-repair')
+        repair_args << 'force'
       end
-    else
-      wait_for_script_to_complete('crossing-repair')
     end
+    wait_for_script_to_complete('crossing-repair', repair_args)
   end
 
   def hunting_combo

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -107,12 +107,6 @@ class TrainingManager
     end
   end
 
-  def should_repair_by_count
-    return false if @repair_every.nil?
-    return false if UserVars.repair_every_counter >= @repair_every
-    true
-  end
-
   def hunting_combo
     wait_for_script_to_complete('hunting-buddy')
     wait_for_script_to_complete('safe-room')

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -98,10 +98,14 @@ class TrainingManager
   # Otherwise, lets crossing-repair decide if it should run or not.
   def check_repair
     return false if @skip_repair
-    UserVars.repair_every_counter += 1
-    if UserVars.repair_every_counter >= @repair_every
-      UserVars.repair_every_counter = 0
-      wait_for_script_to_complete('crossing-repair', ['force'])
+    if @repair_every
+      UserVars.repair_every_counter += 1
+      if UserVars.repair_every_counter >= @repair_every
+        UserVars.repair_every_counter = 0
+        wait_for_script_to_complete('crossing-repair', ['force'])
+      else
+        wait_for_script_to_complete('crossing-repair')
+      end
     else
       wait_for_script_to_complete('crossing-repair')
     end

--- a/training-manager.lic
+++ b/training-manager.lic
@@ -22,9 +22,7 @@ class TrainingManager
     town_data = get_data('town')
     @hometown = town_data[@settings.hometown]
     @skip_repair = @settings.skip_repair
-	@sell_loot = @settings.sell_loot
-    @repair_timer = @settings.repair_timer
-    UserVars.repair_timer_snap ||= Time.now
+    @sell_loot = @settings.sell_loot
     @repair_every = @settings.repair_every
     @use_favor_altars = @settings.use_favor_altars
     UserVars.repair_every_counter ||= 0
@@ -94,31 +92,31 @@ class TrainingManager
     end
   end
 
+  # Designed to be called after every hunt to check if should repair or not.
+  # Increments a counter and when it meets or exceeds the repair every hunt threshold
+  # then forces crossing-repair script to run.
+  # Otherwise, lets crossing-repair decide if it should run or not.
   def check_repair
     return false if @skip_repair
-    return false unless should_repair_by_count || should_repair_by_time
-
-    UserVars.repair_every_counter = 0
-    UserVars.repair_timer_snap = Time.now
-    true
-  end
-
-  def should_repair_by_time
-    return false if @repair_timer.nil?
-    return false if Time.now - UserVars.repair_timer_snap < @repair_timer
-    true
+    UserVars.repair_every_counter += 1
+    if UserVars.repair_every_counter >= @repair_every
+      UserVars.repair_every_counter = 0
+      wait_for_script_to_complete('crossing-repair', ['force'])
+    else
+      wait_for_script_to_complete('crossing-repair')
+    end
   end
 
   def should_repair_by_count
     return false if @repair_every.nil?
-    return false if (UserVars.repair_every_counter += 1) < @repair_every
+    return false if UserVars.repair_every_counter >= @repair_every
     true
   end
 
   def hunting_combo
     wait_for_script_to_complete('hunting-buddy')
     wait_for_script_to_complete('safe-room')
-    wait_for_script_to_complete('crossing-repair') if check_repair
+    check_repair
   end
 
   def check_favors


### PR DESCRIPTION
### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/4879
* `training-manager` includes logic to run `crossing-repair` no more often than every N seconds.
* Players who use T2 to run `crossing-repair` would also like to benefit from this interval logic.

### Changes
* Migrate `should_repair?` and `should_repair_by_time?` logic to `crossing-repair` out of `training-manager`
* Add new heuristic option to repair only if specified item(s) appraise at or below a condition threshold
* Add module prefixes (DRC, DRCM, DRCT) to methods as general cleanup and coding style
* Add `force` argument to force script to run, regardless of timer
* Add `debug` argument to toggle debug statements when script runs
* For backwards compatibility, uses the same `repair_every` yaml setting that `training-manager` referenced

### Configuration
_crossing-repair_
```yaml
# Use this to control how frequently you repair your gear based on
# the amount of elapsed time since you last repaired them.
# The value is specified in seconds.
# 60 = 1 minute
# 3600 = 1 hour
# 86400 = 1 day
# Define variable but leave value blank to disable this check.
repair_timer: 7200

# Which item(s) to appraise that if
# any of their conditions are at or below
# the heuristic threshold then run crossing-repair.
# Shields and/or parry sticks are good choices.
# Use this repair scheduling option to only
# try to repair all your gear if some key items show wear and tear.
repair_heuristic_gear:
- oval shield
- parry stick

# Specify the condition of your gear listed in `repair_heuristic_gear`
# for when to run crossing-repair to repair your gear.
# Define variable but leave value blank to disable this check.
#
# --- NO REPAIRS NEEDED ---
# 10 = in pristine condition
# --- GEAR IS EFFECTIVE BUT STARTING TO DING UP ---
#  9 = practically in mint condition
#  8 = in good condition
# --- GEAR IS LESS EFFECTIVE BELOW THIS LINE, YOU SHOULD REPAIR ---
#  7 = rather scuffed up
#  6 = some minor scratches
#  5 = a few dents and dings
#  4 = several unsightly notches
#  3 = heavily scratched and notched
#  2 = badly damaged
#  1 = battered and practically destroyed
repair_heuristic_threshold: 8
```

_training-manager_
```yaml
# Repair your gear after every N hunts.
repair_every: 2

# Or, leave blank to rely on crossing-repair
# script's config for how often to repair your gear.
repair_every:
```

## Tests

### training-manager
* I (Katoak) verified the repair logic updates to `training-manager`.
  - Will force a repair after `repair_every` number of hunts
  - Otherwise, calls `crossing-repair` normally after every hunt to rely on any interval logic implemented there

### should repair if sufficient time has elapsed
```
> ,crossing-repair debug

--- Lich: crossing-repair active.

[crossing-repair: last repair time: 2021-04-10 17:03:35 -0500]

[crossing-repair: current time: 2021-04-11 17:03:39 -0500]

[crossing-repair: elapsed time (seconds): 86404]

[crossing-repair: repair timer (seconds): 14400]

[crossing-repair: does elapsed time exceed repair timer? true]

[crossing-repair]>inv combat
....
```

### should skip repair if gear not below heuristic threshold
```
> ,crossing-repair debug

--- Lich: crossing-repair active.

[crossing-repair: last repair time: 2021-04-11 16:10:40 -0500]

[crossing-repair: current time: 2021-04-11 17:02:16 -0500]

[crossing-repair: elapsed time (seconds): 3095]

[crossing-repair: repair timer (seconds): 14400]

[crossing-repair: does elapsed time exceed repair timer? false]

[crossing-repair: Skipping repair]

--- Lich: crossing-repair has exited.
```

### should skip repair if not enough time has elapsed
```
[crossing-repair]>appraise my demonscale armwrap quick

A woven demonscale armwrap secured by a pair of brass rings is a brawling type weapon.
A woven demonscale armwrap secured by a pair of brass rings trains the brawling skill.

You are certain that the armwrap is a purely defensive item.

You are certain that the armwrap is soundly (8/17) balanced and is poorly (3/17) suited to gaining extra attack power from your strength.

You are certain that the demonscale armwrap is appreciably susceptible to damage (7/18) and is in pristine condition (100%).

It appears that the demonscale armwrap can be worn on the right arm.
You wonder if the demonscale armwrap might weigh several tens of stones.
You are certain that the demonscale armwrap is worth exactly 27500 Kronars (2.7 plat).
The demonscale armwrap looks to bear your familiar marks of registration.
Roundtime: 5 seconds.
> 
[crossing-repair: item: demonscale armwrap]

[crossing-repair: condition: 10 (in pristine condition)]

[crossing-repair: threshold: 8]

[crossing-repair: should repair? false]

[crossing-repair: Skipping repair]

--- Lich: crossing-repair has exited.
```

### should repair if force argument provided
```
,crossing-repair force
--- Lich: crossing-repair active.

> 
[crossing-repair]>inv combat
...
```