### PR TITLE
[data] [base-spells] Remove duplicate `harmless: true` entry

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -825,7 +825,6 @@ spell_data:
     abbrev: COMPEL
     mana: 15
     mana_type: life
-    harmless: true
   Compost:
     skill: Utility
     abbrev: COMPOST


### PR DESCRIPTION
### Background
* The spell `Compel` has two entries for `harmless: true`, only one is needed

### Changes
* Remove the duplicate `harmless: true` from the `Compel` spell definition