### PR TITLE
[script] [combat-trainer] charged maneuvers don't have ramp time anymore

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3237,8 +3237,6 @@ class AttackProcess
     attempt = bput("maneuver #{action}", 'You raise your', 'You brace your', 'balanced and', 'Taking a full step back', 'You take a step back', 'You lower your shoulders', 'You angle to the side and ', 'rest a bit longer', 'You square up your feet', 'You crouch down', 'You step to the side')
     return if attempt == 'rest a bit longer'
 
-    # Maneuvers have extra non-RT delays
-    pause 7
     waitrt?
 
     # Only react to the powershot flag if we just did a powershot manuever.


### PR DESCRIPTION
### Background
* http://forums.play.net/forums/DragonRealms/Combat%20-%20Weapons%20and%20Armor/Game%20Master%20and%20Official%20Announcements/thread/1941605?get_newest=true

### Changes
* Remove the 7 second pause before performing the combat maneuver since it's not needed anymore