### PR TITLE
[script] [combat-trainer] Advanced Combat Maneuvers

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -269,17 +269,17 @@ class SetupProcess
     if !last_summoned
       @equipment_manager.stow_weapon(game_state.last_weapon_name)
       game_state.sheath_whirlwind_offhand
-      # Reset state that was specific to the prior weapon.
-      # This prevents, for example, attempting to do a powershot maneuver
-      # as soon as you equip another ranged weapon before you've had
-      # a chance to load it because the game_state thinks you're still holding a loaded weapon.
-      game_state.loaded = false
-      game_state.selected_maneuver = nil
     elsif !next_summoned && !DRStats.moon_mage?
       break_summoned_weapon(game_state.last_weapon_name)
     elsif !next_summoned && DRStats.moon_mage?
       DRCMM.wear_moon_weapon?
     end
+
+    # Reset state that was specific to the prior weapon.
+    # This prevents, for example, attempting to do a powershot maneuver
+    # as soon as you equip another ranged weapon before you've had
+    # a chance to load it because the game_state thinks you're still holding a loaded weapon.
+    game_state.loaded = false
 
     # Prepare the next weapon
     if next_summoned
@@ -2875,6 +2875,7 @@ class AttackProcess
     Flags.add('ct-ranged-ready', 'You think you have your best shot possible now.')
     Flags.add('ct-face-what', 'Face what')
     Flags.add('ct-maneuver-cooldown-reduced', "With expert skill you end the attack and maneuver into a better position")
+    Flags.add('ct-attack-out-of-range', "You aren't close enough to attack")
   end
 
   def execute(game_state)
@@ -2925,6 +2926,8 @@ class AttackProcess
 
   def attack_melee(charged_maneuver, game_state)
     waitrt?
+
+    maneuver_success = false
     if charged_maneuver
       # If you're prioritizing doublestrike but only wielding one melee weapon
       # then temporarily wield a second weapon offhand to perform the maneuver.
@@ -2937,10 +2940,13 @@ class AttackProcess
         end
       end
 
-      use_charged_maneuver(charged_maneuver, game_state)
+      maneuver_success = use_charged_maneuver(charged_maneuver, game_state)
 
       game_state.sheath_offhand_weapon(skill) if offhand_weapon_name
-    else
+    end
+
+    # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
+    unless maneuver_success
       if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush?
         hide?(@hide_type)
       end
@@ -3057,7 +3063,6 @@ class AttackProcess
   end
 
   def attack_aimed(charged_maneuver, game_state)
-    game_state.selected_maneuver = charged_maneuver unless game_state.loaded
     game_state.loaded = false if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
     game_state.clear_aim_queue if Flags['ct-ranged-ready']
 
@@ -3067,8 +3072,8 @@ class AttackProcess
     end
 
     if game_state.loaded && (game_state.done_aiming? || (Time.now - @firing_timer).to_i >= @firing_delay)
-      if game_state.selected_maneuver
-        use_charged_maneuver(game_state.selected_maneuver, game_state)
+      if charged_maneuver
+        use_charged_maneuver(charged_maneuver, game_state)
         game_state.action_taken
       else
         command = if game_state.use_stealth_ranged? && hide?(@hide_type)
@@ -3185,7 +3190,7 @@ class AttackProcess
       end
 
       waitrt?
-      unless game_state.selected_maneuver
+      unless charged_maneuver
         game_state.set_aim_queue
         aim(game_state)
         Flags.reset('ct-ranged-ready')
@@ -3269,9 +3274,9 @@ class AttackProcess
 
     Flags.reset('ct-powershot-ammo')
     Flags.reset('ct-maneuver-cooldown-reduced')
+    Flags.reset('ct-attack-out-of-range')
 
-    attempt = bput("maneuver #{action}",
-      # Random maneuver messages
+    maneuver_success_messages = [
       /^You raise your/,
       /^Taking a full step back/,
       /^You take a step back/,
@@ -3280,7 +3285,10 @@ class AttackProcess
       /^You square up your feet/,
       /^You crouch down/,
       /^You step to the side/,
-      /^You brace your .* to increase the power of the next shot/,
+      /^You brace your .* to increase the power of the next shot/
+    ]
+
+    maneuver_failure_messages = [
       # Your ranged weapon is unloaded
       /^You prepare the shot, but stop when you realize/,
       # Maneuver is still on cooldown
@@ -3294,37 +3302,59 @@ class AttackProcess
       /^This works best when you are dual wielding suitable weapons/,
       # Maneuver requires a weapon but you're not wielding any
       /^With your fist?  That might hurt/
-    )
+    ]
+
+    attempt = bput("maneuver #{action}", *maneuver_success_messages, *maneuver_failure_messages)
 
     waitrt?
 
