### PR TITLE
[script] [combat-trainer] Match strings need to be regex for use in case/when

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3073,8 +3073,22 @@ class AttackProcess
         waitrt?
       end
     else
-      load_weapon_success = ["You reach into", "You load", "You carefully load", "already loaded", "in your hand"]
-      load_weapon_failure = ["As you try to reach", "You don't have the proper ammunition", "You don't have enough .* to load two at once", "What weapon are you trying to load", "Such a feat would be impossible without the winds to guide", "but are unable to draw upon its majesty", "without steadier hands"]
+      load_weapon_success = [
+        /You reach into/,
+        /You load/,
+        /You carefully load/,
+        /already loaded/,
+        /in your hand/
+      ]
+      load_weapon_failure = [
+        /As you try to reach/,
+        /You don't have the proper ammunition/,
+        /You don't have enough .* to load two at once/,
+        /What weapon are you trying to load/,
+        /Such a feat would be impossible without the winds to guide/,
+        /but are unable to draw upon its majesty/,
+        /without steadier hands/
+      ]
 
       dual_load = game_state.dual_load?
 


### PR DESCRIPTION
### Background
* When attempting to dual load arrows and you don't have sufficient ammo you get an error "You don't have enough {ammo} to load two at once"
* That message is detected by the match string "You don't have enough .* to load two at once" in `load_weapon_failure` variable
* For reuse, the `load_weapon_failure` variable is also used in a `case/when` statement to fallback to single arrow load
* `case/when` treats strings as literal values, so the `.*` in the match string was not interpreted as a regular expression and the combat loop would enter an infinite loop trying to load a bow that would never be loaded

```
[combat-trainer]>aim

Your assassin's longbow isn't loaded!
> 
[combat-trainer]>load arrows

You don't have enough boar-tusk arrows to load two at once.
> 
[combat-trainer]>load arrows

You don't have enough boar-tusk arrows to load two at once.
> 
[combat-trainer]>aim

Your assassin's longbow isn't loaded!

...
```

### Changes
* Convert the match strings in `load_weapon_success` and `load_weapon_failure` to be regular expressions so that they work in both `bput` and `case/when` statements

```
You sling a tenebrous demonbone-backed assassin's longbow adorned with serrated tips off from over your shoulder.
> 
[combat-trainer]>load arrows

You don't have enough boar-tusk arrows to load two at once.
> 
[combat-trainer]>load arrows

You don't have enough boar-tusk arrows to load two at once.
> 
[combat-trainer]>load

Your demonscale shield makes the task more difficult.
You reach into your quiver to load the assassin's longbow with your last lemon-striped arrow.
Roundtime 6 sec.
```