### PR TITLE
athletics - added max argument

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -30,12 +30,14 @@ class Athletics
         { name: 'undergondola', regex: /^un.*/i, optional: true, description: 'Climb branch etc undergondola' },
         { name: 'xalas', regex: /^xala.*/i, optional: true, description: 'Climb xalas in zoluren in instead of undergondola' },
         { name: 'stationary', regex: /^stat.*/i, optional: true, description: 'Stand still and use a climbing rope' },
-        { name: 'cliffs', regex: /^cliff.*/i, optional: true, description: 'Climb undergondola without attempting branch' }
+        { name: 'cliffs', regex: /^cliff.*/i, optional: true, description: 'Climb undergondola without attempting branch' },
+        { name: 'max', regex: /^max/i, optional: true, description: 'Keep training until 29/34+' }
       ]
     ]
 
     args = parse_args(arg_definitions)
 
+    @end_exp = 29 if args.max
     start_script('skill-recorder') unless Script.running?('skill-recorder')
     if args.wyvern || (@settings.climbing_target == 'wyvern')
       climb_wyvern


### PR DESCRIPTION
I've added an optional argument named max.

This can be used in conjunction with t2 or when calling it manually so that even if you start at 0/34, it will keep cycling until you've reached or passed 29/34 field experience.
For example, currently I use this to make sure athletics trains enough:

```training_list:
- skill: Athletics
  start: 10
  scripts:
  - athletics xalas
  - athletics xalas
```

This causes the second run to start immediately after the first one finishes if athletics is still below 29/34 and in doing so it does not wait for the timer between climbs.
With this change you can run this:

```training_list:
- skill: Athletics
  start: 10
  scripts:
  - athletics xalas max
```

It will keep training until your athletics is >= 29/34 and respect the athletics timer.