### PR TITLE
combat-trainer - smite message addition

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2354,7 +2354,7 @@ class TrainerProcess
     return if game_state.brawling? || game_state.offhand? || game_state.aimed_skill?
     return if right_hand.nil?
 
-    bput("smite", "Drawing strength from your conviction", "You aren't close enough", "What are you trying to attack")
+    bput("smite", "Drawing strength from your conviction", "Drawing upon holy wrath", "You aren't close enough", "What are you trying to attack")
   end
 
   def meraud_commune(game_state)


### PR DESCRIPTION
Added the messaging for smite when you draw upon soul pool instead of using the free conviction smites.

Soul pool smite:
`Drawing upon holy wrath, you execute a divinely inspired strike!`