### PR TITLE
[script] [common-items] New methods: lower_item? and container_is_empty?

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -305,6 +305,23 @@ module DRCI
     result =~ /^(You get|You pick|You pluck|You deftly remove|You are already holding|You fade in for a moment as you get)/
   end
 
+  # Lowers the item to the ground.
+  # Determines which hand is holding the item then lowers it to your feet slot.
+  def lower_item?(item)
+    return false unless in_hands?(item)
+    item_regex = /\b#{item}\b/
+    hand = (DRC.left_hand =~ item_regex) ? 'left' : 'right'
+    DRC.bput("lower ground #{hand}", "You lower", "But you aren't holding anything") =~ /You lower/
+  end
+
+  # Checks if the container is empty.
+  # Returns true if certain the container is empty.
+  # Returns false if certain the container is not empty.
+  # Returns nil if unable to determine either way (e.g. can't open container or look in it).
+  def container_is_empty?(container)
+    look_in_container(container).empty?
+  end
+
   # Gets a list of items found in a container via RUMMAGE or LOOK.
   # Default is 'rummage' which returns the full item tap descriptions (e.g. some grey ice skates with black laces)
   # You can pass in 'LOOK' to get back the short item names, which is easier to parse to know the adjective and noun (e.g. some grey ice skates)


### PR DESCRIPTION
### Changes
* Add `lower_item?(item)` method that lowers to your feet slot the item that's in one of your hands
* Add `container_is_empty?(container)` method that returns true if container is empty, false if it's not, nil if unable to determine

## Tests

### lower rope in right hand to ground
```
> ,e fput('glance') ; echo DRCI.lower_item?('bundling rope')

--- Lich: exec1 active.

[exec1]>glance

You glance down to see some bundling rope in your right hand and nothing in your left hand.
> 
[exec1]>lower ground right

You lower the rope and place it on the ground at your feet.
> 
[exec1: 0]

--- Lich: exec1 has exited.
```

### lower runestone in left hand to ground
```
> ,e fput('glance') ; echo DRCI.lower_item?('runestone')

--- Lich: exec1 active.

[exec1]>glance

You glance down to see some bundling rope in your right hand and a colorful elbaite runestone in your left hand.
> 
[exec1]>lower ground left

You lower the runestone and place it on the ground at your feet.
> 
[exec1: 0]

--- Lich: exec1 has exited.
```

### do nothing if hands are empty
```
> ,e fput('glance') ; echo DRCI.lower_item?('runestone')

--- Lich: exec1 active.

[exec1]>glance

You glance down at your empty hands.
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### should return true if container is empty
```
> ,e echo DRCI.container_is_empty?('thigh bag')

--- Lich: exec1 active.

[exec1]>look in my thigh bag

There is nothing in there.
> 
[exec1: true]

--- Lich: exec1 has exited.
```

### should return false if container is not empty
```
> ,e echo DRCI.container_is_empty?('thigh bag')

--- Lich: exec1 active.

[exec1]>look in my thigh bag

In the thigh bag you see some bundling rope.
> 
[exec1: false]

--- Lich: exec1 has exited.
```

### should return nil if unable to look in container
```
> ,e echo DRCI.container_is_empty?('haversack')

--- Lich: exec1 active.

[exec1]>look in my haversack

I could not find what you were referring to.
> 
[exec1: ]

--- Lich: exec1 has exited.
```