### PR TITLE
[script] [common-items] Add match for 'You tug' when wear item

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -81,6 +81,7 @@ module DRCI
     /You slip/,
     /You place/,
     /You hang/,
+    /You tug/,
     /You toss one strap/,
     /You carefully loop/,
     /You work your way into/,

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -48,11 +48,20 @@ class TestDRCI < Minitest::Test
   # WEAR ITEM
   #########################################
 
-  def test_wear_item_you_toss_one_strap
+  def test_wear_item__you_toss_one_strap
     run_drci_command(
       ["You toss one strap of the harness over your shoulder, pull it down and buckle it to its mate."],
       'wear_item?',
       ["weapon harness"],
+      [assert_result]
+    )
+  end
+
+  def test_wear_item__you_tug
+    run_drci_command(
+      ["You tug on the chain gloves, flexing your hand as you pull them on for a snug fit."],
+      'wear_item?',
+      ["chain gloves"],
       [assert_result]
     )
   end


### PR DESCRIPTION
### Background
* Reported by [Dantia](https://discord.com/channels/745675889622384681/745676101392793651/849008745878388736) in the Lich discord

```
[pick: message: You tug on the chain gloves, flexing your hand as you pull them on for a snug fit.]
 
[pick: checked against [/You put/, /You sling/, /You attach/, /You strap/, /You slide/, /You spin/, /You slip/, /You place/, /You hang/, /You toss one strap/, /You carefully loop/, /You work your way into/, /slide effortlessly onto your/, /You are already wearing/, /You can't wear/, /You (need to|should) unload/, /close the fan/, /You don't seem to be able to move/, /Wear what/, /I could not/, /What were you/]]
 
[pick: for command wear my chain.gloves]
```

### Changes
* Add `You tug` to the success patterns when wear an item

## Tests
* See `test/test_common_items.rb`