### PR TITLE
[script] [buff-watcher] New script to keep buffs active

### DIFF
--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -7,7 +7,7 @@ no_pause_all
 
 custom_require.call(%w[common common-arcana common-items spellmonitor])
 
-class WaggleWatcher
+class BuffWatcher
   include DRC
   include DRCA
   include DRCI
@@ -15,7 +15,7 @@ class WaggleWatcher
   def initialize
     arg_definitions = [
       [
-        { name: 'waggle', regex: /\w+/, optional: true, description: 'spell list to use, otherwise default' }
+        { name: 'buff_set_name', regex: /\w+/, optional: true, description: 'Name of a set of buffs defined in waggle_sets: in your YAML' }
       ]
     ]
 
@@ -26,7 +26,7 @@ class WaggleWatcher
     @no_use_rooms = @settings.buff_watcher_no_use_rooms
     @startup_delay = @settings.buff_watcher_startup_delay
     @passive_delay = @settings.buff_watcher_passive_delay
-    @waggle_name = args.waggle || @settings.buff_watcher_waggle_name || 'default'
+    @buff_set_name = args.buff_set_name || @settings.buff_watcher_name || 'default'
     @barb_buffs_inner_fire_threshold = @settings.barb_buffs_inner_fire_threshold
 
     # Don't allow users to make foolish mistakes, always prevent use during go2/burgle
@@ -73,7 +73,7 @@ class WaggleWatcher
     end
 
     # Do the needful
-    DRCA.do_buffs(@settings, @waggle_name)
+    DRCA.do_buffs(@settings, @buff_set_name)
 
     # Pick item back up if you lowered something
     DRCI.get_item(temp_left_item) if temp_left_item
@@ -84,14 +84,14 @@ class WaggleWatcher
 
   def buffs_active?
     if DRStats.thief?
-      # Elements in the waggle are ability names (strings) without the Khri prefix
-      return @settings.waggle_sets[@waggle_name].all? { |spell| DRSpells.active_spells["Khri #{spell}"] }
+      # Elements in the buff are ability names (strings) without the Khri prefix
+      return @settings.waggle_sets[@buff_set_name].all? { |spell| DRSpells.active_spells["Khri #{spell}"] }
     elsif DRStats.barbarian?
-      # Elements in the waggle are ability names (strings)
-      return @settings.waggle_sets[@waggle_name].all? { |spell| DRSpells.active_spells[spell] }
+      # Elements in the buff are ability names (strings)
+      return @settings.waggle_sets[@buff_set_name].all? { |spell| DRSpells.active_spells[spell] }
     else
-      # Elements in the waggle are maps of spell name to spell data
-      return @settings.waggle_sets[@waggle_name].all? { |spell, data| DRSpells.active_spells[spell] }
+      # Elements in the buff are maps of spell name to spell data
+      return @settings.waggle_sets[@buff_set_name].all? { |spell, data| DRSpells.active_spells[spell] }
     end
   end
 
@@ -115,4 +115,4 @@ class WaggleWatcher
 
 end
 
-WaggleWatcher.new
+BuffWatcher.new

