### PR TITLE
[script] [common-travel] delete flags when no longer needed

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -86,9 +86,6 @@ module DRCT
   end
 
   def walk_to(target_room, restart_on_fail = true)
-    Flags.add('travel-closed-shop', 'The door is locked up tightly for the night', 'You smash your nose', '^A servant (blocks|stops)')
-    Flags.add('travel-engaged', 'You are engaged')
-
     target_room = tag_to_id(target_room) if target_room.is_a?(String) && target_room.count("a-zA-Z") > 0
 
     return false if target_room.nil?
@@ -118,13 +115,25 @@ module DRCT
 
     timer = Time.now
     prev_room = XMLData.room_description + XMLData.room_title
+
+    # Moved flag declaration from the start of the method to here
+    # so that they only exist when needed and because the above code
+    # has lots of 'return' statements that'd have to be refactored to
+    # properly delete the flags at each method exit point.
+    # I didn't want to tackle that endeavor in this change.
+    Flags.add('travel-closed-shop', 'The door is locked up tightly for the night', 'You smash your nose', '^A servant (blocks|stops)')
+    Flags.add('travel-engaged', 'You are engaged')
+
     while Script.running.include?(script_handle)
       # Shop closed, stop script and open door then restart
       if Flags['travel-closed-shop']
         Flags.reset('travel-closed-shop')
         kill_script(script_handle)
         if /You open/ !~ DRC.bput('open door', 'It is locked', 'You .+', 'What were')
-          return false
+          # You cannot get to where you want to go,
+          # and no amount of retries will get you through the locked door.
+          restart_on_fail = false
+          break
         end
         timer = Time.now
         script_handle = start_script('go2', [room_num.to_s])
@@ -141,8 +150,8 @@ module DRCT
       if (Time.now - timer) > 90
         kill_script(script_handle)
         pause 0.5 while Script.running.include?(script_handle)
-        timer = Time.now
         break unless restart_on_fail
+        timer = Time.now
         script_handle = start_script('go2', [room_num.to_s])
       end
       # If an escort script is running or we're making progress then update our timer so we don't timeout (see above)
@@ -153,6 +162,10 @@ module DRCT
       prev_room = XMLData.room_description + XMLData.room_title
       pause 0.5
     end
+
+    # Delete flags, no longer needed at this point
+    Flags.delete('travel-closed-shop')
+    Flags.delete('travel-engaged')
 
     # Consider just returning this boolean and letting callers decide what to do on a failed move.
     if room_num != Room.current.id && restart_on_fail


### PR DESCRIPTION
### Background
* Inspired by conversation with @wstampley 
* Typical scripts run then exit, and any flags in them can be deleted in a `before_dying` block.
* Modules that are loaded in memory and not "ran and exited" don't have this cleanup step, so flags need to be deleted manually.
* Deleting unused flags can improve performance by reducing the amount of processing over received messages

### Changes
* Move declaration of the travel flags in `walk_to` method to the place where they're actually needed, by-passing several `return` statements that exit the method and wouldn't have cleaned up the flags.
* At end of method, delete the travel flags tracking if a shop is closed or you're in combat.

## Tests
* I tested while engaged with ship rats -- able to retreat then move to destination.
* I tested in Arthe Dale trying to enter room 19237 in the evening when it's closed up.