-    # Only react to the powershot flag if we just did a powershot manuever.
-    # This is an added protection in case the flag was tripped by an unrelated
-    # action like throwing a weapon. This way we don't try to "stow my throwing hammer"
-    # after a 'maneuver cleave' action, for example.
-    if Flags['ct-powershot-ammo'] && action == 'powershot'
-      # When the flag matches game output then the value of the flag
-      # is the regular expression matches. This is how we know the ammo to stow.
-      stow_ammo(Flags['ct-powershot-ammo'][:ammo])
-      Flags.reset('ct-powershot-ammo')
-      # When dual loading, powershot only fires one of the arrows.
-      # So let's take advantage of the remaining arrow that's still loaded.
-      if game_state.dual_load?
-        shoot_aimed('shoot', game_state)
+    return false if Flags['ct-attack-out-of-range']
+
+    case attempt
+    when /^You must rest a bit longer before attempting that maneuver again/
+      # Barbarians who reduced the cooldown on this maneuver last time
+      # could have reduced it to anywhere between 45-55 seconds.
+      # We optimistically assumed 45 seconds. If that wasn't enough then
+      # we'll wait another 15 seconds and retry.
+      game_state.cooldown_timers[action] += 15
+      return false
+    when *maneuver_failure_messages
+      return false
+    when *maneuver_success_messages
+      # Only react to the powershot flag if we just did a powershot manuever.
+      # This is an added protection in case the flag was tripped by an unrelated
+      # action like throwing a weapon. This way we don't try to "stow my throwing hammer"
+      # after a 'maneuver cleave' action, for example.
+      if Flags['ct-powershot-ammo'] && action == 'powershot'
+        # When the flag matches game output then the value of the flag
+        # is the regular expression matches. This is how we know the ammo to stow.
+        stow_ammo(Flags['ct-powershot-ammo'][:ammo])
+        Flags.reset('ct-powershot-ammo')
+        # When dual loading, powershot only fires one of the arrows.
+        # So let's take advantage of the remaining arrow that's still loaded.
+        if game_state.dual_load?
+          shoot_aimed('shoot', game_state)
+        end
       end
-    end
 
-    # Woot! Barbarian reduced their maneuver cooldown so
-    # they can retry this specific ability sooner rather than later.
-    if Flags['ct-maneuver-cooldown-reduced'] && DRStats.barbarian?
-      game_state.cooldown_timers[action] = Time.now + 60
-      Flags.reset('ct-maneuver-cooldown-reduced')
-    else
-      # No special favors for you. Full cooldown!
-      game_state.cooldown_timers[action] = Time.now + 90
-    end
+      # Woot! Barbarian reduced their maneuver cooldown so
+      # they can retry this specific ability sooner rather than later.
+      if Flags['ct-maneuver-cooldown-reduced'] && DRStats.barbarian?
+        # The new cooldown is somewhere between 45-55 seconds.
+        # We'll be optimistic and hope we got the shorter cooldown.
+        # If we didn't then next time around we'll add a few more seconds
+        # to finish out a 60 second cooldown.
+        game_state.cooldown_timers[action] = Time.now + 45
+        Flags.reset('ct-maneuver-cooldown-reduced')
+      else
+        # No special favors for you. Full cooldown!
+        game_state.cooldown_timers[action] = Time.now + 90
+      end
 
-    game_state.use_charged_maneuvers = false
+      game_state.use_charged_maneuvers = false
+
+      return true
+    end
   end
 
   def stow_ammo(ammo = nil, quantity = 1)
@@ -3480,7 +3510,7 @@ class GameState
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
   $tactics_actions = %w[bob weave circle]
 
-  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :selected_maneuver, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type, :casting_regalia, :starlight_values, :casting_cyclic
+  attr_accessor :mob_died, :last_weapon_skill, :danger, :parrying, :casting, :need_bundle, :cooldown_timers, :no_stab_current_mob, :loaded, :cast_timer, :casting_moonblade, :casting_weapon_buff, :use_charged_maneuvers, :casting_consume, :prepare_consume, :casting_cfb, :prepare_cfb, :wounds, :blessed_room, :currently_whirlwinding, :whirlwind_trainables, :reset_stance, :charges_total, :casting_sorcery, :hide_on_cast, :regalia_cancel, :last_regalia_type, :swap_regalia_type, :casting_regalia, :starlight_values, :casting_cyclic
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -3495,7 +3525,6 @@ class GameState
     @cooldown_timers = {}
     @no_stab_current_mob = false
     @loaded = false
