### PR TITLE
[script] [spellmonitor] Parse apprenticeship spells (Ease Burden, Manifest Force, etc)

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -203,11 +203,12 @@ known_spells_hook = proc do |server_string|
     DRSpells.known_spells.clear()
     DRSpells.known_feats.clear()
     server_string = nil if DRSpells.silence_known_spells_hook
-  when /^In the chapter entitled|^You have temporarily memorized/
+  when /^In the chapter entitled|^You have temporarily memorized|^From your apprenticeship you remember practicing/
     if DRSpells.grabbing_known_spells
       server_string
         .sub(/^In the chapter entitled "[\w\s\'-]+", you have notes on the /, '')
         .sub(/^You have temporarily memorized the /, '')
+        .sub(/^From your apprenticeship you remember practicing with the /, '')
         .sub(/ spells?\./, '')
         .sub(/,? and /, ',')
         .split(',')

--- a/test/test_spellmonitor.rb
+++ b/test/test_spellmonitor.rb
@@ -77,6 +77,7 @@ class TestSpellMonitor < Minitest::Test
   def test_detect_known_spells
     messages = [
       "You recall the spells you have learned from your training.",
+      "From your apprenticeship you remember practicing with the Burden, Ease Burden [ease], Manifest Force [maf], and Strange Arrow [stra] spells.",
       "In the chapter entitled \"Perception\", you have notes on the Clear Vision [cv], Piercing Gaze [pg], Locate, Seer's Sense [seer], and Aura Sight [aus] spells.",
       "In the chapter entitled \"Psychic Projection\", you have notes on the Calm, Telekinetic Throw [tkt], Telekinetic Storm [tks], and Psychic Shield [psy] spells.",
       "In the chapter entitled \"Moonlight Manipulation\", you have notes on the Shadows, Focus Moonbeam [fm], Dazzle, Refractive Field [rf], Burn, Moonblade, Dinazen Olkar [do], Shape Moonblade [shmo], Cage of Light [col], and Shift Moonbeam [sm] spells.",
@@ -91,6 +92,10 @@ class TestSpellMonitor < Minitest::Test
     ]
     run_downstream_hook(messages, [
       # Spells
+      assert_know_spell('Burden', true),
+      assert_know_spell('Ease Burden', true),
+      assert_know_spell('Manifest Force', true),
+      assert_know_spell('Strange Arrow', true),
       assert_know_spell("Bless", false),
       assert_know_spell("Clear Vision", true),
       assert_know_spell("Locate", true),


### PR DESCRIPTION
### Background
* Reported by @wstampley 
* Magic users under circle 10 have access to analogous patterns but the spells are not currently parsed by `spellmonitor`

```
From your apprenticeship you remember practicing with the Burden, Ease Burden [ease], Manifest Force [maf], and Strange Arrow [stra] spells.
```

### Changes
* Parse apprenticeship spells and silence that output when `spellmonitor` is parsing the data

## Tests
* See `test/test_spellmonitor.rb`