### PR TITLE
[Script] [workorders.lic] Fix bundling when using a cauldron.

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -618,10 +618,8 @@ class WorkOrders
         stow_tool(right_hand)
         /(\d+)/ =~ bput("count my first #{recipe['noun']}", 'You count out \d+ uses remaining.')
         temp_count = Regexp.last_match(1).to_i
-        DRC.message("temp_count: #{temp_count}")
         if temp_count >= 10 # If cauldron used, 2 or 3 are made at once depending on material left.
-          temp_count = (temp_count / 5).ceil
-          DRC.message("temp_count: #{temp_count}")
+          temp_count = (temp_count / 5).ceil# Set the count to the number of completed items then loop through to bundle.
           temp_count.times do
             bput("get #{recipe['noun']} from my #{@bag}", 'You get', 'What were') unless (left_hand || right_hand) =~ /#{recipe['noun']}/
             remedy_mark_bundle(recipe['noun'])
@@ -661,8 +659,6 @@ class WorkOrders
       case bput('read my alchemy logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
       when /You must bundle and deliver (\d+) more/
         log_num = Regexp.last_match(1).to_i
-        DRC.message("log_num = #{log_num}.")
-        DRC.message("count = #{count}.")
         break if count + 1 + log_num != quantity
       when /This work order appears to be complete./
         break

--- a/workorders.lic
+++ b/workorders.lic
@@ -575,6 +575,17 @@ class WorkOrders
     stow_tool(right_hand)
   end
 
+  def remedy_mark_bundle(noun)
+    return unless bput("Mark my #{noun} at 5", 'You measure', 'There is not enough') =~ /You measure/
+    bput("Break my #{noun}", 'You carefully')
+    /(\d+)/ =~ bput("count my first #{noun}", 'You count out \d+ uses remaining.')
+    if Regexp.last_match(1).to_i == 5
+      bput("stow my second #{noun}", 'You put', 'You combine')
+    else
+      bput("stow my first #{noun}", 'You put', 'You combine')
+    end
+  end
+
   def remedy_items(info, recipe, quantity)
     ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
     herb2_needed = ''
@@ -605,16 +616,18 @@ class WorkOrders
       case bput("bun my #{recipe['noun']} with logbook", 'You notate', 'You put', 'You notice the workorder', 'The work order requires items of a higher quality')
       when 'You notice the workorder'
         stow_tool(right_hand)
-        bput("Mark my #{recipe['noun']} at 5", 'You measure')
-        bput("Break my #{recipe['noun']}", 'You carefully')
         /(\d+)/ =~ bput("count my first #{recipe['noun']}", 'You count out \d+ uses remaining.')
-        if Regexp.last_match(1).to_i == 5
-          bput("stow my second #{recipe['noun']}", 'You put', 'You combine')
+        if Regexp.last_match(1).to_i >= 10 # If cauldron used, 2 or 3 are made at once depending on material left.
+          3.times do
+            remedy_mark_bundle(recipe['noun'])
+            bundle_item(recipe['noun'], info['logbook'])
+            bput("get #{recipe['noun']}", 'You get', 'What were')
+          end
         else
-          bput("stow my first #{recipe['noun']}", 'You put', 'You combine')
+          remedy_mark_bundle(recipe['noun'])
+          leftovers += 1
+          bundle_item(recipe['noun'], info['logbook'])
         end
-        leftovers += 1
-        bundle_item(recipe['noun'], info['logbook'])
       when 'You notate', 'You put'
         bput('stow my logbook', 'You put')
       when 'The work order requires items of a higher quality'
@@ -624,6 +637,13 @@ class WorkOrders
         stow_tool(left_hand)
         stow_tool(right_hand)
         break
+      end
+      case bput('read my alchemy logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
+      when /You must bundle and deliver \d+ more/
+        log_num = Regexp.last_match(1).to_i
+        break if count + 1 + log_num != quantity
+      #when /This work order appears to be complete./
+        #break
       end
     end
     leftovers.times { |_| DRCT.dispose(recipe['noun']) }

--- a/workorders.lic
+++ b/workorders.lic
@@ -367,7 +367,7 @@ class WorkOrders
 
       wait_for_script_to_complete('shape', ['log', recipe['chapter'], recipe['name'], info['stock-name'], recipe['noun']])
       case bput('read my engineering logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
-      when /You must bundle and deliver \d+ more /
+      when /You must bundle and deliver (\d+) more /
         log_num = Regexp.last_match(1).to_i
         break if count + 1 + log_num != quantity
       end
@@ -440,7 +440,7 @@ class WorkOrders
     quantity.times do |count|
       wait_for_script_to_complete('sew', ['log', 'sewing', recipe['chapter'], recipe['name'], recipe['noun'], info['sew-stock-name']])
       case bput('read my outfitting logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
-      when /You must bundle and deliver \d+ more /
+      when /You must bundle and deliver (\d+) more/
         log_num = Regexp.last_match(1).to_i
         break if count + 1 + log_num != quantity
       end
@@ -470,7 +470,7 @@ class WorkOrders
     quantity.times do |count|
       wait_for_script_to_complete('sew', ['log', 'knitting', recipe['chapter'], recipe['name'], recipe['noun'], info['knit-stock-name']])
       case bput('read my outfitting logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
-      when /You must bundle and deliver \d+ more /
+      when /You must bundle and deliver (\d+) more /
         log_num = Regexp.last_match(1).to_i
         break if count + 1 + log_num != quantity
       end
@@ -606,7 +606,7 @@ class WorkOrders
     walk_to(@alchemy_room)
 
     leftovers = 0
-    quantity.times do
+    quantity.times do |count|
       if herb2_needed == 'na'
         wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], herb2_needed, info['catalyst'], recipe['container'], recipe['noun']])
       else
@@ -617,11 +617,31 @@ class WorkOrders
       when 'You notice the workorder'
         stow_tool(right_hand)
         /(\d+)/ =~ bput("count my first #{recipe['noun']}", 'You count out \d+ uses remaining.')
-        if Regexp.last_match(1).to_i >= 10 # If cauldron used, 2 or 3 are made at once depending on material left.
-          3.times do
+        temp_count = Regexp.last_match(1).to_i
+        DRC.message("temp_count: #{temp_count}")
+        if temp_count >= 10 # If cauldron used, 2 or 3 are made at once depending on material left.
+          temp_count = (temp_count / 5).ceil
+          DRC.message("temp_count: #{temp_count}")
+          temp_count.times do
+            bput("get #{recipe['noun']} from my #{@bag}", 'You get', 'What were') unless (left_hand || right_hand) =~ /#{recipe['noun']}/
             remedy_mark_bundle(recipe['noun'])
+            leftovers += 1
             bundle_item(recipe['noun'], info['logbook'])
-            bput("get #{recipe['noun']}", 'You get', 'What were')
+            if reget(3, 'There is not enough')
+              leftovers -= 1
+              stow_tool('logbook')
+              5.times do # combine any remaining bits from previous combines.
+                case bput("get #{recipe['noun']} from my #{@bag}", 'You get', 'What were')
+                when 'You get'
+                  bput('combine', 'You combine')
+                when 'What were'
+                  break
+                end
+              end
+              remedy_mark_bundle(recipe['noun'])
+              leftovers += 1
+              bundle_item(recipe['noun'], info['logbook'])
+            end
           end
         else
           remedy_mark_bundle(recipe['noun'])
@@ -639,11 +659,13 @@ class WorkOrders
         break
       end
       case bput('read my alchemy logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
-      when /You must bundle and deliver \d+ more/
+      when /You must bundle and deliver (\d+) more/
         log_num = Regexp.last_match(1).to_i
+        DRC.message("log_num = #{log_num}.")
+        DRC.message("count = #{count}.")
         break if count + 1 + log_num != quantity
-      #when /This work order appears to be complete./
-        #break
+      when /This work order appears to be complete./
+        break
       end
     end
     leftovers.times { |_| DRCT.dispose(recipe['noun']) }
@@ -782,7 +804,7 @@ class WorkOrders
       wait_for_script_to_complete('enchant', [recipe['chapter'], recipe['name'], recipe['noun']])
       bundle_item(recipe['noun'], info['logbook'])
       case bput('read my enchanting logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
-      when /You must bundle and deliver \d+ more /
+      when /You must bundle and deliver (\d+) more /
         log_num = Regexp.last_match(1).to_i
         break if count + 1 + log_num != quantity
       end


### PR DESCRIPTION
Updating the bundling logic when using a cauldron. A cauldron allows one to put a complete combined herb stack of 75 in it to craft the recipe. I have not updated to add more than a completed stack. I will need to test if more can go in. However, the logic here should catch even that as I am checking for more 10 or more units in the completed stack to bundle. I will remove the commented-out lines, 645 and 646, if I find they are not required. 

Testers are welcomed. :smile: 