### PR TITLE
[script] [common-items] Add match string for "You drum your fingers"

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -189,8 +189,8 @@ module DRCI
   end
 
   def exists?(description)
-    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You thump your fingers', 'The orb is delicate')
-    result =~ /You tap|You thump|The orb is delicate/
+    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You (thump|drum) your fingers', 'The orb is delicate')
+    result =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
   end
 
   def count_item_parts(item)


### PR DESCRIPTION
### Background
* When you tap a hitman's backpack, the output is "You drum your fingers against the soft material of the backpack, creating a very quiet tattoo."
* The phrase "You thumb your fingers" is a match string, but "You drum your fingers" is not.

### Changes
* To `exists?` method, add phrase "You drum your fingers" to match string

## Tests

### should detect that hitman's backpack exists

```
> ,e echo DRCI.exists?('hitman backpack')

--- Lich: exec1 active.

[exec1]>tap my hitman backpack

You drum your fingers against the soft material of the backpack, creating a very quiet tattoo.
> 
[exec1: 0]

--- Lich: exec1 has exited.
```