### PR TITLE
[script] [common] Add options arg to bput/wput

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -96,6 +96,7 @@ module DRC
   # Will wait for matching text up to 15 seconds then timeout.
   def bput(message, *matches)
     options = (matches.shift if matches.first.is_a?(Hash)) || {}
+    options['timeout'] ||= 15
     wput(message, options, matches)
   end
 
@@ -103,7 +104,7 @@ module DRC
   # before performing command and do smart retries.
   # Will wait for matching text up til the given timeout in seconds.
   def wput(message, options, *matches)
-    timeout = (options['timeout'] ||= 15)
+    timeout = options['timeout']
     suppress = options['suppress_no_match']
 
     if options['debug']

--- a/common.lic
+++ b/common.lic
@@ -95,13 +95,23 @@ module DRC
   # before performing command and do smart retries.
   # Will wait for matching text up to 15 seconds then timeout.
   def bput(message, *matches)
-    wput(message, 15, matches)
+    options = (matches.shift if matches.first.is_a?(Hash)) || {}
+    wput(message, options, matches)
   end
 
   # Like `fput` but better because will wait for RT
   # before performing command and do smart retries.
   # Will wait for matching text up til the given timeout in seconds.
-  def wput(message, timeout, *matches)
+  def wput(message, options, *matches)
+    timeout = (options['timeout'] ||= 15)
+    suppress = options['suppress_no_match']
+
+    if options['debug']
+      echo "bput.message=#{message}"
+      echo "bput.options=#{options}"
+      echo "bput.matches=#{matches}"
+    end
+
     waitrt?
     log = []
     matches.flatten!
@@ -154,11 +164,15 @@ module DRC
         end
       end
     end
-    echo "*** No match was found after #{timeout} seconds, dumping info"
-    echo "messages seen length: #{log.length}"
-    log.reverse.each { |logged_response| echo "message: #{logged_response}" }
-    echo "checked against #{matches}"
-    echo "for command #{message}"
+
+    unless suppress
+      echo "*** No match was found after #{timeout} seconds, dumping info"
+      echo "messages seen length: #{log.length}"
+      log.reverse.each { |logged_response| echo "message: #{logged_response}" }
+      echo "checked against #{matches}"
+      echo "for command #{message}"
+    end
+
     ''
   end
 

--- a/common.lic
+++ b/common.lic
@@ -97,13 +97,7 @@ module DRC
   def bput(message, *matches)
     options = (matches.shift if matches.first.is_a?(Hash)) || {}
     options['timeout'] ||= 15
-    wput(message, options, matches)
-  end
 
-  # Like `fput` but better because will wait for RT
-  # before performing command and do smart retries.
-  # Will wait for matching text up til the given timeout in seconds.
-  def wput(message, options, *matches)
     timeout = options['timeout']
     suppress = options['suppress_no_match']
 

--- a/feed-cloak.lic
+++ b/feed-cloak.lic
@@ -44,9 +44,7 @@ class FeedCloak
     # Seconds to wait for a message before raise error.
     # If a cloak successfully feeds, it may take a variable
     # amount of time depending on how hungry it is. A few seconds to minutes.
-    # Therefore we use `wput` instead of `bput` which is a 15 second timeout.
-    timeout = 300
-    case DRC.wput("feed my cloak", timeout, *no_food_in_room, not_hungry, done_eating, no_cloak, cant_feed)
+    case DRC.bput("feed my cloak", { 'timeout' => 300 }, *no_food_in_room, not_hungry, done_eating, no_cloak, cant_feed)
     when no_cloak, cant_feed
       DRC.message("You aren't wearing a cloak that can be fed.")
       exit

--- a/test/test_bput.rb
+++ b/test/test_bput.rb
@@ -8,6 +8,8 @@ class TestCommon < Minitest::Test
   def setup
     sent_messages.clear
     @result = nil
+    $history = []
+    $displayed_messages = []
   end
 
   def teardown
@@ -67,4 +69,63 @@ class TestCommon < Minitest::Test
 
     assert_equal 8.1, $pause
   end
+
+  def test_bput_not_suppresses_no_match_message
+    $history = [nil, 'not the correct string', '']
+    timeout = 0.1
+
+    @test = run_script_with_proc('common', proc do
+      DRC.bput('a test message', { 'timeout' => timeout, 'suppress_no_match' => false }, 'result')
+    end)
+
+    @test.join # wait for bput to timeout and finish
+
+    assert_includes($displayed_messages, "*** No match was found after #{timeout} seconds, dumping info")
+  end
+
+  def test_bput_suppresses_no_match_message
+    $history = [nil, 'not the correct string', '']
+    timeout = 0.1
+
+    @test = run_script_with_proc('common', proc do
+      DRC.bput('a test message', { 'timeout' => timeout, 'suppress_no_match' => true }, 'result')
+    end)
+
+    @test.join # wait for bput to timeout and finish
+
+    refute_includes($displayed_messages, "*** No match was found after #{timeout} seconds, dumping info")
+  end
+
+  def test_bput_displays_debug_info
+    $history = [nil, 'not the correct string', '']
+
+    @test = run_script_with_proc('common', proc do
+      DRC.bput('a test message', { 'debug' => true }, 'result')
+    end)
+
+    $history << 'result'
+
+    @test.join # wait for bput to timeout and finish
+
+    assert_includes($displayed_messages, 'bput.message=a test message')
+    assert_includes($displayed_messages, 'bput.options={"debug"=>true, "timeout"=>15}')
+    assert_includes($displayed_messages, 'bput.matches=["result"]')
+  end
+
+  def test_bput_not_displays_debug_info
+    $history = [nil, 'not the correct string', '']
+
+    @test = run_script_with_proc('common', proc do
+      DRC.bput('a test message', { 'debug' => false }, 'result')
+    end)
+
+    $history << 'result'
+
+    @test.join # wait for bput to timeout and finish
+
+    refute_includes($displayed_messages, 'bput.message=a test message')
+    refute_includes($displayed_messages, 'bput.options={"debug"=>false, "timeout"=>15}')
+    refute_includes($displayed_messages, 'bput.matches=["result"]')
+  end
+
 end

