### PR TITLE
[script] [esp] configure channels via yaml, add recovery logic

### DIFF
--- a/esp.lic
+++ b/esp.lic
@@ -13,10 +13,11 @@ class ESP
     channels = settings.esp_channels.map { |channel| channel.downcase.capitalize }
     default_channel = settings.esp_default_channel
 
-    activate_gweth
-    listen_to_these_channels_and_not_others(channels)
-    set_default_send_channel(default_channel)
-    show_channel_subscriptions
+    if activate_gweth?
+      listen_to_these_channels_and_not_others(channels)
+      set_default_send_channel(default_channel)
+      show_channel_subscriptions
+    end
   end
 
   def show_channel_subscriptions
@@ -49,10 +50,11 @@ class ESP
     end
   end
 
-  def activate_gweth(retry_count = 0)
+  def activate_gweth?(retry_count = 0)
+    return false
     case DRC.bput("touch my gweth", { 'timeout' => 3, 'suppress_no_match' => true }, "A chorus of foreign thoughts joins your own", "Since you already have telepathy, nothing more happens", "Touch what?", "The chain snaps in two places and falls to the ground")
     when /A chorus of foreign thoughts joins your own/, /Since you already have telepathy, nothing more happens/
-      true
+      return true
     when /Touch what?/
       DRC.message("You don't have a gweth!")
       exit
@@ -62,10 +64,17 @@ class ESP
     else
       # Not wearing a gweth, try to wear one and retry
       if retry_count < 1
-        DRCI.get_item_if_not_held?('gwethdesuan')
-        DRCI.wear_item?('gwethdesuan')
-        activate_gweth(retry_count + 1)
+        unless DRCI.get_item_if_not_held?('gwethdesuan')
+          DRC.message("Failed to get gweth to wear!")
+          exit
+        end
+        unless DRCI.wear_item?('gwethdesuan')
+          DRC.message("Failed to wear gweth!")
+          exit
+        end
+        return activate_gweth?(retry_count + 1)
       end
+      return false
     end
   end
 

--- a/esp.lic
+++ b/esp.lic
@@ -1,13 +1,75 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#esp
 =end
-custom_require.call(%w[common])
 
-bput("esp listen general", "With a moment of focus")
-bput("esp listen trade", "With a moment of focus")
-bput("esp listen personal", "With a moment of focus")
-bput("esp listen guild", "With a moment of focus")
-bput("esp listen race", "With a moment of focus")
-bput("esp listen local", "With a moment of focus")
+custom_require.call(%w[common common-items])
 
