### PR TITLE
[script] [dependency] delete unused variable @item_url

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -159,7 +159,6 @@ class ScriptManager
     @paste_bin_url = 'https://pastebin.com/api/api_post.php'
     @firebase_url = 'https://dr-scripts.firebaseio.com/'
     @status_url = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/master'
-    @item_url = 'https://api.github.com/repos/rpherbig/dr-scripts/git/blobs/'
     @lich_url = 'https://api.github.com/repos/dragon-realms/dr-lich/git/trees/master'
     UserVars.autostart_scripts ||= []
     UserVars.autostart_scripts.uniq!


### PR DESCRIPTION
### Background
* While investigating what [Melindrha](https://discord.com/channels/745675889622384681/745675890242879671/831709254699581440) reported in Lich discord about `dependency` exiting due to failure of api.github.com response, found this (unrelated) unused variable.

### Changes
* Delete `@item_url` because it's not used and the URL gives a 404 not found error