### PR TITLE
[script] [common-items] Handle "You tuck (a|your)" strings when put item away

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -135,7 +135,7 @@ module DRCI
   @@put_away_item_success_patterns = [
     /^You put your .* in/,
     /^You hold out/,
-    /^You tuck your/,
+    /^You tuck/,
     # The next message is when item crumbles when stowed, like a moonblade.
     /^As you open your hand to release the/,
     # You're a thief and you binned a stolen item.

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -272,11 +272,20 @@ class TestDRCI < Minitest::Test
     )
   end
 
-  def test_put_away_item__you_tuck
+  def test_put_away_item__you_tuck_your
     run_drci_command(
       ["You tuck your jaguar-spotted kitten safely into its comfortable cat cottage."],
       'put_away_item?',
       ["kitten", ["cottage", "home"]],
+      [assert_result]
+    )
+  end
+
+  def test_put_away_item__you_tuck_a
+    run_drci_command(
+      ["You tuck a blue-black Adan'f-scaled spellbook into the spellbook compartment of your diacan case."],
+      'put_away_item?',
+      ["spellbook", "case"],
       [assert_result]
     )
   end
@@ -472,7 +481,7 @@ class TestDRCI < Minitest::Test
       [assert_result]
     )
   end
-    
+
   def test_open_container__should_already_be_open2
     run_drci_command(
       ["The wyvern skull's jaw is already open."],
@@ -620,7 +629,7 @@ class TestDRCI < Minitest::Test
       [assert_result]
     )
   end
-    
+
   def test_close_container__should_already_be_closed2
     run_drci_command(
       ["The wyvern skull's jaw is already closed."],


### PR DESCRIPTION
### Background
* Reported by [Sinistrad](https://discord.com/channels/745675889622384681/745676101392793651/855656815614492692) in the Lich discord
* `common-items` has a match string for `You tuck your` when putting items away but the spellbooks and cases from Guildfest have `You tuck a` response, which is not matched.

### Changes
* Shorten the existing `You tuck your` phrase to just `You tuck`