### PR TITLE
Support Worn Trashcans

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -253,7 +253,7 @@ module DRCI
     return if item.nil?
 
     if worn_trashcan
-      case DRC.bput("put my #{item} in my #{worn_trashcan}", @@drop_trash_success_patterns, @@drop_trash_failure_patterns, @@drop_trash_retry_patterns)
+      case DRC.bput("put my #{item} in my #{worn_trashcan}", @@drop_trash_retry_patterns, @@drop_trash_success_patterns, @@drop_trash_failure_patterns)
       when *@@drop_trash_retry_patterns
         return true if dispose_trash(item, worn_trashcan, worn_trashcan_verb)
       when *@@drop_trash_success_patterns

--- a/common-items.lic
+++ b/common-items.lic
@@ -47,6 +47,12 @@ module DRCI
     /perhaps try doing that again/
   ]
 
+  @@worn_trashcan_verb_patterns = [
+    /You drum your fingers/,
+    /You pull a lever/,
+    /You poke your finger around/
+  ]
+
   @@get_item_success_patterns = [
     /You get/,
     /You pick/,
@@ -243,8 +249,20 @@ module DRCI
   # TRASH ITEM
   #########################################
 
-  def dispose_trash(item)
+  def dispose_trash(item, worn_trashcan = nil, worn_trashcan_verb = nil)
     return if item.nil?
+
+    if worn_trashcan
+      case DRC.bput("put my #{item} in my #{worn_trashcan}", @@drop_trash_success_patterns, @@drop_trash_failure_patterns, @@drop_trash_retry_patterns)
+      when *@@drop_trash_retry_patterns
+        return true if dispose_trash(item, worn_trashcan, worn_trashcan_verb)
+      when *@@drop_trash_success_patterns
+        DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *@@worn_trashcan_verb_patterns)
+        DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *@@worn_trashcan_verb_patterns)
+        return true
+      end
+    end
+
     trashcans = DRRoom.room_objs
                       .reject { |obj| obj =~ /azure \w+ tree/ }
                       .map { |long_name| DRC.get_noun(long_name) }
@@ -277,6 +295,7 @@ module DRCI
         return true
       end
     end
+
     # No trash bins or not able to put item in a bin, just drop it.
     case DRC.bput("drop my #{item}", @@drop_trash_success_patterns, @@drop_trash_failure_patterns, @@drop_trash_retry_patterns)
     when *@@drop_trash_retry_patterns

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -263,8 +263,45 @@ class TestDRCI < Minitest::Test
   # DISPOSE TRASH
   #########################################
 
-  def test_dispose_trash_in_bin
-    # TODO get test coverage for various trash bins
+  def test_dispose_trash__early_exit__no_item
+    run_drci_command(
+      [
+      ],
+      'dispose_trash',
+      [nil],
+      [refute_result]
+    )
+  end
+
+  def test_dispose_trash__worn_trashcan__retries
+    run_drci_command(
+      [
+        'perhaps try doing that again',
+        'You drop a rock into a portable silversteel bucket with a flared rim.  Glancing inside, you notice the item being swirled in a whirlpool before dropping to the bottom of the bucket.',
+        'You drum your fingers on the bucket rhythmically.',
+        '[OOC: TAP the bucket again within the next 30 seconds to flush it.].',
+        'You drum your fingers on the bucket rhythmically.',
+        'After a moment, a dull THUD echoes from within the bucket.'
+      ],
+      'dispose_trash',
+      ["rock", "silversteel bucket", "tap"],
+      [assert_result]
+    )
+  end
+
+  def test_dispose_trash__worn_trashcan__happy_path
+    run_drci_command(
+      [
+        'You drop a rock into a portable silversteel bucket with a flared rim.  Glancing inside, you notice the item being swirled in a whirlpool before dropping to the bottom of the bucket.',
+        'You drum your fingers on the bucket rhythmically.',
+        '[OOC: TAP the bucket again within the next 30 seconds to flush it.].',
+        'You drum your fingers on the bucket rhythmically.',
+        'After a moment, a dull THUD echoes from within the bucket.'
+      ],
+      'dispose_trash',
+      ["rock", "silversteel bucket", "tap"],
+      [assert_result]
+    )
   end
 
   def test_dispose_trash__should_drop_ocarina_on_ground


### PR DESCRIPTION
Adding common-support so that scripts can use worn trashcans if they want to.

Opening this PR as a draft so people with trashcans can test it. I don't own one, personally, but it has been mentioned several times and Skinz requested it again recently for lockpicking speedup (not dismantling).