### PR TITLE
[script] [combat-trainer] Exclude mainhand weapon when equipping offhand

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4384,7 +4384,7 @@ class GameState
     options -= $twohanded_skills # can't be a twohanded skill, you need both hands
     options -= $aim_skills # can't use aimable weapons in your offhand
     options -= $martial_skills # shouldn't be brawling, you need a weapon in your offhand
-    echo "determine_doublestrike_skill::options(a): #{options}" if $debug_mode_ct
+    echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
     options -= weapon_training.select { |skill, weapon| weapon == weapon_training[weapon_skill] }.keys # can't be same weapon that's equipped in your mainhand
     sort_by_rate_then_rank(options).first
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4367,10 +4367,12 @@ class GameState
   # Determine the weapon skill to train offhand while aiming a ranged weapon.
   def determine_aiming_skill
     options = @aiming_trainables
-    options -= [weapon_skill] # can't be your mainhand skill
-    options -= $twohanded_skills # can't be a twohanded skill
-    options -= $melee_skills if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow)
+    options -= [weapon_skill] # can't be your mainhand skill, it's in your main hand
+    options -= $twohanded_skills # can't be a twohanded skill, you need both hands
+    options -= $aim_skills # can't use aimable weapons in your offhand
+    options -= $melee_skills if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow) # can't aim with weapon in your offhand
     options -= $thrown_skills if (weapon_skill.eql?('Bow') && @left_hand_free)
+    options -= weapon_training.select { |skill, weapon| weapon == weapon_training[weapon_skill] }.keys # can't be same weapon that's equipped in your mainhand
     echo "determine_aiming_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
   end
@@ -4380,8 +4382,10 @@ class GameState
     options = @aiming_trainables
     options -= [weapon_skill] # can't be your main hand skill, it's in your main hand
     options -= $twohanded_skills # can't be a twohanded skill, you need both hands
+    options -= $aim_skills # can't use aimable weapons in your offhand
     options -= $martial_skills # shouldn't be brawling, you need a weapon in your offhand
-    echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
+    echo "determine_doublestrike_skill::options(a): #{options}" if $debug_mode_ct
+    options -= weapon_training.select { |skill, weapon| weapon == weapon_training[weapon_skill] }.keys # can't be same weapon that's equipped in your mainhand
     sort_by_rate_then_rank(options).first
   end
 
@@ -4391,7 +4395,10 @@ class GameState
   # If the main hand weapon skill is doublestrikable then `determine_doublestrike_skill`
   # is used to determine what to equip offhand to perform the maneuver.
   def doublestrikable_weapon_skill?
-    @doublestrike_trainables.include?(weapon_skill) && (melee_weapon_skill? || thrown_skill?) && !twohanded_weapon_skill?
+    @doublestrike_trainables.include?(weapon_skill) && # mainhand weapon is listed for doublestrikes
+    (melee_weapon_skill? || thrown_skill?) && # mainhand weapon is a one-handed, melee weapon
+    !twohanded_weapon_skill? && # mainhand weapon is not a twohanded weapon (extra precaution)
+    determine_doublestrike_skill # there's at least one weapon skill that can be equipped offhand that's different from the mainhand (can't equip same weapon in both hands)
   end
 
   def use_stealth?


### PR DESCRIPTION
### Background
* Reported by [Tekhelet](https://discord.com/channels/745675889622384681/745678330933805157/864222634840948757) in the Lich discord
* When picking a weapon to equip offhand for aiming or doublestrike, it's possible to try and wield the already mainhand equipped weapon if that weapon is used for multiple skills (e.g. using a light spear for both Heavy Thrown and Polearms)
* Since you can't equip the same single item in both hands, this confuses combat-trainer

### Changes
* When choosing a skill to equip offhand, exclude skills that use the same weapon as the currently equipped mainhand skill
* Exclude aiming skills (Slings, Bows, Crossbow) from eligible skills to equip offhand (just in case someone misconfigures their yaml)

### Example
In the following config, if you were training Polearms, the script would try to equip your Heavy Thrown weapon in your offhand to perform a doublestrike. Since both skills use the same weapon, combat-trainer would bork trying to wield offhand the weapon that's already in your mainhand.
```yaml
weapon_training:
  Heavy Thrown: light spear
  Polearms: light spear

doublestrike_trainables:
  - Polearms

aiming_trainables:
  - Heavy Thrown
```