### PR TITLE
[script] [combat-trainer] Invoke current weapon in case have multiple bonded items

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4177,7 +4177,7 @@ class GameState
 
   def thrown_retrieve_verb
     if bound_weapon?
-      'invoke'
+      "invoke #{weapon_name}"
     else
       "get my #{weapon_name}"
     end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4177,7 +4177,7 @@ class GameState
 
   def thrown_retrieve_verb
     if bound_weapon?
-      "invoke #{weapon_name}"
+      "invoke bond #{weapon_name}"
     else
       "get my #{weapon_name}"
     end


### PR DESCRIPTION
### Background
* Reported by [Tekhelet](https://discord.com/channels/745675889622384681/745675890242879671/863456621823524914) in the Lich discord
* Tekhelet has two bonded weapons and since combat-trainer only performs `invoke` without specifying the bonded item then the game randomly decides which to return to their hands, which may be the wrong weapon.
* Having the wrong item returned causes the combat routine to go awry.

### Changes
* Update `thrown_retrieve_verb` method to specify the weapon name when using the invoke verb

### Tests
* Awaiting Tekhelet's results as I don't have any bonded items to test with myself