### PR TITLE
[script] [buff-watcher] add cli options to override startup delay

### DIFF
--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -12,7 +12,16 @@ class BuffWatcher
   def initialize
     arg_definitions = [
       [
-        { name: 'buff_set_name', regex: /\w+/, optional: true, description: 'Name of a set of buffs defined in waggle_sets: in your YAML' }
+        # override the buff name, optionally override the startup delay
+        { name: 'buff_set_name', regex: /^[a-z][\w\-]+$/i, optional: false, description: 'Name of a set of buffs defined in waggle_sets in your YAML' },
+        { name: 'delay', regex: /^\d+$/, optional: true, description: 'Override buff_watcher_startup_delay from yaml' }
+      ],
+      [
+        # use yaml config for buff name, override the startup delay
+        { name: 'delay', regex: /^\d+$/, optional: false, description: 'Override buff_watcher_startup_delay from yaml' }
+      ],
+      [
+        # no args, use yaml config and defaults
       ]
     ]
 
@@ -21,7 +30,7 @@ class BuffWatcher
 
     @no_use_scripts = @settings.buff_watcher_no_use_scripts
     @no_use_rooms = @settings.buff_watcher_no_use_rooms
-    @startup_delay = @settings.buff_watcher_startup_delay
+    @startup_delay = args.delay || @settings.buff_watcher_startup_delay
     @passive_delay = @settings.buff_watcher_passive_delay
     @buff_set_name = args.buff_set_name || @settings.buff_watcher_name || 'default'
     @barb_buffs_inner_fire_threshold = @settings.barb_buffs_inner_fire_threshold


### PR DESCRIPTION
### Background
* Inspired by #5052

### Changes
* Support 3 ways to start `buff-watcher` script

Option 1: use defaults / yaml config only

```
;buff-watcher
```

Option 2: override buff, optionally override startup delay

```
;buff-watfcher waggle-set-to-use [startup-delay]

;buff-watcher combat

;buff-watcher crafting 2
```

Option 3: override startup delay only, use yaml for buff to use

```
;buff-watcher startup-delay

;buff-watcher 5
```