### PR TITLE
[script] [burgle] add match string "You spread" when drop blanket

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -477,7 +477,7 @@ class Burgle
 
   #ripped out of steal.lic
   def drop_item(item)
-    case bput("drop my #{item}", 'You drop', 'You wince', 'would damage it', 'smashing it to bits', 'Something appears different about', 'What were you')
+    case bput("drop my #{item}", 'You drop', 'You spread', 'You wince', 'would damage it', 'smashing it to bits', 'Something appears different about', 'What were you')
     when 'would damage it', 'Something appears different about'
       drop_item(item)
     when 'What were you'

--- a/steal.lic
+++ b/steal.lic
@@ -299,7 +299,7 @@ class Steal
   end
 
   def drop_item(item)
-    case bput("drop my #{item}", 'You drop', 'would damage it', 'smashing it to bits', 'Something appears different about', 'What were you')
+    case bput("drop my #{item}", 'You drop', 'You spread', 'You wince', 'would damage it', 'smashing it to bits', 'Something appears different about', 'What were you')
     when 'would damage it', 'Something appears different about'
       drop_item(item)
     when 'What were you'


### PR DESCRIPTION
### Background
* Reported by [MulletByNature](https://discord.com/channels/745675889622384681/745678330933805157/844025148239773717) in the Lich discord

```
[burgle]>drop my wool blanket
You spread a thick sea-blue wool blanket embroidered with twining vines on the ground.

[Remember, if you leave the game or are disconnected, someone else may take your blanket.  If it's lost to a crash, we won't replace it.  And the janitor and shadowlings are acquisitive creatures, who are quite capable of stealing this from you -- leave it on the ground at your own risk.]
>
[burgle: *** No match was found after 15 seconds, dumping info]
[burgle: messages seen length: 2]
[burgle: message: [Remember, if you leave the game or are disconnected, someone else may take your blanket.  If it's lost to a crash, we won't replace it.  And the janitor and shadowlings are acquisitive creatures, who are quite capable of stealing this from you -- leave it on the ground at your own risk.]]
[burgle: message: You spread a thick sea-blue wool blanket embroidered with twining vines on the ground.]
[burgle: checked against [/You drop/i, /You wince/i, /would damage it/i, /smashing it to bits/i, /Something appears different about/i, /What were you/i]]
[burgle: for command drop my wool blanket]
--- Lich: sanowret-crystal unpaused.
--- Lich: t2 unpaused.
--- Lich: burgle has exited.
```

### Changes
* Add match string for "You spread" (this is a quick fix, the long-term fix may be to look at using DRCI methods)