### PR TITLE
[script] [pick] Add support for skeleton keys

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -234,7 +234,7 @@ class LockPicker
 
   def attempt_open(box)
     echo "attempt_open(#{box})" if UserVars.lockpick_debug
-    unless disarm?(box)
+    unless unlock_box_with_key?(box) || disarm?(box)
       if @settings.picking_box_storage && right_hand
         case bput("put my #{box} in my #{@settings.picking_box_storage}", 'You put your .* in ', "You just can\'t get", "There isn\'t any more")
         when "You just can\'t get", "There isn\'t any more"
@@ -246,30 +246,32 @@ class LockPicker
       return
     end
 
-    if @make_pets
-      case bput("put my #{box} in my #{@settings.picking_pet_box_source}", 'You put your', "You just can\'t get", "There isn\'t any more")
-      when "You just can\'t get", "There isn\'t any more"
-        bput("put my #{box} in my #{@settings.picking_box_source}", 'You put your')
-        @pet_count = @pet_goal
-      when 'You put your'
-        @pet_count += 1
+    unless @settings.use_skeleton_key
+      if @make_pets
+        case bput("put my #{box} in my #{@settings.picking_pet_box_source}", 'You put your', "You just can\'t get", "There isn\'t any more")
+        when "You just can\'t get", "There isn\'t any more"
+          bput("put my #{box} in my #{@settings.picking_box_source}", 'You put your')
+          @pet_count = @pet_goal
+        when 'You put your'
+          @pet_count += 1
+        end
+        return
       end
-      return
-    end
 
-    if DRStats.thief?
-      if DRC.bput("glance my #{box}", /there.*(no|\d) traps? left/, 'I could').scan(/there.*(no|\d) traps? left/)[0].first.to_i > 0
-        DRC.message("Hit the Thief Hasten bug, disarming again!") if UserVars.lockpick_debug
-        attempt_open(box)
+      if DRStats.thief?
+        if DRC.bput("glance my #{box}", /there.*(no|\d) traps? left/, 'I could').scan(/there.*(no|\d) traps? left/)[0].first.to_i > 0
+          DRC.message("Hit the Thief Hasten bug, disarming again!") if UserVars.lockpick_debug
+          attempt_open(box)
+        else
+          attempt_pick(box)
+        end
       else
         attempt_pick(box)
       end
-    else
-      attempt_pick(box)
     end
 
     waitrt?
-    fput('stow left') unless @settings.use_lockpick_ring
+    stow_hands_except(box)
 
     waitrt?
     loot(box)
@@ -277,12 +279,23 @@ class LockPicker
     waitrt?
   end
 
+  # Put away lockpick or skeleton key, need both hands to loot and dismantle box.
+  def stow_hands_except(item)
+    fput('stow left') unless DRC.left_hand.nil? || DRCI.in_left_hand?(item)
+    fput('stow right') unless DRC.right_hand.nil? || DRCI.in_right_hand?(item)
+  end
+
   def dismantle(box)
     release_invisibility
     command = "dismantle my #{box} #{@settings.lockpick_dismantle}"
-    case bput(command, 'repeat this request in the next 15 seconds', 'Roundtime', 'You must be holding the object you wish to dismantle')
+    case bput(command, 'repeat this request in the next 15 seconds', 'Roundtime', 'You must be holding the object you wish to dismantle', 'Your hands are too full for that', 'You can not dismantle that')
     when 'repeat this request in the next 15 seconds'
       dismantle(box)
+    when 'Your hands are too full for that'
+      stow_hands_except(box)
+      dismantle(box)
+    when 'You can not dismantle that'
+      dispose_trash(box)
     end
   end
 
@@ -338,6 +351,14 @@ class LockPicker
       echo('***Unrecognized Item! trashing it.***')
       dispose_trash(item)
     end
+  end
+
+  def unlock_box_with_key?(box)
+    return false unless @settings.use_skeleton_key
+    DRCI.get_item_if_not_held?(@settings.skeleton_key)
+    result = bput("turn my #{@settings.skeleton_key} at my #{box}", "^You turn", "that doesn't seem to do much", "I could not find", "What were you referring")
+    waitrt?
+    return result =~ /^You turn/
   end
 
   def attempt_pick(box)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -849,6 +849,12 @@ stop_pick_on_mindlock: true
 always_pick_blind: false
 # If your skill is capable of blind picking the lock, this will force a quick pick instead.
 never_pick_blind: false
+# Name of your box opener to bypass traps and locks.
+# Required if 'use_skeleton_key: true'
+skeleton_key: skeleton key
+# Skeleton keys take precedence over using lockpicks to pick boxes.
+# Set to false to use lockpicks instead.
+use_skeleton_key: false
 use_lockpick_ring: true
 skip_lockpick_ring_refill: false
 # If you set 'use_lockpick_ring: false' then specify


### PR DESCRIPTION
### Background
* Droughtman's MT event introduced the [vardite skeleton key](https://elanthipedia.play.net/Item:Vardite_skeleton_key), an unlimited box opener.
* The `pick` script does not yet support this as a picking method.