-    @selected_maneuver = nil
     @cast_timer = nil
     @casting_moonblade = false
     @casting_sorcery = false
@@ -4435,6 +4464,7 @@ before_dying do
   Flags.delete('ct-germshieldlost')
   Flags.delete('ct-itemdropped')
   Flags.delete('ct-shock-warning')
+  Flags.delete('ct-attack-out-of-range')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3277,7 +3277,7 @@ class AttackProcess
     Flags.reset('ct-attack-out-of-range')
 
     maneuver_success_messages = [
-      /^You raise your/,
+      /^You raise your weapons before you and prepare to strike/,
       /^Taking a full step back/,
       /^You take a step back/,
       /^You lower your shoulders/,
@@ -3285,6 +3285,7 @@ class AttackProcess
       /^You square up your feet/,
       /^You crouch down/,
       /^You step to the side/,
+      /^Swiftly, you attempt to/,
       /^You brace your .* to increase the power of the next shot/
     ]
 
@@ -3505,7 +3506,7 @@ class GameState
   $melee_skills = ['Small Edged', 'Large Edged', 'Twohanded Edged', 'Small Blunt', 'Large Blunt', 'Twohanded Blunt', 'Staves', 'Polearms']
   $thrown_skills = ['Heavy Thrown', 'Light Thrown']
   $twohanded_skills = ['Twohanded Edged', 'Twohanded Blunt']
-  $aim_skills = %w[Bow Slings Crossbow]
+  $aim_skills = ['Bow', 'Slings', 'Crossbow']
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
   $tactics_actions = %w[bob weave circle]
@@ -3627,6 +3628,10 @@ class GameState
 
     @charged_maneuvers = settings.charged_maneuvers
     echo("  @charged_maneuvers: #{@charged_maneuvers}") if $debug_mode_ct
+    # Initialize the maneuver timers. This avoids a later issue where a number
+    # is assigned to the cooldown rather than a Time and then crash with error
+    # when we compare a Time object with a number wanting to know if ability is off cooldown.
+    @charged_maneuvers.each_value { |maneuver| @cooldown_timers[maneuver.downcase] = Time.now }
 
     @prioritize_maneuver_doublestrike = settings.prioritize_maneuver_doublestrike
     echo("  @prioritize_maneuver_doublestrike: #{@prioritize_maneuver_doublestrike}") if $debug_mode_ct
@@ -4329,7 +4334,6 @@ class GameState
     options = @aiming_trainables
     options -= [weapon_skill] # can't be your main hand skill, it's in your main hand
     options -= $twohanded_skills # can't be a twohanded skill, you need both hands
-    options -= $thrown_skills # shouldn't be a thrown skill, you're doing a melee attack
     options -= $martial_skills # shouldn't be brawling, you need a weapon in your offhand
     echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
@@ -4341,7 +4345,7 @@ class GameState
   # If the main hand weapon skill is doublestrikable then `determine_doublestrike_skill`
   # is used to determine what to equip offhand to perform the maneuver.
   def doublestrikable_weapon_skill?
-    @doublestrike_trainables.include?(weapon_skill) && melee_weapon_skill? && !twohanded_weapon_skill?
+    @doublestrike_trainables.include?(weapon_skill) && (melee_weapon_skill? || thrown_skill?) && !twohanded_weapon_skill?
   end
 
   def use_stealth?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4006,8 +4006,8 @@ class GameState
     @use_stealth_attacks && use_stealth?
   end
 
-  def use_stealth_ranged? # new
-    @use_stealth_ranged && use_stealth? # new
+  def use_stealth_ranged?
+    @use_stealth_ranged && use_stealth?
   end
 
   def ambush?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3072,8 +3072,7 @@ class AttackProcess
     end
 
     if game_state.loaded && (game_state.done_aiming? || (Time.now - @firing_timer).to_i >= @firing_delay)
-      if charged_maneuver
-        use_charged_maneuver(charged_maneuver, game_state)
+      if charged_maneuver && use_charged_maneuver(charged_maneuver, game_state)
         game_state.action_taken
       else
         command = if game_state.use_stealth_ranged? && hide?(@hide_type)
@@ -3271,6 +3270,7 @@ class AttackProcess
   end
 
   def use_charged_maneuver(action, game_state)
