### PR TITLE
Improving common-arcana's handling of khri 

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2058,19 +2058,18 @@ class AbilityProcess
       fput action
       waitrt?
     end
+
     @khri
       .map { |name| "Khri #{name}" }
       .each do |name|
         next if game_state.danger && DRCA.kneel_for_khri?(@kneel_khri, name)
-        timer = game_state.cooldown_timers[name]
-        next unless !timer || (Time.now - timer).to_i > 30
         if DRCA.activate_khri?(@kneel_khri, name)
-          game_state.cooldown_timers[name] = Time.now
           echo "Activated khri #{name}" if $debug_mode_ct
         else
           echo "Did not activate khri #{name}" if $debug_mode_ct
         end
       end
+
     @barb_buffs
       .select { |name| Flags["ap-#{name}-expired"] }
       .reject { |name| DRSpells.active_spells[name] }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2063,7 +2063,11 @@ class AbilityProcess
       .map { |name| "Khri #{name}" }
       .each do |name|
         next if game_state.danger && DRCA.kneel_for_khri?(@kneel_khri, name)
+        timer = game_state.cooldown_timers[name]
+        next unless !timer || (Time.now - timer).to_i > 30
+
         if DRCA.activate_khri?(@kneel_khri, name)
+          game_state.cooldown_timers[name] = Time.now
           echo "Activated khri #{name}" if $debug_mode_ct
         else
           echo "Did not activate khri #{name}" if $debug_mode_ct

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -70,10 +70,10 @@ module DRCA
     abilities = abilities.drop(1) if should_delay
 
     # Check each khri in the list against Active Spells, Drop any that are active
-    needed_abilities = abilities.select { |ability| DRSpells.active_spells["Khri #{ability}"].nil? }
+    needed_abilities = abilities.select { |ability_to_check| DRSpells.active_spells["Khri #{ability_to_check}"].nil? }
     return false if needed_abilities.empty?
 
-    kneel = needed_abilities.any? { |ability| kneel_for_khri?(settings_kneel, ability) }
+    kneel = needed_abilities.any? { |ability_to_check| kneel_for_khri?(settings_kneel, ability_to_check) }
     DRC.retreat if kneel
     DRC.bput('kneel', 'You kneel', 'You are already', 'You rise') if kneel && !kneeling?
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -81,7 +81,7 @@ module DRCA
     waitrt?
     DRC.fix_standing
 
-    ['Your body is willing', 'You have not recovered'].include?(result)
+    ['Your mind and body are willing', 'Your body is willing', 'You have not recovered'].exclude?(result)
   end
 
   def kneel_for_khri?(kneel, ability)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -71,7 +71,7 @@ module DRCA
 
     # Check each khri in the list against Active Spells, Drop any that are active
     needed_abilities = abilities.select { |ability_to_check| DRSpells.active_spells["Khri #{ability_to_check}"].nil? }
-    return false if needed_abilities.empty?
+    return true if needed_abilities.empty?
 
     kneel = needed_abilities.any? { |ability_to_check| kneel_for_khri?(settings_kneel, ability_to_check) }
     DRC.retreat if kneel
@@ -81,7 +81,7 @@ module DRCA
     waitrt?
     DRC.fix_standing
 
-    ['Your mind and body are willing', 'Your body is willing', 'You have not recovered'].exclude?(result)
+    return !['Your mind and body are willing', 'Your body is willing', 'You have not recovered'].include?(result)
   end
 
   def kneel_for_khri?(kneel, ability)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -75,7 +75,7 @@ module DRCA
 
     kneel = needed_abilities.any? { |ability_to_check| kneel_for_khri?(settings_kneel, ability_to_check) }
     DRC.retreat if kneel
