### PR TITLE
Update base-hunting.yaml to correct dire_bears

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -895,7 +895,6 @@ hunting_zones:
   - 1565
   - 1582
   - 1581
-  - 1578
   - 1566
   # https://elanthipedia.play.net/Dire_Bear                              120-170
   # same bears, just premie only rooms


### PR DESCRIPTION
Removed room 1578 from dire_bears because it consistently spawns only silver-backed bears.