### PR TITLE
[script] [drinfomon] Robustify capturing contents on vault furniture

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -869,10 +869,10 @@ while line = script.gets
         .select { |_town, titles| titles.include?(checkroom) }
         .each do |town, _titles|
           contents = Regexp.last_match(1)
-          line.scan(/a.*?(?:(\w+ (?:shelf|rack|box|case|tree))) with some stuff (on|in) it/).each do |noun, location|
-            fput 'look ' + location + ' ' + noun
-            if get =~ /(?:On|In) the \w+ (?:shelf|rack|box|case|tree) you see(.*)\./
-              contents += Regexp.last_match(1).sub(/ and(.*)/, ',\1,')
+          line.scan(/a.*?(?<furniture>\w+ \w+) with some stuff (?<location>\w+) it/).each do |furniture, location|
+            fput "look #{location} #{furniture}"
+            if get =~ /#{location} the #{furniture} you see(.*)\./i
+              contents += ',' + Regexp.last_match(1).sub(/ and(.*)/, ',\1')
             end
           end
           CharSettings['vault_info']['location'] = town


### PR DESCRIPTION
### Background
* I put an item on a brass hook in my vault
* I noticed `drinfomon` script perform a look on a large shelf in my vault
* Intrigued that the script was automatically looking on/in vault furniture, I got to wondering why it wasn't looking on my hook.
* Turns out, `drinfomon` has hard coded the furniture names

```
[drinfomon]>look on large shelf

On the large shelf you see a dirt-covered backpack and a warrior's belt.
```

### Changes
* Update the regex to handle any furniture in the vault and items anywhere on that furniture (in/on/behind/under/etc)
* Fix a missing comma issue if contents are on two pieces of vault furniture

## Tests

### should look on all furniture with stuff on them
```
> l in vault
In the secure vault you see a rugged tan backpack, a spotted white hobbyhorse, a large shelf with some stuff on it, a bottom drawer, a middle drawer, a top drawer, a small shelf, a steel wire rack and a brass hook with some stuff on it.
> 
[drinfomon]>look on large shelf

On the large shelf you see a dirt-covered backpack and a warrior's belt.
> 

[drinfomon]>look on brass hook

On the brass hook you see a Sunderstone shard and a lemon-striped arrow.
```

### should output contents seen on all furniture
```
,vault
          Your vault is located in Fang Cove

          ---------------------------------------

          a rugged tan backpack, a spotted white hobbyhorse, a large shelf with some stuff on it, a bottom drawer, a middle drawer, a top drawer, a small shelf, a steel wire rack and a brass hook with some stuff on it, a dirt-covered backpack, a warrior's belt, a Sunderstone shard, a lemon-striped arrow
```