### PR TITLE
[script] [combat-trainer] Handle when fail powershot maneuver because you were aiming

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3400,7 +3400,9 @@ class AttackProcess
       /^This works best when you use a suitable weapon/,
       /^This works best when you are dual wielding suitable weapons/,
       # Maneuver requires a weapon but you're not wielding any
-      /^With your fist?  That might hurt/
+      /^With your fist?  That might hurt/,
+      # You can't aim before powershot maneuver
+      /^You are unable to focus on performing a maneuver while aiming at an enemy/
     ]
 
     attempt = bput("maneuver #{action}", *maneuver_success_messages, *maneuver_failure_messages)


### PR DESCRIPTION
### Background
* The powershot maneuver can't be performed if you're aiming
* You can fall into this scenario if the creature you were aiming at dies then you go back through the load weapon routine

```
[combat-trainer]>aim
You begin to target a dire bear.

(you cast spell or attack offhand or something)
A dire bear growls one last time and collapses.
Roundtime: 1 sec.

[combat-trainer]>loot
You search the dire bear.
You find nothing of interest.

[combat-trainer]>load
Your battle stonebow is already loaded with a Sunderstone shard.

[combat-trainer]>maneuver powershot
You are unable to focus on performing a maneuver while aiming at an enemy.

A dire bear rots away into nothingness.

You think you have your best shot possible now.

[combat-trainer: *** No match was found after 15 seconds, dumping info]
...
[combat-trainer: for command maneuver powershot]

[combat-trainer]>aim
You turn to face a dire bear.
You shift your target to a dire bear.

[combat-trainer]>shoot
< Moving in gracefully, you fire a Sunderstone shard at a dire bear.  A dire bear fails to evade, moving almost completely out of harm's reach.  
The shard lands a heavy strike that thumps painfully on the toes of the left foot.
The Sunderstone shard falls to the ground!
[You're solidly balanced with opponent in very strong position.]
[Roundtime 1 sec.]
```

### Changes
* Add match string for when powershot fails because you were aiming; combat-trainer will fallback to performing a normal shot (it does fall back to this already, we're just getting rid of the "no match found after 15 seconds" message)