### PR TITLE
Cleric Bead Carving

### DIFF
--- a/carve-bead.lic
+++ b/carve-bead.lic
@@ -1,0 +1,169 @@
+=begin
+  Carves a prayer bead from scratch.
+
+  ARGS:
+  debug - Forces on debug mode
+  primer - Forces on using a primer
+  aspect - Forces a particular animal aspect to carve (i.e. boar, ram, etc.)
+
+  YAML:
+  theurgy_supply_container
+  immortal_aspect
+  water_holder
+
+  crafting_container
+  crafting_items_in_container
+  engineering_belt
+
+  carve-bead:
+    debug: true | false
+    primer: true | false
+=end
+
+custom_require.call(%w[common common-arcana common-crafting common-theurgy drinfomon events])
+
+class CarveBead
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Turn on debug logging' },
+        { name: 'primer', regex: /primer/i, optional: true, description: 'Force primer use, regardless of settings' },
+        { name: 'aspect', regex: /^[A-z0-9\s\-\'\.]+$/i, optional: true, description: 'Aspect to use, regardless of settings' }
+      ],
+      [
+        { name: 'help', regex: /help/i, description: 'Display help text and exit'}
+      ]
+    ]
+    args = parse_args(arg_definitions)
+
+    display_help_and_exit if args.help
+
+    @settings = get_settings
+    @debug = args.debug || @settings['carve-bead']['debug']
+    @theurgy_supply_container = @settings.theurgy_supply_container
+    @immortal_aspect = args.aspect || @settings.immortal_aspect
+    @crafting_container = @settings.crafting_container
+    @crafting_container_items = @settings.crafting_items_in_container
+    @belt = @settings.engineering_belt
+    @water_holder = @settings.water_holder
+    @use_primer = args.primer || @settings['carve-bead']['primer'] || false
+    @knife_adjective = @settings['carve-bead']['knife-adjective'] || 'carving'
+    all_theurgy_data = get_data('theurgy')
+    @hometown_theurgy_data = all_theurgy_data[@hometown]
+    @use_held_block = false
+
+    @training_spells = @settings.crafting_training_spells
+
+    if @debug
+      DRC.message(
+        "carve-bead-debug:\n" +
+        "- immortal_aspect: #{@immortal_aspect}\n" +
+        "- use_primer: #{@use_primer}\n" +
+        "- knife_adjective: #{@knife_adjective}"
+      )
+    end
+
+    main
+  end
+
+  def display_help_and_exit
+    DRC.message(
+      'carve-bead:\n' +
+      '  Carves a prayer bead from a foraged and carved block, or an existing one if held when called\n' +
+      'args:\n' +
+      '  debug : forces on debug output\n' +
+      '  primer : forces on usage of a carving primer\n' +
+      '  <aspect> : name of the animal to carve (i.e. boar, panther, etc.)'
+    )
+    exit
+  end
+
+  def main
+    if DRCI.in_right_hand?('block')
+      @use_held_block = true
+      DRCI.stow_hand('left') if DRC.left_hand
+    elsif DRCI.in_left_hand?('block')
+      @use_held_block = true
+      DRC.bput('swap', 'You move a')
+      DRCI.stow_hand('left') if DRC.left_hand
+    else
+      DRCI.stow_hands
+    end
+
+    read_primer if @use_primer
+
+    if !@use_held_block
+      make_block
+    end
+    carve_bead
+  end
+
+  def read_primer
+    DRCI.get_item?("#{@immortal_aspect} primer", @theurgy_supply_container)
+    open_primer
+
+    keep_reading = true
+    while keep_reading
+      case DRC.bput('study my primer', 'Roundtime:', 'You have already studied this page', 'You should start on the first page', "You've too recently been studying how to carve a")
+      when 'You should start on the first page'
+        reset_primer
+        next
+      when "You've too recently been studying how to carve a"
+        DRC.message('You cannot switch between primers that fast. Try again later.')
+        DRCI.put_away_item?("#{@immortal_aspect} primer", @theurgy_supply_container)
+        exit
+      end
+
+      keep_reading = turn_primer?
+    end
+    DRCI.put_away_item?("#{@immortal_aspect} primer", @theurgy_supply_container)
+  end
+
+  def open_primer
+    DRC.bput('open my primer', 'You open the cover of', 'The primer is already open')
+  end
+
+  def close_primer
+    DRC.bput('close my primer', '.*')
+  end
+
+  def reset_primer
+    close_primer
+    open_primer
+  end
+
+  def turn_primer?
+    DRC.bput('turn my primer', 'You flip forward a page', 'You flip to the end of your primer') == 'You flip forward a page'
+  end
+
+  def make_block
+    return false unless DRCTH.has_holy_water?(@theurgy_supply_container, @water_holder)
+
+    DRCT.walk_to(@hometown_theurgy_data['limb_foraging']['id'])
+    DRCA.prepare?('bless', 1)
+    DRC.forage?('limb')
+    DRCI.get_item?(@water_holder, @theurgy_supply_container)
+    DRC.bput("sprinkle #{@water_holder} on my limb", 'You sprinkle')
+    DRCI.put_away_item?(@water_holder, @theurgy_supply_container)
+    pause 1
+    DRCA.cast?('cast my limb')
+    DRCC.get_crafting_item("#{@knife_adjective} knife", @crafting_container, @crafting_container_items, @belt)
+    while DRC.right_hand.include?('limb')
+      DRC.bput('carve my limb with my knife', 'You begin to hack', 'With fluid strokes, you', 'You continue to whittle', 'narrowing the connection', 'With a final deep cut')
+      waitrt?
+    end
+    DRCC.stow_crafting_item("#{@knife_adjective} knife", @crafting_container, @belt)
+  end
+
+  def carve_bead
+    DRCC.get_crafting_item('shaper', @crafting_container, @crafting_container_items, @belt)
+    while DRC.right_hand.include?('block')
+      DRC.bput("shape my block to #{@immortal_aspect}", "block suddenly cracks and breaks", "Roundtime")
+      waitrt?
+    end
+    DRCC.stow_crafting_item('shaper', @crafting_container, @belt)
+  end
+end
+
+CarveBead.new

