### PR TITLE
[script] [spellmonitor] Capture known spells and feats

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -3,6 +3,7 @@
 =end
 
 custom_require.call(%w[drinfomon])
+
 no_kill_all
 no_pause_all
 
@@ -10,13 +11,28 @@ setpriority(0)
 
 class DRSpells
   @@active_spells = {}
+  @@known_spells = {}
+  @@known_feats = {}
   @@refresh_data = {}
   @@slivers = false
 
-  @@grabbing_spell_data = false
+  @@grabbing_active_spells = false
+  @@grabbing_known_spells = false
+
+  # Use this to silence the initial output
+  # of calling 'spells' command to populate our data.
+  @@silence_known_spells_hook = false
 
   def self.active_spells
     @@active_spells
+  end
+
+  def self.known_spells
+    @@known_spells
+  end
+
+  def self.known_feats
+    @@known_feats
   end
 
   def self.refresh_data
@@ -31,12 +47,38 @@ class DRSpells
     @@slivers = val
   end
 
-  def self.grabbing_spell_data
-    @@grabbing_spell_data
+  def self.grabbing_active_spells
+    @@grabbing_active_spells
   end
 
-  def self.grabbing_spell_data=(val)
-    @@grabbing_spell_data = val
+  def self.grabbing_active_spells=(val)
+    @@grabbing_active_spells = val
+  end
+
+  def self.grabbing_known_spells
+    @@grabbing_known_spells
+  end
+
+  def self.grabbing_known_spells=(val)
+    @@grabbing_known_spells = val
+  end
+
+  def self.silence_known_spells_hook
+    @@silence_known_spells_hook
+  end
+
+  def self.silence_known_spells_hook=(val)
+    @@silence_known_spells_hook = val
+  end
+
+  # Call this method to cause the script to recheck for known spells and feats.
+  # Should be called whenever the character learns (or forgets) a spell or feat.
+  # Example scenarios: learning from a guild leader, Ozursus, scrolls, Throne City, rerolling, death.
+  def self.refresh_known_spells
+    @@silence_known_spells_hook = true
+    fput('spells')
+    pause 1
+    @@silence_known_spells_hook = false
   end
 end
 
@@ -73,7 +115,7 @@ UNKNOWN_DURATION = 1000
 # One or more spells may be listed between a <pushStream/> <popStream/> pair,
 # but only one spell and its duration are ever listed per line.
 #
-spell_action = proc do |server_string|
+active_spells_hook = proc do |server_string|
   # New information about active spells, reset our cached data.
   if server_string =~ %r{<clearStream id="percWindow"/>}
     DRSpells.slivers = false
@@ -105,18 +147,18 @@ spell_action = proc do |server_string|
   # However, the next characters in the line might be
   # another <pushStream/> or something else, so keep going.
   if data =~ %r{^<popStream/>}
-    DRSpells.grabbing_spell_data = false
+    DRSpells.grabbing_active_spells = false
     data.slice!(0, 12).strip!
   end
 
   # The start of one or more active spells!
   if data =~ %r{<pushStream id="percWindow"/>}
-    DRSpells.grabbing_spell_data = true
+    DRSpells.grabbing_active_spells = true
     index = data.index("<pushStream id=\"percWindow\"/>")
     data.slice!(0, index+29).strip!
   end
 
-  if DRSpells.grabbing_spell_data
+  if DRSpells.grabbing_active_spells
     spell = nil
     duration = nil
     case data
@@ -154,16 +196,65 @@ spell_action = proc do |server_string|
   server_string
 end
 
