### PR TITLE
[scripts] [common-arcana] Match string when not been trained in barbarian ability

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -82,7 +82,7 @@ module DRCA
     return true if DRSpells.active_spells[name]
     activated = false
     ability_data = get_data('spells').barb_abilities[name]
-    case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
+    case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'You have not been trained', 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
     when 'You must be unengaged'
       DRC.retreat
       activated = activate_barb_buff?(name, meditation_pause_timer)


### PR DESCRIPTION
### Background
* GM Javac [rolled out](http://forums.play.net/forums/DragonRealms/The%20Barbarians/General%20Discussions%20-%20Barbarians/view/6791) changes to Barbarian abilities and those characters have auto unlearned abilities and need to rechoose.
* Attempting to start a berserk/form/meditation/etc when you don't know it gives a "You have not been trained..." message.
* This match string is not handled by  `common-arcana` and you get the "no message found in 15 seconds" error.

### Changes
* Add match string for "You have not been trained" so scripts don't hang.