### PR TITLE
[script] [common] add match strings when try to hide or retreat

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -408,7 +408,7 @@ module DRC
 
   def hide?(hide_type = 'hide')
     unless hiding?
-      case bput(hide_type, 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself', 'Stalk what', 'You\'re already stalking', 'Stalking is an inherently stealthy', 'You haven\'t had enough time')
+      case bput(hide_type, 'Roundtime', 'too busy performing', 'can\'t see any place to hide yourself', 'Stalk what', 'You\'re already stalking', 'Stalking is an inherently stealthy', 'You haven\'t had enough time', 'You search but find no place to hide')
       when 'too busy performing'
         bput('stop play', 'You stop playing', 'In the name of')
         return hide?(hide_type)
@@ -467,9 +467,32 @@ module DRC
   def retreat(ignored_npcs = [])
     return if (DRRoom.npcs - ignored_npcs).empty?
 
-    escape_messages = ['You are already as far away as you can get', 'You retreat from combat', 'You sneak back out of combat']
-    until escape_messages.include?(DRC.bput('retreat', *(escape_messages + ['retreat', 'You try to back ', 'sneak', 'grip remains solid', 'You must stand first', 'grip on you', 'You stop advancing', 'You are already'])))
-      DRC.fix_standing
+    escape_messages = [
+      /You are already as far away as you can get/,
+      /You retreat from combat/,
+      /You sneak back out of combat/,
+      /Retreat to where/,
+      /There's no place to retreat to/
+    ]
+
+    retreat_messages = [
+      /retreat/,
+      /sneak/,
+      /grip on you/,
+      /grip remains solid/,
+      /You try to back/,
+      /You must stand first/,
+      /You stop advancing/,
+      /You are already/
+    ]
+
+    loop do
+      case DRC.bput("retreat", *escape_messages, *retreat_messages)
+      when *escape_messages
+        return true
+      else
+        DRC.fix_standing
+      end
     end
   end
 


### PR DESCRIPTION
### Background
* Based on conversation with @wstampley and [Sekhemt](https://discord.com/channels/745675889622384681/745675890242879671/857097306012778507) in Lich discord

### Changes
* Add match string "You search but find no place to hide" when fail to hide
* Add match strings "Retreat to where" and "There's no place to retreat to" when in a small room where you can't retreat
* Format retreat method to be more readable (subjective opinion)