### PR TITLE
[remedy.lic] [Update] Added cauldron support.

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -59,7 +59,13 @@ class Remedy
     @herb1 = args.herb1
     @herb2 = args.herb2
     @catalyst = args.catalyst
-    @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool } || args.container
+    @container = args.container
+    if @container =~ /bowl/
+      # Check for cauldron in place of bowl
+      @container = @settings.alchemy_tools.find { |tool| /cauldron|bowl/ =~ tool }
+    else
+      @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool } || args.container
+    end
     @pestle = @settings.alchemy_tools.find { |tool| /pestle/ =~ tool } || 'pestle'
     @verb = 'crush'
     @noun = args.noun


### PR DESCRIPTION
Workorders calls remedy using the items in base-recipes. Container is one of those items set. However, cauldrons were added that take the place of the bowl and require `remedy.lic` to support both. One must only have cauldron or bowl defined in `alchemy_tools` and `alchemy_belt`:

<details>
<summary>:cd: Tool settings:</summary>

```
alchemy_tools:
- grey pestle
- grey mortar
- wirework sieve
#- driftwood bowl
- cauldron
- mixing stick
- stamp

alchemy_belt:
  name: alchemist's belt
  items:
    - grey mortar
    - grey pestle
    - wirework sieve
    #- driftwood bowl
    - cauldron
    - mixing stick
```
</details>

<details>
<summary>:floppy_disk: Log of successful cauldron selection</summary>

```
;remedy remedies 6 "a body elixir" ojhenik "not used" coal bowl elixir
--- Lich: remedy active.
| bowl is container
| In if statement checking cauldron or bowl.
| cauldron is container
```
</details>