### PR TITLE
[script] [common-items] Add match strings (wear/open/close)

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -198,6 +198,7 @@ module DRCI
 
   @@open_container_success_patterns = [
     /^You open/,
+    /^You slowly open/,
     /^You unbutton/,
     /^That is already open/,
     /^You spread your arms, carefully holding your bag well away from your body/
@@ -216,6 +217,7 @@ module DRCI
 
   @@close_container_success_patterns = [
     /^You close/,
+    /^You quickly close/,
     /^You pull/,
     /^That is already closed/
   ]

--- a/common-items.lic
+++ b/common-items.lic
@@ -74,6 +74,7 @@ module DRCI
 
   @@wear_item_success_patterns = [
     /You put/,
+    /You pull/,
     /You sling/,
     /You attach/,
     /You strap/,

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -66,6 +66,15 @@ class TestDRCI < Minitest::Test
     )
   end
 
+  def test_wear_item__you_pull
+    run_drci_command(
+      ["You pull the chain balaclava over your head, tugging at the links to smooth them into optimal coverage."],
+      'wear_item?',
+      ["chain balaclava"],
+      [assert_result]
+    )
+  end
+
   #########################################
   # GET ITEM
   #########################################

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -337,6 +337,15 @@ class TestDRCI < Minitest::Test
   # OPEN CONTAINER
   #########################################
 
+  def test_open_container__should_slowly_open
+    run_drci_command(
+      ["You slowly open some dark encompassing shadows, glancing around suspiciously."],
+      'open_container?',
+      ["shadows"],
+      [assert_result]
+    )
+  end
+
   def test_open_container__should_unbutton
     run_drci_command(
       ["You unbutton the flap of your satchel, pulling it open to reveal the contents."],
@@ -490,6 +499,15 @@ class TestDRCI < Minitest::Test
       ["You close your medicine pouch."],
       'close_container?',
       ["medicine pouch"],
+      [assert_result]
+    )
+  end
+
+  def test_close_container__should_quickly_close
+    run_drci_command(
+      ["You quickly close your bag."],
+      'close_container?',
+      ["bag"],
       [assert_result]
     )
   end


### PR DESCRIPTION
### Background
* As a human wearing `heavy chain balaclava with wide accents resembling flaming phoenix wings`, I got the message "You pull the chain balaclava over your head, tugging at the links to smooth them into optimal coverage." but `You pull` was not a match string yet.

### Changes
* Add `You pull` as success pattern for wearing an item
* Add `You quickly close` as success pattern for closing a container
* Add `You slowly open` as success pattern for opening a container

## Tests
See `test\test_common_items.rb`