### PR TITLE
Chop-wood Match Improvements

### DIFF
--- a/chop-wood.lic
+++ b/chop-wood.lic
@@ -60,9 +60,9 @@ class ChopWood
       matches = DRRoom.room_objs.grep(/(?:\b|^)#{item}(?:\b|$)/i)
       matches.each do |match|
         if @use_packet && packet?
-          bput("push #{item} #{match.scan(/\w+/).last} with my packet", 'You push')
+          bput("push #{item} #{match.scan(/\w+/).last} with my packet", 'you decide to wait and see if they will collect it first', 'You push')
           bput('stow my packet', 'You put', 'Stow what')
-          bput('stow deed', 'You put')
+          bput('stow deed', 'You put', 'Stow what')
         else
           bput("stow #{match.scan(/\w+/).last}", 'You put')
         end


### PR DESCRIPTION
Matches for when you're chopping wood at the same time as someone else, and try to loot their findings.

This happens pretty rarely for me, so it might be a bit before I get to test this case again.