### PR TITLE
[script] [sell-loot] Add option to sell metal/stone nuggets/bars at gem shop

### DIFF
--- a/data/base-items.yaml
+++ b/data/base-items.yaml
@@ -165,9 +165,8 @@ scroll_nouns:
 - moldy papyrus
 
 metal_types:
-- steel
+# Common Metals
 - brass
-- pewter
 - bronze
 - copper
 - covellite
@@ -175,37 +174,46 @@ metal_types:
 - lead
 - nickel
 - oravir
+- pewter
 - silver
+- steel
 - tin
 - zinc
-- electrum
-- kadepa
-- muracite
-- niello
-- niniam
-- orichalcum
+# Rare Metals
+- agonite
 - aldamdin
 - animite
 - audrualm
+- coralite
 - damite
 - darkstone
+- electrum
 - glaes
 - haledroth
 - haralun
 - icesteel
 - indurium
+- kadepa
+- kelpzyte
 - kertig
 - kiralan
+- loimic
 - lumium
+- muracite
+- niello
+- niniam
+- orichalcum
 - platinum
 - quelium
 - silversteel
 - telothian
+- tomiek
 - tyrium
 - vardite
 - yellow gold
 
 stone_types:
+# Common Stones
 - alabaster
 - andesite
 - basalt
@@ -225,6 +233,7 @@ stone_types:
 - serpentine
 - soapstone
 - travertine
+# Rare Stones
 - anjisis
 - belzune
 - blackwater jet

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -100,3 +100,4 @@ empty_values:
   wand_watcher_no_use_scripts: []
   wand_watcher_no_use_rooms: []
   noheal_empathylink: []
+  sell_loot_ignored_metals_and_stones: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -884,8 +884,60 @@ bankbot_enabled: false
 
 # Sell loot settings
 sell_loot: true
+# To sell gems from untied gem pouches.
 sell_loot_pouch: true
+# To sell worn bundle.
 sell_loot_bundle: true
+# To sell nuggets and bars (e.g. zinc nugget and bronze bar).
+# If true, you may also want to add 'nugget' and 'bar' to `loot_additions:`
+sell_loot_metals_and_stones: false
+# The container that has the nuggets and bars (e.g. zinc nugget and bronze bar) to sell.
+sell_loot_metals_and_stones_container:
+# Specify the metals (brass, bronze, etc) and stones (jade, onyx, etc) NOT TO SELL.
+# Rare metals and stones are excluded by default.
+# Full list of metals and stones are in scripts/data/base-items.yaml
+sell_loot_ignored_metals_and_stones:
+# Rare Metals
+- agonite
+- aldamdin
+- animite
+- audrualm
+- coralite
+- damite
+- darkstone
+- electrum
+- glaes
+- haledroth
+- haralun
+- icesteel
+- indurium
+- kadepa
+- kelpzyte
+- kertig
+- kiralan
+- loimic
+- lumium
+- muracite
+- niello
+- niniam
+- orichalcum
+- platinum
+- quelium
+- silversteel
+- telothian
+- tomiek
+- tyrium
+- vardite
+- yellow gold
+# Rare Stones
+- anjisis
+- belzune
+- blackwater jet
+- diamondique
+- felstone
+- fulginode
+- senci
+- xenomite
 # For thieves to sell their component pouch of harvested traps.
 # If set to true, you likely also want to set harvest_traps and component_container.
 sell_loot_traps: false

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -34,6 +34,8 @@ class SellLoot
     sell_gems("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}") if @settings.sell_loot_pouch
     check_spare_pouch(@settings.spare_gem_pouch_container, @settings.gem_pouch_adjective) if @settings.spare_gem_pouch_container
 
+    sell_metals_and_stones(@settings.sell_loot_metals_and_stones_container) if @settings.sell_loot_metals_and_stones
+
     sell_bundle if @settings.sell_loot_bundle
 
     sell_traps(@settings.component_container) if @settings.sell_loot_traps
@@ -172,6 +174,41 @@ class SellLoot
     end
 
     fput("close my #{container}") unless @settings.sell_loot_skip_pouch_close
