### PR TITLE
[script] [echo] Code style only changes to match spellmonitor's convention

### DIFF
--- a/echo.lic
+++ b/echo.lic
@@ -4,15 +4,19 @@
 
 echo_action = proc do |server_string|
   open('echo_log_room.txt', 'a') do |f|
-    f.puts server_string
+    f.puts(server_string)
   end
   server_string
 end
+
+DownstreamHook.remove('echo_action')
 DownstreamHook.add('echo_action', echo_action)
 
-before_dying { DownstreamHook.remove('echo_action') }
+before_dying do
+  DownstreamHook.remove('echo_action')
+end
 
-loop do
-  pause 10
-  clear
+until script.gets.nil?
+  # Keep script alive while game is connected
+  # so that we continue to receive and parse data.
 end


### PR DESCRIPTION
### Changes
* parens around arguments
* comments about infinite loop
* `before_dying` is a `do/end` block
* remove hook when script starts