### PR TITLE
Script and example profile settings to run yaml autostarts.

### DIFF
--- a/autostart_yaml_scripts.lic
+++ b/autostart_yaml_scripts.lic
@@ -1,0 +1,23 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#autostart_yaml_scripts
+=end
+
+custom_require.call(%w[common])
+
+no_kill_all
+no_pause_all
+
+class AutostartYamlScripts
+  def initialize
+    settings = get_settings
+    @autostart_scripts = settings.autostart_scripts
+    @autostart_scripts_delay = settings.autostart_scripts_delay
+
+    pause @autostart_scripts_delay
+    for s in @autostart_scripts
+      start_script(s)
+    end
+  end
+end
+
+AutostartYamlScripts.new

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -5,6 +5,15 @@ hometown: Crossing
 # Cap on time crossing-training runs
 training_manager_town_duration:
 
+# delays yaml autostart scripts on startup
+autostart_scripts_delay: 5
+# autostart scripts can also be specified in the YAML
+autostart_scripts:
+  - spellmonitor
+  - drinfomon
+  - sanowret-crystal
+  - skill-recorder
+
 # T2 Settings
 training_list:
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -9,10 +9,9 @@ training_manager_town_duration:
 autostart_scripts_delay: 5
 # autostart scripts can also be specified in the YAML
 autostart_scripts:
-  - spellmonitor
-  - drinfomon
-  - sanowret-crystal
-  - skill-recorder
+#  - spellmonitor
+#  - drinfomon
+#  - skill-recorder
 
 # T2 Settings
 training_list:


### PR DESCRIPTION
Add a script to autostart scripts according to a YAML configuration.

When added to dependency autostart, this script creates an alternative path for autostart scripts to be configurable as code, per character, in `profiles/my.yaml`.

FUTURE: integrate this more tightly into dependency.