### PR TITLE
[script] [tendme] Add background monitoring mode; use DRCH

### DIFF
--- a/tendme.lic
+++ b/tendme.lic
@@ -1,85 +1,81 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#tendme
 =end
 
-custom_require.call(%w[common common-healing])
+custom_require.call(%w[common common-healing events])
 
-def bind_open_wounds?
-  DRC.bput('heal', '^You')
-  pause 1
-  raw = reget(15)
-  bleeders = raw
-             .dup
-             .reverse
-             .take_while { |item| item !~ /^Bleeding/ }
-             .keep_if { |item| item =~ /^\s+(?:\w+|\w+\s\w+)\s{7}.+/ }
-             .delete_if { |item| item =~ /\bskin\b/ }
-  leeches = raw
-            .dup
-            .map { |x| x.scan(/leech on your [^\,\.]+,|leech on your [^\,\.]+\./).to_a }
-            .flatten
-            .compact
-  mites = raw
-          .dup
-          .map { |x| x.scan(/mite on your [^\,\.]+,|mite on your [^\,\.]+\./).to_a }
-          .flatten
-          .compact
-  lodged = raw
-           .dup
-           .map { |x| x.scan(/lodged \w* into your [^\,\.]+/).to_a }
-           .flatten
-           .compact
+class TendMe
 
