### PR TITLE
[script] [roomnumbers] use conventional &&

### DIFF
--- a/roomnumbers.lic
+++ b/roomnumbers.lic
@@ -16,13 +16,13 @@ r_nums = proc do |server_string|
   elsif $room_number_ready && server_string =~ /<prompt / && Room.current
     respond("Room Number: #{Room.current.id}")
 
-    if @display_exits || @display_stringproc_exits # only do next steps if going to display at least one 
+    if @display_exits || @display_stringproc_exits # only do next steps if going to display at least one
       # clear entries on nextroom
       room_exits = []
       string_proc_exits = []
 
       # for each exit (wayto) from the current room, store the movement info
-      Room.current.wayto.each_value do |value| 
+      Room.current.wayto.each_value do |value|
         if value.class == Proc
           # class = Proc means it's a stringproc, and can have long data.
           string_proc_exits << value.inspect.gsub(/StringProc.new\((.*?)\)/,'\1')
@@ -33,7 +33,7 @@ r_nums = proc do |server_string|
       end
 
       # output standard exits
-      respond("Room Exits: #{room_exits.join(', ')}") if room_exits.size > 0 if @display_exits 
+      respond("Room Exits: #{room_exits.join(', ')}") if room_exits.size > 0 && @display_exits
 
       # output StringProc Exits
       if @display_stringproc_exits


### PR DESCRIPTION
### Background
* Follow up to https://github.com/rpherbig/dr-scripts/pull/5054
* In code review, [rpherbig](https://github.com/rpherbig/dr-scripts/pull/5054#pullrequestreview-698556746) noticed the double use of `if ... if ...` and [VTCifer](https://github.com/rpherbig/dr-scripts/pull/5054#discussion_r663343554) acknowledged it was a typo

### Changes
* Despite Ruby supporting the `if ... if ...` syntax, it's not the conventional syntax most developers in our community will be familiar with so am changing it to use `&&`, and since it wasn't intentional to be the other way either. Our future selves will thank us 😅 