### PR TITLE
[script] [equipmanager] Remove check if item in your hand, is griefing people with imprecise adjectives in their gear config

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -151,9 +151,7 @@ class EquipmentManager
       return false
     end
     if get_item?(item)
-      # If getting item transforms it to immediately be worn (e.g. orb => exoskeletal armor)
-      # then the item won't be in our hands, it'll already be worn, so skip that step.
-      DRCI.wear_item?(item.short_name) if DRCI.in_hands?(item.short_name)
+      DRCI.wear_item?(item.short_name)
       return true
     end
     return false


### PR DESCRIPTION
### Background
* Per https://github.com/rpherbig/dr-scripts/pull/4976, made updates to support wearing/removing exoskeletal armor.
* The changes introduced an optimization to only try to wear an item if it's still in your hands (e.g. orb that transformed to worn armor doesn't need to be "worn" explicitly, it does so automatically).
* That optimization [broke for people](https://discord.com/channels/745675889622384681/745675890242879671/849087665931812924) whose gear config's don't use the full adjective of an item (e.g. "assassin" instead of "assassin's" for "assassin's cowl")

### Changes
* Remove the optimization to only wear if item isn't in your hands. The majority of the time the item will be in your hands unless it's an exoskeletal item, and even then the extra "wear" command won't hold up the script. `DRCI.wear_item?` will keep moving forward.