### PR TITLE
[script] [combat-trainer] Robustify stowing non-lodged ammo after shooting

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2808,11 +2808,13 @@ class AttackProcess
     echo("@firing_timer: #{@firing_timer}") if $debug_mode_ct
     @firing_check = 0
 
-    # Monitor for ammo falling to ground after powershot maneuver.
-    # The regular expression is important because we need a capturing group
-    # of the ammo so that we can stow it after the powershot.
-    # We are not interested in ammo that lodges, we will get that when looting the critter.
-    Flags.add('ct-powershot-ammo', "The (?<ammo>.*) (?:falls to the ground|lands nearby)!")
+    # Monitor for ammo falling to ground after firing your ranged weapon.
+    # Tests: https://regex101.com/r/J5RsYD/8/
+    # IMPORTANT: 'stone shard' must be listed before 'shard' and 'stone' in the pattern else won't match 'senci stone shard' correctly.
+    ammo_pattern = "(?<ammo>arrow|bolt|stone shard|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|blowgun dart|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment)s?"
+    Flags.add('ct-ranged-ammo', "(you (?<action>fire|poach|snipe) an?|your) (?<prefix>[^\.!]*? )?#{ammo_pattern}(?<suffix> [^\.!]*?)?? (at|passes through)")
+    Flags.add('ct-powershot-ammo', "With a loud twang, you let fly your #{ammo_pattern}!")
+    Flags.add('ct-ranged-loaded', 'You reach into', 'You load', 'You carefully load', 'already loaded', 'in your hand')
     Flags.add('ct-aim-failed', 'you stop aiming', 'stop concentrating on aiming')
     Flags.add('ct-ranged-ready', 'You think you have your best shot possible now.')
     Flags.add('ct-face-what', 'Face what')
@@ -2953,18 +2955,41 @@ class AttackProcess
     echo("Time now: #{Time.now.to_i}") if $debug_mode_ct
     echo("@firing_timer: #{@firing_timer}") if $debug_mode_ct
     echo("@firing_delay: #{@firing_delay}") if $debug_mode_ct
