### PR TITLE
[script] [hunting-buddy] Add option for max searches for a room

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -185,14 +185,17 @@ module DRCT
     DRC.retreat(ignored_npcs)
   end
 
-  def find_empty_room(search_rooms, idle_room, predicate = nil, min_mana = 0, strict_mana = false)
+  def find_empty_room(search_rooms, idle_room, predicate = nil, min_mana = 0, strict_mana = false, max_search_attempts = Float::INFINITY)
+    search_attempt = 0
     check_mana = min_mana > 0
     loop do
+      search_attempt = search_attempt + 1
+      echo "*** Search attempt #{search_attempt} of #{max_search_attempts} to find a suitable room ***"
       found_empty = false
       search_rooms.each do |room_id|
         walk_to(room_id)
         pause 0.1 until room_id == Room.current.id
-        suitable_room = predicate ? predicate.call : (DRRoom.pcs - DRRoom.group_members).empty?
+        suitable_room = predicate ? predicate.call(search_attempt) : (DRRoom.pcs - DRRoom.group_members).empty?
         if suitable_room && check_mana && !DRStats.moon_mage?
           found_empty = true
           suitable_room = (DRCA.perc_mana >= min_mana)
@@ -208,14 +211,14 @@ module DRCT
 
       (check_mana = min_mana > 0) && !check_mana
 
-      if idle_room
+      if idle_room && search_attempt < max_search_attempts
         idle_room = idle_room.sample if idle_room.is_a?(Array)
         walk_to(idle_room)
         wait_time = rand(20..40)
-        echo "***Failed to find an empty room, pausing #{wait_time} sec***"
+        echo "*** Failed to find an empty room, pausing #{wait_time} seconds ***"
         pause wait_time
       else
-        echo '***Failed to find an empty room, stopping the search***'
+        echo '*** Failed to find an empty room, stopping the search ***'
         return false
       end
     end

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -208,10 +208,16 @@ class HuntingBuddy
     else
       @exit = nil
       find_empty_room(rooms, waiting_room,
-                      lambda do
+                      lambda do |search_attempt|
+                        # Skip room if has more people than your max limit
                         return false if DRRoom.pcs.size > @hunting_buddies_max
+                        # Skip if one of your nemesis is in the room
                         return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
+                        # Continue if one of your friends is in the room
                         return true if (DRRoom.pcs & UserVars.friends).any?
+                        # Continue if this is not the first search attempt and character will settle for "good enough" room
+                        return true if search_attempt > 1 && !@settings.hunting_room_strict_empty_or_buddies
+                        # Skip if anyone not in your group is in the room
                         return false if (DRRoom.pcs - DRRoom.group_members).any?
                         # No visible friends in the room and no visible people
                         UserVars.friends.each { |friend| Flags.add("room-check-#{friend}", friend) }
@@ -232,7 +238,9 @@ class HuntingBuddy
                         true
                       end,
                       @settings.hunting_room_min_mana,
-                      @settings.hunting_room_strict_mana)
+                      @settings.hunting_room_strict_mana,
+                      @settings.hunting_room_max_searches
+                    )
     end
 
     true

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -207,7 +207,7 @@ class HuntingBuddy
       @exit = [escort_info['area'], 'exit']
     else
       @exit = nil
