### PR TITLE
[script] [combat-trainer] New option: prioritize maneuver doublestrike

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2883,7 +2883,20 @@ class AttackProcess
   def attack_melee(charged_maneuver, game_state)
     waitrt?
     if charged_maneuver
+      # If you're prioritizing doublestrike but only wielding one melee weapon
+      # then temporarily wield a second weapon offhand to perform the maneuver.
+      offhand_weapon_name = nil
+      if charged_maneuver.casecmp?('doublestrike') && DRC.left_hand.nil?
+        skill = game_state.determine_doublestrike_skill
+        if skill
+          echo "attack_melee::maneuver_doublestrike:skill: #{skill}" if $debug_mode_ct
+          offhand_weapon_name = game_state.wield_offhand_weapon(skill)
+        end
+      end
+
       use_charged_maneuver(charged_maneuver, game_state)
+
+      game_state.sheath_offhand_weapon(skill) if offhand_weapon_name
     else
       if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush?
         hide?(@hide_type)
@@ -3381,12 +3394,14 @@ class GameState
   include DRCS
   include DRC
 
+  $martial_skills = ['Brawling']
+  $melee_skills = ['Small Edged', 'Large Edged', 'Twohanded Edged', 'Small Blunt', 'Large Blunt', 'Twohanded Blunt', 'Staves', 'Polearms']
   $thrown_skills = ['Heavy Thrown', 'Light Thrown']
   $twohanded_skills = ['Twohanded Edged', 'Twohanded Blunt']
   $aim_skills = %w[Bow Slings Crossbow]
-  $tactics_actions = %w[bob weave circle]
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
+  $tactics_actions = %w[bob weave circle]
 
   attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type, :casting_regalia, :starlight_values, :casting_cyclic
 
@@ -3506,6 +3521,9 @@ class GameState
 
     @charged_maneuvers = settings.charged_maneuvers
     echo("  @charged_maneuvers: #{@charged_maneuvers}") if $debug_mode_ct
+
+    @prioritize_maneuver_doublestrike = settings.prioritize_maneuver_doublestrike
+    echo("  @prioritize_maneuver_doublestrike: #{@prioritize_maneuver_doublestrike}") if $debug_mode_ct
 
     @fatigue_regen_threshold = settings.fatigue_regen_threshold
     echo("  @fatigue_regen_threshold: #{@fatigue_regen_threshold}") if $debug_mode_ct
@@ -3706,15 +3724,15 @@ class GameState
   end
 
   def sheath_offhand_weapon(skill)
-    return if skill.eql?'Brawling'
-    return if skill.eql?'Tactics'
+    return if skill.eql?('Brawling')
+    return if skill.eql?('Tactics')
 
     @equipment_manager.stow_weapon(weapon_training[skill])
   end
 
   def wield_offhand_weapon(skill)
-    return if skill.eql?'Brawling'
-    return if skill.eql?'Tactics'
+    return if skill.eql?('Brawling')
+    return if skill.eql?('Tactics')
 
     @equipment_manager.wield_weapon_offhand(weapon_training[skill], skill)
     weapon_training[skill]
@@ -3755,7 +3773,11 @@ class GameState
   end
 
   def twohanded_weapon_skill?
-    weapon_skill.include?'Twohanded'
+    $twohanded_skills.include?(weapon_skill)
+  end
+
+  def melee_weapon_skill?
+    $melee_skills.include?(weapon_skill)
   end
 
   def dance
@@ -3894,8 +3916,11 @@ class GameState
   end
 
   def charged_maneuver
-    return @charged_maneuvers['Dual Wield'] if currently_whirlwinding && !twohanded_weapon_skill?
-    @charged_maneuvers[weapon_skill]
+    if !twohanded_weapon_skill? && (@currently_whirlwinding || (@prioritize_maneuver_doublestrike && melee_weapon_skill?))
+      @charged_maneuvers['Dual Wield']
+    else
+      @charged_maneuvers[weapon_skill]
+    end
   end
 
   def fatigue_low?
@@ -4161,12 +4186,22 @@ class GameState
   end
 
   def determine_aiming_skill
-    held_types = ['Small Edged', 'Large Edged', 'Small Blunt', 'Large Blunt', 'Staves', 'Polearms']
-    thrown_types = ['Light Thrown', 'Heavy Thrown']
     options = @aiming_trainables