+  end
+
+  def sell_metals_and_stones(container)
+    DRC.release_invisibility
+
+    item_data = get_data('items')
+    metal_types = item_data['metal_types']
+    stone_types = item_data['stone_types']
+
+    material_types = metal_types + stone_types
+    ignore_types = @settings.sell_loot_ignored_metals_and_stones
+
+    materials_regex = /^(?<size>\w+) (?<material>#{(material_types).join('|')}) (?<noun>nugget|bar)$/i
+    ignored_regex = /\b#{ignore_types.join('|')}\b/i unless ignore_types.empty?
+
+    items = DRCI.get_item_list(container)
+      .select { |item| item =~ materials_regex }
+      .reject { |item| ignored_regex ? item =~ ignored_regex : false }
+      .map do |item|
+        # Do regex then grab matches for details.
+        item =~ materials_regex
+        material = Regexp.last_match[:material]
+        noun = Regexp.last_match[:noun]
+        "#{material} #{noun}"
+      end
+
+    unless items.empty?
+      return unless DRCT.walk_to(@hometown['gemshop']['id'])
+      clerk = which_clerk(@hometown['gemshop']['name'])
+
+      items.each do |item|
+        fput("get my #{item} from my #{container}")
+        fput("sell my #{item} to #{clerk}")
+      end
+    end
   end
 
   # Thief only.


### PR DESCRIPTION
### Background
* I like to loot nuggets and bars and sell them at gem shops. Every copper helps build wealth ;)
* I lazily use `;multi 15, get nugget, sell nugget, get bar, sell bar` as part of my hunting routine, would like something more sophisticated
* Other folks might want to sell nuggets and bars if they loot them, too

### Changes
* Add new method `sell_metals_and_stones(container)` that's called after selling gems (since you'll be in the same shop)
* This new option is OFF by default
* Add the following new settings:
  - `sell_loot_metals_and_stones` (boolean)
  - `sell_loot_metals_and_stones_container` (string)
  - `sell_loot_ignored_metals_and_stones` (list)

### Configuration
_base.yaml_
```yaml
# To sell nuggets and bars (e.g. zinc nugget and bronze bar).
# If true, you may also want to add 'nugget' and 'bar' to `loot_additions:`
sell_loot_metals_and_stones: false

# The container that has the nuggets and bars (e.g. zinc nugget and bronze bar) to sell.
sell_loot_metals_and_stones_container:

# Specify the metals (brass, bronze, etc) and stones (jade, onyx, etc) NOT TO SELL.
# Rare metals and stones are excluded by default.
# Full list of metals and stones are in scripts/data/base-items.yaml
sell_loot_ignored_metals_and_stones:
# Rare Metals
- agonite
- aldamdin
- animite
- audrualm
- coralite
- damite
- darkstone
- electrum
- glaes
- haledroth
- haralun
- icesteel
- indurium
- kadepa
- kelpzyte
- kertig
- kiralan
- loimic
- lumium
- muracite
- niello
- niniam
- orichalcum
- platinum
- quelium
- silversteel
- telothian
- tomiek
- tyrium
- vardite
- yellow gold
# Rare Stones
- anjisis
- belzune
- blackwater jet
- diamondique
- felstone
- fulginode
- senci
- xenomite
```

_Character-setup.yaml_
```yaml
# To sell nuggets and bars (e.g. zinc nugget and bronze bar).
# If true, you may also want to add 'nugget' and 'bar' to `loot_additions:`
sell_loot_metals_and_stones: true

# The container that has the nuggets and bars (e.g. zinc nugget and bronze bar) to sell.
sell_loot_metals_and_stones_container: hitman backpack

# Other items to consider as loot on the ground.
# Particularly we want to snatch up all our ammo!
# Or any items we might accidentally drop that are
# pulled out during combat routine, like an almanac!
loot_additions:
- nugget
- bar
- ...
```

## Tests

### should sell nuggets and bars when setting on
GIVEN:
_above configuration_
THEN:
```
[sell-loot]>rummage my hitman backpack

You rummage through a worn grey hitman's backpack with fraying straps and see a large oravir nugget, a large lead nugget, a large oravir nugget, a small zinc nugget, a hefty hunting bola with three quelium weights connected by braided barkcloth, a huge copper nugget, a large bronze bar, a cracked granite heavy mallet with a wire-bound black ironwood handle and some bundling rope.
> 
[sell-loot]>get my oravir nugget from my hitman backpack

You get a large oravir nugget from inside your hitman's backpack.
> 
[sell-loot]>sell my oravir nugget to appraiser

You ask the Dwarf to buy a large oravir nugget.
The Dwarven appraiser scrutinizes the oravir nugget carefully, then hands you 126 Kronars.
> 
[sell-loot]>get my lead nugget from my hitman backpack

You get a large lead nugget from inside your hitman's backpack.
> 
[sell-loot]>sell my lead nugget to appraiser

...
```