### PR TITLE
update base-crafting - add shadow's reach forge

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -223,14 +223,52 @@ blacksmithing:
       - 9613
       - 9615
       - 9617
+      - 16410
+      - 16411
+      - 16412
     grindstones:
       - 9612
+      - 9614
+      - 9616
       - 9618
+      - 16406
+      - 16407
+      - 16408
     anvils:
       - 9612
       - 9614
       - 9616
       - 9618
+      - 16406
+      - 16407
+      - 16408
+  Shadow's Reach:
+    anvils:
+      - 16406
+      - 16407
+      - 16408
+    grindstones:
+      - 16406
+      - 16407
+      - 16408
+    crucibles:
+      - 16410
+      - 16411
+      - 16412
+    logbook: forging
+    pattern-book: blacksmithing
+    finisher: oil
+    finisher-full: flask of oil
+    finisher-room: 16409
+    finisher-number: 6
+    repair-room: 16409
+    repair-npc: clerk
+    stock-volume: 5
+    stock-room: 16405
+    stock-number: 11
+    stock-name: bronze ingot
+    trash-room: 16412
+    idle-room: 16405
   Ratha:
     npc: Grimbly
     npc_last_name: Grimbly
@@ -1222,11 +1260,13 @@ deeds:
     << : *theren_deeds
   Therenborough:
     << : *theren_deeds
-  Shard:
+  Shard: &shard_deeds
     room: 4433
     small_number: 1
     medium_number: 2
     large_number: 3
+  Shadow's Reach:
+    << : *shard_deeds
   Mer'Kresh:
     room: 8811
     small_number: 14
@@ -1272,6 +1312,9 @@ recipe_parts:
     Shard:
       part-room: 4436
       part-number:
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Boar Clan:
       part-room: 4436 # Shard
       part-number:
@@ -1299,6 +1342,9 @@ recipe_parts:
       part-number:
     Shard:
       part-room: 4436
+      part-number:
+    Shadow's Reach:
+      part-room: 16409
       part-number:
     Boar Clan:
       part-room: 4436 # Shard
@@ -1328,6 +1374,9 @@ recipe_parts:
     Shard:
       part-room: 10939
       part-number: 11
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Mer'Kresh:
       part-room: 8810
       part-number:
@@ -1364,6 +1413,9 @@ recipe_parts:
       part-number:
     Shard:
       part-room: 4436
+      part-number:
+    Shadow's Reach:
+      part-room: 16409
       part-number:
     Hibarnhvidar:
       part-room: 8892
@@ -1405,6 +1457,9 @@ recipe_parts:
     Shard:
       part-room: 4436
       part-number:
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Hibarnhvidar:
       part-room: 8892
       part-number:
@@ -1445,6 +1500,9 @@ recipe_parts:
     Shard:
       part-room: 10939
       part-number: 17
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Mer'Kresh:
       part-room: 8810
       part-number:
@@ -1491,6 +1549,9 @@ recipe_parts:
     Shard:
       part-room: 4436
       part-number:
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Boar Clan:
       part-room: 4436 # Shard
       part-number:
@@ -1510,6 +1571,9 @@ recipe_parts:
     Shard:
       part-room: 10939
       part-number: 12
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Mer'Kresh:
       part-room: 8810
       part-number:
@@ -1547,6 +1611,9 @@ recipe_parts:
     Shard:
       part-room: 4436
       part-number:
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Mer'Kresh:
       part-room: 8810
       part-number:
@@ -1583,6 +1650,9 @@ recipe_parts:
       part-number:
     Shard:
       part-room: 4436
+      part-number:
+    Shadow's Reach:
+      part-room: 16409
       part-number:
     Mer'Kresh:
       part-room: 8810
@@ -1628,6 +1698,9 @@ recipe_parts:
     Shard:
       part-room: 10939
       part-number: 16
+    Shadow's Reach:
+      part-room: 16409
+      part-number:
     Mer'Kresh:
       part-room: 8810
       part-number:
@@ -1800,6 +1873,9 @@ recipe_parts:
       part-number:
     Shard:
       part-room: 19306
+      part-number:
+    Shadow's Reach:
+      part-room: 16409
       part-number:
     Muspar'i:
       part-room: 11263

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -243,6 +243,19 @@ blacksmithing:
       - 16407
       - 16408
   Shadow's Reach:
+    npc: Serric
+    npc_last_name: Serric
+    npc-rooms:
+      - 4417
+      - 4433
+      - 4418
+      - 4431
+      - 8013
+      - 4436
+      - 8014
+      - 4435
+      - 4434
+      - 4432
     anvils:
       - 16406
       - 16407


### PR DESCRIPTION
I've added in Shadow's Reach forge, which was released on 3/30/2021.   It can be used either as a standalone location, or as overflow from Shard the way the Lava Forge is setup as overflow from Crossing.

I also added the other 2 grindstone rooms in the Shard forging society into the list since they were missing.

Here is a link to that post:
http://forums.play.net/forums/DragonRealms/Discussions%20with%20DragonRealms%20Staff%20and%20Players/Game%20Master%20and%20Official%20Announcements/thread/1938145?get_newest=true