### PR TITLE
[script] [common-healing] Fix parsing for 'tail' bleeders

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -194,7 +194,7 @@ module DRCH
   # are the severity and the values are the list of bleeding wounds.
   def parse_bleeders(health_lines)
     bleeders = Hash.new { |h, k| h[k] = [] }
-    bleeder_line_regex = /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg)\b/
+    bleeder_line_regex = /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg|tail)\b/
     if health_lines.grep(/^Bleeding|^\s*\bArea\s+Rate\b/).any?
       health_lines
         .drop_while { |line| !(bleeder_line_regex =~ line) }
@@ -208,7 +208,7 @@ module DRCH
           # Internal bleeders use the abbreviations.
           body_part = body_part.gsub('l.', 'left').gsub('r.', 'right')
           # Check for the bleeding severity.
-          bleed_rate = /(?:head|eye|neck|chest|abdomen|back|arm|hand|leg)\s+(.+)/.match(line)[1]
+          bleed_rate = /(?:head|eye|neck|chest|abdomen|back|arm|hand|leg|tail)\s+(.+)/.match(line)[1]
           severity = $DRCH_BLEED_RATE_TO_SEVERITY_MAP[bleed_rate][:severity]
           # Check if internal or not. Want an actual boolean result here, not just "truthy/falsey".
           is_internal = line =~ /^inside/ ? true : false

--- a/test/test_check_health.rb
+++ b/test/test_check_health.rb
@@ -14,6 +14,10 @@ class TestCheckHealth < Minitest::Test
     @test.join if @test
   end
 
+  def assert_bleeding
+    proc { |health| assert_equal(false, health['bleeders'].empty?, 'Person is bleeding but reported as not bleeding') }
+  end
+
   def assert_wounded
     proc { |health| assert_equal(false, health['wounds'].empty?, 'Person is wounded but reported as not wounded') }
   end
@@ -59,6 +63,19 @@ class TestCheckHealth < Minitest::Test
       assertions = [assertions] unless assertions.is_a?(Array)
       assertions.each { |assertion| assertion.call(health_result) }
     end)
+  end
+
+  def test_that_tail_is_bleeding
+    messages = [
+      'Your body feels slightly battered.',
+      'Your spirit feels full of life.',
+      'You have deep cuts across the tail.',
+      'Bleeding',
+      '            Area       Rate',
+      '-----------------------------------------',
+      '            tail       slight'
+    ]
+    check_health_with_buffer(messages, [assert_wounded, assert_bleeding])
   end
 
   def test_that_wounded_person_is_wounded


### PR DESCRIPTION
### Background
* Reported by Moiyra on Lnet that `tendme` was not tending their tail bleeders.
* Upon investigation, the `tail` body part was not part of any of the regex patterns (oops!)

### Changes
* Add `tail` to the bleeder regex body part patterns

## Tests
See `test/test_check_health.rb`, and also Moiyra confirmed the fix.