--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -1,0 +1,118 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#buff-watcher
+=end
+
+no_kill_all
+no_pause_all
+
+custom_require.call(%w[common common-arcana common-items spellmonitor])
+
+class WaggleWatcher
+  include DRC
+  include DRCA
+  include DRCI
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'waggle', regex: /\w+/, optional: true, description: 'spell list to use, otherwise default' }
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
+    @settings = get_settings
+
+    @no_use_scripts = @settings.buff_watcher_no_use_scripts
+    @no_use_rooms = @settings.buff_watcher_no_use_rooms
+    @startup_delay = @settings.buff_watcher_startup_delay
+    @passive_delay = @settings.buff_watcher_passive_delay
+    @waggle_name = args.waggle || @settings.buff_watcher_waggle_name || 'default'
+    @barb_buffs_inner_fire_threshold = @settings.barb_buffs_inner_fire_threshold
+
+    # Don't allow users to make foolish mistakes, always prevent use during go2/burgle
+    @no_use_scripts << 'go2'
+    @no_use_scripts << 'burgle'
+
+    # Pause for the startup delay so you can control spammyness of autostart scripts
+    pause @startup_delay
+
+    # Run passively in a loop
+    # If you want to run this only once, just call `buff` script directly
+    passive_run
+  end
+
+  def passive_run
+    loop do
+      pause @passive_delay
+      activate_buffs if should_activate_buffs?
+    end
+  end
+
+  def should_activate_buffs?
+    !(hidden? || invisible? || running_no_use_scripts? || inside_no_use_room? || need_inner_fire? || buffs_active?)
+  end
+
+  def activate_buffs
+    # Pause other scripts so they don't interfere with our casting
+    scripts_to_unpause = smart_pause_all
+    temp_left_item = nil
+    waitrt?
+
+    # Free up a hand in case you use held cambrinth
+    unless DRStats.thief? || DRStats.barbarian? || !use_stored_cambrinth?
+      if /nothing in your left hand\.$|at your empty hands\.$/ !~ bput('glance', 'You glance down')
+        # If both hands are full, store the left hand item in a variable for future
+        # use and lower the left hand to the feet slot.
+        # - Left causes less problems with combat (less likely to be a loaded weapon)
+        # - Feet slot causes less space/correct container issues
+        if DRC.left_hand && DRC.right_hand
+          temp_left_item = DRC.left_hand
+          temp_left_item = nil unless DRCI.lower_item?(DRC.left_hand)
+        end
+      end
+    end
+
+    # Do the needful
+    DRCA.do_buffs(@settings, @waggle_name)
+
+    # Pick item back up if you lowered something
+    DRCI.get_item(temp_left_item) if temp_left_item
+
+    # Resume scripts
+    unpause_all_list(scripts_to_unpause)
+  end
+
+  def buffs_active?
+    if DRStats.thief?
+      # Elements in the waggle are ability names (strings) without the Khri prefix
+      return @settings.waggle_sets[@waggle_name].all? { |spell| DRSpells.active_spells["Khri #{spell}"] }
+    elsif DRStats.barbarian?
+      # Elements in the waggle are ability names (strings)
+      return @settings.waggle_sets[@waggle_name].all? { |spell| DRSpells.active_spells[spell] }
+    else
+      # Elements in the waggle are maps of spell name to spell data
+      return @settings.waggle_sets[@waggle_name].all? { |spell, data| DRSpells.active_spells[spell] }
+    end
+  end
+
+  def running_no_use_scripts?
+    @no_use_scripts.any? { |name| Script.running?(name) }
+  end
+
+  def inside_no_use_room?
+    @no_use_rooms.any? { |room| room === DRRoom.title.to_s()[2..-3] || room == Room.current.id }
+  end
+
+  def need_inner_fire?
+    return false unless DRStats.barbarian?
+    DRStats.mana < @barb_buffs_inner_fire_threshold
+  end
+
+  def use_stored_cambrinth?
+    return false if DRStats.thief? || DRStats.barbarian?
+    @settings.stored_cambrinth || @settings.cambrinth_items.any? { |item| item['stored'] }
+  end
+
+end
+
+WaggleWatcher.new

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -99,6 +99,8 @@ empty_values:
   wands: []
   wand_watcher_no_use_scripts: []
   wand_watcher_no_use_rooms: []
+  buff_watcher_no_use_scripts: []
+  buff_watcher_no_use_rooms: []
   noheal_empathylink: []
   repair_heuristic_gear: []
   sell_loot_ignored_metals_and_stones: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1766,8 +1766,37 @@ wand_watcher_no_use_rooms:
 
 # Wait n seconds on startup before doing anything [Optional - defaults to 10 s]
 wand_watcher_startup_delay: 10
+
 # Wait n seconds between checks for reusing wands [Optional - defaults to 60 s]
 wand_watcher_passive_delay: 60
