### PR TITLE
[script] [discern] Consolidate duplicated code

### DIFF
--- a/discern.lic
+++ b/discern.lic
@@ -7,6 +7,16 @@ custom_require.call(%w[common-arcana])
 class Discern
 
   def initialize
+    arg_definitions = [
+      [
+        { name: 'reset', regex: /^reset$/i, optional: true, description: 'Delete existing discern data and re-discern spells.' },
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
+
+    UserVars.discerns = {} if args.reset
+
     settings = get_settings
 
     spells = []

--- a/discern.lic
+++ b/discern.lic
@@ -1,43 +1,32 @@
 =begin
-  Documentation: https://elanthipedia.play.net/Lich_script_repository#Discern
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#discern
 =end
 
-custom_require.call(%w[common common-travel events spellmonitor drinfomon])
+custom_require.call(%w[common-arcana])
 
 class Discern
-  include DRC
-  include DRCA
 
   def initialize
     settings = get_settings
-    echo 'Reading spell list'
 
-    settings.buff_spells
-            .each_value do |value|
-              next unless value['use_auto_mana']
-              abbrev = value['abbrev']
-              echo "Discerning: '#{abbrev}'"
-              check_discern(value, settings)
-              echo " Current Discern data valid until '#{UserVars.discerns[abbrev]['time_stamp'] + 24 * 60 * 60}'"
-            end
-    settings.offensive_spells
-            .select { |x| x['use_auto_mana'] }
-            .each do |x|
-              abbrev = x['abbrev']
-              echo "Discerning: '#{abbrev}'"
-              check_discern(x, settings)
-              echo " Current Discern data valid until '#{UserVars.discerns[abbrev]['time_stamp'] + 24 * 60 * 60}'"
-            end
+    spells = []
+    spells << settings.offensive_spells
+    spells << settings.buff_spells.values
+    spells << settings.combat_spell_training.values
+    spells << settings.training_spells.values
+    spells << settings.crafting_training_spells.values
+    spells << settings.waggle_sets.values.map(&:values)
+    spells.flatten!
 
-    settings.training_spells
-            .each_value do |value|
-              next unless value['use_auto_mana']
-              abbrev = value['abbrev']
-              echo "Discerning: '#{abbrev}'"
-              check_discern(value, settings)
-              echo " Current Discern data valid until '#{UserVars.discerns[abbrev]['time_stamp'] + 24 * 60 * 60}'"
-            end
+    discern_spells(spells, settings)
   end
+
+  def discern_spells(spells, settings)
+    spells
+      .select { |spell| spell['use_auto_mana'] }
+      .each { |spell| DRCA.check_discern(spell, settings) }
+  end
+
 end
 
 Discern.new


### PR DESCRIPTION
### Background
* Stumbled upon this script. I _think_ people might use it to pre-discern their spells so they aren't discerning in combat??
* In either case, it exists, and it could use some TLC

### Changes
* Consolidate repetitive code
* Add support for waggle_sets and crafting_training_spells
* Add argument to reset and recompute discern data

### Notes
* The list of spells does not have to be de-duped, the `DRCA.discern` method skips spells that it's already computed discern data for