### PR TITLE
[script] [crossing-repair] Wait for appraisal RT to finish

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -159,6 +159,7 @@ class CrossingRepair
         # Catchall in case none of the other strings are matched
         "Roundtime"
       )
+      waitrt?
       # Do regex then grab matches for condition details.
       result =~ conditions_regex
       condition_match = Regexp.last_match[:condition]


### PR DESCRIPTION
### Background
* When using T2 or other script manager to run scripts back to back, because `crossing-repair` doesn't wait for the RT from appraising your gear before it returns and exits then those script managers might try to launch the next script too soon
* Often, those scripts that get started too soon already handle the "...wait" game message so they don't actually error/fail, I just don't like that it happens 😆 

### Changes
* Add `waitrt?` after appraising an item before moving on