### PR TITLE
[script] [roomnumbers] display non-compass room exits

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1909,3 +1909,7 @@ runestone_harness: 30
 ### These runestones are only purchasable there.
 ### Uses restock section.
 runestone_purchase: false
+
+### Roomnumbers.lic Settings:
+roomnumbers_display_exits: true
+roomnumbers_display_stringproc_exits: false

--- a/roomnumbers.lic
+++ b/roomnumbers.lic
@@ -7,11 +7,42 @@ no_kill_all
 
 pause 2
 
+@display_exits = get_settings.roomnumbers_display_exits
+@display_stringproc_exits = get_settings.roomnumbers_display_stringproc_exits
+
 r_nums = proc do |server_string|
   if server_string =~ %r{<style id=""/><preset id='roomDesc'>} && !XMLData.in_stream
     $room_number_ready = true
   elsif $room_number_ready && server_string =~ /<prompt / && Room.current
     respond("Room Number: #{Room.current.id}")
+
+    if @display_exits || @display_stringproc_exits # only do next steps if going to display at least one 
+      # clear entries on nextroom
+      room_exits = []
+      string_proc_exits = []
+
+      # for each exit (wayto) from the current room, store the movement info
+      Room.current.wayto.each_value do |value| 
+        if value.class == Proc
+          # class = Proc means it's a stringproc, and can have long data.
+          string_proc_exits << value.inspect.gsub(/StringProc.new\((.*?)\)/,'\1')
+        else
+          # Don't include cardinals / up/down/out (usually just climb/go)
+          room_exits << value if value !~ /^(?:o|d|u|n|ne|e|se|s|sw|w|nw|out|down|up|north|northeast|east|southeast|south|southwest|west|northwest)$/
+        end
+      end
+
+      # output standard exits
+      respond("Room Exits: #{room_exits.join(', ')}") if room_exits.size > 0 if @display_exits 
+
+      # output StringProc Exits
+      if @display_stringproc_exits
+        string_proc_exits.each do |value|
+          respond("StringProc Exit: #{value}")
+        end
+      end
+
+    end
     $room_number_ready = false
     if $frontend == 'stormfront'
       _respond("<streamWindow id='main' title='Story' subtitle=\" - [#{Room.current.title.first[2..-3]} - #{Room.current.id}]\" location='center' target='drop'/>")


### PR DESCRIPTION
Adds the ability for roomnumbers.lic to display non-compass room exits similar to how it shows roomnumbers after room info.
 - non-StringProc exits (generally climb/go X) turned on by default
 - StringProc exits (complex, and bescort style) turned off by default as they are one line each, and can be quite long