### PR TITLE
Adding optional way to configure combat buffs with a waggle

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -978,7 +978,11 @@ class SpellProcess
 
     @settings = settings
 
-    @buff_spells = settings.buff_spells
+    if settings.combat_buff_waggle && settings.waggle_sets[settings.combat_buff_waggle]
+      @buff_spells = settings.waggle_sets[settings.combat_buff_waggle]
+    else
+      @buff_spells = settings.buff_spells
+    end
     echo("  @buff_spells: #{@buff_spells}") if $debug_mode_ct
 
     @offensive_spells = settings.offensive_spells

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -140,8 +140,10 @@ summoned_weapons:
 summoned_weapons_element:
 summoned_weapons_ingot:
 # buff_spells are what combat-trainer will keep you buffed with when in combat.
+# Alternatively, you can provide a waggle name in combat_buff_waggle for it to use instead.
 # See combat-trainer documentation above for some attributes.
 buff_spells:
+combat_buff_waggle:
 # offensive_spells are what combat-trainer will use offensively.
 # See combat-trainer documentation above for some attributes.
 offensive_spells:


### PR DESCRIPTION
Many people configure all their spells in their char-setup.yaml, and have one or more hunt files. While this works nicely, it can be a pain to use different buffs in each of those hunts, due to the inability to use YAML anchors/references across files. This lets you define a waggle for each hunt, and refer to it by name in the hunt specific file.

If you make no changes to your YAML, you will continue to use `buff_spells:` for all hunts as normal.

@ubiquitous42 - I think this was something you had explicitly asked for as well, if you want to test.