### PR TITLE
dependency.lic updates:

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1244,12 +1244,14 @@ end
 
 def set_dev_mode
   echo "Now turning dev mode on"
-  echo "Developer mode now set to: #{$manager.developer = true}"
+  $manager.developer = true
+  echo "Developer mode now set to: #{$manager.developer}"
 end
 
 def unset_dev_mode
   echo "Now turning dev mode off"
-  echo "Developer mode now set to: #{$manager.developer = false}"
+  $manager.developer = false
+  echo "Developer mode now set to: #{$manager.developer}"
 end
 
 def check_dev_mode
@@ -1262,12 +1264,14 @@ end
 
 def ignore_dependency
   echo "Now ignoring dependency updates"
-  echo "ignore_dependency now set to: #{$manager.ignore_dependency = true}"
+  $manager.ignore_dependency = true
+  echo "ignore_dependency now set to: #{$manager.ignore_dependency}"
 end
 
 def unignore_dependency
   echo "Now processing dependency updates"
-  echo "ignore_dependency now set to: #{$manager.ignore_dependency = false}"
+  $manager.ignore_dependency = false
+  echo "ignore_dependency now set to: #{$manager.ignore_dependency}"
 end
 
 def check_dependency

--- a/dependency.lic
+++ b/dependency.lic
@@ -1392,7 +1392,7 @@ def help_me(user = nil)
   result = $manager.submit_help_pastebin
   if user
     LNet.send_message({ 'type' => 'private', 'to' => user }, result)
-    echo("Attempted to  PM YAML link on lnet to #{user}.  Check lnet window for success or failure.")
+    echo("Attempted to PM YAML link on lnet to #{user}.  Check lnet window for success or failure.")
   else
     LNet.send_message({ 'type' => 'channel' }, result)
     echo('YAML link sent to lnet.  Check lnet window.')

--- a/dependency.lic
+++ b/dependency.lic
@@ -9,7 +9,8 @@ require 'yaml'
 require 'ostruct'
 require 'digest/sha1'
 
-$DEPENDENCY_VERSION = '1.2'
+$DEPENDENCY_VERSION = '1.3'
+$MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all
 no_kill_all
@@ -137,7 +138,11 @@ class OpenStruct
       if len != 1
         raise ArgumentError, "wrong number of arguments (#{len} for 1)", caller(1)
       end
-      modifiable[new_ostruct_member(mname)] = args[0]
+      if !respond_to?(:modifiable?, true) # for backwards compatability <2.3, to be removed eventually
+        modifiable[new_ostruct_member(mname)] = args[0]
+      else                                # new >=2.3 method
+        modifiable?[new_ostruct_member(mname)] = args[0]
+      end
     elsif len.zero?
       @table[mid]
     elsif len == 1
@@ -170,6 +175,7 @@ class ScriptManager
     Settings['base_versions'] ||= {}
 
     @developer = Settings['dependency-developer'] || false
+    @ignore_dependency = Settings['ignore-dependency'] || false
     @add_autos = []
     @remove_autos = []
     update_autostarts
@@ -190,8 +196,32 @@ class ScriptManager
     @autostarts = UserVars.autostart_scripts + Settings['autostart']
   end
 
-  def toggle_developer
-    @developer = !@developer
+  def set_developer
+    @developer = true if !@developer
+    @developer
+  end
+
+  def unset_developer
+    @developer = false if @developer
+    @developer
+  end
+
+  def check_developer
+    @developer
+  end
+
+  def set_ignore_dependency
+    @ignore_dependency = true if !@ignore_dependency
+    @ignore_dependency
+  end
+
+  def unset_ignore_dependency
+    @ignore_dependency = false if @ignore_dependency
+    @ignore_dependency
+  end
+
+  def check_ignore_dependency
+    @ignore_dependency
   end
 
   def add_global_auto(script)
@@ -233,6 +263,7 @@ class ScriptManager
 
   def run_queue
     Settings['dependency-developer'] = @developer
+    Settings['ignore-dependency'] = @ignore_dependency
     update = false
 
     unless @add_autos.empty?
@@ -329,6 +360,11 @@ class ScriptManager
 
   def download_script(filename, force = false)
     return if filename.nil? || filename.empty?
+    if filename == 'dependency.lic' && @ignore_dependency
+      respond 'ignoring dependency download due to ignore_dependency setting'
+      respond "use '#{$lich_char}e check_dependency' to check the value."
+      return
+    end
     echo("downloading:#{filename}") if @debug
     info = get_file_status(filename)
     return unless info
@@ -1167,15 +1203,23 @@ def list_tracked_scripts
 end
 
 def full_install