-    case bput(command, 'isn\'t loaded', 'There is nothing', 'But your', /you (fire|poach|snipe) an? (?:.*\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment).* at/i, 'I could not find', 'with no effect and falls to the ground', 'Face what', 'How can you (poach|snipe)', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire')
+
+    # Occasionally the game borks and the phrases like "Face what?"
+    # appear before the text that you fired your weapon.
+    # So, we use a flag to see if the message ever appears
+    # rather than relying on the first message returned from bput.
+    Flags.reset('ct-ranged-ammo')
+
+    result = bput(command, 'you (fire|poach|snipe)', 'isn\'t loaded', 'There is nothing', 'But your', 'I could not find', 'with no effect and falls (to the ground|to your feet)', 'Face what', 'How can you (poach|snipe)', 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire', 'But you don\'t have a ranged weapon in your hand to fire with')
+    waitrt?
+
+    case result
     when /How can you (poach|snipe)/
       shoot_aimed('shoot', game_state)
-    when /you (fire|poach|snipe) an? (?:.*\s)?(arrows?|bolt|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|blowgun dart|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment).* at/i
+    when /That weapon must be in your right hand to fire|But you don't have a ranged weapon in your hand to fire with/
+      # Explicitly say 'swap right' because if you're holding a swappable weapon (e.g. riste)
+      # then just 'swap' will try to switch the weapon mode, not move it to other hand.
+      if fput('swap right') =~ /You (swap|move)/i
+        shoot_aimed(command, game_state)
+      end
+    when /you don't feel like fighting right now/
+      pause 1
+      shoot_aimed(command, game_state)
+    when /you (fire|poach|snipe)|with no effect and falls (to the ground|to your feet)/
+      # If you fired without Bless at an incorporeal undead then it'll have no effect.
+      # However, that's still considered an action taken, just you missed.
       game_state.action_taken
-      ammo = Regexp.last_match(2)
+    end
+
+    # If detected that you shot, then stow any non-lodged ammo.
+    if Flags['ct-ranged-ammo']
+      ammo = Flags['ct-ranged-ammo'][:ammo].to_s
       @firing_check = 0
       quantity = game_state.dual_load? ? 2 : 1
       stow_ammo(ammo, quantity)
-    when 'you don\'t feel like fighting right now', 'That weapon must be in your right hand to fire'
-      pause 1
-      shoot_aimed(command, game_state)
+      Flags.reset('ct-ranged-ammo')
     end
   end
 
@@ -3041,14 +3066,19 @@ class AttackProcess
         waitrt?
       end
     else
+      load_weapon_success = ["You reach into", "You load", "You carefully load", "already loaded", "in your hand"]
+      load_weapon_failure = ["As you try to reach", "You don't have the proper ammunition", "You don't have enough .* to load two at once", "What weapon are you trying to load", "Such a feat would be impossible without the winds to guide", "but are unable to draw upon its majesty", "without steadier hands"]
+
       dual_load = game_state.dual_load?
 
       if dual_load
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
-        fput('load arrows')
-        case bput('load arrows', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')
-        when "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands'
+        Flags.reset('ct-ranged-loaded')
+        load_weapon_result = bput('load arrows', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
+        load_weapon_result = bput('load arrows', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        case load_weapon_result
+        when *load_weapon_failure
           dual_load = false # fallback to single load
           game_state.loaded = false
         else
@@ -3059,10 +3089,12 @@ class AttackProcess
       unless dual_load
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
-        fput('load')
-        case bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load")
-        when "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load"
-          DRC.message("Out of ammunition for #{game_state.weapon_name}, dancing until can switch to next weapon")
+        Flags.reset('ct-ranged-loaded')
+        load_weapon_result = bput('load', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
+        load_weapon_result = bput('load', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        case load_weapon_result
+        when *load_weapon_failure
+          DRC.message("Unable to load #{game_state.weapon_name}, you may be out of ammunition, dancing until can switch to next weapon")
           game_state.loaded = false
           game_state.clear_aim_queue
           dance(game_state)
@@ -3178,6 +3210,7 @@ class AttackProcess
       # When the flag matches game output then the value of the flag
       # is the regular expression matches. This is how we know the ammo to stow.
       stow_ammo(Flags['ct-powershot-ammo'][:ammo])
+      Flags.reset('ct-powershot-ammo')
     end
 
     game_state.use_charged_maneuvers = false
@@ -3187,6 +3220,10 @@ class AttackProcess
     echo "Stowing ammo: #{ammo}, #{quantity}" if $debug_mode_ct
     return unless ammo
     return unless quantity > 0
+    # The ammo may be 1, 2, or 3 words depending on the item (e.g. rock, crossbow bolt, matte indurium sphere)
+    # The majority of the time, if not always, the words to reference the item are the first and last (e.g. matte sphere).
+    ammo_parts = ammo.strip.split(' ')
+    ammo = [ammo_parts.first, ammo_parts.last].compact.uniq.join(' ')
     case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
     when 'You pick up', 'You put your'
       stow_ammo(ammo, quantity - 1)
@@ -4198,6 +4235,9 @@ before_dying do
   Flags.delete('glyph-mana-expired')
   Flags.delete('ct-face-what')
   Flags.delete('ct-aim-failed')
+  Flags.delete('ct-powershot-ammo')
+  Flags.delete('ct-ranged-ammo')
+  Flags.delete('ct-ranged-loaded')
   Flags.delete('ct-ranged-ready')
   Flags.delete('ct-accuracy-ready')
   Flags.delete('ct-damage-ready')
@@ -4206,7 +4246,6 @@ before_dying do
   Flags.delete('ct-regalia-expired')
   Flags.delete('ct-starlight-depleted')
   Flags.delete('ct-regalia-succeeded')
-  Flags.delete('ct-powershot-ammo')
   Flags.delete('ct-germshieldlost')
   Flags.delete('ct-itemdropped')
 end


### PR DESCRIPTION
### Dependencies
* ~~Depends on https://github.com/rpherbig/dr-scripts/pull/4894~~

### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/4877 - misidentifies what ammo was shot and doesn't pick it up
* Fixes https://github.com/rpherbig/dr-scripts/issues/4871 - doesn’t stow ammo if “Face what?” message appears first

### Changes
* To handle when game messages arrive out of order or are flat out wrong (e.g. "Face what?" appearing before the "you fire..." message), switch to using `Flags` to detect that you fired your ranged weapon. If yes, after RT then stow the ammo.
* Since the purpose of identifying the kind of ammo shot is for stowing it, and you can't stow lodged ammo, I removed the complicated regex and instead added a simpler flag that specific looks for ammo that doesn't lodge (falls to your feet, lands nearby, passes through incorporeal undead, etc).

## Tests

I tested with the following ammo on incorporeal undead and non-undead:
- crossbow bolt
- Sunderstone shard
- lemon-striped arrow
- blunt-tipped arrows with chevron stripes

Golameth tested with the following ammo on umbra moth's and arthelun cabalists:
- matte indurium sphere

<details>
<summary>Click to toggle tests</summary>

### should stow non-lodging ammo after powershot maneuver (matte indurium sphere)
```
[combat-trainer]>maneuver powershot
You square up your feet and arch your back while searching for an engaged enemy to target.
>
Knowledge from your sanowret crystal about Lunar Magic rings clear in your mind:
The youngest of the magical disciplines, Lunar magic's scholarly study begins in the Imperial era.  Broadly, it is the study of the powers derived from the celestial bodies, which include magical ('enlightened') geometry, psychic phenomenon, and light manipulation.
>
With a loud twang, you let fly your sphere!
 
Your matte indurium sphere lands a hard hit (5/23) to a fuligin umbral moth's left front leg!
The matte indurium sphere falls to the ground!
A fuligin umbral moth's wings spasm one last time, drifting away from its body like a cloud of acrid smoke.  The creature goes still, now nothing more than an ungainly mound of disintegrating shadow.
With expert skill you end the attack and maneuver into a better position.
>
[combat-trainer]>stow my matte sphere
The fuligin moth's massive proboscis licks the air lasciviously as it stands motionless.
>
You pick up the sphere lying at your feet.
You put your sphere in your drake-hide quiver.
```

### should stow non-lodging ammo after powershot maneuver (Sunderstone shard)
```
[combat-trainer]>maneuver powershot

You square up your feet and arch your back while searching for an engaged enemy to target.
> 
* Tentatively, a dire bear saunters forward, its jaws wide open in menacing fashion at you.  You partially block with a round gladiator's shield with a razaksel boss.  
[You're solidly balanced with opponent in superior position.]
> 
* As if fumbling muscle flab were natural, a dire bear saunters forward, its jaws wide open in menacing fashion at you.  You dodge, moving out of the way.  
[You're solidly balanced and have slight advantage.]
> 
* Apparently without direction or thought, a dire bear saunters forward, its jaws wide open in menacing fashion at you.  You block with a round gladiator's shield with a razaksel boss.  
[You're solidly balanced with opponent in very strong position.]
> 
With a loud twang, you let fly your shard!

Your Sunderstone shard lands a heavy strike (7/22) to a dire bear's right eye!
The dire bear is severely stunned!
The Sunderstone shard falls to the ground!
With expert skill you end the attack and maneuver into a better position.

> 
[combat-trainer]>stow my Sunderstone shard

You pick up the shard lying at your feet.
You put your shard in your thigh quiver.
```

### should stow non-lodging ammo after powershot maneuver (lemon-striped arrow)
```
[combat-trainer]>maneuver powershot

You square up your feet and arch your back while searching for an engaged enemy to target.
> 
* With pathetic timing, a dire bear swipes with powerful and sharp claws at you.  You block with a round gladiator's shield with a razaksel boss.  
[You're incredibly balanced and overwhelming your opponent.]
> 
A dire bear regains its confidence, and ability to defend itself.
> 
* As if effort and skill were a bad thing, a dire bear swipes with powerful and sharp claws at you.  You block with a round gladiator's shield with a razaksel boss.  
[You're incredibly balanced and overwhelming your opponent.]
> 
With a loud twang, you let fly your arrow!

Your lemon-striped arrow lands a strong hit (6/22) to a dire bear's chest!
The lemon-striped arrow falls to the ground!
With expert skill you end the attack and maneuver into a better position.
> 
[combat-trainer]>stow my lemon-striped arrow

You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

### should stow non-lodging ammo after powershot maneuver (crossbow bolt)
```
[combat-trainer]>maneuver powershot

You brace your shoulder against the crossbow to increase the power of the next shot.  Then you begin to look for an engaged enemy to target.
> 
You turn to face a wary field goblin.
With a loud twang, you let fly your bolt!

Your crossbow bolt lands an awesome strike (12/22) to a wary field goblin's right leg!
The field goblin is severely stunned!
That would have stuck if there was anything left to stick to!
The crossbow bolt falls to the ground!
The field goblin howls in pain and collapses to the ground moaning.
With expert skill you end the attack and maneuver into a better position.

> 
A goblin shaman gestures at you.
Several shards of elemental flame fly at you!

A fire shard misses you!
You block the fire shard with your shield.
> 
[combat-trainer]>stow my crossbow bolt

You pick up the bolt lying at your feet.
You put your bolt in your thigh quiver.
```

### should stow non-lodging ammo after powershot maneuver (blunt-tipped arrows with chevron stripes)
```
[combat-trainer]>maneuver powershot

You square up your feet and arch your back while searching for an engaged enemy to target.
> 
* Ineptly, a tall field goblin chops wide at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're solidly balanced with opponent in good position.]
> 
With a loud twang, you let fly your arrow!

Your blunt-tipped arrow lands a very heavy hit (8/22) to a goblin shaman's abdomen!
The goblin shaman is lightly stunned!
The blunt-tipped arrow falls to the ground!
With expert skill you end the attack and maneuver into a better position.

> 
[combat-trainer]>stow my blunt-tipped arrow

The goblin shaman closes to pole weapon range on you!
> 
You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

### should stow ammo after powershot maneuver that passes through incorporeal undead (Sunderstone shard)
```
[combat-trainer]>maneuver powershot

You square up your feet and arch your back while searching for an engaged enemy to target.
> 
* Apparently without direction or thought, a revenant conscript slices wide at you.  You evade.  
[You're adeptly balanced and in very strong position.]
> 
Your Sunderstone shard passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 3 sec.]
With a loud twang, you let fly your shard!

Your Sunderstone shard lands a glancing (0/23) strike to a revenant conscript's $UNKNOWN!
The Sunderstone shard falls to the ground!
With expert skill you end the attack and maneuver into a better position.
> 
[combat-trainer]>stow my Sunderstone shard

You pick up the shard lying at your feet.
You put your shard in your thigh quiver.
``` 

### should stow ammo after powershot maneuver that passes through incorporeal undead (lemon-striped arrow)
```
[combat-trainer]>maneuver powershot

You square up your feet and arch your back while searching for an engaged enemy to target.
> 
* As if fumbling muscle flab were natural, a revenant conscript claws at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're nimbly balanced and in good position.]
> 
* Moving in like a timid schoolboy, a revenant conscript claws at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're nimbly balanced and in strong position.]
> 
* As if effort and skill were a bad thing, a revenant conscript claws at you.  You dodge.  
[You're nimbly balanced and in excellent position.]
> 
Your lemon-striped arrow passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 3 sec.]
With a loud twang, you let fly your arrow!

Your lemon-striped arrow lands a glancing (0/23) strike to a revenant conscript's $UNKNOWN!
The lemon-striped arrow falls to the ground!
With expert skill you end the attack and maneuver into a better position.
> 
* Apparently without direction or thought, a revenant conscript claws at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're nimbly balanced and in better position.]
> 
* As if fumbling muscle flab were natural, a revenant conscript claws at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're nimbly balanced and in better position.]
> 
[combat-trainer]>stow my lemon-striped arrow

You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
``` 

### should stow ammo after powershot maneuver that passes through incorporeal undead (crossbow bolt)
```
[combat-trainer]>maneuver powershot

You brace your shoulder against the crossbow to increase the power of the next shot.  Then you begin to look for an engaged enemy to target.
> 
* Apparently without direction or thought, a revenant conscript pounds at you.  You evade.  
[You're nimbly balanced and in dominating position.]
> 
Your crossbow bolt passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 3 sec.]
With a loud twang, you let fly your bolt!

Your crossbow bolt lands a glancing (0/23) strike to a revenant conscript's $UNKNOWN!
The crossbow bolt falls to the ground!
With expert skill you end the attack and maneuver into a better position.
> 
[combat-trainer]>stow my crossbow bolt

You pick up the bolt lying at your feet.
You put your bolt in your thigh quiver.
```

### should stow ammo after powershot maneuver that passes through incorporeal undead (blunt-tipped arrow with chevron stripes)
```
[combat-trainer]>maneuver powershot

You square up your feet and arch your back while searching for an engaged enemy to target.
> 
Your blunt-tipped arrow passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 3 sec.]
With a loud twang, you let fly your arrow!

Your blunt-tipped arrow lands a glancing (0/23) strike to a revenant conscript's $UNKNOWN!
The blunt-tipped arrow falls to the ground!
With expert skill you end the attack and maneuver into a better position.
> 
* As if fumbling muscle flab were natural, a revenant conscript claws at you.  You block solidly with a round gladiator's shield with a razaksel boss.  
[You're solidly balanced and have slight advantage.]
>  
[combat-trainer]>stow my blunt-tipped arrow

You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

### should stow ammo after ranged shot that passes through incorporeal undead (Sunderstone shard)
```
[combat-trainer]>shoot

Your Sunderstone shard passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 1 sec.]
> 
 
The revenant conscript begins to advance on you!
The revenant conscript is still a distance away from you and is closing steadily.
> 
[combat-trainer]>stow my Sunderstone shard

You pick up the shard lying at your feet.
You put your shard in your thigh quiver.
```

### should stow ammo after ranged shot that passes through incorporeal undead (lemon-striped arrow)
```
[combat-trainer]>shoot

Your lemon-striped arrow passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 1 sec.]
> 
[combat-trainer]>stow my lemon-striped arrow

You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

### should stow ammo after ranged shot that passes through incorporeal undead (crossbow bolt)
```
[combat-trainer]>shoot

Your crossbow bolt passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 1 sec.]
> 
[combat-trainer]>stow my crossbow bolt

You pick up the bolt lying at your feet.
You put your bolt in your thigh quiver.
```

### should stow ammo after ranged shot that passes through incorporeal undead (blunt-tipped arrows with chevron stripes)
```
[combat-trainer]>shoot

Your blunt-tipped arrow passes through the revenant conscript with no effect and falls to your feet!
[Roundtime 1 sec.]
> 
[combat-trainer]>stow my blunt-tipped arrow

You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

### should stow non-lodging ammo after ranged shot (Sunderstone shard)
```
[combat-trainer]>shoot

< Moving with dominating grace, you fire a Sunderstone shard at a dire bear.  A dire bear fails to evade, stepping partly into the blow.  
The shard lands an extremely heavy hit (9/22) that explodes the heart and lungs with a bone-shattering blow to the chest.
The Sunderstone shard falls to the ground!
A dire bear growls one last time and collapses.
[You're adeptly balanced]
[Roundtime 1 sec.]
> 
[combat-trainer]>stow my Sunderstone shard

You pick up the shard lying at your feet.
You put your shard in your thigh quiver.
```

### should stow non-lodging ammo after ranged shot (lemon-striped arrow)
```
[combat-trainer]>shoot

< Driving in with an overwhelming assault, you fire a lemon-striped arrow at a dire bear.  A dire bear fails to evade, mis-stepping and blundering into the blow.  
The arrow lands a spine-rattling strike (16/22) that doubles the bear's right leg over backwards with a direct hit to the right knee.
The lemon-striped arrow falls to the ground!
A dire bear growls low and dies.
[You're adeptly balanced]
[Roundtime 1 sec.]
> 
[combat-trainer]>stow my lemon-striped arrow

You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

### should stow non-lodging ammo after ranged shot (crossbow bolt)
```
[combat-trainer]>shoot

> 
< Moving with amazing force and guile, you fire a crossbow bolt at a gap-toothed field goblin.  A gap-toothed field goblin fails to evade, taking the full blow.  
The bolt lands an apocalyptic strike (22/22) (So that's what it felt like when Grazhir shattered!) that rips the entire left arm from its socket.
That would have stuck if there was anything left to stick to!
The crossbow bolt falls to the ground!
A gap-toothed field goblin shudders and then suddenly stops all movement.
[You're adeptly balanced]
[Roundtime 1 sec.]

> 
[combat-trainer]>stow my crossbow bolt

You pick up the bolt lying at your feet.
You put your bolt in your thigh quiver.
```

### should stow non-lodging ammo after ranged shot (blunt-tipped arrows with chevron stripes)
```
[combat-trainer]>shoot

< With the precision and elegance of a plunging goshawk, you fire a blunt-tipped arrow with chevron stripes at a goblin shaman.  A goblin shaman attempts to evade, taking the full blow.  
The arrow lands an apocalyptic strike (22/22) (So that's what it felt like when Grazhir shattered!) that partially splits the sternum, snapping some ribs surrounding the heart.
The blunt-tipped arrow falls to the ground!
A goblin shaman sinks to the ground in a rustle of cloth and covers its face with the hood of its cloak.  Slowly the movements of the cloaked creature stop.
A glowing stick shatters into a million glittering splinters.
The shimmering ethereal shield fades from around a goblin shaman.
[You're nimbly balanced]
[Roundtime 1 sec.]
> 
[combat-trainer]>stow my blunt-tipped arrow

You pick up the arrow lying at your feet.
You put your arrow in your thigh quiver.
```

</details>