### PR TITLE
Shard - Craft Data - Metal Shield Parts

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -371,7 +371,7 @@ blacksmithing:
     stock-name: bronze ingot
     trash-room: 8895
     idle-room: 8893
-  Fang Cove: 
+  Fang Cove:
     npc: Phahoe
     npc_last_name: Phahoe
     npc-rooms:
@@ -409,7 +409,7 @@ blacksmithing:
     stock-number: 11
     stock-name: bronze ingot
     trash-room: 14881
-    idle-room: 9136         
+    idle-room: 9136
   Mer'Kresh:
     npc: Kapric
     npc_last_name: Kapric
@@ -1692,6 +1692,9 @@ recipe_parts:
     Fang Cove:
       part-room: 9118
       part-number:
+    Shard:
+      part-room: 10939
+      part-number: 16
   shield handle:
     Crossing:
       part-room: 8776
@@ -1709,8 +1712,8 @@ recipe_parts:
       part-room: 8784
       part-number:
     Shard:
-      part-room: 10939
-      part-number: 16
+      part-room: 4436
+      part-number:
     Shadow's Reach:
       part-room: 16409
       part-number:


### PR DESCRIPTION
Wrong room number for metal shield parts, was buying leather shield handles instead.