-bput("esp send general", "You prepare to project")
+class ESP
+
+  def initialize
+    @all_channels = ['General', 'Trade', 'Guild', 'Race', 'Local', 'Private', 'Personal']
+
+    settings = get_settings
+    channels = settings.esp_channels.map { |channel| channel.downcase.capitalize }
+    default_channel = settings.esp_default_channel
+
+    activate_gweth
+    listen_to_these_channels_and_not_others(channels)
+    set_default_send_channel(default_channel)
+    show_channel_subscriptions
+  end
+
+  def show_channel_subscriptions
+    fput('esp channel')
+  end
+
+  def set_default_send_channel(channel)
+    DRC.bput("esp send #{channel}", "You prepare to project your thoughts into the #{channel} channel", "You are already sending thoughts to the #{channel} channel")
+  end
+
+  def listen_to_these_channels_and_not_others(channels)
+    @all_channels.each do |channel|
+      listen = channels.include?(channel)
+      update_channel_subscription(channel, listen)
+    end
+  end
+
+  def update_channel_subscription(channel, listen)
+    # We don't have an easy way to know whether you are or are not currently
+    # listening to a channel, but the `esp listen <channel>` command toggles it.
+    # So we check if the listen attempt aligns with our goal, and if not, retry.
+    case DRC.bput("esp listen #{channel}", /With a moment of focus,? you (open|close) your mind to the #{channel} channel/, /ESP controls your ability to listen and send/)
+    when /With a moment of focus,? you (open|close) your mind to the #{channel} channel/
+      listening = Regexp.last_match[1] == 'open'
+      if listen != listening
+        update_channel_subscription(channel, listen)
+      end
+    else
+      DRC.message("Unrecognized channel: #{channel}")
+    end
+  end
+
+  def activate_gweth(retry_count = 0)
+    case DRC.bput("touch my gweth", { 'timeout' => 3, 'suppress_no_match' => true }, "A chorus of foreign thoughts joins your own", "Since you already have telepathy, nothing more happens", "Touch what?", "The chain snaps in two places and falls to the ground")
+    when /A chorus of foreign thoughts joins your own/, /Since you already have telepathy, nothing more happens/
+      true
+    when /Touch what?/
+      DRC.message("You don't have a gweth!")
+      exit
+    when /The chain snaps in two places and falls to the ground/
+      DRC.message("Uh oh, your gweth broke!")
+      exit
+    else
+      # Not wearing a gweth, try to wear one and retry
+      if retry_count < 1
+        DRCI.get_item_if_not_held?('gwethdesuan')
+        DRCI.wear_item?('gwethdesuan')
+        activate_gweth(retry_count + 1)
+      end
+    end
+  end
+
+end
+
+# Don't auto-run during unit tests
+ESP.new unless $_TEST_MODE_

--- a/esp.lic
+++ b/esp.lic
@@ -50,8 +50,7 @@ class ESP
     end
   end
 
-  def activate_gweth?(retry_count = 0)
-    return false
+  def activate_gweth?(retry_on_fail = true)
     case DRC.bput("touch my gweth", { 'timeout' => 3, 'suppress_no_match' => true }, "A chorus of foreign thoughts joins your own", "Since you already have telepathy, nothing more happens", "Touch what?", "The chain snaps in two places and falls to the ground")
     when /A chorus of foreign thoughts joins your own/, /Since you already have telepathy, nothing more happens/
       return true
@@ -63,7 +62,7 @@ class ESP
       exit
     else
       # Not wearing a gweth, try to wear one and retry
-      if retry_count < 1
+      if retry_on_fail
         unless DRCI.get_item_if_not_held?('gwethdesuan')
           DRC.message("Failed to get gweth to wear!")
           exit
@@ -72,7 +71,8 @@ class ESP
           DRC.message("Failed to wear gweth!")
           exit
         end
-        return activate_gweth?(retry_count + 1)
+        # Avoid loop and don't retry if this fails, too
+        return activate_gweth?(false)
       end
       return false
     end

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -104,3 +104,4 @@ empty_values:
   noheal_empathylink: []
   repair_heuristic_gear: []
   sell_loot_ignored_metals_and_stones: []
+  esp_channels: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1922,3 +1922,18 @@ runestone_purchase: false
 ### Roomnumbers.lic Settings:
 roomnumbers_display_exits: true
 roomnumbers_display_stringproc_exits: false
+
+# ESP Settings
+# List the channels you want to subscribe to when `esp` script runs.
+# You'll unsubscribe from any channels not listed.
+esp_channels:
+  - General
+  - Trade
+  - Guild
+  - Race
+  - Local
+  - Private
+  - Personal
+
+# Which channel to set you up to send to by default.
+esp_default_channel: General


### PR DESCRIPTION
### Background
* Following up on https://github.com/rpherbig/dr-scripts/pull/5046#pullrequestreview-693522835

### Changes
* Convert script to a class named `ESP`
* Read from YAML which channels to subscribe you to
* Add error recovery and handling logic if you're not wearing a gweth or it breaks
* Handle that `esp listen <channel>` toggles on/off you listening to that channel so the command may need to be run twice to get your preference configured

### Configuration
```yaml
# ESP Settings
# List the channels you want to subscribe to when `esp` script runs.
# You'll unsubscribe from any channels not listed.
esp_channels:
  - General
  - Trade
  - Guild
  - Race
  - Local
  - Private
  - Personal

# Which channel to set you up to send to by default.
esp_default_channel: General
```