### PR TITLE
[script] [combat-trainer] New 'Summon <element>' training ability for Warrior Mages

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2117,6 +2117,17 @@ class TrainerProcess
       @training_abilities['Favor Orb'] = settings.favor_orb_rub_frequency
     end
 
+    # Skill check that you can summon an elemental domain
+    summoning_ranks = DRSkill.getrank('Summoning')
+    @training_abilities
+      .select { |ability| ability =~ /Summon .* Domain/i }
+      .each do |ability|
+        if summoning_ranks < 200
+          DRC.message("Removing training ability '#{ability}' because you need at least 200 ranks of Summoning, and you only have #{summoning_ranks}")
+          @training_abilities.delete(ability)
+        end
+      end
+
     @no_app = []
 
     @dont_stalk = settings.dont_stalk
@@ -2193,50 +2204,50 @@ class TrainerProcess
     return if game_state.danger
 
     case select_ability(game_state)
-    when 'PercMana'
+    when /PercMana/i
       moon_mage_perc(game_state)
-    when 'Perc'
+    when /Perc/i
       bput('perc', 'You reach out') unless game_state.retreating?
-    when 'Perc Health'
+    when /Perc Health/i
       bput('perc heal', 'You close your eyes')
-    when 'Astro'
+    when /Astro/i
       astrology(game_state)
-    when 'Flee'
+    when /Flee/i
       waitfor('Obvious') unless bput('flee bluff', 'You begin', 'see anything engaged with you', 'You suddenly realize') == 'see anything engaged with you'
-    when 'App'
+    when /App/i
       appraise(game_state, '')
-    when 'App Quick'
+    when /App Quick/i
       appraise(game_state, 'quick')
-    when 'App Careful'
+    when /App Careful/i
       appraise(game_state, 'careful')
