### PR TITLE
[script] [combat-trainer] Improve loading/powershot support for repeating crossbows

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3305,6 +3305,7 @@ class AttackProcess
       # is the regular expression matches. This is how we know the ammo to stow.
       stow_ammo(Flags['ct-powershot-ammo'][:ammo])
       Flags.reset('ct-powershot-ammo')
+      game_state.loaded = false
     end
 
     game_state.use_charged_maneuvers = false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3153,7 +3153,7 @@ class AttackProcess
           abort_attack_aimed(game_state)
           return
         when *load_weapon_success
-          # Check if loading a repeating a crossbow because we need to then push ammo into the chamber
+          # Check if loading a repeating crossbow because we need to then push ammo into the chamber
           if Flags['ct-using-repeating-crossbow']
             case bput("push my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure)
             when *load_weapon_failure

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -275,6 +275,12 @@ class SetupProcess
       DRCMM.wear_moon_weapon?
     end
 
+    # Reset state that was specific to the prior weapon.
+    # This prevents, for example, attempting to do a powershot maneuver
+    # as soon as you equip another ranged weapon before you've had
+    # a chance to load it because the game_state thinks you're still holding a loaded weapon.
+    game_state.loaded = false
+
     # Prepare the next weapon
     if next_summoned
       game_state.prepare_summoned_weapon(last_summoned)
@@ -2837,6 +2843,7 @@ class AttackProcess
     Flags.add('ct-ranged-ammo', "(you (?<action>fire|poach|snipe) an?|your) (?<prefix>[^\.!]*? )?#{ammo_pattern}(?<suffix> [^\.!]*?)?? (at|passes through)")
     Flags.add('ct-powershot-ammo', "With a loud twang, you let fly your #{ammo_pattern}!")
     Flags.add('ct-ranged-loaded', 'You reach into', 'You load', 'You carefully load', 'already loaded', 'in your hand')
+    Flags.add('ct-using-repeating-crossbow', /Your repeating crossbow/i, /Your repeating arbalest/i, /Your marksman's arbalest/i, /Your assassin's crossbow/i, /Your riot crossbow/i, /You .* ammunition chamber/, /already loaded with as much ammunition as it can hold/, /You realize readying more than one/)
     Flags.add('ct-aim-failed', 'you stop aiming', 'stop concentrating on aiming')
     Flags.add('ct-ranged-ready', 'You think you have your best shot possible now.')
     Flags.add('ct-face-what', 'Face what')
@@ -3022,7 +3029,6 @@ class AttackProcess
   end
 
   def attack_aimed(charged_maneuver, game_state)
-    game_state.selected_maneuver = charged_maneuver unless game_state.loaded
     game_state.loaded = false if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
     game_state.clear_aim_queue if Flags['ct-ranged-ready']
 
@@ -3032,19 +3038,14 @@ class AttackProcess
     end
 
     if game_state.loaded && (game_state.done_aiming? || (Time.now - @firing_timer).to_i >= @firing_delay)
-      if game_state.selected_maneuver
-        use_charged_maneuver(game_state.selected_maneuver, game_state)
-        game_state.action_taken
-      else
-        command = if game_state.use_stealth_ranged? && hide?(@hide_type)
-                    @stealth_attack_aimed_action
-                  elsif game_state.use_stealth_attack? && hide?(@hide_type)
-                    @stealth_attack_aimed_action
-                  else
-                    'shoot'
-                  end
-        shoot_aimed(command, game_state)
-      end
+      command = if game_state.use_stealth_ranged? && hide?(@hide_type)
+                  @stealth_attack_aimed_action
+                elsif game_state.use_stealth_attack? && hide?(@hide_type)
+                  @stealth_attack_aimed_action
+                else
+                  'shoot'
+                end
+      shoot_aimed(command, game_state)
       game_state.loaded = false
       waitrt?
     elsif game_state.loaded && !game_state.aiming_trainables.empty?
@@ -3101,6 +3102,7 @@ class AttackProcess
         /already loaded/,
         /in your hand/
       ]
+
       load_weapon_failure = [
         /As you try to reach/,
         /You don't have the proper ammunition/,
@@ -3108,7 +3110,8 @@ class AttackProcess
         /What weapon are you trying to load/,
         /Such a feat would be impossible without the winds to guide/,
         /but are unable to draw upon its majesty/,
-        /without steadier hands/
+        /without steadier hands/,
+        /You can not load .* in your left hand/
       ]
 
       dual_load = game_state.dual_load?