### Changes
* Add new configuration settings, `skeleton_key:`, to specify the adj. + noun of your skeleton key, and `use_skeleton_key:` to indicate if you want to use one while picking or not, similar to `use_lockpick_ring:` setting.
* Add new method, `unlock_box_with_key?(box)` that uses your skeleton key to unlock the box.
* In the `attempt_open(box)` method, unlock box with skeleton key if you have one, else fallback to disarming it like normal.

### Configuration
```yaml
# Name of your box opener to bypass traps and locks.
# Required if 'use_skeleton_key: true'
skeleton_key: skeleton key

# Skeleton keys take precedence over using lockpicks to pick boxes.
# Set to false to use lockpicks instead.
use_skeleton_key: true
```

## Tests

### unlock and loot box with skeleton key (new feature)
GIVEN:
```yaml
# Name of your box opener to bypass traps and locks.
# Required if 'use_skeleton_key: true'
skeleton_key: skeleton key

# Skeleton keys take precedence over using lockpicks to pick boxes.
# Set to false to use lockpicks instead.
use_skeleton_key: true
```
THEN:
```
[pick]>get my iron strongbox from my thornweave lootsack

You get a misshaped iron strongbox from inside your thornweave lootsack.
s> 
[pick]>get my skeleton key 

You get a vardite skeleton key from inside your hitman's backpack.
s> 
[pick]>turn my skeleton key at my iron strongbox

You turn a vardite skeleton key at a misshaped iron strongbox and a soft glow surrounds it.
The key writhes in your hand.
A sharp click emanates from the locking mechanism.
s> 
[pick]>stow left

s> 
You put your key in your hitman's backpack.
s> 
[pick]>open my iron strongbox

You open the iron strongbox...

In the iron strongbox you see a colorful elbaite runestone, some copper coins, some bronze coins, some silver coins, and a gold coin.
s> 
[pick]>fill my black pouch with my iron strongbox

There aren't any gems in the iron strongbox.
s> 
[pick]>look in my iron strongbox

In the iron strongbox you see a colorful elbaite runestone (Instinct: introductory augmentation), some copper coins, some bronze coins, some silver coins and a gold coin.
s> 
[pick]>get runestone from my iron strongbox

You get a colorful elbaite runestone from inside your iron strongbox.
s> 
[pick]>drop my runestone

You drop a colorful elbaite runestone.

s> 
[pick]>get coins from my iron strongbox

s> 
You pick up 2 copper Lirums.
s> 
[pick]>get coins from my iron strongbox

You pick up 2 bronze Kronars.
s> 
[pick]>get coins from my iron strongbox

You pick up 8 silver Kronars.
s> 
[pick]>get coin from my iron strongbox

You pick up 1 gold Dokora.
s> 
[pick]>dismantle my iron strongbox thump

With a smirk of supreme confidence, you rap the iron strongbox once with a knuckle.  The strongbox collapses and its pieces fall to the ground in what can only be described as a surreally ordered fashion.  You could almost reassemble the neatly laid out pieces, needing no plans for its construction.  Order being something of an anathema to you, you kick the pieces aside.
Roundtime: 3 seconds.
s> 
```

### disarm, pick, and loot box with lockpick ring (regression test)
GIVEN:
```yaml
use_skeleton_key: false
use_lockpick_ring: true
lockpick_container: lockpick wristcuff
```
THEN:
```
[pick]>get my deobar trunk from my thornweave lootsack

You get a mildewy deobar trunk from inside your thornweave lootsack.
s> 
[pick]>disarm my deobar trunk identify

You notice two silver studs right below the keyhole which look dangerously out of place there.
An aged grandmother could defeat this trap in her sleep. (1/17)
Roundtime: 1 sec.

s> 
[pick]>disarm my deobar trunk quick

You quickly work at disarming the trunk.
Working slowly, you carefully pry at the studs working them away from what you surmise are contacts located somewhere under the keyhole.
Roundtime: 1 sec.

s> 
[pick]>disarm my deobar trunk analyze

You believe you may be able to safely extract the silver studs by carefully manipulating them to widen the casings that hold them firmly in place.
Roundtime: 3 sec.

s> 
[pick]>disarm my deobar trunk harvest

Picking up where you left off, you gingerly work the silver studs back and forth in an attempt to dislodge them from their casings.  With a solid shake, the studs finally slide easily out of their casings and into your palm.
You silently slip some silver studs into your leather pouch.
Roundtime: 5 sec.

s> 
[pick]>glance my deobar trunk

s> 
It looks like there are no traps left on the trunk.

It looks like there are 3 locks left on the trunk.
Looking more closely you see...
An intricate steel star houses a complex locking mechanism, with two different spots that each look like they're meant to house keys.
s> 
[pick]>pick my deobar trunk ident

Somebody has already inspected the current lock on this trunk...

This lock is a laughable matter -- you could do it blindfolded! (2/17)

s> 
[pick]>pick my deobar trunk quick

You deftly remove a lockpick from the lockpick wristcuff and begin to work at quickly picking open the trunk.
With a soft click, you remove your lockpick and open and remove the lock.
You discover another lock protecting the deobar trunk's contents as soon as you remove this one.
You return your lockpick to the lockpick wristcuff.
Roundtime: 1 sec.

...

s> 
[pick]>pick my deobar trunk quick

You deftly remove a lockpick from the lockpick wristcuff and begin to work at quickly picking open the trunk.
With a soft click, you remove your lockpick and open and remove the lock.
You return your lockpick to the lockpick wristcuff.
Roundtime: 1 sec.

s> 
[pick]>open my deobar trunk

You open the deobar trunk...

In the deobar trunk you see some copper coins, some bronze coins, some silver coins, and a gold coin.
s> 
[pick]>fill my black pouch with my deobar trunk

There aren't any gems in the deobar trunk.
s> 
[pick]>look in my deobar trunk

In the deobar trunk you see some copper coins, some bronze coins, some silver coins and a gold coin.
s> 
[pick]>get coins from my deobar trunk

You pick up 4 copper Kronars.
s> 
[pick]>get coins from my deobar trunk

You pick up 4 bronze Dokoras.
s> 
[pick]>get coins from my deobar trunk

You pick up 2 silver Kronars.
s> 
[pick]>get coin from my deobar trunk

You pick up 1 gold Kronar.
s> 
[pick]>dismantle my deobar trunk thump

With a smirk of supreme confidence, you rap the deobar trunk once with a knuckle.  The trunk collapses and its pieces fall to the ground in what can only be described as a surreally ordered fashion.  You could almost reassemble the neatly laid out pieces, needing no plans for its construction.  Order being something of an anathema to you, you kick the pieces aside.
Roundtime: 3 seconds.
```

