### PR TITLE
Vault room name is wrong for Shard

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -588,7 +588,7 @@ vault_titles = {
   "Muspar'i"           => ["[[Muspar'i, Carousel Square]]"],
   "Ratha"              => ["[[Ratha, Carousel Square]]"],
   "Riverhaven"         => ["[[Riverhaven, Carousel Chamber]]"],
-  "Shard"              => ["[[Shard, Carousel Square]]"],
+  "Shard"              => ["[[Shard, Carousel Chamber]]"],
   "Therenborough"      => ["[[Therenborough, Carousel Square]]"]
 }
 #


### PR DESCRIPTION
```
>go door
[Shard, Carousel Chamber]
A sturdy vault, set in the back wall...
```