### PR TITLE
[DRAFT] Add spellbook utility and add unleash feature to prepare? method. These will probably be split up.

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1498,7 +1498,7 @@ class Bescort
   def open_gate(shard, entering_ap)
     Flags.reset('gate-failure')
     release_cyclics
-    unless prepare?('mg', 5)
+    unless prepare?(get_settings, 'mg', 5)
       echo 'You may need to move to another room'
       exit
     end

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -137,8 +137,32 @@ module DRCA
     activated
   end
 
-  def prepare?(abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false, runestone_name = nil, runestone_tm = false)
+  def prepare?(settings, abbrev, mana, symbiosis = false, command = 'prepare', tattoo_tm = false, runestone_name = nil, runestone_tm = false, unleash_item = false)
     return false unless abbrev
+
+    # minimum settings to handle unleash items
+    # 1. yaml entry of unleash spells, their items, and containers: unleash: list of spells with parameters: item, container
+    # 2. safety function for unleashing the right scroll by "glance #{unleash.spell.unleash_item} in #{unleash.unleash_container}"
+    # 3. option to integrate spellbook with unleash at that point with like "unleash.spell.is_spellbook = true"
+    # 4. special spellbook logic from this
+    if unleash_item
+      # TODO: This makes me think that any ritual spell should have a manifest with: container, item...
+      # TODO: maybe there should be a helper to get a scroll with a particular read, as well, or at least safety check the read
+      if not DRCI.in_hands?(unleash_item)
+        # TODO: this is not normal, if we can get the logic inside this module, then these items can be used in buff scripts
+        # TODO: however, one excellent case for this is the spellbook, which requires travel, special logic, and more yaml settings
+        # TODO: Spellbook management is not a good fit for this module, but maybe it should be called in this clause
+        echo("*** WARNING: Unleash item management must be handled outside of the cast_spell function.")
+        return false
+      end
+      cast_action = "cast my #{unleash_item}" # nb: ruby doesn't interpolate inside the data payload
+      # TODO: Unleash can be optimized based on the cost of the spell, requires an overhaul to discern logic based on skill+spell
+      # TODO: add a prep action for tattoo from settings
+      unleash_data = {"abbrev" => "unleash", "mana" => 15, "cast" => cast_action}
+      cast_spell(unleash_data, settings)
+      DRC.bput('prepare symbiosis', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
+      return true
+    end
 
     DRC.bput('prepare symbiosis', 'You recall the exact details of the', 'But you\'ve already prepared') if symbiosis
 
@@ -150,7 +174,7 @@ module DRCA
     case match
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
-      return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
+      return prepare?(settings, abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm, unleash_item)
     when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now', 'You have no idea how to cast that spell', 'You have yet to receive any training in the magical arts'
       DRC.bput('release symbiosis', 'You release the', 'But you haven\'t') if symbiosis
       return false
@@ -166,6 +190,13 @@ module DRCA
     match
   end
 
+  # purpose of unleash is to do a normal spell prep with a normal spell payload, but with unleash
+  # unleash requires: item, container, data for unleashed spell, mana (% of scroll spell)
+  # ideally cast_spell should pick it up, but that doesn't seem possible with the state of prep.
+  # the goal is for the spell data to get picked up after the unleash
+  def unleash(spell, settings)
+  end
+
   def ritual(spell, settings)
     DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
     DRC.release_invisibility
@@ -175,7 +206,7 @@ module DRCA
     command = spell['prep'] if spell['prep']
     command = spell['prep_type'] if spell['prep_type']
 
-    return unless prepare?(spell['abbrev'], spell['mana'], spell['symbiosis'], command, spell['tattoo_tm'], spell['runestone_name'], spell['runestone_tm'])
+    return unless prepare?(settings, spell['abbrev'], spell['mana'], spell['symbiosis'], command, spell['tattoo_tm'], spell['runestone_name'], spell['runestone_tm'], data['unleash_item'])
     find_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'], spell['sheathed_focus'])
 
     invoke(spell['focus'], nil, nil)
@@ -619,7 +650,8 @@ module DRCA
 
     cast_lifecycle_lambda.call('pre-prep', data, settings) if cast_lifecycle_lambda != nil
 
-    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
+    return unless prepare?(settings, data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'], data['unleash_item'])
+
     DRCI.put_away_item?(data['runestone_name'], settings.runestone_storage) if DRCI.in_hands?(data['runestone_name'])
     prepare_time = Time.now
 
@@ -793,7 +825,8 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
 
-    prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
+    prepare?(settings, data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'], data['unleash_item'])
+
   end
 
   def crafting_magic_routine(settings)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -206,7 +206,7 @@ module DRCA
     command = spell['prep'] if spell['prep']
     command = spell['prep_type'] if spell['prep_type']
 
-    return unless prepare?(settings, spell['abbrev'], spell['mana'], spell['symbiosis'], command, spell['tattoo_tm'], spell['runestone_name'], spell['runestone_tm'], data['unleash_item'])
+    return unless prepare?(settings, spell['abbrev'], spell['mana'], spell['symbiosis'], command, spell['tattoo_tm'], spell['runestone_name'], spell['runestone_tm'], spell['unleash_item'])
     find_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'], spell['sheathed_focus'])
 
     invoke(spell['focus'], nil, nil)

--- a/spellbook.lic
+++ b/spellbook.lic
@@ -1,0 +1,195 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#spellbook
+
+  # Future
+  This script should probably be a wrapper around casting unleash with certain parameters in common-arcana.
+  Right now it's more of a casting script with a wrapper.
+
+  This script will:
+    1. travel to an indoors room
+      - use go2, but also determine the nearest room or something
+      - start with just a single room configurable in player yaml
+      - this is kind of interesting, because we may want to travel as part of buffwatcher
+    2. safely unleash a sorcery from a spellbook at a certain prep
+      - this is the main module
+      - check that the room is indoors before taking out the spellbook
+        - fail entirely if false
+    3. cast the spell
+      - can we use any arcana/magic common methods/classes/scripts?
+      - harness etc. all apply
+
+  A method for storing your current room before moving, from invoke-rune.lic:
+  def buy_runestone
+    current_room = Room.current.id
+    DRC.wait_for_script_to_complete('restock') unless Script.running?('combat-trainer')
+    DRCT.walk_to(current_room)
+  end
+=end
+
+custom_require.call(%w[common common-arcana common-items events spellmonitor drinfomon equipmanager])
+
+no_kill_all
+
+def junky_titleize(words)
+  return words.split(/ |\_|\-/).map(&:capitalize).join(" ")
+end
+
+class SpellBookManager
+  include DRC
+  include DRCA
+  include DRCI
+
+  def initialize
+
+    arg_definitions = [
+      [
+        { name: 'spellbook_spell', display: 'spellbook spell', regex: /\w+/, variable: true, description: 'Full name of the spellbook spell, wrap in double quotes if this is multiple words.' },
+      ]
+    ]
+    args = parse_args(arg_definitions)
+
+    @settings = get_settings
+    @hometown = @settings.hometown
+
+    @spellbook_case = @settings.spellbook_case
+    @spellbook_name = @settings.spellbook_name
+    @spellbook_scrolls_chapter = @settings.spellbook_scrolls_chapter
+    @spellbook_spell = junky_titleize(args.spellbook_spell)
+    @spellbook_spell_data = get_data("spells").spell_data[@spellbook_spell]
+
+    @unleashed_spell_data = {"abbrev" => @spellbook_spell_data["abbrev"], "unleash_item" => @spellbook_name}
+
+    @equipment_manager = EquipmentManager.new
+
+    main_spellbook
+
+    before_dying do
+      safe_empty_hands
+    end
+  end
+
+  # change this function name and the orientation of the script overall
+  # script is more utility for handling the spellbook, and probably 2nd utility for unleashing a spell once you are on it
+  def main_spellbook
+    safe_get_spellbook
+    open_spellbook_for_casting
+    turn_to_spell_page(find_spell_page)
+    unleash_spellbook(@unleashed_spell_data)
+    store_spellbook
+  end
+
+  def check_indoors
+    indoors_str = "That's a bit hard to do while inside."
+    indoors_portal_str = "You glance outside."
+    weather = bput("weather", indoors_str, indoors_portal_str)
+    if weather == indoors_str or weather == indoors_portal_str
+      return true
+    end
+    return false
+  end
+
+  # this is mainly to help this script fail out
+  def check_holding_spellbook
+    hands = bput("inv held", @spellbook_name, "Both of your hands are empty.", "right hand", "left hand")
+    if hands == @spellbook_name
+      return true
+    end
+    return false
+  end
+
+  def safe_empty_hands
+    if check_holding_spellbook
+      store_spellbook
+    end
+    if check_spellbook_safe
+      @equipment_manager.empty_hands
+    else
+      # should not hit this anymore
+      echo("*** WARNING: Your hands are not in a safe state, please empty your hands and start start over.")
+      safe_exit
+    end
+  end
+
+  def open_and_turn_spellbook_case_to_spellbook
+    bput("open my #{@spellbook_case}", "You open a", "That is already open")
+    bput("turn my #{@spellbook_case} to spellbook", "The compartment of your spellbook case which holds a spellbook is already open.", "You shift the partitions")
+  end
+
+  # TODO: would be nice if this was a wrapper that always did something and put the spellbook away safely.
+  # TODO: this would prevent me from being in an bad state if the script doesn't exit
+  # TODO: and if the script does exit unexpectedly, then before_dying would call the any unhandled exit.
+  def safe_get_spellbook
+    safe_empty_hands
+    open_and_turn_spellbook_case_to_spellbook
+    if check_indoors
+      bput("get my #{@spellbook_name} from my #{@spellbook_case}", "You get")
+    else
+      echo("*** WARNING: You must be indoors! This is very unsafe! Please debug this before using the script again... exiting.")
+      safe_exit
+    end
+  end
+
+  def store_spellbook
+    open_and_turn_spellbook_case_to_spellbook
+    bput("close my #{@spellbook_name}", "You close your", "That is already closed!")
+    tucked_spellbook = bput("put my #{@spellbook_name} in my #{@spellbook_case}", "You tuck")
+    check_spellbook_safe
+    # TODO: verify spellbook case does not need closed
+  end
+
+  def check_spellbook_safe
+    not_found = "I could not find what you were referring to."
+    found = "You tap a"
+    open_and_turn_spellbook_case_to_spellbook
+    result = bput("tap my #{@spellbook_name} in my #{@spellbook_case}", found, not_found)
+    if found == result
+      return true
+    end
+    if not_found == result
+      echo("*** WARNING: SPELLBOOK #{@spellbook_name} NOT FOUND IN #{@spellbook_case}")
+      return false
+    end
+    # TODO: verify spellbook case does not need closed
+  end
+
+  def safe_exit
+    if check_holding_spellbook
+      store_spellbook
+    end
+    exit
+  end
+
+  def open_spellbook_for_casting
+    already_open = "That is already open!"
+    opening_spellbook = bput("open my #{@spellbook_name}", "You open a", already_open)
+    if opening_spellbook = already_open
+      bput("turn my #{@spellbook_name} to contents", "You flip back", "The spellbook is already opened to the table of contents.")
+    end
+
+    bput("turn my #{@spellbook_name} to chapter #{@spellbook_scrolls_chapter}", "You turn the")
+  end
+
+  def find_spell_page
+    # TODO: consider trying this 3+ times
+    bput("read my #{@spellbook_name}", "spellbook reads")
+    page_line = matchtimeout 5, @spellbook_spell
+    if not page_line:
+      echo("*** WARNING: The spell is not in your spellbook. Did it get erased?")
+      safe_exit
+    end
+    # ref: Page 4.......Iron Constitution
+    page_number = page_line[/\d+/]  # get first decimal substring
+    return page_number
+  end
+
+  # TODO NB: It is not necessary to read the spellbook to unleash it.
+  def turn_to_spell_page(page_number)
+    bput("turn my #{@spellbook_name} to page #{page_number}", "You turn to page", "is already open to page")
+  end
+
+  def unleash_spellbook(data)
+    cast_spell(data, @settings)
+  end
+end
+
+SpellBookManager.new

--- a/spellbook.lic
+++ b/spellbook.lic
@@ -71,6 +71,7 @@ class SpellBookManager
   # change this function name and the orientation of the script overall
   # script is more utility for handling the spellbook, and probably 2nd utility for unleashing a spell once you are on it
   def main_spellbook
+    wait_for_script_to_complete('go2', [@settings.spellbook_safe_room] )
     safe_get_spellbook
     open_spellbook_for_casting
     turn_to_spell_page(find_spell_page)
@@ -173,7 +174,7 @@ class SpellBookManager
     # TODO: consider trying this 3+ times
     bput("read my #{@spellbook_name}", "spellbook reads")
     page_line = matchtimeout 5, @spellbook_spell
-    if not page_line:
+    if not page_line
       echo("*** WARNING: The spell is not in your spellbook. Did it get erased?")
       safe_exit
     end


### PR DESCRIPTION
Clean up some rough edges and split up this PR.

1. Determine how to add a yaml for unleash:

```
buffs:
  prehunt_buffs:
    Sentinel's Resolve:
      abbrev: sr
      recast: 2
      cambrinth:
        - 20
      unleash_item: flame-hued scroll  # need safety 'glance scroll' match for Sentinel's Resolve
      unleash_container: spidersilk pouch
      # or
      unleash_item: diamondwood spellbook
      unleash_container: spellbook case
      unleash_mana: 15
```

2. Update unleash logic so that it is more context free. Today the standard is that you can cast_spell() and common-arcana.lic will do everything for you, and that means item handling. So we will need to do item handling and spellbook handling inside the unleash context.  For spellbook users, this will add ;go2 to their waggle_sets and a `spellbook_safe_room` yaml variable. Spellbooks cannot get wet, so it's better to not reuse any other rooms that could be outdoors.

3. Add unleash tattoo logic (see other tattoo logic and just update the data map.
4. probably just pass `data` into prepare?
  - A very long laundry list of data properties are now being passed and it makes more sense just to give prepare? the payload.

5. spellbook: allow specifying more parameters as arguments for one-offs or script-based usage (but still prefer waggle sets).