### PR TITLE
[script] [su-helmas] New script that solves tasks from empath NPC

### DIFF
--- a/su-helmas.lic
+++ b/su-helmas.lic
@@ -1,0 +1,150 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#su-helmas
+  This script runs non-combat tasks for Su Helmas.
+=end
+
+custom_require.call(%w(common drinfomon equipmanager events common-travel common-items))
+
+class SuHelmas
+
+  def initialize
+    settings = get_settings
+    catacombs_settings = settings.suhelmas['catacombs']
+
+    @loot_container = catacombs_settings['loot_container']
+    @contract_container = catacombs_settings['contract_container']
+    @redeem_contract = catacombs_settings['redeem_contract']
+    @weapon = catacombs_settings['weapon']
+
+    equipment_manager = EquipmentManager.new
+    equipment_manager.empty_hands
+    equipment_manager.wield_weapon(@weapon) if @weapon
+
+    run_short_maze
+
+    equipment_manager.empty_hands
+  end
+
+  def run_short_maze
+
+    Flags.add('catacombs_done', "Thanks for all the hard work.  Here's a little something to show my appreciation.")
+    Flags.add('task_search', "tickle at the frayed edges of sanity")
+    Flags.add('task_sit', "In the center of the lit area is a metal seat")
+    Flags.add('task_meditate', "but it's certainly enough to make someone scream, too")
+    Flags.add('task_climb', "granite slab at the center of the sunken pit")
+    Flags.add('task_dodge', "past the vines you see a lit chamber beckoning")
+    Flags.add('task_crawl', "little sense moving forward until this is dealt with")
+    Flags.add('task_break', "magical barrier blocks further travel down the cold passageway")
+    Flags.add('task_smite', "The seed might well be the only thing in the world right now")
+    Flags.add('task_stow', "Here, I have something for you!")
+    Flags.add('need_weapon', "being unarmed you have no way to exploit the weakness")
+
+    join_empath
+
+    until Flags['catacombs_done'] do
+      do_short_task('search')    if Flags['task_search']
+      do_short_task('sit')       if Flags['task_sit']
+      do_short_task('meditate')  if Flags['task_meditate']
+      do_short_task('climb')     if Flags['task_climb']
+      do_short_task('dodge')     if Flags['task_dodge']
+      do_short_task('crawl')     if Flags['task_crawl']
+      do_short_task('break')     if Flags['task_break']
+      do_short_task('smite')     if Flags['task_smite']
+      do_short_task('stow')      if Flags['task_stow']
+      warn_need_weapon()         if Flags['need_weapon']
+      pause 1
+    end
+
+  end
+
+  def join_empath
+    empath_room = 11553 # empath wreathed in violet robes
+    DRCT.walk_to(empath_room)
+    join_success = [
+      "who leads you deep into the catacombs"
+    ]
+    join_failure = [
+      "What were you referring to?"
+    ]
+    join_need_pass = [
+      "Sorry, I'm quite busy"
+    ]
+    case DRC.bput("join empath", *join_success, *join_failure, *join_need_pass)
+    when *join_failure
+      DRC.message("Unable to join an empath wreathed in violet robes. Is one here?")
+      exit
+    when *join_need_pass
+      redeem_contract
+      join_empath
+    end
+  end
+
+  def do_short_task(task)
+    Flags.reset("task_#{task}")
+    waitrt?
+    case task
+    when 'break'
+      # Magic users invoke the barrier instead of break it.
+      unless DRStats.commoner? || DRStats.barbarian? || DRStats.thief?
+        task = 'invoke'
+      end
+    when 'move'
+      task = 'move darkness'
+    when 'sit'
+      task = 'sit seat'
+    when 'smite'
+      # Empath's touch the seed whereas others smite it.
+      if DRStats.empath?
+        task = 'touch seed'
+      end
+    when 'stow'
+      stow_loot(DRC.left_hand)
+      join_empath
+      return
+    end
+    fput("#{task}")
+    waitrt?
+  end
+
+  def stow_loot(item)
+    return unless item
+    unless DRCI.put_away_item?(item, @loot_container)
+      DRC.message("Could not find a loot container to stow #{item}. Put items away then retry this script.")
+      exit
+    end
+  end
+
+  def redeem_contract
+    if @redeem_contract && DRCI.get_item?('contract', @contract_container)
+      fput('redeem contract')
+      fput('redeem contract')
+      # If still holding a stack of contracts, put them away.
+      DRCI.put_away_item?('contract', @contract_container) if DRCI.in_hands?('contract')
+    else
+      DRC.message("You need to REDEEM a Su Helmas contract first, then retry this script.")
+      exit
+    end
+  end
+
+  def warn_need_weapon
+    DRC.message("You need to wield a melee weapon in your right hand to break the barrier.")
+    DRC.message("Wield a weapon and BREAK the barrier then the script will continue.")
+  end
+
+end
+
+before_dying do
+  Flags.delete('catacombs_done')
+  Flags.delete('task_search')
+  Flags.delete('task_sit')
+  Flags.delete('task_meditate')
+  Flags.delete('task_climb')
+  Flags.delete('task_dodge')
+  Flags.delete('task_crawl')
+  Flags.delete('task_break')
+  Flags.delete('task_smite')
+  Flags.delete('task_stow')
+  Flags.delete('need_weapon')
+end
+
+SuHelmas.new


### PR DESCRIPTION
### Background
* Inspired by the `corn-maze` script that does the 10 short tasks in that event.

### Configuration
```yaml
####################
# To group all Su Helmas related settings.
# https://elanthipedia.play.net/Category:Su_Helmas
####################
suhelmas:
  # Settings specific to the cataombs offered by the empath.
  # https://elanthipedia.play.net/Su_Helmas:_The_Forbidden_Temple_438#Seeds_of_Entropy
  catacombs:
    # Which containers to put the incidental items you earn from completing this task.
    # You can specify multiple containers, useful in case one becomes full.
    # At least one of the containers should be able to hold really long items like staves.
    # If not specified then the default is to "stow left"
    # so make sure to have your STORE settings configured.
    loot_container:
    - watery portal
    - thornweave lootsack
    - thigh bag
    # If true then will repeatedly do the catacombs task
    # until you run out of contracts to redeem.
    # If false then you must redeem a contract prior to running the script.
    redeem_contract: true
    # If script will redeem contracts, where do you keep them?
    # If not specified then default is to "get/stow my contract"
    # so make sure to have your STORE settings configured.
    contract_container: hitman backpack
    # If you are not an Empath then you'll need a weapon to smite the Seed of Entropy.
    # Specify the weapon's <adjective> <noun> as listed in your gear config.
    weapon: assassin's blade
```

### Usage
1. Obtain one or more Su Helmas contracts
2. Enter the event area (In Crossing, go to TGSE, go portal)
3. Run the script `;su-helmas`