### PR TITLE
[script] [common-travel] StringProc bugfix when recovering from being in unknown room

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -107,7 +107,12 @@ module DRCT
         return room_num == room.id
       end
       path = Map.findpath(room, Map[room_num])
-      move room.wayto[path.first.to_s]
+      way = room.wayto[path.first.to_s]
+      if way.class == Proc
+        way.call
+      else
+        move way
+      end
       return walk_to(room_num)
     end
 


### PR DESCRIPTION
When walk_to is called when lich doesn't know where it is (Room.current.id = nil) but it is able to recover, if the first movement out is a StringProc it tries to send the Proc as a command, instead of calling the Proc.