+    return false unless action
 
     Flags.reset('ct-powershot-ammo')
     Flags.reset('ct-maneuver-cooldown-reduced')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2060,6 +2060,7 @@ class AbilityProcess
     @buffs.each do |action, cooldown|
       timer = game_state.cooldown_timers[action]
       next unless !timer || (Time.now - timer).to_i > cooldown
+
       game_state.cooldown_timers[action] = Time.now
       fput action
       waitrt?
@@ -2086,6 +2087,7 @@ class AbilityProcess
       .each do |name|
         timer = game_state.cooldown_timers[name]
         next unless !timer || (Time.now - timer).to_i > 30
+
         if name == 'Tsunami' && (!game_state.melee_weapon_skill? || DRC.right_hand.nil? || DRC.right_hand.empty?)
           echo "Not activating barb_buff #{name} because you're not currently wielding a melee weapon. Will retry when you're training melee weapons." if $debug_mode_ct
         elsif DRStats.mana < @barb_buffs_inner_fire_threshold
@@ -2367,6 +2369,9 @@ class TrainerProcess
     when /^Favor Orb$/i
       fput("rub my #{@favor_god} orb")
     when /^Charged Maneuver$/i
+      # This tells the attack process to perform a combat maneuver as soon as it can.
+      # Depending on cooldowns and which weapon is equipped, it may not be immediate.
+      # Once a maneuver is performed then this flag gets reset to false.
       game_state.use_charged_maneuvers = true
     when /^Meraud$/i
       meraud_commune(game_state)
@@ -3203,8 +3208,9 @@ class AttackProcess
       waitrt?
 
       if game_state.loaded
-        if charged_maneuver
-          use_charged_maneuver(charged_maneuver, game_state)
+        # If we successfully perform a maneuver then count that as our action.
+        # Otherwise begin aiming for normal shot.
+        if charged_maneuver && use_charged_maneuver(charged_maneuver, game_state)
           game_state.action_taken
         else
           game_state.set_aim_queue
@@ -4494,7 +4500,6 @@ before_dying do
   Flags.delete('ct-face-what')
   Flags.delete('ct-aim-failed')
   Flags.delete('ct-powershot-ammo')
-  Flags.delete('ct-maneuver-cooldown-reduced')
   Flags.delete('ct-ranged-ammo')
   Flags.delete('ct-ranged-loaded')
   Flags.delete('ct-using-repeating-crossbow')
@@ -4509,6 +4514,7 @@ before_dying do
   Flags.delete('ct-germshieldlost')
   Flags.delete('ct-itemdropped')
   Flags.delete('ct-shock-warning')
+  Flags.delete('ct-maneuver-cooldown-reduced')
   Flags.delete('ct-attack-out-of-range')
 end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -269,6 +269,12 @@ class SetupProcess
     if !last_summoned
       @equipment_manager.stow_weapon(game_state.last_weapon_name)
       game_state.sheath_whirlwind_offhand
+      # Reset state that was specific to the prior weapon.
+      # This prevents, for example, attempting to do a powershot maneuver
+      # as soon as you equip another ranged weapon before you've had
+      # a chance to load it because the game_state thinks you're still holding a loaded weapon.
+      game_state.loaded = false
+      game_state.selected_maneuver = nil
     elsif !next_summoned && !DRStats.moon_mage?
       break_summoned_weapon(game_state.last_weapon_name)
     elsif !next_summoned && DRStats.moon_mage?
@@ -2164,14 +2170,42 @@ class TrainerProcess
     @training_abilities = settings.training_abilities
     echo("  @training_abilities: #{@training_abilities}") if $debug_mode_ct
 
