### PR TITLE
[script] [spellmonitor] squelch message for barbarians

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -236,7 +236,7 @@ known_spells_hook = proc do |server_string|
     server_string = nil if DRSpells.silence_known_spells_hook
   when /^You have \d+ spell slots? available|You do not know any magic feats/
     server_string = nil if DRSpells.silence_known_spells_hook
-  when /^You can use SPELL STANCE|^You have (no|yet to receive any) training in the magical arts|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
+  when /^You can use SPELL STANCE|^You have (no|yet to receive any) training in the magical arts|You have no desire to soil yourself with magical trickery|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
     DRSpells.grabbing_known_spells = false
     server_string = nil if DRSpells.silence_known_spells_hook
   end


### PR DESCRIPTION
### Changes
* Squelch the phrase "You have no desire to soil yourself with magical trickery" when `spellmonitor` starts up for Barbarians