@@ -3132,29 +3135,52 @@ class AttackProcess
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
         Flags.reset('ct-ranged-loaded')
+        Flags.reset('ct-using-repeating-crossbow')
+
         load_weapon_result = bput('load', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
         load_weapon_result = bput('load', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        waitrt?
+
         case load_weapon_result
         when *load_weapon_failure
-          DRC.message("Unable to load #{game_state.weapon_name}, you may be out of ammunition, dancing until can switch to next weapon")
-          game_state.loaded = false
-          game_state.clear_aim_queue
-          dance(game_state)
-          # Increment action count so that the script
-          # will eventually progress to next skill to train.
-          game_state.action_taken(99)
-        else
+          abort_attack_aimed(game_state)
+          return
+        when *load_weapon_success
+          # Check if loading a repeating a crossbow because we need to then push ammo into the chamber
+          if Flags['ct-using-repeating-crossbow']
+            case bput("push my #{game_state.weapon_name}", 'A rapid series of clicks', 'You realize readying', 'You attempt to ready your')
+            when 'You attempt to ready your'
+              abort_attack_aimed(game_state)
+              return
+            end
+          end
           game_state.loaded = true
         end
       end
 
       waitrt?
-      unless game_state.selected_maneuver
-        game_state.set_aim_queue
-        aim(game_state)
-        Flags.reset('ct-ranged-ready')
+
+      if game_state.loaded
+        if charged_maneuver
+          use_charged_maneuver(charged_maneuver, game_state)
+          game_state.action_taken
+        else
+          game_state.set_aim_queue
+          aim(game_state)
+          Flags.reset('ct-ranged-ready')
+        end
       end
     end
+  end
+
+  def abort_attack_aimed(game_state)
+    DRC.message("Unable to load #{game_state.weapon_name}, you may be out of ammunition, dancing until can switch to next weapon")
+    game_state.loaded = false
+    game_state.clear_aim_queue
+    dance(game_state)
+    # Increment action count so that the script
+    # will eventually progress to next skill to train.
+    game_state.action_taken(99)
   end
 
   def execute_aiming_action?(action, game_state)
@@ -3178,29 +3204,57 @@ class AttackProcess
   end
 
   def aim(game_state)
-    case bput('aim', 'You begin to target', 'You are already', 'There is nothing else', 'Face what\?', 'You shift your target', 'Your repeating crossbow', 'Your assassin\'s crossbow', 'Your repeating arbalest', 'Strangely, you don\'t feel like fighting right now', 'Your riot crossbow', 'In one frozen moment', "isn't loaded", "You don't have a ranged weapon to aim with")
-    when 'You are already', 'You begin to target'
+    aim_success_messages = [
+      /You are already/,
+      /You begin to target/,
+      /You shift your target/,
+      /In one frozen moment/ # Syamelyo Kuniyo spell effect
+    ]
+
+    repeating_crossbow_messages = [
+      /Your repeating crossbow/,
+      /Your repeating arbalest/,
+      /Your marksman's arbalest/, # lacquered dragonwood marksman's arbalest with a tightly braided steelsilk string
+      /Your assassin's crossbow/, # dull black assassin's repeating crossbow
+      /Your riot crossbow/ # compact ironwood riot crossbow with a yew lath
+    ]
+
+    unloaded_messages = [
+      /isn't loaded/,
+      /You don't have a ranged weapon to aim with/
+    ]
+
+    no_enemy_messages = [
+      /There is nothing else/,
+      /Face what/
+    ]
+
+    wait_and_retry_messages = [
+      /Strangely, you don't feel like fighting right now/
+    ]
+
+    case bput("aim", *aim_success_messages, *repeating_crossbow_messages, *unloaded_messages, *no_enemy_messages, *wait_and_retry_messages)
+    when *aim_success_messages
       game_state.loaded = true
       check_firing_time
-    when 'Your repeating crossbow', 'Your assassin\'s crossbow', 'Your riot crossbow'
-      case bput('push my cross', 'A rapid series of clicks', 'You attempt to ready your repeating crossbow', 'You attempt to ready your assassin\'s crossbow', 'You attempt to ready your riot crossbow','You realize readying')
-      when 'A rapid series of clicks','You realize readying'
+    when *repeating_crossbow_messages
+      # Repeating crossbows require you to load ammo into its storage then push one piece into the chamber.
+      # Multiple bolts can be in the ammunition storage. Only one can be in the chamber at a time for firing.
+      # If we detected that the crossbow doesn't have ammo in the chamber then we need to push one in.
+      case bput("push my #{game_state.weapon_name}", 'A rapid series of clicks', 'You realize readying', 'You attempt to ready your')
+      when 'A rapid series of clicks', 'You realize readying'
+        # Your crossbow's firing chamber now has ammo in it
         aim(game_state)
-      when 'You attempt to ready your repeating crossbow', 'You attempt to ready your assassin\'s crossbow', 'You attempt to ready your riot crossbow', "isn't loaded"
+      when 'You attempt to ready your'
+        # Your crossbow's ammo storage is empty, need to load more
         game_state.loaded = false
       end
-    when 'Your repeating arbalest'
-      case bput('push my arbalest', 'A rapid series of clicks', 'You attempt to ready your repeating arbalest')
-      when 'A rapid series of clicks'
-        aim(game_state)
-      when 'You attempt to ready your repeating arbalest'
-        game_state.loaded = false
-      end
-    when "isn't loaded", "You don't have a ranged weapon to aim with"
-      game_state.loaded = false
-    when 'Face what?'
       game_state.clear_aim_queue
-    when 'Strangely, you don\'t feel like fighting right now'
+    when *unloaded_messages
+      game_state.loaded = false
+    when *no_enemy_messages
+      game_state.clear_aim_queue
+    when *wait_and_retry_messages
       pause 1
       aim(game_state)
     end
@@ -3404,7 +3458,7 @@ class GameState
   $melee_skills = ['Small Edged', 'Large Edged', 'Twohanded Edged', 'Small Blunt', 'Large Blunt', 'Twohanded Blunt', 'Staves', 'Polearms']
   $thrown_skills = ['Heavy Thrown', 'Light Thrown']
   $twohanded_skills = ['Twohanded Edged', 'Twohanded Blunt']
-  $aim_skills = %w[Bow Slings Crossbow]
+  $aim_skills = ['Bow', 'Slings', 'Crossbow']
   $ranged_skills = $thrown_skills + $aim_skills
   $non_dance_skills = $ranged_skills + ['Brawling', 'Offhand Weapon']
   $tactics_actions = %w[bob weave circle]
@@ -4319,6 +4373,7 @@ before_dying do
   Flags.delete('ct-powershot-ammo')
   Flags.delete('ct-ranged-ammo')
   Flags.delete('ct-ranged-loaded')
+  Flags.delete('ct-using-repeating-crossbow')
   Flags.delete('ct-ranged-ready')
   Flags.delete('ct-accuracy-ready')
   Flags.delete('ct-damage-ready')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2843,7 +2843,7 @@ class AttackProcess
     Flags.add('ct-ranged-ammo', "(you (?<action>fire|poach|snipe) an?|your) (?<prefix>[^\.!]*? )?#{ammo_pattern}(?<suffix> [^\.!]*?)?? (at|passes through)")
     Flags.add('ct-powershot-ammo', "With a loud twang, you let fly your #{ammo_pattern}!")
     Flags.add('ct-ranged-loaded', 'You reach into', 'You load', 'You carefully load', 'already loaded', 'in your hand')
-    Flags.add('ct-using-repeating-crossbow', /Your repeating crossbow/i, /Your repeating arbalest/i, /Your marksman's arbalest/i, /Your assassin's crossbow/i, /Your riot crossbow/i, /You .* ammunition chamber/, /already loaded with as much ammunition as it can hold/, /You realize readying more than one/)
+    Flags.add('ct-using-repeating-crossbow', /Your repeating crossbow/i, /Your repeating arbalest/i, /Your marksman's arbalest/i, /Your assassin's crossbow/i, /Your riot crossbow/i, /You .* ammunition (chamber|store)/, /already loaded with as much ammunition as it can hold/, /You realize readying more than one/)
     Flags.add('ct-aim-failed', 'you stop aiming', 'stop concentrating on aiming')
     Flags.add('ct-ranged-ready', 'You think you have your best shot possible now.')
     Flags.add('ct-face-what', 'Face what')
@@ -3100,7 +3100,10 @@ class AttackProcess
         /You load/,
         /You carefully load/,
         /already loaded/,
-        /in your hand/
+        /in your hand/,
+        /A rapid series of clicks/,
+        /into firing position/,
+        /You realize readying/
       ]
 
       load_weapon_failure = [
@@ -3111,7 +3114,11 @@ class AttackProcess
         /Such a feat would be impossible without the winds to guide/,
         /but are unable to draw upon its majesty/,
         /without steadier hands/,
-        /You can not load .* in your left hand/
+        /You can not load .* in your left hand/,
+        /You attempt to ready your/,
+        /Push what?/,
+        /It's best to hold/,
+        /pushing that would have any effect/
       ]
 
       dual_load = game_state.dual_load?
@@ -3148,8 +3155,8 @@ class AttackProcess
         when *load_weapon_success
           # Check if loading a repeating a crossbow because we need to then push ammo into the chamber
           if Flags['ct-using-repeating-crossbow']
-            case bput("push my #{game_state.weapon_name}", 'A rapid series of clicks', 'You realize readying', 'You attempt to ready your')
-            when 'You attempt to ready your'
+            case bput("push my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure)
+            when *load_weapon_failure
               abort_attack_aimed(game_state)
               return
             end
@@ -3211,14 +3218,6 @@ class AttackProcess
       /In one frozen moment/ # Syamelyo Kuniyo spell effect
     ]
 
-    repeating_crossbow_messages = [
-      /Your repeating crossbow/,
-      /Your repeating arbalest/,
-      /Your marksman's arbalest/, # lacquered dragonwood marksman's arbalest with a tightly braided steelsilk string
-      /Your assassin's crossbow/, # dull black assassin's repeating crossbow
-      /Your riot crossbow/ # compact ironwood riot crossbow with a yew lath
-    ]
-
     unloaded_messages = [
       /isn't loaded/,
       /You don't have a ranged weapon to aim with/
@@ -3233,23 +3232,10 @@ class AttackProcess
       /Strangely, you don't feel like fighting right now/
     ]
 
-    case bput("aim", *aim_success_messages, *repeating_crossbow_messages, *unloaded_messages, *no_enemy_messages, *wait_and_retry_messages)
+    case bput("aim", *aim_success_messages, *unloaded_messages, *no_enemy_messages, *wait_and_retry_messages)
     when *aim_success_messages
       game_state.loaded = true
       check_firing_time
-    when *repeating_crossbow_messages
-      # Repeating crossbows require you to load ammo into its storage then push one piece into the chamber.
-      # Multiple bolts can be in the ammunition storage. Only one can be in the chamber at a time for firing.
-      # If we detected that the crossbow doesn't have ammo in the chamber then we need to push one in.
-      case bput("push my #{game_state.weapon_name}", 'A rapid series of clicks', 'You realize readying', 'You attempt to ready your')
-      when 'A rapid series of clicks', 'You realize readying'
-        # Your crossbow's firing chamber now has ammo in it
-        aim(game_state)
-      when 'You attempt to ready your'
-        # Your crossbow's ammo storage is empty, need to load more
-        game_state.loaded = false
-      end
-      game_state.clear_aim_queue
     when *unloaded_messages
       game_state.loaded = false
     when *no_enemy_messages
@@ -3257,6 +3243,8 @@ class AttackProcess
     when *wait_and_retry_messages
       pause 1
       aim(game_state)
+    else
+      game_state.loaded = false
     end
   end
 


### PR DESCRIPTION
### Background
* Required for https://github.com/rpherbig/dr-scripts/pull/5070
* Prior exploration on the topic https://github.com/rpherbig/dr-scripts/pull/4556
* While testing advanced combat maneuvers, came across issue where powershot maneuver was being attempted after aiming (it'll always fail) and other inefficiencies with loading repeating crossbows

### Changes
* Anytime the script switches to another weapon, reset loaded state to false so the next attack command doesn't think you have a loaded weapon in hand (which you won't)
* Don't try to perform the powershot maneuver if you've been aiming, it'll fail with error _"You are unable to focus on performing a maneuver while aiming at an enemy."_. Instead, try immediately after loading the weapon but before you begin to aim.
* When loading a repeating crossbow, go ahead and `push` the ammo into the chamber so it's ready for _either_ doing a powershot maneuver or aiming.
* Consolidate some duplicated logic split across repeating crossbows and repeating arbalests.