-    @skill_map = { 'Hunt' => 'Perception', 'Pray' => 'Theurgy', 'PercMana' => 'Attunement', 'Almanac' => 'Anything',
-                   'Perc' => 'Attunement', 'Astro' => 'Astrology', 'App' => 'Appraisal', 'PrayerMat' => 'Theurgy', 'Flee' => 'Athletics',
-                   'App Quick' => 'Appraisal', 'App Careful' => 'Appraisal', 'Tactics' => 'Tactics', 'Analyze' => 'Tactics',
-                   'Scream' => 'Bardic Lore', 'Perc Health' => 'Empathy', 'Khri Prowess' => 'Debilitation', 'Teach' => 'Scholarship',
-                   'Stealth' => 'Stealth', 'Ambush Stun' => settings.stun_skill, 'Ambush Choke' => 'Debilitation', 'App Pouch' => 'Appraisal',
-                   'Favor Orb' => 'Anything', 'Charged Maneuver' => 'Expertise', 'Meraud' => 'Theurgy', 'Recall' => 'Scholarship',
-                   'Barb Research Warding' => 'Warding', 'Barb Research Augmentation' => 'Augmentation', 'App Bundle' => 'Appraisal',
-                   'Barb Research Debilitation' => 'Debilitation', 'Barb Research Utility' => 'Utility', 'Collect' => 'Outdoorsmanship', 'Smite' => 'Conviction', 'Locks' => 'Locksmithing', 'Tessera' => 'Trading' }
+    @skill_map = {
+      'Almanac' => 'Anything',
+      'Ambush Choke' => 'Debilitation',
+      'Ambush Stun' => settings.stun_skill,
+      'Analyze' => 'Tactics',
+      'App Bundle' => 'Appraisal',
+      'App Careful' => 'Appraisal',
+      'App Pouch' => 'Appraisal',
+      'App Quick' => 'Appraisal',
+      'App' => 'Appraisal',
+      'Astro' => 'Astrology',
+      'Barb Research Augmentation' => 'Augmentation',
+      'Barb Research Debilitation' => 'Debilitation',
+      'Barb Research Utility' => 'Utility',
+      'Barb Research Warding' => 'Warding',
+      'Charged Maneuver' => 'Expertise',
+      'Collect' => 'Outdoorsmanship',
+      'Favor Orb' => 'Anything',
+      'Flee' => 'Athletics',
+      'Hunt' => 'Perception',
+      'Khri Prowess' => 'Debilitation',
+      'Locks' => 'Locksmithing',
+      'Meraud' => 'Theurgy',
+      'Perc Health' => 'Empathy',
+      'Perc' => 'Attunement',
+      'PercMana' => 'Attunement',
+      'Pray' => 'Theurgy',
+      'PrayerMat' => 'Theurgy',
+      'Recall' => 'Scholarship',
+      'Scream' => 'Bardic Lore',
+      'Smite' => 'Conviction',
+      'Stealth' => 'Stealth',
+      'Tactics' => 'Tactics',
+      'Teach' => 'Scholarship',
+      'Tessera' => 'Trading'
+    }
 
     @skill_map['Hunt'] = %w[Perception Scouting] if DRStats.ranger?
     @favor_god = settings.favor_god
@@ -2840,6 +2874,7 @@ class AttackProcess
     Flags.add('ct-aim-failed', 'you stop aiming', 'stop concentrating on aiming')
     Flags.add('ct-ranged-ready', 'You think you have your best shot possible now.')
     Flags.add('ct-face-what', 'Face what')
+    Flags.add('ct-maneuver-cooldown-reduced', "With expert skill you end the attack and maneuver into a better position")
   end
 
   def execute(game_state)
@@ -2884,7 +2919,7 @@ class AttackProcess
   def check_face(game_state)
     return unless Flags['ct-face-what']
 
-    fput("eng #{game_state.npcs.first}")
+    fput("engage #{game_state.npcs.first}")
     Flags.reset('ct-face-what')
   end
 
@@ -2922,7 +2957,7 @@ class AttackProcess
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip', 'You can not slam with that')
     end
 
     pause
@@ -3108,7 +3143,8 @@ class AttackProcess
         /What weapon are you trying to load/,
         /Such a feat would be impossible without the winds to guide/,
         /but are unable to draw upon its majesty/,
-        /without steadier hands/
+        /without steadier hands/,
+        /You can not load .* in your left hand/,
       ]
 
       dual_load = game_state.dual_load?
@@ -3222,23 +3258,43 @@ class AttackProcess
   end
 
   def check_charged_maneuver(game_state)
-    return nil unless game_state.use_charged_maneuvers
-    return nil unless game_state.charged_maneuver
-
-    timer = game_state.cooldown_timers[game_state.charged_maneuver]
-    return nil if timer && (Time.now - timer).to_i < 60
-
-    echo "***Ready to use charged maneuver: #{game_state.charged_maneuver}***" if $debug_mode_ct
-    game_state.charged_maneuver
+    # Determines the next maneuver to do that's not on cooldown
+    maneuver = game_state.determine_charged_maneuver
+    return nil unless maneuver
+    echo "***Ready to use charged maneuver: #{maneuver}***" if $debug_mode_ct
+    maneuver
   end
 
   def use_charged_maneuver(action, game_state)
-    game_state.cooldown_timers[action] = Time.now
 
     Flags.reset('ct-powershot-ammo')
+    Flags.reset('ct-maneuver-cooldown-reduced')
 
