### PR TITLE
[script] [common-items] Add match string for item that won't leave your hands

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -258,7 +258,8 @@ module DRCI
       "is too long",
       "As you open your hand to release the",
       "You easily strap",
-      "You hold out"
+      "You hold out",
+      "Oddly, when you attempt to stash it away safely"
     )
     dispose_trash(DRC.get_noun(Regexp.last_match(1))) if braid_regex.match(result)
   end


### PR DESCRIPTION
### Background
* The `gosafe` script uses `EquipmentManager.empty_hands` which uses `DRCI.stow_hands` to empty items from your hands when running to your safe room.
* The phrase "Oddly, when you attempt to stash it away safely, the nugget clings to your palm as tightly as a cat to a raft in water." was not in the match strings and the script hung up.

### Changes
* Add match string `Oddly, when you attempt to stash it away safely` to `stow_hands` method.

## Tests

### don't hang when try to stow item that's stuck to your hands
```
--- Lich: gosafe active.

> 
[gosafe]>stow left

Oddly, when you attempt to stash it away safely, the nugget clings to your palm as tightly as a cat to a raft in water.
> 
[gosafe]>stow feet

Stow what?  Type 'STOW HELP' for details.
> 
--- Lich: go2 active.

[go2: ETA: 0:00:05 (29 rooms to move through)]

[go2]>out

You drift out.
...
```