+
+# Name of the waggle whose abilities to monitor and keep active on you.
+buff_watcher_waggle_name: default
+
+# Don't try to rebuff while these scripts are running.
+buff_watcher_no_use_scripts:
+- athletics
+- burgle
+- steal
+- go2
+- get2
+- feed-cloak
+- combat-trainer
+- hunting-buddy
+- healme
+
+# Don't try to rebuff while in these rooms (genearlly anti-magic rooms), can use roomnumber, title or regex that matches the title.
+buff_watcher_no_use_rooms:
+  - 1900                                          # Crossing bank teller - included with regex below but shown for example
+  - Knife Clan, Triage                            # Dokt - silenced room
+  - !ruby/regexp '/^(?:First )?Provincial Bank,/' # Crossing Bank - mapped, but 1 regex- -> 3 rooms
+  - !ruby/regexp '/Carousel (?:Booth|Chamber)$/'  # Vaults - unmapped silenced / nomagic
+
+# Wait n seconds on startup before doing anything [Optional - defaults to 10 s]
+buff_watcher_startup_delay: 10
+
+# How long to wait between checks to recasting    [Optional - defaults to 60 s]
+buff_watcher_passive_delay: 60
 
 # settings for tarantula: (HE 2019 gift)
 # See: https://elanthipedia.play.net/Lich_script_repository#tarantula for details

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1770,8 +1770,8 @@ wand_watcher_startup_delay: 10
 # Wait n seconds between checks for reusing wands [Optional - defaults to 60 s]
 wand_watcher_passive_delay: 60
 
-# Name of the waggle whose abilities to monitor and keep active on you.
-buff_watcher_waggle_name: default
+# Name of the buff list defined in waggle_sets: whose abilities to monitor and keep active on you.
+buff_watcher_name: default
 
 # Don't try to rebuff while these scripts are running.
 buff_watcher_no_use_scripts:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1775,15 +1775,20 @@ buff_watcher_name: default
 
 # Don't try to rebuff while these scripts are running.
 buff_watcher_no_use_scripts:
+- buff
 - athletics
 - burgle
 - steal
+- pick
+- locksmithing
 - go2
 - get2
-- feed-cloak
-- combat-trainer
+- bescort
+- stabbity
 - hunting-buddy
+- combat-trainer
 - healme
+- feed-cloak
 
 # Don't try to rebuff while in these rooms (genearlly anti-magic rooms), can use roomnumber, title or regex that matches the title.
 buff_watcher_no_use_rooms:


### PR DESCRIPTION
### Background
* Sometimes you want to keep your buffs up all the time, even when you're out of combat, and even when not running T2 or training-manager
* And if not for the buff's benefits then for the magical skill training it can provide as you're milling around town
* Similar in principle to `wand-watcher` that keeps buffs active via wands

### Credits
* Inspired by requests and code from B-Money42, Blackheart, and VTCifer

### Changes
* New script `buff-watcher` modeled after `wand-watcher` and `buff`
* Adds new configuration settings that mirror those used with `wand-watcher`
* Designed to be run in the background, and suitable as an autostart

### Usage
* `;buff-watcher [buff-set-name]`
  - If no buff set name is specified at script start then will use `buff_watcher_name:` else the 'default' buff set
* `;e autostart('buff-watcher', false)`
  - Also suitable as an autostart

### Notes
* This script _can_ be used by Barbarians, but it would be a waste of your inner fire out of combat
* This script _can_ be used by Necromancers, just beware of justice zones and which buffs you put up

### Configuration
Shamelessly copied from wand-watcher's config.

<details>
<summary>click to toggle</summary>

```yaml
# Name of the buff list defined in waggle_sets: whose abilities to monitor and keep active on you.
buff_watcher_name: default

# Don't try to rebuff while these scripts are running.
buff_watcher_no_use_scripts:
- buff
- athletics
- burgle
- steal
- pick
- locksmithing
- go2
- get2
- bescort
- stabbity
- hunting-buddy
- combat-trainer
- healme
- feed-cloak

# Don't try to rebuff while in these rooms (genearlly anti-magic rooms), can use roomnumber, title or regex that matches the title.
buff_watcher_no_use_rooms:
  - 1900                                          # Crossing bank teller - included with regex below but shown for example
  - Knife Clan, Triage                            # Dokt - silenced room
  - !ruby/regexp '/^(?:First )?Provincial Bank,/' # Crossing Bank - mapped, but 1 regex- -> 3 rooms
  - !ruby/regexp '/Carousel (?:Booth|Chamber)$/'  # Vaults - unmapped silenced / nomagic

# Wait n seconds on startup before doing anything [Optional - defaults to 10 s]
buff_watcher_startup_delay: 10

# How long to wait between checks to recasting    [Optional - defaults to 60 s]
buff_watcher_passive_delay: 60
```
</details>

## Tests
<details>
<summary>click to toggle</summary>