-    attempt = bput("maneuver #{action}", 'You raise your', 'You brace your', 'balanced and', 'Taking a full step back', 'You take a step back', 'You lower your shoulders', 'You angle to the side and ', 'rest a bit longer', 'You square up your feet', 'You crouch down', 'You step to the side')
-    return if attempt == 'rest a bit longer'
+    attempt = bput("maneuver #{action}",
+      # Random maneuver messages
+      /^You raise your/,
+      /^Taking a full step back/,
+      /^You take a step back/,
+      /^You lower your shoulders/,
+      /^You angle to the side/,
+      /^You square up your feet/,
+      /^You crouch down/,
+      /^You step to the side/,
+      /^You brace your .* to increase the power of the next shot/,
+      # Your ranged weapon is unloaded
+      /^You prepare the shot, but stop when you realize/,
+      # Maneuver is still on cooldown
+      /^You must rest a bit longer before attempting that maneuver again/,
+      # Trying to suplex but you're not grappled
+      /^You must first be grappled with an enemy/,
+      # Trying to doublestrike with a weapon that requires two hands (e.g. quarterstaff or long polearm)
+      /^You must free up your left hand first/,
+      # Trying to doublestrike without wielding two, one-handed melee weapons
+      /^This works best when you use a suitable weapon/,
+      /^This works best when you are dual wielding suitable weapons/,
+      # Maneuver requires a weapon but you're not wielding any
+      /^With your fist?  That might hurt/
+    )
 
     waitrt?
 
@@ -3251,6 +3307,21 @@ class AttackProcess
       # is the regular expression matches. This is how we know the ammo to stow.
       stow_ammo(Flags['ct-powershot-ammo'][:ammo])
       Flags.reset('ct-powershot-ammo')
+      # When dual loading, powershot only fires one of the arrows.
+      # So let's take advantage of the remaining arrow that's still loaded.
+      if game_state.dual_load?
+        shoot_aimed('shoot', game_state)
+      end
+    end
+
+    # Woot! Barbarian reduced their maneuver cooldown so
+    # they can retry this specific ability sooner rather than later.
+    if Flags['ct-maneuver-cooldown-reduced'] && DRStats.barbarian?
+      game_state.cooldown_timers[action] = Time.now + 60
+      Flags.reset('ct-maneuver-cooldown-reduced')
+    else
+      # No special favors for you. Full cooldown!
+      game_state.cooldown_timers[action] = Time.now + 90
     end
 
     game_state.use_charged_maneuvers = false
@@ -3531,6 +3602,9 @@ class GameState
     @prioritize_maneuver_doublestrike = settings.prioritize_maneuver_doublestrike
     echo("  @prioritize_maneuver_doublestrike: #{@prioritize_maneuver_doublestrike}") if $debug_mode_ct
 
+    @doublestrike_trainables = settings.doublestrike_trainables & settings.weapon_training.keys # Intersection of the arrays to make sure weapons are available in the hunt
+    echo("  @doublestrike_trainables: #{@doublestrike_trainables}") if $debug_mode_ct
+
     @fatigue_regen_threshold = settings.fatigue_regen_threshold
     echo("  @fatigue_regen_threshold: #{@fatigue_regen_threshold}") if $debug_mode_ct
 
@@ -3629,10 +3703,13 @@ class GameState
 
     @is_empath = DRStats.empath?
     echo("  @is_empath: #{@is_empath}") if $debug_mode_ct
+
     @construct_mode = settings.construct(false)
     echo("  @construct_mode: #{@construct_mode}") if $debug_mode_ct
+
     @is_permashocked = settings.permashocked
     echo("  @is_permashocked: #{@is_permashocked}") if $debug_mode_ct
+
     @undead_mode = settings.undead(false)
     echo("  @undead_mode: #{@undead_mode}") if $debug_mode_ct
   end
@@ -3921,12 +3998,28 @@ class GameState
     @retreating
   end
 