-    DRC.bput('kneel', 'You kneel', 'You are already', 'You rise') if kneel && !kneeling?
+    DRC.bput('kneel', 'You kneel', 'You are already', 'You rise', "While swimming?  Don't be silly") if kneel && !kneeling?
 
     result = DRC.bput("Khri #{should_delay ? 'Delay ' : ''}#{needed_abilities.join(' ')}", get_data('spells').khri_preps)
     waitrt?

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -81,7 +81,7 @@ module DRCA
     waitrt?
     DRC.fix_standing
 
-    return !['Your mind and body are willing', 'Your body is willing', 'You have not recovered'].include?(result)
+    return ['Your mind and body are willing', 'Your body is willing', 'You have not recovered'].none?(result)
   end
 
   def kneel_for_khri?(kneel, ability)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -46,19 +46,38 @@ module DRCA
 
   def start_khris(khris, settings)
     khris
-      .map { |name| "Khri #{name.capitalize}" }
-      .each do |name|
-        activate_khri?(settings.kneel_khri, name)
+      .each do |khri_set|
+        activate_khri?(settings.kneel_khri, khri_set)
       end
   end
 
+  # Needs to handle (based on current usage):
+  # - Hasten
+  # - Delay Hasten
+  # - Hasten Focus
+  # - Delay Hasten Focus
+  # - Khri Hasten
+  # - Khri Delay Hasten
+  # - Khri Delay Hasten Focus
   def activate_khri?(settings_kneel, ability)
-    return false if DRSpells.active_spells[ability]
+    abilities = ability.split.map(&:capitalize)
 
-    kneel = kneel_for_khri?(settings_kneel, ability)
+    # Standardize for with/without 'Khri' on the front
+    abilities = abilities.drop(1) if abilities.first.casecmp('khri') == 0
+
+    # Handling for 'Delay'
+    should_delay = abilities.first.casecmp('delay') == 0
+    abilities = abilities.drop(1) if should_delay
+
+    # Check each khri in the list against Active Spells, Drop any that are active
+    needed_abilities = abilities.select { |ability| DRSpells.active_spells["Khri #{ability}"].nil? }
+    return false if needed_abilities.empty?
+
+    kneel = needed_abilities.any? { |ability| kneel_for_khri?(settings_kneel, ability) }
     DRC.retreat if kneel
     DRC.bput('kneel', 'You kneel', 'You are already', 'You rise') if kneel && !kneeling?
-    result = DRC.bput(ability, get_data('spells').khri_preps)
+
+    result = DRC.bput("Khri #{should_delay ? 'Delay ' : ''}#{needed_abilities.join(' ')}", get_data('spells').khri_preps)
     waitrt?
     DRC.fix_standing
 

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -247,6 +247,7 @@ khri_preps:
 - Honing your mind and body to a single purpose
 - Nothing happens
 - Your body is willing
+- Your mind and body are willing
 - You have not recovered
 - You're already using
 - With but a moment's focus

--- a/test/test_common_arcana.rb
+++ b/test/test_common_arcana.rb
@@ -137,7 +137,7 @@ class TestDRCA < Minitest::Test
   end
 
   def test_handles_delayed_single_khri_not_running_no_kneeling
