### PR TITLE
[Script] [restock.lic] When trying to withdraw a large amount of copper, the bank teller will refuse.

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -70,7 +70,6 @@ module DRCM
   end
 
   def ensure_copper_on_hand(copper, settings, hometown = nil)
-    DRC.message hometown
     hometown = settings.hometown if hometown == nil
 
     on_hand = wealth(hometown)

--- a/common-money.lic
+++ b/common-money.lic
@@ -107,12 +107,12 @@ module DRCM
     DRCT.walk_to(get_data('town')[hometown]['deposit']['id'])
     DRC.release_invisibility
     loop do
-      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account')
+      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account', /The clerk says, "I'm afraid you can't withdraw that much at once/)
       when 'The clerk counts', 'You count out'
         break true
       when 'The clerk glares at you.', 'Hey!  Slow down!'
         pause 15
-      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account'
+      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account', /The clerk says, "I'm afraid you can't withdraw that much at once/
         break false
       else
         break false

--- a/common-money.lic
+++ b/common-money.lic
@@ -70,6 +70,7 @@ module DRCM
   end
 
   def ensure_copper_on_hand(copper, settings, hometown = nil)
+    DRC.message hometown
     hometown = settings.hometown if hometown == nil
 
     on_hand = wealth(hometown)

--- a/restock.lic
+++ b/restock.lic
@@ -67,7 +67,7 @@ class Restock
     if coin_needed > 0
       ### The following line is for the bribe to the night attendant to let you in.
       coin_needed += 2502 if UserVars.sun['night'] && town =~ /\bShard\b/
-      DRCM.ensure_copper_on_hand(coin_needed, DRCM.town_currency(town), "#{town}")
+      DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
     end
 
     items_to_restock.each do |item|

--- a/restock.lic
+++ b/restock.lic
@@ -67,7 +67,24 @@ class Restock
     if coin_needed > 0
       ### The following line is for the bribe to the night attendant to let you in.
       coin_needed += 2502 if UserVars.sun['night'] && town =~ /\bShard\b/
-      DRCM.get_money_from_bank("#{coin_needed} copper", "#{DRCM.town_currency(town)}", "#{town}")
+      got_coin = false
+      while !got_coin
+        if !DRCM.get_money_from_bank("#{coin_needed} copper", "#{DRCM.town_currency(town)}", "#{town}")
+          if reget(3, /The clerk says, "I'm afraid you can't withdraw that much at once/)
+            new_coin_needed = coin_needed / 4 # Ran into a situation where the copper value was too much to withdraw
+            4.times do
+              DRCM.get_money_from_bank("#{new_coin_needed} copper", "#{DRCM.town_currency(town)}", "#{town}")
+            end
+          end
+        end
+        on_hand = DRCM.wealth("#{town}")
+        echo "On_hand = #{on_hand}." if @debug
+        if on_hand >= coin_needed
+          got_coin = true
+        else
+          got_coin = false
+        end
+      end
     end
 
     items_to_restock.each do |item|

--- a/restock.lic
+++ b/restock.lic
@@ -67,24 +67,7 @@ class Restock
     if coin_needed > 0
       ### The following line is for the bribe to the night attendant to let you in.
       coin_needed += 2502 if UserVars.sun['night'] && town =~ /\bShard\b/
-      got_coin = false
-      while !got_coin
-        if !DRCM.get_money_from_bank("#{coin_needed} copper", "#{DRCM.town_currency(town)}", "#{town}")
-          if reget(3, /The clerk says, "I'm afraid you can't withdraw that much at once/)
-            new_coin_needed = coin_needed / 4 # Ran into a situation where the copper value was too much to withdraw
-            4.times do
-              DRCM.get_money_from_bank("#{new_coin_needed} copper", "#{DRCM.town_currency(town)}", "#{town}")
-            end
-          end
-        end
-        on_hand = DRCM.wealth("#{town}")
-        echo "On_hand = #{on_hand}." if @debug
-        if on_hand >= coin_needed
-          got_coin = true
-        else
-          got_coin = false
-        end
-      end
+      DRCM.ensure_copper_on_hand(coin_needed, DRCM.town_currency(town), "#{town}")
     end
 
     items_to_restock.each do |item|


### PR DESCRIPTION
I had to restock many runestones and encountered an error.  

Symptom: 
```
[restock]>withdraw 116000 copper
The clerk says, "I'm afraid you can't withdraw that much at once, unless you want to close your account completely."
```

Some amounts, even when halved, are still too large to withdraw. I decided to break down into fourths and loop through 4 times. 

After this fix, I was able to withdraw and purchase the runestones. 