### PR TITLE
[script] [equipmanager] Handle when need two hands to remove item

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -127,23 +127,27 @@ class EquipmentManager
   end
 
   def remove_item(item)
-    result = bput("remove my #{item.short_name}", "You .*#{item.name}", 'The leather gauntlets slide', 'Without any effort', 'you manage to loosen', "You'll need both hands free to do that", "then constricts tighter around your")
+    result = bput("remove my #{item.short_name}", "You .*#{item.name}", 'The leather gauntlets slide', 'Without any effort', 'you manage to loosen', "You need a free hand for that", "You'll need both hands free to do that", "then constricts tighter around your")
     waitrt?
     case result
     when /then constricts tighter around your/
       # Items that auto-repair, like exoskeletal armor,
       # may have a timer on them that prevents you removing them.
-      DRC.message("The #{item.name} is not ready to be removed yet. Try again later.")
+      DRC.message("The #{item.short_name} is not ready to be removed yet. Try again later.")
       return false
-    when /You'll need both hands free to do that/
+    when /You need a free hand for that/, /You'll need both hands free to do that/
       # We may need to empty our hands to remove the item.
       # For example, exoskeletal armor requires two hands.
       temp_left_item = DRC.left_hand
       temp_right_item = DRC.right_hand
       # Lower the items because that preserves loaded bows.
       # Stowing them in a container would require unloading.
-      [temp_left_item, temp_right_item].compact.each { |item_in_hand| DRCI.lower_item?(item_in_hand) }
-      remove_item(item)
+      did_lower = [temp_left_item, temp_right_item].compact.all? { |item_in_hand| DRCI.lower_item?(item_in_hand) }
+      if did_lower
+        remove_item(item)
+      else
+        DRC.message("*** Unable to empty your hands to remove #{item.short_name} ***")
+      end
       # Pick up the items in reverse order you lowered them
       # so that they end up in the correct hands again.
       DRCI.get_item_if_not_held?(temp_right_item)

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -127,20 +127,43 @@ class EquipmentManager
   end
 
   def remove_item(item)
-    bput("remove my #{item.short_name}", "You .*#{item.name}", 'The leather gauntlets slide', 'Without any effort', 'you manage to loosen')
+    result = bput("remove my #{item.short_name}", "You .*#{item.name}", 'The leather gauntlets slide', 'Without any effort', 'you manage to loosen', "You'll need both hands free to do that", "then constricts tighter around your")
     waitrt?
-    # If removing item transforms it (e.g. exoskeletal armor => orb) then continue with the transformed item.
-    if item.transforms_to && DRCI.in_hands?(item.transforms_to)
-      item = item_by_desc(item.transforms_to)
-    end
-    if item.tie_to
-      stow_helper("tie my #{item.short_name} to #{item.tie_to}", item.short_name, 'You attach', 'you tie', 'You are a little too busy', 'Your wounds hinder your ability to do that')
-    elsif item.wield
-      stow_helper("sheath my #{item.short_name}", item.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'You secure your', 'You slip', 'You hang', 'You .* strap')
-    elsif item.container
-      stow_helper("put my #{item.short_name} into #{item.container}", item.short_name, 'You put', 'You should unload', 'You easily strap', 'You secure your')
-    elsif /more room|too long to fit/ =~ bput("stow my #{item.short_name}", 'You put', 'You should unload', 'You easily strap', 'You secure your', 'There isn\'t any more room', 'straps have all been used', 'is too long to fit')
-      bput("wear my #{item.short_name}", 'You ')
+    case result
+    when /then constricts tighter around your/
+      # Items that auto-repair, like exoskeletal armor,
+      # may have a timer on them that prevents you removing them.
+      DRC.message("The #{item.name} is not ready to be removed yet. Try again later.")
+      return false
+    when /You'll need both hands free to do that/
+      # We may need to empty our hands to remove the item.
+      # For example, exoskeletal armor requires two hands.
+      temp_left_item = DRC.left_hand
+      temp_right_item = DRC.right_hand
+      # Lower the items because that preserves loaded bows.
+      # Stowing them in a container would require unloading.
+      [temp_left_item, temp_right_item].compact.each { |item_in_hand| DRCI.lower_item?(item_in_hand) }
+      remove_item(item)
+      # Pick up the items in reverse order you lowered them
+      # so that they end up in the correct hands again.
+      DRCI.get_item_if_not_held?(temp_right_item)
+      DRCI.get_item_if_not_held?(temp_left_item)
+      # In case they end up in different hands, swap.
+      DRC.bput('swap', 'You move') if (DRC.left_hand != temp_left_item || DRC.right_hand != temp_right_item)
+    else
+      # If removing item transforms it (e.g. exoskeletal armor => orb) then continue with the transformed item.
+      if item.transforms_to && DRCI.in_hands?(item.transforms_to)
+        item = item_by_desc(item.transforms_to)
+      end
+      if item.tie_to
+        stow_helper("tie my #{item.short_name} to #{item.tie_to}", item.short_name, 'You attach', 'you tie', 'You are a little too busy', 'Your wounds hinder your ability to do that')
+      elsif item.wield
+        stow_helper("sheath my #{item.short_name}", item.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'You secure your', 'You slip', 'You hang', 'You .* strap')
+      elsif item.container
+        stow_helper("put my #{item.short_name} into #{item.container}", item.short_name, 'You put', 'You should unload', 'You easily strap', 'You secure your')
+      elsif /more room|too long to fit/ =~ bput("stow my #{item.short_name}", 'You put', 'You should unload', 'You easily strap', 'You secure your', 'There isn\'t any more room', 'straps have all been used', 'is too long to fit')
+        wear_item?(item)
+      end
     end
     waitrt?
   end


