### PR TITLE
[scripts] [common-items] [07] rummage and look in container

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -458,7 +458,7 @@ module DRCI
   # REMOVE ITEM
   #########################################
 
-  # Removes an item you're removeing.
+  # Removes an item you're wearing.
   def remove_item?(item)
     remove_item_safe?(item)
   end
@@ -470,7 +470,7 @@ module DRCI
     remove_item_unsafe?(item)
   end
 
-  # Removes an item you're removeing.
+  # Removes an item you're wearing.
   def remove_item_unsafe?(item)
     case DRC.bput("remove #{item}", /You .*#{item}/i, $DRCI_REMOVE_ITEM_SUCCESS_PATTERNS, $DRCI_REMOVE_ITEM_FAILURE_PATTERNS)
     when /You .*#{item}/i, *$DRCI_REMOVE_ITEM_SUCCESS_PATTERNS

--- a/common-items.lic
+++ b/common-items.lic
@@ -102,10 +102,6 @@ $DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
   /^You tuck your/
 ]
 
-$DRCI_PUT_AWAY_ITEM_OPEN_PATTERNS = [
-  /^But that's closed/
-]
-
 $DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS = [
   /^Please rephrase that command/,
   /^What were you referring to/,
@@ -133,6 +129,18 @@ $DRCI_STOW_ITEM_SUCCESS_PATTERNS = [
 $DRCI_STOW_ITEM_FAILURE_PATTERNS = [
   *$DRCI_GET_ITEM_FAILURE_PATTERNS,
   *$DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS,
+]
+
+$DRCI_RUMMAGE_SUCCESS_PATTERNS = [
+  /You rummage through .* and see (.*)\./,
+  /In the .* you see (.*)\./,
+  /there is nothing/i
+]
+
+$DRCI_RUMMAGE_FAILURE_PATTERNS = [
+  /I could not find/,
+  /I don't know what you are referring to/,
+  /What were you referring to/
 ]
 
 $DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS = [
@@ -570,17 +578,43 @@ module DRCI
     end
   end
 
+  # Gets a list of items by RUMMAGE the container.
+  # Returns a list (empty or otherwise) if able to rummage the container.
+  # Returns nil if unable to determine if container's contents (e.g. can't open it or rummage it).
   def rummage_container(container)
-    DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'there is nothing')
-    .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
-    .split(/(?:, | and )?(?:a|an|some) /)
+    container = "my #{container}" unless container.nil? || container =~ /^my /i
+    contents = DRC.bput("rummage #{container}", $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_RUMMAGE_SUCCESS_PATTERNS, $DRCI_RUMMAGE_FAILURE_PATTERNS)
+    case contents
+    when *$DRCI_RUMMAGE_FAILURE_PATTERNS
+      return nil
+    when *$DRCI_CONTAINER_IS_CLOSED_PATTERNS
+      return nil unless open_container?(container)
+      rummage_container(container)
+    else
+      contents
+        .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
+        .split(/(?:, | and )?(?:a|an|some) /)
+    end
   end
 
+  # Gets a list of items by LOOK in the container.
+  # Returns a list (empty or otherwise) if able to look in the container.
+  # Returns nil if unable to determine if container's contents (e.g. can't open it or look in it).
   def look_in_container(container)
-    DRC.bput("look in my #{container}", 'In the .* you see (.*)\.', 'there is nothing')
-    .match(/In the .* you see (?:some|an|a) (?<items>.*)\./)[:items]
-    .split(/(?:,|and) (?:some|an|a)/)
-    .map(&:strip)
+    container = "my #{container}" unless container.nil? || container =~ /^my /i
+    contents = DRC.bput("look in #{container}", $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_RUMMAGE_SUCCESS_PATTERNS, $DRCI_RUMMAGE_FAILURE_PATTERNS)
+    case contents
+    when *$DRCI_RUMMAGE_FAILURE_PATTERNS
+      return nil
+    when *$DRCI_CONTAINER_IS_CLOSED_PATTERNS
+      return nil unless open_container?(container)
+      look_in_container(container)
+    else
+      contents
+        .match(/In the .* you see (?:some|an|a) (?<items>.*)\./)[:items]
+        .split(/(?:,|and) (?:some|an|a)/)
+        .map(&:strip)
+    end
   end
 
   #########################################


### PR DESCRIPTION
This is the 7th of many PRs I'll be submitting for common-items. It depends on https://github.com/rpherbig/dr-scripts/pull/4935

To make it easier to review the changes, I'm phasing them in. However, because I can't open a PR in this repo against my forked branch of https://github.com/rpherbig/dr-scripts/pull/4935, until that dependency is merged then this PR's diff is noisier than it really is. Instead, please review the net new commit https://github.com/rpherbig/dr-scripts/commit/31a1299ded4cc0e2fe909bad13adb7cdb16d3f2d

This one focuses on the `rummage_container` and `look_in_container` methods.
* Moved their match strings to $DRCI constants like the other methods
* If container is closed then will try to open it then rummage/look

<details>
<summary>Click to toggle tests</summary>

### should return items when rummage container
```
> ,e echo DRCI.rummage_container('hip pouch')

--- Lich: exec1 active.

[exec1]>rummage my hip pouch

You rummage through a light spidersilk hip pouch stitched with a dragon ouroboros and see a vault book, some bundling rope and a severely curved matte black longbow carved with an intricate scale pattern.
> 
[exec1: ["vault book", "bundling rope", "severely curved matte black longbow carved with ", "intricate scale pattern"]]

--- Lich: exec1 has exited.
```

### should return 0 items when rummage container
```
,e echo DRCI.rummage_container('boots')
--- Lich: exec1 active.

[exec1]>rummage my boots

You put on a dark watersilk bag bearing a detailed cambrinth medallion.
> 
You rummage through a pair of knee-high demonscale boots with square kertig buckles but there is nothing in there.
> 
[exec1: []]

--- Lich: exec1 has exited.
```

### should open container and rummage
```
> ,e echo DRCI.rummage_container('hip pouch')

--- Lich: exec1 active.

[exec1]>rummage my hip pouch

While it's closed?
> 
[exec1]>open my hip pouch

You open your hip pouch.
> 
[exec1]>rummage my hip pouch

You rummage through a light spidersilk hip pouch stitched with a dragon ouroboros and see a vault book, some bundling rope and a severely curved matte black longbow carved with an intricate scale pattern.
> 
[exec1: ["vault book", "bundling rope", "severely curved matte black longbow carved with ", "intricate scale pattern"]]

--- Lich: exec1 has exited.
```

### should return false when no container to rummage
```
> ,e echo DRCI.rummage_container('abc')

--- Lich: exec1 active.

[exec1]>rummage my abc

I don't know what you are referring to.
> 
[exec1: ]

--- Lich: exec1 has exited.
```

### should return items when look in container
```
> ,e echo DRCI.look_in_container('hip pouch')

--- Lich: exec1 active.

[exec1]>look in my hip pouch

In the hip pouch you see a vault book, some bundling rope and a matte black longbow.
> 
[exec1: ["vault book", "bundling rope", "matte black longbow"]]

--- Lich: exec1 has exited.
```

### should return 0 items when look in container
```
> ,e echo DRCI.look_in_container('boots')

--- Lich: exec1 active.

[exec1]>look in my boots

There is nothing in there.
> 
[exec1: []]

--- Lich: exec1 has exited.
```

### should open container and look in it
```
> ,e echo DRCI.look_in_container('hip pouch')

--- Lich: exec1 active.

[exec1]>look in my hip pouch

That is closed.
> 
[exec1]>open my hip pouch

You open your hip pouch.
> 
[exec1]>look in my hip pouch

In the hip pouch you see a vault book, some bundling rope and a matte black longbow.
> 
[exec1: ["vault book", "bundling rope", "matte black longbow"]]

--- Lich: exec1 has exited.
```

### should return false when no container to look in
```
> ,e echo DRCI.look_in_container('abc')

--- Lich: exec1 active.

[exec1]>look in my abc

I could not find what you were referring to.
> 
[exec1: ]

--- Lich: exec1 has exited.
```

</details>