-  respond 'Removing lich autostarts for existing scripts...'
+  if !supported_ruby_version?
+    echo "You are using an unsupported version of ruby."
+    echo "In order to prevent people from wasting too much work on an unsupported version, this will not proceed."
+    echo "Please update to at least version #{$MIN_RUBY_VERSION} and try again."
+    echo "For further details / assistance, please join the dr-scripts Lich Discord: https://discord.gg/uxZWxuX "
+    exitfrom
+  end
+  respond 'Performing setup for dr-scripts.  This will take some time.  Do not stop this script until finished.'
+  respond '(Step 1 of 5) Removing lich autostarts for existing scripts...'
   remove_from_autostart(managed_scripts)
-  respond 'Adding dependency.lic to lich autostart'
+  respond '(Step 2 of 5) Adding dependency.lic to lich autostart'
   add_self_to_autostart
-  respond 'Creating a /profiles directory and downloading default profiles'
+  respond '(Step 3 of 5) Creating a /profiles directory and downloading default profiles (this will take a while)'
   setup_profiles
-  respond 'Creating a /data directory and downloading data files'
+  respond '(Step 4 of 5) Creating a /data directory and downloading data files (this will take a while)'
   setup_data
-  respond 'Backing up existing scripts and replacing with latest versions'
+  respond '(Step 5 of 5) Backing up existing scripts and replacing with latest versions (this will take a while)'
   replace_all
   respond 'Finished install!'
 end
@@ -1183,7 +1227,12 @@ end
 def replace_all
   managed_scripts
     .each do |script|
-      new_name = "#{script}#{Time.now.to_i}.bak"
+      if script == 'dependency.lic' && $manager.check_ignore_dependency
+        respond 'ignoring replace dependency due to ignore_dependency setting'
+        respond "use '#{$lich_char}e check_dependency' to check the value."
+        next
+      end
+      new_name = "#{script}.#{Time.now.to_i}.bak"
       respond "Renaming existing script #{script} to #{new_name}"
       File.rename("./scripts/#{script}", "./scripts/#{new_name}")
     end
@@ -1220,20 +1269,57 @@ def stop_autostart(script)
   end
 end
 
+def set_dev_mode
+  echo "Now turning dev mode on"
+  echo "Developer mode now set to: #{$manager.set_developer}"
+end
+
+def unset_dev_mode
+  echo "Now turning dev mode off"
+  echo "Developer mode now set to: #{$manager.unset_developer}"
+end
+
+def check_dev_mode
+  echo "Developer mode set to: #{$manager.check_developer}"
+end
+
 def toggle_developer_mode
-  echo "Developer mode now set to: #{$manager.toggle_developer}"
+  echo "THIS METHOD IS NO LONGER USED. USE '#{$lich_char}e set_dev_mode' and '#{$lich_char}e unset_dev_mode'."
+end
+
+def ignore_dependency
+  echo "Now ignoring dependency updates"
+  echo "ignore_dependency now set to: #{$manager.set_ignore_dependency}"
+end
+
+def unignore_dependency
+  echo "Now processing dependency updates"
+  echo "ignore_dependency now set to: #{$manager.unset_ignore_dependency}"
+end
+
+def check_dependency
+  echo "ignore_dependency is set to: #{$manager.check_ignore_dependency}"
+  echo "Use '#{$lich_char}e ignore_dependency' and '#{$lich_char}e unignore_dependency' to change."
 end
 
 def use_lich_fork
   echo 'Now switching onto the DR lich fork...'
   start_script('repository', ['unset-lich-updatable'])
+  pause 1 while Script.running?('repository')
+  echo 'Turning off updates from main lich branch on go2...'
+  start_script('repository', ['unset-updatable', 'go2'])
   $manager.queue_lich
 end
 
 def use_lich_main
   echo 'Now switching onto the lich mainline...'
   start_script('repository', ['set-lich-updatable'])
-  pause
+  pause 1 while Script.running?('repository')
+
+  echo 'Turning updates from main lich branch on go2 back on...'
+  start_script('repository', ['set-updatable', 'go2'])
+  pause 1 while Script.running?('repository')
+
   start_script('repository', ['download-lich'])
   pause
   pause 1 while Script.running?('repository')
@@ -1241,7 +1327,7 @@ def use_lich_main
 end
 
 def toggle_lich_fork
-  echo 'THIS METHOD IS NO LONGER USED. USE ;e use_lich_fork and ;e use_lich_main'
+  echo "THIS METHOD IS NO LONGER USED. USE #{$lich_char}e use_lich_fork and #{$lich_char}e use_lich_main"
 end
 
 def setup_profiles
@@ -1250,6 +1336,32 @@ end
 
 def setup_data
   $manager.setup_data
