### PR TITLE
Fixing False Positive Validate Errors

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -58,6 +58,8 @@ class DRYamlValidator
   end
 
   def assert_that_holy_weapon_charging_has_valid_hometown_unless_using_icon(settings)
+    return unless DRStats.paladin?
+    return unless settings.holy_weapon['weapon_name']
     return if settings.hometown.include?'Crossing'
     return if settings.hometown.include?'Shard'
     return if settings.holy_weapon['icon_name']


### PR DESCRIPTION
Turning off holy weapon validation for non-paladins, and paladins who don't have a weapon (name) declared