### PR TITLE
find_press_grinder_room to not require empty room

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -92,7 +92,8 @@ module DRCC
     return unless DRC.bput('tap grinder', 'I could not', 'You tap.*grinder') == 'I could not'
     pressgrinderrooms = get_data('crafting')['remedies'][hometown]['press-grinder-rooms']
     idle_room = get_data('crafting')['remedies'][hometown]['idle-room']
-    DRCT.find_sorted_empty_room(pressgrinderrooms, idle_room)
+    DRTC.walk_to(pressgrinderrooms[0])
+    #DRCT.find_sorted_empty_room(pressgrinderrooms, idle_room)
   end
 
   def find_enchanting_room(hometown, override = nil)


### PR DESCRIPTION
press grinders can be used by multiple people at once, no need to use the find empty room function