### PR TITLE
[scripts] [common-items] [04] get item

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -133,19 +133,27 @@ module DRCI
     /Your .* is in/ =~ DRC.bput("inv search #{item}", 'You can\'t seem to find anything that looks like that', 'Your .* is in')
   end
 
-  def wearing?(description)
-    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder')
-    result =~ /wearing/
+  # Taps items to check if you're wearing it.
+  def wearing?(item)
+    tap(item) =~ /wearing/
   end
 
-  def inside?(description, container)
-    result = DRC.bput("tap my #{description} in my #{container}", 'You tap .*', 'atop your', 'I could not find', 'on the shoulder')
-    result =~ /inside/
+  # Taps item to determine if it's in the given container.
+  def inside?(item, container = nil)
+    tap(item, container) =~ /inside/
   end
 
-  def exists?(description)
-    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You (thump|drum) your fingers', 'The orb is delicate')
-    result =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
+  # Taps an item to confirm it exists.
+  def exists?(item)
+    tap(item) =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
+  end
+
+  # Taps an item and returns the match string.
+  # If no container specified then generically taps whatever's in your immediate inventory.
+  def tap(item, container = nil)
+    from = container
+    from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
+    DRC.bput("tap my #{item} #{from}", 'You tap .*', 'atop your', 'I could not find', 'on the shoulder', '^You (thump|drum) your fingers', 'The orb is delicate')
   end
 
   def in_hands?(item)

--- a/common-items.lic
+++ b/common-items.lic
@@ -3,15 +3,15 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-items
 =end
 
-$TRASH_STORAGE = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot]
+$DRCI_TRASH_STORAGE = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot]
 
