### PR TITLE
Update common-items - remove get failure message

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -44,7 +44,6 @@ module DRCI
     /You just can't/,
     /push you over the item limit/,
     /You stop as you realize the .* is not yours/,
-    /Stow what/,
     /Get what/,
     /I could not/,
     /What were you/,

--- a/common-items.lic
+++ b/common-items.lic
@@ -109,7 +109,7 @@ module DRCI
   ]
 
   @@put_away_item_failure_patterns = [
-    /^Stow what/
+    /^Stow what/,
     /^Please rephrase that command/,
     /^What were you referring to/,
     /^I could not find what you were referring to/,

--- a/common-items.lic
+++ b/common-items.lic
@@ -109,6 +109,7 @@ module DRCI
   ]
 
   @@put_away_item_failure_patterns = [
+    /^Stow what/
     /^Please rephrase that command/,
     /^What were you referring to/,
     /^I could not find what you were referring to/,


### PR DESCRIPTION
I removed `/Stow what/` from ` @@get_item_failure_patterns` as it shouldn't be a failure message for that action.