-    @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
+    @fake_drc.expect(:bput, "You begin to draw your focus on increasing your celerity of motion", ['Khri Delay Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
     run_activate_khri_test_with_mocks(false, 'delay HASTEN', true)
   end
@@ -232,7 +232,8 @@ class TestDRCA < Minitest::Test
 
   def test_handles_delayed_multiple_khri_with_prefix_some_running_no_kneeling_failure
     DRSpells._set_active_spells({"Khri Hasten" => 3})
-    @fake_drc.expect(:bput, "------------------------TODO", ['Khri Delay Dampen', Array])
+    # You have not recovered from your previous use of the Hasten meditation.
+    @fake_drc.expect(:bput, 'You have not recovered', ['Khri Delay Dampen', Array])
     @fake_drc.expect(:fix_standing, nil)
     run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASten', false)
   end

--- a/test/test_common_arcana.rb
+++ b/test/test_common_arcana.rb
@@ -184,6 +184,16 @@ class TestDRCA < Minitest::Test
     run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', false)
   end
 
+  def test_handles_multiple_khri_all_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
+    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', false)
+  end
+
+  def test_handles_multiple_khri_with_prefix_all_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
+    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', false)
+  end
+
   def test_handles_delayed_mulitple_khri_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
@@ -208,6 +218,16 @@ class TestDRCA < Minitest::Test
     @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen', Array])
     @fake_drc.expect(:fix_standing, nil)
     run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASten', false)
+  end
+
+  def test_handles_delayed_multiple_khri_all_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
+    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', false)
+  end
+
+  def test_handles_delayed_multiple_khri_with_prefix_all_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
+    run_activate_khri_test_with_mocks(false, 'khri DELay DAMPEN HASTEN', false)
   end
 
   #########################################

--- a/test/test_common_arcana.rb
+++ b/test/test_common_arcana.rb
@@ -117,117 +117,124 @@ class TestDRCA < Minitest::Test
   def test_handles_single_khri_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'Hasten', false)
+    run_activate_khri_test_with_mocks(false, 'Hasten', true)
   end
 
   def test_handles_single_khri_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
-    run_activate_khri_test_with_mocks(false, 'Hasten', false)
+    run_activate_khri_test_with_mocks(false, 'Hasten', true)
   end
 
   def test_handles_single_khri_with_prefix_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'khri Hasten', false)
+    run_activate_khri_test_with_mocks(false, 'khri Hasten', true)
   end
 
   def test_handles_single_khri_with_prefix_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
-    run_activate_khri_test_with_mocks(false, 'KHRI Hasten', false)
+    run_activate_khri_test_with_mocks(false, 'KHRI Hasten', true)
   end
 
   def test_handles_delayed_single_khri_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'delay HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'delay HASTEN', true)
   end
 
   def test_handles_delayed_single_khri_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
-    run_activate_khri_test_with_mocks(false, 'delay hasten', false)
+    run_activate_khri_test_with_mocks(false, 'delay hasten', true)
   end
 
   def test_handles_delayed_single_khri_with_prefix_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'KHRI DELAY HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'KHRI DELAY HASTEN', true)
   end
 
   def test_handles_delayed_single_khri_with_prefix_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
