### PR TITLE
[script] [combat-trainer] Skip ranged weapon when can't use it

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2988,8 +2988,8 @@ class AttackProcess
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
         fput('load arrows')
-        case bput('load arrows', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')
-        when "As you try to reach", "You don't have the proper ammunition", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands'
+        case bput('load arrows', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands', 'Your .* makes the task more difficult')
+        when "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load", 'Such a feat would be impossible without the winds to guide', 'but are unable to draw upon its majesty', 'without steadier hands'
           dual_load = false # fallback to single load
           game_state.loaded = false
         else
@@ -3001,8 +3001,8 @@ class AttackProcess
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
         fput('load')
-        case bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition")
-        when "As you try to reach", "You don't have the proper ammunition"
+        case bput('load', 'You reach into', 'You carefully load', 'already loaded', 'in your hand', "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load")
+        when "As you try to reach", "You don't have the proper ammunition", "What weapon are you trying to load"
           DRC.message("Out of ammunition for #{game_state.weapon_name}, dancing until can switch to next weapon")
           game_state.loaded = false
           game_state.clear_aim_queue
@@ -3045,7 +3045,7 @@ class AttackProcess
   end
 
   def aim(game_state)
-    case bput('aim', 'You begin to target', 'You are already', 'There is nothing else', 'Face what\?', 'You shift your target', 'Your repeating crossbow', 'Your assassin\'s crossbow', 'Your repeating arbalest', 'Strangely, you don\'t feel like fighting right now', 'Your riot crossbow', 'In one frozen moment', "isn't loaded")
+    case bput('aim', 'You begin to target', 'You are already', 'There is nothing else', 'Face what\?', 'You shift your target', 'Your repeating crossbow', 'Your assassin\'s crossbow', 'Your repeating arbalest', 'Strangely, you don\'t feel like fighting right now', 'Your riot crossbow', 'In one frozen moment', "isn't loaded", "You don't have a ranged weapon to aim with")
     when 'You are already', 'You begin to target'
       game_state.loaded = true
       check_firing_time
@@ -3063,7 +3063,7 @@ class AttackProcess
       when 'You attempt to ready your repeating arbalest'
         game_state.loaded = false
       end
-    when "isn't loaded"
+    when "isn't loaded", "You don't have a ranged weapon to aim with"
       game_state.loaded = false
     when 'Face what?'
       game_state.clear_aim_queue


### PR DESCRIPTION
### Background
* If you're casting sorcerous spells, `combat-trainer` will stow and equip your current weapon so as to avoid item loss due to sorcerous backlash (e.g. lose a hand).
* When re-equipping a ranged weapon after sorcerous backlash destroyed your right hand, the weapon will go to your left hand.
* Attempts to load or aim will fail while the ranged weapon is not in your right hand; however, `combat-trainer` is missing match strings for these scenarios and result in "No match was found after 15 seconds" errors.

```
You feel fully prepared to cast your spell.

[combat-trainer]>put my yew.shortbow in my encompassing shadows
You should unload the yew shortbow first.

[combat-trainer]>unload my yew.shortbow
You stop aiming.
You unload the shortbow.
Roundtime: 1 seconds.

[combat-trainer]>stow left
You put your arrow in your encompassing shadows.

[combat-trainer]>put my yew.shortbow in my encompassing shadows
You put your shortbow in your encompassing shadows.

[combat-trainer]>cast
You gesture.
Your platinum bracer emits a loud *snap* as it discharges all its power to aid your spell.
The spell pattern resists the influx of Lunar mana, and a strange burning sensation backwashes from the spell pattern into your body.
An instant rush of black and blue fire explodes into being, consuming your right hand and turning it into ash!
!> 
| ***STATUS*** stopping due to bleeding

[combat-trainer]>get yew.shortbow from my encompassing shadows
You get a yew shortbow with a rawhide grip from inside your encompassing shadows.

[tendme]>heal
Your body feels slightly battered.
Your spirit feels full of life.
You have an ugly stump for a right hand.
Bleeding
            Area       Rate              
-----------------------------------------
      right hand       very bad

[tendme]>tend my right hand
Your right hand is too injured for you to do that.
!> 
[combat-trainer]>retreat
You retreat back to pole range.
!> 
[combat-trainer]>retreat
You retreat from combat.

[combat-trainer]>load
What weapon are you trying to load?

[combat-trainer]>load
What weapon are you trying to load?

...

[combat-trainer: *** No match was found after 15 seconds, dumping info]

...

[combat-trainer]>aim
You don't have a ranged weapon to aim with!

...

[combat-trainer: *** No match was found after 15 seconds, dumping info]
```

### Changes
* If unable to load or aim weapon because it can't be found or isn't in your right hand, skip to next weapon as if you were out of ammunition.

## Tests

### skip weapon if unable to load
```
[combat-trainer]>load
What weapon are you trying to load?

| Out of ammunition for yew shortbow, dancing until can switch to next weapon
```

### skip weapon if unable to aim
```
[combat-trainer]>aim
You don't have a ranged weapon to aim with!

[combat-trainer]>put my yew.shortbow in my encompassing shadows
You put your shortbow in your encompassing shadows.

[combat-trainer]>aim stop
But you're not aiming at anything!

[combat-trainer]>get leather.sling from my encompassing shadows
You get a leather sling with a reinforced cup from inside your encompassing shadows.
```