### PR TITLE
Hunting Buddy - Handle Empty "Stop On" List

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -25,7 +25,7 @@ class HuntingBuddy
                      'Lunar Magic', 'Attunement', 'Arcana', 'Targeted Magic', 'Inner Fire',\
                      'Inner Magic', 'Augmentation', 'Debilitation', 'Utility', 'Warding', 'Sorcery']
     @hunting_buddies_max = @settings.hunting_buddies_max
-    
+
     # Will deprecate prehunt_buffs tag as a room
     @buff_room = @settings.prehunt_buffing_room || @settings.prehunt_buffs
 
@@ -239,7 +239,7 @@ class HuntingBuddy
   end
 
   def all_skills_at_cap?(stop_on_skills)
-    stop_on_skills && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }
+    stop_on_skills && !stop_on_skills.empty? && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }
   end
 
   def stop_on_low_skills_too_low?(stop_on_low_skills)


### PR DESCRIPTION
Current behavior is un-intuitive - null entry in yaml never stops, but an empty list immediately stops.