### PR TITLE
[script] [common-items] Robustify 'dispose_items' method

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -5,6 +5,22 @@
 
 $TRASH_STORAGE = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot]
 
+$DROP_TRASH_SUCCESS_PATTERNS = [
+  /^You drop/,
+  /^You put/,
+  /^You spread .* on the ground/
+]
+
+$DROP_TRASH_FAILURE_PATTERNS = [
+  /What were you referring to/,
+  /I could not find/,
+  /But you aren't holding that/,
+  /You're kidding, right/,
+  /You can't do that/,
+  /No littering/,
+  /You really shouldn't be loitering/
+]
+
 $PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
   /^You put your .* in/,
   /^You hold out/,
@@ -82,14 +98,14 @@ module DRCI
 
     trashcans.each do |trashcan|
       if trashcan == 'gloop'
-        trashcan = 'bucket' if DRRoom.room_objs.include? 'bucket of viscous gloop'
-        trashcan = 'cauldron' if DRRoom.room_objs.include? 'small bubbling cauldron of viscous gloop'
+        trashcan = 'bucket' if DRRoom.room_objs.include?('bucket of viscous gloop')
+        trashcan = 'cauldron' if DRRoom.room_objs.include?('small bubbling cauldron of viscous gloop')
       elsif trashcan == 'bucket'
-        trashcan = 'sturdy bucket' if DRRoom.room_objs.include? 'sturdy bucket'
+        trashcan = 'sturdy bucket' if DRRoom.room_objs.include?('sturdy bucket')
       elsif trashcan == 'basket'
-        trashcan = 'waste basket' if DRRoom.room_objs.include? 'waste basket'
+        trashcan = 'waste basket' if DRRoom.room_objs.include?('waste basket')
       elsif trashcan == 'bin'
-        trashcan = 'waste bin' if DRRoom.room_objs.include? 'waste bin'
+        trashcan = 'waste bin' if DRRoom.room_objs.include?('waste bin')
       elsif trashcan == 'arms'
         trashcan = 'statue'
       elsif trashcan == 'tree'
@@ -98,11 +114,11 @@ module DRCI
         trashcan = 'bin'
       end
 
-      if /^You (drop|put)/ =~ DRC.bput("put my #{item} in #{trashcan}", '^You drop', '^You put', "You're kidding, right", 'What were you referring to', "You can't do that")
-        return
+      if /^You (drop|put|spread)/ =~ DRC.bput("put my #{item} in #{trashcan}", *$DROP_TRASH_SUCCESS_PATTERNS, *$DROP_TRASH_FAILURE_PATTERNS)
+        return true
       end
     end
-    DRC.bput("drop my #{item}", 'You drop', 'What were you', 'You spread .* on the ground.')
+    return /^You (drop|put|spread)/ =~ DRC.bput("drop my #{item}", *$DROP_TRASH_SUCCESS_PATTERNS, *$DROP_TRASH_FAILURE_PATTERNS)
   end
 
   def search?(item)


### PR DESCRIPTION
### Background
* A script got hung up trying to dispose of an item that no longer was in my hands.

### Changes
* Add more match strings to `dispose_trash` method.
* Return a truthy/falsey value from `dispose_trash` method if disposed of trash or not.
* Code style: add parenthesis around arguments to `include?` method calls.

## Tests

### puts item in trash can when available
```
> ,e echo DRCI.dispose_trash('brown backpack') ? 'true' : 'false'

--- Lich: exec1 active.

[exec1]>put my brown backpack in bucket

You drop a rugged brown backpack in a silver bucket.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### drops item if no trash can available
```
> ,e echo DRCI.dispose_trash('brown backpack') ? 'true' : 'false'

--- Lich: exec1 active.

[exec1]>drop my brown backpack

You drop a rugged brown backpack.

> 
[exec1: true]

--- Lich: exec1 has exited.
```

### don't hang up if room blocks littering
```
,e echo DRCI.dispose_trash('brown backpack') ? 'true' : 'false'
--- Lich: exec1 active.

[exec1]>drop my brown backpack

A guard steps over to you and says, "No littering in the bank."
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### don't hang up if room blocks loitering
```
> ,e echo DRCI.dispose_trash('brown backpack') ? 'true' : 'false'

--- Lich: exec1 active.

[exec1]>drop my brown backpack

You really shouldn't be loitering in here.
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### don't hang up if not holding item to dispose
```
> ,e echo DRCI.dispose_trash('racoon') ? 'true' : 'false'

--- Lich: exec1 active.

[exec1]>drop my racoon

What were you referring to?
> 
[exec1: false]

--- Lich: exec1 has exited.
```