### PR TITLE
[script] [combat-trainer] Fix bug where backstabbing overwrites the 'attack_override' for a weapon skill

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2829,7 +2829,7 @@ class AttackProcess
         if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
           command += " #{@ambush_location}"
         else
-          command.sub!(verb, 'backstab')
+          command = command.sub(verb, 'backstab')
         end
       end
 


### PR DESCRIPTION
### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/4865
* As a Thief, after using backstab to train then the `@attack_overrides` variable becomes overwritten, changing the attack verb for the weapon skill used for backstabbing from then on out.
* This causes all attacks by the weapon skill to now be `backstab` or `backstab left` even when combat-trainer isn't trying to train backstab.

```
[combat-trainer]>hide

You melt into the background, convinced that your attempt to hide went unobserved.
Roundtime: 2 sec.

[combat-trainer]>backstab

You turn to face a quartz gargoyle.
Your blade is a little awkward, but usable.
You slip out of concealment and blindside a quartz gargoyle!
< Driving in with exacting precision....

(swap out weapons, now training with a ranged weapon)

[combat-trainer]>load
..
[combat-trainer]>aim
..
[combat-trainer]>wield my assassin's.blade
..
[combat-trainer]>backstab left

You must be hidden to blindside.
```

### Changes
* Change use of in-place variable modification with assignment to another variable, thereby preserving the original variable's value.

This was a very subtle bug to track down.