### PR TITLE
[script] [tendme] Show skill warning only for bleeders

### DIFF
--- a/tendme.lic
+++ b/tendme.lic
@@ -27,13 +27,14 @@ class TendMe
       health_data['bleeders'].values.flatten
     )
     .reject { |wound| wound.internal? || wound.bleeding_rate =~ /tended|clotted/ } # untendable
-    .select do |wound|      
-      skilled_to_tend = DRCH.skilled_to_tend_wound?(wound.bleeding_rate)
-      unless wound.bleeding? && skilled_to_tend
+    .select do |wound|
+      if wound.bleeding? && !DRCH.skilled_to_tend_wound?(wound.bleeding_rate)
         DRC.message("You are not skilled enough to tend a #{wound.bleeding_rate.upcase} bleeder on a #{wound.body_part.upcase}, skipping")
+        false
+      else
+        # the wound is either a tendable bleeder, parasite, or lodged item
+        true
       end
-      # if not bleeding then it's a parasite or lodged item
-      !wound.bleeding? || skilled_to_tend
     end
     .sort_by { |wound| wound.severity * -1 } # sort descending
     .each { |wound| tended_wounds = DRCH.bind_wound(wound.body_part) || tended_wounds }


### PR DESCRIPTION
### Background
* Reported by [Xif](https://discord.com/channels/745675889622384681/745678251250417674/836688267873222708) in Lich discord
* `tendme` was recently updated in https://github.com/rpherbig/dr-scripts/pull/4916
* A skill check was added to warn the user if a bleeder is skipped
* The warning is incorrectly being shown for non-bleeders, too (logic flaw)

<details>
<summary>Example of problem</summary>

```
> ,tendme

--- Lich: tendme active.

[tendme]>health

Your body feels slightly battered.
Your spirit feels full of life.
You are strangely full of extra energy.
You have some minor abrasions to the right arm.

You have a small red blood mite on your right arm.

> 
| You are not skilled enough to tend a  bleeder on a RIGHT ARM, skipping

[tendme]>tend my right arm

You expertly remove the blood mite from your right arm with a gentle touch, leaving the wound no worse than it was before.

The blood mite slips free and quickly slithers away, vanishing from sight within moments.
Roundtime: 10 seconds.

...
```
</details>

### Changes
* Update condition logic to be clearer on when to show warning

## Tests
<details>
<summary>click to toggle</summary>

### should not show warning for non-bleeders (fixed logic)
```
> ,tendme

--- Lich: tendme active.

[tendme]>health

Your body feels slightly battered.
Your spirit feels full of life.
You are strangely full of extra energy.
You have some minor abrasions to the right arm.

You have a small red blood mite on your right arm.

> 
[tendme]>tend my right arm

You expertly remove the blood mite from your right arm with a gentle touch, leaving the wound no worse than it was before.

The blood mite slips free and quickly slithers away, vanishing from sight within moments.
Roundtime: 10 seconds.
> 
[tendme]>tend my right arm

That area is not bleeding.
> 
[tendme]>health

Your body feels slightly battered.
Your spirit feels full of life.
You are strangely full of extra energy.
You have some minor abrasions to the right arm.
You have no significant injuries. 

> 
--- Lich: tendme has exited.
``` 

### should show warning for bleeders beyond your skill (regression test)
GIVEN:
```
First Aid: 30 ranks
```
THEN:
```
!> ,tendme

--- Lich: tendme active.

[tendme]>health

Your body feels at full strength.
Your spirit feels full of life.
You have (lots of wounds...)

Bleeding
            Area       Rate              
-----------------------------------------
       right arm       slight
           chest       light
         abdomen       light
   inside r. arm       slight

You have a small red blood mite on your right leg, a small red blood mite on your neck.

!> 
| You are not skilled enough to tend a LIGHT bleeder on a ABDOMEN, skipping

| You are not skilled enough to tend a LIGHT bleeder on a CHEST, skipping

[tendme]>tend my right arm

You work carefully at tending your wound.
Doing your best, you are able to stop the bleeding.
Roundtime: 3 sec.
!> 
[tendme]>tend my neck

You expertly remove the blood mite from your neck with a gentle touch, leaving the wound no worse than it was before.

The blood mite slips free and quickly slithers away, vanishing from sight within moments.
Roundtime: 10 seconds.
!> 
The serpent earcuff coils, sensing your danger.  Tiny fangs suddenly puncture your flesh, but the expected pain doesn't come.  Instead, soothing warmth radiates outward from the bite, leaving you feeling a little better than before.
!> 
The serpent earcuff coils, sensing your danger.  Tiny fangs suddenly puncture your flesh, but the expected pain doesn't come.  Instead, soothing warmth radiates outward from the bite, leaving you feeling a little better than before.
!> 
Your wooden medallion warms in response to your danger.  A dull crimson glow radiates from the device and seeps into your exposed skin, leaving you feeling a little better than before.
!> 
[tendme]>tend my neck

That area is not bleeding.
!> 
[tendme]>tend my right leg

You expertly remove the blood mite from your right leg with a gentle touch, leaving the wound no worse than it was before.

The blood mite slips free and quickly slithers away, vanishing from sight within moments.
Roundtime: 10 seconds.
!> 
[tendme]>tend my right leg

That area is not bleeding.
```
</details>