### PR TITLE
[script] [events] Store raw match data so can use named groups

### DIFF
--- a/events.lic
+++ b/events.lic
@@ -47,7 +47,7 @@ events_action = proc do |server_string|
   Flags.matchers.each do |key, regexes|
     regexes.each do |regex|
       if matches = server_string.match(regex)
-        Flags.flags[key] = matches.to_a
+        Flags.flags[key] = matches
         break
       end
     end


### PR DESCRIPTION
### Background
* Suggested by @rcuhljr (https://github.com/rpherbig/dr-scripts/pull/4890#discussion_r612112575) to facilitate using named capturing groups in regular expressions used with `Flags` class.
* I'm planning to use named capturing groups with a revised regex for identifying ammo shot in `combat-trainer`

### Changes
* Store the raw regex match data in the flag rather than an array of the captured groups

## Tests

### regex without names can reference groups by number (regression test)
GIVEN:
```
Your birthday is more than 4 months away.
```
THEN:
```ruby
    Flags.add('birthday', /Your birthday is more than (\d+) (\w+) away/)
    fput('info')
    echo Flags['birthday'][1] # 4
    echo Flags['birthday'][2] # months
```

### regex with names can reference groups by name (new functionality)
GIVEN:
```
Your birthday is more than 4 months away.
```
THEN:
```ruby
    Flags.add('birthday', /Your birthday is more than (?<qty>\d+) (?<unit>\w+) away/)
    fput('info')
    echo Flags['birthday'][:qty] # 4
    echo Flags['birthday'][:unit] # months
```