### PR TITLE
[script] [equipmanager] Unload ranged weapons before putting away

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -321,9 +321,9 @@ module DRC
   # Items class. Name is the noun of the object. Leather/metal boolean. Is the item worn (defaults to true). Does it hinder lockpicking? (false)
   # Item.new(name:'gloves', leather:true, worn:true, hinders_locks:true, adjective:'ring', bound:true)
   class Item
-    attr_accessor :name, :leather, :worn, :hinders_lockpicking, :container, :swappable, :tie_to, :adjective, :bound, :wield, :transforms_to, :transform_verb, :transform_text, :lodges, :skip_repair
+    attr_accessor :name, :leather, :worn, :hinders_lockpicking, :container, :swappable, :tie_to, :adjective, :bound, :wield, :transforms_to, :transform_verb, :transform_text, :lodges, :skip_repair, :ranged
 
-    def initialize(name: nil, leather: nil, worn: false, hinders_locks: nil, container: nil, swappable: false, tie_to: nil, adjective: nil, bound: false, wield: false, transforms_to: nil, transform_text: nil, transform_verb: nil, lodges: true, skip_repair: false)
+    def initialize(name: nil, leather: nil, worn: false, hinders_locks: nil, container: nil, swappable: false, tie_to: nil, adjective: nil, bound: false, wield: false, transforms_to: nil, transform_text: nil, transform_verb: nil, lodges: true, skip_repair: false, ranged: false)
       @name = name
       @leather = leather
       @worn = worn
@@ -339,6 +339,7 @@ module DRC
       @transform_text = transform_text
       @lodges = lodges.nil? ? true : lodges
       @skip_repair = skip_repair
+      @ranged = ranged.nil? ? false : ranged
     end
 
     def short_name

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -18,7 +18,7 @@ class EquipmentManager
     @gear_sets = {}
     settings.gear_sets.each { |set_name, gear_list| @gear_sets[set_name] = gear_list.flatten.uniq }
     @sort_head = settings.sort_auto_head
-    @items = settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound], wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text], lodges: item[:lodges], skip_repair: item[:skip_repair], container: item[:container]) }
+    @items = settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound], wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text], lodges: item[:lodges], ranged: item[:ranged], skip_repair: item[:skip_repair], container: item[:container]) }
   end
 
   def remove_gear_by(&_block)
@@ -443,11 +443,11 @@ class EquipmentManager
     end
     weapon = item_by_desc(description)
     return unless weapon
+    unload_weapon(weapon.short_name) if is_ranged_weapon?(weapon)
     if weapon.wield
-      stow_helper("sheath my #{weapon.short_name}", weapon.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'close the fan', 'You secure your', 'You slip', 'You hang', 'You strap', "You don't seem to be able to move", 'You easily strap', 'is too small to hold that', 'With a flick of your wrist you stealthily sheathe', '^The .* slides easily', "There's no room")
+      stow_helper("sheath my #{weapon.short_name}", weapon.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'close the fan', 'You secure your', 'You slip', 'You hang', 'You strap', "You don't seem to be able to move", 'You easily strap', 'is too small to hold that', 'With a flick of your wrist you stealthily sheathe', '^The .* slides easily', "There's no room", "Sheathe your .* where?")
     elsif weapon.worn
-      unload_weapon(weapon.short_name)
-      stow_helper("wear my #{weapon.short_name}", weapon.short_name, 'You sling', 'You attach', 'You .* unload', 'You slide', 'You place', 'close the fan', 'You hang', 'You spin', 'You strap', 'You put', 'You carefully loop', "You don't seem to be able to move", "You are already wearing")
+      stow_helper("wear my #{weapon.short_name}", weapon.short_name, 'You sling', 'You attach', 'You .* unload', 'You slide', 'You place', 'close the fan', 'You hang', 'You spin', 'You strap', 'You put', 'You carefully loop', "You don't seem to be able to move", "You are already wearing", "You work your way into")
     elsif !weapon.tie_to.nil?
       stow_helper("tie my #{weapon.short_name} to my #{weapon.tie_to}", weapon.short_name, 'You attach', 'close the fan', 'you tie', 'You are a little too busy', "You don't seem to be able to move", 'Your wounds hinder your ability to do that')
     elsif weapon.transforms_to
