### PR TITLE
[data] [base-town] Add nearby locksmith in Ain Ghazal

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -1196,8 +1196,9 @@ Hibarnhvidar:
     name: Vandorf
   npc_empath:
     id: 8881
-  locksmithing:
-    id:
+  locksmithing: # Ain Ghazal
+    id: 13190
+    name: Sephina
   theurgy_supplies:
     id:
   favor_altar:
@@ -1303,8 +1304,9 @@ Boar Clan:
     name: Gudthar
   npc_empath:
     id: 8881
-  locksmithing:
-    id:
+  locksmithing: # Ain Ghazal
+    id: 13190
+    name: Sephina
   theurgy_supplies:
     id:
   favor_altar:


### PR DESCRIPTION
### Background
* Requested by [Greyhallow](https://discord.com/channels/745675889622384681/745675890242879671/850559839863046175) in the Lich discord
* A F2P player whose hometown is set to **Boar Clan** was looking for how to configure `pick` to refill their lockpicks from a nearby locksmith.
* `base-town.yaml` does not have a locksmith room for either `Hibarnhvidar` nor `Boar Clan`.
* Greyhallow suggested the use of [Sephina's Lockbane](https://elanthipedia.play.net/Sephina%27s_Lockbane) in Ain Ghazal.

### Changes
* Add Sephina's Lockbane room `13190` as the locksmith location for `Hibarnhvidar` and `Boar Clan`.