--- a/common-items.lic
+++ b/common-items.lic
@@ -378,6 +378,20 @@ module DRCI
     end
   end
 
+  def have_item_by_look?(item, container)
+    return false unless item
+
+    item = item.delete_prefix('my ')
+    preposition = 'in my' if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
+
+    case DRC.bput("look at my #{item} #{preposition} #{container}", "#{item}", 'You see nothing unusual', 'I could not find', 'What were you referring to')
+    when 'You see nothing unusual', "#{item}"
+      true
+    else
+      false
+    end
+  end
+
   #########################################
   # COUNT ITEMS
   #########################################
@@ -488,10 +502,14 @@ module DRCI
 
   # Same as 'get_item_unsafe' but ensures that
   # the container argument is prefixed with 'my' qualifier.
-  def get_item_safe(item, container = nil)
+  def get_item_safe?(item, container = nil)
     item = "my #{item}" if item && !(item =~ /^my /i)
     container = "my #{container}" if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
     get_item_unsafe(item, container)
+  end
+
+  def get_item_safe(item, container = nil)
+    get_item_safe?(item, container)
   end
 
   # Gets an item, optionally from a specific container.

--- a/common-theurgy.lic
+++ b/common-theurgy.lic
@@ -1,0 +1,225 @@
+#quiet
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_development#common-arcana
+=end
+
+custom_require.call(%w[common common-items common-travel])
+
+module DRCTH
+  module_function
+
+  CLERIC_ITEMS = [
+    'holy water', 'holy oil', 'wine', 'incense', 'flint', 'chamomile', 'sage', 'jalbreth balm'
+  ] unless defined?(CLERIC_ITEMS)
+
+  COMMUNE_ERRORS = [
+    'You stop as you realize that you have attempted a commune',
+    'completed this commune too recently'
+  ] unless defined?(COMMUNE_ERRORS)
+
+  DEVOTION_LEVELS = [
+    'You sense nothing special from your communing',
+    'You feel unclean and unworthy',
+    'You close your eyes and start to concentrate',
+    'You call out to your god, but there is no answer',
+    'After a moment, you sense that your god is barely aware of you',
+    'After a moment, you sense that your efforts have not gone unnoticed',
+    'After a moment, you sense a distinct link between you and your god',
+    'After a moment, you sense that your god is aware of your devotion',
+    'After a moment, you sense that your god knows your name',
+    'After a moment, you sense that your god is pleased with your devotion',
+    'After a moment, you see a vision of your god, though the visage is cloudy',
+    'After a moment, you sense a slight pressure on your shoulder',
+    'After a moment, you see a silent vision of your god',
+    'After a moment, you see a vision of your god who calls to you by name, "Come here, my child',
+    'After a moment, you see a vision of your god who calls to you by name, "My child, though you may',
+    'After a moment, you see a crystal-clear vision of your god who speaks slowly and deliberately',
+    'After a moment, you feel a clear presence like a warm blanket covering you'
+  ] unless defined?(DEVOTION_LEVELS)
+
+  def has_holy_water?(theurgy_supply_container, water_holder)
+    DRCI.get_item?(water_holder, theurgy_supply_container)
+    DRCI.inside?('holy water', water_holder)
+    DRCI.put_away_item?(water_holder, theurgy_supply_container)
+  end
+
+  def has_holy_oil?(theurgy_supply_container)
+    DRCI.have_item_by_look?('holy oil', theurgy_supply_container)
+  end
+
+  def has_incense?(theurgy_supply_container)
+    DRCI.have_item_by_look?('incense', theurgy_supply_container)
+  end
+
+  def has_jalbreth_balm?(theurgy_supply_container)
+    DRCI.have_item_by_look?('jalbreth balm', theurgy_supply_container)
+  end
+
+  def buying_cleric_item_requires_bless?(town, item_name)
+    town_theurgy_data = get_data('theurgy')[town]
+    return if town_theurgy_data.nil?
+
+    item_shop_data = town_theurgy_data["#{item_name}_shop"]
+    return if item_shop_data.nil?
+
+    return item_shop_data['needs_bless']
+  end
+
+  def buy_cleric_item?(town, item_name, stackable, num_to_buy, theurgy_supply_container)
+    town_theurgy_data = get_data('theurgy')[town]
+    return false if town_theurgy_data.nil?
+
+    item_shop_data = town_theurgy_data["#{item_name}_shop"]
+    return false if item_shop_data.nil?
+
+    DRCT.walk_to(item_shop_data['id'])
+    if stackable
+      num_to_buy.times do
+        buy_single_supply(item_name, item_shop_data)
+        if DRCI.get_item?(item_name, theurgy_supply_container)
+          DRC.bput("combine #{item_name} with #{item_name}", 'You combine', 'You can\'t combine', 'You must be holding')
+        end
+        # Put this back in the container each cycle so it doesn't interfere
+        # with bless of next purchase.
+        DRCI.put_away_item?(item_name, @theurgy_supply_container)
+      end
+    else
+      num_to_buy.times do
+        buy_single_supply(item_name, item_shop_data)
+        DRCI.put_away_item?(item_name, theurgy_supply_container)
+      end
+    end
+
+    return true
+  end
+
+  def buy_single_supply(item_name, shop_data)
+    if shop_data['method']
+      send(shop_data['method'])
+    else
+      DRCT.buy_item(shop_data['id'], item_name)
+    end
+
+    return unless shop_data['needs_bless'] && @known_spells.include?('Bless')
+    quick_bless_item(item[:name])
+  end
+
+  def quick_bless_item(item_name)
+    # use dummy settings object since this isn't complex enough for camb, etc.
+    DRCA.cast_spell({
+        'abbrev' => 'bless', 'mana' => 1, 'prep_time' => 2, 'cast' => "cast my #{item_name}"
+      }, {})
+  end
+
+  def empty_cleric_hands(theurgy_supply_container)
+    empty_cleric_right_hand(theurgy_supply_container)
+    empty_cleric_left_hand(theurgy_supply_container)
+  end
+
+  def empty_cleric_right_hand(theurgy_supply_container)
+    return if DRC.right_hand.nil?
+
+    container = CLERIC_ITEMS.any? { |item| DRC.right_hand =~ /#{item}/i } ? theurgy_supply_container : nil
+    DRCI.put_away_item?(DRC.right_hand, container)
+  end
+
+  def empty_cleric_left_hand(theurgy_supply_container)
+    return if DRC.left_hand.nil?
+
+    container = CLERIC_ITEMS.any? { |item| DRC.left_hand =~ /#{item}/i } ? theurgy_supply_container : nil
+    DRCI.put_away_item?(DRC.left_hand, container)
+  end
+
+  def sprinkle_holy_water(theurgy_supply_container, water_holder, target)
+    DRCI.get_item?(water_holder, theurgy_supply_container)
+    sprinkle?(water_holder, target)
+    DRCI.put_away_item?(water_holder, theurgy_supply_container)
+  end
+
+  def sprinkle_holy_oil(theurgy_supply_container, target)
+    DRCI.get_item?('holy oil', theurgy_supply_container)
+    sprinkle?('oil', target)
+    DRCI.put_away_item?('holy oil', theurgy_supply_container) if DRCI.in_hands?('oil')
+  end
+
+  def sprinkle?(item, target)
+    result = DRC.bput("sprinkle #{item} on #{target}", 'You sprinkle', 'Sprinkle what', 'What were you referring to')
+    result =~ /'You sprinkle'/
+  end
+
+  def apply_jalbreth_balm(theurgy_supply_container, target)
+    DRCI.get_item?('jalbreth balm', theurgy_supply_container)
+    DRC.bput("apply balm to #{target}", '.*')
+    DRCI.put_away_item?('jalbreth balm', theurgy_supply_container) if DRCI.in_hands?('balm')
+  end
+
+  def wave_incense?(theurgy_supply_container, flint_lighter, target)
+    empty_cleric_hands(theurgy_supply_container)
+
+    if !DRCI.get_item?(flint_lighter)
+      DRC.message("Can't find #{flint_lighter} to light incense")
+      return false
+    end
+    if !DRCI.get_item?('incense', theurgy_supply_container)
+      DRC.message("Can't find incense to light")
+      empty_cleric_hands(theurgy_supply_container)
+      return false
+    end
+
+    lighting_attempts = 0
+    while DRC.bput('light my incense with my flint', 'nothing happens', 'bursts into flames', 'much too dark in here to do that') == 'nothing happens'
+      waitrt?
+
+      lighting_attempts += 1
+      if (lighting_attempts >= 5)
+        DRC.message("Can't light your incense for some reason. Tried 5 times, giving up.")
+        empty_cleric_hands
+        return false
+      end
+    end
+    DRC.bput("wave my incense at #{target}", 'You wave')
+    DRC.bput('snuff my incense', 'You snuff out') if DRCI.in_hands?('incense')
+
+    DRCI.put_away_item?(flint_lighter)
+    empty_cleric_hands(theurgy_supply_container)
+    return true
+  end
+
+  def commune_sense
+    DRC.bput('commune sense', 'Roundtime:')
+    pause 0.5
+
+    commune_ready = true
+    active_communes = []
+    recent_communes = []
+
+    theurgy_lines = reget(50).map(&:strip)
+    theurgy_lines.each do |line|
+      case line
+      when /You will not be able to open another divine conduit yet/
+        commune_ready = false
+      when /Tamsine\'s benevolent eyes are upon you/, /The miracle of Tamsine has manifested about you/
+        active_communes << 'Tamsine'
+      when /You are under the auspices of Kertigen/
+        active_communes << 'Kertigen'
+      when /Meraud's influence is woven into the area/
+        active_communes << 'Meraud'
+      when /The waters of Eluned are still in your thoughts/
+        recent_communes << 'Eluned'
+      when /You have been recently enlightened by Tamsine/
+        recent_communes << 'Tamsine'
+      when /The sounds of Kertigen\'s forge still ring in your ears/
+        recent_communes << 'Kertigen'
+      when /You are still captivated by Truffenyi\'s favor/
+        recent_communes << 'Truffenyi'
+      end
+    end
+
+    return {
+      'active_communes' => active_communes,
+      'recent_communes' => recent_communes,
+      'commune_ready' => commune_ready
+    }
+  end
+
+end

--- a/commune.lic
+++ b/commune.lic
@@ -2,315 +2,33 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#commune
 =end
 
-custom_require.call(%w[common common-crafting common-items common-arcana drinfomon])
+custom_require.call(%w[common common-items common-theurgy drinfomon])
 
 class Commune
-  include DRC
-  include DRCC
-  include DRCI
-  include DRCA
-
-  ######################## ITEM ACTIONS ########################
-
-  def get_cleric_item(item)
-    case bput("get #{item} from my #{@theurgy_supply_container}", 'You get', 'You are already holding', 'I could not find', 'What were you referring to')
-    when 'You get'
-      nil
-    when 'You are already holding'
-      nil
-    else
-      missing_item(item.to_s)
-    end
-  end
-
-  def stow_cleric_item(item)
-    bput("put my #{item} in my #{@theurgy_supply_container}", 'You put', 'What were you referring to')
-  end
-
-  def empty_cleric_hands
-    empty_cleric_right_hand
-    empty_cleric_left_hand
-  end
-
-  def empty_cleric_right_hand
-    stow_cleric_item(GameObj.right_hand.noun) if @cleric_items.include?(GameObj.right_hand.name)
-    stow_cleric_item(GameObj.right_hand.noun) if @cleric_items.include?(GameObj.right_hand.noun)
-    fput('stow right') unless GameObj.right_hand.noun.nil?
-  end
-
-  def empty_cleric_left_hand
-    stow_cleric_item(GameObj.left_hand.noun) if @cleric_items.include?(GameObj.left_hand.name)
-    stow_cleric_item(GameObj.left_hand.noun) if @cleric_items.include?(GameObj.left_hand.noun)
-    fput('stow left') unless GameObj.left_hand.noun.nil?
-  end
-
-  ######################## ITEM CHECKS ########################
-
-  def holy_water?
-    case bput("count holy water in my #{@water_holder}", 'left of the holy water', 'I could not find', 'What were you referring to')
-    when 'left of the holy water'
-      true
-    else
-      echo('No holy water found. Please make sure containers are open.')
-      missing_item('holy water')
-    end
-  end
-
-  def have_cleric_item?(item)
-    case bput("look at my #{item} in my #{@theurgy_supply_container}", 'You see nothing unusual', 'I could not find', 'What were you referring to')
-    when 'You see nothing unusual'
-      nil
-    else
-      echo("No #{item} found. Please make sure containers are open.")
-      missing_item(item.to_s)
-    end
-  end
-
-  def holding?(noun)
-    if GameObj.right_hand.noun == noun.to_s
-      true
-    else
-      GameObj.left_hand.noun == noun.to_s
-    end
-  end
-
-  # must pass items in an array
-  def have_cleric_items?(items)
-    items.each do |item|
-      if item == 'holy water'
-        holy_water?
-      elsif @cleric_items.include?(item.to_s)
-        have_cleric_item?(item.to_s)
-      else
-        echo("Unrecognized item required: #{item}")
-        exit
-      end
-    end
-    true
-  end
-
-  def missing_item(item)
-    echo("### You do not have #{item}. Exiting commmune script. ###")
-    exit
-  end
-
-  ######################## COMMUNE ACTIONS ########################
-
-  def sprinkle_holy_water(target = @self)
-    get_cleric_item(@water_holder)
-    sprinkle?(@water_holder, target)
-    stow_cleric_item(@water_holder)
-  end
-
-  def sprinkle_holy_oil(target = @self)
-    get_cleric_item('holy oil')
-    sprinkle?('oil', target)
-    stow_cleric_item('holy oil') if holding?('oil')
-  end
-
-  def sprinkle?(item, target = @self)
-    case bput("sprinkle #{item} on #{target}", 'You sprinkle', 'Sprinkle what', 'What were you referring to')
-    when 'You sprinkle'
-      true
-    else
-      false
-    end
-  end
-
-  def wave_incense(target = @self)
-    empty_cleric_hands
-    case bput("get my #{@flint_lighter}", 'You get', 'You are already holding', 'I could not find', 'What were you referring to')
-    when 'You get' || 'You are already holding'
-      get_cleric_item('incense')
-      while bput('light my incense with my flint', 'nothing happens', 'bursts into flames', 'much too dark in here to do that') == 'nothing happens'
-        waitrt?
-      end
-      bput("wave my incense at #{target}", 'You wave')
-      bput('snuff my incense', 'You snuff out') if holding?('incense')
-    else
-      missing_item(@flint_lighter.to_s)
-    end
-    empty_cleric_hands
-  end
-
-  ######################## DEVOTION ########################
-
-  def check_devotion
-    result = bput('commune', @devotion_levels)
-    @devotion_level = @devotion_levels.index(result)
-    @devotion_level
-  end
-
-  ##################### CARVING ########################
-
-  def create_bead(bead_type = 'meraud')
-    symbols = get_data('theurgy')['immortal_to_aspect']
-    if symbols.key?(bead_type.to_s.capitalize)
-      @shape = symbols[bead_type.to_s.capitalize]
-    elsif symbols.value?(bead_type.to_s)
-      @shape = bead_type
-    else
-      missing_item('a valid carving target')
-    end
-
-    echo "Carving: #{@shape}"
-    if GameObj.right_hand.noun == 'block'
-      # Do nothing
-    elsif exists?('block')
-      # Do nothing
-    else
-      carve_block
-    end
-    carve_bead(@shape.to_s)
-  end
-
-  def get_item(name)
-    get_crafting_item(name, @bag, @bag_items, @belt)
-  end
-
-  def stow_item(name)
-    stow_crafting_item(name, @bag, @belt)
-  end
-
-  def carve_block
-    return unless have_cleric_items?(['holy water'])
-    return unless exists?('carving knife')
-
-    empty_cleric_hands
-    if forage?('limb')
-      prepare?('bless', 1)
-      sprinkle_holy_water('my limb')
-      bput('cast my limb', 'You gesture at', "You don't have")
-      get_item('carving knife')
-      if GameObj.right_hand.noun == 'limb' && GameObj.left_hand.noun == 'knife'
-        while GameObj.right_hand.noun == 'limb'
-          bput('carve my limb with my carving knife', 'You begin to hack', 'With fluid strokes', 'You continue to whittle', 'You grow more careful', 'With a final deep cut')
-        end
-      else
-        missing_item('limb or carving knife')
-      end
-      waitrt
-      stow_item('carving knife')
-    else
-      missing_item('a limb')
-    end
-  end
-
-  def carve_bead(shape)
-    if exists?('shaper')
-      empty_cleric_left_hand if GameObj.left_hand.noun != 'shaper'
-      empty_cleric_right_hand if GameObj.right_hand.noun != 'block'
-      fput('get my block') if GameObj.right_hand.noun != 'block'
-      get_item('shaper') if GameObj.left_hand.noun != 'shaper'
-      while GameObj.right_hand.noun == 'block'
-        case bput("shape my block to #{shape}", 'You fumble around but', 'Roundtime')
-        when 'You fumble around but'
-          missing_item('a valid shaping target')
-        end
-      end
-      waitrt
-      stow_item('shaper')
-    else
-      missing_item('shaper')
-    end
-  end
-
-  ######################## COMMUNES ########################
-
-  def commune_tamsine
-    return unless have_cleric_items?(['holy water'])
-
-    sprinkle_holy_water
-    bput('commune tamsine', 'You feel warmth spread throughout your body', @commune_errors, @devotion_levels)
-  end
-
-  def commune_eluned
-    empty_cleric_hands
-    return unless forage?('dirt')
-
-    get_cleric_item(@water_holder)
-    bput('commune eluned', 'You grind some dirt in your fist', @commune_errors, @devotion_levels)
-    stow_cleric_item(@water_holder)
-    dispose_trash('dirt') if holding?('dirt')
-  end
-
-  def commune_kertigen(target)
-    target ||= @self
-    return unless have_cleric_items?(['holy oil'])
-
-    sprinkle_holy_oil(target)
-    bput('commune kertigen', 'The thick smell of ozone fills your nostrils', 'You whisper a prayer over', 'covered in a fine white powder that wipes off easily', 'crackles and sizzles for a moment', 'Perhaps it is already blessed', @commune_errors, @devotion_levels)
-  end
-
-  def commune_hodierna
-    return unless have_cleric_items?(['holy water', 'holy oil'])
-
-    sprinkle_holy_water
-    sprinkle_holy_oil
-    bput('commune hodierna', 'Your skin tingles and you feel a fiery pain', 'Your body tingles for a moment, but there are no injuries', @commune_errors, @devotion_levels)
-  end
-
-  def commune_meraud
-    return unless have_cleric_items?(['holy water', 'incense'])
-
-    wave_incense
-    sprinkle_holy_water
-    bput('commune meraud', 'For a split second you embrace existence without substance', @commune_errors, @devotion_levels)
-  end
-
-  def commune_truffenyi(target)
-    target ||= @self
-    case bput("commune truffenyi #{target}", 'The power of Truffenyi has answered your prayer', 'You must be holding your favor offering or orb in your right hand', @commune_errors, @devotion_levels)
-    when 'The power of Truffenyi has answerd your prayer'
-      return true
-    when 'You must be holding your favor offering or orb in your right hand'
-      missing_item('a proper offering in your right hand')
-    else
-      return false
-    end
-  end
-
-  ##################### INITIALIZE #####################
 
   def initialize
+    if !DRStats.cleric?
+      DRC.message('Silly rabbit, communes are for clerics.')
+      exit
+    end
+
     settings = get_settings
-    exit if DRStats.cleric? == false
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container
-    @belt = settings.engineering_belt
     @theurgy_supply_container = settings.theurgy_supply_container
     @water_holder = settings.water_holder
     @flint_lighter = settings.flint_lighter
     @immortal_aspect = settings.immortal_aspect
-    @cleric_items = [@water_holder.to_s, 'holy water', 'holy oil', 'wine', 'incense', 'flint', 'chamomile', 'sage', 'jalbreth balm']
     @self = checkname.to_s
-    @commune_errors = ['You stop as you realize that you have attempted a commune', 'completed this commune too recently']
-    @devotion_level = nil
-    @devotion_levels = [
-      'You sense nothing special from your communing',
-      'You feel unclean and unworthy',
-      'You close your eyes and start to concentrate',
-      'You call out to your god, but there is no answer',
-      'After a moment, you sense that your god is barely aware of you',
-      'After a moment, you sense that your efforts have not gone unnoticed',
-      'After a moment, you sense a distinct link between you and your god',
-      'After a moment, you sense that your god is aware of your devotion',
-      'After a moment, you sense that your god knows your name',
-      'After a moment, you sense that your god is pleased with your devotion',
-      'After a moment, you see a vision of your god, though the visage is cloudy',
-      'After a moment, you sense a slight pressure on your shoulder',
-      'After a moment, you see a silent vision of your god',
-      'After a moment, you see a vision of your god who calls to you by name, "Come here, my child',
-      'After a moment, you see a vision of your god who calls to you by name, "My child, though you may',
-      'After a moment, you see a crystal-clear vision of your god who speaks slowly and deliberately',
-      'After a moment, you feel a clear presence like a warm blanket covering you'
-    ]
 
     arg_definitions = [
       [
         { name: 'Tamsine', regex: /^ta.*/i, variable: true, description: 'Increase TM vs. undead.' }
       ], [
         { name: 'Eluned', regex: /^e.*/i, variable: true, description: 'Create holy water.' }
+      ], [
+        { name: 'Athletics', regex: /^ath.*/i, variable: true, description: 'Use jalbreth balm to boost athletics.' },
+        { name: 'debug', regex: /debug/, optional: true, description: 'Forces debugging output on'}
       ], [
         { name: 'Kertigen', regex: /^k.*/i, variable: true, description: 'Bless weapon or person.' },
         { name: 'target', regex: /\w/i, optional: true, description: 'Target weapon or person. Defaults to self.' }
@@ -321,19 +39,25 @@ class Commune
       ], [
         { name: 'Truffenyi', regex: /^tr.*/i, variable: true, description: 'Get or return favor orb for you. Get favor orb for others (kneeling). Proper offering required in right hand.' },
         { name: 'target', regex: /\w/i, optional: true, description: 'Target person. Defaults to self.' }
-      ],
-      [
-        { name: 'Carve', regex: /^carve/i, variable: true, description: 'Carve a prayer bead. Must have block or be able to forage a limb.' },
-        { name: 'target', regex: /\w/i, optional: true, description: 'Immortal for prayer bead. Defaults to Meraud. Must use full name.' }
+      ], [
+        { name: 'Carve', regex: /^carve/i, variable: true, description: 'Carve a prayer bead. Must have block or be able to forage a limb.' }
       ]
     ]
 
     args = parse_args(arg_definitions)
+    @debug = args.debug
+
+    if @debug
+      echo "commune-debug:\n" +
+           "- args: #{args.to_yaml}"
+    end
 
     if args.Tamsine
       commune_tamsine
     elsif args.Eluned
       commune_eluned
+    elsif args.Athletics
+      commune_eluned_athletics
     elsif args.Kertigen
       commune_kertigen(args.target)
     elsif args.Hodierna
@@ -343,13 +67,82 @@ class Commune
     elsif args.Truffenyi
       commune_truffenyi(args.target)
     elsif args.Carve
-      if args.target
-        create_bead(args.target.to_s)
-      else
-        create_bead
-      end
+      create_bead
     end
   end
+
+  def create_bead(bead_type = 'meraud')
+    DRC.message("
+      #####################################################
+      ### Bead Carving has been moved to carve-bead.lic ###
+      #####################################################"
+    )
+  end
+
+  def commune_tamsine
+    return unless DRCTH.has_holy_water?(@theurgy_supply_container, @water_holder)
+
+    DRCTH.sprinkle_holy_water(@theurgy_supply_container, @water_holder, @self)
+    DRC.bput('commune tamsine', 'You feel warmth spread throughout your body', DRCTH::COMMUNE_ERRORS, DRCTH::DEVOTION_LEVELS)
+  end
+
+  def commune_eluned
+    DRCTH.empty_cleric_hands(@theurgy_supply_container)
+    return unless DRC.forage?('dirt')
+
+    DRCI.get_item_safe(@water_holder, @theurgy_supply_container)
+    DRC.bput('commune eluned', 'You grind some dirt in your fist', DRCTH::COMMUNE_ERRORS, DRCTH::DEVOTION_LEVELS)
+    DRCI.put_away_item?(@water_holder, @theurgy_supply_container)
+    DRCI.dispose_trash('dirt') if DRCI.in_hands?('dirt')
+  end
+
+  def commune_eluned_athletics
+    echo "commune-debug: starting Eluned's second commune" if @debug
+    return unless DRCTH.has_jalbreth_balm?(@theurgy_supply_container)
+
+    DRCTH.apply_jalbreth_balm(@theurgy_supply_container, @self)
+    DRC.bput('commune', '.*')
+  end
+
+  def commune_kertigen(target)
+    return unless DRCTH.has_holy_oil?(@theurgy_supply_container)
+
+    target ||= @self
+    DRCTH.sprinkle_holy_oil(@theurgy_supply_container, target)
+    DRC.bput('commune kertigen', 'The thick smell of ozone fills your nostrils', 'You whisper a prayer over', 'covered in a fine white powder that wipes off easily', 'crackles and sizzles for a moment', 'Perhaps it is already blessed', DRCTH::COMMUNE_ERRORS, DRCTH::DEVOTION_LEVELS)
+  end
+
+  def commune_hodierna
+    return unless DRCTH.has_holy_water?(@theurgy_supply_container, @water_holder)
+    return unless DRCTH.has_holy_oil?(@theurgy_supply_container)
+
+    DRCTH.sprinkle_holy_water(@theurgy_supply_container, @water_holder, @self)
+    DRCTH.sprinkle_holy_oil(@theurgy_supply_container, @self)
+    DRC.bput('commune hodierna', 'Your skin tingles and you feel a fiery pain', 'Your body tingles for a moment, but there are no injuries', DRCTH::COMMUNE_ERRORS, DRCTH::DEVOTION_LEVELS)
+  end
+
+  def commune_meraud
+    return unless DRCTH.has_holy_water?(@theurgy_supply_container, @water_holder)
+    return unless DRCTH.has_incense?(@theurgy_supply_container)
+
+    DRCTH.wave_incense?(@theurgy_supply_container, @flint_lighter, @self)
+    DRCTH.sprinkle_holy_water(@theurgy_supply_container, @water_holder, @self)
+    DRC.bput('commune meraud', 'For a split second you embrace existence without substance', DRCTH::COMMUNE_ERRORS, DRCTH::DEVOTION_LEVELS)
+  end
+
+  def commune_truffenyi(target)
+    target ||= @self
+    case DRC.bput("commune truffenyi #{target}", 'The power of Truffenyi has answered your prayer', 'You must be holding your favor offering or orb in your right hand', DRCTH::COMMUNE_ERRORS, DRCTH::DEVOTION_LEVELS)
+    when 'The power of Truffenyi has answerd your prayer'
+      return true
+    when 'You must be holding your favor offering or orb in your right hand'
+      DRC.message('You must be holding a proper offering or favor orb in your right hand')
+      return false
+    else
+      return false
+    end
+  end
+
 end
 
 Commune.new

--- a/test/test_common_theurgy.rb
+++ b/test/test_common_theurgy.rb
@@ -1,0 +1,136 @@
+require 'minitest/autorun'
+load 'test/test_harness.rb'
+
+include Harness
+
+class TestCommonTheurgy < Minitest::Test
+  def setup
+    Object.send(:remove_const, :DRCTH) if defined?(DRCTH)
+    $server_buffer.clear
+    $history.clear
+    @fake_drc = Minitest::Mock.new
+  end
+
+  def teardown
+    @test.join if @test
+  end
+
+  def assert_ready_to_commune
+    proc { |commune_state| assert_equal(true, commune_state['commune_ready'], 'Incorrectly captured ready to commune flag as false') }
+  end
+
+  def assert_not_ready_to_commune
+    proc { |commune_state| assert_equal(false, commune_state['commune_ready'], 'Incorrectly captured ready to commune flag as true') }
+  end
+
+  def assert_no_active_communes
+    proc { |commune_state| assert_empty(commune_state['active_communes'], 'Incorrectly flagged communes as active.') }
+  end
+
+  def assert_active_commune(commune_name)
+    proc { |commune_state| assert_equal(true, commune_state['active_communes'].include?(commune_name), "Missed active commune: #{commune_name}") }
+  end
+
+  def assert_no_recent_communes
+    proc { |commune_state| assert_empty(commune_state['recent_communes'], 'Incorrectly flagged communes as recent.') }
+  end
+
+  def assert_recent_commune(commune_name)
+    proc { |commune_state| assert_equal(true, commune_state['recent_communes'].include?(commune_name), "Missed recent commune: #{commune_name}") }
+  end
+
+  def run_commune_sense(messages, assertions = [])
+    @test = run_script_with_proc(['common-theurgy'], proc do
+      # Setup
+      DRCTH.const_set("DRC", @fake_drc)
+      $server_buffer = messages.dup
+      $history = $server_buffer.dup
+      @fake_drc.expect(:bput, 'Roundtime: 2 sec.', ['commune sense', String])
+
+      # Test
+      commune_state = DRCTH.commune_sense()
+
+      #Assert
+      @fake_drc.verify
+      assertions = [assertions] unless assertions.is_a?(Array)
+      assertions.each { |assertion| assertion.call(commune_state) }
+    end)
+  end
+
+  def test_commune_sense_1
+    messages = [
+      'Tamsine\'s benevolent eyes are upon you.',
+      'You will not be able to open another divine conduit yet.',
+      'You have been recently enlightened by Tamsine.',
+      'Roundtime: 2 sec.'
+    ]
+    run_commune_sense(messages, [
+      assert_not_ready_to_commune,
+      assert_active_commune('Tamsine'),
+      assert_recent_commune('Tamsine')
+    ])
+  end
+
+  def test_commune_sense_2
+    messages = [
+      'The miracle of Tamsine has manifested about you.',
+      'The waters of Eluned are still in your thoughts.',
+      'You have been recently enlightened by Tamsine.',
+      'Roundtime: 2 sec.'
+    ]
+    run_commune_sense(messages, [
+      assert_ready_to_commune,
+      assert_active_commune('Tamsine'),
+      assert_recent_commune('Eluned'),
+      assert_recent_commune('Tamsine')
+    ])
+  end
+
+  def test_commune_sense_3
+    messages = [
+      'The miracle of Tamsine has manifested about you.',
+      'You are under the auspices of Kertigen.',
+      'You will not be able to open another divine conduit yet.',
+      'The sounds of Kertigen\'s forge still ring in your ears.',
+      'You have been recently enlightened by Tamsine.',
+      'The waters of Eluned are still in your thoughts.',
+      'Roundtime: 2 sec.'
+    ]
+    run_commune_sense(messages, [
+      assert_not_ready_to_commune,
+      assert_active_commune('Tamsine'),
+      assert_active_commune('Kertigen'),
+      assert_recent_commune('Tamsine'),
+      assert_recent_commune('Eluned'),
+      assert_recent_commune('Kertigen')
+    ])
+  end
+
+  def test_commune_sense_4
+    messages = [
+      'You are not a vessel for the gods at present.',
+      'You are still captivated by Truffenyi\'s favor.',
+      'The waters of Eluned are still in your thoughts.',
+      'Roundtime: 2 sec.'
+    ]
+    run_commune_sense(messages, [
+      assert_ready_to_commune,
+      assert_no_active_communes,
+      assert_recent_commune('Truffenyi'),
+      assert_recent_commune('Eluned')
+    ])
+  end
+
+  def test_commune_sense_5
+    messages = [
+      'Meraud\'s influence is woven into the area.',
+      'You are eager to better understand your relationship with the Immortals.',
+      'Roundtime: 2 sec.'
+    ]
+    run_commune_sense(messages, [
+      assert_ready_to_commune,
+      assert_active_commune('Meraud'),
+      assert_no_recent_communes
+    ])
+  end
+end


### PR DESCRIPTION
The version of bead carving in Theurgy isn't up to date with the mech lore swap, and doesn't support all the edge cases. Bead carving isn't necessarily a great way to train theurgy itself, but can be useful for field replacing a lost OM orb, favor orbs, etc.

@Hiinky - Any thoughts? 

If you wanted to switch out the bead carving portion of your test-theurgy improvements, you could just call this to make the bead for you.