### PR TITLE
[script] [common-items] Match strings for "The {container} is already open|closed"

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -208,7 +208,7 @@ module DRCI
     /^You open/,
     /^You slowly open/,
     /^You unbutton/,
-    /^That is already open/,
+    /is already open/,
     /^You spread your arms, carefully holding your bag well away from your body/
   ]
 
@@ -227,7 +227,7 @@ module DRCI
     /^You close/,
     /^You quickly close/,
     /^You pull/,
-    /^That is already closed/
+    /is already closed/
   ]
 
   @@close_container_failure_patterns = [

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -472,6 +472,15 @@ class TestDRCI < Minitest::Test
       [assert_result]
     )
   end
+    
+  def test_open_container__should_already_be_open2
+    run_drci_command(
+      ["The wyvern skull's jaw is already open."],
+      'open_container?',
+      ["skull"],
+      [assert_result]
+    )
+  end
 
   def test_open_container__please_rephrase
     run_drci_command(
@@ -608,6 +617,15 @@ class TestDRCI < Minitest::Test
       ["That is already closed."],
       'close_container?',
       ["medicine pouch"],
+      [assert_result]
+    )
+  end
+    
+  def test_close_container__should_already_be_closed2
+    run_drci_command(
+      ["The wyvern skull's jaw is already closed."],
+      'close_container?',
+      ["skull"],
       [assert_result]
     )
   end


### PR DESCRIPTION
### Background
* [Reported](https://discord.com/channels/745675889622384681/745696628714897508/855195408547315713) in the Lich discord
* There's match strings for "That is already (open|closed)" but not "The {container} is already (open|closed)"

### Changes
* Add new match strings and tests