### PR TITLE
[script] [common-arcana] Handle when character doesn't know magic or spell being prepared

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -127,7 +127,7 @@ module DRCA
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
       return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
-    when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now'
+    when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now', 'You have yet to receive any training in the magical arts'
       DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
       return false
     when 'Well, that was fun'

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -116,7 +116,7 @@ module DRCA
   def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false, runestone_name = nil, runestone_tm = false)
     return false unless abbrev
 
-    DRC.bput('prep symb', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
+    DRC.bput('prepare symbiosis', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 
     if runestone_name.nil?
       match = DRC.bput("#{command} #{abbrev} #{mana}", get_data('spells').prep_messages)
@@ -128,7 +128,7 @@ module DRCA
       pause 1
       return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
     when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now', 'You have no idea how to cast that spell', 'You have yet to receive any training in the magical arts'
-      DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
+      DRC.bput('release symbiosis', 'You release the', 'But you haven\'t') if symbiosis
       return false
     when 'Well, that was fun'
       DRCI.dispose_trash(runestone_name)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -127,7 +127,7 @@ module DRCA
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
       return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
-    when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now', 'You have yet to receive any training in the magical arts'
+    when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now', 'You have no idea how to cast that spell', 'You have yet to receive any training in the magical arts'
       DRC.bput('rel symb', 'You release the', 'But you haven\'t') if symbiosis
       return false
     when 'Well, that was fun'

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -115,6 +115,8 @@ prep_messages:
 - You are now prepared to cast
 - You already have a cantrip prepared!
 - Invoke what
+- You have yet to receive any training in the magical arts
+- You have no idea how to cast that spell
 
 cast_messages:
 - You clench your fists


### PR DESCRIPTION
### Background
* Commoners and characters that don't know spells may get error messages trying to prepare one which aren't currently match strings in `common-arcana`.

```
> prep justice
You have no idea how to cast that spell.

> discern y'ntrel
You have no idea how to cast that spell.

[buff]>prep CV 1
You have yet to receive any training in the magical arts.
```

### Changes
* Add `'You have no idea how to cast that spell', 'You have yet to receive any training in the magical arts'` as prepare failure messages
* For clarity, spell out `prepare symbiosis` and `release symbiosis`