### PR TITLE
combat-trainer - new wear message added

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -919,7 +919,7 @@ class SafetyProcess
     when 'you pick up'
       case action
       when 'wear'
-        bput("wear my #{item}", 'You sling', 'You attach', 'You .* unload', 'You strap', 'You slide', 'You work your way into', 'You spin', 'You put', 'You carefully loop', 'slide effortlessly onto your', 'You slip', "^You .* #{item.short_regex}")
+        bput("wear my #{item}", 'You sling', 'You attach', 'You .* unload', 'You strap', 'You slide', 'You work your way into', 'You spin', 'You put', 'You carefully loop', 'slide effortlessly onto your', 'You slip', "^You .* #{item.short_regex}", /^You place/)
         waitrt?
       when 'stow'
         warn_failed_item_recovery(item) unless DRCI.put_away_item?(item)


### PR DESCRIPTION
Added a match for this wear message:
You place your helm on your head and secure its straps.

Error text:
[combat-trainer: checked against [/You sling/i, /You attach/i, /You .* unload/i, /You strap/i, /You slide/i, /You work your way into/i, /You spin/i, /You put/i, /You carefully loop/i, /slide effortlessly onto your/i, /You slip/i, /You toss one strap/i, /^You .* (?i-mx:\bcerulean.*\bhelm)/i]]