### PR TITLE
Swappable Tools using Equipment Manager

### DIFF
--- a/carve-bead.lic
+++ b/carve-bead.lic
@@ -43,6 +43,7 @@ class CarveBead
     @debug = args.debug || @settings['carve-bead']['debug']
     @theurgy_supply_container = @settings.theurgy_supply_container
     @immortal_aspect = args.aspect || @settings.immortal_aspect
+    @equipment_manager = EquipmentManager.new
     @crafting_container = @settings.crafting_container
     @crafting_container_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
@@ -148,21 +149,21 @@ class CarveBead
     DRCI.put_away_item?(@water_holder, @theurgy_supply_container)
     pause 1
     DRCA.cast?('cast my limb')
-    DRCC.get_crafting_item("#{@knife_adjective} knife", @crafting_container, @crafting_container_items, @belt)
+    @equipment_manager.get_tool?('shaping', 'knife')
     while DRC.right_hand.include?('limb')
       DRC.bput('carve my limb with my knife', 'You begin to hack', 'With fluid strokes, you', 'You continue to whittle', 'narrowing the connection', 'With a final deep cut')
       waitrt?
     end
-    DRCC.stow_crafting_item("#{@knife_adjective} knife", @crafting_container, @belt)
+    @equipment_manager.return_tool?('shaping', 'knife')
   end
 
   def carve_bead
-    DRCC.get_crafting_item('shaper', @crafting_container, @crafting_container_items, @belt)
+    @equipment_manager.get_tool?('shaping', 'shaper')
     while DRC.right_hand.include?('block')
       DRC.bput("shape my block to #{@immortal_aspect}", "block suddenly cracks and breaks", "Roundtime")
       waitrt?
     end
-    DRCC.stow_crafting_item('shaper', @crafting_container, @belt)
+    @equipment_manager.return_tool?('shaping', 'shaper')
   end
 end
 

--- a/carve.lic
+++ b/carve.lic
@@ -68,21 +68,23 @@ class Carve
 
   def turn_to(section)
     unless section
-      echo('Failed to find recipe in book, buy a better book?')
+      DRC.message('Failed to find recipe in book, buy a better book?')
       stow_item('book')
       magic_cleanup
       exit
     end
-    bput("turn my book to #{section}", 'You turn your', 'The book is already')
+
+    DRC.bput("turn my book to #{section}", 'You turn your', 'The book is already')
   end
 
   def carve_item
-    crafting_magic_routine(@settings)
+    DRC.message('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
+
+    DRCA.crafting_magic_routine(@settings)
+
     get_item('carving book')
-    echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
-    turn_to("chapter #{@chapter}")
-    turn_to("page #{find_recipe(@chapter, @recipe_name)}")
-    bput('study my book', 'Roundtime')
+    turn_to("page #{DRCC.find_recipe(@chapter, @recipe_name)}")
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
 
     @equipment_manager.get_tool?('carving', @current_tool)
@@ -90,7 +92,7 @@ class Carve
       case DRC.bput("get my #{@material} #{@type}", '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
       when 'What do you', 'What were you'
         beep
-        echo("You seem to be missing: #{name}")
+        echo("You seem to be missing: #{@material} #{@type}")
         exit
       when /can\'t quite lift it/
         @my = ''
@@ -121,10 +123,11 @@ class Carve
   end
 
   def carve(command)
-    waitrt?
     crafting_magic_routine(@settings)
+
     assemble_part
-    case bput(command,
+
+    case DRC.bput(command,
               /need a larger .* to continue crafting/,
               'rough, jagged',
               'determine',
@@ -137,22 +140,13 @@ class Carve
       DRC.message("Source material not big enough to make desired item. Exiting...")
       exit
     when 'rough, jagged'
-      waitrt?
-      @equipment_manager.return_tool?('carving', @current_tool)
-      @current_tool = 'rifflers'
-      @equipment_manager.get_tool?('carving', @current_tool)
+      change_tool('rifflers')
       command = "rub #{@my}#{@noun} with my rifflers"
     when 'determine', 'developed an uneven texture along its surface'
-      waitrt?
-      @equipment_manager.return_tool?('carving', @current_tool)
-      @current_tool = 'rasp'
-      @equipment_manager.get_tool?('carving', @current_tool)
+      change_tool('rasp')
       command = "rub #{@my}#{@noun} with my rasp"
     when 'you see some discolored areas'
-      waitrt?
-      @equipment_manager.return_tool?('carving', @current_tool)
-      @current_tool = 'polish'
-      get_item('polish')
+      change_tool('polish')
       command = "apply my polish to #{@my}#{@noun}"
     when 'You cannot figure out how to do that.'
       finish
@@ -171,9 +165,7 @@ class Carve
   end
 
   def resume
-    waitrt?
-
-    case bput("get #{@noun}", /You get/, /You are already holding/, /You pick up/, /You are not strong enough/, /What were you referring to/)
+    case DRC.bput("get #{@noun}", /You get/, /You are already holding/, /You pick up/, /You are not strong enough/, /What were you referring to/)
     when /You get/, /You are already holding/, /You pick up/
       @my = 'my '
       DRC.bput('swap', /to your left hand/) unless left_hand.include?(@noun)
@@ -186,7 +178,7 @@ class Carve
 
     stow_item(right_hand) if right_hand
 
-    case bput("analyze my #{@noun}",
+    case DRC.bput("analyze my #{@noun}",
               /You do not see anything that would (prevent|obstruct) carving/,
               /free of defects that would impede further carving/,
               /ready for further carving/,
@@ -197,20 +189,16 @@ class Carve
               'This appears to be a type of finished',
               'Roundtime')
     when /You do not see anything that would (prevent|obstruct) carving|free of defects that would impede further carving|ready for further carving/
-      waitrt?
-      @equipment_manager.get_tool?('carving', @main_tool)
+      change_tool(@main_tool)
       command = "cut #{@my}#{@noun} with my #{@main_tool}"
     when /corrected by rubbing the .* with a riffler set/
-      waitrt?
-      @equipment_manager.get_tool?('carving', 'rifflers')
+      change_tool('rifflers')
       command = "rub #{@my}#{@noun} with my rifflers"
     when /corrected by scraping the .* with a rasp/, 'angle of cut will improve if scraped with a rasp'
-      waitrt?
-      @equipment_manager.get_tool?('carving', 'rasp')
+      change_tool('rasp')
       command = "rub #{@my}#{@noun} with my rasp"
     when 'by applying some polish to'
-      waitrt?
-      get_item('polish')
+      change_tool('polish')
       command = "apply my polish to #{@my}#{@noun}"
     when 'This appears to be a type of finished'
       echo '*** THIS ITEM IS ALREADY FINISHED ***'
@@ -222,12 +210,22 @@ class Carve
     carve(command)
   end
 
+  def change_tool(new_tool_type)
+    return if new_tool_type == @current_tool_type
+
+    stow_item(@current_tool_type) unless @equipmentmanager.return_tool?('carving', @current_tool_type)
+    @current_tool_type = new_tool_type
+
+    return if @current_tool_type.nil?
+    get_item(@current_tool_type) unless @equipmentmanager.get_tool?('carving', @current_tool_type)
+  end
+
   def magic_cleanup
     return if @training_spells.empty?
 
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-    bput('release mana', 'You release all', "You aren't harnessing any mana")
-    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 
   def finish

--- a/carve.lic
+++ b/carve.lic
@@ -15,6 +15,7 @@ class Carve
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
     @stamp = @settings.mark_crafted_goods
+    @equipment_manager = EquipmentManager.new
 
     arg_definitions = [
       [
@@ -43,8 +44,9 @@ class Carve
     @main_tool = if @type == 'stack' || @type == 'bone'
                    'saw'
                  else
-                   'chisel'
+                   'chisels'
                  end
+    @current_tool = @main_tool
 
     wait_for_script_to_complete('buff', ['carve'])
     Flags.add('carve-assembly', 'another finished wooden (hilt|haft)', 'another finished (long|short) wooden (pole)', 'another finished (long|short) leather (cord)')
@@ -82,7 +84,8 @@ class Carve
     turn_to("page #{find_recipe(@chapter, @recipe_name)}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item(@main_tool)
+
+    @equipment_manager.get_tool?('carving', @current_tool)
     if @type != 'boulder'
       case DRC.bput("get my #{@material} #{@type}", '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
       when 'What do you', 'What were you'
@@ -102,19 +105,19 @@ class Carve
     else
       @my = ''
     end
+
     carve("cut #{@my}#{@type} with my #{@main_tool}")
   end
 
   def assemble_part
     return unless Flags['carve-assembly']
 
-    tool = right_hand
-    stow_item(tool)
+    @equipment_manager.return_tool?('carving', @current_tool)
     part = Flags['carve-assembly'].to_a[1..-1].join('.')
     Flags.reset('carve-assembly')
     get_item(part)
-    bput("assemble #{@my}#{@noun} with my #{part}", 'affix it securely in place', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations')
-    get_item(tool)
+    DRC.bput("assemble #{@my}#{@noun} with my #{part}", 'affix it securely in place', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations')
+    @equipment_manager.get_tool?('carving', @current_tool)
   end
 
   def carve(command)
@@ -122,25 +125,33 @@ class Carve
     crafting_magic_routine(@settings)
     assemble_part
     case bput(command,
+              /need a larger .* to continue crafting/,
               'rough, jagged',
               'determine',
               'developed an uneven texture along its surface',
               'You cannot figure out how to do that.',
               'you see some discolored areas',
               'Roundtime')
+    when /need a larger .* to continue crafting/
+      @equipment_manager.return_tool?('carving', @current_tool)
+      DRC.message("Source material not big enough to make desired item. Exiting...")
+      exit
     when 'rough, jagged'
       waitrt?
-      stow_item(right_hand)
-      get_item('rifflers')
+      @equipment_manager.return_tool?('carving', @current_tool)
+      @current_tool = 'rifflers'
+      @equipment_manager.get_tool?('carving', @current_tool)
       command = "rub #{@my}#{@noun} with my rifflers"
     when 'determine', 'developed an uneven texture along its surface'
       waitrt?
-      stow_item(right_hand)
-      get_item('rasp')
+      @equipment_manager.return_tool?('carving', @current_tool)
+      @current_tool = 'rasp'
+      @equipment_manager.get_tool?('carving', @current_tool)
       command = "rub #{@my}#{@noun} with my rasp"
     when 'you see some discolored areas'
       waitrt?
-      stow_item(right_hand)
+      @equipment_manager.return_tool?('carving', @current_tool)
+      @current_tool = 'polish'
       get_item('polish')
       command = "apply my polish to #{@my}#{@noun}"
     when 'You cannot figure out how to do that.'
@@ -148,8 +159,9 @@ class Carve
     else
       waitrt?
       unless right_hand =~ /#{@main_tool}/i
-        stow_item(right_hand)
-        get_item(@main_tool)
+        @equipment_manager.return_tool?('carving', @current_tool)
+        @current_tool = @main_tool
+        @equipment_manager.get_tool?('carving', @current_tool)
       end
       command = "cut #{@my}#{@noun} with my #{@main_tool}"
     end
@@ -186,15 +198,15 @@ class Carve
               'Roundtime')
     when /You do not see anything that would (prevent|obstruct) carving|free of defects that would impede further carving|ready for further carving/
       waitrt?
-      get_item(@main_tool)
+      @equipment_manager.get_tool?('carving', @main_tool)
       command = "cut #{@my}#{@noun} with my #{@main_tool}"
     when /corrected by rubbing the .* with a riffler set/
       waitrt?
-      get_item('rifflers')
+      @equipment_manager.get_tool?('carving', 'rifflers')
       command = "rub #{@my}#{@noun} with my rifflers"
     when /corrected by scraping the .* with a rasp/, 'angle of cut will improve if scraped with a rasp'
       waitrt?
-      get_item('rasp')
+      @equipment_manager.get_tool?('carving', 'rasp')
       command = "rub #{@my}#{@noun} with my rasp"
     when 'by applying some polish to'
       waitrt?
@@ -221,11 +233,11 @@ class Carve
   def finish
     stow_item(right_hand)
     if @stamp
-      get_item('stamp')
+      @equipment_manager.get_tool?('carving', 'stamp')
       fput("mark #{@my}#{@noun} with my stamp")
       pause
       waitrt?
-      stow_item('stamp')
+      @equipment_manager.return_tool?('carving', 'stamp')
     end
     waitrt?
     magic_cleanup

--- a/carve.lic
+++ b/carve.lic
@@ -46,7 +46,6 @@ class Carve
                  else
                    'chisels'
                  end
-    @current_tool = @main_tool
 
     wait_for_script_to_complete('buff', ['carve'])
     Flags.add('carve-assembly', 'another finished wooden (hilt|haft)', 'another finished (long|short) wooden (pole)', 'another finished (long|short) leather (cord)')
@@ -87,7 +86,8 @@ class Carve
     DRC.bput('study my book', 'Roundtime')
     stow_item('book')
 
-    @equipment_manager.get_tool?('carving', @current_tool)
+    change_tool(@main_tool)
+
     if @type != 'boulder'
       case DRC.bput("get my #{@material} #{@type}", '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")
       when 'What do you', 'What were you'
@@ -151,12 +151,7 @@ class Carve
     when 'You cannot figure out how to do that.'
       finish
     else
-      waitrt?
-      unless right_hand =~ /#{@main_tool}/i
-        @equipment_manager.return_tool?('carving', @current_tool)
-        @current_tool = @main_tool
-        @equipment_manager.get_tool?('carving', @current_tool)
-      end
+      change_tool(@main_tool)
       command = "cut #{@my}#{@noun} with my #{@main_tool}"
     end
     waitrt?
@@ -165,6 +160,8 @@ class Carve
   end
 
   def resume
+    echo 'Resuming carving...' if @debug
+
     case DRC.bput("get #{@noun}", /You get/, /You are already holding/, /You pick up/, /You are not strong enough/, /What were you referring to/)
     when /You get/, /You are already holding/, /You pick up/
       @my = 'my '
@@ -214,8 +211,8 @@ class Carve
     return if new_tool_type == @current_tool_type
 
     stow_item(@current_tool_type) unless @equipmentmanager.return_tool?('carving', @current_tool_type)
-    @current_tool_type = new_tool_type
 
+    @current_tool_type = new_tool_type
     return if @current_tool_type.nil?
     get_item(@current_tool_type) unless @equipmentmanager.get_tool?('carving', @current_tool_type)
   end

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -133,7 +133,7 @@ module DRCC
   end
 
   def find_recipe(chapter, match_string)
-    case bput("turn my book to chapter #{chapter}", 'You turn', 'You are too distracted to be doing that right now', 'The book is already turned')
+    case DRC.bput("turn my book to chapter #{chapter}", 'You turn', 'You are too distracted to be doing that right now', 'The book is already turned')
     when 'You are too distracted to be doing that right now'
       echo '***CANNOT TURN BOOK, ASSUMING I AM ENGAGED IN COMBAT***'
       fput('look')
@@ -212,16 +212,16 @@ module DRCC
   def order_enchant(stock_room, stock_needed, stock_number, bag, belt)
     stock_needed.times do
       DRCT.order_item(stock_room, stock_number)
-      stow_crafting_item(left_hand, bag, belt)
-      stow_crafting_item(right_hand, bag, belt)
-      next unless left_hand && right_hand
+      stow_crafting_item(DRC.left_hand, bag, belt)
+      stow_crafting_item(DRC.right_hand, bag, belt)
+      next unless DRC.left_hand && DRC.right_hand
     end
   end
 
   def fount(stock_room, stock_needed, stock_number, quantity, bag, bag_items, belt)
-    case bput('tap my fount', /You tap .* inside your .*/, /You tap .*your .*/, /I could not find what you were referring to./)
+    case DRC.bput('tap my fount', /You tap .* inside your .*/, /You tap .*your .*/, /I could not find what you were referring to./)
     when /You tap (.*) inside your (.*)/, /You tap (.*) your (.*)/
-      /(\d+)/ =~ bput('analyze my fount', 'This appears to be a crafting tool and it has approximately \d+ uses remaining')
+      /(\d+)/ =~ DRC.bput('analyze my fount', 'This appears to be a crafting tool and it has approximately \d+ uses remaining')
       if Regexp.last_match(1).to_i < (quantity + 1)
         get_crafting_item('fount', bag, bag_items, belt)
         DRCT.dispose('fount')
@@ -229,9 +229,9 @@ module DRCC
         order_enchant(stock_room, stock_needed, stock_number, bag, belt)
       end
     when /I could not find what you were referring to./
-      case bput('tap my fount on my brazier', /You tap .* atop a .*brazier./, /I could not find what you were referring to./)
+      case DRC.bput('tap my fount on my brazier', /You tap .* atop a .*brazier./, /I could not find what you were referring to./)
       when /You tap (.*) atop a (.*)brazier./
-        /(\d+)/ =~ bput('analyze my fount on my brazier', 'This appears to be a crafting tool and it has approximately \d+ uses remaining')
+        /(\d+)/ =~ DRC.bput('analyze my fount on my brazier', 'This appears to be a crafting tool and it has approximately \d+ uses remaining')
         if Regexp.last_match(1).to_i < quantity
           stow_hands
           order_enchant(stock_room, stock_needed, stock_number, bag, belt)

--- a/common.lic
+++ b/common.lic
@@ -336,8 +336,8 @@ module DRC
       @skip_repair = skip_repair
       @ranged = ranged.nil? ? is_ranged_weapon?(name) : ranged
       @needs_unloading = needs_unloading.nil? ? @ranged : needs_unloading
-      @crafts = crafts
-      @tool_types = tool_types
+      @crafts = crafts || []
+      @tool_types = tool_types || []
     end
 
     def short_name

--- a/common.lic
+++ b/common.lic
@@ -313,9 +313,12 @@ module DRC
   # Items class. Name is the noun of the object. Leather/metal boolean. Is the item worn (defaults to true). Does it hinder lockpicking? (false)
   # Item.new(name:'gloves', leather:true, worn:true, hinders_locks:true, adjective:'ring', bound:true)
   class Item
-    attr_accessor :name, :leather, :worn, :hinders_lockpicking, :container, :swappable, :tie_to, :adjective, :bound, :wield, :transforms_to, :transform_verb, :transform_text, :lodges, :skip_repair, :ranged, :needs_unloading
+    attr_accessor :name, :leather, :worn, :hinders_lockpicking, :container, :swappable, :tie_to, :adjective, :bound, :wield,
+      :transforms_to, :transform_verb, :transform_text, :lodges, :skip_repair, :ranged, :needs_unloading, :crafts, :tool_types
 
-    def initialize(name: nil, leather: nil, worn: false, hinders_locks: nil, container: nil, swappable: false, tie_to: nil, adjective: nil, bound: false, wield: false, transforms_to: nil, transform_text: nil, transform_verb: nil, lodges: true, skip_repair: false, ranged: nil, needs_unloading: nil)
+    def initialize(name: nil, leather: nil, worn: false, hinders_locks: nil, container: nil, swappable: false, tie_to: nil, adjective: nil,
+      bound: false, wield: false, transforms_to: nil, transform_text: nil, transform_verb: nil, lodges: true, skip_repair: false, ranged: nil,
+      needs_unloading: nil, crafts: [], tool_types: [])
       @name = name
       @leather = leather
       @worn = worn
@@ -333,6 +336,8 @@ module DRC
       @skip_repair = skip_repair
       @ranged = ranged.nil? ? is_ranged_weapon?(name) : ranged
       @needs_unloading = needs_unloading.nil? ? @ranged : needs_unloading
+      @crafts = crafts
+      @tool_types = tool_types
     end
 
     def short_name

--- a/craft.lic
+++ b/craft.lic
@@ -304,7 +304,7 @@ class Craft
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 6) unless DRCI.exists?("bone totem")
       stow_item(right_hand)
       stow_item(left_hand)
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [2, 'a radiant trinket', 'totem'])
       dispose_trash('totem', @worn_trashcan, @worn_trashcan_verb)
@@ -315,7 +315,7 @@ class Craft
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 6) unless DRCI.exists?("bone totem")
       stow_item(right_hand)
       stow_item(left_hand)
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [2, 'a flash trinket', 'totem'])
       dispose_trash('totem', @worn_trashcan, @worn_trashcan_verb)
@@ -326,7 +326,7 @@ class Craft
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 6) unless DRCI.exists?("bone totem")
       stow_item(right_hand)
       stow_item(left_hand)
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [2, 'a wind trinket', 'totem'])
       dispose_trash('totem', @worn_trashcan, @worn_trashcan_verb)
@@ -337,7 +337,7 @@ class Craft
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 6) unless DRCI.exists?("bone totem")
       stow_item(right_hand)
       stow_item(left_hand)
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [2, 'an earth trinket', 'totem'])
       dispose_trash('totem', @worn_trashcan, @worn_trashcan_verb)
@@ -350,7 +350,7 @@ class Craft
       stow_item(left_hand)
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 6) unless DRCI.exists?("bone totem")
       stow_item('totem')
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [3, 'basic holy ritual focus', 'totem'])
       dispose_trash('totem', @worn_trashcan, @worn_trashcan_verb)
@@ -363,7 +363,7 @@ class Craft
       stow_item(left_hand)
       DRCT.buy_item(crafting_data['artificing'][@hometown]['stock-room'], 'runestone') unless DRCI.exists?("basic runestone")
       stow_item('runestone')
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'], 2, @bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [6, 'strange arrow runestone', 'runestone'])
       dispose_trash('runestone', @worn_trashcan, @worn_trashcan_verb)
@@ -376,7 +376,7 @@ class Craft
       stow_item(left_hand)
       DRCT.buy_item(crafting_data['artificing'][@hometown]['stock-room'], 'runestone') unless DRCI.exists?("basic runestone")
       stow_item('runestone')
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag,@bag_items,@belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'], 2, @bag, @bag_items,@belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [6, 'gauge flow runestone', 'runestone'])
       dispose_trash('runestone', @worn_trashcan, @worn_trashcan_verb)
@@ -389,7 +389,7 @@ class Craft
       stow_item(left_hand)
       DRCT.buy_item(crafting_data['artificing'][@hometown]['stock-room'], 'runestone') unless DRCI.exists?("basic runestone")
       stow_item('runestone')
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'], 2, @bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant', [6, 'dispel runestone', 'runestone'])
       dispose_trash('runestone', @worn_trashcan, @worn_trashcan_verb)
