### PR TITLE
[common-crafting] [Update] Added .* to line 232 to catch extra long brazier names.

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -229,8 +229,8 @@ module DRCC
         order_enchant(stock_room, stock_needed, stock_number, bag, belt)
       end
     when /I could not find what you were referring to./
-      case bput('tap my fount on my brazier', 'You tap .* atop a brazier.', 'I could not find what you were referring to.')
-      when /You tap (.*) atop a brazier./
+      case bput('tap my fount on my brazier', /You tap .* atop a .* brazier./, /I could not find what you were referring to./)
+      when /You tap (.*) atop a (.*) brazier./
         /(\d+)/ =~ bput('analyze my fount on my brazier', 'This appears to be a crafting tool and it has approximately \d+ uses remaining')
         if Regexp.last_match(1).to_i < quantity
           stow_hands

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -229,8 +229,8 @@ module DRCC
         order_enchant(stock_room, stock_needed, stock_number, bag, belt)
       end
     when /I could not find what you were referring to./
-      case bput('tap my fount on my brazier', /You tap .* atop a .* brazier./, /I could not find what you were referring to./)
-      when /You tap (.*) atop a (.*) brazier./
+      case bput('tap my fount on my brazier', /You tap .* atop a .*brazier./, /I could not find what you were referring to./)
+      when /You tap (.*) atop a (.*)brazier./
         /(\d+)/ =~ bput('analyze my fount on my brazier', 'This appears to be a crafting tool and it has approximately \d+ uses remaining')
         if Regexp.last_match(1).to_i < quantity
           stow_hands


### PR DESCRIPTION
Per https://discord.com/channels/745675889622384681/745762938991804556/858509717092433920, needed to add the extra .* to catch names like `a potbellied silver brazier`. Alternative pointed it out and will test. 

I also changed to the regex method instead of single or double-quotes. 