### PR TITLE
DRCT.buy_item Regex Improvements

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -14,7 +14,8 @@ module DRCT
     # Amount to pay should be first capturing group.
     patterns = [/prepared to offer it to you for (.*) (?:kronar|lirum|dokora)s?/,
                 /Let me but ask the humble sum of (.*) coins/,
-                /for a (?:mere )?(.*) (?:kronar|lirum|dokora)s?/,
+                /it would be just (\d*) (?:kronar|lirum|dokora)s?/,
+                /for a (?:mere )?(\d*) (?:kronar|lirum|dokora)s?/,
                 /I can let that go for...(.*) (?:kronar|lirum|dokora)s?/,
                 /cost you (?:just )?(.*) (?:kronar|lirum|dokora)s?/,
                 /it may be yours for just (.*) (?:kronar|lirum|dokora)s?/,


### PR DESCRIPTION
These regexs are trying to capture coin values, and are currently using .* which can cause some hilarious issues.

Allye from Discord posted this log:

```
[herb-stock]>buy jadice flower
Ktrini adjusts her spectacles, peering near-sightedly at the catalog.  "I've some in stock -- for a nice child like you, it would be just 650 lirums."
>
[herb-stock]>offer nice child like you, it would be just 650
You must specify how many coins you wish to offer.
>
[herb-stock]>combine flower with flower
```

Ideally we would update all the regexes in this method to use digit character classes for their capture groups, but that also terrifies me a bit for some reason (from a testing and regression point of view).