### PR TITLE
[Update] [pattern-hues] Fixed random not working.

### DIFF
--- a/pattern-hues.lic
+++ b/pattern-hues.lic
@@ -20,12 +20,12 @@ class PatternHues
     @settings = get_settings
     @duration = @settings.pattern_hues['duration']
 
-    adj = @settings.pattern_hues['pattern_hues_styles']['pattern'] ||
+    @adj = @settings.pattern_hues['pattern_hues_styles']['pattern'] ||
       ['bright', 'crystalline', 'gleaming', 'glimmering', 'glistening',\
       'hazy', 'iridescent', 'lucent', 'opalescent', 'phosphorescent', 'relucent',\
       'scintillating', 'shadowy', 'shimmering', 'sparkling', 'translucent']
 
-    color = @settings.pattern_hues['pattern_hues_styles']['hue'] ||
+    @color = @settings.pattern_hues['pattern_hues_styles']['hue'] ||
       ['alabaster', 'white', 'amber', 'aqua', 'ash grey', 'azure',\
       'blizzard', 'blue-white', 'beige', 'blue', 'bone white', 'brackish brown',\
       'burgundy', 'charcoal black', 'chartreuse', 'chrome', 'cobalt blue',\
@@ -45,12 +45,21 @@ class PatternHues
   end
 
   def cast_pattern_hues
+    match_messages = [
+      /You trace the complex sigils of the Pattern Hues cantrip around yourself./,
+      /You already have/,
+      /You gesture/,
+      /Something in the area is interfering/,
+      /You try, but the dolphin choose/,
+      /You should stop practicing/,
+      /You find it hard to concentrate on anything/
+    ]
     DRC.pause_all
     bput("prep cantrip pattern hues", "You are now prepared to cast the Pattern Hues cantrip.","You already have", "You should stop practicing")
     if @settings.pattern_hues['gesture'] == "random"
-      bput("gesture #{adj.sample} #{color.sample}", "You trace the complex sigils of the Pattern Hues cantrip around yourself.", "You already have", "You gesture", "Something in the area is interfering", "You try, but the dolphin choose", 'You should stop practicing')
+      bput("gesture #{@adj.sample} #{@color.sample}", *match_messages)
     else
-      bput("gesture #{@settings.pattern_hues['gesture']}", "You trace the complex sigils of the Pattern Hues cantrip around yourself.", "You already have", "You gesture", "Something in the area is interfering", "You try, but the dolphin choose", 'You should stop practicing')
+      bput("gesture #{@settings.pattern_hues['gesture']}", *match_messages)
     end
     DRC.unpause_all
   end


### PR DESCRIPTION
Had to make adj and color global. Also add more matches. 

<details>
<summary>:floppy_disk: Log of successful random gesture from pattern-hues</summary>

```
pattern-hues now
--- Lich: pattern-hues active.
[pattern-hues]>prep cantrip pattern hues
You are now prepared to cast the Pattern Hues cantrip.
[pattern-hues]>gesture bright charcoal black
You trace the complex sigils of the Pattern Hues cantrip around yourself.
The faint lucent snowflake white aura around you slowly shifts until it assumes a bright charcoal black glow.
Roundtime: 3 seconds.
--- Lich: pattern-hues has exited.
```
/<details>