--- a/test/test_bput.rb
+++ b/test/test_bput.rb
@@ -6,10 +6,10 @@ include Harness
 
 class TestCommon < Minitest::Test
   def setup
+    reset_data
+    $history.clear
     sent_messages.clear
-    @result = nil
-    $history = []
-    $displayed_messages = []
+    displayed_messages.clear
   end
 
   def teardown


### PR DESCRIPTION
### Background
* I want to perform commands with variable wait times and take an action based on if a response was received within the timeout.
* In these cases, I may also want to suppress the "*** No match was found" error messages because it's acceptable if a response was not received within the timeout.
* In these cases, echoing the error would serve only to confuse the players and create scroll spam.

### Changes
* Refactor `wput` method so that it's second argument is an options hash map instead of a timeout number.
  - Initially supported option values are:
    - `timeout` _number of seconds to wait for an expected response before returning. Default is 15._
    - `debug` _boolean flag to echo debug info, such as what command, options, and match strings are being evaluated. Default is false._
    - `suppress_no_match` _boolean flag that when true will not echo the "*** No match was found" error messages. Default is false._
* Refactor `bput` method to check if the first element in the matches array is an options hash map (way to go dynamic languages!).
  - This keeps `bput` method's behavior and signature backwards compatible while also supporting accepting a new options argument.
 * In test class, remove unused `@result = nil` from setup method

## Usage Examples
<details>
<summary>Click to toggle examples</summary>

### command only
```
> ,e DRC.bput('enc')

--- Lich: exec1 active.

[exec1]>enc

  Encumbrance : None (0/11)
> 
[exec1: *** No match was found after 15 seconds, dumping info]

[exec1: messages seen length: 1]

[exec1: message:   Encumbrance : None]

[exec1: checked against []]

[exec1: for command enc]

--- Lich: exec1 has exited.
```

### command and match strings
```
> ,e DRC.bput('enc', 'Encumbrance')

--- Lich: exec1 active.

[exec1]>enc

  Encumbrance : None (0/11)
> 
--- Lich: exec1 has exited.
```

### command and no matches, suppress errors
```
> ,e DRC.bput('enc', { 'suppress_no_match' => true, 'debug' => true }, 'Obvious paths')

--- Lich: exec1 active.

[exec1: bput.message=enc]

[exec1: bput.options={"suppress_no_match"=>true, "debug"=>true, "timeout"=>15}]

[exec1: bput.matches=[["Obvious paths"]]]

[exec1]>enc

  Encumbrance : None (0/11)
> 

... (wait 15 seconds) ...

--- Lich: exec1 has exited.
```

### command with configurable timeout, show errors
_For demonstration, using an impossibly short timeout_
```
> ,e echo DRC.bput('load', { 'timeout' => 0.1, 'debug' => true }, 'You load', 'You carefully load', 'You reach into', 'is already loaded')

--- Lich: exec1 active.

[exec1: bput.message=load]

[exec1: bput.options={"timeout"=>0.1, "debug"=>true}]

[exec1: bput.matches=[["You load", "You carefully load", "You reach into", "is already loaded"]]]

[exec1]>load

[exec1: *** No match was found after 0.1 seconds, dumping info]

[exec1: messages seen length: 0]

[exec1: checked against [/You load/i, /You carefully load/i, /You reach into/i, /is already loaded/i]]

[exec1: for command load]

[exec1: ]

--- Lich: exec1 has exited.
```

### command with configurable timeout, suppress errors
_For demonstration, using an impossibly short timeout_
```
> ,e echo DRC.bput('load', { 'timeout' => 0.1, 'suppress_no_match' => true, 'debug' => true }, 'You load', 'You carefully load', 'You reach into', 'is already loaded')

--- Lich: exec1 active.

[exec1: bput.message=load]

[exec1: bput.options={"timeout"=>0.1, "suppress_no_match"=>true, "debug"=>true}]

[exec1: bput.matches=[["You load", "You carefully load", "You reach into", "is already loaded"]]]

[exec1]>load

[exec1: ]

--- Lich: exec1 has exited.
```
</details>