-$DROP_TRASH_SUCCESS_PATTERNS = [
+$DRCI_DROP_TRASH_SUCCESS_PATTERNS = [
   /^You drop/,
   /^You put/,
   /^You spread .* on the ground/
 ]
 
-$DROP_TRASH_FAILURE_PATTERNS = [
+$DRCI_DROP_TRASH_FAILURE_PATTERNS = [
   /What were you referring to/,
   /I could not find/,
   /But you aren't holding that/,
@@ -21,17 +21,17 @@ $DROP_TRASH_FAILURE_PATTERNS = [
   /You really shouldn't be loitering/
 ]
 
-$PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
+$DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
   /^You put your .* in/,
   /^You hold out/,
   /^You tuck your/
 ]
 
-$PUT_AWAY_ITEM_OPEN_PATTERNS = [
+$DRCI_PUT_AWAY_ITEM_OPEN_PATTERNS = [
   /^But that's closed/
 ]
 
-$PUT_AWAY_ITEM_FAILURE_PATTERNS = [
+$DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS = [
   /^Please rephrase that command/,
   /^What were you referring to/,
   /^I could not find what you were referring to/,
@@ -49,13 +49,13 @@ $PUT_AWAY_ITEM_FAILURE_PATTERNS = [
   /Containers can't be placed in/
 ]
 
-$OPEN_CONTAINER_SUCCESS_PATTERNS = [
+$DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS = [
   /^You open/,
   /^That is already open/,
   /^You spread your arms, carefully holding your bag well away from your body/
 ]
 
-$OPEN_CONTAINER_FAILURE_PATTERNS = [
+$DRCI_OPEN_CONTAINER_FAILURE_PATTERNS = [
   /^Please rephrase that command/,
   /^What were you referring to/,
   /^I could not find what you were referring to/,
@@ -66,12 +66,12 @@ $OPEN_CONTAINER_FAILURE_PATTERNS = [
   /^You can't do that/
 ]
 
-$CLOSE_CONTAINER_SUCCESS_PATTERNS = [
+$DRCI_CLOSE_CONTAINER_SUCCESS_PATTERNS = [
   /^You close/,
   /^That is already closed/
 ]
 
-$CLOSE_CONTAINER_FAILURE_PATTERNS = [
+$DRCI_CLOSE_CONTAINER_FAILURE_PATTERNS = [
   /^Please rephrase that command/,
   /^What were you referring to/,
   /^I could not find what you were referring to/,
@@ -94,7 +94,7 @@ module DRCI
     trashcans = DRRoom.room_objs
                       .reject { |obj| obj =~ /azure \w+ tree/ }
                       .map { |long_name| DRC.get_noun(long_name) }
-                      .select { |obj| $TRASH_STORAGE.include?(obj) }
+                      .select { |obj| $DRCI_TRASH_STORAGE.include?(obj) }
 
     trashcans.each do |trashcan|
       if trashcan == 'gloop'
@@ -114,11 +114,11 @@ module DRCI
         trashcan = 'bin'
       end
 
-      if /^You (drop|put|spread)/ =~ DRC.bput("put my #{item} in #{trashcan}", *$DROP_TRASH_SUCCESS_PATTERNS, *$DROP_TRASH_FAILURE_PATTERNS)
+      if /^You (drop|put|spread)/ =~ DRC.bput("put my #{item} in #{trashcan}", *$DRCI_DROP_TRASH_SUCCESS_PATTERNS, *$DRCI_DROP_TRASH_FAILURE_PATTERNS)
         return true
       end
     end
-    return /^You (drop|put|spread)/ =~ DRC.bput("drop my #{item}", *$DROP_TRASH_SUCCESS_PATTERNS, *$DROP_TRASH_FAILURE_PATTERNS)
+    return /^You (drop|put|spread)/ =~ DRC.bput("drop my #{item}", *$DRCI_DROP_TRASH_SUCCESS_PATTERNS, *$DRCI_DROP_TRASH_FAILURE_PATTERNS)
   end
 
   def search?(item)
@@ -388,14 +388,14 @@ module DRCI
   def put_away_item_unsafe?(item, container = nil)
     command = "put my #{item} in #{container}" if container
     command = "stow my #{item}" unless container
-    result = DRC.bput(command, $PUT_AWAY_ITEM_SUCCESS_PATTERNS, $PUT_AWAY_ITEM_OPEN_PATTERNS, $PUT_AWAY_ITEM_FAILURE_PATTERNS)
+    result = DRC.bput(command, $DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS, $DRCI_PUT_AWAY_ITEM_OPEN_PATTERNS, $DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS)
     case result
-    when *$PUT_AWAY_ITEM_OPEN_PATTERNS
+    when *$DRCI_PUT_AWAY_ITEM_OPEN_PATTERNS
       return false if open_container?(container) == false
       return put_away_item_unsafe?(item,container)
-    when *$PUT_AWAY_ITEM_SUCCESS_PATTERNS
+    when *$DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS
       return true
-    when $PUT_AWAY_ITEM_FAILURE_PATTERNS
+    when $DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS
       return false
     else
       return false
@@ -403,16 +403,16 @@ module DRCI
   end
 
   def open_container?(container)
-    case DRC.bput("open #{container}", $OPEN_CONTAINER_SUCCESS_PATTERNS, $OPEN_CONTAINER_FAILURE_PATTERNS)
-    when *$OPEN_CONTAINER_SUCCESS_PATTERNS
+    case DRC.bput("open #{container}", $DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS, $DRCI_OPEN_CONTAINER_FAILURE_PATTERNS)
+    when *$DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS
       return true
     end
     return false
   end
 
   def close_container?(container)
-    case DRC.bput("close #{container}", $CLOSE_CONTAINER_SUCCESS_PATTERNS, $CLOSE_CONTAINER_FAILURE_PATTERNS)
-    when *$CLOSE_CONTAINER_SUCCESS_PATTERNS
+    case DRC.bput("close #{container}", $DRCI_CLOSE_CONTAINER_SUCCESS_PATTERNS, $DRCI_CLOSE_CONTAINER_FAILURE_PATTERNS)
+    when *$DRCI_CLOSE_CONTAINER_SUCCESS_PATTERNS
       return true
     end
     return false

--- a/common-items.lic
+++ b/common-items.lic
@@ -89,6 +89,10 @@ custom_require.call(%w[common])
 module DRCI
   module_function
 
+  #########################################
+  # TRASH ITEM
+  #########################################
+
   def dispose_trash(item)
     return if item.nil?
     trashcans = DRRoom.room_objs
@@ -121,6 +125,10 @@ module DRCI
     return /^You (drop|put|spread)/ =~ DRC.bput("drop my #{item}", *$DRCI_DROP_TRASH_SUCCESS_PATTERNS, *$DRCI_DROP_TRASH_FAILURE_PATTERNS)
   end
 
+  #########################################
+  # SEARCH FOR ITEM
+  #########################################
+
   def search?(item)
     /Your .* is in/ =~ DRC.bput("inv search #{item}", 'You can\'t seem to find anything that looks like that', 'Your .* is in')
   end
@@ -133,6 +141,11 @@ module DRCI
   def inside?(description, container)
     result = DRC.bput("tap my #{description} in my #{container}", 'You tap .*', 'atop your', 'I could not find', 'on the shoulder')
     result =~ /inside/
+  end
+
+  def exists?(description)
+    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You (thump|drum) your fingers', 'The orb is delicate')
+    result =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
   end
 
   def in_hands?(item)
@@ -173,41 +186,9 @@ module DRCI
     end
   end
 
-  # Returns a list of item descriptions from the `INVENTORY <type|slot>` verb output.
-  # Where <type> can be armor, weapon, fluff, container, or combat.
-  # Where <slot> can be any phrase from INV SLOTS LIST command.
-  def get_inventory_by_type(type = 'combat', line_count = 40)
-    case DRC.bput("inventory #{type}", "Use INVENTORY HELP for more options.", "The INVENTORY command is the best way")
-    when "The INVENTORY command is the best way"
-      DRC.message("Unrecognized inventory type: #{type}. Valid options are ARMOR, WEAPON, FLUFF, CONTAINER, COMBAT, or any slot from INVENTORY SLOTS LIST.")
-      return []
-    end
-    # Multiple lines may have been printed to the game window,
-    # grab the last several lines for analysis.
-    snapshot = reget(line_count)
-    # Unless you're looking for items at your feet, this is noise.
-    items_at_feet = snapshot.grep(/(^Lying at your feet)/).any?
-    # If the snapshot found all the inventory then begin processing.
-    if snapshot.grep(/^All of your (#{type}|items)|^You aren't wearing anything like that|Both of your hands are empty/).any? && snapshot.grep(/Use INVENTORY HELP/).any?
-      snapshot
-      .map(&:strip)
-      .reverse
-      .take_while { |line| [/^All of your (#{type}|items)/, /^You aren't wearing anything like that/, /Both of your hands are empty/].none? { |phrase| phrase =~ line } }
-      .drop_while { |line| !line.start_with?('[Use INVENTORY HELP for more options.]') }
-      .drop(1)
-      .reverse
-      .take_while { |line| !items_at_feet || !line.start_with?('Lying at your feet') }
-      .map { |item| item.gsub(/^(a|an|some)\s+/, '').gsub(/\s+\(closed\)/, '') }
-    else
-      # Otherwise, retry the command. Other actions may have flooded the game window.
-      get_inventory_by_type(type, line_count + 40)
-    end
-  end
-
-  def exists?(description)
-    result = DRC.bput("tap my #{description}", 'You tap .*', 'I could not find', 'on the shoulder', '^You (thump|drum) your fingers', 'The orb is delicate')
-    result =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
-  end
+  #########################################
+  # COUNT ITEMS
+  #########################################
 
   def count_item_parts(item)
     match_messages = [
@@ -256,6 +237,10 @@ module DRCI
     count
   end
 
+  #########################################
+  # STOW ITEM
+  #########################################
+
   def stow_hands
     stow_hand('right') if DRC.right_hand
     stow_hand('left') if DRC.left_hand
@@ -279,6 +264,10 @@ module DRCI
     )
     dispose_trash(DRC.get_noun(Regexp.last_match(1))) if braid_regex.match(result)
   end
+
+  #########################################
+  # GET ITEM
+  #########################################
 
   # Gets an item unless you are already hold it.
   # Use this method to avoid having two of an item
@@ -321,6 +310,10 @@ module DRCI
     result =~ /^(You get|You pick|You pluck|You deftly remove|You are already holding|You fade in for a moment as you get)/
   end
 
+  #########################################
+  # LOWER ITEM
+  #########################################
+
   # Lowers the item to the ground.
   # Determines which hand is holding the item then lowers it to your feet slot.
   def lower_item?(item)
@@ -330,12 +323,47 @@ module DRCI
     DRC.bput("lower ground #{hand}", "You lower", "But you aren't holding anything") =~ /You lower/
   end
 
+  #########################################
+  # CHECK CONTAINER CONTENTS
+  #########################################
+
   # Checks if the container is empty.
   # Returns true if certain the container is empty.
   # Returns false if certain the container is not empty.
   # Returns nil if unable to determine either way (e.g. can't open container or look in it).
   def container_is_empty?(container)
     look_in_container(container).empty?
+  end
+
+  # Returns a list of item descriptions from the `INVENTORY <type|slot>` verb output.
+  # Where <type> can be armor, weapon, fluff, container, or combat.
+  # Where <slot> can be any phrase from INV SLOTS LIST command.
+  def get_inventory_by_type(type = 'combat', line_count = 40)
+    case DRC.bput("inventory #{type}", "Use INVENTORY HELP for more options.", "The INVENTORY command is the best way")
+    when "The INVENTORY command is the best way"
+      DRC.message("Unrecognized inventory type: #{type}. Valid options are ARMOR, WEAPON, FLUFF, CONTAINER, COMBAT, or any slot from INVENTORY SLOTS LIST.")
+      return []
+    end
+    # Multiple lines may have been printed to the game window,
+    # grab the last several lines for analysis.
+    snapshot = reget(line_count)
+    # Unless you're looking for items at your feet, this is noise.
+    items_at_feet = snapshot.grep(/(^Lying at your feet)/).any?
+    # If the snapshot found all the inventory then begin processing.
+    if snapshot.grep(/^All of your (#{type}|items)|^You aren't wearing anything like that|Both of your hands are empty/).any? && snapshot.grep(/Use INVENTORY HELP/).any?
+      snapshot
+      .map(&:strip)
+      .reverse
+      .take_while { |line| [/^All of your (#{type}|items)/, /^You aren't wearing anything like that/, /Both of your hands are empty/].none? { |phrase| phrase =~ line } }
+      .drop_while { |line| !line.start_with?('[Use INVENTORY HELP for more options.]') }
+      .drop(1)
+      .reverse
+      .take_while { |line| !items_at_feet || !line.start_with?('Lying at your feet') }
+      .map { |item| item.gsub(/^(a|an|some)\s+/, '').gsub(/\s+\(closed\)/, '') }
+    else
+      # Otherwise, retry the command. Other actions may have flooded the game window.
+      get_inventory_by_type(type, line_count + 40)
+    end
   end
 
   # Gets a list of items found in a container via RUMMAGE or LOOK.
@@ -362,6 +390,10 @@ module DRCI
     .split(/(?:,|and) (?:some|an|a)/)
     .map(&:strip)
   end
+
+  #########################################
+  # PUT AWAY ITEM
+  #########################################
 
   # Puts away an item, optionally into a specific container.
   # If no container specified then uses the default stow location.
@@ -401,6 +433,10 @@ module DRCI
       return false
     end
   end
+
+  #########################################
+  # OPEN/CLOSE CONTAINERS
+  #########################################
 
   def open_container?(container)
     case DRC.bput("open #{container}", $DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS, $DRCI_OPEN_CONTAINER_FAILURE_PATTERNS)

--- a/common-items.lic
+++ b/common-items.lic
@@ -21,6 +21,30 @@ $DRCI_DROP_TRASH_FAILURE_PATTERNS = [
   /You really shouldn't be loitering/
 ]
 
+$DRCI_GET_ITEM_SUCCESS_PATTERNS = [
+  /You get/,
+  /You pick/,
+  /You pluck/,
+  /You deftly remove/,
+  /You are already holding/,
+  /You fade in for a moment as you get/
+]
+
+$DRCI_GET_ITEM_FAILURE_PATTERNS = [
+  /already in your inventory/,
+  /You need a free hand/,
+  /needs to be tended to be removed/,
+  /You just can't/,
+  /push you over the item limit/,
+  /You stop as you realize the .* is not yours/,
+  /Stow what/,
+  /Get what/,
+  /I could not/,
+  /What were you/,
+  /rapidly decays away/,
+  /cracks and rots away/
+]
+
 $DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
   /^You put your .* in/,
   /^You hold out/,
@@ -289,6 +313,11 @@ module DRCI
     return get_item(item, container)
   end
 
+  # Provide a predicate-named method to follow convention.
+  def get_item?(item, container = nil)
+    get_item(item, container)
+  end
+
   # Gets an item, optionally from a specific container.
   # If no container specified then generically grabs from the room/your person.
   # Can provide an array of containers to try, too, in case some might be empty.
@@ -303,8 +332,9 @@ module DRCI
   end
 
   # Same as 'get_item_unsafe' but ensures that
-  # the container argument is prefixed with ' my '.
+  # the container argument is prefixed with 'my' qualifier.
   def get_item_safe(item, container = nil)
+    item = "my #{item}" if item && !(item =~ /^my /i)
     container = "my #{container}" if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
     get_item_unsafe(item, container)
   end
@@ -314,8 +344,12 @@ module DRCI
   def get_item_unsafe(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
-    result = DRC.bput("get #{item} #{from}", 'You get', 'You pick', 'You pluck', 'You deftly remove', 'You are already holding', 'You fade in for a moment as you get', 'I could not', 'What were you', 'Get what', 'You need a free hand')
-    result =~ /^(You get|You pick|You pluck|You deftly remove|You are already holding|You fade in for a moment as you get)/
+    case DRC.bput("get #{item} #{from}", $DRCI_GET_ITEM_SUCCESS_PATTERNS, $DRCI_GET_ITEM_FAILURE_PATTERNS)
+    when *$DRCI_GET_ITEM_SUCCESS_PATTERNS
+      return true
+    else
+      return false
+    end
   end
 
   #########################################


### PR DESCRIPTION
This is the 4th of many PRs I'll be submitting for common-items. It depends on #4932

To make it easier to review the changes, I'm phasing them in. However, because I can't open a PR in this repo against my forked branch of #4932, until that dependency is merged then this PR's diff is noisier than it really is. Instead, please review the net new commit https://github.com/rpherbig/dr-scripts/commit/e53212945e461707c91bd1a71e24d619824701cc

This one focuses on moving the match strings for the "get item" methods to $DRCI constants for easier maintenance and readability as is done with other methods in this class.