+end
+
+def supported_ruby_version?
+  return Gem::Version.new(RUBY_VERSION) >= Gem::Version.new($MIN_RUBY_VERSION)
+end
+
+def validate_supported_ruby_version
+  # Get stored time for next check (or now if not stored yet)
+  next_check_datetime = Settings['next_ruby_version_check_datetime'] || Time.now
+
+  # Don't spam user every time it starts up
+  return if next_check_datetime > Time.now
+
+  #Check for supported version
+  if !supported_ruby_version?
+    echo "*** WARN WARN WARN WARN WARN WARN WARN ***"
+    echo "WARN: You are using an unsupported version of ruby."
+    echo "WARN: While many scripts may still continue to run, there are some that may not."
+    echo "WARN: Please update to at least version #{$MIN_RUBY_VERSION} as soon as possible."
+    echo "WARN: For further details / assistance, please join the dr-scripts Lich Discord: https://discord.gg/uxZWxuX."
+    echo "WARN: This warning will repeat on startup after 7 days."
+    echo "*** WARN WARN WARN WARN WARN WARN WARN ***"
+  end
+
+  # Set next check time to 7 days from now
+  Settings['next_ruby_version_check_datetime'] = Time.now + (60 * 60 * 24 * 7) 
 end
 
 def remove_from_autostart(scripts)
@@ -1280,8 +1392,10 @@ def help_me(user = nil)
   result = $manager.submit_help_pastebin
   if user
     LNet.send_message({ 'type' => 'private', 'to' => user }, result)
+    echo("Attempted to  PM YAML link on lnet to #{user}.  Check lnet window for success or failure.")
   else
     LNet.send_message({ 'type' => 'channel' }, result)
+    echo('YAML link sent to lnet.  Check lnet window.')
   end
 end
 
@@ -1321,6 +1435,8 @@ if $manager.updated_dependency?
   echo('Update found for dependency.lic')
   update_d
 end
+
+validate_supported_ruby_version
 
 before_dying do
   $moon_watch = nil

--- a/dependency.lic
+++ b/dependency.lic
@@ -156,6 +156,7 @@ end
 
 class ScriptManager
   attr_reader :autostarts
+  attr_accessor :developer, :ignore_dependency
 
   def initialize(debug)
     @debug = debug
@@ -194,34 +195,6 @@ class ScriptManager
 
   def update_autostarts
     @autostarts = UserVars.autostart_scripts + Settings['autostart']
-  end
-
-  def set_developer
-    @developer = true if !@developer
-    @developer
-  end
-
-  def unset_developer
-    @developer = false if @developer
-    @developer
-  end
-
-  def check_developer
-    @developer
-  end
-
-  def set_ignore_dependency
-    @ignore_dependency = true if !@ignore_dependency
-    @ignore_dependency
-  end
-
-  def unset_ignore_dependency
-    @ignore_dependency = false if @ignore_dependency
-    @ignore_dependency
-  end
-
-  def check_ignore_dependency
-    @ignore_dependency
   end
 
   def add_global_auto(script)
@@ -1227,7 +1200,7 @@ end
 def replace_all
   managed_scripts
     .each do |script|
-      if script == 'dependency.lic' && $manager.check_ignore_dependency
+      if script == 'dependency.lic' && $manager.ignore_dependency
         respond 'ignoring replace dependency due to ignore_dependency setting'
         respond "use '#{$lich_char}e check_dependency' to check the value."
         next
@@ -1271,16 +1244,16 @@ end
 
 def set_dev_mode
   echo "Now turning dev mode on"
-  echo "Developer mode now set to: #{$manager.set_developer}"
+  echo "Developer mode now set to: #{$manager.developer = true}"
 end
 
 def unset_dev_mode
   echo "Now turning dev mode off"
-  echo "Developer mode now set to: #{$manager.unset_developer}"
+  echo "Developer mode now set to: #{$manager.developer = false}"
 end
 
 def check_dev_mode
-  echo "Developer mode set to: #{$manager.check_developer}"
+  echo "Developer mode set to: #{$manager.developer}"
 end
 
 def toggle_developer_mode
@@ -1289,16 +1262,16 @@ end
 
 def ignore_dependency
   echo "Now ignoring dependency updates"
-  echo "ignore_dependency now set to: #{$manager.set_ignore_dependency}"
+  echo "ignore_dependency now set to: #{$manager.ignore_dependency = true}"
 end
 
 def unignore_dependency
   echo "Now processing dependency updates"
-  echo "ignore_dependency now set to: #{$manager.unset_ignore_dependency}"
+  echo "ignore_dependency now set to: #{$manager.ignore_dependency = false}"
 end
 
 def check_dependency
-  echo "ignore_dependency is set to: #{$manager.check_ignore_dependency}"
+  echo "ignore_dependency is set to: #{$manager.ignore_dependency}"
   echo "Use '#{$lich_char}e ignore_dependency' and '#{$lich_char}e unignore_dependency' to change."
 end
 


### PR DESCRIPTION
 - handle deprecated ostruct method (closes #4958)
 - Introduce min ruby version
   - prohibits new install on versions below min ruby version
   - warn users (weekly) if version lower than min
 - bump dependency minor version due to above
 - change developer toggles to prevent accidently turning it off and losing work
 - create toggle for ignoring just dependency update: far easier to test changes during install
 - added additional info on number of steps during install process
 - also removed go2 from repsoitory updates to prevent overwrites of our own version
 - removed hardcoded lich script start charcters in favor of variable to handle different FEs
 - additional output when running help_me to direct to lnet window for link