-  def charged_maneuver
-    if !twohanded_weapon_skill? && (@currently_whirlwinding || (@prioritize_maneuver_doublestrike && melee_weapon_skill?))
-      @charged_maneuvers['Dual Wield']
-    else
-      @charged_maneuvers[weapon_skill]
+  def charged_maneuver_off_cooldown?(maneuver)
+    # Non-Barbarians can perform a maneuver every 90 seconds.
+    # Barbarians have a chance to reduce that to 60 seconds.
+    # To account for the adjustable cooldown, the timer we store
+    # for maneuvers is the future time when it'll be ready rather
+    # than the start time as we do with other ability timers.
+    # This allows us to shorten or lengthen the "time when it'll be ready".
+    timer = @cooldown_timers[maneuver]
+    timer.nil? || (Time.now > timer)
+  end
+
+  def determine_charged_maneuver
+    return nil unless @use_charged_maneuvers
+    maneuver = nil
+    can_dual_wield_whirlwind = @currently_whirlwinding && !twohanded_weapon_skill?
+    can_dual_wield_doublestrike = @prioritize_maneuver_doublestrike && doublestrikable_weapon_skill?
+    if charged_maneuver_off_cooldown?(@charged_maneuvers['Dual Wield']) && (can_dual_wield_whirlwind || can_dual_wield_doublestrike)
+      maneuver = @charged_maneuvers['Dual Wield']
+    elsif charged_maneuver_off_cooldown?(@charged_maneuvers[weapon_skill])
+      maneuver = @charged_maneuvers[weapon_skill]
     end
+    maneuver
   end
 
   def fatigue_low?
@@ -4191,6 +4284,7 @@ class GameState
     @construct_mode
   end
 
+  # Determine the weapon skill to train offhand while aiming a ranged weapon.
   def determine_aiming_skill
     options = @aiming_trainables
     options -= [weapon_skill] # can't be your mainhand skill
@@ -4201,6 +4295,7 @@ class GameState
     sort_by_rate_then_rank(options).first
   end
 
+  # Determine the weapon skill to equip offhand to perform a doublestrike maneuver.
   def determine_doublestrike_skill
     options = @aiming_trainables
     options -= [weapon_skill] # can't be your main hand skill, it's in your main hand
@@ -4209,6 +4304,15 @@ class GameState
     options -= $martial_skills # shouldn't be brawling, you need a weapon in your offhand
     echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
+  end
+
+  # Is the main hand weapon skill suitable to perform a doublestrike maneuver?
+  # For example, the two-handed variants of Staves and Polearms are not,
+  # but their shorter, one-handed variants are.
+  # If the main hand weapon skill is doublestrikable then `determine_doublestrike_skill`
+  # is used to determine what to equip offhand to perform the maneuver.
+  def doublestrikable_weapon_skill?
+    @doublestrike_trainables.include?(weapon_skill) && melee_weapon_skill? && !twohanded_weapon_skill?
   end
 
   def use_stealth?
@@ -4317,6 +4421,7 @@ before_dying do
   Flags.delete('ct-face-what')
   Flags.delete('ct-aim-failed')
   Flags.delete('ct-powershot-ammo')
+  Flags.delete('ct-maneuver-cooldown-reduced')
   Flags.delete('ct-ranged-ammo')
   Flags.delete('ct-ranged-loaded')
   Flags.delete('ct-ranged-ready')

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -105,3 +105,4 @@ empty_values:
   repair_heuristic_gear: []
   sell_loot_ignored_metals_and_stones: []
   esp_channels: []
+  doublestrike_trainables: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -91,7 +91,7 @@ charged_maneuvers:
   Dual Wield: doublestrike
 # If "Charged Maneuver" is set in your training_abilities, this setting
 # will prioritize dual wield attacks by temporarily wielding an "aiming trainable"
-# in your offhand when your holding a one-handed weapon in your main hand.
+# in your offhand when you're holding a one-handed weapon in your main hand.
 # If this is false then a charged manuever for your main hand weapon is used instead.
 prioritize_maneuver_doublestrike: false
 # When prioritizing doublestrike maneuvers, this is the list

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -91,9 +91,24 @@ charged_maneuvers:
   Dual Wield: doublestrike
 # If "Charged Maneuver" is set in your training_abilities, this setting
 # will prioritize dual wield attacks by temporarily wielding an "aiming trainable"
-# in your offhand when you're holding a one-handed weapon in your main hand.
+# in your offhand when your holding a one-handed weapon in your main hand.
 # If this is false then a charged manuever for your main hand weapon is used instead.
 prioritize_maneuver_doublestrike: false
+# When prioritizing doublestrike maneuvers, this is the list
+# of melee one-handed skills that when equipped in your mainhand
+# you want to attempt a doublestrike with an aiming_trainables
+# weapon skill equipped in your offhand.
+#
+# For example, if you use quarterstaves or polearms that require two hands
+# then those aren't suitable for doublestrikes. But if you use short staves
+# or short polearms like light spears then those are suitable for doublestrikes.
+doublestrike_trainables:
+  - Small Edged
+  - Small Blunt
+  - Large Edged
+  - Large Blunt
+  # - Staves
+  # - Polearms
 # Defines the number of monsters you will keep in combat with you by performing 'dance actions' or attacking with only 'harmless: true' spells. 0 means kill everything.
 dance_threshold: 0
 # What weapon skill to use while dancing