-    run_activate_khri_test_with_mocks(false, 'khri delay hasten', false)
+    run_activate_khri_test_with_mocks(false, 'khri delay hasten', true)
   end
 
   def test_handles_mulitple_khri_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Dampen Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', true)
   end
 
   def test_handles_multiple_khri_some_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
     @fake_drc.expect(:bput, "foo", ['Khri Dampen', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', true)
   end
 
   def test_handles_mulitple_khri_with_prefix_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Dampen Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', true)
   end
 
   def test_handles_multiple_khri_with_prefix_some_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
     @fake_drc.expect(:bput, "foo", ['Khri Dampen', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', true)
   end
 
   def test_handles_multiple_khri_all_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
-    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', true)
   end
 
   def test_handles_multiple_khri_with_prefix_all_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
-    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', true)
   end
 
   def test_handles_delayed_mulitple_khri_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', true)
   end
 
   def test_handles_delayed_multiple_khri_some_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
     @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', true)
   end
 
   def test_handles_delayed_mulitple_khri_with_prefix_not_running_no_kneeling
     @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen Hasten', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASTEN', true)
   end
 
   def test_handles_delayed_multiple_khri_with_prefix_some_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3})
     @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen', Array])
     @fake_drc.expect(:fix_standing, nil)
-    run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASten', false)
+    run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASten', true)
   end
 
   def test_handles_delayed_multiple_khri_all_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
-    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', true)
   end
 
   def test_handles_delayed_multiple_khri_with_prefix_all_running_no_kneeling
     DRSpells._set_active_spells({"Khri Hasten" => 3, "Khri Dampen" => 5})
-    run_activate_khri_test_with_mocks(false, 'khri DELay DAMPEN HASTEN', false)
+    run_activate_khri_test_with_mocks(false, 'khri DELay DAMPEN HASTEN', true)
+  end
+
+  def test_handles_delayed_multiple_khri_with_prefix_some_running_no_kneeling_failure
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    @fake_drc.expect(:bput, "------------------------TODO", ['Khri Delay Dampen', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASten', false)
   end
 
   #########################################

--- a/test/test_common_arcana.rb
+++ b/test/test_common_arcana.rb
@@ -8,7 +8,13 @@ include Harness
 class TestDRCA < Minitest::Test
 
   def setup
+    if defined?(DRCA)
+      Object.send(:remove_const, :DRCA)
+      $LOADED_FEATURES.delete_if {|file| file =~ /common/}
+    end
     reset_data
+    @fake_drc = Minitest::Mock.new
+    @fake_drci = Minitest::Mock.new
     load_base_settings
   end
 
@@ -94,6 +100,122 @@ class TestDRCA < Minitest::Test
   end
 
   #########################################
+  # ACTIVATE KHRI
+  #########################################
+
+  def test_handles_single_khri_not_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
+      @fake_drc.expect(:fix_standing, nil)
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'Hasten')
+      assert_equal(false, activated)
+    end)
+  end
+
+  def test_handles_single_khri_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      DRSpells._set_active_spells({"Khri Hasten" => 3})
+      # Do not mock bput, because this path should execute no commands
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'Hasten')
+      assert_equal(false, activated)
+    end)
+  end
+
+  def test_handles_single_khri_with_prefix_not_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
+      @fake_drc.expect(:fix_standing, nil)
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'Khri Hasten')
+      assert_equal(false, activated)
+    end)
+  end
+
+  def test_handles_single_khri_with_prefix_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      DRSpells._set_active_spells({"Khri Hasten" => 3})
+      # Do not mock bput, because this path should execute no commands
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'Khri Hasten')
+      assert_equal(false, activated)
+    end)
+  end
+
+  def test_handles_delayed_single_khri_not_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
+      @fake_drc.expect(:fix_standing, nil)
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'delay hasten')
+      assert_equal(false, activated)
+    end)
+  end
+
+  def test_handles_delayed_single_khri_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      DRSpells._set_active_spells({"Khri Hasten" => 3})
+      # Do not mock bput, because this path should execute no commands
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'delay hasten')
+      assert_equal(false, activated)
+    end)
+  end
+
+  def test_handles_delayed_single_khri_with_prefix_not_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
+      @fake_drc.expect(:fix_standing, nil)
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'KHRI DELAY HASTEN')
+      assert_equal(false, activated)
+    end)
+  end
+
+  def test_handles_delayed_single_khri_with_prefix_running_no_kneeling
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+    @test = run_script_with_proc(['common-arcana'], proc do
+
+      DRSpells._set_active_spells({"Khri Hasten" => 3})
+      # Do not mock bput, because this path should execute no commands
+      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
+      DRCA.const_set("DRC", @fake_drc)
+
+      activated = DRCA.activate_khri?(false, 'khri delay hasten')
+      assert_equal(false, activated)
+    end)
+  end
+
+  #########################################
   # SKILLED TO CHARGE WHILE WORN
   #########################################
 
@@ -133,61 +255,46 @@ class TestDRCA < Minitest::Test
     proc { |found_cambrinth| assert_equal(false, found_cambrinth) }
   end
 