@@ -477,8 +477,23 @@ class EquipmentManager
     when /is too small to hold that/
       fput("swap my #{weapon_name}")
       stow_helper(action, weapon_name, accept_strings)
-    when /Your wounds hinder your ability to do that/
+    when /Your wounds hinder your ability to do that/, /Sheathe your .* where/
       stow_helper("stow my #{weapon_name}", weapon_name, 'You put', 'You should unload', 'You easily strap', 'You secure your')
     end
+  end
+
+  # Is the weapon noun likely to be a ranged weapon?
+  # This is an optimization attempt so that the script
+  # isn't trying to unload every weapon that gets put away.
+  # Would be silly to try "unload my scimitar" wouldn't it? :grins:
+  def is_ranged_weapon?(item)
+    return false if item.nil? || item.name.nil?
+    return true if item.ranged
+    # Common weapon names
+    return item.name =~ /^(bow|shortbow|longbow|crossbow|stonebow|latchbow|slurbow|lockbow|pelletbow|arbalest|sling|slingshot|blowgun)$/i
+    # Gamgweth or racial weapon names
+    # https://elanthipedia.play.net/Genie_racial_language_item_subs
+    # https://elanthipedia.play.net/Category:Language_Book
+    return item.name =~ /^(jranoki|uku'uan|uku'uanstaho|chunenguti|hhr'ibu|guti|mahil|taisgwelduan|chyeb|sverfil|tangara|alaer|kari|wami|usus|srigos|href|vrope|falocisana|stof|dzelt)$/i
   end
 end


### PR DESCRIPTION
### Background
* Reported by [DMAN](https://discord.com/channels/745675889622384681/745675890242879671/854908277951561758) in the Lich discord
* The phrase "There's no room in the harness." is not a match string when stowing weapons and causing script to hang
* The phrase "Sheathe your {weapon} where?" is not a match string when sheathing weapons and causing script to hang
* `equipmanager` script currently only tries to unload a weapon when you wear it but would be better if it always unloaded ranged weapons to better handle edge cases where trying to put away a loaded weapon causes one grief

### Changes
* Fixes #4911

## Tests

<details>
<summary>unload longbow before wearing</summary>

```
> ,e em = EquipmentManager.new ; em.stow_weapon("assassin's longbow")

--- Lich: exec1 active.

[exec1]>unload my assassin's.longbow

You unload the longbow.
Roundtime: 1 seconds.
> 
[exec1]>stow left

You put your arrow in your black quiver.
> 
[exec1]>wear my assassin's.longbow

You sling a tenebrous demonbone-backed assassin's longbow adorned with serrated tips over your shoulder.
> 
--- Lich: exec1 has exited.
```
</details>

<details>
<summary>unload sling before stowing</summary>

```
> ,e em = EquipmentManager.new ; em.stow_weapon("leather sling")

--- Lich: exec1 active.

[exec1]>unload my leather.sling

You unload the sling.
Roundtime: 1 seconds.
> 
[exec1]>stow left

You put your shard in your black quiver.
> 
[exec1]>sheath my leather.sling

> 
Sheathe your leather sling where?
> 
[exec1]>stow my leather.sling

You put your sling in your hitman's backpack.
> 
--- Lich: exec1 has exited.
```
</details>

<details>
<summary>does not unload a non-ranged weapon</summary>

```
> ,e em = EquipmentManager.new ; em.stow_weapon("silversteel longsword")

--- Lich: exec1 active.

[exec1]>sheath my silversteel.longsword

You hang your silversteel longsword from your belt.  It rattles against the assassin's blade hanging from your belt, and you adjust them.
> 
--- Lich: exec1 has exited.
```
</details>

<details>
<summary>always attempts to unload weapon with `ranged: true` property</summary>

GIVEN:
```yaml
- :adjective: rockwood
  :name: tanbo
  :wield: true
  :ranged: true
```
THEN:
```
,e em = EquipmentManager.new ; em.stow_weapon("rockwood tanbo")
--- Lich: exec1 active.

[exec1]>unload my rockwood.tanbo

You can't unload such a weapon.
> 
[exec1]>sheath my rockwood.tanbo

Sheathe your rockwood tanbo where?
> 
[exec1]>stow my rockwood.tanbo

You put your tanbo in your hitman's backpack.
> 
--- Lich: exec1 has exited.
```
</details>