### PR TITLE
[script] [combat-trainer] Fix bug with charged manuevers and stowing powershot ammo

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2754,6 +2754,11 @@ class AttackProcess
     echo("@firing_timer: #{@firing_timer}") if $debug_mode_ct
     @firing_check = 0
 
+    # Monitor for ammo falling to ground after powershot maneuver.
+    # The regular expression is important because we need a capturing group
+    # of the ammo so that we can stow it after the powershot.
+    # We are not interested in ammo that lodges, we will get that when looting the critter.
+    Flags.add('ct-powershot-ammo', "The (?<ammo>.*) (?:falls to the ground|lands nearby)!")
     Flags.add('ct-aim-failed', 'you stop aiming', 'stop concentrating on aiming')
     Flags.add('ct-ranged-ready', 'You think you have your best shot possible now.')
     Flags.add('ct-face-what', 'Face what')
@@ -3102,11 +3107,7 @@ class AttackProcess
   def use_charged_maneuver(action, game_state)
     game_state.cooldown_timers[action] = Time.now
 
-    # Monitor for ammo falling to ground after powershot maneuver.
-    # The regular expression is important because we need a capturing group
-    # of the ammo so that we can stow it after the powershot.
-    # We are not interested in ammo that lodges, we will get that when looting the critter.
-    Flags.add('ct-powershot-ammo', "The (?<ammo>.*) (?:falls to the ground|lands nearby)!") if action == 'powershot'
+    Flags.reset('ct-powershot-ammo')
 
     attempt = bput("maneuver #{action}", 'You raise your', 'You brace your', 'balanced and', 'Taking a full step back', 'You take a step back', 'You lower your shoulders', 'You angle to the side and ', 'rest a bit longer', 'You square up your feet', 'You crouch down', 'You step to the side')
     return if attempt == 'rest a bit longer'
@@ -3115,11 +3116,14 @@ class AttackProcess
     pause 7
     waitrt?
 
-    if Flags['ct-powershot-ammo']
+    # Only react to the powershot flag if we just did a powershot manuever.
+    # This is an added protection in case the flag was tripped by an unrelated
+    # action like throwing a weapon. This way we don't try to "stow my throwing hammer"
+    # after a 'maneuver cleave' action, for example.
+    if Flags['ct-powershot-ammo'] && action == 'powershot'
       # When the flag matches game output then the value of the flag
       # is the regular expression matches. This is how we know the ammo to stow.
       stow_ammo(Flags['ct-powershot-ammo'][:ammo])
-      Flags.reset('ct-powershot-ammo')
     end
 
     game_state.use_charged_maneuvers = false


### PR DESCRIPTION
### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/4912
* After performing a `powershot` maneuver, the `ct-powershot-ammo` flag is actively monitoring for things that match the pattern `"The (?<ammo>.*) (?:falls to the ground|lands nearby)!"`
* When you throw a weapon that lands at your feet, the game text follows that same pattern and the powershot flag now thinks your `throwing hammer` (or whatever weapon you threw) is the ammo to be stowed.
* The logic that stowed powershot ammo only checked if the flag was true but not that the manuever just performed was a `powershot`, so after doing an unrelated action like `manuever cleave` then you might try to stow your most recently thrown weapon, which might be equipped and then lead to combat-trainer getting confused why you don't have a weapon out to fight with.

### Changes
* Move the creation of the flag to the AttackProcess constructor with the other flags (only needs to be done once anyways)
* Reset the `ct-powershot-ammo` flag before every manuever (to clear out false positives)
* If `Flags['ct-powershot-ammo']` is true, only attempt to stow when also attempting a `powershot` maneuver so what you stow is the ammo you just shot