+known_spells_hook = proc do |server_string|
+  case server_string
+  when /^You recall the spells you have learned/
+    DRSpells.grabbing_known_spells = true
+    DRSpells.known_spells.clear()
+    DRSpells.known_feats.clear()
+    server_string = nil if DRSpells.silence_known_spells_hook
+  when /^In the chapter entitled|^You have temporarily memorized/
+    if DRSpells.grabbing_known_spells
+      server_string
+        .sub(/^In the chapter entitled "[\w\s\'-]+", you have notes on the /, '')
+        .sub(/^You have temporarily memorized the /, '')
+        .sub(/ spells?\./, '')
+        .sub(/, and/, ',')
+        .split(',')
+        .map { |spell| spell.include?('[') ? spell.slice(0, spell.index('[')) : spell }
+        .map(&:strip)
+        .reject { |spell| spell.nil? || spell.empty? }
+        .each { |spell| DRSpells.known_spells[spell] = true }
+    end
+    server_string = nil if DRSpells.silence_known_spells_hook
+  when /^You recall proficiency with the magic feats of/
+    # The feats are listed without the Oxford comma separating the last item.
+    # This makes splitting the string by comma difficult because the next to last and last
+    # items would be captured together. The workaround is we'll replace ' and ' with a comma
+    # and hope no feats ever have the word 'and' in them...
+    server_string
+      .sub(/^You recall proficiency with the magic feats of/, '')
+      .sub(/ and /, ',')
+      .sub('.', '')
+      .split(',')
+      .map(&:strip)
+      .reject { |feat| feat.nil? || feat.empty? }
+      .each { |feat| DRSpells.known_feats[feat] = true }
+    server_string = nil if DRSpells.silence_known_spells_hook
+  when /^You can use SPELL STANCE|^You have no training in the magical arts|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
+    DRSpells.grabbing_known_spells = false
+    server_string = nil if DRSpells.silence_known_spells_hook
+  end
+  server_string
+end
+
 # Unsure the historical significance of this pause
 # https://github.com/rpherbig/dr-scripts/commit/04b7474b21c809d960ccb0c720808b44ae0f1ff8
 pause 5
 
-DownstreamHook.remove('spell_action')
-DownstreamHook.add('spell_action', spell_action)
+DownstreamHook.remove('active_spells_hook')
+DownstreamHook.add('active_spells_hook', active_spells_hook)
+
+DownstreamHook.remove('known_spells_hook')
+DownstreamHook.add('known_spells_hook', known_spells_hook)
 
 before_dying do
-  DownstreamHook.remove('spell_action')
+  DownstreamHook.remove('active_spells_hook')
+  DownstreamHook.remove('known_spells_hook')
 end
+
+# Do an initial capture of known spells and feats.
+DRSpells.refresh_known_spells
 
 until script.gets.nil?
   # Keep script alive while game is connected


### PR DESCRIPTION
### Background
* Inspired by Corgar's [question](https://discord.com/channels/745675889622384681/745676101392793651/841033008538714112) in the Lich discord for such a feature

### Changes
* Add new downstream hook to parse the output from the `spells` command
* Add new properties `DRSpells.known_spells` and `DRSpells.known_feats`

_Note, in this initial version, the script does not know when you learn or forget spells or feats. It relies entirely on something running the 'spells' command. In future enhancements it would be nice to automate calling DRSpells.refresh_known_spells during one of these events._

_Unit tests are forthcoming_

## Example Output
1. Start `;spellmonitor`
2. Wait 5 seconds for the script to initialize. It's ready when you see `[spellmonitor]>spells` output.

### Active Spells
```
> ,e echo DRSpells.active_spells

--- Lich: exec1 active.

[exec1: {"Cage of Light"=>2}]

--- Lich: exec1 has exited.
```

### Known Spells
```
> ,e echo DRSpells.known_spells

--- Lich: exec1 active.

[exec1: {"Clear Vision"=>true, "Piercing Gaze"=>true, "Locate"=>true, "Seer's Sense"=>true, "Aura Sight"=>true, "Calm"=>true, "Telekinetic Throw"=>true, "Telekinetic Storm"=>true, "Psychic Shield"=>true, "Shadows"=>true, "Focus Moonbeam"=>true, "Dazzle"=>true, "Refractive Field"=>true, "Burn"=>true, "Moonblade"=>true, "Dinazen Olkar"=>true, "Shape Moonblade"=>true, "Cage of Light"=>true, "Shift Moonbeam"=>true, "Partial Displacement"=>true, "Teleport"=>true, "Moongate"=>true, "Minor Physical Protection"=>true}]

--- Lich: exec1 has exited.
```

### Known Feats
```
> ,e echo DRSpells.known_feats

--- Lich: exec1 active.

[exec1: {"Basic Preparation Recognition"=>true, "Augmentation Mastery"=>true, "Utility Mastery"=>true, "Warding Mastery"=>true, "Cautious Casting"=>true, "Injured Casting"=>true, "Deep Attunement"=>true, "Raw Channeling"=>true, "Efficient Channeling"=>true, "Efficient Harnessing"=>true, "Magic Theorist"=>true}]

--- Lich: exec1 has exited.
```