-    when 'App Pouch'
+    when /App Pouch/i
       retreat
       bput("app my #{@gem_pouch_adjective} pouch quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
-    when 'App Bundle'
+    when /App Bundle/i
       retreat
       bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
-    when /Summon (?<element>Aether|Air|Earth|Electricity|Fire|Water)/
+    when /Summon (?<element>.*?) Domain/i
       retreat
-      bput("summon #{Regexp.last_match[:element]}", 'turn your attention inward', 'Roundtime')
+      bput("summon #{Regexp.last_match[:element]} domain", "turn your attention inward", "It isn't possible to perform", "Summon allows Warrior Mages", "Roundtime")
       waitrt?
       fix_standing
-    when 'Tactics'
+    when /Tactics/i
       bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
-    when 'Analyze'
+    when /Analyze/i
       analyze(game_state, 0)
-    when 'Locks'
+    when /Locks/i
       pickbox(game_state)
-    when 'Hunt'
+    when /Hunt/i
       bput('hunt', 'You take note of ', 'You find yourself unable to hunt in this area') unless game_state.retreating?
-    when 'Teach'
+    when /Teach/i
       UserVars.friends.select { |c| DRRoom.pcs.include?(c) }.each do |character|
         bput("teach #{@combat_teaching_skill} to #{character}", 'You begin to', 'is already listening to you', 'is listening to someone else', 'I could not find who you were referring to', 'You have already offered', 'That person is too busy teaching', 'You are already teaching', 'You cannot teach two different classes at the same time', 'is not paying attention to you', 'You cannot listen to a teacher and teach', 'already trying to teach you something', 'trying to teach someone else')
       end
-    when 'Pray'
+    when /Pray/i
       bput('pray meraud', 'You glance')
-    when 'Scream'
+    when /Scream/i
       bput('Scream conc', 'Inhaling deeply', 'There is nothing', 'You open your mouth, then close it suddenly, looking somewhat like a fish') unless game_state.npcs.empty?
-    when 'Khri Prowess'
+    when /Khri Prowess/i
       unless game_state.npcs.empty?
         if kneel_for_khri?(@kneel_khri, 'khri prowess')
           retreat
@@ -2248,32 +2259,32 @@ class TrainerProcess
           fix_standing
         end
       end
-     when 'Stealth'
+     when /Stealth/i
       hide_action(game_state)
-    when 'Ret Stealth'
+    when /(Ret|Retreat) Stealth/i
       retreat
       hide_action(game_state)
-    when 'Ambush Stun'
+    when /Ambush Stun/i
       return ambush_stun(game_state)
-    when 'Ambush Choke'
+    when /Ambush Choke/i
       ambush_choke(game_state)
-    when 'Favor Orb'
+    when /Favor Orb/i
       fput("rub my #{@favor_god} orb")
-    when 'Charged Maneuver'
+    when /Charged Maneuver/i
       game_state.use_charged_maneuvers = true
-    when 'Meraud'
+    when /Meraud/i
       meraud_commune(game_state)
-    when 'PrayerMat'
+    when /PrayerMat/i
       pray_mat(game_state)
-    when 'Recall'
+    when /Recall/i
       bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
-    when 'Barb Research Augmentation'
+    when /Barb Research Augmentation/i
       bput('meditate research monkey', 'You clear ')
-    when 'Barb Research Warding'
+    when /Barb Research Warding/i
       bput('meditate research turtle', 'You clear ')
-    when 'Barb Research Debilitation'
+    when /Barb Research Debilitation/i
       bput('meditate research earthquake', 'You clear ')
-    when 'Collect'
+    when /Collect/i
       game_state.sheath_whirlwind_offhand
       retreat
       put('engage') unless game_state.npcs.empty? || game_state.retreating?
@@ -2281,12 +2292,12 @@ class TrainerProcess
       waitrt?
       game_state.wield_whirlwind_offhand
       kick_pile?
-    when 'Almanac'
+    when /Almanac/i
       UserVars.almanac_last_use ||= Time.now - 600
       use_almanac(game_state)
-    when 'Smite'
+    when /Smite/i
       smite(game_state)
-    when 'Herbs'
+    when /Herbs/i
       if game_state.npcs.empty?
         game_state.sheath_whirlwind_offhand
         wait_for_script_to_complete('heal-remedy', ['quick'])
@@ -2294,7 +2305,7 @@ class TrainerProcess
       else
         wait_for_script_to_complete('heal-remedy', %w[quick nohands])
       end
-    when 'Tessera'
+    when /Tessera/i
       invoke_tessera(game_state)
     end
     waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2214,6 +2214,11 @@ class TrainerProcess
     when 'App Bundle'
       retreat
       bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
+    when /Summon (?<element>\w+)/i
+      retreat
+      bput("summon #{Regexp.last_match[:element]}", 'turn your attention inward', 'Roundtime')
+      waitrt?
+      fix_standing
     when 'Tactics'
       bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
     when 'Analyze'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2215,7 +2215,7 @@ class TrainerProcess
     when 'App Bundle'
       retreat
       bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
-    when /Summon (?<element>\w+)/i
+    when /Summon (?<element>Aether|Air|Earth|Electricity|Fire|Water)/
       retreat
       bput("summon #{Regexp.last_match[:element]}", 'turn your attention inward', 'Roundtime')
       waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2204,50 +2204,50 @@ class TrainerProcess
     return if game_state.danger
 
     case select_ability(game_state)
-    when /PercMana/i
+    when /^PercMana$/i
       moon_mage_perc(game_state)
-    when /Perc/i
+    when /^Perc$/i
       bput('perc', 'You reach out') unless game_state.retreating?
-    when /Perc Health/i
+    when /^Perc Health$/i
       bput('perc heal', 'You close your eyes')
-    when /Astro/i
+    when /^Astro$/i
       astrology(game_state)
-    when /Flee/i
+    when /^Flee$/i
       waitfor('Obvious') unless bput('flee bluff', 'You begin', 'see anything engaged with you', 'You suddenly realize') == 'see anything engaged with you'
-    when /App/i
+    when /^App$/i
       appraise(game_state, '')
-    when /App Quick/i
+    when /^App Quick$/i
       appraise(game_state, 'quick')
-    when /App Careful/i
+    when /^App Careful$/i
       appraise(game_state, 'careful')
-    when /App Pouch/i
+    when /^App Pouch$/i
       retreat
       bput("app my #{@gem_pouch_adjective} pouch quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
-    when /App Bundle/i
+    when /^App Bundle$/i
       retreat
       bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
-    when /Summon (?<element>.*?) Domain/i
+    when /^Summon (?<element>.*?) Domain$/i
       retreat
       bput("summon #{Regexp.last_match[:element]} domain", "turn your attention inward", "It isn't possible to perform", "Summon allows Warrior Mages", "Roundtime")
       waitrt?
       fix_standing
-    when /Tactics/i
+    when /^Tactics$/i
       bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
-    when /Analyze/i
+    when /^Analyze$/i
       analyze(game_state, 0)
-    when /Locks/i
+    when /^Locks$/i
       pickbox(game_state)
-    when /Hunt/i
+    when /^Hunt$/i
       bput('hunt', 'You take note of ', 'You find yourself unable to hunt in this area') unless game_state.retreating?
-    when /Teach/i
+    when /^Teach$/i
       UserVars.friends.select { |c| DRRoom.pcs.include?(c) }.each do |character|
         bput("teach #{@combat_teaching_skill} to #{character}", 'You begin to', 'is already listening to you', 'is listening to someone else', 'I could not find who you were referring to', 'You have already offered', 'That person is too busy teaching', 'You are already teaching', 'You cannot teach two different classes at the same time', 'is not paying attention to you', 'You cannot listen to a teacher and teach', 'already trying to teach you something', 'trying to teach someone else')
       end
-    when /Pray/i
+    when /^Pray$/i
       bput('pray meraud', 'You glance')
-    when /Scream/i
+    when /^Scream$/i
       bput('Scream conc', 'Inhaling deeply', 'There is nothing', 'You open your mouth, then close it suddenly, looking somewhat like a fish') unless game_state.npcs.empty?
-    when /Khri Prowess/i
+    when /^Khri Prowess$/i
       unless game_state.npcs.empty?
         if kneel_for_khri?(@kneel_khri, 'khri prowess')
           retreat
@@ -2259,32 +2259,32 @@ class TrainerProcess
           fix_standing
         end
       end
-     when /Stealth/i
+     when /^Stealth$/i
       hide_action(game_state)
-    when /(Ret|Retreat) Stealth/i
+    when /^(Ret|Retreat) Stealth$/i
       retreat
       hide_action(game_state)
-    when /Ambush Stun/i
+    when /^Ambush Stun$/i
       return ambush_stun(game_state)
-    when /Ambush Choke/i
+    when /^Ambush Choke$/i
       ambush_choke(game_state)
-    when /Favor Orb/i
+    when /^Favor Orb$/i
       fput("rub my #{@favor_god} orb")
-    when /Charged Maneuver/i
+    when /^Charged Maneuver$/i
       game_state.use_charged_maneuvers = true
-    when /Meraud/i
+    when /^Meraud$/i
       meraud_commune(game_state)
-    when /PrayerMat/i
+    when /^PrayerMat$/i
       pray_mat(game_state)
-    when /Recall/i
+    when /^Recall$/i
       bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
-    when /Barb Research Augmentation/i
+    when /^Barb Research Augmentation$/i
       bput('meditate research monkey', 'You clear ')
-    when /Barb Research Warding/i
+    when /^Barb Research Warding$/i
       bput('meditate research turtle', 'You clear ')
-    when /Barb Research Debilitation/i
+    when /^Barb Research Debilitation$/i
       bput('meditate research earthquake', 'You clear ')
-    when /Collect/i
+    when /^Collect$/i
       game_state.sheath_whirlwind_offhand
       retreat
       put('engage') unless game_state.npcs.empty? || game_state.retreating?
@@ -2292,12 +2292,12 @@ class TrainerProcess
       waitrt?
       game_state.wield_whirlwind_offhand
       kick_pile?
-    when /Almanac/i
+    when /^Almanac$/i
       UserVars.almanac_last_use ||= Time.now - 600
       use_almanac(game_state)
-    when /Smite/i
+    when /^Smite$/i
       smite(game_state)
-    when /Herbs/i
+    when /^Herbs$/i
       if game_state.npcs.empty?
         game_state.sheath_whirlwind_offhand
         wait_for_script_to_complete('heal-remedy', ['quick'])
@@ -2305,7 +2305,7 @@ class TrainerProcess
       else
         wait_for_script_to_complete('heal-remedy', %w[quick nohands])
       end
-    when /Tessera/i
+    when /^Tessera$/i
       invoke_tessera(game_state)
     end
     waitrt?

--- a/validate.lic
+++ b/validate.lic
@@ -434,8 +434,51 @@ class DRYamlValidator
   def assert_that_training_abilities_are_valid(settings)
     return unless settings.training_abilities
 
+    valid_skills = [
+      'Almanac',
+      'Ambush Choke',
+      'Ambush Stun',
+      'Analyze',
+      'App Bundle',
+      'App Careful',
+      'App Pouch',
+      'App Quick',
+      'App',
+      'Astro',
+      'Barb Research Augmentation',
+      'Barb Research Debilitation',
+      'Barb Research Warding',
+      'Charged Maneuver',
+      'Collect',
+      'Favor Orb',
+      'Flee',
+      'Herbs',
+      'Hunt',
+      'Khri Prowess',
+      'Locks',
+      'Meraud',
+      'Perc Health',
+      'Perc',
+      'PercMana',
+      'Pray',
+      'PrayerMat',
+      'Recall',
+      'Ret Stealth',
+      'Scream',
+      'Smite',
+      'Stealth',
+      'Summon Aether',
+      'Summon Air',
+      'Summon Earth',
+      'Summon Electricity',
+      'Summon Fire',
+      'Summon Water',
+      'Tactics',
+      'Teach',
+      'Tessera'
+    ]
     settings.training_abilities
-            .reject { |skill, _cooldown| ['PercMana', 'Perc', 'Perc Health', 'Astro', 'App', 'App Quick', 'App Careful', 'Tactics', 'Hunt', 'Pray', 'Scream', 'Khri Prowess', 'Ret Stealth', 'Stealth', 'Ambush Stun', 'Ambush Choke', 'Favor Orb', 'Charged Maneuver', 'Meraud', 'Recall', 'Barb Research Debilitation', 'Barb Research Augmentation', 'Barb Research Warding', 'Collect', 'Analyze', 'Flee', 'PrayerMat', 'Smite', 'Locks', 'Teach', 'Almanac', 'Herbs', 'App Pouch', 'App Bundle', 'Tessera'].include?(skill) }
+            .reject { |skill, _cooldown| valid_skills.include?(skill) }
             .each_key { |skill| error("Ability in training_abilities is not valid: #{skill}") }
   end
 

--- a/validate.lic
+++ b/validate.lic
@@ -463,7 +463,7 @@ class DRYamlValidator
       'Pray',
       'PrayerMat',
       'Recall',
-      'Ret Stealth',
+      '(Ret|Retreat) Stealth',
       'Scream',
       'Smite',
       'Stealth',

--- a/validate.lic
+++ b/validate.lic
@@ -473,7 +473,7 @@ class DRYamlValidator
       'Tessera'
     ]
     settings.training_abilities
-            .reject { |skill, _cooldown| valid_skills.any? { |valid_skill| skill =~ /#{valid_skill}/i } }
+            .reject { |skill, _cooldown| valid_skills.any? { |valid_skill| skill =~ /^#{valid_skill}$/i } }
             .each_key { |skill| error("Ability in training_abilities is not valid: #{skill}") }
   end
 

--- a/validate.lic
+++ b/validate.lic
@@ -467,18 +467,13 @@ class DRYamlValidator
       'Scream',
       'Smite',
       'Stealth',
-      'Summon Aether',
-      'Summon Air',
-      'Summon Earth',
-      'Summon Electricity',
-      'Summon Fire',
-      'Summon Water',
+      'Summon .* Domain',
       'Tactics',
       'Teach',
       'Tessera'
     ]
     settings.training_abilities
-            .reject { |skill, _cooldown| valid_skills.include?(skill) }
+            .reject { |skill, _cooldown| valid_skills.any? { |valid_skill| skill =~ /#{valid_skill}/i } }
             .each_key { |skill| error("Ability in training_abilities is not valid: #{skill}") }
   end
 


### PR DESCRIPTION
### Goal
* Mitigate the dangers of sitting while engaged at melee to summon an element domain

### Background
* Inspired by [BlueWolf](https://discord.com/channels/745675889622384681/745676299594629272/837955667276201985) in the Lich discord
* Warrior Mages can `summon <element> domain` to gain benefits from aligning to an element
* [Elemental domain](https://elanthipedia.play.net/Elemental_domain) is a room AoE, and useful in combat
* `combat-trainer` does not natively support summoning an element domain but it's possible via `buff_nonspells`
* Summoning an element domain causes the mage to sit for ~10-15 seconds, which can be dangerous while engaged in melee.
* Players are welcome to continue use of `buff_nonspells`, but if they want the retreat mechanic then this update lets them specify the abilty in `training_abilities`

### Changes
* Add support for new `training_abilities:` setting: `summon <element> domain`
* Similar to training outdoorsmanship in combat, the script will retreat then summon the element domain

### Configuration
This example shows how to periodically `summon fire domain`. The element **Fire** can be replaced with any element that's supported by the `summon <element> domain` ability (e.g. Aether, Air, Earth, Electricity, Fire, Water)
```yaml
training_abilities:
  Summon Fire Domain: 480
```

### Workaround
Without the change proposed by this pull request, players use unintuitive workarounds to stagger actions via buff_nonspells like this sample config provided by [Dartellum](https://discord.com/channels/745675889622384681/745676299594629272/838280977163091988):
```yaml
buff_nonspells:
   pathway focus quick: 300
   retreat: 596
   retreat: 598
   summon air domain: 600
```

<details>
<summary>Click to toggle tests</summary>

### should retreat, summon element, then stand
```
[combat-trainer]>stance set 100 0 82

Setting your Evasion stance to 100%, your Parry stance to 0%, and your Shield stance to 82%.  You have 0 stance points left.
> 
[combat-trainer]>retreat

You retreat back to pole range.
> 
[combat-trainer]>retreat

You retreat from combat.
> 
[combat-trainer]>summon Fire domain

You make yourself comfortable and turn your attention inward.
Drawing down extraplanar laws, you attempt to create a fire domain spanning the area.
Discharging a burst of elemental power in the esoteric "direction" of the Elemental Plane of Fire, you carefully draw down subtle lines of power across the Void.
The strands anchor themselves to the ground, infusing the area with an additional, subordinate set of physical laws that make fire magic easier.
Roundtime: 10 sec.
You feel a sudden tingle of heat in your palms.

s> 
The silver-backed bear begins to advance on you!
The silver-backed bear is still a distance away from you and is closing steadily.
s> 
The strong smell of ozone accompanies a bolt discharging through a silver-backed bear.
The strong smell of ozone accompanies a bolt discharging through a dire bear.
s> 
The dire bear begins to advance on you!
The dire bear is still a distance away from you and is closing steadily.
s> 
You feel fully prepared to cast your spell.
s> 
The silver-backed bear closes to pole weapon range on you!
s> 
You feel fully attuned to the mana streams again.
s> 
[combat-trainer]>stand

You stand back up.

> 
[combat-trainer]>feint
```

### should warn at script start if you don't have 200 summoning
```
GIVEN:
Summoning less than 200 ranks
THEN:
| Removing training ability '["Summon Fire Domain", 480]' because you need at least 200 ranks of Summoning, and you only have 149
```

</details>