### PR TITLE
[script] [heal-remedy] Fix typo when drink remedy

### DIFF
--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -202,7 +202,7 @@ def eat_remedy?(remedy)
   when "better off trying to inhale"
     inhale_remedy?(remedy)
   when "better off trying to drink", "you should try drinking that?"
-    drink_remedy(remedy)
+    drink_remedy?(remedy)
   else
     false
   end


### PR DESCRIPTION
### Background
* Reported by [Sagadin](https://discord.com/channels/745675889622384681/745675890242879671/850405027814047764) in the Lich discord

```
[heal-remedy]>eat my ojhenik potion
You'd be better off trying to drink some vials of ojhenik potion.
>
--- Lich: error: undefined method `drink_remedy' for main:Object
Did you mean?  drink_remedy?
    heal-remedy:205:in `eat_remedy?'
    heal-remedy:180:in `block in herb_apply_scars'
```

### Changes
* Fix typo in the method call to `drink_remedy?`