### PR TITLE
[script] [common-arcana] Add option for barbs to sit to meditate

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -74,15 +74,19 @@ module DRCA
   end
 
   def start_barb_abilities(abilities, settings)
-    abilities.each { |name| activate_barb_buff?(name, settings.meditation_pause_timer) }
+    abilities.each { |name| activate_barb_buff?(name, settings.meditation_pause_timer, settings.sit_to_meditate) }
   end
 
-  def activate_barb_buff?(name, meditation_pause_timer = 20)
+  def activate_barb_buff?(name, meditation_pause_timer = 20, sit_to_meditate = false)
     # Note, you must know Power meditation or Powermonger mastery
     # for your active abilities to be detected by DRSpells.
     return true if DRSpells.active_spells[name]
     activated = false
     ability_data = get_data('spells').barb_abilities[name]
+    if sit_to_meditate
+      DRC.retreat
+      fput('sit')
+    end
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'You have not been trained', 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
     when 'You must be unengaged'
       DRC.retreat

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -85,7 +85,7 @@ module DRCA
     ability_data = get_data('spells').barb_abilities[name]
     if sit_to_meditate
       DRC.retreat
-      fput('sit')
+      DRC.bput('sit', 'You sit', 'You are already', 'You rise', 'While swimming?')
     end
     case DRC.bput(ability_data['start_command'], ability_data['activated_message'], 'You have not been trained', 'But you are already', 'Your inner fire lacks', 'find yourself lacking the inner fire', 'You should stand', 'You must be sitting', 'You must be unengaged', 'While swimming?')
     when 'You must be unengaged'

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -83,7 +83,7 @@ module DRCA
     return true if DRSpells.active_spells[name]
     activated = false
     ability_data = get_data('spells').barb_abilities[name]
-    if sit_to_meditate
+    if ability_data['type'].eql?('meditation') && sit_to_meditate
       DRC.retreat
       DRC.bput('sit', 'You sit', 'You are already', 'You rise', 'While swimming?')
     end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -431,7 +431,7 @@ check_discern_timer_in_hours: 24 # i.e., checking every 24 hours
 # With sufficient skill, you can activate while standing
 kneel_khri: false
 # Barbarian only - kneel to activate barbarian meditation
-# With the Strategos mastery, you can meditate while standing
+# With the Yogi mastery, you can meditate while standing
 sit_to_meditate: false
 cambrinth_items:
 - name:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -427,8 +427,12 @@ stored_cambrinth: false
 prep_scaling_factor: 0.85
 # used with use_auto_mana. How often it will check discerns in hours. Lower circle/ranks should check more often.
 check_discern_timer_in_hours: 24 # i.e., checking every 24 hours
-# force kneeling to engage khris
+# Thief only - kneel to activate khri
+# With sufficient skill, you can activate while standing
 kneel_khri: false
+# Barbarian only - kneel to activate barbarian meditation
+# With the Strategos mastery, you can meditate while standing
+sit_to_meditate: false
 cambrinth_items:
 - name:
   cap:


### PR DESCRIPTION
### Background
* Unless you have the Yogi mastery, Barbarians must sit to meditate
* Attempting to meditate while not sitting will waste your inner fire (sad trombone)

### Changes
* Add new setting `sit_to_meditate: boolean` for players to indicate if they want to sit to meditate or not (modeled after the `kneel_khri` setting for Thieves). As new behavior, this defaults to `false` so players must opt-in by setting it to `true`.
* Update `common-arcana`'s `activate_barb_buff?` to accept a new third, optional, parameter to denote if should sit or not.

### Configuration
```yaml
# Barbarian only - kneel to activate barbarian meditation
# With the Yogi mastery, you can meditate while standing
sit_to_meditate: true
```

### Tests
* See `test/test_common_arcana.rb`