### PR TITLE
Fix DRCTH Unit Tests Setup for SimpleCov Harness

### DIFF
--- a/test/test_common_theurgy.rb
+++ b/test/test_common_theurgy.rb
@@ -5,9 +5,11 @@ include Harness
 
 class TestCommonTheurgy < Minitest::Test
   def setup
-    Object.send(:remove_const, :DRCTH) if defined?(DRCTH)
-    $server_buffer.clear
-    $history.clear
+    if defined?(DRCTH)
+      Object.send(:remove_const, :DRCTH)
+      $LOADED_FEATURES.delete_if {|file| file =~ /common/}
+    end
+    reset_data
     @fake_drc = Minitest::Mock.new
   end
 


### PR DESCRIPTION
Changing how we 'reset' the DRCTH module every test, due to the changes made for code coverage

(require vs. load means we have to reset the loader's knowledge of what it has already loaded when we 'unload' the module itself.)