### PR TITLE
[script] [equipmanager] Avoid infinite loop when fail to swap weapon to skill

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -307,41 +307,73 @@ class EquipmentManager
     if noun =~ /\bfan\b/i
       command = skill =~ /edged/i ? 'open' : 'close'
       bput("#{command} my fan", 'you snap', 'already')
-      return
+      return true
     end
     proper_skill = case skill
                    when /^he$|heavy edge|large edge|one-handed/i
                      'heavy edged'
-                   when /2he|^the$|twohanded edge|two-handed/i
+                   when /^2he$|^the$|twohanded edge|two-handed edge/i
                      'two-handed edged'
-                   when /2hb|^thb$|twohanded blunt/i
-                     'two-handed blunt'
                    when /^hb$|heavy blunt|large blunt/i
                      'heavy blunt'
-                   when /se|small edged/i
+                   when /^2hb$|^thb$|twohanded blunt|two-handed blunt/i
+                     'two-handed blunt'
+                   when /^se$|small edged|light edge|medium edge/i
                      '(light edged|medium edged)'
-                   when /sb|small blunt/i
+                   when /^sb$|small blunt|light blunt|medium blunt/i
                      '(light blunt|medium blunt)'
-                   when /lt|light thrown/i
+                   when /^lt$|light thrown/i
                      'light thrown'
+                   when /^ht$|heavy thrown/i
+                     'heavy thrown'
                    when /stave/i
                      '(short|quarter) staff'
                    when /polearms/i
                      '(halberd|pike)'
-                   when /ow|offhand weapon/i
-                     return
+                   when /^ow$|offhand weapon/i
+                     return true # just use weapon in your left hand
                    else
-                     echo('unsupported weapon swap, please help us add this weapon')
+                     DRC.message("Unsupported weapon swap: #{noun} to #{skill}. Please report this to https://github.com/rpherbig/dr-scripts/issues")
+                     return false
                    end
-
-    Flags.add('hand-full', 'You must have two free hands')
+    # All possible weapon skills to swap into.
+    weapon_skills = [
+      'light edged',
+      'medium edged',
+      'heavy edged',
+      'two-handed edged',
+      'light blunt',
+      'medium blunt',
+      'heavy blunt',
+      'two-handed blunt',
+      'light thrown',
+      'heavy thrown',
+      'short staff',
+      'quarter staff',
+      'halberd',
+      'pike'
+    ]
+    # The spaces in the regex are deliberate
     skill_match = / #{proper_skill} /i
-    until skill_match =~ bput("swap my #{noun}", skill_match, "\\b#{noun}\\b.*(heavy edged|two-handed edged|heavy blunt|two-handed blunt|light edged|medium edged|light blunt|medium blunt|light thrown|short staff|quarter staff|halberd)")
+    swapped_count = 0
+    loop do
       pause 0.25
-      next unless Flags['hand-full']
-      fput('stow left') if left_hand && left_hand !~ /#{noun}/i
-      fput('stow right') if right_hand && right_hand !~ /#{noun}/i
-      Flags.reset('hand-full')
+      # Avoid infinite loop where weapon can't swap to desired skill.
+      return false if swapped_count > weapon_skills.length
+      # Try to swap weapon to desired skill.
+      case bput("swap my #{noun}", skill_match, "\\b#{noun}\\b.*(#{weapon_skills.join('|')})", "You must have two free hands", "You have nothing to swap", "Your (left|right) hand is too injured")
+      when /You must have two free hands/
+        fput('stow left') if left_hand && left_hand !~ /#{noun}/i
+        fput('stow right') if right_hand && right_hand !~ /#{noun}/i
+        next
+      when /You have nothing to swap/
+        return false
+      when /Your (left|right) hand is too injured/
+        return false
+      when skill_match
+        return true
+      end
+      swapped_count = swapped_count + 1
     end
   end
 

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#equipmanager
 =end
 
-custom_require.call(%w[common common-items events])
+custom_require.call(%w[common common-items])
 
 class EquipmentManager
   include DRC

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -353,6 +353,12 @@ class EquipmentManager
       'halberd',
       'pike'
     ]
+    failure_matches = [
+      /You have nothing to swap/,
+      /Your (left|right) hand is too injured/,
+      /Will alone cannot conquer the paralysis that has wracked your body/,
+      /^You move a .* to your (left|right) hand/
+    ]
     # The spaces in the regex are deliberate
     skill_match = / #{proper_skill} /i
     swapped_count = 0
@@ -361,14 +367,12 @@ class EquipmentManager
       # Avoid infinite loop where weapon can't swap to desired skill.
       return false if swapped_count > weapon_skills.length
       # Try to swap weapon to desired skill.
