### PR TITLE
Remove Absolution Expire Data

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -421,7 +421,6 @@ spell_data:
     harmless: true
     abbrev: Absolution
     mana: 150
-    expire: As the Absolution spell fails, you feel your connection to the world renew and sharpen once again
     before:
     - message: release gol
       matches:


### PR DESCRIPTION
Reverting the expire message for Absolution. Apparently it causes problems for some people who buff certain ways.

@BinuDR
