### PR TITLE
[script] [healme] Robustify 'build_composite_key_for_wound_details'

### DIFF
--- a/healme.lic
+++ b/healme.lic
@@ -439,8 +439,11 @@ class HealMe
   end
 
   def get_cast_command_for_wound(wound)
-    # Default, the cast command must specify a body part.
-    return 'cast skin' unless wound
+    unless wound
+      # Default, the cast command must specify a body part.
+      echo "No longer aware of a wound healable by the prepared spell. Casting on skin just to discharge harness and cambrinth."
+      return 'cast skin'
+    end
     if should_heal_body_part?(wound)
       # If an internal wound then focus healing power there,
       # with any remaining healing power going to the external wound.
@@ -470,6 +473,17 @@ class HealMe
 
   # Generate a key to uniquely identify this wound. Good for map keys.
   def build_composite_key_for_wound_details(body_part, wound_location, wound_type)
+    # Get rid of extraneous whitespace.
+    body_part = body_part.strip.downcase
+    wound_location = wound_location.strip.downcase
+    wound_type = wound_type.strip.downcase
+    # The game may refer to internal skin wounds as nerves, but the body part is skin.
+    # Standardize on skin as the body part.
+    wound_location = 'skin' if wound_location =~ /^nerves?$/
+    # The wound type may be passed to us either as singular (scar or wound) or plural (scars or wounds).
+    # Standardize on the singular variant.
+    wound_type = wound_type.delete_suffix('s')
+    # Build the key!
     "#{body_part}|#{wound_location}|#{wound_type}".downcase
   end
 


### PR DESCRIPTION
### Background
* Reported by [B-Money42](https://discord.com/channels/745675889622384681/745678251250417674/833853591025352734) in the Lich discord

_Abbreviated conversation:_
> BMoney: i kept seeing myself cast hw/hs on a section right after heal took effect, rendering the cast worthless

> Corgar: it's got flags in there watching for spots that get healed.

> BMoney: so - cast HS 3 times, 2nd + 3rd wasted, perc health, prep HS, Heal pulses, cast HS twice on right arm

> Katoak: You know what.... I do think today's update to common-healing and healme broke it's detection of the "your wounds are completely healed" messaging.... The type of injury (wound or scar) parsed from "The external scars on your head appear completely healed." is the word scars but when checking the injury type when the code is looking at a perceived injury it's now the singular scar.... even though the code detects that your wound got fully healed it's generating the wrong reference key to look up in the list of healed wounds to know and react to that fact

> BMoney: i added Katoaks above fix, overhealed a spot that Heal pulsed on, i don't have the severity setting though - i wasn't using it before so i didn't add it

> Corgar: (noticing another issue) I think the issue is that the 'target' is skin, but the heal proc returns messaging for 'nerves'

> Katoak: Here's an updated version of healme we can test with. 

> BMoney: Sweet. Will test tonight

> BMoney: ok - i just ran new healme, on this group of wounds. i only had 1 overheal, it was my very last cast on wounds

> Corgar: it doesn't try to abort the last cast if there's no good target, cause that gives weird "you don't have a spell prepared" messaging the way it has to be done.
one overheal of each (wounds/scars) is considered normal

> BMoney: ok - then we're basically perfect

### Changes
* Strip whitespace and lowercase the wound details (body part, location, type)
* Standardize on `skin` as body part when encounter `nerves` since the game treats them as synonyms
* Standardize on singular variants of `wound` and `scar`
* Explain to user why `cast skin` is being done, often it's the very last cast when out of wounds/scars and appears to be for no reason but the reason is to not bork common-arcana's attempt to cast HW or HS and to discharge cambrinth so you don't overcharge on your next spell.

## Tests

### notify player why casting on skin when it's not injured
```
[healme]>health

Your body feels at full strength.
Your spirit feels full of life.
You are strangely full of extra energy.
You have some minor abrasions to the left hand.
You have no significant injuries. 

> 
[healme]>release mana

You aren't harnessing any mana.
> 
[healme]>prep HW 1

With meditative movements you prepare your body for the Heal Wounds spell.
> 
[healme]>charge my cambrinth armband 5

You harness a small amount of energy and attempt to channel it into your cambrinth armband.
You are able to channel all the energy into the armband.
The cambrinth armband absorbs all of the energy.
Roundtime: 2 sec.
> 
A nearly painful prickling sensation surges through you as your protective healing matrix focuses on the worst hurts to your body.
The external wounds on your left hand appear completely healed.
The internal wounds on your left hand appear completely healed.
The external scars on your left hand appear completely healed.
The internal scars on your left hand appear completely healed.
>  
[healme]>invoke my cambrinth armband

The cambrinth armband pulses with Life energy.  You reach for its center and forge a magical link to it, readying all of its mana for your use.
Roundtime: 1 sec.
> 
[healme: No longer aware of a wound healable by the prepared spell. Casting on skin just to discharge harness and cambrinth.]

[healme]>cast skin
```