-  def run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, assertions = [])
-    @test = run_script_with_proc(['common', 'common-items', 'common-arcana'], proc do
+  def run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, assertions = [])
+    @test = run_script_with_proc(['common', 'common-arcana'], proc do
       # Setup
       $server_buffer = messages.dup
       $history = $server_buffer.dup
-
-      original_DRCI = DRCA::DRCI if defined?(DRCA::DRCI)
-      DRCA.send(:remove_const, "DRCI") if defined?(DRCA::DRCI)
-      DRCA.const_set("DRCI", fake_drci)
+      DRCA.const_set("DRCI", @fake_drci)
 
       # Test
       found_cambrinth = DRCA.find_cambrinth(cambrinth, stored_cambrinth, cambrinth_cap)
 
-      # Restore injected dependencies
-      DRCA.send(:remove_const, "DRCI") if defined?(DRCA::DRCI)
-      DRCA.const_set("DRCI", original_DRCI)
-
       # Assert
-      fake_drci.verify
+      @fake_drci.verify
       assertions = [assertions] unless assertions.is_a?(Array)
       assertions.each { |assertion| assertion.call(found_cambrinth) }
     end)
   end
 
   def test_find_stored_cambrinth_by_get
+    messages = []
     cambrinth = 'cambrinth armband'
     stored_cambrinth = true
     cambrinth_cap = 32
-
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
+    @fake_drci.expect(:get_item_if_not_held?, true, [String])
 
-    messages = []
-
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:get_item_if_not_held?, true, [String])
-
-    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_found_cambrinth
     ])
   end
 
   def test_find_stored_cambrinth_by_remove
+    messages = []
     cambrinth = 'cambrinth armband'
     stored_cambrinth = true
     cambrinth_cap = 32
-
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
+    @fake_drci.expect(:get_item_if_not_held?, false, [String])
+    @fake_drci.expect(:remove_item?, true, [String])
 
-    messages = []
-
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:get_item_if_not_held?, false, [String])
-    fake_drci.expect(:remove_item?, true, [String])
-
-    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_found_cambrinth
     ])
   end
@@ -200,12 +307,10 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:get_item_if_not_held?, false, [String])
+    @fake_drci.expect(:remove_item?, false, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:get_item_if_not_held?, false, [String])
-    fake_drci.expect(:remove_item?, false, [String])
-
-    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_not_found_cambrinth
     ])
   end
@@ -218,11 +323,9 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', 1) # insufficient skill so must remove 'worn' cambrinth
 
     messages = []
+    @fake_drci.expect(:in_hands?, true, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, true, [String])
-
-    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_found_cambrinth
     ])
   end
@@ -235,12 +338,10 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', 1) # insufficient skill so must remove 'worn' cambrinth
 
     messages = []
+    @fake_drci.expect(:in_hands?, false, [String])
+    @fake_drci.expect(:remove_item?, true, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, false, [String])
-    fake_drci.expect(:remove_item?, true, [String])
-
-    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_found_cambrinth
     ])
   end
@@ -253,13 +354,11 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', 1) # insufficient skill so must remove 'worn' cambrinth
 
     messages = []
+    @fake_drci.expect(:in_hands?, false, [String])
+    @fake_drci.expect(:remove_item?, false, [String])
+    @fake_drci.expect(:get_item?, true, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, false, [String])
-    fake_drci.expect(:remove_item?, false, [String])
-    fake_drci.expect(:get_item?, true, [String])
-
-    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_found_cambrinth
     ])
   end
@@ -272,13 +371,11 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', 1) # insufficient skill so must remove 'worn' cambrinth
 
     messages = []
+    @fake_drci.expect(:in_hands?, false, [String])
+    @fake_drci.expect(:remove_item?, false, [String])
+    @fake_drci.expect(:get_item?, false, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, false, [String])
-    fake_drci.expect(:remove_item?, false, [String])
-    fake_drci.expect(:get_item?, false, [String])
-
-    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_find_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_not_found_cambrinth
     ])
   end
@@ -295,25 +392,18 @@ class TestDRCA < Minitest::Test
     proc { |stowed_cambrinth| assert_equal(false, stowed_cambrinth) }
   end
 