-  bleeders = bleeders.keep_if { |item| !item.include?('tended') && !item.include?('inside') && !item.include?('Area') }
-
-  lodged.each do |message|
-    message =~ /into your ([^\,\.]+)/
-    DRCH.bind_wound(Regexp.last_match(1))
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'train', regex: /train/i, optional: true, description: 'unwrap and rebind wounds for optimum learning' },
+        { name: 'monitor', regex: /monitor/i, optional: true, description: 'run in background to keep bleeders tended' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
+    waitrt? while bind_open_wounds?
+    monitor_health(args.train) if args.monitor
   end
 
-  bleeders.each do |message|
-    message =~ /^\s+(\w+|\w+\s\w+)\s{7}/
-    DRCH.bind_wound(Regexp.last_match(1))
+  def bind_open_wounds?
+    health_data = DRCH.check_health
+    wounds = (
+      health_data['lodged'].values.flatten +
+      health_data['parasites'].values.flatten +
+      health_data['bleeders'].values.flatten
+    )
+    wounds
+      .reject { |wound| wound.internal? || wound.bleeding_rate =~ /tended|clotted/ }
+      .any? { |wound| DRCH.bind_wound(wound.body_part) }
   end
 
-  leeches.each do |message|
-    message =~ /on your ([^\,\.]+)|(\,|\.)/
-    DRCH.bind_wound(Regexp.last_match(1))
+  # Monitor for wounds to begin bleeding again then tend them.
+  def monitor_health(train)
+    Flags.add('tendme-bind-lodged', /You feel a slight pain from the (?<item>.*) lodged in your (?<body_part>.*)\./)
+    Flags.add('tendme-bind-wound', /The bandages binding your (?<body_part>.*) (become|come|soak)/)
+    Flags.add('tendme-rewrap-wound', /You feel like now might be a good time to change the bandages on your (?<body_part>.*)\./)
+
+    loop do
+      pause 0.5
+      body_part = nil
+      # One or more active bleeders, tend them.
+      if Flags['tendme-bind-wound']
+        body_part = get_body_part_from_flag('tendme-bind-wound')
+      end
+      # If training, you can rewrap wound for more experience.
+      if Flags['tendme-rewrap-wound'] && train
+        body_part = get_body_part_from_flag('tendme-rewrap-wound')
+        DRCH.unwrap_wound(body_part)
+        # Unwrapping a wound will cause a message that trips our flag.
+        # Clear the flag so we don't try to double tend a wound.
+        # If the flag was already tripped for a different bleeder
+        # then that'll get taken cared of when we bind all open wounds.
+        Flags.reset('tendme-bind-wound')
+      end
+      # Detected lodged ammo or parasites, tend them out.
+      if Flags['tendme-bind-lodged']
+        body_part = get_body_part_from_flag('tendme-bind-lodged')
+      end
+      if body_part
+        DRCH.bind_wound(body_part)
+        bind_open_wounds?
+      end
+    end
   end
 
-  mites.each do |message|
-    message =~ /on your ([^\,\.]+)|(\,|\.)/
-    DRCH.bind_wound(Regexp.last_match(1))
+  def get_body_part_from_flag(flag)
+    body_part = Flags[flag][:body_part]
+    Flags.reset(flag)
+    return body_part
   end
 
-  exit if bleeders.empty?
 end
 
-arg_definitions = [
-  [
-    { name: 'train', regex: /train/i, optional: true, description: 'unwrap and rebind wounds for optimum learning.' }
-  ]
-]
-
-args = parse_args(arg_definitions)
-
-waitrt? while bind_open_wounds?
-
-loop do
-  case script.gets
-  when /The bandages binding your (.*) come loose and you begin to bleed even more/
-    DRCH.bind_wound(Regexp.last_match(1))
-    bind_open_wounds?
-  when /The bandages binding your (.*) soak through with blood becoming useless and you begin bleeding again/
-    DRCH.bind_wound(Regexp.last_match(1))
-    bind_open_wounds?
-  when /You feel like now might be a good time to change the bandages on your (.*)\./
-    next unless args.train
-    DRCH.unwrap_wound(Regexp.last_match(1))
-    DRCH.bind_wound(Regexp.last_match(1))
-    bind_open_wounds?
-  when /You feel a slight pain from the .* lodged in your/
-    bind_open_wounds?
-  end
+before_dying do
+  Flags.delete('tendme-bind-wound')
+  Flags.delete('tendme-rewrap-wound')
+  Flags.delete('tendme-bind-lodged')
 end
+
+TendMe.new

--- a/tendme.lic
+++ b/tendme.lic
@@ -44,9 +44,11 @@ class TendMe
         body_part = get_body_part_from_flag('tendme-bind-wound')
       end
       # If training, you can rewrap wound for more experience.
-      if Flags['tendme-rewrap-wound'] && train
-        body_part = get_body_part_from_flag('tendme-rewrap-wound')
-        DRCH.unwrap_wound(body_part)
+      if Flags['tendme-rewrap-wound']
+        if train && DRSkill.getxp('First Aid') < 30
+          body_part = get_body_part_from_flag('tendme-rewrap-wound')
+          DRCH.unwrap_wound(body_part)
+        end
         # Unwrapping a wound will cause a message that trips our flag.
         # Clear the flag so we don't try to double tend a wound.
         # If the flag was already tripped for a different bleeder

--- a/tendme.lic
+++ b/tendme.lic
@@ -19,15 +19,25 @@ class TendMe
   end
 
   def bind_open_wounds?
+    tended_wounds = false
     health_data = DRCH.check_health
-    wounds = (
+    (
       health_data['lodged'].values.flatten +
       health_data['parasites'].values.flatten +
       health_data['bleeders'].values.flatten
     )
-    wounds
-      .reject { |wound| wound.internal? || wound.bleeding_rate =~ /tended|clotted/ }
-      .any? { |wound| DRCH.bind_wound(wound.body_part) }
+    .reject { |wound| wound.internal? || wound.bleeding_rate =~ /tended|clotted/ } # untendable
+    .select do |wound|      
+      skilled_to_tend = DRCH.skilled_to_tend_wound?(wound.bleeding_rate)
+      unless wound.bleeding? && skilled_to_tend
+        DRC.message("You are not skilled enough to tend a #{wound.bleeding_rate.upcase} bleeder on a #{wound.body_part.upcase}, skipping")
+      end
+      # if not bleeding then it's a parasite or lodged item
+      !wound.bleeding? || skilled_to_tend
+    end
+    .sort_by { |wound| wound.severity * -1 } # sort descending
+    .each { |wound| tended_wounds = DRCH.bind_wound(wound.body_part) || tended_wounds }
+    return tended_wounds
   end
 
   # Monitor for wounds to begin bleeding again then tend them.
@@ -38,38 +48,31 @@ class TendMe
 
     loop do
       pause 0.5
-      body_part = nil
-      # One or more active bleeders, tend them.
-      if Flags['tendme-bind-wound']
-        body_part = get_body_part_from_flag('tendme-bind-wound')
-      end
+      tend_wounds = false
       # If training, you can rewrap wound for more experience.
       if Flags['tendme-rewrap-wound']
         if train && DRSkill.getxp('First Aid') < 30
-          body_part = get_body_part_from_flag('tendme-rewrap-wound')
+          tend_wounds = true
+          body_part = Flags['tendme-rewrap-wound'][:body_part]
+          Flags.reset('tendme-rewrap-wound')
           DRCH.unwrap_wound(body_part)
         end
-        # Unwrapping a wound will cause a message that trips our flag.
-        # Clear the flag so we don't try to double tend a wound.
-        # If the flag was already tripped for a different bleeder
-        # then that'll get taken cared of when we bind all open wounds.
+      end
+      # One or more active bleeders, tend them.
+      if Flags['tendme-bind-wound']
+        tend_wounds = true
         Flags.reset('tendme-bind-wound')
       end
       # Detected lodged ammo or parasites, tend them out.
       if Flags['tendme-bind-lodged']
-        body_part = get_body_part_from_flag('tendme-bind-lodged')
+        tend_wounds = true
+        Flags.reset('tendme-bind-lodged')
       end
-      if body_part
-        DRCH.bind_wound(body_part)
+      if tend_wounds
+        tend_wounds = false
         bind_open_wounds?
       end
     end
-  end
-
-  def get_body_part_from_flag(flag)
-    body_part = Flags[flag][:body_part]
-    Flags.reset(flag)
-    return body_part
   end
 
 end


### PR DESCRIPTION
### Dependencies
* Depends on https://github.com/rpherbig/dr-scripts/pull/4918
 
### Background
* `tendme` is duplicating logic for parsing bleeders from your health; should use DRCH instead.
* `tendme` will exit the script after tending a wound (likely a bug in the script), it won't stay perpetually in passive mode monitoring for bleeders to be retended

### Changes
* Use DRCH common methods for parsing health and identifying wounds
* Add optional argument `monitor` to put script into passive loop to retend as needed
* Add optional argument `train` to unwrap and tend wounds to maximize experience
* Encapsulate logic in a class and use `events` module instead of the low-level `scripts.get` 
* Checks `DRCH.skilled_to_tend_wound?(bleeding_rate)`, and if not then warns user and skips that wound to avoid making it worse and/or incurring long RT

### Usage
* `;tendme [train] [monitor]`
  - `train` will unwrap and rewrap bandages to maximize experience
  - `monitor` will enter passive loop and retend bleeders when bandages fall off
  - if not in monitor mode (default) then will check health and tend bleeders once then exit

## Tests

### should rewrap wound when bandages fall off
```
> ,tendme monitor

...

The bandages binding your chest become useless and fall apart.

> 
[tendme]>tend my chest

You work carefully at tending your wound.
Doing your best, you only manage to reduce the bleeding a little.
Roundtime: 10 sec.
```

### should train by unwrapping wounds when bandages are ready to be changed
```
> ,tendme train

--- Lich: tendme active.

...

You feel like now might be a good time to change the bandages on your neck.
> 
[tendme]>unwrap my neck

The bandages binding your neck become useless and fall apart.

You unwrap your bandages.
[Roundtime: 20 seconds]

[tendme]>tend my neck

You work carefully at tending your wound.
Doing your best, you are able to stop the bleeding.
Roundtime: 1 sec.
> 
[tendme]>health

```

### should not try to tend clotted, tended, or internal bleeders, warn about too difficult bleeders
```
> ,tendme

--- Lich: tendme active.

[tendme]>health

Your body feels at full strength.
Your spirit feels full of life.
You are strangely full of extra energy.
You have some minor abrasions to the head, a few nearly invisible scars along the head, minor swelling and bruising around the neck compounded by deep cuts across the neck, minor swelling and bruising around the right arm compounded by cuts and bruises about the right arm, an occasional twitching in the right arm, cuts and bruises about the left arm, a severely swollen and deeply bruised right leg compounded by cuts and bruises about the right leg, a constant twitching in the right leg, a severely swollen and deeply bruised left leg compounded by deep slashes across the left leg, some tiny scratches to the right hand, an occasional twitching in the right hand, some tiny scratches to the left hand, a few nearly invisible scars along the left hand, deep slashes across the chest area, minor swelling and bruising in the abdomen compounded by cuts and bruises about the abdomen, a few nearly invisible scars along the abdomen, some tiny scratches to the back, some tiny scars across the back, some minor abrasions to the right eye, some tiny scars across the right eye, some minor abrasions to the left eye, a few nearly invisible scars along the left eye.

Bleeding
            Area       Rate              
-----------------------------------------
            neck       (tended)
        left leg       light
           chest       very profuse
   inside r. leg       very bad
   inside l. leg       slight

> 

| You are not skilled enough to tend a VERY PROFUSE bleeder on a CHEST, skipping

[tendme]>tend my left leg

You work carefully at tending your wound.
Doing your best, you are able to stop the bleeding.
Roundtime: 2 sec.

--- Lich: tendme has exited.
```

### should tend lodged ammo
```
> ,tendme

--- Lich: tendme active.

[tendme]>health

Your body feels slightly battered.
Your spirit feels full of life.
You are strangely full of extra energy.

You have a crossbow bolt lodged shallowly into your right leg, a crossbow bolt lodged shallowly into your left leg.

> 
[tendme]>tend my right leg

You skillfully remove the crossbow bolt from your leg leaving the wound no worse than it was before.
Roundtime: 5 seconds.

> 
[tendme]>drop my crossbow bolt

You drop a crossbow bolt.

> 
[tendme]>tend my right leg

That area is not bleeding.
> 
[tendme]>health

Your body feels slightly battered.
Your spirit feels full of life.
You are strangely full of extra energy.

You have a crossbow bolt lodged shallowly into your left leg.

> 
[tendme]>tend my left leg

You skillfully remove the crossbow bolt from your leg leaving the wound no worse than it was before.
Roundtime: 5 seconds.

> 
[tendme]>drop my crossbow bolt

You drop a crossbow bolt.

> 
[tendme]>tend my left leg

That area is not bleeding.
> 
[tendme]>health

Your body feels slightly battered.
Your spirit feels full of life.
You are strangely full of extra energy.
You have no significant injuries. 

> 
--- Lich: tendme has exited.
```