@@ -401,7 +401,7 @@ class Craft
       stow_hands
       DRCT.buy_item(crafting_data['artificing'][@hometown]['stock-room'], 'runestone') unless DRCI.exists?("basic runestone")
       stow_hands
-      fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
+      DRCC.fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'], 2, @bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant',[6,'lay ward runestone','runestone'])
       dispose_trash('runestone', @worn_trashcan, @worn_trashcan_verb)
@@ -456,7 +456,7 @@ class Craft
 
     wait_for_script_to_complete('shape', ['trash', chapter, unique_name, 'maple', item])
 
-    bput('get my lumber', 'You get some', 'You pick up')
+    DRC.bput('get my lumber', 'You get some', 'You pick up')
     dispose_trash('lumber', @worn_trashcan, @worn_trashcan_verb)
   end
 
@@ -524,24 +524,24 @@ class Craft
 
   def check_fabric(fabric_volumes)
     crafting_data = get_data('crafting')['tailoring'][@hometown]
-    existing = if bput("get burlap cloth from my #{@bag}", 'What were', 'You get') == 'What were'
+    existing = if DRC.bput("get burlap cloth from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
                else
-                 while bput("get burlap cloth from my #{@bag}", 'What were', 'You get') == 'You get'
-                   bput("combine burlap cloth with burlap cloth", 'You combine')
+                 while DRC.bput("get burlap cloth from my #{@bag}", 'What were', 'You get') == 'You get'
+                   DRC.bput("combine burlap cloth with burlap cloth", 'You combine')
                  end
-                 bput("count my burlap cloth", 'You count out \d+ yards').scan(/\d+/).first.to_i
+                 DRC.bput("count my burlap cloth", 'You count out \d+ yards').scan(/\d+/).first.to_i
                end
     stock_needed = ((fabric_volumes - existing) / 10.0).ceil
     order_fabric(crafting_data['stock-room'], stock_needed, crafting_data['sew-stock-number'], 'burlap cloth')
   end
 
   def check_wood
-    case bput('get my maple lumber', 'You get', 'You are already', 'What were you')
+    case DRC.bput('get my maple lumber', 'You get', 'You are already', 'What were you')
     when 'What were you'
       buy_wood
     when 'You get', 'You are already'
-      count = bput('count my lumber', 'You count out \d+ pieces of lumber remaining').scan(/\d+/).first.to_i
+      count = DRC.bput('count my lumber', 'You count out \d+ pieces of lumber remaining').scan(/\d+/).first.to_i
       buy_wood if count < 5
     end
     stow_hands
@@ -578,10 +578,6 @@ class Craft
                     .first
 
     @listen_timer = @last_teacher ? nil : Time.now
-  end
-
-  def get_item(name)
-    get_crafting_item(name, @bag, @bag_items, @belt)
   end
 
   def stow_item(name)

--- a/enchant.lic
+++ b/enchant.lic
@@ -60,7 +60,9 @@ class Enchant
     @equipment_manager = EquipmentManager.new
     @equipment_manager.empty_hands
     wait_for_script_to_complete('buff', ['enchant'])
+
     study_recipe
+
     @item = 'fount' if @item == 'small sphere'
     if @item != 'fount'
       case bput("tap my #{@fount}", /You tap an unfinished .* atop your brazier./, /You tap .*your .*/, /What were/)
@@ -87,11 +89,11 @@ class Enchant
   def study_recipe
     get_item("#{@book_type} book")
     turn_to("page #{find_recipe(@chapter, @recipe)}")
-    bput("study my #{@book_type} book", 'You scan', 'You review', 'You peruse')
+    DRC.bput("study my #{@book_type} book", 'You scan', 'You review', 'You peruse')
     stow_item("#{@book_type} book")
-    get_item(@brazier) if @use_own_brazier
 
-    case bput("get my #{@item} from my #{@bag}", 'You get a', 'That is far too dangerous')
+    get_item(@brazier) if @use_own_brazier
+    case DRC.bput("get my #{@item} from my #{@bag}", 'You get a', 'That is far too dangerous')
     when 'That is far too dangerous'
       clean_brazier
       empty_brazier
@@ -140,9 +142,9 @@ class Enchant
   end
 
   def clean_brazier
-    case bput("clean #{@brazier}", 'You prepare to clean off the brazier', 'There is nothing', 'The brazier is not currently lit')
+    case DRC.bput("clean #{@brazier}", 'You prepare to clean off the brazier', 'There is nothing', 'The brazier is not currently lit')
     when 'You prepare to clean off the brazier'
-      bput("clean #{@brazier}", 'a massive ball of flame jets forward and singes everything nearby')
+      DRC.bput("clean #{@brazier}", 'a massive ball of flame jets forward and singes everything nearby')
     when 'The brazier is not currently lit'
       stow_item(left_hand) if left_hand
     end

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -8,17 +8,147 @@ class EquipmentManager
   include DRC
   include DRCI
 
+  SHOVEL_MATCHES = [
+    /and pull free the head of a shovel/
+  ]
+
+  TONGS_MATCHES = [
+    /readying them for use as tongs/
+  ]
+
   def initialize(settings = nil)
-    items(settings)
+    @settings = settings || get_settings
+    @debug = @settings.equipmanager['debug'] || false
+    @sort_head = @settings.sort_auto_head
+    @gear_sets = {}
+    @settings.gear_sets.each { |set_name, gear_list| @gear_sets[set_name] = gear_list.flatten.uniq }
+    @items = process_settings_gear_map
+    # Toolbelts and Tools should go away once people migrate to gear entries
+    process_toolbelts
+    process_tools
   end
 
-  def items(settings = nil)
-    return @items if @items
-    settings ||= get_settings
-    @gear_sets = {}
-    settings.gear_sets.each { |set_name, gear_list| @gear_sets[set_name] = gear_list.flatten.uniq }
-    @sort_head = settings.sort_auto_head
-    @items = settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking], worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound], wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text], lodges: item[:lodges], ranged: item[:ranged], needs_unloading: item[:needs_unloading], skip_repair: item[:skip_repair], container: item[:container]) }
+  def process_settings_gear_map
+    return @settings.gear.map { |item| Item.new(name: item[:name], leather: item[:is_leather], hinders_locks: item[:hinders_lockpicking],
+        worn: item[:is_worn], swappable: item[:swappable], tie_to: item[:tie_to], adjective: item[:adjective], bound: item[:bound],
+        wield: item[:wield], transforms_to: item[:transforms_to], transform_verb: item[:transform_verb], transform_text: item[:transform_text],
+        lodges: item[:lodges], ranged: item[:ranged], needs_unloading: item[:needs_unloading], skip_repair: item[:skip_repair],
+        container: item[:container], crafts: item[:crafts], tool_types: item[:tool_types]
+      )}
+  end
+
+  def process_toolbelts
+    # Anything in a toolbelt entry, that is not already in @items, should be added
+    add_tools_from_toolbelt(@settings.forging_belt['name'], @settings.forging_belt['items'])
+    add_tools_from_toolbelt(@settings.outfitting_belt['name'], @settings.outfitting_belt['items'])
+    add_tools_from_toolbelt(@settings.alchemy_belt['name'], @settings.alchemy_belt['items'])
+    add_tools_from_toolbelt(@settings.enchanting_belt['name'], @settings.enchanting_belt['items'])
+    add_tools_from_toolbelt(@settings.engineering_belt['name'], @settings.engineering_belt['items'])
+  end
+
+  def add_tools_from_toolbelt(belt_name, belt_items)
+    return unless belt_name && belt_items
+
+    belt_items.each { |belt_item|
+      next if item_by_desc(belt_item)
+
+      item = DRC::Item::from_text(belt_item)
+      item.tie_to = belt_name
+      item.skip_repair = true
+      @items << item
+    }
+  end
+
+  def process_tools
+    add_tools('forging', @settings.forging_tools)
+    add_tools('tinkering', @settings.tinkering_tools)
+    add_tools('outfitting', @settings.outfitting_tools)
+    add_tools('shaping', @settings.shaping_tools)
+    add_tools('alchemy', @settings.alchemy_tools)
+    add_tools('carving', @settings.carving_tools)
+    add_tools('enchanting', @settings.enchanting_tools)
+    add_tools('mining', [@settings.mining_implement])
+  end
+
+  def add_tools(craft_type, tools_items)
+    tools_items.each { |tool_item|
+      next unless tool_item
+
+      item = item_by_desc(tool_item)
+      if item.nil?
+        item = DRC::Item::from_text(tool_item) unless item
+        item.skip_repair = true
+        @items << item
+      end
+
+      item.crafts << craft_type unless item.crafts.include?(craft_type)
+      tool_type = get_tool_type_for_item(item)
+      item.tool_types << tool_type unless item.tool_types.include?(tool_type)
+    }
+  end
+
+  def items()
+    @items
+  end
+
+  def get_tool_info(craft_type, tool_type)
+    items.find { |item| item.crafts.include?(craft_type) && item.tool_types.include?(tool_type) }
+  end
+
+  def get_tool_info_for_craft(craft_type)
+    items.select { |item| item.crafts.include?(craft_type) }
+  end
+
+  def get_tool?(craft_type, tool_type)
+    # Check gear for matching item
+    echo "Searching items for tool flagged: #{craft_type} + #{tool_type}..." if @debug
+    item = items.find { |item| item.crafts.include?(craft_type) && item.tool_types.include?(tool_type) }
+
+    # Couldn't find anything that would work, fail out
+    echo "No matching item found for #{craft_type} + #{tool_type}" if @debug && item.nil?
+    return false unless item
+
+    return false unless get_item?(item)
+
+    return true unless item.swappable
+
+    return swap_to_tool_type?(item, tool_type)
+  end
+
+  def return_tool?(craft_type, tool_type)
+    echo "Searching items for tool flagged: #{craft_type} + #{tool_type}..." if @debug
+    item = items.find { |item| item.crafts.include?(craft_type) && item.tool_types.include?(tool_type) }
+    return false unless item
+
+    return_item(item)
+    return true
+  end
+
+  def get_tool_type_for_item(item)
+    case "#{item.adjective} #{item.name}"
+    when /hammer|mallet/
+      return 'hammer'
+    when /knitting needles/
+      return 'knitting needles'
+    when /sewing needles/
+      return 'sewing needles'
+    else
+      return item.name
+    end
+  end
+
+  def swap_to_tool_type?(item, tool_type)
+    tool_swap_command = "adjust my #{item.adjective} #{item.name}"
+
+    item.tool_types.length.times {
+      case DRC.bput(tool_swap_command, SHOVEL_MATCHES, TONGS_MATCHES)
+      when *SHOVEL_MATCHES
+        return true if tool_type =~ /shovel/i
+      when *TONGS_MATCHES
+        return true if tool_type =~ /tongs/i
+      end
+    }
+    return false
   end
 
   def remove_gear_by(&_block)
