### PR TITLE
[script] [common-items] give/accept items

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -688,7 +688,7 @@ module DRCI
   def give_item?(target, item)
     # An offer expires after 30 seconds. 
     # The timeout is set to 35 to give some buffer for clock skew.
-    case DRC.bput("give my #{item} to #{target}", { 'timeout' => 35 }, "has accepted your offer", "has declined the offer", "Your offer to .* has expired", "You may only have one outstanding offer at a time", "What is it you're trying to give")
+    case DRC.bput("give my #{item} to #{target}", { 'timeout' => 35 }, "has accepted your offer", "has declined the offer", "Your offer to .* has expired", "You may only have one outstanding offer at a time", "What is it you're trying to give", "There's nothing in your right hand to give away")
     when "has accepted your offer"
       true
     else

--- a/common-items.lic
+++ b/common-items.lic
@@ -680,4 +680,31 @@ module DRCI
     end
     return false
   end
+
+  #########################################
+  # GIVE/ACCEPT ITEM
+  #########################################
+
+  def give_item?(target, item)
+    # An offer expires after 30 seconds. 
+    # The timeout is set to 35 to give some buffer for clock skew.
+    case DRC.bput("give my #{item} to #{target}", { 'timeout' => 35 }, "has accepted your offer", "has declined the offer", "Your offer to .* has expired", "You may only have one outstanding offer at a time", "What is it you're trying to give")
+    when "has accepted your offer"
+      true
+    else
+      false
+    end
+  end
+
+  # If you accept then returns the name of the person whose offer you accepted. This serves as a "truthy" value, too.
+  # If you don't, or aren't able to, accept then returns false.
+  def accept_item?
+    case DRC.bput("accept", "You accept .* offer and are now holding", "You have no offers", "Both of your hands are full", "would push you over your item limit")
+    when /You accept (?<name>\w+)'s offer and are now holding/
+      Regexp.last_match[:name]
+    else
+      false
+    end
+  end
+
 end

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -1,0 +1,162 @@
+require 'minitest/autorun'
+require 'yaml'
+require 'ostruct'
+load 'test/test_harness.rb'
+
+include Harness
+
+class TestDRCI < Minitest::Test
+  def setup
+    reset_data
+    $history.clear
+    $server_buffer.clear
+    sent_messages.clear
+    displayed_messages.clear
+  end
+
+  def teardown
+    @test.join if @test
+  end
+
+  #########################################
+  # GIVE ITEM
+  #########################################
+
+  def assert_give_item_success
+    proc { |accepted| assert_equal(true, accepted) }
+  end
+
+  def assert_give_item_failure
+    proc { |accepted| assert_equal(false, accepted) }
+  end
+
+  def run_give_item(messages, assertions = [])
+    @test = run_script_with_proc(['common', 'common-items'], proc do
+      # Setup
+      $server_buffer = messages.dup
+      $history = $server_buffer.dup
+
+      # Test
+      accepted = DRCI.give_item?('Frodo', 'ring')
+
+      # Assert
+      assertions = [assertions] unless assertions.is_a?(Array)
+      assertions.each { |assertion| assertion.call(accepted) }
+    end)
+  end
+
+  def test_give_item_accepts_offer
+    messages = [
+      'You offer your magic ring to Frodo, who has 30 seconds to accept the offer.  Type CANCEL to prematurely cancel the offer.',
+      'Frodo has accepted your offer and is now holding a magical ring to rule them all.'
+    ]
+    run_give_item(messages, [
+      assert_give_item_success
+    ])
+  end
+
+  def test_give_item_offer_declined
+    messages = [
+      'You offer your magic ring to Frodo, who has 30 seconds to accept the offer.  Type CANCEL to prematurely cancel the offer.',
+      'Frodo has declined the offer.'
+    ]
+    run_give_item(messages, [
+      assert_give_item_failure
+    ])
+  end
+
+  def test_give_item_offer_expires
+    messages = [
+      'You offer your magic ring to Frodo, who has 30 seconds to accept the offer.  Type CANCEL to prematurely cancel the offer.',
+      'Your offer to Frodo has expired.'
+    ]
+    run_give_item(messages, [
+      assert_give_item_failure
+    ])
+  end
+
+  def test_give_item_multiple_outstanding_offers
+    messages = [
+      'You may only have one outstanding offer at a time.'
+    ]
+    run_give_item(messages, [
+      assert_give_item_failure
+    ])
+  end
+
+  def test_give_item_nothing_to_give
+    messages = [
+      "What is it you're trying to give"
+    ]
+    run_give_item(messages, [
+      assert_give_item_failure
+    ])
+  end
+
+  #########################################
+  # ACCEPT ITEM
+  #########################################
+
+  def assert_accept_item_success
+    proc { |giver| assert_equal('Frodo', giver) }
+  end
+
+  def assert_accept_item_failure
+    proc { |giver| assert_equal(false, giver) }
+  end
+
+  def run_accept_item(messages, assertions = [])
+    @test = run_script_with_proc(['common', 'common-items'], proc do
+      # Setup
+      $server_buffer = messages.dup
+      $history = $server_buffer.dup
+
+      # Test
+      giver = DRCI.accept_item?
+
+      # Assert
+      assertions = [assertions] unless assertions.is_a?(Array)
+      assertions.each { |assertion| assertion.call(giver) }
+    end)
+  end
+
+  def test_accept_item_accepted
+    messages = [
+      "Frodo offers you a magical ring.  Enter ACCEPT to accept the offer or DECLINE to decline it.  The offer will expire in 30 seconds.",
+      "You accept Frodo's offer and are now holding a magical ring."
+    ]
+    run_accept_item(messages, [
+      assert_accept_item_success
+    ])
+  end
+
+  def test_accept_item_no_offers
+    messages = [
+      "You have no offers to accept."
+    ]
+    run_accept_item(messages, [
+      assert_accept_item_failure
+    ])
+  end
+
+  def test_accept_item_hands_full
+    messages = [
+      "Frodo offers you a magical ring.  Enter ACCEPT to accept the offer or DECLINE to decline it.  The offer will expire in 30 seconds.",
+      "Both of your hands are full."
+    ]
+    run_accept_item(messages, [
+      assert_accept_item_failure
+    ])
+  end
+
+  def test_accept_item_inventory_limit
+    messages = [
+      "Frodo offers you a magical ring.  Enter ACCEPT to accept the offer or DECLINE to decline it.  The offer will expire in 30 seconds.",
+      "Accepting a magical ring would push you over your item limit of 100 items.  Please reduce your inventory count before you try again."
+    ]
+    run_accept_item(messages, [
+      assert_accept_item_failure
+    ])
+  end
+
+end

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -1,6 +1,4 @@
 require 'minitest/autorun'
-require 'yaml'
-require 'ostruct'
 load 'test/test_harness.rb'
 
 include Harness


### PR DESCRIPTION
### Dependencies
* ~~Depends on https://github.com/rpherbig/dr-scripts/pull/4945 (the diff will be smaller once that's merged)~~

### Background
* Some utility methods to help with some refactoring in `accept-sell` and a new script I'm working on, `accept-pick`
* Supercedes https://github.com/rpherbig/dr-scripts/pull/4949 per https://github.com/rpherbig/dr-scripts/pull/4949#issuecomment-836964461 and https://github.com/rpherbig/dr-scripts/pull/4949#issuecomment-836966710

### Changes
* Until dependencies merged, see the new commits https://github.com/rpherbig/dr-scripts/pull/4949/commits/ea8b30106501dac156682b23c7e89d3e974e4ca7 and https://github.com/rpherbig/dr-scripts/pull/4949/commits/d755a20e04f31ad005bb0ea6f45ffb30665f3a6d
* Add `give_item?` method to give an item to someone and wait for an appropriate response
* Add `accept_item?` method to accept an item from someone and wait for an appropriate response
* Add unit tests, `test/test_common_items.rb`œ