### PR TITLE
[script] [combat-trainer] "Battle Cries" for Bardic Screams and Barbarian Roars

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1963,6 +1963,15 @@ class AbilityProcess
     @kneel_khri = settings.kneel_khri
     echo("  @kneel_khri: #{@kneel_khri}") if $debug_mode_ct
 
+    @battle_cries = settings.battle_cries
+    echo("  @battle_cries: #{@battle_cries}") if $debug_mode_ct
+
+    @battle_cry_cycle = settings.battle_cry_cycle || @battle_cries.map { |battle_cry| battle_cry['name'] }
+    echo("  @battle_cry_cycle: #{@battle_cry_cycle}") if $debug_mode_ct
+
+    @battle_cry_cooldown = settings.battle_cry_cooldown
+    echo("  @battle_cry_cooldown: #{@battle_cry_cooldown}") if $debug_mode_ct
+
     @barb_buffs = @buffs.delete('barb_buffs') || []
     echo("  @barb_buffs: #{@barb_buffs}") if $debug_mode_ct
 
@@ -1973,6 +1982,7 @@ class AbilityProcess
     echo("  @meditation_pause_timer: #{@meditation_pause_timer}") if $debug_mode_ct
 
     setup_barb_buff_flags
+    Flags.add('ct-battle-cry-not-facing', 'You are not facing an enemy')
 
     @paladin_use_badge = settings.paladin_use_badge
     echo("  @paladin_use_badge: #{@paladin_use_badge}") if $debug_mode_ct
@@ -2003,6 +2013,7 @@ class AbilityProcess
   def execute(game_state)
     check_paladin_skills
     check_nonspell_buffs(game_state)
+    check_battle_cries(game_state)
     false
   end
 
@@ -2100,6 +2111,50 @@ class AbilityProcess
           echo "Did not activate barb_buff #{name}" if $debug_mode_ct
         end
       end
+    end
+
+  def check_battle_cries(game_state)
+    timer = game_state.cooldown_timers['Battle Cry']
+    return unless !timer || (Time.now - timer).to_i > @battle_cry_cooldown
+    return unless game_state.npcs.length > 0
+
+    Flags.reset('ct-battle-cry-not-facing')
+
+    battle_cries = @battle_cries
+      .select { |battle_cry| battle_cry['target_enemy'] ? game_state.npcs.include?(battle_cry['target_enemy']) : true }
+      .select { |battle_cry| battle_cry['min_threshold'] ? game_state.npcs.length >= battle_cry['min_threshold'] : true }
+      .select { |battle_cry| battle_cry['max_threshold'] ? game_state.npcs.length <= battle_cry['max_threshold'] : true }
+
+    # Of the ready battle cries, find the next best one according to the preferred cycle
+    battle_cry_name = @battle_cry_cycle.find { |next_cry| battle_cries.find { |ready_cry| ready_cry['name'] == next_cry } }
+
+    # Get the details about the selected battle cry
+    battle_cry_data = battle_cries.find { |battle_cry| battle_cry['name'] == battle_cry_name }
+
+    if battle_cry_data
+      echo "Selected battle cry: #{battle_cry_data}" if $debug_mode_ct
+      command = battle_cry_data['command']
+      command = (command + " at " + battle_cry_data['target_enemy']) if battle_cry_data['target_enemy']
+      fput(command)
+      pause
+      waitrt?
+      if Flags['ct-battle-cry-not-facing']
+        # Oops, you're not actually facing an enemy to roar/scream at
+        case DRC.bput('face next', 'You turn', 'There is nothing else to face')
+        when 'You turn'
+          # Let's try that again...
+          check_battle_cries(game_state)
+        else
+          # Nothing to roar/scream at, maybe next time
+          return
+        end
+      else
+        game_state.cooldown_timers['Battle Cry'] = Time.now
+        @battle_cry_cycle.rotate!
+      end
+    else
+      echo "No battle cries met criteria" if $debug_mode_ct
+    end
   end
 end
 
@@ -4516,6 +4571,7 @@ before_dying do
   Flags.delete('ct-shock-warning')
   Flags.delete('ct-maneuver-cooldown-reduced')
   Flags.delete('ct-attack-out-of-range')
+  Flags.delete('ct-battle-cry-not-facing')
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -410,6 +410,55 @@ barb_abilities:
     activated_message: ^You .* to meditate
     expired_message: Focus meditation slips away from your mind
 
+# Barbarian Roars and Bardic Screams
+# https://elanthipedia.play.net/Category:Roars
+# https://elanthipedia.play.net/Bardic_scream
+battle_cries:
+  # Bardic Screams
+  Concussive:
+    type: scream
+    command: scream concussive
+  Havoc:
+    type: scream
+    command: scream havoc
+  Defiance:
+    type: scream
+    command: scream defiance
+  # Barbarian Roars
+  Anger the Earth:
+    type: roar
+    command: roar anger
+  Death's Embrace:
+    type: roar
+    command: roar embrace
+  Death's Shriek:
+    type: roar
+    command: roar shriek
+  Everild's Rage:
+    type: roar
+    command: roar rage
+  Kuniyo's Strike:
+    type: roar
+    command: roar strike
+  Mage's Lash:
+    type: roar
+    command: roar lash
+  Mana Torment:
+    type: roar
+    command: roar mana
+  Screech of Madness:
+    type: roar
+    command: roar screech
+  Serpent's Hiss:
+    type: roar
+    command: roar hiss
+  Slash the Shadows:
+    type: roar
+    command: roar slash
+  Wail of Torment:
+    type: roar
+    command: roar wail
+
 spell_data:
   Abandoned Heart:
     skill: Targeted Magic