-      find_empty_room(rooms, waiting_room,
+      return find_empty_room(rooms, waiting_room,
                       lambda do |search_attempt|
                         # Skip room if has more people than your max limit
                         return false if DRRoom.pcs.size > @hunting_buddies_max

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -208,39 +208,37 @@ class HuntingBuddy
     else
       @exit = nil
       return find_empty_room(rooms, waiting_room,
-                      lambda do |search_attempt|
-                        # Skip room if has more people than your max limit
-                        return false if DRRoom.pcs.size > @hunting_buddies_max
-                        # Skip if one of your nemesis is in the room
-                        return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
-                        # Continue if one of your friends is in the room
-                        return true if (DRRoom.pcs & UserVars.friends).any?
-                        # Continue if this is not the first search attempt and character will settle for "good enough" room
-                        return true if search_attempt > 1 && !@settings.hunting_room_strict_empty_or_buddies
-                        # Skip if anyone not in your group is in the room
-                        return false if (DRRoom.pcs - DRRoom.group_members).any?
-                        # No visible friends in the room and no visible people
-                        UserVars.friends.each { |friend| Flags.add("room-check-#{friend}", friend) }
-                        Flags.add('room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
-                        bput('search', 'roundtime')
-                        data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
-                        if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
-                          pause
-                          waitrt?
-                          return UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
-                        end
-                        fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
-                        20.times do |_|
-                          pause 0.5
-                          return true if UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
-                          return false if Flags['room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
-                        end
-                        true
-                      end,
-                      @settings.hunting_room_min_mana,
-                      @settings.hunting_room_strict_mana,
-                      @settings.hunting_room_max_searches
-                    )
+        lambda do |search_attempt|
+          # Skip room if has more people than your max limit
+          return false if DRRoom.pcs.size > @hunting_buddies_max
+          # Skip if one of your nemesis is in the room
+          return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
+          # Continue if one of your friends is in the room
+          return true if (DRRoom.pcs & UserVars.friends).any?
+          # Skip if anyone not in your group is in the room
+          return false if (DRRoom.pcs - DRRoom.group_members).any?
+          # No visible friends in the room and no visible people
+          UserVars.friends.each { |friend| Flags.add("room-check-#{friend}", friend) }
+          Flags.add('room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
+          bput('search', 'roundtime')
+          data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
+          if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
+            pause
+            waitrt?
+            return UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
+          end
+          fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
+          20.times do |_|
+            pause 0.5
+            return true if UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
+            return false if Flags['room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+          end
+          true
+        end,
+        @settings.hunting_room_min_mana,
+        @settings.hunting_room_strict_mana,
+        @settings.hunting_room_max_searches
+      )
     end
 
     true

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -334,6 +334,28 @@ prehunt_buffing_room:
 # Minimum perc mana to look for in a hunting room. If hunting_room_strict_mana is true, then it will skip a hunt if it can't find the mana
 hunting_room_min_mana: 0
 hunting_room_strict_mana: false
+# When looking for a room to hunt in,
+# try to find one that's empty or only has your buddies in it.
+#
+# Set this to false if when no ideal hunting room can be found,
+# such as an empty room or rooms with just your hunting buddies,
+# you'll hunt in a room with other players so long as none of
+# your nemesis are in the room and the player count doesn't
+# exceed your hunting buddies max limit.
+#
+# This is similar to `hunting_room_strict_mana` where it tries
+# to find a room with your mana preference, but may have to settle
+# on a less ideal room unless your preference must be satisfied.
+hunting_room_strict_empty_or_buddies: true
+# When unable to find a room to hunt in,
+# hunting-buddy will run back to a safe room and wait 20-40 seconds
+# before returning to the hunting zone to look for a room again.
+# How many times should hunting-buddy revist the area to look for
+# a suitable hunting room before ultimately giving up?
+#
+# Note, this is not the number of physical rooms to be checked.
+# This is the number of times to wait then revisit the area to find a room.
+hunting_room_max_searches: 30
 hunting_file_list:
 stop_on_low_threshold: 2
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -334,25 +334,11 @@ prehunt_buffing_room:
 # Minimum perc mana to look for in a hunting room. If hunting_room_strict_mana is true, then it will skip a hunt if it can't find the mana
 hunting_room_min_mana: 0
 hunting_room_strict_mana: false
-# When looking for a room to hunt in,
-# try to find one that's empty or only has your buddies in it.
-#
-# Set this to false if when no ideal hunting room can be found,
-# such as an empty room or rooms with just your hunting buddies,
-# you'll hunt in a room with other players so long as none of
-# your nemesis are in the room and the player count doesn't
-# exceed your hunting buddies max limit.
-#
-# This is similar to `hunting_room_strict_mana` where it tries
-# to find a room with your mana preference, but may have to settle
-# on a less ideal room unless your preference must be satisfied.
-hunting_room_strict_empty_or_buddies: true
 # When unable to find a room to hunt in,
 # hunting-buddy will run back to a safe room and wait 20-40 seconds
 # before returning to the hunting zone to look for a room again.
 # How many times should hunting-buddy revist the area to look for
 # a suitable hunting room before ultimately giving up?
-#
 # Note, this is not the number of physical rooms to be checked.
 # This is the number of times to wait then revisit the area to find a room.
 hunting_room_max_searches: 30


### PR DESCRIPTION
_(Note, per feedback the option to hunt with people not in your buddies list has been removed. The description has been updated to that effect.)_

### Background
* When `hunting-buddy` cannot find a suitable hunting room then it will go back to your safe room and wait 20-40 seconds then return to the area and look for a room again.
* This loop runs forever until a suitable room opens up, which could take several minutes or never happen.
* It would be nice to have an upper limit to the number of times the script will scan an area for a suitable room before giving up. Secondary and tertiary hunting zones can be configured for other places to check per the `zone:` property on `hunting_info:` as shown in [Dartellum's example](https://github.com/rpherbig/dr-scripts/pull/4993#issuecomment-855422270).


### Changes
* Update `common-travel`'s `find_empty_room` method to
  - accept a new `max_search_attempts` parameter (number, default to infinity) and after N passes of the hunting zone and no suitable room has been found then break out of the loop
  - pass a counter as new argument to the predicate so that it can take into consideration how many times the character has tried to search for a suitable room (i.e. is this the first pass through the area? the second? the third?)
* Update `hunting-buddy`'s `find_hunting_room?` method to
  - include comments in the predicate lambda for its true/false decisions
  - `return` the result of calling `find_empty_room(..)` to fix bug that when no suitable room is found (after exhausting max searches or if no idle room) that you'd begin hunting in the first room of the hunting area no matter what. With this fix you'll return to your safe room and hunting-buddy will exit rather than hunting in a random room.

### Configuration
_base.yaml_
```yaml
# When unable to find a room to hunt in,
# hunting-buddy will run back to a safe room and wait 20-40 seconds
# before returning to the hunting zone to look for a room again.
# How many times should hunting-buddy revist the area to look for
# a suitable hunting room before ultimately giving up?
# Note, this is not the number of physical rooms to be checked.
# This is the number of times to wait then revisit the area to find a room.
hunting_room_max_searches: 30
```
