### PR TITLE
[script] [buff-watcher] [wand-watcher] Fix "You glance down" regex and use DRCI methods

### DIFF
--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -62,7 +62,7 @@ class BuffWatcher
 
     # Free up a hand in case you use held cambrinth
     unless DRStats.thief? || DRStats.barbarian? || !use_stored_cambrinth?
-      if /nothing in your left hand\.$|at your empty hands\.$/ !~ DRC.bput('glance', 'You glance down')
+      if /nothing in your left hand\.$|at your empty hands\.$/ !~ DRC.bput('glance', /You glance down .*/)
         # If both hands are full, store the left hand item in a variable for future
         # use and lower the left hand to the feet slot.
         # - Left causes less problems with combat (less likely to be a loaded weapon)

--- a/test/test_buff_watcher.rb
+++ b/test/test_buff_watcher.rb
@@ -539,7 +539,7 @@ class TestBuffWatcher < Minitest::Test
     fake_drci.expect(:lower_item?, true, ['backpack'])
     fake_drci.expect(:get_item?, true, ['backpack'])
 
-    fake_drc.expect(:bput, "You glance down to see a reed-woven basket in your right hand and a rugged yellow backpack in your left hand.", ['glance', 'You glance down'])
+    fake_drc.expect(:bput, "You glance down to see a reed-woven basket in your right hand and a rugged yellow backpack in your left hand.", ['glance', /You glance down .*/])
 
     on_script_start_hook = proc do |thread|
       # Let the buff watcher's passive loop run a bit then kill the script.
@@ -602,7 +602,7 @@ class TestBuffWatcher < Minitest::Test
       end
     end
 
-    fake_drc.expect(:bput, "You glance down to see a reed-woven basket in your right hand and nothing in your left hand.", ['glance', 'You glance down'])
+    fake_drc.expect(:bput, "You glance down to see a reed-woven basket in your right hand and nothing in your left hand.", ['glance', /You glance down .*/])
 
     on_script_start_hook = proc do |thread|
       # Let the buff watcher's passive loop run a bit then kill the script.

--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -96,14 +96,15 @@ class WandWatcher
     scripts_to_unpause = smart_pause_all
     temp_left_item = nil    
     waitrt?
-    if /nothing in your left hand\.$|at your empty hands\.$/ !~ bput('glance','You glance down')
+
+    if /nothing in your left hand\.$|at your empty hands\.$/ !~ bput('glance', /You glance down .*/)
       # If both hands are full, store the left hand item in a variable for future 
       # use and lower the left hand to the feet slot.  
       # - Left causes less problems with combat (less likely to be a loaded weapon)
       # - Feet slot causes less space/correct container issues
       if DRC.right_hand && DRC.left_hand
         temp_left_item = DRC.left_hand
-        temp_left_item = nil if /^You lower/ !~ bput("lower ground left",/^You lower/,"But you aren't holding anything in your left hand")
+        temp_left_item = nil unless DRCI.lower_item?(DRC.left_hand)
       end
     end
 
@@ -128,7 +129,7 @@ class WandWatcher
       # - or it's not in the right container
       # - or you simply don't have them
       # message the user, and remove the wand from the list of wands checked
-      if !get_item("#{$ORDINALS[count]} #{wand}",container)
+      if !DRCI.get_item?("#{$ORDINALS[count]} #{wand}",container)
         message "Could not find correct number of wands for #{wand} in #{container}."
         message "Double check your wand name, count, and container settings." 
         message "Removing this wand from the list."
@@ -144,7 +145,7 @@ class WandWatcher
       when *@activation_failure_messages
         # If activation fails, could just be a sort issue due login:
         # retry, until you succeed, or run out of wands
-        put_away_item?(wand,container)
+        DRCI.put_away_item?(wand,container)
         redo_count += 1
         redo unless redo_count > count
         # If you run out of wands to try, set next attempt to be 1/2 the cooldown time
@@ -174,12 +175,12 @@ class WandWatcher
       end
 
       # Put away the wand and reset the redo counter for next wand
-      put_away_item?(wand,container)
+      DRCI.put_away_item?(wand,container)
       redo_count = 0
     end
 
     # Pick item back up if you lowered something
-    bput("get #{temp_left_item}",/^You pick up/) if temp_left_item != nil
+    DRCI.get_item?(temp_left_item) if temp_left_item
 
     # Resume scripts
     unpause_all_list(scripts_to_unpause)


### PR DESCRIPTION
### Background
* The `bput` command returns only a portion of a game response message that matches exactly one of the patterns passed to it.
* Both `wand-watcher` and `buff-watcher` use the phrase 'You glance down' as a match string but then check if the matched result contains other specific phrases.
* Because of how `bput` works, the expression `/nothing in your left hand\.$|at your empty hands\.$/` never matches the returned result, which would only be the exact text "You glance down", so the code always goes down that path (which means the condition is superfluous)
* It's not really an issue per se because the code in that block has another check if things are in your hands and does the needful. But it is a bug insomuch as the `bput` command is not returning what the code _thinks_ it's doing.

### Changes
* `wand-watcher`
  - Change "You glance down" to capture the rest of the line => `/You glance down .*/`
* `buff-watcher`
  - Change "You glance down" to capture the rest of the line => `/You glance down .*/`
  - Use `DRCI` prefix on calls to methods in `common-items`
  - Use `DRCI` methods to lower/pickup the item in the character's left hand