@@ -219,7 +349,7 @@ class EquipmentManager
 
   def get_item?(item)
     if item.wield
-      bput("wield my #{item.short_name}", 'You draw', 'You deftly remove', 'You slip', 'Wield what', 'With a flick of your wrist you stealthily unsheathe') != 'Wield what'
+      DRC.bput("wield my #{item.short_name}", 'You draw', 'You deftly remove', 'You slip', 'Wield what', 'With a flick of your wrist you stealthily unsheathe') != 'Wield what'
     elsif item.transforms_to
       item = item_by_desc(item.transforms_to)
       item.worn ? get_item_helper(item, :worn) : get_item_helper(item, :stowed)
@@ -227,7 +357,7 @@ class EquipmentManager
     elsif (item.tie_to && get_item_helper(item, :tied)) || (item.worn && get_item_helper(item, :worn)) || (item.container && DRCI.get_item(item.short_name, item.container)) || get_item_helper(item, :stowed)
       true
     else
-      echo("Could not find #{item.short_name} anywhere.")
+      DRC.message("Could not find #{item.short_name} anywhere.")
       false
     end
   end
@@ -248,20 +378,24 @@ class EquipmentManager
         stow_helper("wear my #{info.short_name}", info.short_name, 'You sling', 'You attach', 'You .* unload', 'You strap', 'You slide', 'You work your way into', 'You spin', '^You ', 'You carefully loop', 'slide effortlessly onto your', 'You slip')
         true
       elsif info = items.find { |item| item.short_regex =~ held_item }
-        unload_weapon(info.short_name) if info.needs_unloading
-        if info.tie_to
-          stow_helper("tie my #{info.short_name} to #{info.tie_to}", info.short_name, 'You attach', 'you tie', 'You are a little too busy', 'Your wounds hinder your ability to do that')
-        elsif info.wield
-          stow_helper("sheath my #{info.short_name}", info.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'You secure your', 'You slip', 'You hang', 'You .* strap')
-        elsif info.container
-          stow_helper("put my #{info.short_name} into #{info.container}", info.short_name, 'You put', 'You should unload', 'You easily strap', 'You secure your', 'You hang')
-        else
-          stow_helper("stow my #{info.short_name}", info.short_name, 'You put', 'You should unload', 'You easily strap', 'You secure your')
-        end
+        return_item(info)
         true
       else
         false
       end
+    end
+  end
+
+  def return_item(item)
+    unload_weapon(item.short_name) if item.needs_unloading
+    if item.tie_to
+      stow_helper("tie my #{item.short_name} to #{item.tie_to}", item.short_name, 'You attach', 'you tie', 'You are a little too busy', 'Your wounds hinder your ability to do that')
+    elsif item.wield
+      stow_helper("sheath my #{item.short_name}", item.short_name, 'Sheathing', 'You sheathe', 'You .* unload', 'You secure your', 'You slip', 'You hang', 'You .* strap')
+    elsif item.container
+      stow_helper("put my #{item.short_name} into #{item.container}", item.short_name, 'You put', 'You should unload', 'You easily strap', 'You secure your', 'You hang')
+    else
+      stow_helper("stow my #{item.short_name}", item.short_name, 'You put', 'You should unload', 'You easily strap', 'You secure your')
     end
   end
 

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -100,6 +100,8 @@ class EquipmentManager
   end
 
   def get_tool?(craft_type, tool_type)
+    return false unless craft_type && tool_type
+
     # Check gear for matching item
     echo "Searching items for tool flagged: #{craft_type} + #{tool_type}..." if @debug
     item = items.find { |item| item.crafts.include?(craft_type) && item.tool_types.include?(tool_type) }

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -76,7 +76,8 @@ class EquipmentManager
 
       item = item_by_desc(tool_item)
       if item.nil?
-        item = DRC::Item::from_text(tool_item) unless item
+        echo "No matching items, creating new gear entry for #{craft_type}+#{tool_item}" if @debug
+        item = DRC::Item::from_text(tool_item)
         item.skip_repair = true
         @items << item
       end

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -370,9 +370,10 @@ class EquipmentManager
   end
 
   def return_held_gear(gear_set = 'standard')
+    echo 'Returning held gear...' if @debug
     return unless right_hand || left_hand
-    todo = [left_hand, right_hand].compact
 
+    todo = [left_hand, right_hand].compact
     worn_items = desc_to_items(@gear_sets[gear_set])
 
     todo.all? do |held_item|
@@ -390,6 +391,8 @@ class EquipmentManager
   end
 
   def return_item(item)
+    echo "Returning #{item.short_name}" if @debug
+
     unload_weapon(item.short_name) if item.needs_unloading
     if item.tie_to
       stow_helper("tie my #{item.short_name} to #{item.tie_to}", item.short_name, 'You attach', 'you tie', 'You are a little too busy', 'Your wounds hinder your ability to do that')

--- a/forge.lic
+++ b/forge.lic
@@ -117,7 +117,7 @@ class Forge
       exit
     end
 
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
 
     # Do this once here to eat the warning message
     DRC.bput("put my #{@item} on the forge", 'Put your item onto the forge')
@@ -127,10 +127,10 @@ class Forge
 
   def hone
     find_grindstone(@hometown)
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     get_item('weaponsmithing book')
     turn_to("page #{find_recipe(10, 'metal weapon honing')}")
-    bput('study my book', 'Roundtime')
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
     Flags.reset('hone-done')
     do_hone
@@ -138,10 +138,10 @@ class Forge
 
   def balance
     find_grindstone(@hometown)
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     get_item('weaponsmithing book')
     turn_to("page #{find_recipe(10, 'metal weapon balancing')}")
-    bput('study my book', 'Roundtime')
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
     Flags.reset('hone-done')
     do_hone
@@ -150,11 +150,11 @@ class Forge
   def lighten
     find_grindstone(@hometown)
 
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
 
     get_item('armorsmithing book')
     turn_to("page #{find_recipe(5, 'metal armor lightening')}")
-    bput('study my book', 'Roundtime')
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
 
     @equipmanager.get_tool?('forging', 'pliers')
@@ -173,56 +173,59 @@ class Forge
   end
 
   def spin_grindstone
-    until bput('turn grind', 'keeping it spinning fast', 'Roundtime') == 'keeping it spinning fast'
+    until DRC.bput('turn grind', 'keeping it spinning fast', 'Roundtime') == 'keeping it spinning fast'
       pause
       waitrt?
     end
   end
 
   def do_hone
+    DRCA.crafting_magic_routine(@settings)
+
     spin_grindstone
-    crafting_magic_routine(@settings)
-    case bput("push grind with #{@item}", 'The grinding has left many nicks and burs in the metal that should be cleaned away', 'roundtime')
+    case DRC.bput("push grind with #{@item}", 'The grinding has left many nicks and burs in the metal that should be cleaned away', 'roundtime')
     when /nicks and burs/
       get_item('wire brush')
-      bput("rub #{@item} with my brush", 'roundtime')
+      DRC.bput("rub #{@item} with my brush", 'roundtime')
       stow_item('brush')
     end
+
     pause
     waitrt?
+
     if Flags['hone-done']
       pour_oil
     else
-      crafting_magic_routine(@settings)
+      DRCA.crafting_magic_routine(@settings)
       do_hone
     end
   end
 
   def do_lighten
     spin_grindstone
-    crafting_magic_routine(@settings)
-    case bput("push grind with #{@item}", 'With the grinding complete', 'roundtime')
+    DRCA.crafting_magic_routine(@settings)
+    case DRC.bput("push grind with #{@item}", 'With the grinding complete', 'roundtime')
     when 'With the grinding complete'
-      bput("put #{@item} on anvil", 'You put')
+      DRC.bput("put #{@item} on anvil", 'You put')
       @equipmanager.get_tool?('forging', 'hammer')
       @equipmanager.get_tool?('forging', 'tongs')
-      bput("pound #{@item} with my #{@hammer}", 'roundtime')
+      DRC.bput("pound #{@item} with my #{@hammer}", 'roundtime')
       @equipmanager.return_tool?('forging', 'hammer')
       @equipmanager.return_tool?('forging', 'tongs')
-      bput("get #{@item}", 'You get')
+      DRC.bput("get #{@item}", 'You get')
       @equipmanager.get_tool?('forging', 'pliers')
-      bput("pull my #{@item} with my pliers", 'roundtime')
+      DRC.bput("pull my #{@item} with my pliers", 'roundtime')
       @equipmanager.return_tool?('forging', 'pliers')
       pour_oil
     else
