### PR TITLE
[script] [tinker.lic] Removed if conditions from stow_item(part) on line 208.

### DIFF
--- a/tinker.lic
+++ b/tinker.lic
@@ -205,7 +205,7 @@ class Tinker
         bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'loop both ends', 'loop the string', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations', 'boltheads is not required to continue')
       end
     end
-    stow_item(part) if part.include?('mechanism') || part.include?('bolthead')
+    stow_item(part)
     get_item(tool)
   end
 


### PR DESCRIPTION
Was brought to my attention on Discord by Gorteous, https://discord.com/channels/745675889622384681/745675890242879671/848673759296749618, that bolt flights were not stowing if some were left in hand after assembly. I removed the conditional pieces from the line. When I added bolt creation, the `if part.include?('mechanism')` was already there so I added the or piece for bolthead(s). I never questioned why the mechanism was called out specifically but any part left in hand after assembly should get stowed. I could add `|| part.include?('flight')` if testing reveals why this line was specific. 