-  def run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, assertions = [])
-    @test = run_script_with_proc(['common', 'common-items', 'common-arcana'], proc do
+  def run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, assertions = [])
+    @test = run_script_with_proc(['common', 'common-arcana'], proc do
       # Setup
       $server_buffer = messages.dup
       $history = $server_buffer.dup
-
-      original_DRCI = DRCA::DRCI if defined?(DRCA::DRCI)
-      DRCA.send(:remove_const, "DRCI") if defined?(DRCA::DRCI)
-      DRCA.const_set("DRCI", fake_drci)
+      DRCA.const_set("DRCI", @fake_drci)
 
       # Test
       stowed_cambrinth = DRCA.stow_cambrinth(cambrinth, stored_cambrinth, cambrinth_cap)
 
-      # Restore injected dependencies
-      DRCA.send(:remove_const, "DRCI") if defined?(DRCA::DRCI)
-      DRCA.const_set("DRCI", original_DRCI || DRCI)
-
       # Assert
-      fake_drci.verify
+      @fake_drci.verify
       assertions = [assertions] unless assertions.is_a?(Array)
       assertions.each { |assertion| assertion.call(stowed_cambrinth) }
     end)
@@ -327,12 +417,10 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:get_item_if_not_held?, true, [String])
+    @fake_drci.expect(:stow_item?, true, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:get_item_if_not_held?, true, [String])
-    fake_drci.expect(:stow_item?, true, [String])
-
-    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_stow_cambrinth
     ])
   end
@@ -345,13 +433,11 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:get_item_if_not_held?, false, [String])
+    @fake_drci.expect(:remove_item?, true, [String])
+    @fake_drci.expect(:stow_item?, true, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:get_item_if_not_held?, false, [String])
-    fake_drci.expect(:remove_item?, true, [String])
-    fake_drci.expect(:stow_item?, true, [String])
-
-    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_stow_cambrinth
     ])
   end
@@ -364,13 +450,11 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:get_item_if_not_held?, false, [String])
+    @fake_drci.expect(:remove_item?, false, [String])
+    @fake_drci.expect(:stow_item?, false, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:get_item_if_not_held?, false, [String])
-    fake_drci.expect(:remove_item?, false, [String])
-    fake_drci.expect(:stow_item?, false, [String])
-
-    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_not_stow_cambrinth
     ])
   end
@@ -383,12 +467,10 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:in_hands?, true, [String])
+    @fake_drci.expect(:wear_item?, true, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, true, [String])
-    fake_drci.expect(:wear_item?, true, [String])
-
-    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_stow_cambrinth
     ])
   end
@@ -401,13 +483,11 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:in_hands?, true, [String])
+    @fake_drci.expect(:wear_item?, false, [String])
+    @fake_drci.expect(:stow_item?, true, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, true, [String])
-    fake_drci.expect(:wear_item?, false, [String])
-    fake_drci.expect(:stow_item?, true, [String])
-
-    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_stow_cambrinth
     ])
   end
@@ -420,13 +500,11 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:in_hands?, true, [String])
+    @fake_drci.expect(:wear_item?, false, [String])
+    @fake_drci.expect(:stow_item?, false, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, true, [String])
-    fake_drci.expect(:wear_item?, false, [String])
-    fake_drci.expect(:stow_item?, false, [String])
-
-    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_not_stow_cambrinth
     ])
   end
@@ -439,11 +517,9 @@ class TestDRCA < Minitest::Test
     DRSkill._set_rank('Arcana', ((cambrinth_cap.to_i * 2) + 100))
 
     messages = []
+    @fake_drci.expect(:in_hands?, false, [String])
 
