### PR TITLE
[script] [common] Get and wear instrument for "Are you sure that's the right instrument?"

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -493,9 +493,9 @@ module DRC
       play_command = play_command + " on my #{instrument}"
     end
     fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
-    result = bput(play_command, 'too damaged to play', 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
+    result = bput(play_command, 'too damaged to play', 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'Are you sure that\'s the right instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
     case result
-    when 'Play on what instrument'
+    when 'Play on what instrument', 'Are you sure that\'s the right instrument'
       snapshot = "#{right_hand}#{left_hand}"
       fput("get #{instrument}")
       return false if snapshot == "#{right_hand}#{left_hand}"


### PR DESCRIPTION
### Background
* If you use `worn_instrument:` property in your yaml but the instrument is currently not worn, such as got stowed in a container, then attempting to play a song on it will give the message "Are you sure that's the right instrument?"
* That message is not a match string and the script hangs.
* There exists recovery logic for the message "Play on what instrument" that we can use.

### Changes
* To `play_song?` method, add match string for "Are you sure that's the right instrument?" and perform same recovery logic as for "Play on what instrument".

## Tests

### get and wear intrument then play
GIVEN:
Your instrument is in an open container and you have the following config:
```yaml
worn_instrument: zills
```
THEN:
```
> ,performance

--- Lich: performance active.

[performance]>play lullaby on my zills

> 
Are you sure that's the right instrument?
> 
[performance]>get zills

You get some polished thin-edged zills with silvered esoteric filigree from inside your encompassing shadows.
> 
[performance]>wear zills

You slide some polished thin-edged zills with silvered esoteric filigree onto your finger.
> 
[performance]>play lullaby on my zills

You begin a quiet lullaby on your thin-edged zills with only the slightest hint of difficulty.
```