-      crafting_magic_routine(@settings)
+      DRCA.crafting_magic_routine(@settings)
       do_lighten
     end
   end
 
   def temper_turn(first = false)
     waitrt?
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     command = first ? "put my #{@item} on the forge" : "turn #{@item} on forge with my tongs"
 
     case DRC.bput(command,
@@ -256,24 +259,24 @@ class Forge
   end
 
   def temper_finish
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     @equipmanager.return_tool?('forging', 'tongs')
     fput("get #{@item} from forge")
     pour_oil
   end
 
   def smith
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     if @chapter
       get_item("#{@book_type} book")
       echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
       turn_to("page #{find_recipe(@chapter, @recipe_name)}")
-      bput('study my book', 'Roundtime')
+      DRC.bput('study my book', 'Roundtime')
       stow_item('book')
     elsif @instruction
       get_item("#{@instruction} instructions")
       if /again/ =~ bput('study my instructions', 'Roundtime', 'Study them again')
-        bput('study my instructions', 'Roundtime', 'Study them again')
+        DRC.bput('study my instructions', 'Roundtime', 'Study them again')
       end
       stow_item('instructions')
     end
@@ -286,8 +289,8 @@ class Forge
 
   def pound(item = @item)
     waitrt?
-    crafting_magic_routine(@settings)
-    case bput("pound #{item} on anvil with my #{@hammer}",
+    DRCA.crafting_magic_routine(@settings)
+    case DRC.bput("pound #{item} on anvil with my #{@hammer}",
               /You must be holding .* to do that.$/,
               /You must be holding some metal tongs in your other hand to do that/,
               'needs more fuel', 'need some more fuel',
@@ -320,7 +323,7 @@ class Forge
     when 'You believe you can assemble'
       @equipmanager.return_tool?('forging', 'hammer')
       @equipmanager.return_tool?('forging', 'tongs')
-      bput("get #{@item} from anvil", 'You get')
+      DRC.bput("get #{@item} from anvil", 'You get')
       assemble_part
       Flags.reset('forge-assembly')
       bput("put #{@item} on anvil", 'You put')
@@ -337,7 +340,7 @@ class Forge
       @equipmanager.return_tool?('forging', 'tongs')
       exit
     else
-      crafting_magic_routine(@settings)
+      DRCA.crafting_magic_routine(@settings)
       pound
     end
   end
@@ -345,7 +348,7 @@ class Forge
   def add_fuel
     @equipmanager.return_tool?('forging', 'tongs')
     @equipmanager.get_tool?('forging', 'shovel')
-    case bput("push fuel with my #{@shovel}", 'Roundtime', 'That tool does not seem')
+    case DRC.bput("push fuel with my #{@shovel}", 'Roundtime', 'That tool does not seem')
     when 'That tool does not seem'
       analyze_item
     else
@@ -359,7 +362,7 @@ class Forge
   def bellows
     @equipmanager.return_tool?('forging', 'hammer')
     @equipmanager.get_tool?('forging', 'bellows')
-    case bput('push my bellows', 'Roundtime', 'That tool does not seem')
+    case DRC.bput('push my bellows', 'Roundtime', 'That tool does not seem')
     when 'That tool does not seem'
       analyze_item
     else
@@ -372,7 +375,7 @@ class Forge
 
   def turn_item
     waitrt?
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     case bput("turn #{@item} on anvil with my tongs",
               'ready for cooling in the slack tub', 'ready for a quench hardening in the slack tub',
               'Roundtime',
@@ -389,20 +392,22 @@ class Forge
   def slack_tub
     @equipmanager.return_tool?('forging', 'hammer')
     @equipmanager.return_tool?('forging', 'tongs')
-    Flags.reset('forge-assembly')
-    bput('push slack tub', 'Roundtime')
-    waitrt?
-    bput("get #{@item} from anvil", 'You get')
+    DRCA.crafting_magic_routine(@settings)
 
+    Flags.reset('forge-assembly')
+    DRC.bput('push slack tub', 'Roundtime')
+    waitrt?
+
+    DRC.bput("get #{@item} from anvil", 'You get')
     assemble_part
 
     if 'armorsmithing'.include? @book_type
       @equipmanager.get_tool?('forging', 'pliers')
       loop do
-        case bput("pull my #{@item} with my pliers", 'roundtime', 'need of some oil', 'That tool does not seem suitable for that task', 'doesn\'t appear suitable for working')
+        case DRC.bput("pull my #{@item} with my pliers", 'roundtime', 'need of some oil', 'That tool does not seem suitable for that task', 'doesn\'t appear suitable for working')
         when 'That tool does not seem suitable for that task', 'doesn\'t appear suitable for working'
           @equipmanager.return_tool?('forging', 'pliers')
-          bput("put #{@item} on anvil", 'You put')
+          DRC.bput("put #{@item} on anvil", 'You put')
           Flags.reset('forge-assembly')
           analyze_item
           return
@@ -416,7 +421,6 @@ class Forge
         @equipmanager.get_tool?('forging', 'pliers')
       end
       @equipmanager.return_tool?('forging', 'pliers')
-
     elsif 'weaponsmithing'.include? @book_type
       grind_item
     end
@@ -444,16 +448,16 @@ class Forge
   def grind_item
     find_grindstone(@hometown)
     spin_grindstone
-    bput("push grind with my #{@item}", 'Roundtime', 'needs protection')
+    DRC.bput("push grind with my #{@item}", 'Roundtime', 'needs protection')
     waitrt?
   end
 
   def pour_oil
     ords = %w[second third fourth fifth sixth]
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     get_item('oil')
     while ords.any?
-      case bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour", 'You pour all of')
+      case DRC.bput("pour my oil on my #{@item}", 'Roundtime', 'Applying the final touches', "You can't pour", 'You pour all of')
       when 'Roundtime', 'Applying the final touches'
         waitrt?
         stow_item('oil')
@@ -481,7 +485,7 @@ class Forge
 
   def analyze_item
     waitrt?
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
     stow_item(left_hand) # store contents of both hands, reacquire hammer and tongs
     stow_item(right_hand)
     @equipmanager.get_tool?('forging', 'hammer')
@@ -497,7 +501,7 @@ class Forge
     when 'metal will quickly rust'
       stow_item(left_hand)
       stow_item(right_hand)
-      bput("get #{@item} from anvil", 'You get')
+      DRC.bput("get #{@item} from anvil", 'You get')
       add_oil
     when 'The forge fire has died down'
       bellows
@@ -506,7 +510,7 @@ class Forge
     when 'with the pliers to stitch them together'
       @equipmanager.return_tool?('forging', 'tongs')
       @equipmanager.get_tool?('forging', 'pliers')
-      bput("pull my #{@item} with my pliers", 'roundtime')
+      DRC.bput("pull my #{@item} with my pliers", 'roundtime')
       @equipmanager.return_tool?('forging', 'pliers')
       analyze_item
     end
@@ -515,9 +519,9 @@ class Forge
   def magic_cleanup
     return if @training_spells.empty?
 
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-    bput('release mana', 'You release all', "You aren't harnessing any mana")
-    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 end
 

--- a/forge.lic
+++ b/forge.lic
@@ -290,6 +290,7 @@ class Forge
   def pound(item = @item)
     waitrt?
     DRCA.crafting_magic_routine(@settings)
+
     case DRC.bput("pound #{item} on anvil with my #{@hammer}",
               /You must be holding .* to do that.$/,
               /You must be holding some metal tongs in your other hand to do that/,
@@ -329,13 +330,13 @@ class Forge
       bput("put #{@item} on anvil", 'You put')
       analyze_item
     when 'You need a larger volume of metal'
-      echo '***You need a larger ingot to forge this item.***'
+      DRC.message('***You need a larger ingot to forge this item.***')
       @equipmanager.return_tool?('forging', 'hammer')
       @equipmanager.return_tool?('forging', 'tongs')
       magic_cleanup
       exit
     when 'I could not find what you were referring to'
-      echo '*** ERROR TRYING TO CRAFT, EXITING ***'
+      DRC.message('*** ERROR TRYING TO CRAFT, EXITING ***')
       @equipmanager.return_tool?('forging', 'hammer')
       @equipmanager.return_tool?('forging', 'tongs')
       exit
@@ -486,6 +487,7 @@ class Forge
   def analyze_item
     waitrt?
     DRCA.crafting_magic_routine(@settings)
+
     stow_item(left_hand) # store contents of both hands, reacquire hammer and tongs
     stow_item(right_hand)
     @equipmanager.get_tool?('forging', 'hammer')

--- a/forge.lic
+++ b/forge.lic
@@ -56,15 +56,21 @@ class Forge
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.forging_belt
-    @hammer = @settings.forging_tools.find { |item| /hammer|mallet/ =~ item }
-    @shovel = @settings.forging_tools.find { |item| /shovel/ =~ item }
     @training_spells = @settings.crafting_training_spells
+    @equipmanager = EquipmentManager.new
+    hammer_info = @equipmanager.get_tool_info('forging', 'hammer')
+    @hammer = "#{hammer_info.adjective} #{hammer_info.name}"
+    shovel_info = @equipmanager.get_tool_info('forging', 'shovel')
+    @shovel = "#{shovel_info.adjective} #{shovel_info.name}"
 
     @item = args.noun
     wait_for_script_to_complete('buff', ['forge'])
 
-    Flags.add('forge-assembly', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)', 'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)', 'another finished (long|short) wooden (pole)', 'ready to be woven into and around the material')
+    Flags.add('forge-assembly', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)',
+      'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)',
+      'another finished (long|short) wooden (pole)')
     Flags.add('hone-done', 'the metal now needs protection by pouring oil on it')
+
     if args.temper
       temper
     elsif args.hone
@@ -106,12 +112,16 @@ class Forge
 
   def temper
     unless left_hand =~ /#{@item}/i || right_hand =~ /#{@item}/i
-      echo('***Please hold the item to temper.***')
+      DRC.message('***Please hold the item to temper.***')
       magic_cleanup
       exit
     end
+
     crafting_magic_routine(@settings)
-    bput("put my #{@item} on the forge", 'Put your item onto the forge')
+
+    # Do this once here to eat the warning message
+    DRC.bput("put my #{@item} on the forge", 'Put your item onto the forge')
+
     temper_turn(true)
   end
 
@@ -139,21 +149,26 @@ class Forge
 
   def lighten
     find_grindstone(@hometown)
+
     crafting_magic_routine(@settings)
+
     get_item('armorsmithing book')
     turn_to("page #{find_recipe(5, 'metal armor lightening')}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('plier')
-    bput("pull my #{@item} with my pliers", 'must be pounded free')
-    stow_item('plier')
-    bput("put #{@item} on anvil", 'You put')
-    get_item(@hammer)
-    get_item('tongs')
-    bput("pound #{@item} with my #{@hammer}", 'roundtime')
-    stow_item(@hammer)
-    stow_item('tongs')
-    bput("get #{@item}", 'You get')
+
+    @equipmanager.get_tool?('forging', 'pliers')
+    DRC.bput("pull my #{@item} with my pliers", 'must be pounded free')
+    @equipmanager.return_tool?('forging', 'pliers')
+
+    DRC.bput("put #{@item} on anvil", 'You put')
+    @equipmanager.get_tool?('forging', 'hammer')
+    @equipmanager.get_tool?('forging', 'tongs')
+    DRC.bput("pound #{@item} with my #{@hammer}", 'roundtime')
+    @equipmanager.return_tool?('forging', 'hammer')
+    @equipmanager.return_tool?('forging', 'tongs')
+
+    DRC.bput("get #{@item}", 'You get')
     do_lighten
   end
 
@@ -189,15 +204,15 @@ class Forge
     case bput("push grind with #{@item}", 'With the grinding complete', 'roundtime')
     when 'With the grinding complete'
       bput("put #{@item} on anvil", 'You put')
-      get_item(@hammer)
-      get_item('tongs')
+      @equipmanager.get_tool?('forging', 'hammer')
+      @equipmanager.get_tool?('forging', 'tongs')
       bput("pound #{@item} with my #{@hammer}", 'roundtime')
-      stow_item(@hammer)
-      stow_item('tongs')
+      @equipmanager.return_tool?('forging', 'hammer')
+      @equipmanager.return_tool?('forging', 'tongs')
       bput("get #{@item}", 'You get')
-      get_item('plier')
+      @equipmanager.get_tool?('forging', 'pliers')
       bput("pull my #{@item} with my pliers", 'roundtime')
-      stow_item('plier')
+      @equipmanager.return_tool?('forging', 'pliers')
       pour_oil
     else
       crafting_magic_routine(@settings)
@@ -208,34 +223,41 @@ class Forge
   def temper_turn(first = false)
     waitrt?
     crafting_magic_routine(@settings)
-    command = first ? "put my #{@item} on the forge" : "turn #{@item} on forge with my tong"
+    command = first ? "put my #{@item} on the forge" : "turn #{@item} on forge with my tongs"
 
-    case bput(command,
-              'needs more fuel', 'need some more fuel',
-              'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel',
-              'Roundtime',
-              'metal looks to be in need of some oil to preserve', 'to be cleaned')
+    case DRC.bput(command,
+            'has already been tempered',
+            'needs more fuel', 'need some more fuel',
+            'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel',
+            'Roundtime',
+            'metal looks to be in need of some oil to preserve', 'to be cleaned')
+    when 'has already been tempered'
+      DRC.message('***Item has already been tempered.***')
+      magic_cleanup
+      exit
     when 'needs more fuel', 'need some more fuel'
-      get_item(@shovel)
-      bput('push fuel with my shovel', 'Roundtime')
+      @equipmanager.return_tool?('forging', 'tongs') if right_hand
+      @equipmanager.get_tool?('forging', 'shovel')
+      DRC.bput("push fuel with my #{@shovel}", 'Roundtime')
       waitrt?
-      stow_item(@shovel)
+      @equipmanager.return_tool?('forging', 'shovel')
     when 'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel'
-      get_item('bellows')
+      @equipmanager.get_tool?('forging', 'bellows')
       bput('push my bellows', 'Roundtime')
       waitrt?
-      stow_item('bellows')
+      @equipmanager.return_tool?('forging', 'bellows')
     when 'metal looks to be in need of some oil to preserve', 'to be cleaned'
       temper_finish
       return
     end
-    get_item('tongs') unless right_hand
+
+    @equipmanager.get_tool?('forging', 'tongs') unless right_hand
     temper_turn
   end
 
   def temper_finish
     crafting_magic_routine(@settings)
-    stow_item('tong')
+    @equipmanager.return_tool?('forging', 'tongs')
     fput("get #{@item} from forge")
     pour_oil
   end
@@ -257,8 +279,8 @@ class Forge
     end
     get_item("#{@metal} ingot")
     bput('put my ingot on anvil', 'You put your')
-    get_item(@hammer)
-    get_item('tongs')
+    @equipmanager.get_tool?('forging', 'hammer')
+    @equipmanager.get_tool?('forging', 'tongs')
     pound('ingot')
   end
 
@@ -280,10 +302,10 @@ class Forge
               'You need a larger volume of metal',
               'I could not find what you were referring to')
     when /You must be holding .* to do that.$/
-      get_item(@hammer)
+      @equipmanager.get_tool?('forging', 'hammer')
       pound(item)
     when /You must be holding some metal tongs in your other hand to do that/
-      get_item('tongs')
+      @equipmanager.get_tool?('forging', 'tongs')
       pound(item)
     when 'needs more fuel', 'need some more fuel'
       add_fuel
@@ -296,8 +318,8 @@ class Forge
     when 'That tool does not seem'
       analyze_item
     when 'You believe you can assemble'
-      stow_item(@hammer)
-      stow_item('tongs')
+      @equipmanager.return_tool?('forging', 'hammer')
+      @equipmanager.return_tool?('forging', 'tongs')
       bput("get #{@item} from anvil", 'You get')
       assemble_part
       Flags.reset('forge-assembly')
@@ -305,14 +327,14 @@ class Forge
       analyze_item
     when 'You need a larger volume of metal'
       echo '***You need a larger ingot to forge this item.***'
-      stow_item(@hammer)
-      stow_item('tongs')
+      @equipmanager.return_tool?('forging', 'hammer')
+      @equipmanager.return_tool?('forging', 'tongs')
       magic_cleanup
       exit
     when 'I could not find what you were referring to'
       echo '*** ERROR TRYING TO CRAFT, EXITING ***'
-      stow_item(@hammer)
-      stow_item('tongs')
+      @equipmanager.return_tool?('forging', 'hammer')
+      @equipmanager.return_tool?('forging', 'tongs')
       exit
     else
       crafting_magic_routine(@settings)
@@ -321,29 +343,29 @@ class Forge
   end
 
   def add_fuel
-    stow_item('tongs')
-    get_item(@shovel)
-    case bput('push fuel with my shovel', 'Roundtime', 'That tool does not seem')
+    @equipmanager.return_tool?('forging', 'tongs')
+    @equipmanager.get_tool?('forging', 'shovel')
+    case bput("push fuel with my #{@shovel}", 'Roundtime', 'That tool does not seem')
     when 'That tool does not seem'
       analyze_item
     else
       waitrt?
-      stow_item(@shovel)
-      get_item('tongs')
+      @equipmanager.return_tool?('forging', 'shovel')
+      @equipmanager.get_tool?('forging', 'tongs')
       pound
     end
   end
 
   def bellows
-    stow_item(@hammer)
-    get_item('bellows')
+    @equipmanager.return_tool?('forging', 'hammer')
+    @equipmanager.get_tool?('forging', 'bellows')
     case bput('push my bellows', 'Roundtime', 'That tool does not seem')
     when 'That tool does not seem'
       analyze_item
     else
       waitrt?
-      stow_item('bellows')
-      get_item(@hammer)
+      @equipmanager.return_tool?('forging', 'bellows')
+      @equipmanager.get_tool?('forging', 'hammer')
       pound
     end
   end
@@ -365,8 +387,8 @@ class Forge
   end
 
   def slack_tub
-    stow_item(@hammer)
-    stow_item('tongs')
+    @equipmanager.return_tool?('forging', 'hammer')
+    @equipmanager.return_tool?('forging', 'tongs')
     Flags.reset('forge-assembly')
     bput('push slack tub', 'Roundtime')
     waitrt?
@@ -375,11 +397,11 @@ class Forge
     assemble_part
 
     if 'armorsmithing'.include? @book_type
-      get_item('pliers')
+      @equipmanager.get_tool?('forging', 'pliers')
       loop do
         case bput("pull my #{@item} with my pliers", 'roundtime', 'need of some oil', 'That tool does not seem suitable for that task', 'doesn\'t appear suitable for working')
         when 'That tool does not seem suitable for that task', 'doesn\'t appear suitable for working'
-          stow_item('pliers')
+          @equipmanager.return_tool?('forging', 'pliers')
           bput("put #{@item} on anvil", 'You put')
           Flags.reset('forge-assembly')
           analyze_item
@@ -389,11 +411,11 @@ class Forge
         end
         pause
         waitrt?
-        stow_item('pliers')
+        @equipmanager.return_tool?('forging', 'pliers')
         assemble_part
-        get_item('pliers')
+        @equipmanager.get_tool?('forging', 'pliers')
       end
-      stow_item('pliers')
+      @equipmanager.return_tool?('forging', 'pliers')
 
     elsif 'weaponsmithing'.include? @book_type
       grind_item
@@ -449,11 +471,11 @@ class Forge
     pour_oil
 
     return unless @stamp
-    get_item('stamp')
+    @equipmanager.get_tool?('forging', 'stamp')
     fput("mark my #{@item} with my stamp")
     pause
     waitrt?
-    stow_item('stamp')
+    @equipmanager.return_tool?('forging', 'stamp')
     magic_cleanup
   end
 
@@ -462,8 +484,8 @@ class Forge
     crafting_magic_routine(@settings)
     stow_item(left_hand) # store contents of both hands, reacquire hammer and tongs
     stow_item(right_hand)
-    get_item(@hammer)
-    get_item('tongs')
+    @equipmanager.get_tool?('forging', 'hammer')
+    @equipmanager.get_tool?('forging', 'tongs')
 
     case bput("analyze #{@item}", 'The metal is ready to be cooled', 'Almost all of the coal has been consumed', 'ready for more pounding', 'metal will quickly rust', 'The forge fire has died down', 'metal is in need of some gentle bending', 'to be pulled', 'ready to be pounded', 'would obstruct pounding', 'ready for pounding', 'with the pliers to stitch them together')
     when 'The metal is ready to be cooled'
@@ -482,10 +504,10 @@ class Forge
     when 'metal is in need of some gentle bending', 'to be pulled', 'a mandrel or mold set'
       turn_item
     when 'with the pliers to stitch them together'
-      stow_item('tongs')
-      get_item('plier')
+      @equipmanager.return_tool?('forging', 'tongs')
+      @equipmanager.get_tool?('forging', 'pliers')
       bput("pull my #{@item} with my pliers", 'roundtime')
-      stow_item('plier')
+      @equipmanager.return_tool?('forging', 'pliers')
       analyze_item
     end
   end

--- a/mine.lic
+++ b/mine.lic
@@ -32,7 +32,12 @@ class Mine
     @ignored_deed = settings.mining_ignored_deed_sizes
     @mining_attempt_timer = settings.mining_attempt_timer
 
-    @equipment_manager.get_tool?('mining', @mining_tool_type)
+    have_tool = @equipment_manager.get_tool?('mining', @mining_tool_type)
+    if !have_tool
+      DRC.message("Unable to get your mining tool!")
+      pause 10
+      exit
+    end
 
     DRC.bput('prospect', 'roundtime', 'You carefully scan')
 

--- a/mine.lic
+++ b/mine.lic
@@ -9,16 +9,38 @@ class Mine
   include DRCT
 
   def initialize
-    setup
+    settings = get_settings
+    @equipment_manager = EquipmentManager.new
+    @mining_tool_type = settings.mining_buddy['tool_type'] || guess_tool_type
+    @mining_tool_info = @equipment_manager.get_tool_info('mining', @mining_tool_type)
+    @mining_tool_name = "#{@mining_tool_info.adjective} #{@mining_tool_info.name}"
 
-    get_mining_tool
+    @equipment_manager.empty_hands
 
-    bput('prospect', 'roundtime', 'You carefully scan')
+    Flags.add('mine-danger', 'The ground rumbles ominously', 'A bitter smell seeps into the air', 'The floor shudders briefly', 'continued mining .* hazardous', 'slightly dangerous because the ground')
+    Flags.add('mine-exit', 'The entire wall of rock fractures at your blow and comes crashing down atop you')
+    Flags.add('resource-level',
+              'certain a scattering of resources', 'enormous quantity remains to be found', 'substantial quantity remains to be found',
+              'good quantity remains to be found', 'decent quantity remains to be found', 'small quantity remains to be found',
+              'enormous quantity \(5/5\) remains to be found', 'substantial quantity \(4/5\) remains to be found', 'good quantity \(3/5\) remains to be found',
+              'decent quantity \(2/5\) remains to be found', 'small quantity \(1/5\) remains to be found', 'scattering of resources \(0/5\) remains to be found')
 
-    @multiplier = @mining_implement =~ /pick/i ? 4 : 5
+    @mining_skip_populated = settings.mining_skip_populated
+    @loot_list = settings.mining_buddy_vein_list
+    @use_packet = settings.mine_use_packet
+    @ignored_rock_sizes = settings.mining_ignored_stone_sizes
+    @ignored_deed = settings.mining_ignored_deed_sizes
+    @mining_attempt_timer = settings.mining_attempt_timer
+
+    @equipment_manager.get_tool?('mining', @mining_tool_type)
+
+    DRC.bput('prospect', 'roundtime', 'You carefully scan')
+
+    @multiplier = @mining_tool_type == "pickaxe" ? 4 : 5
 
     mine(@multiplier * resource_level)
-    while bput('prospect careful', 'roundtime', 'You carefully scan')
+
+    while DRC.bput('prospect careful', 'roundtime', 'You carefully scan')
       bput('prospect', 'roundtime', 'You carefully scan')
       results = reget(10, 'can be mined here')
       waitrt?
@@ -26,7 +48,16 @@ class Mine
       mine(@multiplier * resource_level)
     end
 
-    store_mining_tool
+    @equipment_manager.return_tool?('mining', @mining_tool_type)
+  end
+
+  def guess_tool_type
+    return 'shovel' unless @settings.mining_implement
+    return 'shovel' if @settings.mining_implement =~ /shovel/i
+    return 'pickaxe' if @settings.mining_implement =~ /pick/i
+
+    DRC.message('Assuming you want to use a shovel to mine, cause you are missing settings.mining_buddy.tool_type')
+    return 'shovel'
   end
 
   def resource_level
@@ -52,14 +83,17 @@ class Mine
 
     if bleeding?
       snapshot = Room.current.id
-      bput("get #{@mining_implement}", 'You get', 'You are already')
-      store_mining_tool
+      DRC.bput("get #{@mining_tool_name}", 'You get', 'You are already')
+      @equipment_manager.return_tool?('mining', @mining_tool_type)
+
       wait_for_script_to_complete('safe-room')
-      walk_to(snapshot)
+      DRCT.walk_to(snapshot)
+
       if @mining_skip_populated && !DRRoom.pcs.empty?
         DRC.message("Returned from healing and another player is in the room. Returning to mining-buddy to move on!")
       end
-      get_mining_tool
+
+      @equipment_manager.get_tool?('mining', @mining_tool_type)
     end
 
     return unless Flags['mine-danger']
@@ -76,15 +110,16 @@ class Mine
     handle_danger
 
     if count.zero?
-      bput('prospect', 'roundtime', 'You carefully scan')
+      DRC.bput('prospect', 'roundtime', 'You carefully scan')
       results = reget(10, 'can be mined here')
       waitrt?
       return if results.nil?
+
       mine(@multiplier * resource_level)
       return
     end
 
-    bput('mine', 'roundtime')
+    DRC.bput('mine', 'roundtime')
     pause @mining_attempt_timer
     waitrt?
 
@@ -94,11 +129,11 @@ class Mine
         next if @ignored_rock_sizes.any? { |x| match =~ /\b#{x}\b/i }
         noun = match.scan(/\w+/).last
         if @use_packet && @ignored_deed.none? { |x| match =~ /\b#{x}\b/i } && packet?
-          bput("push #{item} #{noun} with my packet", 'You push')
-          bput('stow my packet', 'You put', 'Stow what')
-          bput('stow deed', 'You put')
+          DRC.bput("push #{item} #{noun} with my packet", 'You push')
+          DRC.bput('stow my packet', 'You put', 'Stow what')
+          DRC.bput('stow deed', 'You put')
         else
-          bput("stow #{noun}", 'You put')
+          DRC.bput("stow #{noun}", 'You put')
         end
       end
     end
@@ -107,45 +142,7 @@ class Mine
   end
 
   def packet?
-    bput('get my packet', 'You get', 'What were you referring to') == 'You get'
-  end
-
-  def get_mining_tool
-    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
-      bput("untie my #{@mining_implement}", 'You remove', 'You untie')
-    else
-      bput("get my #{@mining_implement}", 'You get', 'You are already')
-    end
-  end
-
-  def store_mining_tool
-    waitrt?
-    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
-      fput("tie my #{@mining_implement} to #{@forging_belt['name']}")
-    else
-      fput("stow my #{@mining_implement}")
-    end
-  end
-
-  def setup
-    EquipmentManager.new.empty_hands
-    Flags.add('mine-danger', 'The ground rumbles ominously', 'A bitter smell seeps into the air', 'The floor shudders briefly', 'continued mining .* hazardous', 'slightly dangerous because the ground')
-    # Flags.add('mine-stand', 'clear away enough rubble to lever yourself free', 'You probably would have better luck while standing', 'You peacefully awaken, feeling refreshed', 'The world slowly comes into focus again, followed swiftly by a throbbing headache')
-    Flags.add('mine-exit', 'The entire wall of rock fractures at your blow and comes crashing down atop you')
-    Flags.add('resource-level',
-              'certain a scattering of resources', 'enormous quantity remains to be found', 'substantial quantity remains to be found',
-              'good quantity remains to be found', 'decent quantity remains to be found', 'small quantity remains to be found',
-              'enormous quantity \(5/5\) remains to be found', 'substantial quantity \(4/5\) remains to be found', 'good quantity \(3/5\) remains to be found',
-              'decent quantity \(2/5\) remains to be found', 'small quantity \(1/5\) remains to be found', 'scattering of resources \(0/5\) remains to be found')
-    settings = get_settings
-    @mining_skip_populated = settings.mining_skip_populated
-    @mining_implement = settings.mining_implement
-    @forging_belt = settings.forging_belt
-    @loot_list = settings.mining_buddy_vein_list
-    @use_packet = settings.mine_use_packet
-    @ignored_rock_sizes = settings.mining_ignored_stone_sizes
-    @ignored_deed = settings.mining_ignored_deed_sizes
-    @mining_attempt_timer = settings.mining_attempt_timer
+    DRC.bput('get my packet', 'You get', 'What were you referring to') == 'You get'
   end
 end
 

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -8,10 +8,30 @@ class MiningBuddy
   include DRC
   include DRCI
   include DRCM
-  include DRCT
 
   def initialize
-    setup
+    @debug = UserVars.mining_debug || @settings.mining_buddy['debug']
+    @settings = get_settings
+
+    @equipment_manager = EquipmentManager.new
+    @mining_tool_type = @settings.mining_buddy['tool_type'] || guess_tool_type
+    @mining_tool_info = @equipment_manager.get_tool_info('mining', @mining_tool_type)
+    @mining_tool_name = "#{@mining_tool_info.adjective} #{@mining_tool_info.name}"
+
+    @area_list = get_data('mining').mining_buddy_rooms
+    @areas = @settings.mines_to_mine
+    @skip_populated = @settings.mining_skip_populated
+    @mine_every_room = @settings.mining_buddy_mine_every_room
+    @vein_list = @settings.mining_buddy_vein_list
+    @use_packet = @settings.mine_use_packet
+    @hometown = @settings.hometown
+
+    deeds_data = get_data('crafting').deeds[@hometown]
+    @deeds_room = deeds_data['room']
+    @deeds_number = deeds_data['medium_number']
+    echo("#{@areas}:#{@vein_list}") if @debug
+
+    @repair_data = get_data('town')[@hometown]['metal_repair']
 
     ensure_copper_on_hand(10_000, @settings)
 
@@ -19,16 +39,19 @@ class MiningBuddy
       buy_deed_packet unless exists?('packet')
       buy_deed_packet unless exists?('second packet')
 
-      first = bput('look first packet', 'You count \d+').scan(/\d+/).first.to_i
-      second = bput('look second packet', 'You count \d+').scan(/\d+/).first.to_i
+      first = DRC.bput('look first packet', 'You count \d+').scan(/\d+/).first.to_i
+      second = DRC.bput('look second packet', 'You count \d+').scan(/\d+/).first.to_i
 
       if second < first
         fput('get my second packet')
         fput('stow my packet')
       end
     end
+
     wait_for_script_to_complete('buff', ['mining'])
-    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
+
+    DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
+
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
 
@@ -42,55 +65,30 @@ class MiningBuddy
     fput('stow my packet')
   end
 
-  def setup
-    @settings = get_settings
-    @area_list = get_data('mining').mining_buddy_rooms
-    @forging_belt = @settings.forging_belt
-    @areas = @settings.mines_to_mine
-    @skip_populated = @settings.mining_skip_populated
-    @mine_every_room = @settings.mining_buddy_mine_every_room
-    @vein_list = @settings.mining_buddy_vein_list
-    @mining_implement = @settings.mining_implement
-    @use_packet = @settings.mine_use_packet
-    @hometown = @settings.hometown
-    deeds_data = get_data('crafting').deeds[@hometown]
-    @deeds_room = deeds_data['room']
-    @deeds_number = deeds_data['medium_number']
-    echo("#{@areas}:#{@vein_list}") if UserVars.mining_debug
-  end
+  def guess_tool_type
+    return 'shovel' unless @settings.mining_implement
+    return 'shovel' if @settings.mining_implement =~ /shovel/i
+    return 'pickaxe' if @settings.mining_implement =~ /pick/i
 
-  def get_mining_tool
-    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
-      bput("untie my #{@mining_implement}", 'You remove', 'You untie')
-    else
-      bput("get my #{@mining_implement}", 'You get', 'You are already')
-    end
-  end
-
-  def store_mining_tool
-    waitrt?
-    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
-      fput("tie my #{@mining_implement} to #{@forging_belt['name']}")
-    else
-      fput("stow my #{@mining_implement}")
-    end
+    DRC.message('Assuming you want to use a shovel to mine, cause you are missing settings.mining_buddy.tool_type')
+    return 'shovel'
   end
 
   def check_repair
-    get_mining_tool
-    result = bput("anal my #{@mining_implement}", 'practically in mint', 'pristine condition', 'in good condition', 'crafting tool and it is rather scuffed up', 'Roundtime')
-    waitrt?
+    @equipment_manager.get_tool?('mining', @mining_tool_type)
+    result = DRC.bput("anal my #{@mining_tool_name}", 'practically in mint', 'pristine condition', 'in good condition', 'crafting tool and it is rather scuffed up', 'Roundtime')
+    @equipment_manager.return_tool?('mining', @mining_tool_type)
 
-    store_mining_tool
     return unless /roundtime/i =~ result
-    repair = get_data('town')[@hometown]['metal_repair']
-    walk_to(repair['id'])
-    get_mining_tool
-    fput("give #{repair['name']}")
-    fput("give #{repair['name']}")
+
+    DRCT.walk_to(@repair_data['id'])
+
+    @equipment_manager.get_tool?('mining', @mining_tool_type)
+    fput("give #{@repair_data['name']}")
+    fput("give #{@repair_data['name']}")
     pause 10 until bput('look at my ticket', 'should be ready by now', 'Looking at the') == 'should be ready by now'
-    fput("give #{repair['name']}")
-    store_mining_tool
+    fput("give #{@repair_data['name']}")
+    @equipment_manager.return_tool?('mining', @mining_tool_type)
   end
 
   def mine_rooms(rooms)
@@ -105,18 +103,18 @@ class MiningBuddy
 
   def mine?(room)
     waitrt?
-    walk_to(room)
+    DRCT.walk_to(room)
+
     unless DRRoom.pcs.empty?
       return false if @skip_populated
-
       fput('wave')
     end
 
     unless @mine_every_room
-      bput('prospect', 'Roundtime')
+      DRC.bput('prospect', 'Roundtime')
       results = reget(20, 'can be mined here')
 
-      echo(results) if UserVars.mining_debug
+      echo("Prospect saw: #{results}") if @debug
 
       return false if results.nil?
       return false unless results
@@ -127,7 +125,6 @@ class MiningBuddy
     end
 
     waitrt?
-
     wait_for_script_to_complete('mine')
     true
   end

--- a/sew.lic
+++ b/sew.lic
@@ -57,6 +57,7 @@ class Sew
     @mat_type = args.material
     @stamp = @settings.mark_crafted_goods
     @training_spells = @settings.crafting_training_spells
+    @current_tool_type = nil
 
     wait_for_script_to_complete('buff', ['sew'])
 
@@ -90,6 +91,19 @@ class Sew
     @bag = "other #{@bag}" unless stow_crafting_item(name, @bag, @belt)
   end
 
+  def change_tool(new_tool_type)
+    return if new_tool_type == @current_tool_type
+
+    if @current_tool_type
+      stow_item(@current_tool_type) unless @equipmentmanager.return_tool?('outfitting', @current_tool_type)
+    end
+
+    @current_tool_type = new_tool_type
+    return if @current_tool_type.nil?
+
+    get_item(@current_tool_type) unless @equipmentmanager.get_tool?('outfitting', @current_tool_type)
+  end
+
   def check_thread
     return if exists?('cotton thread')
 
@@ -104,13 +118,16 @@ class Sew
     return unless Flags['sew-pins'] || !exists?('straight pins')
 
     ensure_copper_on_hand(125, @settings)
-    item = left_hand
-    stow_item(item)
+
+    tool_type_snapshot = @current_tool_type
+    change_tool(nil)
+
     room = Room.current.id
     DRCT.order_item(@hometown_data['tool-room'], 5)
     stow_item('pin')
+
     walk_to(room)
-    get_item(item)
+    change_tool(tool_type_snapshot)
     Flags.reset('sew-pins')
   end
 
@@ -272,9 +289,9 @@ class Sew
     echo "Executing sewing step: #{command} #{next_tool}"
     DRCA.crafting_magic_routine(@settings)
 
-    stow_item(left_hand) unless @equipmentmanager.return_tool?('outfitting', @last_tool)
-
     if @last_command == "cut my #{@mat_type} cloth with my scissors"
+      change_tool(nil)
+
       fput("stow my #{@mat_type} cloth")
       pause
       fput("stow my #{@mat_type} cloth") if checkleft
@@ -282,10 +299,8 @@ class Sew
 
     assemble_part
 
-    get_item(next_tool) unless @equipmentmanager.get_tool?('outfitting', next_tool)
+    change_tool(next_tool)
     @last_command = command
-    @last_tool = next_tool
-
     next_command = "push my #{@noun} with my needles"
     case DRC.bput(command, MEASURE_MATCHES,
               'dimensions appear to have shifted and could benefit from some remeasuring',
@@ -321,12 +336,12 @@ class Sew
       next_tool = 'awl'
       next_command = "poke my #{@noun} with my awl"
     when 'You realize that cannot be repaired', 'not damaged enough to warrant repair', 'You cannot figure out how to do that'
-      stow_item(left_hand)
+      change_tool(nil)
       finish
     when 'New seams must now be sewn to properly fit the lightened material together'
       next_tool = 'sewing needles'
     when 'appears ready to be reinforced with some large cloth padding'
-      stow_item(left_hand)
+      change_tool(nil)
       get_item('large padding')
       DRC.bput("assemble my #{@noun} with my padding", 'carefully mark where it will attach when you continue crafting')
       case DRC.bput("analy my #{@noun}", 'needle and thread', 'pinning', 'slickstone', 'remeasuring', 'scissor')
@@ -353,7 +368,7 @@ class Sew
         next_tool = 'sewing needles'
       end
     end
-    DRCA.crafting_magic_routine(@settings)
+
     do_sew(next_command, next_tool, lighten)
   end
 

--- a/sew.lic
+++ b/sew.lic
@@ -10,7 +10,10 @@ class Sew
   include DRCI
   include DRCM
   include DRCT
-  include DRCA
+
+  MEASURE_MATCHES = [
+    /dimensions changed while working on it/
+  ]
 
   def initialize
     @settings = get_settings
@@ -89,6 +92,7 @@ class Sew
 
   def check_thread
     return if exists?('cotton thread')
+
     room = Room.current.id
     ensure_copper_on_hand(1000, @settings)
     DRCT.order_item(@hometown_data['stock-room'], 6)
@@ -98,6 +102,7 @@ class Sew
 
   def check_pins
     return unless Flags['sew-pins'] || !exists?('straight pins')
+
     ensure_copper_on_hand(125, @settings)
     item = left_hand
     stow_item(item)
@@ -110,36 +115,41 @@ class Sew
   end
 
   def study_tailoring(chapter, recipe)
+    DRC.message('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Outfitting') == 175
+
     get_item('tailoring book')
-    echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Outfitting') == 175
-    case bput("turn my book to page #{find_recipe(chapter, recipe)}", 'You turn your', 'The book is already', 'Which page do you wish')
+    case DRC.bput("turn my book to page #{find_recipe(chapter, recipe)}", 'You turn your', 'The book is already', 'Which page do you wish')
     when 'Which page do you wish'
-      echo('*** Recipe not found in book, it needs to be upgraded to the next higher level ***')
+      DRC.message('*** Recipe not found in book, it needs to be upgraded to the next higher level ***')
       magic_cleanup
       exit
     end
-    bput('study my book', 'Roundtime')
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
   end
 
   def leather
     check_thread
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
+
     study_tailoring(@chapter, @recipe_name)
+
     get_item("#{@mat_type} leather")
     do_sew("cut my #{@mat_type} leather with my scissors", 'scissors')
   end
 
   def sew
     check_thread
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
+
     study_tailoring(@chapter, @recipe_name)
+
     get_item("#{@mat_type} cloth")
     do_sew("cut my #{@mat_type} cloth with my scissors", 'scissors')
   end
 
   def knit
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
 
     study_tailoring(@chapter, @recipe_name)
 
@@ -159,7 +169,6 @@ class Sew
   def lighten
     check_thread
     study_tailoring(1, 'tailored armor lightening')
-    @equipmentmanager.get_tool?('outfitting', 'scissors')
     @noun = GameObj.right_hand.noun
     do_sew("cut my #{@noun} with my scissors", 'scissors', true)
   end
@@ -167,26 +176,27 @@ class Sew
   def reinforce
     check_thread
     study_tailoring(1, 'tailored armor reinforcing')
-    @equipmentmanager.get_tool?('outfitting', 'scissors')
     @noun = GameObj.right_hand.noun
     do_sew("cut my #{@noun} with my scissors", 'scissors')
   end
 
   def assemble_part
+    return unless Flags['sew-assembly']
+
+    stow_item(left_hand) # TODO - Return tool change
     while Flags['sew-assembly']
       part = Flags['sew-assembly'].to_a[1..-1].join('.')
       Flags.reset('sew-assembly')
-      stow_item(left_hand)
       get_item(part)
-      bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'and tighten the pommel to secure it', 'carefully mark where it will attach when you continue crafting')
+      DRC.bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'and tighten the pommel to secure it', 'carefully mark where it will attach when you continue crafting')
       waitrt?
-      get_item('sewing needles')
     end
+    get_item('sewing needles')  # TODO - get tool change
   end
 
   def do_seal(wax)
-    waitrt?
     return if Flags['sealing-done']
+
     if wax
       get_item('sealing wax')
       DRC.bput("apply my wax to my #{right_hand}", 'roundtime')
@@ -194,7 +204,7 @@ class Sew
       stow_item('wax')
     else
       @equipmentmanager.get_tool?('outfitting', 'slickstone')
-      bput("scrape my #{right_hand} with my slickstone", 'roundtime')
+      DRC.bput("scrape my #{right_hand} with my slickstone", 'roundtime')
       waitrt?
       @equipmentmanager.return_tool?('outfitting', 'slickstone')
     end
@@ -226,15 +236,14 @@ class Sew
     waitrt?
     resume_knit if @noun.include?('needle') || right_hand.include?('knitting needles') || left_hand.include?('knitting needles')
 
-    case DRC.bput("analyze my #{@noun}",
-              'dimensions changed while working on it',
+    case DRC.bput("analyze my #{@noun}", MEASURE_MATCHES,
               'is in need of pinning to help arrange the material for further sewing',
               'pushing it with a needle and thread',
               'Deep creases and wrinkles in the fabric',
               'scissor cuts',
               'cutting with some scissors',
               'Roundtime')
-    when 'dimensions changed while working on it'
+    when *MEASURE_MATCHES
       tool = 'yardstick'
       next_command = "measure my #{@noun} with my yardstick"
     when 'scissor cuts', 'cutting with some scissors'
@@ -259,10 +268,11 @@ class Sew
     do_sew(next_command, tool)
   end
 
-  def do_sew(command, tool, lighten = false)
-    waitrt?
-    crafting_magic_routine(@settings)
-    stow_item(left_hand) if checkleft
+  def do_sew(command, next_tool, lighten = false)
+    echo "Executing sewing step: #{command} #{next_tool}"
+    DRCA.crafting_magic_routine(@settings)
+
+    stow_item(left_hand) unless @equipmentmanager.return_tool?('outfitting', @last_tool)
 
     if @last_command == "cut my #{@mat_type} cloth with my scissors"
       fput("stow my #{@mat_type} cloth")
@@ -272,11 +282,12 @@ class Sew
 
     assemble_part
 
-    get_item(tool) unless @equipmentmanager.get_tool?('outfitting', tool)
+    get_item(next_tool) unless @equipmentmanager.get_tool?('outfitting', next_tool)
     @last_command = command
+    @last_tool = next_tool
 
     next_command = "push my #{@noun} with my needles"
-    case bput(command,
+    case DRC.bput(command, MEASURE_MATCHES,
               'dimensions appear to have shifted and could benefit from some remeasuring',
               'With the measuring complete, now it is time to cut away more',
               'and could use some pins to',
@@ -287,18 +298,18 @@ class Sew
               'appears ready to be reinforced with some large cloth padding',
               'New seams must now be sewn to properly fit the lightened material together',
               'Roundtime')
-    when 'dimensions appear to have shifted and could benefit from some remeasuring'
-      tool = 'yardstick'
+    when *MEASURE_MATCHES
+      next_tool = 'yardstick'
       next_command = "measure my #{@noun} with my yardstick"
     when 'With the measuring complete, now it is time to cut away more'
-      tool = 'scissors'
+      next_tool = 'scissors'
       next_command = "cut my #{@noun} with my scissors"
     when 'and could use some pins to'
-      tool = 'pins'
+      next_tool = 'pins'
       next_command = "poke my #{@noun} with my pins"
       check_pins
     when 'deep crease develops along', 'wrinkles from all the handling and could use'
-      tool = 'slickstone'
+      next_tool = 'slickstone'
       next_command = "scrape my #{@noun} with my slickstone"
     when 'The needles need to have thread put on them before they can be used for sewing'
       item = right_hand
@@ -307,57 +318,57 @@ class Sew
       fput('put thread on my sewing needles')
       fput("get #{item}")
     when 'needs holes punched', 'requires some holes punched'
-      tool = 'awl'
+      next_tool = 'awl'
       next_command = "poke my #{@noun} with my awl"
     when 'You realize that cannot be repaired', 'not damaged enough to warrant repair', 'You cannot figure out how to do that'
       stow_item(left_hand)
       finish
     when 'New seams must now be sewn to properly fit the lightened material together'
-      tool = 'sewing needles'
+      next_tool = 'sewing needles'
     when 'appears ready to be reinforced with some large cloth padding'
       stow_item(left_hand)
       get_item('large padding')
-      bput("assemble my #{@noun} with my padding", 'carefully mark where it will attach when you continue crafting')
-      case bput("analy my #{@noun}", 'needle and thread', 'pinning', 'slickstone', 'remeasuring', 'scissor')
+      DRC.bput("assemble my #{@noun} with my padding", 'carefully mark where it will attach when you continue crafting')
+      case DRC.bput("analy my #{@noun}", 'needle and thread', 'pinning', 'slickstone', 'remeasuring', 'scissor')
       when 'needle and thread'
-        tool = 'sewing needles'
+        next_tool = 'sewing needles'
       when 'pinning'
-        tool = 'pins'
+        next_tool = 'pins'
         next_command = "poke my #{@noun} with my pins"
       when 'slickstone'
-        tool = 'slickstone'
+        next_tool = 'slickstone'
         next_command = "scrape my #{@noun} with my slickstone"
       when 'remeasuring'
-        tool = 'yardstick'
+        next_tool = 'yardstick'
         next_command = "measure my #{@noun} with my yardstick"
       when 'scissor'
-        tool = 'scissors'
+        next_tool = 'scissors'
         next_command = "cut my #{@noun} with my scissors"
       end
     when 'Roundtime'
       if lighten
-        tool = 'scissors'
+        next_tool = 'scissors'
         next_command = "cut my #{@noun} with my scissors"
       else
-        tool = 'sewing needles'
+        next_tool = 'sewing needles'
       end
     end
-    crafting_magic_routine(@settings)
-    do_sew(next_command, tool, lighten)
+    DRCA.crafting_magic_routine(@settings)
+    do_sew(next_command, next_tool, lighten)
   end
 
   def magic_cleanup
     return if @training_spells.empty?
 
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-    bput('release mana', 'You release all', "You aren't harnessing any mana")
-    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 
   def do_knit(command)
     waitrt?
 
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
 
     next_command = 'knit my needles'
     case DRC.bput(command,
@@ -400,7 +411,7 @@ class Sew
 
     waitrt?
     stow_item('yarn') if left_hand =~ /yarn/i
-    crafting_magic_routine(@settings)
+    DRCA.crafting_magic_routine(@settings)
 
     do_knit(next_command)
   end

--- a/sew.lic
+++ b/sew.lic
@@ -19,6 +19,7 @@ class Sew
     @belt = @settings.outfitting_belt
     @hometown = @settings.hometown
     @hometown_data = get_data('crafting')['tailoring'][@hometown]
+    @equipmentmanager = EquipmentManager.new
 
     arg_definitions = [
       [
@@ -139,8 +140,10 @@ class Sew
 
   def knit
     crafting_magic_routine(@settings)
+
     study_tailoring(@chapter, @recipe_name)
-    get_item('knitting needle')
+
+    @equipmentmanager.get_tool?('outfitting', 'knitting needles')
     pause 1
     fput('swap') unless right_hand =~ /needle/i
     get_item("#{@mat_type} yarn")
@@ -156,7 +159,7 @@ class Sew
   def lighten
     check_thread
     study_tailoring(1, 'tailored armor lightening')
-    get_item('scissors')
+    @equipmentmanager.get_tool?('outfitting', 'scissors')
     @noun = GameObj.right_hand.noun
     do_sew("cut my #{@noun} with my scissors", 'scissors', true)
   end
@@ -164,7 +167,7 @@ class Sew
   def reinforce
     check_thread
     study_tailoring(1, 'tailored armor reinforcing')
-    get_item('scissors')
+    @equipmentmanager.get_tool?('outfitting', 'scissors')
     @noun = GameObj.right_hand.noun
     do_sew("cut my #{@noun} with my scissors", 'scissors')
   end
@@ -186,21 +189,21 @@ class Sew
     return if Flags['sealing-done']
     if wax
       get_item('sealing wax')
-      bput("apply my wax to my #{right_hand}", 'roundtime')
+      DRC.bput("apply my wax to my #{right_hand}", 'roundtime')
       waitrt?
       stow_item('wax')
     else
-      get_item('slickstone')
+      @equipmentmanager.get_tool?('outfitting', 'slickstone')
       bput("scrape my #{right_hand} with my slickstone", 'roundtime')
       waitrt?
-      stow_item('slickstone')
+      @equipmentmanager.return_tool?('outfitting', 'slickstone')
     end
 
     do_seal !wax
   end
 
   def resume_knit
-    bput('analyze my knitting needles',
+    DRC.bput('analyze my knitting needles',
          /You analyze both the needles and (?:some|an?) unfinished knitted .+ (.+) on them/,
          'This appears to be a crafting tool',
          'Roundtime')
@@ -223,7 +226,7 @@ class Sew
     waitrt?
     resume_knit if @noun.include?('needle') || right_hand.include?('knitting needles') || left_hand.include?('knitting needles')
 
-    case bput("analyze my #{@noun}",
+    case DRC.bput("analyze my #{@noun}",
               'dimensions changed while working on it',
               'is in need of pinning to help arrange the material for further sewing',
               'pushing it with a needle and thread',
@@ -243,9 +246,6 @@ class Sew
     when 'Deep creases and wrinkles in the fabric'
       tool = 'slickstone'
       next_command = "scrape my #{@noun} with my slickstone"
-    # when 'needs holes punched', 'requires some holes punched'
-    #   tool = 'awl'
-    #   next_command = "poke my #{@noun} with my awl"
     when 'pushing it with a needle and thread'
       tool = 'sewing needles'
       next_command = "push my #{@noun} with my needles"
@@ -263,14 +263,18 @@ class Sew
     waitrt?
     crafting_magic_routine(@settings)
     stow_item(left_hand) if checkleft
+
     if @last_command == "cut my #{@mat_type} cloth with my scissors"
       fput("stow my #{@mat_type} cloth")
       pause
       fput("stow my #{@mat_type} cloth") if checkleft
     end
-    get_item(tool)
-    @last_command = command
+
     assemble_part
+
+    get_item(tool) unless @equipmentmanager.get_tool?('outfitting', tool)
+    @last_command = command
+
     next_command = "push my #{@noun} with my needles"
     case bput(command,
               'dimensions appear to have shifted and could benefit from some remeasuring',
@@ -352,9 +356,11 @@ class Sew
 
   def do_knit(command)
     waitrt?
+
     crafting_magic_routine(@settings)
+
     next_command = 'knit my needles'
-    case bput(command,
+    case DRC.bput(command,
               'Now the needles must be turned', 'Some ribbing should be added',
               'Next the needles must be pushed', 'ready to be pushed',
               'The garment is nearly complete and now must be cast off',
@@ -370,14 +376,14 @@ class Sew
     when 'The garment is nearly complete and now must be cast off'
       cast_and_finish
     when 'You are already knitting'
-      bput('pull my needles', 'Do you really want to discard')
-      bput('pull my needles', 'You untie and discard')
+      DRC.bput('pull my needles', 'Do you really want to discard')
+      DRC.bput('pull my needles', 'You untie and discard')
       do_knit(command)
       next_command = ''
     when 'is not here!'
       do_knit(command.sub(' my', ''))
     when 'That tool does not seem suitable for that task.'
-      case bput('analyze my needles', 'is in need of more knitting.', 'The needles need to be turned', 'Some purl stitching is', 'needles must be cast')
+      case DRC.bput('analyze my needles', 'is in need of more knitting.', 'The needles need to be turned', 'Some purl stitching is', 'needles must be cast')
       when 'is in need of more knitting.'
         next_command = 'knit my needles'
       when 'The needles need to be turned'
@@ -388,31 +394,35 @@ class Sew
         cast_and_finish
       end
     when 'You need a larger amount of material'
-      echo '***STATUS*** CANNOT CRAFT, NEED MORE MATERIAL'
+      DRC.message('***STATUS*** CANNOT CRAFT, NEED MORE MATERIAL')
       exit
     end
+
     waitrt?
     stow_item('yarn') if left_hand =~ /yarn/i
     crafting_magic_routine(@settings)
+
     do_knit(next_command)
   end
 
   def cast_and_finish
-    bput('cast my needles', 'roundtime')
+    DRC.bput('cast my needles', 'roundtime')
     pause 1
     waitrt?
-    stow_item('knitting needle')
+    @equipmentmanager.return_tool?('outfitting', 'knitting needles')
+
     finish
   end
 
   def finish
     if @stamp
-      get_item('stamp')
+      @equipmentmanager.get_tool?('outfitting', 'stamp')
       fput("mark my #{@noun} with my stamp")
       pause
       waitrt?
-      stow_item('stamp')
+      @equipmentmanager.return_tool?('outfitting', 'stamp')
     end
+
     case @finish
     when /log/
       logbook_item('outfitting', @noun, @bag)
@@ -421,6 +431,7 @@ class Sew
     when /trash/
       dispose_trash(@noun)
     end
+
     magic_cleanup
     exit
   end

--- a/shape.lic
+++ b/shape.lic
@@ -103,8 +103,8 @@ class Shape
     turn_to("page #{find_recipe('6', 'bow lamination')}")
     DRC.bput('study my book', 'Roundtime')
     stow_item('book')
-    @current_tool_type = 'clamps'
-    @equipmentmanager.get_tool?('shaping', 'clamps')
+
+    change_tool('clamps')
     shape("push my #{@noun} with my clamp")
   end
 
@@ -114,8 +114,8 @@ class Shape
     turn_to("page #{find_recipe('6', 'bow lightening')}")
     DRC.bput('study my book', 'Roundtime')
     stow_item('book')
-    @current_tool_type = 'clamps'
-    @equipmentmanager.get_tool?('shaping', 'clamps')
+
+    change_tool('clamps')
     shape("push my #{@noun} with my clamp")
   end
 
@@ -125,8 +125,8 @@ class Shape
     turn_to("page #{find_recipe('6', 'bow cable-backing')}")
     DRC.bput('study my book', 'Roundtime')
     stow_item('book')
-    @current_tool_type = 'clamps'
-    @equipmentmanager.get_tool?('shaping', 'clamps')
+
+    change_tool('clamps')
     shape("push my #{@noun} with my clamp")
   end
 
@@ -139,13 +139,11 @@ class Shape
     stow_item('book')
 
     if @material == 'shafts'
+      change_tool('shaper')
       get_item("arrow #{@material}")
-      @current_tool_type = 'shaper'
-      @equipmentmanager.get_tool?('shaping', 'shaper')
       shape('shape my shafts with my shaper')
     else
-      @current_tool_type = 'drawknife'
-      @equipmentmanager.get_tool?('shaping', 'drawknife')
+      change_tool('drawknife')
       get_item("#{@material} lumber")
       shape('scrape my lumber with my drawknife')
     end

--- a/shape.lic
+++ b/shape.lic
@@ -12,9 +12,11 @@ class Shape
 
   def initialize
     @settings = get_settings
+    @debug = @settings.shape['debug'] || false
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
+    @equipmentmanager = EquipmentManager.new
     @stamp = @settings.mark_crafted_goods
 
     arg_definitions = [
@@ -50,6 +52,7 @@ class Shape
     @recipe_name = args.recipe_name
     @material = args.material
     @noun = args.noun
+    @current_tool_type = nil
     @training_spells = @settings.crafting_training_spells
 
     wait_for_script_to_complete('buff', ['shape'])
@@ -91,16 +94,17 @@ class Shape
       magic_cleanup
       exit
     end
-    bput("turn my book to #{section}", 'You turn your', 'The book is already')
+    DRC.bput("turn my book to #{section}", 'You turn your', 'The book is already')
   end
 
   def laminate
     check_hand
     get_item('shaping book')
     turn_to("page #{find_recipe('6', 'bow lamination')}")
-    bput('study my book', 'Roundtime')
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('clamps')
+    @current_tool_type = 'clamps'
+    @equipmentmanager.get_tool?('shaping', 'clamps')
     shape("push my #{@noun} with my clamp")
   end
 
@@ -108,9 +112,10 @@ class Shape
     check_hand
     get_item('shaping book')
     turn_to("page #{find_recipe('6', 'bow lightening')}")
-    bput('study my book', 'Roundtime')
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('clamps')
+    @current_tool_type = 'clamps'
+    @equipmentmanager.get_tool?('shaping', 'clamps')
     shape("push my #{@noun} with my clamp")
   end
 
@@ -118,9 +123,10 @@ class Shape
     check_hand
     get_item('shaping book')
     turn_to("page #{find_recipe('6', 'bow cable-backing')}")
-    bput('study my book', 'Roundtime')
+    DRC.bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('clamps')
+    @current_tool_type = 'clamps'
+    @equipmentmanager.get_tool?('shaping', 'clamps')
     shape("push my #{@noun} with my clamp")
   end
 
@@ -129,15 +135,17 @@ class Shape
     get_item('shaping book')
     echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
     turn_to("page #{find_recipe(@chapter, @recipe_name)}")
-    bput('study my book', 'Roundtime', 'Arrow shaft')
+    DRC.bput('study my book', 'Roundtime', 'Arrow shaft')
     stow_item('book')
-    get_item('drawknife')
+
     if @material == 'shafts'
       get_item("arrow #{@material}")
-      stow_item('drawknife')
-      get_item('shaper')
+      @current_tool_type = 'shaper'
+      @equipmentmanager.get_tool?('shaping', 'shaper')
       shape('shape my shafts with my shaper')
     else
+      @current_tool_type = 'drawknife'
+      @equipmentmanager.get_tool?('shaping', 'drawknife')
       get_item("#{@material} lumber")
       shape('scrape my lumber with my drawknife')
     end
@@ -146,8 +154,8 @@ class Shape
   def assemble_part
     return unless Flags['shaping-assembly']
 
-    tool = right_hand
-    stow_item(tool)
+    stow_item(@current_tool_type) unless @equipmentmanager.return_tool?('shaping', @current_tool_type)
+
     part = Flags['shaping-assembly'].to_a[1..-1].join('.')
     part = 'backer' if part == 'backing'
     part = 'arrow flights' if part == 'flights'
@@ -167,7 +175,8 @@ class Shape
       end
     end
     stow_item(part)
-    get_item(tool)
+
+    get_item(@current_tool_type) unless @equipmentmanager.get_tool?('shaping', @current_tool_type)
   end
 
   def shape(command)
@@ -175,8 +184,9 @@ class Shape
     crafting_magic_routine(@settings)
     check_hand
     assemble_part
-    case bput(command,
-              'a wood shaper is needed', 'with a wood shaper', 'You whittle away', 'Using abrupt motions you shape', 'You flip some', 'You apply some glue', 'Using slow strokes you scrape', 'You dab the surface', 'You lap the',
+
+    case DRC.bput(command,
+              'a wood shaper is needed', 'with a wood shaper', 'You whittle away', 'Using abrupt motions you shape', 'You flip some', 'Using slow strokes you scrape', 'You dab the surface', 'You lap the',
               'carved with a carving knife', 'further carving with a knife', 'continued knife carving', 'require carving with a knife', 'trimmed with a carving knife', 'carved with a knife',
               'rubbed out with a rasp', 'A cluster of small knots',
               'Applying the final touches', 'lamination process', 'lightening process', 'cable-backing process', 'These appear to be a type',
@@ -185,44 +195,38 @@ class Shape
               'Glue should now be applied', 'glue to fasten it', 'glue applied', 'You brush some glue on your', 'You apply a layer',
               'ready to be clamped', 'with clamps',
               'Some wood stain', 'application of stain',
-              'You fumble around but',
+              'You fumble around but', 'You need more pieces of lumber to continue crafting',
               'ASSEMBLE Ingredient1')
-    when 'a wood shaper is needed', 'with a wood shaper', 'You whittle away', 'Using abrupt motions you shape', 'You flip some', 'You apply some glue', 'Using slow strokes you scrape', 'You dab the surface', 'You lap the'
-      waitrt?
-      stow_item(right_hand)
-      get_item('shaper')
+    when 'a wood shaper is needed', 'with a wood shaper', 'You whittle away', 'Using abrupt motions you shape', 'You flip some', 'Using slow strokes you scrape', 'You dab the surface', 'You lap the'
+      echo 'Next Step: Shaper' if @debug
+      change_tool('shaper')
       command = "shape my #{@noun} with my shaper"
     when 'carved with a carving knife', 'further carving with a knife', 'continued knife carving', 'require carving with a knife', 'trimmed with a carving knife', 'carved with a knife'
-      waitrt?
-      stow_item(right_hand)
-      get_item('carving knife')
+      echo 'Next Step: Knife' if @debug
+      change_tool('knife')
       command = "carve my #{@noun} with my knife"
     when 'rubbed out with a rasp', 'A cluster of small knots'
-      waitrt?
-      stow_item(right_hand)
-      get_item('rasp')
+      echo 'Next Step: Rasp' if @debug
+      change_tool('rasp')
       command = "scrape my #{@noun} with my rasp"
     when 'ready to be clamped', 'with clamps'
-      waitrt?
-      stow_item(right_hand)
-      get_item('clamp')
-      command = "push my #{@noun} with my clamp"
+      echo 'Next Step: Clamps' if @debug
+      change_tool('clamps')
+      command = "push my #{@noun} with my clamps"
     when 'Glue should now be applied', 'glue to fasten it', 'glue applied'
-      waitrt?
-      stow_item(right_hand)
-      get_item('glue')
+      echo 'Next Step: Glue' if @debug
+      change_tool('glue')
       command = "apply my glue to my #{@noun}"
     when 'Some wood stain', 'application of stain'
-      waitrt?
-      stow_item(right_hand)
-      get_item('stain')
+      echo 'Next Step: Stain' if @debug
+      change_tool('stain')
       command = "apply my stain to my #{@noun}"
     when 'Applying the final touches', 'lamination process', 'lightening process', 'cable-backing process', 'These appear to be a type'
-      stow_item(right_hand)
+      change_tool(nil)
       finish
-    when 'while it is inside of something', 'You fumble around but'
+    when 'while it is inside of something', 'You fumble around but', 'You need more pieces of lumber to continue crafting'
       echo '*** ERROR TRYING TO CRAFT, EXITING ***'
-      stow_item(right_hand)
+      change_tool(nil)
       exit
     when 'That tool does not seem suitable for that task.', 'You cannot figure out', 'doesn\'t appear suitable for working'
       shape("analyze my #{@noun}")
@@ -231,12 +235,22 @@ class Shape
     shape(command)
   end
 
+  def change_tool(new_tool_type)
+    return if new_tool_type == @current_tool_type
+
+    stow_item(@current_tool_type) unless @equipmentmanager.return_tool?('shaping', @current_tool_type)
+    @current_tool_type = new_tool_type
+
+    return if @current_tool_type.nil?
+    get_item(@current_tool_type) unless @equipmentmanager.get_tool?('shaping', @current_tool_type)
+  end
+
   def magic_cleanup
     return if @training_spells.empty?
 
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-    bput('release mana', 'You release all', "You aren't harnessing any mana")
-    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 
   def finish
@@ -255,11 +269,12 @@ class Shape
 
   def stamp
     return unless @stamp
-    get_item('stamp')
-    bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that')
+
+    @equipmentmanager.get_tool?('shaping', 'stamp')
+    DRC.bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that')
     pause
     waitrt?
-    stow_item('stamp')
+    @equipmentmanager.return_tool?('shaping', 'stamp')
   end
 end
 

--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -20,8 +20,22 @@ class SmeltDeeds
     all_metals = get_data('items').metal_types - alloys
     all_metals += [args.material] if args.material && alloys.include?(args.material)
 
-    unless %w[rod bellows shovel].all? { |tool| exists?(tool) }
-      echo 'A TOOL WAS MISSING. FIND IT AND RESTART'
+    @equipment_manager = EquipmentManager.new
+    rod_info = @equipment_manager.get_tool_info('forging', 'rod')
+    bellows_info = @equipment_manager.get_tool_info('forging', 'bellows')
+    shovel_info = @equipment_manager.get_tool_info('forging', 'shovel')
+
+    if rod_info.nil? || bellows_info.nil? || shovel_info.nil?
+      DRC.message('Configuration is missing one or more required tools [craft: forging, tool_type: rod, bellows, shovel]')
+      exit
+    end
+
+    @rod = "#{rod_info.adjective} #{rod_info.name}"
+    @bellows = "#{bellows_info.adjective} #{bellows_info.name}"
+    @shovel = "#{shovel_info.adjective} #{shovel_info.name}"
+
+    if !DRCI.exists?(@rod) || !DRCI.exists?(@bellows) || !DRCI.exists?(@shovel)
+      DRC.message('A TOOL WAS MISSING. FIND IT AND RESTART')
       exit
     end
 
@@ -29,9 +43,6 @@ class SmeltDeeds
       echo '***NO DEEDS FOUND TO SMELT***'
       return
     end
-
-    @equipment_manager = EquipmentManager.new
-
     @equipment_manager.empty_hands
 
     results = reget(100, 'deed is in')

--- a/smelt.lic
+++ b/smelt.lic
@@ -77,7 +77,7 @@ class Smelt
   def stir
     pause 1
     waitrt?
-    case bput("stir crucible with my #{@rod}", 'You can only mix a crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'needs more fuel', 'needs some more fuel', 'roundtime')
+    case DRC.bput("stir crucible with my #{@rod}", 'You can only mix a crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'needs more fuel', 'needs some more fuel', 'roundtime')
     when /roundtime/i
       return stir
     when 'You can only mix a crucible'

--- a/smelt.lic
+++ b/smelt.lic
@@ -9,14 +9,6 @@ class Smelt
   include DRCC
 
   def initialize
-    EquipmentManager.new.empty_hands
-
-    settings = get_settings
-    @bag = settings.crafting_container
-    @bag_items = settings.crafting_items_in_container
-    @belt = settings.forging_belt
-    @rod = settings.forging_tools.find { |item| /rod/ =~ item }
-
     arg_definitions = [
       [
         { name: 'refine', regex: /refine/i, optional: true }
@@ -25,18 +17,44 @@ class Smelt
 
     args = parse_args(arg_definitions)
 
-    get_crafting_item(@rod, @bag, @bag_items, @belt)
+    @equipment_manager = EquipmentManager.new
+    rod_info = @equipment_manager.get_tool_info('forging', 'rod')
+    bellows_info = @equipment_manager.get_tool_info('forging', 'bellows')
+    shovel_info = @equipment_manager.get_tool_info('forging', 'shovel')
+
+    if rod_info.nil? || bellows_info.nil? || shovel_info.nil?
+      DRC.message('Configuration is missing one or more required tools [craft: forging, tool_type: rod, bellows, shovel]')
+      exit
+    end
+
+    @rod = "#{rod_info.adjective} #{rod_info.name}"
+    @bellows = "#{bellows_info.adjective} #{bellows_info.name}"
+    @shovel = "#{shovel_info.adjective} #{shovel_info.name}"
+
+    if !DRCI.exists?(@rod) || !DRCI.exists?(@bellows) || !DRCI.exists?(@shovel)
+      DRC.message('A TOOL WAS MISSING. FIND IT AND RESTART')
+      exit
+    end
+
+    settings = get_settings
+    @bag = settings.crafting_container
+    @bag_items = settings.crafting_items_in_container
+    @belt = settings.forging_belt
+
+    @equipment_manager.empty_hands
+
+    @equipment_manager.get_tool?('forging', 'rod')
     if args.refine
       refine
     else
       stir
     end
-    stow_crafting_item(@rod, @bag, @belt)
+    @equipment_manager.return_tool?('forging', 'rod')
   end
 
   def refine
-    bput('get flux', 'you get')
-    case bput('pour flux in crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'down and needs more fuel', 'roundtime')
+    DRC.bput('get flux', 'you get')
+    case DRC.bput('pour flux in crucible', 'clumps of molten metal', 'flickers and is unable to consume', 'down and needs more fuel', 'roundtime')
     when /roundtime/i
       waitrt?
       fput('stow flux')
@@ -76,27 +94,27 @@ class Smelt
   def turn
     pause 1
     waitrt?
-    bput('turn crucible', 'roundtime')
+    DRC.bput('turn crucible', 'roundtime')
     stir
   end
 
   def bellows
     pause 1
     waitrt?
-    get_crafting_item('bellow', @bag, @bag_items, @belt)
-    bput('push my bellow', 'roundtime')
+    @equipment_manager.get_tool?('forging', 'bellows')
+    DRC.bput("push my #{@bellows}", 'Roundtime')
     waitrt?
-    stow_crafting_item('bellow', @bag, @belt)
+    @equipment_manager.return_tool?('forging', 'bellows')
     stir
   end
 
   def fuel
     pause 1
     waitrt?
-    get_crafting_item('shovel', @bag, @bag_items, @belt)
-    bput('push fuel with my shovel', 'roundtime')
+    @equipment_manager.get_tool?('forging', 'shovel')
+    DRC.bput("push fuel with my #{@shovel}", 'Roundtime')
     waitrt?
-    stow_crafting_item('shovel', @bag, @belt)
+    @equipment_manager.return_tool?('forging', 'shovel')
     stir
   end
 end

--- a/smith.lic
+++ b/smith.lic
@@ -29,9 +29,11 @@ class Smith
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
+    @equipmanager = EquipmentManager.new
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
+    discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
+
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = recipe_lookup(recipes, args.item_name)
     return unless recipe
@@ -110,11 +112,17 @@ class Smith
   end
 
   def stamp_item(recipe)
-    fput('get my stamp')
+    got_stamp = @equipmanager.get_tool?('forging', 'stamp')
+    if !got_stamp
+      DRC.message('Failed to find stamp for marking this item.')
+      pause 10
+      return
+    end
+
     fput("mark my #{recipe['noun']} with my stamp")
-    pause 1
+    pause
     waitrt?
-    fput("put my stamp in my #{@container}")
+    @equipmanager.return_tool?('forging', 'stamp')
   end
 
   def temper_item(discipline, recipe)

--- a/tinker.lic
+++ b/tinker.lic
@@ -17,6 +17,7 @@ class Tinker
     @belt = @settings.engineering_belt
     @hometown = @settings.hometown
     @stamp = @settings.mark_crafted_goods
+    @equipmentmanager = EquipmentManager.new
 
     arg_definitions = [
       [
@@ -60,7 +61,9 @@ class Tinker
     @training_spells = @settings.crafting_training_spells
 
     wait_for_script_to_complete('buff', ['tinker'])
+
     Flags.add('tinkering-assembly', 'laminated with (backer) material', 'You need another bone, wood or horn (backing) material', 'another bolt (flights)', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* leather (strip|cord)', 'need another (lenses)', 'another finished (mechanism)', 'You must assemble the (strips)', 'another .* (bolthead)')
+
     if args.continue
       tinker("analyze my #{@noun}")
     elsif args.laminate
@@ -76,6 +79,18 @@ class Tinker
     end
   end
 
+  def change_tool(new_tool_type)
+    return if new_tool_type == @current_tool_type
+
+    if @current_tool_type
+      stow_item(@current_tool_type) unless @equipmentmanager.return_tool?('tinkering', @current_tool_type)
+    end
+
+    @current_tool_type = new_tool_type
+    return if @current_tool_type.nil?
+    get_item(@current_tool_type) unless @equipmentmanager.get_tool?('tinkering', @current_tool_type)
+  end
+
   def get_item(name)
     get_crafting_item(name, @bag, @belt, @belt)
   end
@@ -86,18 +101,18 @@ class Tinker
 
   def stow_material
     return unless @material
-    bput('stow ingot', 'Stow what', 'You put') if @mechanism
-    bput('stow lumber', 'Stow what', 'You put') if bput('stow lumber', 'Stow what', 'You put', 'You can.t put that there!') =~ /You can't put that there!/
+    DRC.bput('stow ingot', 'Stow what', 'You put') if @mechanism
+    DRC.bput('stow lumber', 'Stow what', 'You put') if DRC.bput('stow lumber', 'Stow what', 'You put', 'You can.t put that there!') =~ /You can't put that there!/
   end
 
   def turn_to(section)
     unless section
-      echo('Failed to find recipe in book, buy a better book?')
+      DRC.message('Failed to find recipe in book, buy a better book?')
       stow_item('book')
       magic_cleanup
       exit
     end
-    bput("turn my book to #{section}", 'You turn your', 'The book is already')
+    DRC.bput("turn my book to #{section}", 'You turn your', 'The book is already')
   end
 
   def check_hand
@@ -106,23 +121,24 @@ class Tinker
       magic_cleanup
       exit
     end
-    bput('swap', 'You move', 'You have nothing') unless left_hand =~ /#{@noun}/i || left_hand =~ /lumber/ || left_hand =~ /ingot/ || left_hand =~ /shafts/
+    DRC.bput('swap', 'You move', 'You have nothing') unless left_hand =~ /#{@noun}/i || left_hand =~ /lumber/ || left_hand =~ /ingot/ || left_hand =~ /shafts/
   end
 
   def tinker_item
     crafting_magic_routine(@settings)
+
     get_item('tinkering book')
-    echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
+    DRC.message('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
     turn_to("page #{find_recipe(@chapter, @recipe_name)}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('drawknife')
+
     if @material == 'shafts'
+      change_tool('shaper')
       get_item("bolt #{@material}")
-      stow_item('drawknife')
-      get_item('shaper')
       tinker('shape my shafts with my shaper')
     else
+      change_tool('drawknife')
       get_item("#{@material} lumber")
       tinker('scrape my lumber with my drawknife')
     end
@@ -131,22 +147,25 @@ class Tinker
   def mechanisms
     @noun = 'mechanisms'
     find_shaping_room(@hometown, nil)
-    case bput("get my #{@material} ingot", 'You get', 'What were', 'You are already', 'You pick up')
+
+    case DRC.bput("get my #{@material} ingot", 'You get', 'What were', 'You are already', 'You pick up')
     when 'What were'
       echo 'No ingot to form the mechanisms!'
       exit
     end
+
     check_hand
-    stow_item(right_hand)
-    case bput('turn press to 1', 'You dial', 'Turn what')
+    stow_item(right_hand) # TODO: What might be in this hand?
+    case DRC.bput('turn press to 1', 'You dial', 'Turn what')
     when 'Turn what'
       echo "Didn't find a room with a gear press!"
       exit
     end
-    get_item('shovel')
-    bput('push fuel with my shovel', 'furnace')
-    stow_item('shovel')
-    get_item('pliers')
+
+    change_tool('shovel')
+    DRC.bput('push fuel with my shovel', 'furnace')
+
+    change_tool('pliers')
     tinker('push my ingot with press')
   end
 
@@ -156,7 +175,8 @@ class Tinker
     turn_to("page #{find_recipe('8', 'crossbow lamination')}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('clamps')
+
+    change_tool('clamps')
     tinker("push my #{@noun} with my clamp")
   end
 
@@ -166,7 +186,8 @@ class Tinker
     turn_to("page #{find_recipe('8', 'crossbow lightening')}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('clamps')
+
+    change_tool('clamps')
     tinker("push my #{@noun} with my clamp")
   end
 
@@ -176,15 +197,17 @@ class Tinker
     turn_to("page #{find_recipe('8', 'crossbow cable-backing')}")
     bput('study my book', 'Roundtime')
     stow_item('book')
-    get_item('clamps')
+
+    change_tool('clamps')
     tinker("push my #{@noun} with my clamp")
   end
 
   def assemble_part
     return unless Flags['tinkering-assembly']
 
-    tool = right_hand
-    stow_item(tool)
+    tool_snapshot = @current_tool_type
+    change_tool(nil)
+
     part = Flags['tinkering-assembly'].to_a[1..-1].join('.')
     part = 'backer' if part == 'backing'
     part = "#{@mechanism} #{part}" if part == 'mechanism'
@@ -197,24 +220,28 @@ class Tinker
       part = bolt_head.find { |a| a.include?("#{bolt}")  } + (" bolthead")
     end
     Flags.reset('tinkering-assembly')
+
     get_item(part)
-    bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'loop both ends', 'loop the string', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations', 'boltheads is not required to continue')
+    DRC.bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'loop both ends', 'loop the string', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations', 'boltheads is not required to continue')
     if ['long.pole', 'short.pole'].include?(part)
       3.times do
         get_item(part)
-        bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'loop both ends', 'loop the string', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations', 'boltheads is not required to continue')
+        DRC.bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'loop both ends', 'loop the string', 'carefully mark where it will attach when you continue crafting', 'add several marks indicating optimal locations', 'boltheads is not required to continue')
       end
     end
     stow_item(part)
-    get_item(tool)
+
+    change_tool(tool_snapshot)
   end
 
   def tinker(command)
     waitrt?
     crafting_magic_routine(@settings)
+
     check_hand
     assemble_part
-    case bput(command,
+
+    case DRC.bput(command,
               'a wood shaper is needed', 'haping with a wood shaper', 'apply some glue to your', 'You flip some', 'series of grooves', 'Using slow strokes you scrape', 'You dab the surface', 'You lap the', 'You whittle away the rough edges',
               /carving .* knife/, 'continued knife carving', 'carved with a knife', 'with a carving knife', 'trimmed with a carving knife',
               'rubbed out with a rasp', 'A cluster of small knots',
@@ -231,58 +258,42 @@ class Tinker
               'ASSEMBLE Ingredient1', 'before proceeding',
               'You need at least')
     when 'a wood shaper is needed', 'haping with a wood shaper', 'apply some glue to your', 'You flip some', 'series of grooves', 'Using slow strokes you scrape', 'You dab the surface', 'You lap the', 'You whittle away the rough edges'
-      waitrt?
-      stow_item(right_hand)
-      get_item('shaper')
+      change_tool('shaper')
       command = "shape my #{@noun} with my shaper"
     when /carving.* knife/, 'continued knife carving', 'carved with a knife', 'with a carving knife', 'trimmed with a carving knife'
-      waitrt?
-      stow_item(right_hand)
-      get_item('carving knife')
+      change_tool('knife')
       command = "carve my #{@noun} with my knife"
     when 'rubbed out with a rasp', 'A cluster of small knots'
-      waitrt?
-      stow_item(right_hand)
-      get_item('rasp')
+      change_tool('rasp')
       command = "scrape my #{@noun} with my rasp"
     when 'ready to be clamped', 'with clamps'
-      waitrt?
-      stow_item(right_hand)
-      get_item('clamp')
-      command = "push my #{@noun} with my clamp"
+      change_tool('clamps')
+      command = "push my #{@noun} with my clamps"
     when 'Glue should now be applied', 'glue to fasten it', 'application of glue', 'glue applied'
-      waitrt?
-      stow_item(right_hand)
-      get_item('glue')
+      change_tool('glue')
       command = "apply my glue to my #{@noun}"
     when 'adjusting with', 'adjusted with'
-      waitrt?
-      stow_item(right_hand)
-      get_item('tinker tools')
+      change_tool('tools')
       command = "adjust my #{@noun} with my tinker tools"
     when 'Some wood stain', 'application of stain'
-      waitrt?
-      stow_item(right_hand)
-      get_item('stain')
+      change_tool('stain')
       command = "apply my stain to my #{@noun}"
     when 'mechanisms must be affixed', 'pulling them into place'
-      stow_item(right_hand)
-      get_item('pliers')
+      change_tool('pliers')
       command = "pull my #{@noun} with my pliers"
     when 'while it is inside of something', 'You fumble around but'
       echo '*** ERROR TRYING TO CRAFT, EXITING ***'
-      stow_item(right_hand)
+      change_tool(nil)
       exit
     when 'pulling on the gear press'
-      stow_item(right_hand)
-      get_item('pliers')
+      change_tool('pliers')
       command = "pull my #{@noun} with press"
     when 'That tool does not seem suitable for that task.', 'You cannot figure out', 'doesn\'t appear suitable for working', 'boltheads is not required to continue'
       tinker("analyze my #{@noun}")
     when 'before proceeding'
       assemble_part
     when 'Applying the final touches', 'lamination process', 'lightening process', 'cable-backing process', 'complete mechanisms', 'These appear to be a type'
-      stow_item(right_hand)
+      change_tool(nil)
       stow_material
       finish
     when 'You need at least'
@@ -297,22 +308,22 @@ class Tinker
   def magic_cleanup
     return if @training_spells.empty?
 
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-    bput('release mana', 'You release all', "You aren't harnessing any mana")
-    bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 
   def stamp
     return unless @stamp && @finish
-    get_item('stamp')
-    bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that')
-    pause
-    waitrt?
-    stow_item('stamp')
+
+    change_tool('stamp')
+    DRC.bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that')
+    change_tool(nil)
   end
 
   def finish
     stamp
+
     case @finish
     when /log/
       logbook_item('engineering', @noun, @bag)

--- a/workorders.lic
+++ b/workorders.lic
@@ -45,6 +45,7 @@ class WorkOrders
     @retain_crafting_materials = @settings.retain_crafting_materials
     @workorders_repair = @settings.workorders_repair
     @workorders_override_store = @settings.workorders_override_store
+    @equipment_manager = EquipmentManager.new
 
     wait_for_script_to_complete('safe-room', ['force']) if @settings.workorders_force_heal
 
@@ -76,13 +77,12 @@ class WorkOrders
       end
       item = recipes.find { |r| r['name'] == item_name }
     end
-    tools = []
     skill = ''
 
     case discipline
     when 'blacksmithing', 'weaponsmithing', 'armorsmithing'
       skill = 'Forging'
-      tools = @settings.forging_tools
+      @craft_type = 'forging'
       @belt = @settings.forging_belt
       craft_method = if @use_own_ingot_type
                        :forge_items_with_own_ingot
@@ -91,8 +91,8 @@ class WorkOrders
                      end
     when 'tailoring'
       skill = 'Outfitting'
+      @craft_type = 'outfitting'
       @outfitting_room = @settings.outfitting_room
-      tools = @settings.outfitting_tools
       @belt = @settings.outfitting_belt
       case item['chapter']
       when 4, 2, 3
@@ -107,26 +107,26 @@ class WorkOrders
       end
     when 'shaping'
       skill = 'Engineering'
+      @craft_type = 'shaping'
       @engineering_room = @settings.engineering_room
-      tools = @settings.shaping_tools
       @belt = @settings.engineering_belt
       craft_method = :shape_items
     when 'carving'
       skill = 'Engineering'
+      @craft_type = 'carving'
       @engineering_room = @settings.engineering_room
-      tools = @settings.carving_tools
       @belt = @settings.engineering_belt
       craft_method = :carve_items
     when 'remedies'
       skill = 'Alchemy'
+      @craft_type = 'alchemy'
       @alchemy_room = @settings.alchemy_room
-      tools = @settings.alchemy_tools
       @belt = @settings.alchemy_belt
       craft_method = :remedy_items
     when 'artificing'
       skill = 'Enchanting'
+      @craft_type = 'enchanting'
       @enchanting_room = @settings.enchanting_room
-      tools = @settings.enchanting_tools
       @belt = @settings.enchanting_belt
       craft_method = :enchanting_items
     else
@@ -134,7 +134,7 @@ class WorkOrders
       return
     end
 
-    return repair_items(info, tools) if repair
+    return repair_items(info) if repair
 
     if DRSkill.getxp(skill) > @craft_max_mindstate
       echo("Exiting because your current mindstate for #{skill} over the set maximum craft_max_mindstate:#{@craft_max_mindstate}")
@@ -145,7 +145,7 @@ class WorkOrders
 
     complete_work_order(info)
 
-    repair_items(info, tools) if @workorders_repair
+    repair_items(info) if @workorders_repair
   end
 
   def complete_work_order(info)
@@ -168,26 +168,28 @@ class WorkOrders
     stow_crafting_item(name, @bag, @belt)
   end
 
-  def repair_items(info, tools)
+  def repair_items(info)
     walk_to info['repair-room']
 
+    tools = @equipment_manager.get_tool_info_for_craft(@craft_type)
+
     unless tools.size >= 5
-      need_to_repair = tools.find do |tool_name|
-        get_tool(tool_name)
-        result = bput("analyze my #{tool_name}", 'Analyze what', 'practically in mint', 'pristine condition', 'Roundtime')
+      need_to_repair = tools.find do |tool|
+        @equipment_manager.get_tool?(@craft_type, tool.tool_types[0])
+        result = bput("analyze my #{tool.name}", 'Analyze what', 'practically in mint', 'pristine condition', 'Roundtime')
         next if result == 'Analyze what'
         waitrt?
-        stow_tool(tool_name)
+        @equipment_manager.return_tool?(@craft_type, tool.tool_types[0])
         /roundtime/i =~ result
       end
       return unless need_to_repair
     end
 
-    tools.each do |tool_name|
-      get_tool(tool_name)
+    tools.each do |tool|
+      next unless @equipment_manager.get_tool?(@craft_type, tool.tool_types[0])
       case bput("give #{info['repair-npc']}", "I don't repair those here", 'What is it', "There isn't a scratch on that", 'Just give it to me again', 'I will not', "I can't fix those.  They only have so many uses and then you must buy another.")
       when /scratch/, /I will not/, /They only have so many uses/
-        stow_tool(tool_name)
+        @equipment_manager.return_tool?(@craft_type, tool.tool_types[0])
       when /give/
         bput("give #{info['repair-npc']}", 'repair ticket')
         bput('stow ticket', 'You put')
@@ -198,8 +200,7 @@ class WorkOrders
       pause 30 until bput('look at my ticket', 'should be ready by now', 'Looking at the') == 'should be ready by now'
       bput("give #{info['repair-npc']}", 'You hand')
       pause 1
-      stow_tool(right_hand) if right_hand
-      stow_tool(left_hand) if left_hand
+      @equipment_manager.return_held_gear
     end
   end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#workorders
 =end
 
-custom_require.call(%w[common common-crafting common-items common-money common-travel drinfomon])
+custom_require.call(%w[common common-crafting common-items common-money common-travel equipmanager drinfomon])
 
 class WorkOrders
   include DRC


### PR DESCRIPTION
POC to see what it might look like to manage swappable tools in equipment manager entries, since some of the best (fastest) forging tools are the swappable tongs.

@Dartellum - Seems like you've done most of the crafting scripts - thoughts on the approach?

YAML Config
```
############################# TOOLS
- :adjective: clockwork
  :name: tongs
  :is_leather: false
  :swappable: true
  :crafts: [forging]
  :tool_types: [tongs, shovel]
- :adjective: ball-peen
  :name: hammer
  :is_leather: false
  :tie_to: agonite.toolstrap
  :crafts: [forging]
  :tool_types: [hammer]

# I'm using a mix of gear entries and toolbelts to check for backwards compatibility, but you should be able to use all gear if you want
forging_belt:
  name: agonite toolstrap
  items: 
  - corrugated-hide bellows
  - stirring rod
  - complex stamp

# Blank out any tool entries for tools you don't have to keep Appraisal from getting confused
forging_tools:
- corrugated-hide bellows
- stirring rod
- complex stamp
- plain pliers # In backpack
tinkering_tools:
outfitting_tools:
alchemy_tools:
carving_tools:
enchanting_tools:
```
Updated / Validated Crafting Scripts:
- carve
- carve-bead
- craft
- forge
- mine
- mining-buddy
- sew
- shape
- smelt
- smelt-deeds
- smith
- workorders

Un-updated Scripts:
- alchemy
- arrows
- bolts
- clean-leather
- clean-lumber
- enchant
- spin
- tinker
- weave-cloth