-    fake_drci = Minitest::Mock.new
-    fake_drci.expect(:in_hands?, false, [String])
-
-    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, fake_drci, [
+    run_stow_cambrinth(messages, cambrinth, stored_cambrinth, cambrinth_cap, [
       assert_stow_cambrinth
     ])
   end

--- a/test/test_common_arcana.rb
+++ b/test/test_common_arcana.rb
@@ -13,6 +13,7 @@ class TestDRCA < Minitest::Test
       $LOADED_FEATURES.delete_if {|file| file =~ /common/}
     end
     reset_data
+    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
     @fake_drc = Minitest::Mock.new
     @fake_drci = Minitest::Mock.new
     load_base_settings
@@ -103,116 +104,110 @@ class TestDRCA < Minitest::Test
   # ACTIVATE KHRI
   #########################################
 
-  def test_handles_single_khri_not_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
+  def run_activate_khri_test_with_mocks(kneel, khri, expectation)
     @test = run_script_with_proc(['common-arcana'], proc do
-
-      @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
-      @fake_drc.expect(:fix_standing, nil)
       DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
       DRCA.const_set("DRC", @fake_drc)
 
-      activated = DRCA.activate_khri?(false, 'Hasten')
-      assert_equal(false, activated)
+      activated = DRCA.activate_khri?(kneel, khri)
+      assert_equal(expectation, activated)
     end)
+  end
+
+  def test_handles_single_khri_not_running_no_kneeling
+    @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'Hasten', false)
   end
 
   def test_handles_single_khri_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
-    @test = run_script_with_proc(['common-arcana'], proc do
-
-      DRSpells._set_active_spells({"Khri Hasten" => 3})
-      # Do not mock bput, because this path should execute no commands
-      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
-      DRCA.const_set("DRC", @fake_drc)
-
-      activated = DRCA.activate_khri?(false, 'Hasten')
-      assert_equal(false, activated)
-    end)
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    run_activate_khri_test_with_mocks(false, 'Hasten', false)
   end
 
   def test_handles_single_khri_with_prefix_not_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
