### PR TITLE
Update dependency.lic

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -154,7 +154,7 @@ class ScriptManager
 
   def initialize(debug)
     @debug = debug
-    @git_token = '4491b4c6' + '20864db1575' + '3542a5d8729cf362acd1c'
+    @git_token = 'ghp_' + 'Z8AgbZCOYwmdG' + '9zgSr9MyQkFL' + 'exYYo2tROJO'
     @paste_bin_token = 'dca351a27a8af501a8d3123e29af7981'
     @paste_bin_url = 'https://pastebin.com/api/api_post.php'
     @firebase_url = 'https://dr-scripts.firebaseio.com/'


### PR DESCRIPTION
Github has a new token format so I'd like to switch to it for this and eventually delete the old token. We should figure out the right way to do this in the future and stop being hacky.