### PR TITLE
[script] [combat-trainer] Activate Tsunami berserk only if holding melee weapon

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2078,7 +2078,7 @@ class AbilityProcess
         timer = game_state.cooldown_timers[name]
         next unless !timer || (Time.now - timer).to_i > 30
         if name == 'Tsunami' && (!game_state.melee_weapon_skill? || DRC.right_hand.nil? || DRC.right_hand.empty?)
-          echo "Skipping activating #{name} because you're not currently wielding a melee weapon. Will retry when you're training melee weapons." if $debug_mode_ct
+          echo "Skipping activating barb_buff #{name} because you're not currently wielding a melee weapon. Will retry when you're training melee weapons." if $debug_mode_ct
         elsif DRStats.mana < @barb_buffs_inner_fire_threshold
           echo "Not activating barb_buff #{name} until have at least #{@barb_buffs_inner_fire_threshold} inner fire. You currently have #{DRStats.mana}." if $debug_mode_ct
         elsif DRCA.activate_barb_buff?(name, @meditation_pause_timer)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2078,7 +2078,7 @@ class AbilityProcess
         timer = game_state.cooldown_timers[name]
         next unless !timer || (Time.now - timer).to_i > 30
         if name == 'Tsunami' && (!game_state.melee_weapon_skill? || DRC.right_hand.nil? || DRC.right_hand.empty?)
-          echo "Skipping activating barb_buff #{name} because you're not currently wielding a melee weapon. Will retry when you're training melee weapons." if $debug_mode_ct
+          echo "Not activating barb_buff #{name} because you're not currently wielding a melee weapon. Will retry when you're training melee weapons." if $debug_mode_ct
         elsif DRStats.mana < @barb_buffs_inner_fire_threshold
           echo "Not activating barb_buff #{name} until have at least #{@barb_buffs_inner_fire_threshold} inner fire. You currently have #{DRStats.mana}." if $debug_mode_ct
         elsif DRCA.activate_barb_buff?(name, @meditation_pause_timer)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2075,10 +2075,15 @@ class AbilityProcess
       .select { |name| Flags["ap-#{name}-expired"] }
       .reject { |name| DRSpells.active_spells[name] }
       .each do |name|
-        if DRStats.mana < @barb_buffs_inner_fire_threshold
+        timer = game_state.cooldown_timers[name]
+        next unless !timer || (Time.now - timer).to_i > 30
+        if name == 'Tsunami' && (!game_state.melee_weapon_skill? || DRC.right_hand.nil? || DRC.right_hand.empty?)
+          echo "Skipping activating #{name} because you're not currently wielding a melee weapon. Will retry when you're training melee weapons." if $debug_mode_ct
+        elsif DRStats.mana < @barb_buffs_inner_fire_threshold
           echo "Not activating barb_buff #{name} until have at least #{@barb_buffs_inner_fire_threshold} inner fire. You currently have #{DRStats.mana}." if $debug_mode_ct
         elsif DRCA.activate_barb_buff?(name, @meditation_pause_timer)
           Flags.reset("ap-#{name}-expired")
+          game_state.cooldown_timers[name] = Time.now
           echo "Activated barb_buff #{name}" if $debug_mode_ct
         else
           echo "Did not activate barb_buff #{name}" if $debug_mode_ct
@@ -3381,12 +3386,13 @@ class GameState
   include DRCS
   include DRC
 
+  $melee_skills = ['Small Edged', 'Large Edged', 'Twohanded Edged', 'Small Blunt', 'Large Blunt', 'Twohanded Blunt', 'Staves', 'Polearms']
   $thrown_skills = ['Heavy Thrown', 'Light Thrown']
   $twohanded_skills = ['Twohanded Edged', 'Twohanded Blunt']
   $aim_skills = %w[Bow Slings Crossbow]
-  $tactics_actions = %w[bob weave circle]
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
+  $tactics_actions = %w[bob weave circle]
 
   attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type, :casting_regalia, :starlight_values, :casting_cyclic
 
@@ -3706,15 +3712,15 @@ class GameState
   end
 
   def sheath_offhand_weapon(skill)
-    return if skill.eql?'Brawling'
-    return if skill.eql?'Tactics'
+    return if skill.eql?('Brawling')
+    return if skill.eql?('Tactics')
 
     @equipment_manager.stow_weapon(weapon_training[skill])
   end
 
   def wield_offhand_weapon(skill)
-    return if skill.eql?'Brawling'
-    return if skill.eql?'Tactics'
+    return if skill.eql?('Brawling')
+    return if skill.eql?('Tactics')
 
     @equipment_manager.wield_weapon_offhand(weapon_training[skill], skill)
     weapon_training[skill]
@@ -3755,7 +3761,11 @@ class GameState
   end
 
   def twohanded_weapon_skill?
-    weapon_skill.include?'Twohanded'
+    $twohanded_skills.include?(weapon_skill)
+  end
+
+  def melee_weapon_skill?
+    $melee_skills.include?(weapon_skill)
   end
 
   def dance


### PR DESCRIPTION
### Dependencies
* Depends on https://github.com/rpherbig/dr-scripts/pull/5037 for `data/base-spells.yaml`

### Background
* The Barbarian berserk [Tsunami](https://elanthipedia.play.net/Tsunami_(berserk)) requires you to be holding a melee weapon to activate.
* `combat-trainer` has no check before trying to activate buffs, so it can get spammy and waste inner fire failing to activate.

### Changes
* Add method to `GameState` class to track if the current weapon skill being trained is a melee weapon skill
* Update the activate buff logic for Barbarians...
  - to check if you're holding a melee weapon if trying to activate Tsunami
  - to use cooldown timers like the other buff logic sections between check attempts

### Configuration
```yaml
# Barbarian buffs are specified in this part of your yaml
buff_nonspells:
  barb_buffs:
    - Tsunami
```

### Workarounds
* I've heard of folks not listing Tsunami in their `barb_buffs` but rather during their hunting-buddy `before` actions to wield a melee weapon, activate berserk, then stow weapon. However, with the short time duration of the berserk, this isn't a great workaround.

## Tests
* In my hunts, `combat-trainer` waits til I'm training a melee weapon before trying to activate Tsunami. Doesn't attempt if I'm training thrown/ranged/offhand skill.
* [Galtha](https://discord.com/channels/745675889622384681/745696628714897508/858188572783411211) also tested with success.