### PR TITLE
[script] [drinfomon] Silence cumulative Platinum months

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -813,7 +813,7 @@ premiumcheck_silence = proc do |server_string|
   elsif server_string =~ /For more information on LTBs.*/
     DownstreamHook.remove('premiumcheck_silence')
     server_string = nil
-  elsif server_string =~ /As of your last logon:|Premium: http:\/\/www.play.net\/dr\/premium\/|Platinum: http:\/\/www.play.net\/dr\/platinum\/|You have a cumulative Premium time of .* months.|Premium Points Earned: .*|Platinum Points Earned: .*|Total Points Earned: .*|Total Points Spent: .*|Unfinished Scroll Points: .*|Available Points to Spend: .*/
+  elsif server_string =~ /As of your last logon:|(Premium|Platinum): http:\/\/www.play.net\/dr\/(premium|platinum)\/|You have a cumulative (Premium|Platinum) time of .* months.|(Premium|Platinum) Points Earned: .*|Total Points Earned: .*|Total Points Spent: .*|Unfinished Scroll Points: .*|Available Points to Spend: .*/
     server_string = nil
   end
   server_string


### PR DESCRIPTION
### Background
* `drinfomon` runs `LTB INFO` command to determine if  you're premie or not.
* It squelches a bunch of the output to be less spammy.

### Changes
* Squelch "You have a cumulative Platinum time of ..." 
* Consolidated regex patterns for Premium and Platinum strings to use `(Premium|Platinum)` 

## Tests
_ltb info command_
```
As of your last logon:
  Your premium service has been continuous (consecutive) since M/D/YYYY.
  You have a cumulative Premium time of X months.
  You have a cumulative Platinum time of Y months.

    Premium Points Earned: NNNN
   Platinum Points Earned: NNNN
      Total Points Earned: NNNN

       Total Points Spent: NNNN

 Unfinished Scroll Points: NNNN
Available Points to Spend: NNNN

For more information on LTBs, please check PREMIUM 7.
```

_script without change_
```
[drinfomon]>ltb info

  You have a cumulative Platinum time of X months.
```

_script with change_
```
[drinfomon]>ltb info

```