### as thief with hands full, does not need to empty hands to activate khri
```
>glance

You glance down to see a vault book in your right hand and a coil of heavy rope in your left hand.

> ,buff-watcher

--- Lich: buff-watcher active.

--- Lich: faux-atmo paused.

--- Lich: tarantula paused.

--- Lich: almanac paused.

--- Lich: sanowret-crystal paused.

[buff-watcher]>Khri Dampen

Focusing your mind, you attempt to attune your senses to even your most minor movements.  You quickly feel more comfortable with your ability to control your motions to prevent detection.
Roundtime: 3 sec.
>
--- Lich: faux-atmo unpaused.

--- Lich: tarantula unpaused.

--- Lich: almanac unpaused.

--- Lich: sanowret-crystal unpaused.
```

### as barbarian with hands full, does not need to empty hands to activate ability
```
>glance

You glance down to see a vault book in your right hand and a coil of heavy rope in your left hand.

> ,buff-watcher combat

--- Lich: buff-watcher active.

--- Lich: faux-atmo paused.

--- Lich: almanac paused.

--- Lich: sanowret-crystal paused.

[buff-watcher]>med tenacity

You must be sitting to properly reinforce your physical resistance.
>
[buff-watcher]>sit

You sit down.

s>
[buff-watcher]>med tenacity

You begin to meditate upon the chakrel amulet, your inner fire swelling as you center your mind, body, and spirit.
Roundtime: 7 sec.
s>
Peering into the flame you visualize swords, teeth and worse all rending your flesh.
s>
You draw the flames close and bring forth a physical hardening to your body.
s>
The flame infuses your flesh, reinforcing it against physical damage!
You feel a jolt as your vision snaps shut.
s>
[buff-watcher]>stand

You stand back up.

>
--- Lich: faux-atmo unpaused.

--- Lich: almanac unpaused.

--- Lich: sanowret-crystal unpaused.
```

### as magic user with hands full and worn/no cambrinth, does not need to empty hands to cast spell
```
>glance

You glance down to see a vault book in your right hand and a coil of heavy rope in your left hand.

,buff-watcher
--- Lich: buff-watcher active.

>
[buff-watcher]>release mana

You aren't harnessing any mana.
>
[buff-watcher]>prep MAF 6

With meditative movements you prepare your body for the Manifest Force spell.
>
[buff-watcher]>charge my cambrinth armband 11

You harness a small amount of energy and attempt to channel it into your cambrinth armband.
You are able to channel all the energy into the armband.
The cambrinth armband absorbs all of the energy.
Roundtime: 3 sec.

...
```

### as magic user with hands full and stored cambrinth, empties left hand for cambrinth use then picks it back up
```
> ,buff-watcher

--- Lich: buff-watcher active.

> release ic

Your skin loses its protective numbness.

--- Lich: almanac paused.

--- Lich: tendme paused.

[buff-watcher]>glance

You glance down to see a vault book in your right hand and a coil of heavy rope in your left hand.
>
[buff-watcher]>lower ground left

You lower the rope and place it on the ground at your feet.
>
[buff-watcher]>release mana

You aren't harnessing any mana.
>
[buff-watcher]>prep IC 5

With meditative movements you prepare your body for the Iron Constitution spell.
>
[buff-watcher]>remove my cambrinth armband

You remove a braided cambrinth armband from your upper arm.
>

[buff-watcher]>charge my cambrinth armband 7

You harness a small amount of energy and attempt to channel it into your cambrinth armband.
You are able to channel all the energy into the armband.
The cambrinth armband absorbs all of the energy.
Roundtime: 3 sec.
>
[buff-watcher]>invoke my cambrinth armband

The cambrinth armband pulses with Life energy.  You reach for its center and forge a magical link to it, readying all of its mana for your use.
Roundtime: 1 sec.
>
[buff-watcher]>wear my cambrinth armband

You attach a braided cambrinth armband to your upper arm.
>

[buff-watcher]>cast

You gesture.
Your cambrinth armband emits a loud *snap* as it discharges all its power to aid your spell.
The pattern secretes a liquid, dusky light which cascades down your body like thick honey, numbing your skin as it covers you from head to toe before thinning out.

>
[buff-watcher]>get my heavy rope

You pick up the rope lying at your feet.
>
--- Lich: almanac unpaused.

--- Lich: tendme unpaused.

```
</details>