### PR TITLE
[script] [common-items] Use canonical model DRCI::Item to get name/regex

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -356,13 +356,7 @@ module DRCI
   # Hand options are: left, right, either, both.
   def in_hand?(item, which_hand = 'either')
     return false unless item
-    if item.is_a?(String)
-      if item.split.size > 1
-        item = DRC::Item.new(adjective: item.split.first, name: item.split.last)
-      else
-        item = DRC::Item.new(name: item)
-      end
-    end
+    item = DRC::Item.from_text(item) if item.is_a?(String)
     case which_hand.downcase
     when 'left'
       DRC.left_hand =~ item.short_regex
@@ -382,10 +376,12 @@ module DRCI
     return false unless item
 
     item = item.delete_prefix('my ')
+    item = DRC::Item.from_text(item) if item.is_a?(String)
+
     preposition = 'in my' if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
 
-    case DRC.bput("look at my #{item} #{preposition} #{container}", "#{item}", 'You see nothing unusual', 'I could not find', 'What were you referring to')
-    when 'You see nothing unusual', "#{item}"
+    case DRC.bput("look at my #{item.short_name} #{preposition} #{container}", item.short_regex, 'You see nothing unusual', 'I could not find', 'What were you referring to')
+    when 'You see nothing unusual', item.short_regex
       true
     else
       false
@@ -431,10 +427,11 @@ module DRCI
   end
 
   def count_items_in_container(item, container)
-    contents = DRC.bput("rummage /C #{item.split.last} IN MY #{container}", '^You rummage .*', 'That would accomplish nothing')
+    item = DRC::Item.from_text(item) if item.is_a?(String)
+    contents = DRC.bput("rummage /C #{item.name} IN MY #{container}", '^You rummage .*', 'That would accomplish nothing')
     # This regexp avoids counting the quoted item name in the message, as
     # well as avoiding finding the item as a substring of other items.
-    contents.scan(/ #{item}\W/).size
+    contents.scan(/ #{item.short_regex}\W/).size
   end
 
   def count_lockpick_container(container)
@@ -569,8 +566,9 @@ module DRCI
 
   # Removes an item you're wearing.
   def remove_item_unsafe?(item)
-    case DRC.bput("remove #{item}", /You .*#{item}/i, @@remove_item_success_patterns, @@remove_item_failure_patterns)
-    when /You .*#{item}/i, *@@remove_item_success_patterns
+    item = DRC::Item.from_text(item) if item.is_a?(String)
+    case DRC.bput("remove #{item.short_name}", /You .*#{item.short_regex}/i, @@remove_item_success_patterns, @@remove_item_failure_patterns)
+    when /You .*#{item.short_regex}/i, *@@remove_item_success_patterns
       return true
     else
       return false
@@ -617,8 +615,8 @@ module DRCI
   # Determines which hand is holding the item then lowers it to your feet slot.
   def lower_item?(item)
     return false unless in_hands?(item)
-    item_regex = /\b#{item}\b/
-    hand = (DRC.left_hand =~ item_regex) ? 'left' : 'right'
+    item = DRC::Item.from_text(item) if item.is_a?(String)
+    hand = (DRC.left_hand =~ item.short_regex) ? 'left' : 'right'
     DRC.bput("lower ground #{hand}", "You lower", "But you aren't holding anything") =~ /You lower/
   end
 


### PR DESCRIPTION
### Background
* Continuation of https://github.com/rpherbig/dr-scripts/pull/5041
* Some methods in `common-items` were on their own trying to determine the name or noun of an item, or create a regex pattern for it. The success rate depended significantly on how complete one's yaml configuration was when specifying the items.

### Changes
* Use the new `DRCI::Item.from_text(string)` method to convert a string argument into an `Item` class instance.
* Reuse the logic in `Item` class for `name`, `short_name`, and `short_regex` for consistency