--- a/dependency.lic
+++ b/dependency.lic
@@ -886,6 +886,9 @@ class SetupFiles
     scrolls = base_items[:scroll_nouns]
     s.lootables = (base_lootables + boxes + gems + scrolls + s.loot_additions - s.loot_subtractions).uniq
 
+    battle_cries = @base_files['base-spells.yaml'][:battle_cries]
+    s.battle_cries.map! { |battle_cry| battle_cries[battle_cry['name']] ? battle_cries[battle_cry['name']].merge(battle_cry) : battle_cry }
+
     spells = @base_files['base-spells.yaml'][:spell_data]
     s.offensive_spells.map! { |spell| spells[spell['name']] ? spells[spell['name']].merge(spell) : spell }
 
@@ -1338,7 +1341,7 @@ def validate_supported_ruby_version
   end
 
   # Set next check time to 7 days from now
-  Settings['next_ruby_version_check_datetime'] = Time.now + (60 * 60 * 24 * 7) 
+  Settings['next_ruby_version_check_datetime'] = Time.now + (60 * 60 * 24 * 7)
 end
 
 def remove_from_autostart(scripts)

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -106,3 +106,5 @@ empty_values:
   sell_loot_ignored_metals_and_stones: []
   esp_channels: []
   doublestrike_trainables: []
+  battle_cries: []
+  battle_cry_cycle: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -109,6 +109,25 @@ doublestrike_trainables:
   - Large Blunt
   # - Staves
   # - Polearms
+
+# Barbarian Roars or Bardic Screams to use in combat at enemies.
+# A battle cry will be chosen from this list in sequential order unless overridden by `battle_cry_cycle`.
+# You can refine criteria for when and what to roar/scream, similar to configuring `offensive_spells`.
+# == Options
+#   target_enemy: optional name of critter to roar/scream at, default is who you're facing/engaged
+#   min_threshold: optional, number of critters that must be in room before use this ability, default 1
+#   max_threshold: optional, number of critters that above which you won't use this ability, default infinity
+#   command: optional, customize the exact phrase to perform the scream/roar
+battle_cries:
+# The script will cycle through roaring/screaming in this order.
+# By default, you'll roar/scream in a round-robin order as defined
+# in `battle_cries:`. Use this optional setting to further
+# refine the specific order you'd like to roar/scream in.
+# Most useful if you have multiple screams/roars to use.
+battle_cry_cycle:
+# The number of seconds to wait between battle cries.
+battle_cry_cooldown: 90
+
 # Defines the number of monsters you will keep in combat with you by performing 'dance actions' or attacking with only 'harmless: true' spells. 0 means kill everything.
 dance_threshold: 0
 # What weapon skill to use while dancing


### PR DESCRIPTION
### Background
* combat-trainer does not have a built-in robust way for Bards or Barbarians to train with their screams/roars
* The workaround is to use `buff_nonspells` and define a single scream/roar to do on a periodic cycle, or Bards can specify `Scream` in their `training_abilities` to always do  `scream concussive` (despite having other screams available to them)

### Changes
* Inspired by `offensive_spells` and `offensive_spell_cycle` settings, introducing `battle_cries` and `battle_cry_cycle` to let Bards and Barbarians specify one or more screams/roars they'd like performed, in a particular order, with options to customize when/who to scream/roar at (e.g. do X if at least 2 NPCs, do Y if this specific monster is in the room, etc)

### Old Configuration
```yaml
buff_nonspells:
  roar anger: 90 # train debil by roaring

training_abilities:
  Scream: 90 # train bardic lore by screaming concussive
```

### New Configuration
```yaml
# Barbarian Roars or Bardic Screams to use in combat at enemies.
# A battle cry will be chosen from this list in sequential order unless overridden by `battle_cry_cycle`.
# You can refine criteria for when and what to roar/scream, similar to configuring `offensive_spells`.
# == Options
#   target_enemy: optional name of critter to roar/scream at, default is who you're facing/engaged
#   min_threshold: optional, number of critters that must be in room before use this ability, default 1
#   max_threshold: optional, number of critters that above which you won't use this ability, default infinity
#   command: optional, customize the exact phrase to perform the scream/roar
battle_cries:
  - name: Anger the Earth
  - name: Screech of Madness
  - name: Wail of Torment
    command: roar area wail
  - name: Serpent's Hiss
    target_enemy: Medusa

# The script will cycle through roaring/screaming in this order.
# By default, you'll roar/scream in a round-robin order as defined
# in `battle_cries:`. Use this optional setting to further
# refine the specific order you'd like to roar/scream in.
# Most useful if you have multiple screams/roars to use.
battle_cry_cycle:
  - Anger the Earth
  - Screech of Madness
  - Wail of Torment
  - Screech of Madness
  - Serpent's Hiss

# The number of seconds to wait between battle cries.
# Set a value so as not to exhaust your bardic mojo or barbarian voice.
battle_cry_cooldown: 90
```