### PR TITLE
[script] [common-healing-data] Update First Aid skill to tend

### DIFF
--- a/common-healing-data.lic
+++ b/common-healing-data.lic
@@ -4,10 +4,8 @@
 # then the wound is much worse so they should be triaged first.
 # https://elanthipedia.play.net/Damage#Bleeding_Levels
 #
-# As of December 2020, the skill needed to tend bleeders are guestimates.
-# I was not aware of any definitive data.
+# Skill to tend based on https://elanthipedia.play.net/First_Aid_skill#Skill_to_Tend
 # A 'nil' value means that can't be tended because already is tended or isn't bleeding.
-# Please adjust skill needed as appropriate, and be conservative.
 $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'tended' => {
     severity: 1,            # lower numbers are less severe than higher numbers
@@ -32,7 +30,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'slight' => {
     severity: 3,
     bleeding: true,
-    skill_to_tend: 25
+    skill_to_tend: 30
   },
   'slight(tended)' => {
     severity: 4,
@@ -42,7 +40,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'light' => {
     severity: 4,
     bleeding: true,
-    skill_to_tend: 50
+    skill_to_tend: 40
   },
   'light(tended)' => {
     severity: 5,
@@ -52,7 +50,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'moderate' => {
     severity: 5,
     bleeding: true,
-    skill_to_tend: 75
+    skill_to_tend: 50
   },
   'moderate(tended)' => {
     severity: 6,
@@ -62,7 +60,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'bad' => {
     severity: 6,
     bleeding: true,
-    skill_to_tend: 100
+    skill_to_tend: 60
   },
   'bad(tended)' => {
     severity: 7,
@@ -72,7 +70,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'very bad' => {
     severity: 7,
     bleeding: true,
-    skill_to_tend: 200
+    skill_to_tend: 75
   },
   'very bad(tended)' => {
     severity: 8,
@@ -82,7 +80,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'heavy' => {
     severity: 8,
     bleeding: true,
-    skill_to_tend: 300
+    skill_to_tend: 90
   },
   'heavy(tended)' => {
     severity: 9,
@@ -92,7 +90,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'very heavy' => {
     severity: 9,
     bleeding: true,
-    skill_to_tend: 400
+    skill_to_tend: 105
   },
   'very heavy(tended)' => {
     severity: 10,
@@ -102,7 +100,7 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'severe' => {
     severity: 10,
     bleeding: true,
-    skill_to_tend: 500
+    skill_to_tend: 120
   },
   'severe(tended)' => {
     severity: 11,
@@ -112,87 +110,117 @@ $DRCH_BLEED_RATE_TO_SEVERITY_MAP = {
   'very severe' => {
     severity: 11,
     bleeding: true,
-    skill_to_tend: 600
+    skill_to_tend: 140
   },
   'very severe(tended)' => {
     severity: 12,
     bleeding: true,
     skill_to_tend: nil
   },
-  'profuse' => {
+  'extremely severe' => {
     severity: 12,
     bleeding: true,
-    skill_to_tend: 700
+    skill_to_tend: 160
+  },
+  'extremely severe(tended)' => {
+    severity: 13,
+    bleeding: true,
+    skill_to_tend: nil
+  },
+  'profuse' => {
+    severity: 13,
+    bleeding: true,
+    skill_to_tend: 180
   },
   'profuse(tended)' => {
-    severity: 13,
+    severity: 14,
     bleeding: true,
     skill_to_tend: nil
   },
   'very profuse' => {
-    severity: 13,
+    severity: 14,
     bleeding: true,
-    skill_to_tend: 800
+    skill_to_tend: 205
   },
   'very profuse(tended)' => {
-    severity: 14,
+    severity: 15,
+    bleeding: true,
+    skill_to_tend: nil
+  },
+  'massive' => {
+    severity: 15,
+    bleeding: true,
+    skill_to_tend: 230
+  },
+  'massive(tended)' => {
+    severity: 16,
     bleeding: true,
     skill_to_tend: nil
   },
   'gushing' => {
-    severity: 14,
+    severity: 16,
     bleeding: true,
-    skill_to_tend: 900
+    skill_to_tend: 255
   },
   'gushing(tended)' => {
-    severity: 15,
+    severity: 17,
     bleeding: true,
     skill_to_tend: nil
   },
   'massive stream' => {
-    severity: 15,
+    severity: 17,
     bleeding: true,
-    skill_to_tend: 1000
+    skill_to_tend: 285
   },
   'massive stream(tended)' => {
-    severity: 16,
+    severity: 18,
+    bleeding: true,
+    skill_to_tend: nil
+  },
+  'gushing fountain' => {
+    severity: 18,
+    bleeding: true,
+    skill_to_tend: 285
+  },
+  'gushing fountain(tended)' => {
+    severity: 19,
     bleeding: true,
     skill_to_tend: nil
   },
   'uncontrollable' => {
-    severity: 16,
+    severity: 19,
     bleeding: true,
-    skill_to_tend: 1100
+    skill_to_tend: 400
   },
   'uncontrollable(tended)' => {
-    severity: 17,
+    severity: 20,
     bleeding: true,
     skill_to_tend: nil
   },
   'unbelievable' => {
-    severity: 17,
+    severity: 20,
     bleeding: true,
-    skill_to_tend: 1200
+    skill_to_tend: 500
   },
   'unbelievable(tended)' => {
-    severity: 18,
+    severity: 21,
     bleeding: true,
     skill_to_tend: nil
   },
   'beyond measure' => {
-    severity: 18,
+    severity: 21,
     bleeding: true,
-    skill_to_tend: 1300
+    skill_to_tend: 600
   },
   'beyond measure(tended)' => {
-    severity: 19,
+    severity: 22,
     bleeding: true,
     skill_to_tend: nil
   },
   'death awaits' => {
-    severity: 19,
+    severity: 22,
     bleeding: true,
-    skill_to_tend: 1400
+    skill_to_tend: 700
   },
 }
 


### PR DESCRIPTION
### Background
* The original skills to tend each bleeder severity were my best guesses and wildly conservative.
* Anectdoctally from tending bleeders on my empath while training up to 128 ranks of FA, and after review of https://elanthipedia.play.net/Talk:First_Aid_skill, decided this data needed to be revised.

### Changes
* Update FA skill to tend bleeders based on new wiki page, https://elanthipedia.play.net/First_Aid_skill#Skill_to_Tend
* For severities with unknown skill requirements, continue to use conservative values
* Added missing bleeding levels: `extremely severe`, `massive`, and `gushing fountain`