### disarm, pick, and loot box with loose lockpick (regression test)
GIVEN:
```yaml
use_skeleton_key: false
use_lockpick_ring: false
lockpick_container: backpack
```
THEN:
```
[pick]>get my driftwood box from my spidersilk lootsack

You get a mildewy driftwood box from inside your spidersilk lootsack.
s> 
[pick]>disarm my driftwood box identify

You find a series of openings on the front of the box concealing the points of several wickedly barbed crossbow bolts.
An aged grandmother could defeat this trap in her sleep. (1/17)
Roundtime: 1 sec.

s> 
[pick]>disarm my driftwood box quick

You quickly work at disarming the box.
Working with extreme care, you cautiously bend closed the metal plates over the bolts so that the openings are sealed shut.
Roundtime: 1 sec.

s> 
[pick]>disarm my driftwood box analyze

During your work, you note the presence of some tightly coiled steel springs that might prove to be worth something to the right buyer.
Roundtime: 3 sec.

s> 
[pick]>disarm my driftwood box harvest

Careful manipulation allows you to wiggle one of the tightly coiled springs off the pin that holds them in place.  With a few shakes of the driftwood box, the spring slides into your hand.
You silently slip a tightly coiled spring into your leather pouch.
Roundtime: 5 sec.

s> 
[pick]>glance my driftwood box

s> 
It looks like there are no traps left on the box.

It looks like there are 3 locks left on the box.
Looking more closely you see...
The lock's structure is relatively basic, standard in every way without any unusual characteristics.
> 
[pick]>get my lockpick

You get a master's iron lockpick from inside your hitman's backpack.
> 
[pick]>pick my driftwood box ident

Somebody has already inspected the current lock on this box...

An aged grandmother could open this in her sleep. (1/17)

> 
[pick]>pick my driftwood box quick

You quickly work at picking open the box.
With a soft click, you remove your lockpick and open and remove the lock.
You discover another lock protecting the driftwood box's contents as soon as you remove this one.
Roundtime: 1 sec.

...

> 
[pick]>pick my driftwood box quick

You quickly work at picking open the box.
With a soft click, you remove your lockpick and open and remove the lock.
Roundtime: 1 sec.

> 
[pick]>stow left

You put your lockpick in your hitman's backpack.
> 
[pick]>open my driftwood box

You open the driftwood box...

In the driftwood box you see some copper coins, some bronze coins, some silver coins, and some gold coins.
> 
[pick]>fill my black pouch with my driftwood box

> 
There aren't any gems in the driftwood box.
> 
[pick]>look in my driftwood box

In the driftwood box you see some copper coins, some bronze coins, some silver coins and some gold coins.
> 
[pick]>get coins from my driftwood box

You pick up 7 copper Lirums.
> 
[pick]>get coins from my driftwood box

> 
You pick up 2 bronze Kronars.
> 
[pick]>get coins from my driftwood box

You pick up 7 silver Kronars.
> 
[pick]>get coins from my driftwood box

You pick up 2 gold Kronars.
> 
[pick]>dismantle my driftwood box thump

With a smirk of supreme confidence, you rap the driftwood box once with a knuckle.  The box collapses and its pieces fall to the ground in what can only be described as a surreally ordered fashion.  You could almost reassemble the neatly laid out pieces, needing no plans for its construction.  Order being something of an anathema to you, you kick the pieces aside.
Roundtime: 3 seconds.
```