### PR TITLE
[script] [equipmanager] Unload weapon before wearing it to avoid ammo loss

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -387,7 +387,7 @@ class EquipmentManager
     #   (hidden) You unload your <weapon> while blended in with your surroundings, but cannot shake the feeling that you drew attention to yourself.
     #   (one hand empty) You unload the <weapon>.
     #   (hands full) Your <ammo> falls from your <weapon> to your feet.
-    case bput("unload my #{name}", 'You unload', 'Your .* fall.*', 'As you release the string', 'You .* unloading', 'But your .* isn\'t loaded')
+    case bput("unload my #{name}", 'You unload', 'Your .* fall.*', 'As you release the string', 'You .* unloading', 'But your .* isn\'t loaded', 'You can\'t unload such a weapon', 'You don\'t have a ranged weapon to unload')
     when /^(?:Your .*?\b(?<ammo>[\w]+)\b fall.* from your .* to your feet.)$/
       # Ammo fell to ground because hands are full.
       # Lower weapon, stow ammo, then pick it back up.
@@ -416,6 +416,7 @@ class EquipmentManager
     if weapon.wield
       stow_helper("sheath my #{weapon.short_name}", weapon.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'close the fan', 'You secure your', 'You slip', 'You hang', 'You strap', "You don't seem to be able to move", 'You easily strap', 'is too small to hold that', 'With a flick of your wrist you stealthily sheathe', '^The .* slides easily', "There's no room")
     elsif weapon.worn
+      unload_weapon(weapon.short_name)
       stow_helper("wear my #{weapon.short_name}", weapon.short_name, 'You sling', 'You attach', 'You .* unload', 'You slide', 'You place', 'close the fan', 'You hang', 'You spin', 'You strap', 'You put', 'You carefully loop', "You don't seem to be able to move", "You are already wearing")
     elsif !weapon.tie_to.nil?
       stow_helper("tie my #{weapon.short_name} to my #{weapon.tie_to}", weapon.short_name, 'You attach', 'close the fan', 'you tie', 'You are a little too busy', "You don't seem to be able to move", 'Your wounds hinder your ability to do that')


### PR DESCRIPTION
### Background
* I learned the hard way that wearing/removing a loaded crossbow may cause a random misfire and the ammo discharge to the ground.
* The ammo lands on the ground, not at your feet, and easily become lost (I lost a Sunderstone shard 😢)
* My story in the official discord: [link](https://discord.com/channels/619301383451181075/819303984719200297/844822868742373387)
* My store in the lich discord: [link](https://discord.com/channels/745675889622384681/745675890242879671/844810508665356288)

**Examples**
```
You sling a weatherbeaten battle stonebow with a pitted iron windlass over your shoulder.
Failing to notice that your battle stonebow is still loaded, you sling it quickly over one shoulder.  The too-hasty effort jars a heavy vibration along the length of the stonebow, causing it to send a bolt rapidly winging downward with a faint *clicking* sound.  You glance at your feet just in time to witness the bolt bury itself into the ground mere inches away.

> stow feet
Stow what?  Type 'STOW HELP' for details.
```

```
You sling a weatherbeaten battle stonebow with a pitted iron windlass off from over your shoulder.
Your battle stonebow snags while going over your shoulder.  The bolt discharges suddenly, and whizzes past your head, nearly poking an eye out!

> stow feet
Stow what?  Type 'STOW HELP' for details.
```

```
You sling a weatherbeaten battle stonebow with a pitted iron windlass off from over your shoulder.
Your battle stonebow snags while going over your shoulder.  The bolt discharges suddenly, and soars past you.  Be more careful where you point your battle stonebow when it's loaded!

> stow feet
Stow what?  Type 'STOW HELP' for details.
```

### Changes
* Before wearing a weapon, first try to unload it and stow the ammo, then wear the weapon.

### Notes
* This issue does not _seem_ to occur with repeater crossbows or slings. I could not reproduce the issue with the following weapons after 50 wear/remove attempts:
  - sleek diacan repeating arbalest with a wickedly curved lathe
  - leather sling with a reinforced cup
* This issue does not affect bows because you get "You need to unload..." message when trying to wear a bow -- you must unload first.
* Admittedly, not all worn weapons are loaded crossbows, but I feel the benefit of this extra precaution outweighs the cost of having the extra command. Moreso when expensive or rare ammo is involved.
* A potential optimization could be to use a heuristic if the weapon name has certain keywords in it like "bow", "arbalest", or "sling".

## Tests

### unload weapon before wearing
```
> ,e EquipmentManager.new.stow_weapon('battle stonebow')

--- Lich: exec1 active.

[exec1]>unload my battle.stonebow

You unload the stonebow.
Roundtime: 3 seconds.
> 
[exec1]>stow left

You put your rock in your warrior's pack.
> 
[exec1]>wear my battle.stonebow

You sling a weatherbeaten battle stonebow with a pitted iron windlass over your shoulder.
> 
--- Lich: exec1 has exited.
```

### wear weapon (unloaded)
```
> ,e EquipmentManager.new.stow_weapon('battle stonebow')

--- Lich: exec1 active.

[exec1]>unload my battle.stonebow

But your battle stonebow isn't loaded!
> 
[exec1]>wear my battle.stonebow

You sling a weatherbeaten battle stonebow with a pitted iron windlass over your shoulder.
> 
--- Lich: exec1 has exited.
```