### PR TITLE
[script] [common] Add method to parse item name as text into DRC::Item instance

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -350,7 +350,7 @@ module DRC
       @adjective ? /\b#{adjective}.*\b#{@name}/i : /\b#{@name}/i
     end
 
-    # Convenience method to parse the text of an item, with or without an adjective,
+    # Convenience method to parse the text of an item as shown when in your hands, with or without an adjective,
     # into an Item class instance. Originally designed to support DRCI and equipmanager methods.
     def self.from_text(text)
       text = text

--- a/common.lic
+++ b/common.lic
@@ -349,6 +349,23 @@ module DRC
     def short_regex
       @adjective ? /\b#{adjective}.*\b#{@name}/i : /\b#{@name}/i
     end
+
+    # Convenience method to parse the text of an item, with or without an adjective,
+    # into an Item class instance. Originally designed to support DRCI and equipmanager methods.
+    def self.from_text(text)
+      text = text
+        .sub('.', ' ') # convert 'foo.bar' => 'foo bar' so more easily split into adjective and noun
+        .squeeze(' ') # condense repeated runs of whitespace with a single space
+        .strip # remove leading/trailing whitespace
+      parts = text.split
+      if text.nil? || text.empty?
+        nil
+      elsif parts.size > 1
+        DRC::Item.new(adjective: parts.first, name: parts.last)
+      else
+        DRC::Item.new(name: text)
+      end
+    end
   end
 
   # windows only I believe.


### PR DESCRIPTION
### Background
* My plan is to use this method in both `common-items` and `equipmanager` to "robustify" their methods to handle arguments of either an Item instance or text to enable the internal APIs to standardize on a canonical model (the Item class) when operating on items.
* It also provides an easy way to convert what's in your hand into an Item class instance (e.g. `DRC::Item.from_text(DRC.right_hand)` without the calling code needing to split the string and determine if need to set the `adjective` and/or `name` properties.
* This is also motivated by https://github.com/rpherbig/dr-scripts/pull/4980, which had to revert a use of `DRCI.in_hands?(item.short_name)` because of how that method was implemented trying to parse the string into an Item class instance. Words that were joined by a period ("blue.sword") were treated as one word and didn't split. This proposed method will alleviate mishaps like that in the future.

### Changes
* Add static method `from_text` to parse an item's name (as shown when held in your hand) into a `DRC::Item` class instance

I have planned subsequent PRs that will make use of this method.

## Tests

<details>
<summary>nil or blank string</summary>

```
> ,e echo DRC::Item.from_text(nil).inspect
> ,e echo DRC::Item.from_text('').inspect
> ,e echo DRC::Item.from_text('   ').inspect

--- Lich: exec1 active.

[exec1: nil]

--- Lich: exec1 has exited.
```
</details>

<details>
<summary>sword</summary>

```
> ,e echo DRC::Item.from_text('sword').inspect

--- Lich: exec1 active.

[exec1: #<DRC::Item:0x10490c40 @name="sword", @leather=nil, @worn=false, @hinders_lockpicking=nil, @container=nil, @swappable=false, @tie_to=nil, @adjective=nil, @bound=false, @wield=false, @transforms_to=nil, @transform_verb=nil, @transform_text=nil, @lodges=true, @skip_repair=false, @ranged=false, @needs_unloading=false>]

--- Lich: exec1 has exited.
```
</details>

<details>
<summary>steel sword</summary>

```
> ,e echo DRC::Item.from_text('steel sword').inspect

--- Lich: exec1 active.

[exec1: #<DRC::Item:0x12e9ea70 @name="sword", @leather=nil, @worn=false, @hinders_lockpicking=nil, @container=nil, @swappable=false, @tie_to=nil, @adjective="steel", @bound=false, @wield=false, @transforms_to=nil, @transform_verb=nil, @transform_text=nil, @lodges=true, @skip_repair=false, @ranged=false, @needs_unloading=false>]

--- Lich: exec1 has exited.
```
</details>

<details>
<summary>rusty copper sword</summary>

```
> ,e echo DRC::Item.from_text('rusty copper sword').inspect

--- Lich: exec1 active.

[exec1: #<DRC::Item:0x12e9ea70 @name="sword", @leather=nil, @worn=false, @hinders_lockpicking=nil, @container=nil, @swappable=false, @tie_to=nil, @adjective="rusty", @bound=false, @wield=false, @transforms_to=nil, @transform_verb=nil, @transform_text=nil, @lodges=true, @skip_repair=false, @ranged=false, @needs_unloading=false>]

--- Lich: exec1 has exited.
```