### PR TITLE
[script] [scroll-search] support higher ordinals and use of custom_scrolls setting

### DIFF
--- a/scroll-search.lic
+++ b/scroll-search.lic
@@ -11,6 +11,8 @@ class ScrollSearch
   def initialize
     # Variables
     @scroll_nouns = get_data('items').scroll_nouns
+    settings = get_settings
+    @scroll_nouns += settings.custom_scrolls if settings.custom_scrolls
     @global_scroll_index = UserVars.scroll_counter || 0
     @owned_scrolls = UserVars.owned_scrolls || {}
     @scroll_search_debug = UserVars.scroll_search_debug
@@ -77,7 +79,7 @@ class ScrollSearch
       look_scrolls(scroll)
     end
 
-    echo("possibly more than 13 scrolls: #{@too_many.join(', ')}")
+    echo("possibly more than #{$ORDINALS.count} scrolls: #{@too_many.join(', ')}") unless @too_many.count == 0
 
     # Save scrolls to user variables.
     if UserVars.owned_scrolls.nil? && @owned_scrolls.nil?
@@ -143,7 +145,7 @@ class ScrollSearch
   private
 
   def look_scrolls(scroll_type)
-    (0..10).each do |index|
+    (0..$ORDINALS.count).each do |index|
       ordinal = $ORDINALS[index]
 
       case bput("look #{ordinal} #{scroll_type} in my #{@container}", 'It is labeled ".*\."', '.* of the \w*\s*\w* spell.', 'three-dimensional shapes cover much of the', 'You see nothing unusual.', 'I could not find what you were referring to')


### PR DESCRIPTION
- Change script to use for max count the $ORDINALS variable (future proofing in case of increase)
- Don't output about too many scrolls if array is empty
- Support for custom scroll types similar to stack-scrolls