-      case bput("swap my #{noun}", skill_match, "\\b#{noun}\\b.*(#{weapon_skills.join('|')})", "You must have two free hands", "You have nothing to swap", "Your (left|right) hand is too injured")
+      case bput("swap my #{noun}", skill_match, /\b#{noun}\b.*(#{weapon_skills.join('|')})/, "You must have two free hands", *failure_matches)
       when /You must have two free hands/
         fput('stow left') if left_hand && left_hand !~ /#{noun}/i
         fput('stow right') if right_hand && right_hand !~ /#{noun}/i
         next
-      when /You have nothing to swap/
-        return false
-      when /Your (left|right) hand is too injured/
+      when *failure_matches
         return false
       when skill_match
         return true


### PR DESCRIPTION
### Background
* My character got stuck in an infinite loop in `combat-trainer` while it waited for my riste to be swapped to a particular skill but couldn't because my right hand was too injured.
* Although `hunting-buddy` watchdog mechanics were trying to exit the script due to my low health, it was hung waiting on `combat-trainer` to exit cleanly which was hung on `equipmanager` never able to swap riste to skill and stayed in an infinite loop.
* The swap to skill logic needs better boundaries to avoid infinite loops.

### Changes
* Avoid infinite loop if unable to swap weapon to skill (e.g. skill not supported or too injured or nothing in hand, etc).
* Fix bug where trying to swap to skill 'two-handed blunt' misinterpreted as 'two-handed edge'.
* Emphasize error if try to swap weapon to an unsupported skill.
* Skill to swap to can be expressed as the weapon type (e.g. light edged) or weapon skill (e.g. small edged)
* Remove import of `events` module since no more dependency on it.

## Tests
<details>
<summary>click to toggle</summary>

### should stop loop if can't swap to weapon type
```
> ,e echo EquipmentManager.new.swap_to_skill('riste', 'small blunt')

--- Lich: exec1 active.

[exec1]>swap my riste

You switch your riste so that you can use it as a two-handed blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy edged weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a two-handed blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy edged weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a two-handed blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy edged weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a two-handed blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy edged weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a two-handed blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy edged weapon.
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### should stop loop if unable to swap weapon due to injury
```
!> ,e echo EquipmentManager.new.swap_to_skill('riste', 'heavy blunt')

--- Lich: exec1 active.

[exec1]>swap my riste

Your right hand is too injured to do that.
!> 
[exec1: false]

--- Lich: exec1 has exited.
```

### should swap to weapon skill if able (heavy blunt)
```
> ,e echo EquipmentManager.new.swap_to_skill('riste', 'heavy blunt')

--- Lich: exec1 active.

[exec1]>swap my riste

You switch your riste so that you can use it as a two-handed blunt weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a heavy blunt weapon.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### should swap to weapon skill if able (two-handed blunt)
```
,e echo EquipmentManager.new.swap_to_skill('riste', 'two-handed blunt')
--- Lich: exec1 active.

[exec1]>swap my riste

You switch your riste so that you can use it as a heavy edged weapon.
> 
[exec1]>swap my riste

You switch your riste so that you can use it as a two-handed blunt weapon.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### should open fan to use as small edged
```
> ,e echo EquipmentManager.new.swap_to_skill('fan', 'small edged')

--- Lich: exec1 active.

[exec1]>open my fan

With a practiced flick of your wrist, you snap open your avia fan to expose the sharpened edges at the end of the blades.
You switch your fan so that you can use it as a medium edged weapon.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### should close fan to use as blunt
```
> ,e echo EquipmentManager.new.swap_to_skill('fan', 'small blunt')

--- Lich: exec1 active.

[exec1]>close my fan

With a practiced flick of your wrist, you snap your avia fan closed, savoring the weight of the weapon in your fist.
You switch your fan so that you can use it as a medium blunt weapon.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### should warn and exit if try to swap to unsupported skill
```
,e echo EquipmentManager.new.swap_to_skill('riste', 'baseball')
--- Lich: exec1 active.

| Unsupported weapon swap: riste to baseball. Please report this to https://github.com/rpherbig/dr-scripts/issues

[exec1: false]

--- Lich: exec1 has exited.
```

### should swap throwing spike to weapon skill
```
[combat-trainer]>wield my throwing.spike

You draw out your throwing spike from the encompassing shadows, gripping it firmly in your left hand.
> 
[combat-trainer]>swap my spike

You switch your spike so that you can use it as a light thrown and light edged weapon.
> 
[combat-trainer]>feint left
```

### should stop loop if can't swap to weapon type due to paralysis
```
> ,e echo EquipmentManager.new.swap_to_skill('riste', 'he')

--- Lich: exec1 active.

[exec1]>swap my riste

Will alone cannot conquer the paralysis that has wracked your body.
> 
[exec1: false]

--- Lich: exec1 has exited.
```
</details>