### PR TITLE
Support <MatchData> response from Flags class introduced in #4894

### DIFF
--- a/avtalia.lic
+++ b/avtalia.lic
@@ -39,7 +39,7 @@ class Avtalia
       second = camb['name'].split.last
       short_reg = first == second ? /\b#{first}/i : /#{first}.*\b#{second}/i
       Flags.add("avtalia-full-#{camb['name']}", /^Your.* #{short_reg} pulses brightly with Lunar energy/)
-      Flags.add("avtalia-focus-#{camb['name']}", /A.* #{short_reg}.* pulses? .+ (\d+)/)
+      Flags.add("avtalia-focus-#{camb['name']}", /A.* #{short_reg}.* pulses? .+ (?<mana>\d+)/)
       UserVars.avtalia[camb['name']] = {'mana' => 0, 'cap' => camb['cap'], 'time_seen' => Time.now}
     end
   end
@@ -49,7 +49,7 @@ class Avtalia
 
     @avtalia_array.each do |camb|
       if Flags["avtalia-focus-#{camb['name']}"]
-        UserVars.avtalia[camb['name']]['mana'] = Flags["avtalia-focus-#{camb['name']}"][1].to_i
+        UserVars.avtalia[camb['name']]['mana'] = Flags["avtalia-focus-#{camb['name']}"][:mana].to_i
         UserVars.avtalia[camb['name']]['time_seen'] = Time.now
       end
       if Flags["avtalia-full-#{camb['name']}"]

--- a/bescort.lic
+++ b/bescort.lic
@@ -223,7 +223,7 @@ class Bescort
       [
         { name: 'currach', regex: /currach/i, description: "Row a currach between Halasa Temple and Aesry Surlaenis'a." },
         { name: 'mode', options: %w[halasa aesry], description: "halasa or aesry?" }
-      ]  
+      ]
     ]
 
     args = parse_args(arg_definitions)
@@ -346,10 +346,10 @@ class Bescort
   def currach(mode)
     if (mode.include?('aesry') && [5555, 5557, 5558].include?(Room.current.id))
       echo "You're already there silly!"
-      exit    
+      exit
     elsif (mode.include?('halasa') && [15863].include?(Room.current.id))
       echo "You're already there silly!"
-      exit    
+      exit
     elsif mode == 'aesry'
       row_direction = 'pier'
     elsif mode == 'halasa'
@@ -357,7 +357,7 @@ class Bescort
     else
       echo("Unrecognized argument: #{mode}")
       exit
-    end  
+    end
 
     if [5555, 5557, 5558, 15863].include?(Room.current.id)
       move "go currach"
@@ -373,7 +373,7 @@ class Bescort
       else
         bput("row #{row_direction}", 'You pull strongly', 'What were you referring to',  "You can't do that right now")
       end
-    end 
+    end
   end
 
   def jolas(mode)
@@ -385,7 +385,7 @@ class Bescort
 
     if (mode.include?('merkresh') && Room.current.id == 6542) || (mode.include?('harajaal') && Room.current.id == 15253)
       echo "You're already there silly!"
-      exit    
+      exit
     elsif (mode.include?('merkresh') && Room.current.id == 15253) || (mode.include?('harajaal') && Room.current.id == 6542)
       hide? unless DRRoom.room_objs.find { |x| x =~ /The Jolas/ }
       pause 1 until DRRoom.room_objs.find { |x| x =~ /The Jolas/ }
@@ -401,8 +401,8 @@ class Bescort
       else
         jolas(mode)
       end
-    end       
-  end   
+    end
+  end
 
   def hara_polo(mode)
     hara_polo_direction(mode)
@@ -418,7 +418,7 @@ class Bescort
     else
       find_room_list(%w[ne ne ne])
     end
-  end 
+  end
 
   def hara_polo_direction(mode)
     if mode == /up/i && (Room.current.id != 11411 || Room.current.id != 11412)
@@ -429,11 +429,11 @@ class Bescort
       exit
     elsif mode == /hunt/i && (Room.current.id != 11416 || Room.current.id != 11412)
       echo('Going hunting must begin in room 11416 or 11412.')
-      exit      
+      exit
     else
       move 'n' if mode.include?('hunt')
     end
-  end 
+  end
 
   def enter_brocket(mode)
     if mode !~ /exit/i && Room.current.id != 3462
@@ -1384,7 +1384,7 @@ class Bescort
   def power_walk(pattern)
     fput 'exit' if dead? || Flags['ap-danger']
     if Flags['harness-check']
-      harness_mana([20]) unless Flags['harness-check'].include?('effortlessly')
+      harness_mana([20]) unless Flags['harness-check'].to_a.include?('effortlessly')
       Flags.reset('harness-check')
     end
     result = bput('pow', pattern)

--- a/bescort.lic
+++ b/bescort.lic
@@ -1384,7 +1384,7 @@ class Bescort
   def power_walk(pattern)
     fput 'exit' if dead? || Flags['ap-danger']
     if Flags['harness-check']
-      harness_mana([20]) unless Flags['harness-check'].to_a.include?('effortlessly')
+      harness_mana([20]) unless Flags['harness-check'][1] == 'effortlessly'
       Flags.reset('harness-check')
     end
     result = bput('pow', pattern)

--- a/carve.lic
+++ b/carve.lic
@@ -110,7 +110,7 @@ class Carve
 
     tool = right_hand
     stow_item(tool)
-    part = Flags['carve-assembly'][1..-1].join('.')
+    part = Flags['carve-assembly'].to_a[1..-1].join('.')
     Flags.reset('carve-assembly')
     get_item(part)
     bput("assemble #{@my}#{@noun} with my #{part}", 'affix it securely in place', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -211,7 +211,7 @@ class SetupProcess
   end
 
   def last_stance
-    Flags['last-stance'].to_a[0] =~ /(\d+)%.* (\d+)%.* (\d+)%.* (\d+)/
+    Flags['last-stance'][0] =~ /(\d+)%.* (\d+)%.* (\d+)%.* (\d+)/
     { 'EVASION' => Regexp.last_match(1).to_i, 'PARRY' => Regexp.last_match(2).to_i, 'SHIELD' => Regexp.last_match(3).to_i, 'SPARE' => Regexp.last_match(4).to_i }
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -211,7 +211,7 @@ class SetupProcess
   end
 
   def last_stance
-    Flags['last-stance'][0] =~ /(\d+)%.* (\d+)%.* (\d+)%.* (\d+)/
+    Flags['last-stance'].to_a[0] =~ /(\d+)%.* (\d+)%.* (\d+)%.* (\d+)/
     { 'EVASION' => Regexp.last_match(1).to_i, 'PARRY' => Regexp.last_match(2).to_i, 'SHIELD' => Regexp.last_match(3).to_i, 'SPARE' => Regexp.last_match(4).to_i }
   end
 
@@ -883,9 +883,9 @@ class SafetyProcess
   def initialize(settings)
     echo('New SafetyProcess') if $debug_mode_ct
     Flags.add('ct-engaged', 'closes to pole weapon range on you', 'closes to melee range on you')
-    Flags.add('ct-lodged', 'from the .* lodged in your (.*)\.')
-    Flags.add('ct-germshieldlost', 'It jerks the.* (\w+) out of your hands')
-    Flags.add('active-mitigation', 'You believe you could \b(\w+) out of the way of the \b(\w+)')
+    Flags.add('ct-lodged', 'from the .* lodged in your (?<body_part>.*)\.')
+    Flags.add('ct-germshieldlost', 'It jerks the.* (?<shield>\w+) out of your hands')
+    Flags.add('active-mitigation', 'You believe you could \b(?<action>\w+) out of the way of the \b(?<obstacle>\w+)')
     @health_threshold = settings.health_threshold
     echo("  @health_threshold: #{@health_threshold}") if $debug_mode_ct
   end
@@ -905,7 +905,7 @@ class SafetyProcess
 
   def check_item_recovery(game_state)
     if Flags['ct-germshieldlost']
-      recover_item(game_state, Flags['ct-germshieldlost'].last, 'wear')
+      recover_item(game_state, Flags['ct-germshieldlost'][:shield], 'wear')
       Flags.reset('ct-germshieldlost')
     end
   end
@@ -934,7 +934,7 @@ class SafetyProcess
 
   def tend_lodged
     return unless Flags['ct-lodged']
-    bind_wound(Flags['ct-lodged'].last)
+    bind_wound(Flags['ct-lodged'][:body_part])
     Flags.reset('ct-lodged')
   end
 
@@ -946,7 +946,7 @@ class SafetyProcess
 
   def active_mitigation
     return unless Flags['active-mitigation']
-    bput("#{Flags['active-mitigation'][1]} #{Flags['active-mitigation'][2]}", 'You manage to', "You've got to", 'Please rephrase', 'You jump back', "You can't do")
+    bput("#{Flags['active-mitigation'][:action]} #{Flags['active-mitigation'][:obstacle]}", 'You manage to', "You've got to", 'Please rephrase', 'You jump back', "You can't do")
     Flags.reset('active-mitigation')
   end
   def in_danger?(danger)
@@ -3106,7 +3106,7 @@ class AttackProcess
     # The regular expression is important because we need a capturing group
     # of the ammo so that we can stow it after the powershot.
     # We are not interested in ammo that lodges, we will get that when looting the critter.
-    Flags.add('ct-powershot-ammo', "The (.*) (?:falls to the ground|lands nearby)!") if action == 'powershot'
+    Flags.add('ct-powershot-ammo', "The (?<ammo>.*) (?:falls to the ground|lands nearby)!") if action == 'powershot'
 
     attempt = bput("maneuver #{action}", 'You raise your', 'You brace your', 'balanced and', 'Taking a full step back', 'You take a step back', 'You lower your shoulders', 'You angle to the side and ', 'rest a bit longer', 'You square up your feet', 'You crouch down', 'You step to the side')
     return if attempt == 'rest a bit longer'
@@ -3118,7 +3118,7 @@ class AttackProcess
     if Flags['ct-powershot-ammo']
       # When the flag matches game output then the value of the flag
       # is the regular expression matches. This is how we know the ammo to stow.
-      stow_ammo(Flags['ct-powershot-ammo'][1])
+      stow_ammo(Flags['ct-powershot-ammo'][:ammo])
       Flags.reset('ct-powershot-ammo')
     end
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -436,7 +436,7 @@ module DRCA
     Flags.add('aura-growing?', 'Local conditions permit optimal growth of your aura', 'Local conditions are hindering the growth of your aura')
     aura = {}
     DRC.bput('perceive aura', 'Roundtime')
-    aura['level'] = Flags['aura-level'] ? starlight_messages.index(Flags['aura-level'].first) : 0
+    aura['level'] = Flags['aura-level'] ? starlight_messages.index(Flags['aura-level'].to_a.first) : 0
     aura['capped'] = Flags['aura-capped?'] ? true : false
     aura['growing'] = Flags['aura-growing?'] ? true : false
     Flags.delete('aura-level')

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -436,7 +436,7 @@ module DRCA
     Flags.add('aura-growing?', 'Local conditions permit optimal growth of your aura', 'Local conditions are hindering the growth of your aura')
     aura = {}
     DRC.bput('perceive aura', 'Roundtime')
-    aura['level'] = Flags['aura-level'] ? starlight_messages.index(Flags['aura-level'].to_a.first) : 0
+    aura['level'] = Flags['aura-level'] ? starlight_messages.index(Flags['aura-level'][0]) : 0
     aura['capped'] = Flags['aura-capped?'] ? true : false
     aura['growing'] = Flags['aura-growing?'] ? true : false
     Flags.delete('aura-level')

--- a/enchant.lic
+++ b/enchant.lic
@@ -30,7 +30,7 @@ class Enchant
     Flags.add('enchant-meditate', 'The traced sigil pattern blurs before your eyes')
     Flags.add('enchant-imbue', 'Once finished you sense an imbue spell will be required to continue enchanting')
     Flags.add('enchant-push', 'You notice many of the scribed sigils are slowly merging back')
-    Flags.add('enchant-sigil', /You need another ([\w ]*)(primary|secondary) sigil to continue the enchanting process/)
+    Flags.add('enchant-sigil', /You need another (?<type>[\w ]*)(?<order>primary|secondary) sigil to continue the enchanting process/)
     Flags.add('enchant-complete', 'With the enchanting process completed, you believe it is safe to collect your things once more.', 'With the enchantment complete', 'With enchanting complete')
     Flags.add('imbue-failed', 'The streams collide, rending the space before you and disrupting the enchantment')
     Flags.add('imbue-backlash', 'Suddenly the streams slip through your grasp and cascade violently against each other')
@@ -171,7 +171,7 @@ class Enchant
 
   def scribe
     if Flags['enchant-sigil']
-      sigil_type = Flags['enchant-sigil'][1].delete(' ')
+      sigil_type = Flags['enchant-sigil'][:type].delete(' ')
       Flags.reset('enchant-sigil')
       sigil_type = 'induction' if sigil_type == ''
       stow_item(@burin)

--- a/forge.lic
+++ b/forge.lic
@@ -405,7 +405,7 @@ class Forge
   def assemble_part
     while Flags['forge-assembly']
       part = nil
-      part = if Flags['forge-assembly'].to_a.first == 'ready to be woven into and around the material'
+      part = if Flags['forge-assembly'][0] == 'ready to be woven into and around the material'
                'padding'
              else
                Flags['forge-assembly'].to_a[1..-1].join('.')

--- a/forge.lic
+++ b/forge.lic
@@ -405,10 +405,10 @@ class Forge
   def assemble_part
     while Flags['forge-assembly']
       part = nil
-      part = if Flags['forge-assembly'].first == 'ready to be woven into and around the material'
+      part = if Flags['forge-assembly'].to_a.first == 'ready to be woven into and around the material'
                'padding'
              else
-               Flags['forge-assembly'][1..-1].join('.')
+               Flags['forge-assembly'].to_a[1..-1].join('.')
              end
       Flags.reset('forge-assembly')
       fput("get my #{part}")

--- a/mine.lic
+++ b/mine.lic
@@ -30,7 +30,7 @@ class Mine
   end
 
   def resource_level
-    case Flags['resource-level'].to_a.first
+    case Flags['resource-level'][0]
     when 'certain a scattering of resources', 'scattering of resources (0/5) remains to be found'
       1
     when 'enormous quantity remains to be found', 'enormous quantity (5/5) remains to be found'

--- a/mine.lic
+++ b/mine.lic
@@ -30,7 +30,7 @@ class Mine
   end
 
   def resource_level
-    case Flags['resource-level'].first
+    case Flags['resource-level'].to_a.first
     when 'certain a scattering of resources', 'scattering of resources (0/5) remains to be found'
       1
     when 'enormous quantity remains to be found', 'enormous quantity (5/5) remains to be found'

--- a/mm.lic
+++ b/mm.lic
@@ -74,7 +74,7 @@ class MoonMagery
     cast_spell(data, @settings)
     pause 0.25
     if Flags['locate-fail']
-      case Flags['locate-fail'].to_a.first
+      case Flags['locate-fail'][0]
       when /Your vision is not clear/
         echo 'Clear vision was not active when attempting to cast locate. Try again.'
       when /seem to be anyone by that name/

--- a/mm.lic
+++ b/mm.lic
@@ -74,7 +74,7 @@ class MoonMagery
     cast_spell(data, @settings)
     pause 0.25
     if Flags['locate-fail']
-      case Flags['locate-fail'].first
+      case Flags['locate-fail'].to_a.first
       when /Your vision is not clear/
         echo 'Clear vision was not active when attempting to cast locate. Try again.'
       when /seem to be anyone by that name/

--- a/sew.lic
+++ b/sew.lic
@@ -171,7 +171,7 @@ class Sew
 
   def assemble_part
     while Flags['sew-assembly']
-      part = Flags['sew-assembly'][1..-1].join('.')
+      part = Flags['sew-assembly'].to_a[1..-1].join('.')
       Flags.reset('sew-assembly')
       stow_item(left_hand)
       get_item(part)

--- a/shape.lic
+++ b/shape.lic
@@ -148,7 +148,7 @@ class Shape
 
     tool = right_hand
     stow_item(tool)
-    part = Flags['shaping-assembly'][1..-1].join('.')
+    part = Flags['shaping-assembly'].to_a[1..-1].join('.')
     part = 'backer' if part == 'backing'
     part = 'arrow flights' if part == 'flights'
     if part == "arrowhead"

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -431,7 +431,7 @@ class TheurgyActions
   def can_commune?
     return false if @communes.empty?
     return true unless Flags['theurgy-commune']
-    Flags['theurgy-commune'].include?(
+    Flags['theurgy-commune'].to_a.include?(
       'fully prepared to seek assistance from the Immortals once again'
     )
   end
@@ -500,7 +500,7 @@ class TheurgyActions
                    'prep_time' => 2,
                    'cast' => 'cast drink' }, @settings)
       if Flags['theurgy-gg-drink'] &&
-         !Flags['theurgy-gg-drink'].include?('Both your hands are full!')
+         !Flags['theurgy-gg-drink'].to_a.include?('Both your hands are full!')
         offered_item = Flags['theurgy-gg-drink'][1]
       end
       Flags.delete('theurgy-gg-drink')

--- a/tinker.lic
+++ b/tinker.lic
@@ -185,7 +185,7 @@ class Tinker
 
     tool = right_hand
     stow_item(tool)
-    part = Flags['tinkering-assembly'][1..-1].join('.')
+    part = Flags['tinkering-assembly'].to_a[1..-1].join('.')
     part = 'backer' if part == 'backing'
     part = "#{@mechanism} #{part}" if part == 'mechanism'
     part = 'bolt flights' if part == 'flights'


### PR DESCRIPTION
### Background
* https://github.com/rpherbig/dr-scripts/pull/4894 updated Flags class to return `MatchData` regex result rather than array of the string matches to support named groups
* Some scripts treated the response as an array and called methods on the result rather than accessing groups by index, and those scripts are now [breaking](https://discord.com/channels/745675889622384681/745675890242879671/831956248261296158)
* Supercedes #4895

```
--- Lich: error: undefined method `last' for #<MatchData:0x124107c0>
    combat-trainer:937:in `tend_lodged'
    combat-trainer:898:in `execute'
--- Lich: combat-trainer has exited.
```

```
--- Lich: error: undefined method first' for #<MatchData:0x10e94ea8>
    common-arcana:439:in perc_aura'
    combat-trainer:1575:in `check_starlight'
```

### Changes
* Update scripts that treated Flags result as an array to call `.to_a` on the result first
* Use named capture groups where appropriate
* Replace Flags['name'].first/last with Flags['name'][0]