-    @test = run_script_with_proc(['common-arcana'], proc do
-
-      @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
-      @fake_drc.expect(:fix_standing, nil)
-      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
-      DRCA.const_set("DRC", @fake_drc)
-
-      activated = DRCA.activate_khri?(false, 'Khri Hasten')
-      assert_equal(false, activated)
-    end)
+    @fake_drc.expect(:bput, "foo", ['Khri Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'khri Hasten', false)
   end
 
   def test_handles_single_khri_with_prefix_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
-    @test = run_script_with_proc(['common-arcana'], proc do
-
-      DRSpells._set_active_spells({"Khri Hasten" => 3})
-      # Do not mock bput, because this path should execute no commands
-      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
-      DRCA.const_set("DRC", @fake_drc)
-
-      activated = DRCA.activate_khri?(false, 'Khri Hasten')
-      assert_equal(false, activated)
-    end)
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    run_activate_khri_test_with_mocks(false, 'KHRI Hasten', false)
   end
 
   def test_handles_delayed_single_khri_not_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
-    @test = run_script_with_proc(['common-arcana'], proc do
-
-      @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
-      @fake_drc.expect(:fix_standing, nil)
-      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
-      DRCA.const_set("DRC", @fake_drc)
-
-      activated = DRCA.activate_khri?(false, 'delay hasten')
-      assert_equal(false, activated)
-    end)
+    @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'delay HASTEN', false)
   end
 
   def test_handles_delayed_single_khri_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
-    @test = run_script_with_proc(['common-arcana'], proc do
-
-      DRSpells._set_active_spells({"Khri Hasten" => 3})
-      # Do not mock bput, because this path should execute no commands
-      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
-      DRCA.const_set("DRC", @fake_drc)
-
-      activated = DRCA.activate_khri?(false, 'delay hasten')
-      assert_equal(false, activated)
-    end)
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    run_activate_khri_test_with_mocks(false, 'delay hasten', false)
   end
 
   def test_handles_delayed_single_khri_with_prefix_not_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
-    @test = run_script_with_proc(['common-arcana'], proc do
-
-      @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
-      @fake_drc.expect(:fix_standing, nil)
-      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
-      DRCA.const_set("DRC", @fake_drc)
-
-      activated = DRCA.activate_khri?(false, 'KHRI DELAY HASTEN')
-      assert_equal(false, activated)
-    end)
+    @fake_drc.expect(:bput, "foo", ['Khri Delay Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'KHRI DELAY HASTEN', false)
   end
 
   def test_handles_delayed_single_khri_with_prefix_running_no_kneeling
-    $test_data = { :spells => OpenStruct.new({ :khri_preps => ['match strings'] })}
-    @test = run_script_with_proc(['common-arcana'], proc do
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    run_activate_khri_test_with_mocks(false, 'khri delay hasten', false)
+  end
 
-      DRSpells._set_active_spells({"Khri Hasten" => 3})
-      # Do not mock bput, because this path should execute no commands
-      DRCA.send(:remove_const, "DRC") if defined?(DRCA::DRC)
-      DRCA.const_set("DRC", @fake_drc)
+  def test_handles_mulitple_khri_not_running_no_kneeling
+    @fake_drc.expect(:bput, "foo", ['Khri Dampen Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', false)
+  end
 
-      activated = DRCA.activate_khri?(false, 'khri delay hasten')
-      assert_equal(false, activated)
-    end)
+  def test_handles_multiple_khri_some_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    @fake_drc.expect(:bput, "foo", ['Khri Dampen', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'DAMPEN HASTEN', false)
+  end
+
+  def test_handles_mulitple_khri_with_prefix_not_running_no_kneeling
+    @fake_drc.expect(:bput, "foo", ['Khri Dampen Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', false)
+  end
+
+  def test_handles_multiple_khri_with_prefix_some_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    @fake_drc.expect(:bput, "foo", ['Khri Dampen', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'khri DAMPEN HASTEN', false)
+  end
+
+  def test_handles_delayed_mulitple_khri_not_running_no_kneeling
+    @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', false)
+  end
+
+  def test_handles_delayed_multiple_khri_some_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'delay DAMPEN HASTEN', false)
+  end
+
+  def test_handles_delayed_mulitple_khri_with_prefix_not_running_no_kneeling
+    @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen Hasten', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASTEN', false)
+  end
+
+  def test_handles_delayed_multiple_khri_with_prefix_some_running_no_kneeling
+    DRSpells._set_active_spells({"Khri Hasten" => 3})
+    @fake_drc.expect(:bput, "foo", ['Khri Delay Dampen', Array])
+    @fake_drc.expect(:fix_standing, nil)
+    run_activate_khri_test_with_mocks(false, 'khri delay DAMPEN hASten', false)
   end
 
   #########################################

--- a/ulfhara.lic
+++ b/ulfhara.lic
@@ -658,20 +658,6 @@ class UlfHara
 
     if @settings.waggle_sets['pick']
       wait_for_script_to_complete('buff', ['pick'])
-    else
-      buffs = @settings.lockpick_buffs
-      # TODO: Remove this sometime in end of February. That should be enough time for users to move to waggle
-      echo "*** You have outdated settings, please make a waggle_set called 'pick' ***" unless buffs.empty?
-      buffs['spells'].each do |spell|
-        echo "Buffing: #{spell}" if UserVars.lockpick_debug
-        cast_spell(spell, @settings)
-      end
-      buffs['khri']
-        .map { |name| "Khri #{name}" }
-        .each { |name| activate_khri?(@settings.kneel_khri, name) }
-      buffs['meditate'].each do |med|
-        bput("meditate #{med}", 'You feel a jolt as your vision snaps shut', 'Your inner fire lacks the strength')
-      end
     end
   end
 


### PR DESCRIPTION
Several issues were discovered during testing with the new pick (which checks buffs more regularly). This will make it easier to use khri in multiple ways through the multiple entry points (combat-trainer, buff, etc.)

- format tolerant
- common usability
- improved detection for already running to prevent unnecessary retreat / kneeling