-    options -= held_types if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow)
-    options -= thrown_types if (weapon_skill.eql?('Bow') && @left_hand_free)
+    options -= [weapon_skill] # can't be your mainhand skill
+    options -= $twohanded_skills # can't be a twohanded skill
+    options -= $melee_skills if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow)
+    options -= $thrown_skills if (weapon_skill.eql?('Bow') && @left_hand_free)
     echo "determine_aiming_skill::options: #{options}" if $debug_mode_ct
+    sort_by_rate_then_rank(options).first
+  end
+
+  def determine_doublestrike_skill
+    options = @aiming_trainables
+    options -= [weapon_skill] # can't be your main hand skill, it's in your main hand
+    options -= $twohanded_skills # can't be a twohanded skill, you need both hands
+    options -= $thrown_skills # shouldn't be a thrown skill, you're doing a melee attack
+    options -= $martial_skills # shouldn't be brawling, you need a weapon in your offhand
+    echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -89,6 +89,11 @@ charged_maneuvers:
   Staves: twirl
   Polearms: impale
   Dual Wield: doublestrike
+# If "Charged Maneuver" is set in your training_abilities, this setting
+# will prioritize dual wield attacks by temporarily wielding an "aiming trainable"
+# in your offhand when you're holding a one-handed weapon in your main hand.
+# If this is false then a charged manuever for your main hand weapon is used instead.
+prioritize_maneuver_doublestrike: false
 # Defines the number of monsters you will keep in combat with you by performing 'dance actions' or attacking with only 'harmless: true' spells. 0 means kill everything.
 dance_threshold: 0
 # What weapon skill to use while dancing


### PR DESCRIPTION
### Background
* `combat-trainer` already prioritizes the doublestrike maneuver for Barbarians that are whirlwinding since they're actively holding two melee weapons.
* For characters that are not whirlwinding (regardless their guild), there lacks an option to prioritize the doublestrike maneuver.
* I have a desire to doublestrike as much as possible for...
    - the fun of it
    - kill critters fast to fuel my inner fire
    - I don't have whirlwind and would like to use this maneuver to gain EXP in multiple melee weapons with one attack similar to how aiming_trainables lets you gain EXP in two skills when you're training a ranged weapon

### Changes
* Add setting `prioritize_maneuver_doublestrike: boolean`
* Update method `charged_maneuver` to also choose doublestrike when this setting is true and you're training a melee weapon skill
* Add method `determine_doublestrike_skill` that, similar to `determine_aiming_skill`, picks an appropriate skill from your aiming_trainables list as what to equip offhand
* Update the `attack_melee` method that when the doublestrike maneuver should be performed to equip a suitable melee weapon in  your offhand, perform the maneuver, then put away the offhand weapon

### Configuration
```yaml
# If true then whenever you're able to perform a doublestrike maneuver, do so :)
# If false then will perform a specific manuever based on the equipped mainhand weapon.
prioritize_maneuver_doublestrike: true

training_abilities:
  # How often you want to attempt a charged combat maneuver.
  # https://elanthipedia.play.net/Combat_maneuvers#Charged_Maneuvers
  Charged Maneuver: 60 

# When you can do doublestrike maneuver then a non-thrown, non-ranged, non-brawling skill
# will be chosen from this list to temporarily equip in your offhand for the strike.
aiming_trainables:
  - Small Edged
  - Small Blunt
  - Light Thrown
  - Heavy Thrown
  - Staves
  - Polearms
  - Brawling
```

### Example
<details>
<summary>click to view log snippet</summary>

```
[combat-trainer]>wield my throwing.club

You draw out your throwing club from the armor pack, gripping it firmly in your right hand.

... attack with club for a bit ...

... time to do maneuver doublestrike! ...

[combat-trainer]>wield my witchclaw.pilum
You draw out your witchclaw pilum from the armor pack, gripping it firmly in your left hand.

[combat-trainer]>maneuver doublestrike
You step to the side and adjust your stance.

... charge up ...

You turn to face a zombie boar.
You rush at a zombie boar, lashing out with your club!

Your throwing club lands a solid hit (4/22) to a zombie boar's right foreleg!
With expert skill you end the attack and maneuver into a better position.
Your attack momentum continues with a second strike of your pilum!

Your witchclaw pilum lands a heavy strike (7/22) to a zombie boar's abdomen!
The zombie boar is lightly stunned!

[You're incredibly balanced and overwhelming opponent.]
Roundtime: 1 sec.

[combat-trainer]>sheath my witchclaw.pilum
You sheathe the witchclaw pilum in your armor pack.

... continue with club in main hand ...
```
</details>