### PR TITLE
[script] [common-healing] Fix bug with parsing bleeders

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -140,10 +140,11 @@ module DRCH
   # are the severity and the values are the list of bleeding wounds.
   def parse_bleeders(health_lines)
     bleeders = Hash.new { |h, k| h[k] = [] }
+    bleeder_line_regex = /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/
     if health_lines.grep(/^Bleeding|^\s*\bArea\s+Rate\b/).any?
       health_lines
-        .drop_while { |line| !(/^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/ =~ line) }
-        .take_while { |line| /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/ =~ line }
+        .drop_while { |line| !(bleeder_line_regex =~ line) }
+        .take_while { |line| bleeder_line_regex =~ line }
         .drop_while { |line| /^Bleeding|^\s*\bArea\s+Rate\b/ =~ line }
         .each do |line|
           # Do regex then look for the body part match.

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -142,7 +142,7 @@ module DRCH
     bleeders = Hash.new { |h, k| h[k] = [] }
     if health_lines.grep(/^Bleeding|^\s*\bArea\s+Rate\b/).any?
       health_lines
-        .drop_while { |line| /^You have .* poison(?:ed)?|^You feel somewhat tired and seem to be having trouble breathing|^You have a dormant infection|^Your wounds are infected|^Your body is covered in open oozing sores/ =~ line }
+        .drop_while { |line| !(/^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/ =~ line) }
         .take_while { |line| /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/ =~ line }
         .drop_while { |line| /^Bleeding|^\s*\bArea\s+Rate\b/ =~ line }
         .each do |line|

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -145,7 +145,6 @@ module DRCH
       health_lines
         .drop_while { |line| !(bleeder_line_regex =~ line) }
         .take_while { |line| bleeder_line_regex =~ line }
-        .drop_while { |line| /^Bleeding|^\s*\bArea\s+Rate\b/ =~ line }
         .each do |line|
           # Do regex then look for the body part match.
           line =~ $DRCH_WOUND_BODY_PART_REGEX


### PR DESCRIPTION
### Background
* When DRCH.check_health runs, if there exist lines of text OTHER THAN info about you being poisoned/diseased after the list of bleeders then no bleeders will actually be detected because those extraneous lines of text will never match the `take_while` expression.
* This is most noticeable when you get a bleeder in combat then run `DRCH.check_health` because the amount of text to be parsed likely contains other things going on, like critters attacking or you casting other spells.

_**Example of problem**_
GIVEN:
```ruby
    health_lines = [
        "Your body feels slightly battered.",
        "Your spirit feels full of life.",
        "You have deep cuts across the chest area.",
        "",
        "Bleeding",
        "            Area       Rate              ",
        "-----------------------------------------",
        "           chest       light             ",
        "Ignore this line",
        "And this line",
        "Definitely don't worry about this line"
    ]
    bleeder_lines = health_lines.map(&:strip).reverse
      .drop_while { |line| /^You have .* poison(?:ed)?|^You feel somewhat tired and seem to be having trouble breathing|^You have a dormant infection|^Your wounds are infected|^Your body is covered in open oozing sores/ =~ line }
      .take_while { |line| /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/ =~ line }
      .drop_while { |line| /^Bleeding|^\s*\bArea\s+Rate\b/ =~ line }
    echo "bleeders=#{bleeder_lines}"
```
THEN:
```
bleeders=[]
```

### Changes
* Since we don't want _any_ text that doesn't look like a bleeder, modified the `drop_while` expression to be literally that, anything that doesn't look like what we want in the following `take_while` expression.

## Tests

### should  ignore non-bleeder text and parse bleeders
GIVEN:
```ruby
    health_lines = [
        "Your body feels slightly battered.",
        "Your spirit feels full of life.",
        "You have deep cuts across the chest area.",
        "",
        "Bleeding",
        "            Area       Rate              ",
        "-----------------------------------------",
        "           chest       light             ",
        "Ignore this line",
        "And this line",
        "Definitely don't worry about this line"
    ]
    bleeder_line_regex = /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/
    bleeder_lines = health_lines.map(&:strip).reverse
      .drop_while { |line| !(bleeder_line_regex =~ line) }
      .take_while { |line| bleeder_line_regex =~ line }
      .drop_while { |line| /^Bleeding|^\s*\bArea\s+Rate\b/ =~ line }
    echo "bleeders=#{bleeder_lines}"
```
THEN:
```
bleeders=["chest       light"]
```

### combat-trainer should use tendme when you have a bleeder and it get tended
```
* As if fumbling muscle flab were natural, a grass eel bares a set of short but wickedly sharp fangs at you.  You dodge, twisting to one side.
[You're nimbly balanced with opponent in better position.]
>

The bandages binding your chest soak through with blood becoming useless and you begin bleeding again.
>

Moving with dominating grace, a grass eel bares a set of short but wickedly sharp fangs at a grass eel.  A grass eel fails to evade, not quite escaping the blast.  The teeth lands a harmless blow to its abdomen!
>

* Looking as if this were a bad idea, a grass eel bares a set of short but wickedly sharp fangs at you.  You dodge, leaning to one side.
[You're bruised, solidly balanced with opponent in good position.]
>

[combat-trainer]>weave

You weave back and forth in a dance-like motion, drawing your opponent's attention away from the fight.
[You're bruised, nimbly balanced and opponent has slight advantage.]
Roundtime: 4 sec.
>

You feel fully rested.

Moving with dominating grace, a grass eel slices wide at a grass eel.  A grass eel fails to dodge, not quite escaping the blast.  The teeth lands an ineffective strike to its abdomen!
>

* As if effort and skill were a bad thing, a grass eel bares a set of short but wickedly sharp fangs at you.  You evade, leaping aside.
[You're bruised, solidly balanced with opponent in better position.]
>

--- Lich: tendme active.

[tendme]>health
>
Your body feels slightly battered.
Your spirit feels full of life.
You have deep cuts across the chest area.
Bleeding
            Area       Rate
-----------------------------------------
           chest       light
>
[combat-trainer]>invoke my tattoo 5

[tendme]>health

* Looking as if this were a bad idea, a grass eel bares a set of short but wickedly sharp fangs at you.  You evade, leaning just out of harm's reach.
[You're bruised, solidly balanced and in superior position.]

>
The nature of the tattoo does not let you decide how much energy to use.
Closing your eyes, you carefully bend some mana streams through the tattoo on your shoulder.
The saturated tunnels in the tattoo form the foundation of a spell pattern.  With this template in place, you begin preparing the Substratum spell.

>
Your body feels slightly battered.
Your spirit feels full of life.
You have deep cuts across the chest area.
Bleeding
            Area       Rate
-----------------------------------------
           chest       light
>
[combat-trainer]>remove my cambrinth armband

[tendme]>tend my chest
Try though you may, you find it too clumsy to charge the cambrinth armband while wearing it.
>
Your task is made more difficult by being in combat.
You work carefully at tending your wound.
Doing your best, you are able to stop the bleeding.

[tendme]>health
Your body feels slightly battered.
Your spirit feels full of life.
You have deep cuts across the chest area.
Bleeding
            Area       Rate
-----------------------------------------
           chest       (tended)

You remove a braided cambrinth armband from your upper arm.

[combat-trainer]>charge my cambrinth armband 5

--- Lich: tendme has exited.

You harness a small amount of energy and attempt to channel it into your cambrinth armband.
You are able to channel all the energy into the armband.
The cambrinth armband absorbs all of the energy.
Roundtime: 2 sec.
```