### PR TITLE
[script] [validate] Check 'sell_loot_metals_and_stones' settings

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -671,6 +671,16 @@ class DRYamlValidator
     error('sell_loot_money_on_hand is invalid. The proper format is: <amount> <denomination> e.g. 3 silv or 4 bronze')
   end
 
+  def assert_that_sell_loot_metals_and_stones_is_correct(settings)
+    return unless settings.sell_loot_metals_and_stones
+    unless settings.sell_loot_metals_and_stones_container
+      error('You do not have a container set for selling metals and stones. Specify sell_loot_metals_and_stones_container: setting.')
+    end
+    unless ['nugget', 'bar'].any? { |item| settings.loot_additions.include?(item) }
+      warn('sell_loot_metals_and_stones setting is true. You may want to add "nugget" and "bar" to your loot_additions: setting.')
+    end
+  end
+
   def assert_that_pet_buffs_have_spell_requirements(settings)
     return unless settings.buff_spells
 


### PR DESCRIPTION
### Background
* https://github.com/rpherbig/dr-scripts/pull/4913 added new settings for `sell-loot` script
* There are no validations for the new settings

### Changes
* Warn if selling metals and stones but aren't looting nuggets and bars (what the script sells)
* Error if selling metals and stones but don't have a container specified

## Tests

### error if no metal and stone container set
GIVEN:
```yaml
sell_loot_metals_and_stones: true
```
THEN:
```
[validate: ERROR:< You do not have a container set for selling metals and stones. Specify sell_loot_metals_and_stones_container: setting.  >]
```

### no error if metal and stone container set
GIVEN:
```yaml
sell_loot_metals_and_stones: true
sell_loot_metals_and_stones_container: backpack
```
THEN:
```
,validate
--- Lich: validate active.

  Checking 96 different potential errors

  WARNINGS:0 ERRORS:0

  All done!

--- Lich: validate has exited.
```

### no warning if at least "nugget" or "bar" are in loot_additions: setting
GIVEN:
```yaml
sell_loot_metals_and_stones: true
loot_additions:
- nugget
```
or
```yaml
sell_loot_metals_and_stones: true
loot_additions:
- bar
```
THEN:
```
,validate
--- Lich: validate active.

  Checking 96 different potential errors

  WARNINGS:0 ERRORS:0

  All done!

--- Lich: validate has exited.
```

### warn if neither nuggets or bars are in loot_additions
GIVEN:
```yaml
sell_loot_metals_and_stones: true
```
THEN:
```
[validate: WARNING:< sell_loot_metals_and_stones setting is true. You may want to add "nugget" and "bar" to your loot_additions: setting.  >]
```