### PR TITLE
[script] [spellmonitor] [tests] Silence more output, update tests

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -233,7 +233,9 @@ known_spells_hook = proc do |server_string|
         .each { |feat| DRSpells.known_feats[feat] = true }
     end
     server_string = nil if DRSpells.silence_known_spells_hook
-  when /^You can use SPELL STANCE|^You have no training in the magical arts|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
+  when /^You have \d+ spell slots? available/
+    server_string = nil if DRSpells.silence_known_spells_hook
+  when /^You can use SPELL STANCE|^You have (no|yet to receive any) training in the magical arts|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
     DRSpells.grabbing_known_spells = false
     server_string = nil if DRSpells.silence_known_spells_hook
   end

--- a/test/test_afk.rb
+++ b/test/test_afk.rb
@@ -40,7 +40,7 @@ class TestAfk < Minitest::Test
 
     run_script('afk')
 
-    assert_sends_messages expected_messages
+    assert_sends_messages(expected_messages)
   end
 
   def test_exits_if_low_health
@@ -53,7 +53,7 @@ class TestAfk < Minitest::Test
     self.health = 20
     $history << 'another message'
 
-    assert_sends_messages expected_messages
+    assert_sends_messages(expected_messages)
   end
 
   def test_exits_if_low_spirit
@@ -67,6 +67,6 @@ class TestAfk < Minitest::Test
     self.spirit = 20
     $history << 'another message'
 
-    assert_sends_messages expected_messages
+    assert_sends_messages(expected_messages)
   end
 end

--- a/test/test_afk.rb
+++ b/test/test_afk.rb
@@ -7,12 +7,16 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestAfk < Minitest::Test
+
   def setup
-    $history.clear
+    reset_data
     self.dead = false
     self.health = 100
     self.spirit = 100
-    sent_messages.clear
+  end
+
+  def teardown
+    @test.join if @test
   end
 
   def setup_settings(settings)

--- a/test/test_bput.rb
+++ b/test/test_bput.rb
@@ -6,11 +6,9 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestCommon < Minitest::Test
+
   def setup
     reset_data
-    $history.clear
-    sent_messages.clear
-    displayed_messages.clear
   end
 
   def teardown

--- a/test/test_check_health.rb
+++ b/test/test_check_health.rb
@@ -5,9 +5,9 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestCheckHealth < Minitest::Test
+
   def setup
-    $server_buffer.clear
-    $history.clear
+    reset_data
   end
 
   def teardown

--- a/test/test_common_arcana.rb
+++ b/test/test_common_arcana.rb
@@ -10,10 +10,6 @@ class TestDRCA < Minitest::Test
 
   def setup
     reset_data
-    $history.clear
-    $server_buffer.clear
-    sent_messages.clear
-    displayed_messages.clear
   end
 
   def teardown

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -8,10 +8,6 @@ class TestDRCI < Minitest::Test
 
   def setup
     reset_data
-    $history.clear
-    $server_buffer.clear
-    sent_messages.clear
-    displayed_messages.clear
   end
 
   def teardown

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -8,10 +8,6 @@ class TestFind < Minitest::Test
 
   def setup
     reset_data
-    $history.clear
-    $server_buffer.clear
-    sent_messages.clear
-    displayed_messages.clear
   end
 
   def teardown

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -354,8 +354,16 @@ module Harness
   # and then other times they don't.
   # https://stackoverflow.com/questions/11463060/how-to-reload-a-ruby-class
   def reset_data
-    $data_called_with = []
     $test_data = {}
+    $test_settings = {}
+
+    $data_called_with = []
+    $warn_msgs = []
+    $error_msgs = []
+    $history = []
+    $server_buffer = []
+    $sent_messages = []
+    $displayed_messages = []
 
     Flags._reset
     DRSpells._reset

--- a/test/test_items.rb
+++ b/test/test_items.rb
@@ -5,6 +5,11 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestItems < Minitest::Test
+
+  def setup
+    reset_data
+  end
+
   def teardown
     @test.join if @test
   end

--- a/test/test_parse_perceived_health.rb
+++ b/test/test_parse_perceived_health.rb
@@ -5,9 +5,9 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestPerceiveHealth < Minitest::Test
+
   def setup
-    $server_buffer.clear
-    $history.clear
+    reset_data
   end
 
   def teardown

--- a/test/test_setup_config.rb
+++ b/test/test_setup_config.rb
@@ -6,15 +6,16 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestSetupConfig < Minitest::Test
+
   def setup
-    # $audible = true
+    reset_data
     $history = ['quit']
     load('edityaml.lic')
   end
 
   def teardown
+    @test.join if @test
     $save_character_profile = nil
-    # $audible = false
   end
 
   def test_saving_sends_loaded_data

--- a/test/test_valid_yaml.rb
+++ b/test/test_valid_yaml.rb
@@ -6,6 +6,15 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestValidYaml < Minitest::Test
+
+  def setup
+    reset_data
+  end
+
+  def teardown
+    @test.join if @test
+  end
+
   def test_all_yaml_in_profiles
     count = 0
     Dir.glob('profiles/**/*.yaml').each do |file|

--- a/test/test_validate.rb
+++ b/test/test_validate.rb
@@ -7,8 +7,8 @@ load 'test/test_harness.rb'
 include Harness
 
 class TestValidate < Minitest::Test
+
   def setup
-    $test_settings = nil
     reset_data
     $test_data = {
       mining: OpenStruct.new(mining_buddy_rooms: []),
@@ -16,8 +16,10 @@ class TestValidate < Minitest::Test
       hunting: OpenStruct.new(hunting_zones: [], escort_zones: []),
       spells: OpenStruct.new(spell_data: [])
     }
-    $warn_msgs = []
-    $error_msgs = []
+  end
+
+  def teardown
+    @test.join if @test
   end
 
   def setup_settings(settings)


### PR DESCRIPTION
### Background
* There's a [request](https://github.com/rpherbig/dr-scripts/pull/4953#issuecomment-840561990) to silence more text when `spellmonitor` checks your spells behind the scenes.

### Changes
* Scripts
  - Silence "You have X spell slots available" when `spellmonitor` checks your spells behind the scenes.
* Tests
  - Update `reset_data` method to reset more mocks and spies
  - For consistency, update all tests to use `reset_data` instead of resetting specific variables
  
## Tests
See `test/test_spellmonitor.rb`
```
92.11% lines covered
70.45% branches covered
114 relevant lines. 105 lines covered and 9 lines missed.
44 total branches, 31 branches covered and 13 branches missed.
```