### PR TITLE
[script] [common-travel] If engaged, retreat and retry movement

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -86,7 +86,8 @@ module DRCT
   end
 
   def walk_to(target_room, restart_on_fail = true)
-    Flags.add('closed-shop', 'The door is locked up tightly for the night', 'You smash your nose', '^A servant (blocks|stops)')
+    Flags.add('travel-closed-shop', 'The door is locked up tightly for the night', 'You smash your nose', '^A servant (blocks|stops)')
+    Flags.add('travel-engaged', 'You are engaged')
 
     target_room = tag_to_id(target_room) if target_room.is_a?(String) && target_room.count("a-zA-Z") > 0
 
@@ -118,27 +119,37 @@ module DRCT
     timer = Time.now
     prev_room = XMLData.room_description + XMLData.room_title
     while Script.running.include?(script_handle)
-      if Flags['closed-shop']
-        Flags.reset('closed-shop')
+      # Shop closed, stop script and open door then restart
+      if Flags['travel-closed-shop']
+        Flags.reset('travel-closed-shop')
         kill_script(script_handle)
         if /You open/ !~ DRC.bput('open door', 'It is locked', 'You .+', 'What were')
           return false
         end
         timer = Time.now
-        script_handle = start_script 'go2', [room_num.to_s]
+        script_handle = start_script('go2', [room_num.to_s])
       end
+      # You're engaged, stop script and retreat then restart
+      if Flags['travel-engaged']
+        Flags.reset('travel-engaged')
+        kill_script(script_handle)
+        DRC.retreat
+        timer = Time.now
+        script_handle = start_script('go2', [room_num.to_s])
+      end
+      # Something interferred with movement, stop script then restart
       if (Time.now - timer) > 90
         kill_script(script_handle)
         pause 0.5 while Script.running.include?(script_handle)
         timer = Time.now
-
         break unless restart_on_fail
-
         script_handle = start_script('go2', [room_num.to_s])
       end
+      # If an escort script is running or we're making progress then update our timer so we don't timeout (see above)
       if Script.running?('escort') || Script.running?('bescort') || (XMLData.room_description + XMLData.room_title) != prev_room || XMLData.room_description =~ /The terrain constantly changes as you travel along on your journey/
         timer = Time.now
       end
+      # Where did you come from, where did you go? Where did you come from, Cotten-Eye Joe?
       prev_room = XMLData.room_description + XMLData.room_title
       pause 0.5
     end
@@ -146,7 +157,7 @@ module DRCT
     # Consider just returning this boolean and letting callers decide what to do on a failed move.
     if room_num != Room.current.id && restart_on_fail
       echo "Failed to navigate to room #{room_num}, attempting again"
-      walk_to room_num
+      walk_to(room_num)
     end
     room_num == Room.current.id
   end


### PR DESCRIPTION
### Background
* I got stuck at the barricade to climb out of Rock Trolls in Zoluren because I became engaged
* `hunting-buddy` by way of `common-travel` repeatedly tried to `climb barricade` and move on but would fail, restart, etc

```
[go2]>climb barricade
You are engaged to a rock troll at melee range!

[go2]>east
You can't go there.

[go2]>east
You can't go there.

[go2: move: failed]
[go2: restarting script...]
```

### Changes
* Add flag to check if you're engaged and if so then stop the script, retreat, and restart (mirrors logic when encounter a closed door)

```
--- Lich: get2 active.
--- Lich: go2 active.
[go2: ETA: 0:00:05 (2 rooms to move through)]
[go2]>climb barricade

You are engaged to a rock troll at melee range!

--- Lich: 'go2' has been stopped by get2.
--- Lich: go2 has exited.

[get2]>retreat
You retreat back to pole range.

[get2]>retreat
You retreat from combat.

--- Lich: go2 active.
[go2: ETA: 0:00:05 (2 rooms to move through)]
[go2]>climb barricade

You climb up and over a heavy barricade.

[Journalai Route, Open Grasslands]
The grasslands here are caught between the presence of rolling hills to the west and the small village of Kaerna to the east.  To the north and south is nothing but empty plains, wind-twisted and long ignored by humanity.
You also see a barricade that blocks passage northwest.
Obvious paths: east.
(Roundtime: 5 seconds.)
```