### PR TITLE
[script] [spellmonitor] squelch cantrips for warrior mages

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -234,7 +234,7 @@ known_spells_hook = proc do |server_string|
         .each { |feat| DRSpells.known_feats[feat] = true }
     end
     server_string = nil if DRSpells.silence_known_spells_hook
-  when /^You have \d+ spell slots? available|You do not know any magic feats/
+  when /^You have \d+ spell slots? available|You do not know any magic feats|You know the following .* cantrips/
     server_string = nil if DRSpells.silence_known_spells_hook
   when /^You can use SPELL STANCE|^You have (no|yet to receive any) training in the magical arts|You have no desire to soil yourself with magical trickery|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
     DRSpells.grabbing_known_spells = false

--- a/test/test_spellmonitor.rb
+++ b/test/test_spellmonitor.rb
@@ -19,19 +19,23 @@ class TestSpellMonitor < Minitest::Test
   #########################################
 
   def assert_active_spell(name, duration)
-    proc { |active_spells, known_spells, known_feats, has_slivers| assert_equal(duration, active_spells[name], "Checking for active spell: #{name}, #{active_spells}") }
+    proc { |old_messages, new_messages, active_spells, known_spells, known_feats, has_slivers| assert_equal(duration, active_spells[name], "Checking for active spell: #{name}, #{active_spells}") }
   end
 
   def assert_know_spell(name, is_known)
-    proc { |active_spells, known_spells, known_feats, has_slivers| assert_equal(is_known, !!known_spells[name], "Checking for known spell: #{name}, #{known_spells}") }
+    proc { |old_messages, new_messages, active_spells, known_spells, known_feats, has_slivers| assert_equal(is_known, !!known_spells[name], "Checking for known spell: #{name}, #{known_spells}") }
   end
 
   def assert_know_feat(name, is_known)
-    proc { |active_spells, known_spells, known_feats, has_slivers| assert_equal(is_known, !!known_feats[name], "Checking for known feat: #{name}, #{known_feats}") }
+    proc { |old_messages, new_messages, active_spells, known_spells, known_feats, has_slivers| assert_equal(is_known, !!known_feats[name], "Checking for known feat: #{name}, #{known_feats}") }
   end
 
   def assert_has_slivers
-    proc { |active_spells, known_spells, known_feats, has_slivers| assert(has_slivers, "Expected to have orbiting slivers") }
+    proc { |old_messages, new_messages, active_spells, known_spells, known_feats, has_slivers| assert(has_slivers, "Expected to have orbiting slivers") }
+  end
+
+  def assert_messages(expected_messages)
+    proc { |old_messages, new_messages, active_spells, known_spells, known_feats, has_slivers| expected_messages == new_messages }
   end
 
   def run_downstream_hook(messages, assertions = [])
@@ -41,11 +45,12 @@ class TestSpellMonitor < Minitest::Test
       $history = $server_buffer.dup
 
       # Test
-      messages.each { |message| DownstreamHook.run(message) }
+      old_messages = messages.dup
+      new_messages = messages.map { |message| DownstreamHook.run(message) }
 
       # Assert
       assertions = [assertions] unless assertions.is_a?(Array)
-      assertions.each { |assertion| assertion.call(DRSpells.active_spells, DRSpells.known_spells, DRSpells.known_feats, DRSpells.slivers) }
+      assertions.each { |assertion| assertion.call(old_messages, new_messages, DRSpells.active_spells, DRSpells.known_spells, DRSpells.known_feats, DRSpells.slivers) }
     end)
   end
 
@@ -76,6 +81,8 @@ class TestSpellMonitor < Minitest::Test
 
   def test_detect_known_spells
     messages = [
+      "Text before the SPELL output won't be squelched",
+      # START of SPELL command output
       "You recall the spells you have learned from your training.",
       "From your apprenticeship you remember practicing with the Burden, Ease Burden [ease], Manifest Force [maf], and Strange Arrow [stra] spells.",
       "In the chapter entitled \"Perception\", you have notes on the Clear Vision [cv], Piercing Gaze [pg], Locate, Seer's Sense [seer], and Aura Sight [aus] spells.",
@@ -83,12 +90,18 @@ class TestSpellMonitor < Minitest::Test
       "In the chapter entitled \"Moonlight Manipulation\", you have notes on the Shadows, Focus Moonbeam [fm], Dazzle, Refractive Field [rf], Burn, Moonblade, Dinazen Olkar [do], Shape Moonblade [shmo], Cage of Light [col], and Shift Moonbeam [sm] spells.",
       "In the chapter entitled \"Enlightened Geometry\", you have notes on the Partial Displacement [pd], Teleport, and Moongate [mg] spells.",
       "You have temporarily memorized the Minor Physical Protection [mpp] spell.",
+      "You know the following Aether cantrips: Aether Spheres, Aethereal Image, and Pattern Hues.",
+      "You know the following Electricity cantrips: Electric Charge and Will O' Wisp.",
+      "You know the following Fire cantrips: Burning Touch and Flashpoint.",
+      "You know the following Air cantrips: Air Blast and Gust of Wind.",
       "You recall proficiency with the magic feats of Basic Preparation Recognition, Augmentation Mastery, Utility Mastery, Warding Mastery, Cautious Casting, Injured Casting, Deep Attunement, Raw Channeling, Efficient Channeling, Efficient Harnessing and Magic Theorist.",
       "You have 1 spell slot available.",
       "You are NOT currently set to recognize known spells when prepared by someone else in the area.  (Use SPELL RECOGNIZE ON to change this.)",
       "You are currently set to display full cast messaging.  (Use SPELL BRIEFMSG ON to change this.)",
       "You are currently attempting to hide your spell preparing.  (Use PREPARE /HIDE to change this.)",
-      "You can use SPELL STANCE [HELP] to view or modify your spellcasting preferences."
+      "You can use SPELL STANCE [HELP] to view or modify your spellcasting preferences.",
+      # END of SPELL command output
+      "Text after the SPELL output won't be squelched"
     ]
     run_downstream_hook(messages, [
       # Spells
@@ -109,7 +122,12 @@ class TestSpellMonitor < Minitest::Test
       assert_know_feat("Utility Mastery", true),
       assert_know_feat("Cautious Casting", true),
       assert_know_feat("Efficient Harnessing", true),
-      assert_know_feat("Magic Theorist", true)
+      assert_know_feat("Magic Theorist", true),
+      # Squelching
+      assert_messages([
+        "Text before the SPELL output won't be squelched",
+        "Text after the SPELL output won't be squelched"
+      ])
     ])
   end
 


### PR DESCRIPTION
### Changes
* Squelch the phrase "You know the following .* cantrips" when `spellmonitor` starts up for Warrior Mages

_Example_
```
You know the following Aether cantrips: Aether Spheres, Aethereal Image, and Pattern Hues.
You know the following Electricity cantrips: Electric Charge and Will O' Wisp.
You know the following Fire cantrips: Burning Touch and Flashpoint.
You know the following Air cantrips: Air Blast and Gust of Wind.
```