### PR TITLE
[script] [common-items] [08] Refactor $DRCI constants to class variables

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -458,7 +458,7 @@ module DRCI
   # REMOVE ITEM
   #########################################
 
-  # Removes an item you're removeing.
+  # Removes an item you're wearing.
   def remove_item?(item)
     remove_item_safe?(item)
   end
@@ -470,7 +470,7 @@ module DRCI
     remove_item_unsafe?(item)
   end
 
-  # Removes an item you're removeing.
+  # Removes an item you're wearing.
   def remove_item_unsafe?(item)
     case DRC.bput("remove #{item}", /You .*#{item}/i, $DRCI_REMOVE_ITEM_SUCCESS_PATTERNS, $DRCI_REMOVE_ITEM_FAILURE_PATTERNS)
     when /You .*#{item}/i, *$DRCI_REMOVE_ITEM_SUCCESS_PATTERNS

--- a/common-items.lic
+++ b/common-items.lic
@@ -102,10 +102,6 @@ $DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
   /^You tuck your/
 ]
 
-$DRCI_PUT_AWAY_ITEM_OPEN_PATTERNS = [
-  /^But that's closed/
-]
-
 $DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS = [
   /^Please rephrase that command/,
   /^What were you referring to/,
@@ -133,6 +129,18 @@ $DRCI_STOW_ITEM_SUCCESS_PATTERNS = [
 $DRCI_STOW_ITEM_FAILURE_PATTERNS = [
   *$DRCI_GET_ITEM_FAILURE_PATTERNS,
   *$DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS,
+]
+
+$DRCI_RUMMAGE_SUCCESS_PATTERNS = [
+  /You rummage through .* and see (.*)\./,
+  /In the .* you see (.*)\./,
+  /there is nothing/i
+]
+
+$DRCI_RUMMAGE_FAILURE_PATTERNS = [
+  /I could not find/,
+  /I don't know what you are referring to/,
+  /What were you referring to/
 ]
 
 $DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS = [
@@ -570,17 +578,43 @@ module DRCI
     end
   end
 
+  # Gets a list of items by RUMMAGE the container.
+  # Returns a list (empty or otherwise) if able to rummage the container.
+  # Returns nil if unable to determine if container's contents (e.g. can't open it or rummage it).
   def rummage_container(container)
-    DRC.bput("rummage my #{container}", 'You rummage through .* and see (.*)\.', 'there is nothing')
-    .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
-    .split(/(?:, | and )?(?:a|an|some) /)
+    container = "my #{container}" unless container.nil? || container =~ /^my /i
+    contents = DRC.bput("rummage #{container}", $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_RUMMAGE_SUCCESS_PATTERNS, $DRCI_RUMMAGE_FAILURE_PATTERNS)
+    case contents
+    when *$DRCI_RUMMAGE_FAILURE_PATTERNS
+      return nil
+    when *$DRCI_CONTAINER_IS_CLOSED_PATTERNS
+      return nil unless open_container?(container)
+      rummage_container(container)
+    else
+      contents
+        .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
+        .split(/(?:, | and )?(?:a|an|some) /)
+    end
   end
 
+  # Gets a list of items by LOOK in the container.
+  # Returns a list (empty or otherwise) if able to look in the container.
+  # Returns nil if unable to determine if container's contents (e.g. can't open it or look in it).
   def look_in_container(container)
-    DRC.bput("look in my #{container}", 'In the .* you see (.*)\.', 'there is nothing')
-    .match(/In the .* you see (?:some|an|a) (?<items>.*)\./)[:items]
-    .split(/(?:,|and) (?:some|an|a)/)
-    .map(&:strip)
+    container = "my #{container}" unless container.nil? || container =~ /^my /i
+    contents = DRC.bput("look in #{container}", $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_RUMMAGE_SUCCESS_PATTERNS, $DRCI_RUMMAGE_FAILURE_PATTERNS)
+    case contents
+    when *$DRCI_RUMMAGE_FAILURE_PATTERNS
+      return nil
+    when *$DRCI_CONTAINER_IS_CLOSED_PATTERNS
+      return nil unless open_container?(container)
+      look_in_container(container)
+    else
+      contents
+        .match(/In the .* you see (?:some|an|a) (?<items>.*)\./)[:items]
+        .split(/(?:,|and) (?:some|an|a)/)
+        .map(&:strip)
+    end
   end
 
   #########################################

--- a/common-items.lic
+++ b/common-items.lic
@@ -3,191 +3,191 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-items
 =end
 
-$DRCI_TRASH_STORAGE = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot]
-
-$DRCI_DROP_TRASH_SUCCESS_PATTERNS = [
-  /^You drop/,
-  /^You put/,
-  /^You spread .* on the ground/
-]
-
-$DRCI_DROP_TRASH_FAILURE_PATTERNS = [
-  /What were you referring to/,
-  /I could not find/,
-  /But you aren't holding that/,
-  /You're kidding, right/,
-  /You can't do that/,
-  /No littering/,
-  /You really shouldn't be loitering/
-]
-
-$DRCI_GET_ITEM_SUCCESS_PATTERNS = [
-  /You get/,
-  /You pick/,
-  /You pluck/,
-  /You deftly remove/,
-  /You are already holding/,
-  /You fade in for a moment as you get/
-]
-
-$DRCI_GET_ITEM_FAILURE_PATTERNS = [
-  /already in your inventory/,
-  /You need a free hand/,
-  /needs to be tended to be removed/,
-  /You just can't/,
-  /push you over the item limit/,
-  /You stop as you realize the .* is not yours/,
-  /Stow what/,
-  /Get what/,
-  /I could not/,
-  /What were you/,
-  /rapidly decays away/,
-  /cracks and rots away/
-]
-
-$DRCI_WEAR_ITEM_SUCCESS_PATTERNS = [
-  /You put/,
-  /You sling/,
-  /You attach/,
-  /You strap/,
-  /You slide/,
-  /You spin/,
-  /You slip/,
-  /You place/,
-  /You hang/,
-  /You carefully loop/,
-  /You work your way into/,
-  /slide effortlessly onto your/,
-  /You are already wearing/
-]
-
-$DRCI_WEAR_ITEM_FAILURE_PATTERNS = [
-  /You can't wear/,
-  /You .* unload/,
-  /close the fan/,
-  /You don't seem to be able to move/,
-  /Wear what/,
-  /I could not/,
-  /What were you/
-]
-
-$DRCI_REMOVE_ITEM_SUCCESS_PATTERNS = [
-  /You remove/,
-  /You detach/,
-  /You sling/,
-  /You slide/,
-  /You take off/,
-  /You loosen/,
-  /You tug/,
-  /as you remove/,
-  /Dropping your shoulder/,
-  /The leather gauntlets slide/,
-  /Without any effort/,
-  /you manage to loosen/,
-  /slide themselves off of your/
-]
-
-$DRCI_REMOVE_ITEM_FAILURE_PATTERNS = [
-  /You need a free hand/,
-  /You aren't wearing/,
-  /You don't seem to be able to move/,
-  /Remove what/,
-  /I could not/,
-  /What were you/
-]
-
-$DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS = [
-  /^You put your .* in/,
-  /^You hold out/,
-  /^You tuck your/
-]
-
-$DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS = [
-  /^Please rephrase that command/,
-  /^What were you referring to/,
-  /^I could not find what you were referring to/,
-  /even after stuffing it/,
-  /is too long to fit/,
-  /is too small to hold that/,
-  /There isn't any more room in/,
-  /There's no room/,
-  /to fit in the/,
-  /too heavy to go in there/,
-  /You just can't get/,
-  /You can't put items/,
-  /You can only take items out/,
-  /Perhaps you should be holding that first/,
-  /Containers can't be placed in/,
-  /The .* is not designed to carry anything/
-]
-
-$DRCI_STOW_ITEM_SUCCESS_PATTERNS = [
-  *$DRCI_GET_ITEM_SUCCESS_PATTERNS,
-  *$DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS
-]
-
-$DRCI_STOW_ITEM_FAILURE_PATTERNS = [
-  *$DRCI_GET_ITEM_FAILURE_PATTERNS,
-  *$DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS,
-]
-
-$DRCI_RUMMAGE_SUCCESS_PATTERNS = [
-  /You rummage through .* and see (.*)\./,
-  /In the .* you see (.*)\./,
-  /there is nothing/i
-]
-
-$DRCI_RUMMAGE_FAILURE_PATTERNS = [
-  /I could not find/,
-  /I don't know what you are referring to/,
-  /What were you referring to/
-]
-
-$DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS = [
-  /^You open/,
-  /^That is already open/,
-  /^You spread your arms, carefully holding your bag well away from your body/
-]
-
-$DRCI_OPEN_CONTAINER_FAILURE_PATTERNS = [
-  /^Please rephrase that command/,
-  /^What were you referring to/,
-  /^I could not find what you were referring to/,
-  /^You don't want to ruin your spell just for that do you/,
-  /^It would be a shame to disturb the silence of this place for that/,
-  /^This is probably not the time nor place for that/,
-  /^There is no way to do that/,
-  /^You can't do that/
-]
-
-$DRCI_CLOSE_CONTAINER_SUCCESS_PATTERNS = [
-  /^You close/,
-  /^That is already closed/
-]
-
-$DRCI_CLOSE_CONTAINER_FAILURE_PATTERNS = [
-  /^Please rephrase that command/,
-  /^What were you referring to/,
-  /^I could not find what you were referring to/,
-  /^You don't want to ruin your spell just for that do you/,
-  /^It would be a shame to disturb the silence of this place for that/,
-  /^This is probably not the time nor place for that/,
-  /^There is no way to do that/,
-  /^You can't do that/
-]
-
-$DRCI_CONTAINER_IS_CLOSED_PATTERNS = [
-  /^But that's closed/,
-  /^That is closed/,
-  /^While it's closed/
-]
-
 # This module should be 'bottom-level' and only depend on common.
 # Any modules that deal with items and <something> should be somewhere else
 custom_require.call(%w[common])
 
 module DRCI
   module_function
+
+  @@trash_storage = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot]
+
+  @@drop_trash_success_patterns = [
+    /^You drop/,
+    /^You put/,
+    /^You spread .* on the ground/
+  ]
+
+  @@drop_trash_failure_patterns = [
+    /What were you referring to/,
+    /I could not find/,
+    /But you aren't holding that/,
+    /You're kidding, right/,
+    /You can't do that/,
+    /No littering/,
+    /You really shouldn't be loitering/
+  ]
+
+  @@get_item_success_patterns = [
+    /You get/,
+    /You pick/,
+    /You pluck/,
+    /You deftly remove/,
+    /You are already holding/,
+    /You fade in for a moment as you get/
+  ]
+
+  @@get_item_failure_patterns = [
+    /already in your inventory/,
+    /You need a free hand/,
+    /needs to be tended to be removed/,
+    /You just can't/,
+    /push you over the item limit/,
+    /You stop as you realize the .* is not yours/,
+    /Stow what/,
+    /Get what/,
+    /I could not/,
+    /What were you/,
+    /rapidly decays away/,
+    /cracks and rots away/
+  ]
+
+  @@wear_item_success_patterns = [
+    /You put/,
+    /You sling/,
+    /You attach/,
+    /You strap/,
+    /You slide/,
+    /You spin/,
+    /You slip/,
+    /You place/,
+    /You hang/,
+    /You carefully loop/,
+    /You work your way into/,
+    /slide effortlessly onto your/,
+    /You are already wearing/
+  ]
+
+  @@wear_item_failure_patterns = [
+    /You can't wear/,
+    /You .* unload/,
+    /close the fan/,
+    /You don't seem to be able to move/,
+    /Wear what/,
+    /I could not/,
+    /What were you/
+  ]
+
+  @@remove_item_success_patterns = [
+    /You remove/,
+    /You detach/,
+    /You sling/,
+    /You slide/,
+    /You take off/,
+    /You loosen/,
+    /You tug/,
+    /as you remove/,
+    /Dropping your shoulder/,
+    /The leather gauntlets slide/,
+    /Without any effort/,
+    /you manage to loosen/,
+    /slide themselves off of your/
+  ]
+
+  @@remove_item_failure_patterns = [
+    /You need a free hand/,
+    /You aren't wearing/,
+    /You don't seem to be able to move/,
+    /Remove what/,
+    /I could not/,
+    /What were you/
+  ]
+
+  @@put_away_item_success_patterns = [
+    /^You put your .* in/,
+    /^You hold out/,
+    /^You tuck your/
+  ]
+
+  @@put_away_item_failure_patterns = [
+    /^Please rephrase that command/,
+    /^What were you referring to/,
+    /^I could not find what you were referring to/,
+    /even after stuffing it/,
+    /is too long to fit/,
+    /is too small to hold that/,
+    /There isn't any more room in/,
+    /There's no room/,
+    /to fit in the/,
+    /too heavy to go in there/,
+    /You just can't get/,
+    /You can't put items/,
+    /You can only take items out/,
+    /Perhaps you should be holding that first/,
+    /Containers can't be placed in/,
+    /The .* is not designed to carry anything/
+  ]
+
+  @@stow_item_success_patterns = [
+    *@@get_item_success_patterns,
+    *@@put_away_item_success_patterns
+  ]
+
+  @@stow_item_failure_patterns = [
+    *@@get_item_failure_patterns,
+    *@@put_away_item_failure_patterns,
+  ]
+
+  @@rummage_success_patterns = [
+    /You rummage through .* and see (.*)\./,
+    /In the .* you see (.*)\./,
+    /there is nothing/i
+  ]
+
+  @@rummage_failure_patterns = [
+    /I could not find/,
+    /I don't know what you are referring to/,
+    /What were you referring to/
+  ]
+
+  @@open_container_success_patterns = [
+    /^You open/,
+    /^That is already open/,
+    /^You spread your arms, carefully holding your bag well away from your body/
+  ]
+
+  @@open_container_failure_patterns = [
+    /^Please rephrase that command/,
+    /^What were you referring to/,
+    /^I could not find what you were referring to/,
+    /^You don't want to ruin your spell just for that do you/,
+    /^It would be a shame to disturb the silence of this place for that/,
+    /^This is probably not the time nor place for that/,
+    /^There is no way to do that/,
+    /^You can't do that/
+  ]
+
+  @@close_container_success_patterns = [
+    /^You close/,
+    /^That is already closed/
+  ]
+
+  @@close_container_failure_patterns = [
+    /^Please rephrase that command/,
+    /^What were you referring to/,
+    /^I could not find what you were referring to/,
+    /^You don't want to ruin your spell just for that do you/,
+    /^It would be a shame to disturb the silence of this place for that/,
+    /^This is probably not the time nor place for that/,
+    /^There is no way to do that/,
+    /^You can't do that/
+  ]
+
+  @@container_is_closed_patterns = [
+    /^But that's closed/,
+    /^That is closed/,
+    /^While it's closed/
+  ]
 
   #########################################
   # TRASH ITEM
@@ -198,7 +198,7 @@ module DRCI
     trashcans = DRRoom.room_objs
                       .reject { |obj| obj =~ /azure \w+ tree/ }
                       .map { |long_name| DRC.get_noun(long_name) }
-                      .select { |obj| $DRCI_TRASH_STORAGE.include?(obj) }
+                      .select { |obj| @@trash_storage.include?(obj) }
 
     trashcans.each do |trashcan|
       if trashcan == 'gloop'
@@ -218,11 +218,11 @@ module DRCI
         trashcan = 'bin'
       end
 
-      if /^You (drop|put|spread)/ =~ DRC.bput("put my #{item} in #{trashcan}", *$DRCI_DROP_TRASH_SUCCESS_PATTERNS, *$DRCI_DROP_TRASH_FAILURE_PATTERNS)
+      if /^You (drop|put|spread)/ =~ DRC.bput("put my #{item} in #{trashcan}", *@@drop_trash_success_patterns, *@@drop_trash_failure_patterns)
         return true
       end
     end
-    return /^You (drop|put|spread)/ =~ DRC.bput("drop my #{item}", *$DRCI_DROP_TRASH_SUCCESS_PATTERNS, *$DRCI_DROP_TRASH_FAILURE_PATTERNS)
+    return /^You (drop|put|spread)/ =~ DRC.bput("drop my #{item}", *@@drop_trash_success_patterns, *@@drop_trash_failure_patterns)
   end
 
   #########################################
@@ -420,8 +420,8 @@ module DRCI
   def get_item_unsafe(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
-    case DRC.bput("get #{item} #{from}", $DRCI_GET_ITEM_SUCCESS_PATTERNS, $DRCI_GET_ITEM_FAILURE_PATTERNS)
-    when *$DRCI_GET_ITEM_SUCCESS_PATTERNS
+    case DRC.bput("get #{item} #{from}", @@get_item_success_patterns, @@get_item_failure_patterns)
+    when *@@get_item_success_patterns
       return true
     else
       return false
@@ -446,8 +446,8 @@ module DRCI
 
   # Wears an item from your hands.
   def wear_item_unsafe?(item)
-    case DRC.bput("wear #{item}", $DRCI_WEAR_ITEM_SUCCESS_PATTERNS, $DRCI_WEAR_ITEM_FAILURE_PATTERNS)
-    when *$DRCI_WEAR_ITEM_SUCCESS_PATTERNS
+    case DRC.bput("wear #{item}", @@wear_item_success_patterns, @@wear_item_failure_patterns)
+    when *@@wear_item_success_patterns
       return true
     else
       return false
@@ -472,8 +472,8 @@ module DRCI
 
   # Removes an item you're wearing.
   def remove_item_unsafe?(item)
-    case DRC.bput("remove #{item}", /You .*#{item}/i, $DRCI_REMOVE_ITEM_SUCCESS_PATTERNS, $DRCI_REMOVE_ITEM_FAILURE_PATTERNS)
-    when /You .*#{item}/i, *$DRCI_REMOVE_ITEM_SUCCESS_PATTERNS
+    case DRC.bput("remove #{item}", /You .*#{item}/i, @@remove_item_success_patterns, @@remove_item_failure_patterns)
+    when /You .*#{item}/i, *@@remove_item_success_patterns
       return true
     else
       return false
@@ -502,8 +502,8 @@ module DRCI
   # Unless you include the 'my ' prefix in the item then this may
   # try to stow an item on the ground rather than something in your inventory.
   def stow_item_unsafe?(item)
-    case DRC.bput("stow #{item}", $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_STOW_ITEM_SUCCESS_PATTERNS, $DRCI_STOW_ITEM_FAILURE_PATTERNS)
-    when *$DRCI_STOW_ITEM_SUCCESS_PATTERNS
+    case DRC.bput("stow #{item}", @@container_is_closed_patterns, @@stow_item_success_patterns, @@stow_item_failure_patterns)
+    when *@@stow_item_success_patterns
       return true
     else
       return false
@@ -583,11 +583,11 @@ module DRCI
   # Returns nil if unable to determine if container's contents (e.g. can't open it or rummage it).
   def rummage_container(container)
     container = "my #{container}" unless container.nil? || container =~ /^my /i
-    contents = DRC.bput("rummage #{container}", $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_RUMMAGE_SUCCESS_PATTERNS, $DRCI_RUMMAGE_FAILURE_PATTERNS)
+    contents = DRC.bput("rummage #{container}", @@container_is_closed_patterns, @@rummage_success_patterns, @@rummage_failure_patterns)
     case contents
-    when *$DRCI_RUMMAGE_FAILURE_PATTERNS
+    when *@@rummage_failure_patterns
       return nil
-    when *$DRCI_CONTAINER_IS_CLOSED_PATTERNS
+    when *@@container_is_closed_patterns
       return nil unless open_container?(container)
       rummage_container(container)
     else
@@ -602,11 +602,11 @@ module DRCI
   # Returns nil if unable to determine if container's contents (e.g. can't open it or look in it).
   def look_in_container(container)
     container = "my #{container}" unless container.nil? || container =~ /^my /i
-    contents = DRC.bput("look in #{container}", $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_RUMMAGE_SUCCESS_PATTERNS, $DRCI_RUMMAGE_FAILURE_PATTERNS)
+    contents = DRC.bput("look in #{container}", @@container_is_closed_patterns, @@rummage_success_patterns, @@rummage_failure_patterns)
     case contents
-    when *$DRCI_RUMMAGE_FAILURE_PATTERNS
+    when *@@rummage_failure_patterns
       return nil
-    when *$DRCI_CONTAINER_IS_CLOSED_PATTERNS
+    when *@@container_is_closed_patterns
       return nil unless open_container?(container)
       look_in_container(container)
     else
@@ -647,14 +647,14 @@ module DRCI
   def put_away_item_unsafe?(item, container = nil)
     command = "put #{item} in #{container}" if container
     command = "stow #{item}" unless container
-    result = DRC.bput(command, $DRCI_CONTAINER_IS_CLOSED_PATTERNS, $DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS, $DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS)
+    result = DRC.bput(command, @@container_is_closed_patterns, @@put_away_item_success_patterns, @@put_away_item_failure_patterns)
     case result
-    when *$DRCI_CONTAINER_IS_CLOSED_PATTERNS
+    when *@@container_is_closed_patterns
       return false unless open_container?(container)
       return put_away_item_unsafe?(item, container)
-    when *$DRCI_PUT_AWAY_ITEM_SUCCESS_PATTERNS
+    when *@@put_away_item_success_patterns
       return true
-    when *$DRCI_PUT_AWAY_ITEM_FAILURE_PATTERNS
+    when *@@put_away_item_failure_patterns
       return false
     else
       return false
@@ -666,16 +666,16 @@ module DRCI
   #########################################
 
   def open_container?(container)
-    case DRC.bput("open #{container}", $DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS, $DRCI_OPEN_CONTAINER_FAILURE_PATTERNS)
-    when *$DRCI_OPEN_CONTAINER_SUCCESS_PATTERNS
+    case DRC.bput("open #{container}", @@open_container_success_patterns, @@open_container_failure_patterns)
+    when *@@open_container_success_patterns
       return true
     end
     return false
   end
 
   def close_container?(container)
-    case DRC.bput("close #{container}", $DRCI_CLOSE_CONTAINER_SUCCESS_PATTERNS, $DRCI_CLOSE_CONTAINER_FAILURE_PATTERNS)
-    when *$DRCI_CLOSE_CONTAINER_SUCCESS_PATTERNS
+    case DRC.bput("close #{container}", @@close_container_success_patterns, @@close_container_failure_patterns)
+    when *@@close_container_success_patterns
       return true
     end
     return false


### PR DESCRIPTION
This is the 8th of many PRs I'll be submitting for common-items. It depends on https://github.com/rpherbig/dr-scripts/pull/4936

To make it easier to review the changes, I'm phasing them in. However, because I can't open a PR in this repo against my forked branch of https://github.com/rpherbig/dr-scripts/pull/4936, until that dependency is merged then this PR's diff is noisier than it really is. Instead, please review the net new commit https://github.com/rpherbig/dr-scripts/commit/80b378bd31924bfa91798414f329412175465ad8

This one focuses on refactoring $DRCI constants to class variables per this feedback https://github.com/rpherbig/dr-scripts/pull/4930#issuecomment-830129449