### PR TITLE
[script] [common-items] Add match strings for open/close containers; add more tests

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -193,6 +193,7 @@ module DRCI
 
   @@open_container_success_patterns = [
     /^You open/,
+    /^You unbutton/,
     /^That is already open/,
     /^You spread your arms, carefully holding your bag well away from your body/
   ]
@@ -210,6 +211,7 @@ module DRCI
 
   @@close_container_success_patterns = [
     /^You close/,
+    /^You pull/,
     /^That is already closed/
   ]
 

--- a/common-items.lic
+++ b/common-items.lic
@@ -60,6 +60,7 @@ module DRCI
     /already in your inventory/,
     /You need a free hand/,
     /needs to be tended to be removed/,
+    /You can't pick that up with your hand that damaged/,
     /You just can't/,
     /push you over the item limit/,
     /You stop as you realize the .* is not yours/,

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -138,6 +138,24 @@ class TestDRCI < Minitest::Test
     )
   end
 
+  def test_get_item__should_not_pick_up_with_damaged_hand
+    run_drci_command(
+      ["You can't pick that up with your hand that damaged."],
+      'get_item?',
+      ["anything"],
+      [refute_result]
+    )
+  end
+
+  def test_get_item__should_need_to_tend_wound
+    run_drci_command(
+      ["The crossbow bolt needs to be tended to be removed."],
+      'get_item?',
+      ["crossbow bolt"],
+      [refute_result]
+    )
+  end
+
   def test_get_item__should_already_be_in_your_inventory
     run_drci_command(
       ["But that is already in your inventory."],

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -1,4 +1,5 @@
 require_relative 'test_helper'
+require 'timecop'
 
 load 'test/test_harness.rb'
 
@@ -33,7 +34,9 @@ class TestDRCI < Minitest::Test
       $history = $server_buffer.dup
 
       # Test
+      Timecop.scale(30) # artificially speed up bput's timeout
       result = DRCI.send(command, *args)
+      Timecop.return
 
       # Assert
       assertions = [assertions] unless assertions.is_a?(Array)
@@ -269,6 +272,275 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["moonblade"],
       [assert_result]
+    ).join
+  end
+
+  #########################################
+  # OPEN CONTAINER
+  #########################################
+
+  def test_open_container__should_unbutton
+    run_drci_command(
+      ["You unbutton the flap of your satchel, pulling it open to reveal the contents."],
+      'open_container?',
+      ["satchel"],
+      [assert_result]
+    ).join
+  end
+
+  def test_open_container__should_open
+    run_drci_command(
+      ["You open your medicine pouch."],
+      'open_container?',
+      ["medicine pouch"],
+      [assert_result]
+    ).join
+  end
+
+  def test_open_container__should_spread_arms
+    run_drci_command(
+      ["You spread your arms, carefully holding your bag well away from your body"],
+      'open_container?',
+      ["harvest bag"],
+      [assert_result]
+    ).join
+  end
+
+  def test_open_container__should_already_be_open
+    run_drci_command(
+      ["That is already open."],
+      'open_container?',
+      ["medicine pouch"],
+      [assert_result]
+    ).join
+  end
+
+  def test_open_container__please_rephrase
+    run_drci_command(
+      ["Please rephrase that command."],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__what_were_you_referring
+    run_drci_command(
+      ["What were you referring to?"],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__could_not_find
+    run_drci_command(
+      ["I could not find what you were referring to."],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__ruin_your_spell
+    run_drci_command(
+      ["You don't want to ruin your spell just for that do you?"],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__disturb_the_silence
+    run_drci_command(
+      ["It would be a shame to disturb the silence of this place for that."],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__not_the_place
+    run_drci_command(
+      ["This is probably not the time nor place for that."],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__no_way_to_do_that
+    run_drci_command(
+      ["There is no way to do that."],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__you_cant_do_that
+    run_drci_command(
+      ["You can't do that."],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__you_cant_do_that_while
+    run_drci_command(
+      ["You can't do that while kneeling!"],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__you_cant_do_that_here
+    run_drci_command(
+      ["You can't do that in here."],
+      'open_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_open_container__you_cant_do_that_to_item
+    run_drci_command(
+      ["You can't do that to a brass jailer's nightstick with inconspicuous studs!"],
+      'open_container?',
+      ["jailer's nightstick"],
+      [refute_result]
+    ).join
+  end
+
+  #########################################
+  # CLOSE CONTAINER
+  #########################################
+
+  def test_close_container__should_pull
+    run_drci_command(
+      ["You pull the flap of your satchel closed and button it securely."],
+      'close_container?',
+      ["satchel"],
+      [assert_result]
+    ).join
+  end
+
+  def test_close_container__should_close
+    run_drci_command(
+      ["You close your medicine pouch."],
+      'close_container?',
+      ["medicine pouch"],
+      [assert_result]
+    ).join
+  end
+
+  def test_close_container__should_already_be_closed
+    run_drci_command(
+      ["That is already closed."],
+      'close_container?',
+      ["medicine pouch"],
+      [assert_result]
+    ).join
+  end
+
+  def test_close_container__please_rephrase
+    run_drci_command(
+      ["Please rephrase that command."],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__what_were_you_referring
+    run_drci_command(
+      ["What were you referring to?"],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__could_not_find
+    run_drci_command(
+      ["I could not find what you were referring to."],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__ruin_your_spell
+    run_drci_command(
+      ["You don't want to ruin your spell just for that do you?"],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__disturb_the_silence
+    run_drci_command(
+      ["It would be a shame to disturb the silence of this place for that."],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__not_the_place
+    run_drci_command(
+      ["This is probably not the time nor place for that."],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__no_way_to_do_that
+    run_drci_command(
+      ["There is no way to do that."],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__you_cant_do_that
+    run_drci_command(
+      ["You can't do that."],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__you_cant_do_that_while
+    run_drci_command(
+      ["You can't do that while kneeling!"],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__you_cant_do_that_here
+    run_drci_command(
+      ["You can't do that in here."],
+      'close_container?',
+      ["medicine pouch"],
+      [refute_result]
+    ).join
+  end
+
+  def test_close_container__you_cant_do_that_to_item
+    run_drci_command(
+      ["You can't do that to a brass jailer's nightstick with inconspicuous studs!"],
+      'close_container?',
+      ["jailer's nightstick"],
+      [refute_result]
     ).join
   end
 

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -54,7 +54,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["sanowret crystal"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_get_item__should_pick_up_arrow
@@ -63,7 +63,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["drake-fang arrow"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_get_item__should_pluck_rat_from_sack
@@ -72,7 +72,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["rat"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_get_item__should_remove_barb_from_sash
@@ -81,7 +81,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["spiky barb"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_get_item__should_fade_in_to_pick_up_cowbell
@@ -90,7 +90,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["dainty cowbell"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_get_item__should_fade_in_to_get_gem_from_pouch
@@ -99,7 +99,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["andalusite"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_get_item__should_stop_as_you_realize_not_yours
@@ -108,7 +108,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["boar-tusk arrow"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_not_exceed_inventory_limit
@@ -117,7 +117,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["red backpack"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_need_a_free_hand_to_pick
@@ -126,7 +126,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["anything"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_need_a_free_hand_to_do
@@ -135,7 +135,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["anything"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_already_be_in_your_inventory
@@ -144,7 +144,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["anything"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_ask_get_what
@@ -153,7 +153,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["nothing"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_not_find_what_you_were_referring
@@ -162,7 +162,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["nothing"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_ask_what_were_you_referring
@@ -171,7 +171,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["nothing"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_not_find_container
@@ -180,7 +180,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["nothing"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_not_get_if_rapidly_decays
@@ -189,7 +189,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["large limb"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_get_item__should_not_get_if_rots_away
@@ -198,7 +198,7 @@ class TestDRCI < Minitest::Test
       'get_item?',
       ["large limb"],
       [refute_result]
-    ).join
+    )
   end
 
   #########################################
@@ -218,7 +218,7 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["ocarina"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_dispose_trash__should_smash_ocarina_to_bits
@@ -227,7 +227,7 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["ocarina"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_dispose_trash__should_drop_pack_on_ground
@@ -236,7 +236,7 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["pack"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_dispose_trash__should_drop_pants_in_barrel
@@ -245,7 +245,7 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["faded pants"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_dispose_trash__should_drop_lily_in_bucket
@@ -254,7 +254,7 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["lily"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_dispose_trash__should_spread_blanket_on_ground
@@ -263,7 +263,7 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["wool blanket"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_dispose_trash__should_release_moonblade
@@ -272,7 +272,7 @@ class TestDRCI < Minitest::Test
       'dispose_trash',
       ["moonblade"],
       [assert_result]
-    ).join
+    )
   end
 
   #########################################
@@ -285,7 +285,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["satchel"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_open_container__should_open
@@ -294,7 +294,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_open_container__should_spread_arms
@@ -303,7 +303,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["harvest bag"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_open_container__should_already_be_open
@@ -312,7 +312,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_open_container__please_rephrase
@@ -321,7 +321,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__what_were_you_referring
@@ -330,7 +330,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__could_not_find
@@ -339,7 +339,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__ruin_your_spell
@@ -348,7 +348,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__disturb_the_silence
@@ -357,7 +357,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__not_the_place
@@ -366,7 +366,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__no_way_to_do_that
@@ -375,7 +375,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__you_cant_do_that
@@ -384,7 +384,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__you_cant_do_that_while
@@ -393,7 +393,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__you_cant_do_that_here
@@ -402,7 +402,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_open_container__you_cant_do_that_to_item
@@ -411,7 +411,7 @@ class TestDRCI < Minitest::Test
       'open_container?',
       ["jailer's nightstick"],
       [refute_result]
-    ).join
+    )
   end
 
   #########################################
@@ -424,7 +424,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["satchel"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_close_container__should_close
@@ -433,7 +433,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_close_container__should_already_be_closed
@@ -442,7 +442,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [assert_result]
-    ).join
+    )
   end
 
   def test_close_container__please_rephrase
@@ -451,7 +451,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__what_were_you_referring
@@ -460,7 +460,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__could_not_find
@@ -469,7 +469,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__ruin_your_spell
@@ -478,7 +478,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__disturb_the_silence
@@ -487,7 +487,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__not_the_place
@@ -496,7 +496,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__no_way_to_do_that
@@ -505,7 +505,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__you_cant_do_that
@@ -514,7 +514,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__you_cant_do_that_while
@@ -523,7 +523,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__you_cant_do_that_here
@@ -532,7 +532,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["medicine pouch"],
       [refute_result]
-    ).join
+    )
   end
 
   def test_close_container__you_cant_do_that_to_item
@@ -541,7 +541,7 @@ class TestDRCI < Minitest::Test
       'close_container?',
       ["jailer's nightstick"],
       [refute_result]
-    ).join
+    )
   end
 
   #########################################


### PR DESCRIPTION
### Background
* The [dusky grey satchel branded with geometric shapes](https://elanthipedia.play.net/Item:Dusky_grey_satchel_branded_with_geometric_shapes) from Su Helma's has unique messaging for opening and closing the container.
* When trying to get an item and one hand is full and the other hand doesn't exist (cut or blown off) then you get the message "You can't pick that up with your hand that damaged."
* These match strings are missing from `common-items` patterns.

### Changes
* Add `"You pull"` to close container success patterns
* Add `"You unbutton"` to open container success patterns
* Add `"You can't pick that up with your hand that damaged"` to get item failure patterns

## Tests
See `test/test_common_items.rb`
