### PR TITLE
[script] [combat-trainer] Recover dropped items due to loss of hand or other reason

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -824,7 +824,13 @@ class LootProcess
     end
 
     snap = [left_hand, right_hand]
-    case bput('skin', 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin')
+    case bput('skin', 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
+    when 'You must have one hand free to skin'
+      temp_item = DRC.left_hand
+      if DRCI.lower_item?(temp_item)
+        check_skinning(mob_noun, game_state)
+        DRCI.get_item?(temp_item)
+      end
     when 'carrying far too many items'
       waitrt?
       fput 'get skin from my bundle'
@@ -880,12 +886,16 @@ class SafetyProcess
   include DRCH
   include DRCT
 
-  def initialize(settings)
+  def initialize(settings, equipment_manager)
     echo('New SafetyProcess') if $debug_mode_ct
     Flags.add('ct-engaged', 'closes to pole weapon range on you', 'closes to melee range on you')
     Flags.add('ct-lodged', 'from the .* lodged in your (?<body_part>.*)\.')
+    # When you drop an item due to loss of hand, the phrase is "Your <item> falls to your feet." (do recovery logic)
+    # When you shoot or throw something, the phrase is "The <item> falls to your feet!" (normal mechanics)
+    Flags.add('ct-itemdropped', '^Your (?<item>.*) falls to your feet\.', '^You cannot maintain your grip on the (?<item>.*), and it falls to the ground!')
     Flags.add('ct-germshieldlost', 'It jerks the.* (?<shield>\w+) out of your hands')
     Flags.add('active-mitigation', 'You believe you could \b(?<action>\w+) out of the way of the \b(?<obstacle>\w+)')
+    @equipment_manager = equipment_manager
     @health_threshold = settings.health_threshold
     echo("  @health_threshold: #{@health_threshold}") if $debug_mode_ct
   end
@@ -908,23 +918,46 @@ class SafetyProcess
       recover_item(game_state, Flags['ct-germshieldlost'][:shield], 'wear')
       Flags.reset('ct-germshieldlost')
     end
+    if Flags['ct-itemdropped']
+      # You dropped an item because either your hand is too injured to hold it or stolen or *tingle*.
+      # Since one hand might be useless, free up the other hand so you can pick something up with it.
+      temp_left_item = DRC.left_hand
+      temp_right_item = DRC.right_hand
+      temp_item = [temp_left_item, temp_right_item].compact.first
+      if temp_item
+        # Put item away per gear config, but if not in your config then just put it away.
+        @equipment_manager.stow_weapon(temp_item) || DRCI.put_away_item?(temp_item)
+      end
+      # Try to recover the item you lost.
+      recover_item(game_state, Flags['ct-itemdropped'][:item], 'pickup')
+      Flags.reset('ct-itemdropped')
+      # If put an item away then get it back out.
+      if temp_item
+        @equipment_manager.wield_weapon(temp_item) || DRCI.get_item?(temp_item)
+        # In case the items end up in opposite hands, swap.
+        # This may do nothing if you have only one usable hand.
+        fput('swap') if (DRC.left_hand != temp_left_item && DRC.right_hand != temp_right_item)
+      end
+    end
   end
 
   def recover_item(game_state, item, action = 'pickup')
     return unless item
+    echo "*** Recovering #{item}"
+    recovered = false
     game_state.sheath_whirlwind_offhand
-    case bput("get #{item}", 'You pick up', 'What were you', 'too injured')
-    when 'What were you', 'too injured'
-      warn_failed_item_recovery(item)
-    when 'you pick up'
+    if DRCI.get_item_unsafe(item)
       case action
+      when 'pickup'
+        recovered = true
       when 'wear'
-        bput("wear my #{item}", 'You sling', 'You attach', 'You .* unload', 'You strap', 'You slide', 'You work your way into', 'You spin', 'You put', 'You carefully loop', 'slide effortlessly onto your', 'You slip', "^You .* #{item.short_regex}", /^You place/)
-        waitrt?
+        recovered = DRCI.wear_item?(item)
       when 'stow'
-        warn_failed_item_recovery(item) unless DRCI.put_away_item?(item)
+        recovered = @equipment_manager.stow_weapon(item) || DRCI.put_away_item?(item)
       end
     end
+    warn_failed_item_recovery(item) unless recovered
+    waitrt?
     game_state.wield_whirlwind_offhand
   end
 
@@ -3233,7 +3266,7 @@ class CombatTrainer
     @running = true
     $debug_mode_ct = UserVars.combat_trainer_debug || settings.debug_mode
     @game_state = GameState.new(settings, @equipment_manager)
-    @safety_process = SafetyProcess.new(settings)
+    @safety_process = SafetyProcess.new(settings, @equipment_manager)
     @combat_processes = make_processes(settings)
   end
 
@@ -4175,6 +4208,7 @@ before_dying do
   Flags.delete('ct-regalia-succeeded')
   Flags.delete('ct-powershot-ammo')
   Flags.delete('ct-germshieldlost')
+  Flags.delete('ct-itemdropped')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/common-items.lic
+++ b/common-items.lic
@@ -61,6 +61,7 @@ module DRCI
     /You need a free hand/,
     /needs to be tended to be removed/,
     /You can't pick that up with your hand that damaged/,
+    /Your (left|right) hand is too injured/,
     /You just can't/,
     /push you over the item limit/,
     /You stop as you realize the .* is not yours/,

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -169,6 +169,15 @@ class TestDRCI < Minitest::Test
     )
   end
 
+  def test_get_item__should_not_get_with_injured_hand
+    run_drci_command(
+      ["Your right hand is too injured to do that."],
+      'get_item?',
+      ["anything"],
+      [refute_result]
+    )
+  end
+
   def test_get_item__should_need_to_tend_wound
     run_drci_command(
       ["The crossbow bolt needs to be tended to be removed."],


### PR DESCRIPTION
### Background
* Fixes #4864
* Although `combat-trainer` has special handling for stowing weapons before casting sorcerous spells (since backlash can cause loss of hand and drop items) there are other situations where you lose a hand or arm and then drop the weapon (e.g. accumulation of wounds, disarmed by special attacks or debuffs, etc).

### Changes
* Update `SafetyProcess` to monitor for `"^Your (?<item>.*) falls to your feet\."` and `"^You cannot maintain your grip on the (?<item>.*), and it falls to the ground!"` then try to pick the item back up.
* Bonus: handle when can't skin because hands are full -- lower item in left hand, retry skinning, then pick it back up

## Tests

<details>
<summary>recover item that falls to your feet</summary>

```
> ,e item = "assassin's blade" ; fput("drop #{item}") ; DownstreamHook.run("Your #{item} falls to your feet.")

--- Lich: exec1 active.

[exec1]>drop assassin's blade

You drop a silversteel assassin's blade etched with sinuous pictograms.

> 
--- Lich: exec1 has exited.

[combat-trainer]>jab

Wouldn't it be better if you used a melee weapon?
> 
* Awkwardly, a zombie boar charges ahead and slashes at you.  You block with a demonscale shield tooled with a shadowy crest and secured by thornweave straps.  
[You're nimbly balanced and in dominating position.]
> 
[combat-trainer: *** Recovering assassin's blade]

[combat-trainer]>get assassin's blade 

You pick up a silversteel assassin's blade etched with sinuous pictograms.
```
</details>

<details>
<summary>recover item when you lose your grip</summary>

```
> ,e item = "rockwood tanbo" ; fput("drop #{item}") ; DownstreamHook.run("You cannot maintain your grip on the #{item}, and it falls to the ground!")

--- Lich: exec1 active.

[exec1]>drop rockwood tanbo

You drop a rockwood tanbo with polished darkstone tips.

>
--- Lich: exec1 has exited.

[combat-trainer]>feint

Wouldn't it be better if you used a melee weapon?
 
>
[combat-trainer: *** Recovering rockwood tanbo]

[combat-trainer]>get rockwood tanbo 

* Apparently without direction or thought, a zombie boar chomps fiercely at you.  You partially block with a demonscale shield tooled with a shadowy crest and secured by thornweave straps.  
[You're nimbly balanced and in good position.]
> 
You pick up a rockwood tanbo with polished darkstone tips.

> 
[combat-trainer]>feint

> 
< You feint a rockwood tanbo with polished darkstone tips at a zombie boar.  A zombie boar evades, barely managing to get out of the way.  
[You're nimbly balanced and in good position.]
[Roundtime 1 sec.]
```
</details>

<details>
<summary>retry skinning when both hands full</summary>

```
[combat-trainer]>skin
You must have one hand free to skin.

[combat-trainer]>lower ground left

You lower the book and place it on the ground at your feet.

[combat-trainer]>skin

Working deftly, you skillfully remove a rotting hoof from the remains of a zombie boar.  The task is difficult, but the rewards are worth it.
You carefully fit a rotting hoof into your bundle.
Roundtime: 2 sec.
R> 

[combat-trainer]>get my vault book 

You pick up the book lying at your feet.

[combat-trainer]>loot

You search the zombie boar.
You find nothing of interest.
```
</details>