### PR TITLE
[script] [restock] Support 'container' property for where a restocked item goes

### DIFF
--- a/restock.lic
+++ b/restock.lic
@@ -31,9 +31,9 @@ class Restock
 
     item_list.each do |item|
       remaining = if item['stackable']
-                    count_stackable_item(item['name'])
+                    count_stackable_item(item)
                   else
-                    count_nonstackable_item(item['name'])
+                    count_nonstackable_item(item)
                   end
       next unless remaining < item['quantity']
       num_needed = item['quantity'] - remaining
@@ -91,12 +91,12 @@ class Restock
   def count_stackable_item(item)
     count = 0
     $ORDINALS.each do |ordinal|
-      count_msg = bput("count my #{ordinal} #{item}", 'I could not find what you were referring to.', 'tell you much of anything.', 'and see there \w+ .+ left.')
+      count_msg = bput("count my #{ordinal} #{item['name']}", 'I could not find what you were referring to.', 'tell you much of anything.', 'and see there \w+ .+ left.')
       case count_msg
       when 'I could not find what you were referring to.'
         break
       when 'tell you much of anything.'
-        echo "#{item} is marked as stackable but is not!"
+        echo "#{item['name']} is marked as stackable but is not!"
         count += count_nonstackable_item(item)
         break
       else
@@ -109,15 +109,19 @@ class Restock
   end
 
   def count_nonstackable_item(item)
-    /inside your (.*).|I could not find/ =~ bput("tap my #{item}", 'inside your (.*).', 'I could not find')
-    tap_result = Regexp.last_match(1)
-    return 0 if tap_result.nil?
-    container = tap_result
-    count_items_in_container(item, container)
+    container = item['container']
+    unless container
+      /inside your (.*).|I could not find/ =~ bput("tap my #{item['name']}", 'inside your (.*).', 'I could not find')
+      tap_result = Regexp.last_match(1)
+      return 0 if tap_result.nil?
+      container = tap_result
+    end
+    count_items_in_container(item['name'], container)
   end
 
   def valid_item_data?(item_data)
     %w[name size room price stackable quantity].all? { |x| item_data.key?(x) }
   end
 end
+
 Restock.new


### PR DESCRIPTION
### Background
* `restock` determines which container to count existing inventory in by tapping items
* Some containers have 3 words, like "shadowy black pack"; however, the container can only be referenced in commands by 2 words: its adjective and its noun
* In these instances, `restock` fails to count an item because it uses the wrong phrase (all 3 words) to refer to the container

```
[restock]>tap my brass razor
You tap a steel-bladed brass razor inside your shadowy black pack.
>
[restock]>rummage /C razor IN MY shadowy black pack
I don't know what you are referring to.
```

### Changes
* Fixes #4914
* Support new, optional `container` property on items in the `restock` yaml configuration. Useful if it's ambiguous or complex to determine the `<adj> + <noun>` of a container when tapping an item inside of it.

### Example Configuration
```yaml
restock:
  razor:
    quantity: 15
    container: red quiver
  bolt:
    quantity: 15
```