### PR DESCRIPTION
### Background
* More feedback from [Nestan](https://discord.com/channels/745675889622384681/745676101392793651/848606566487425034) when trying to remove exoskeletal armor in combat and needing both hands free.

### Changes
* When try to remove an item and need both hands free, lower items to ground, retry remove action, then pick items back up and put them in the correct hands.
* Handle phrase "then constricts tighter around your" which means the exoskeletal armor is not ready to be removed yet.

## Tests

<details>
<summary>remove armor with empty hands</summary>

```
> tap my armor
You tap some waxy ridged armor that you are wearing.

> glance
You glance down at your empty hands. 

> ,e em = EquipmentManager.new ; em.remove_item( em.item_by_desc('ridged armor') )

--- Lich: exec1 active.

> 
[exec1]>remove my ridged.armor

As you tug at the ridged armor, its segmented legs pull free from your body, rapidly contracting into a tight little orb.
[Roundtime: 10 seconds.]

> 
[exec1]>put my clouded.orb into black bag

You put your orb in your black bag.

>
--- Lich: exec1 has exited.
```
</details>

<details>
<summary>remove armor with item in left hand</summary>

```
> tap my armor
You tap some waxy ridged armor that you are wearing.

> glance
You glance down to see nothing in your right hand and a vault book in your left hand. 

> ,e em = EquipmentManager.new ; em.remove_item( em.item_by_desc('ridged armor') )

--- Lich: exec1 active.

[exec1]>remove my ridged.armor

You'll need both hands free to do that.

> 
[exec1]>lower ground left

You lower the book and place it on the ground at your feet.
> 
[exec1]>remove my ridged.armor

As you tug at the ridged armor, its segmented legs pull free from your body, rapidly contracting into a tight little orb.
[Roundtime: 10 seconds.]

> 
[exec1]>put my clouded.orb into black bag

You put your orb in your black bag.
> 
[exec1]>get my vault book

You pick up the book lying at your feet.
>
 
[exec1]>swap

You move a vault book to your left hand.

>
--- Lich: exec1 has exited.
```
</details>

<details>
<summary>remove armor with item in right hand</summary>

```
> tap my armor
You tap some waxy ridged armor that you are wearing.

> glance
You glance down to see a severely curved matte black longbow carved with an intricate scale pattern in your right hand and nothing in your left hand. 

> ,e em = EquipmentManager.new ; em.remove_item( em.item_by_desc('ridged armor') )

--- Lich: exec1 active.

[exec1]>remove my ridged.armor

You'll need both hands free to do that.

> 
[exec1]>lower ground right

You lower the longbow and place it on the ground at your feet.
> 
[exec1]>remove my ridged.armor

As you tug at the ridged armor, its segmented legs pull free from your body, rapidly contracting into a tight little orb.
[Roundtime: 10 seconds.]

> 
[exec1]>put my clouded.orb into black bag

You put your orb in your black bag.
> 
[exec1]>get my matte longbow 

You pick up the longbow lying at your feet.
> 
--- Lich: exec1 has exited.
```
</details>

<details>
<summary>remove armor with item in both hands</summary>

```
> tap my armor
You tap some waxy ridged armor that you are wearing.

> glance
You glance down to see a severely curved matte black longbow carved with an intricate scale pattern in your right hand and a vault book in your left hand. 

> ,e em = EquipmentManager.new ; em.remove_item( em.item_by_desc('ridged armor') )

--- Lich: exec1 active.

[exec1]>remove my ridged.armor

You'll need both hands free to do that.
> 
[exec1]>lower ground left

You lower the book and place it on the ground at your feet.
> 
[exec1]>lower ground right

You lower the longbow and place it on the ground at your feet.
> 
[exec1]>remove my ridged.armor

As you tug at the ridged armor, its segmented legs pull free from your body, rapidly contracting into a tight little orb.
[Roundtime: 10 seconds.]

> 
[exec1]>put my clouded.orb into black bag

You put your orb in your black bag.
> 
[exec1]>get my matte longbow 

You pick up the longbow lying at your feet.
> 
[exec1]>get my vault book 

You pick up the book lying at your feet.
> 
--- Lich: exec1 has exited.
```
</details>

<details>
<summary>armor is not ready to be removed</summary>

```
> tap my armor
You tap some waxy ridged armor that you are wearing.

> glance
You glance down at your empty hands. 

>
,e em = EquipmentManager.new ; em.remove_item( em.item_by_desc('ridged armor') )
--- Lich: exec1 active.
> 
[exec1]>remove my ridged.armor

The ridged armor shakes violently for a moment, then constricts tighter around your chest.
[Roundtime: 5 seconds.]
> 
| The armor is not ready to be removed yet. Try again later.

--- Lich: exec1 has exited.
```