### PR TITLE
[script] [spellmonitor] squelch when don't know any feats

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -234,7 +234,7 @@ known_spells_hook = proc do |server_string|
         .each { |feat| DRSpells.known_feats[feat] = true }
     end
     server_string = nil if DRSpells.silence_known_spells_hook
-  when /^You have \d+ spell slots? available/
+  when /^You have \d+ spell slots? available|You do not know any magic feats/
     server_string = nil if DRSpells.silence_known_spells_hook
   when /^You can use SPELL STANCE|^You have (no|yet to receive any) training in the magical arts|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
     DRSpells.grabbing_known_spells = false


### PR DESCRIPTION
### Changes
* When `spellmonitor` is parsing for known spells, squelch "You do not know any magic feats" line