### PR DESCRIPTION
## Dependencies
* Depends on https://github.com/rpherbig/dr-scripts/pull/5076

### Background
* "Charged Combat Maneuvers" were changed to "Advanced Combat Maneuvers" ([forum post](https://elanthipedia.play.net/Post:Charged_Combat_Maneuvers_-_07/07/2021_-_00:32), [wiki page](https://elanthipedia.play.net/Combat_maneuvers#Advanced_Combat_Maneuvers)).
* Without the need for the ramp up time https://github.com/rpherbig/dr-scripts/pull/5069, they are more viable to be part of regular combat routines, especially for Barbarians who have high likelihoods of reducing the 90 second cooldown to 60 seconds.
* Continuation of https://github.com/rpherbig/dr-scripts/pull/5044, which introduced prioritizing doublestrikes maneuvers.

### Changes
* Add new setting `doublestrike_trainables` to define which mainhand weapon skills you want to use when attempting doublestrikes. This lets you, for example, opt out of trying (and failing) doublestrikes with staves if you use a quarterstaff (two-handed) instead of a short staff (one-handed). Same with polearms like halberds vs. light spears.
* For the true combat maneuver enthusiast, including suggested YAML configuration below for how to perform maneuvers frequently.
* When prioritizing doublestrikes, if that specific maneuver is on cooldown then fallback to trying the specific maneuver for the mainhand weapon, and if that maneuver is on cooldown then do regular attack.
* When tracking cooldowns for each combat maneuver, detect when Barbarians reduce their cooldown so that the maneuver will be attempted sooner rather than later.
* Support dual loading with powershot maneuver. Powershot will only fire one arrow from a dual loaded bow, so in these scenarios to not waste the other arrow, the script will perform the second shot immediately.
* Format `@skill_map` to be (subjectively) more readable and maintainable.

### Configuration
<details>
<summary>toggle sample configuration</summary>

```yaml
training_abilities:
  Charged Maneuver:
    # By default, maneuvers are performed as long as the Expertise skill needs training.
    # To make combat maneuvers a regular attack in your routine, set the :check: property to a
    # non-existant skill that'll never reach the value of combat_training_abilities_target.
    :check: Always
    # Also, since every maneuver type has its own cooldown (e.g. you can 'cleave' then 'crash'
    # back to back but then have to wait for their respective cooldowns before you can do them again),
    # set the training ability cooldown to a lowish value so that the script is regularly performing
    # maneuvers for your equipped weapons as soon as they are off cooldown.
    # This example checks every 10 seconds, and if a maneuver is ready then it's performed.
    # This increases the chances of performing a maneuver, especially when you swap to a new weapon.
    :cooldown: 10

# If "Charged Maneuver" is set in your training_abilities, this setting
# will attempt doublestrikes by temporarily wielding an "aiming trainable"
# in your offhand when your holding a "doublestrike trainable" in your main hand.
# If this is false then doublestrikes are only attempted if you are a Barbarian using whirlwind.
# I recommend enabling this, especially if you already use aiming trainables with ranged weapons,
# because it increases the training of multiple weapons at the same time.
prioritize_maneuver_doublestrike: true

# When prioritizing doublestrike maneuvers, this list indicates which
# melee, one-handed weapon skills in your mainhand signal that
# it's ok to attempt doublestrikes. If a doublestrike is attempted then
# a weapon from your aiming trainables will be equipped offhand.
#
# This setting is necessary if you use twohanded staves or polearms so
# that you can opt them out of doublestrike attempts because they will
# fail because the weapon itself requires two hands.
# If you're able to use the weapon for an aiming trainable then it's
# suitable to be a doublestrike trainable. This separate setting gives you control,
# however, to use different weapons for aiming and doublestrike purposes.
doublestrike_trainables:
  - Small Edged
  - Small Blunt
  - Large Edged
  - Large Blunt
  # - Staves
  # - Polearms

# In addition to being the skills trained while aiming ranged weapons,
# when prioritizing doublestrike maneuvers, one of the
# non-thrown, one-handed melee weapons in this list will be
# equipped temporarily in your offhand to do the strike.
aiming_trainables:
  - Small Edged
  - Small Blunt
  - Large Edged
  - Large Blunt
  - Light Thrown
  - Heavy Thrown
  # - Staves
  # - Polearms
  - Brawling
```
</details>