### PR TITLE
[scripts] [common dependency validate] Enhance DRC.message functionality

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -716,7 +716,9 @@ module DRC
 
   def message(text, severity = 'none')
     # legacy message format - not customizable
-    if severity == 'none'
+    # frostbite doesn't suppot extra user defined or system generated windows as of at least 1.12.0b
+    # also allow user selectable legacy mode  (current default)
+    if severity == 'none' || $frontend == 'frostbite' || $LEGACY_DRC_MESSAGE
       clean_text = clean_xml(text)
       string = ''
       $fake_stormfront ? string.concat("\034GSL\r\n ") : string.concat("<pushBold\/>")
@@ -732,7 +734,7 @@ module DRC
     else
       # variables have been cleared for some reason, try reloading
       if UserVars.message_extensions['severities'] == nil || UserVars.message_extensions['severities'].empty?()
-        reload_message_formats
+        reload_message_extensions
         if UserVars.message_extensions['severities'] == nil || UserVars.message_extensions['severities'].empty?()
           # if those are still failing fall back to legacy
           message(text,'none') 
@@ -770,6 +772,8 @@ module DRC
         if $frontend == 'genie'   #fix genie monsterbold
           str1 = str1 + "<pushBold/>" + clean_message
           str2 = "<popBold/>" + str2
+        elsif $frontend == 'profanity'  # profanity hack
+          str1 = str1 + "<pushBold/>" + clean_message + "<popBold/>"
         else
           str1 = str1 + "<preset id='bold'>" + clean_message + "</preset>"
         end

--- a/common.lic
+++ b/common.lic
@@ -714,17 +714,78 @@ module DRC
     DRC.bput("stance set #{stance}", /Setting your/)
   end
 
-  def message(text)
-    string = ''
-    $fake_stormfront ? string.concat("\034GSL\r\n ") : string.concat("<pushBold\/>")
-    string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
-    if text.index('\n')
-      text.split('\n').each { |line| string.concat("| #{line}") }
+  def message(text, severity = 'none')
+    # legacy message format - not customizable
+    if severity == 'none'
+      clean_text = clean_xml(text)
+      string = ''
+      $fake_stormfront ? string.concat("\034GSL\r\n ") : string.concat("<pushBold\/>")
+      string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
+      if clean_text.index("\n")
+        clean_text.split("\n").each { |line| string.concat("\n| #{line}") }
+      else
+        string.concat('| ' + clean_text)
+      end
+      string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
+      $fake_stormfront ? string.concat("\034GSM\r\n ") : string.concat("<popBold\/>")
+      _respond string
     else
-      string.concat('| ' + text)
+      # variables have been cleared for some reason, try reloading
+      if UserVars.message_extensions['severities'] == nil || UserVars.message_extensions['severities'].empty?()
+        reload_message_formats
+        if UserVars.message_extensions['severities'] == nil || UserVars.message_extensions['severities'].empty?()
+          # if those are still failing fall back to legacy
+          message(text,'none') 
+          return
+        end
+      end
+
+      # get window and highlight data
+      window = nil
+      highlight = nil
+      if UserVars.message_extensions['severities'].has_key?(severity)
+        window = UserVars.message_extensions['severities'][severity][:window]
+        highlight = UserVars.message_extensions['severities'][severity][:highlight]
+      elsif UserVars.message_extensions['severities'].has_key?('info')
+        window = UserVars.message_extensions['severities']['info'][:window]
+        highlight = UserVars.message_extensions['severities']['info'][:highlight]
+      end
+      # catch if not set (bad settings)
+      window = 'main' if window == nil
+      highlight = 'bold' if highlight == nil
+
+      # build message output
+      clean_message = clean_xml(text)
+      if window != 'main'
+        str1 = "<pushStream id=\"#{window}\"/>"
+        str2 = "<popStream/>"
+      else
+        str1 = "<pushStream/>"
+        str2 = "<popStream/>"
+      end
+      case highlight
+      when 'normal'
+        str1 = str1 + clean_message
+      when 'bold','monsterbold'
+        if $frontend == 'genie'   #fix genie monsterbold
+          str1 = str1 + "<pushBold/>" + clean_message
+          str2 = "<popBold/>" + str2
+        else
+          str1 = str1 + "<preset id='bold'>" + clean_message + "</preset>"
+        end
+      else
+        str1 = str1 + "<preset id='#{highlight}'>" + clean_message + "</preset>"
+      end
+      str2 = str2 + "<prompt time =\"#{Time.now.to_i}\">&gt;</prompt>"
+      _respond(str1,str2)
     end
-    string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
-    $fake_stormfront ? string.concat("\034GSM\r\n ") : string.concat("<popBold\/>")
-    _respond string
+  end
+
+  # Ensures xml special characters are properly escaped in prep for injection to DRs 'XML' stream
+  def clean_xml(text)
+    text.gsub!("&","&amp;") # this MUST ALWAYS be first as other escape sequences uses &
+    text.gsub!("<","&lt;")
+    text.gsub!(">","&gt;")
+    return text 
   end
 end

--- a/data/base-message-extensions.yaml
+++ b/data/base-message-extensions.yaml
@@ -1,0 +1,27 @@
+--- 
+## stores minimum settings for use in DRC.message custom windows and highlighitng options
+## these settings can be overridden and/or added to using custom_message_windows: and custom_message_severities:
+
+base_message_windows:
+  log:                        # required - window id 
+    :title: Log               # optional - default: capitalization case of window id
+    :location: center         # optional - default: center, [left,center,right]
+    :styleIfClosed: ''        # optional - default: '', [select from presets - roomName, bold, monsterbold, speech, whisper, thought, watching, link, selectedLink, command, normal]
+    :windowIfClosed: main     # optional - default: '', window id of where to send text if this window is closed
+    :timestamp: true          # optional - default: true, use timestampes on this window
+
+## supported highlights are based off of the presets from the game: 
+## roomName bold monsterbold speech whisper thought watching link selectedLink command none normal
+base_message_severities:
+  info:
+    :window: log
+    :highlight: none
+  warning:
+    :window: log
+    :highlight: bold
+  severe:
+    :window: log
+    :highlight: speech
+  fatal:
+    :window: log
+    :highlight: whisper

--- a/dependency.lic
+++ b/dependency.lic
@@ -907,11 +907,8 @@ class SetupFiles
     return if !self.loaded?
     # merge user settings, but don't wipe out min required settings
     UserVars.message_extensions = {}
-    UserVars.message_extensions['windows'] = @base_files['base-message-extensions.yaml'][:base_message_windows]
-    UserVars.message_extensions['windows'].merge!(@settings.custom_message_windows) unless @settings.custom_message_windows == nil
-
-    UserVars.message_extensions['severities'] = @base_files['base-message-extensions.yaml'][:base_message_severities]
-    UserVars.message_extensions['severities'].merge!(@settings.custom_message_severities) unless @settings.custom_message_severities == nil
+    UserVars.message_extensions['windows'] = @base_files['base-message-extensions.yaml'][:base_message_windows].merge(@settings.custom_message_windows)
+    UserVars.message_extensions['severities'] = @base_files['base-message-extensions.yaml'][:base_message_severities].merge(@settings.custom_message_severities)
 
     $LEGACY_DRC_MESSAGE ||= @settings.legacy_drc_message 
 

--- a/dependency.lic
+++ b/dependency.lic
@@ -11,6 +11,7 @@ require 'digest/sha1'
 
 $DEPENDENCY_VERSION = '1.3'
 $MIN_RUBY_VERSION = '2.5.5'
+$LEGACY_DRC_MESSAGE = true
 
 no_pause_all
 no_kill_all
@@ -906,8 +907,13 @@ class SetupFiles
     return if !self.loaded?
     # merge user settings, but don't wipe out min required settings
     UserVars.message_extensions = {}
-    UserVars.message_extensions['windows'] = @settings.base_message_extension['windows'].merge(@settings.custom_message_extension['windows'])
-    UserVars.message_extensions['severities'] = @settings.base_message_extension['severities'].merge(@settings.custom_message_extension['severities'])
+    UserVars.message_extensions['windows'] = @settings.base_message_extension['windows']
+    UserVars.message_extensions['windows'].merge!(@settings.custom_message_extension['windows']) unless @settings.custom_message_extension['windows'] == nil
+
+    UserVars.message_extensions['severities'] = @settings.base_message_extension['severities']
+    UserVars.message_extensions['severities'].merge!(@settings.custom_message_extension['severities']) unless @settings.custom_message_extension['severities'] == nil
+
+    $LEGACY_DRC_MESSAGE ||= @settings.legacy_drc_message 
 
     # create / modify windows
     UserVars.message_extensions['windows'].each do |window_id,window_details|
@@ -918,6 +924,7 @@ class SetupFiles
                             windowIfClosed: window_details[:windowIfClosed], 
                             timestamp: window_details[:timestamp]).getWindowXML
     end
+
     @load_message_extensions = false
   end
 

--- a/dependency.lic
+++ b/dependency.lic
@@ -739,10 +739,38 @@ class SlackbotManager
   end
 end
 
+class CustomWindow
+  attr_accessor :id, :title, :location, :styleIfClosed, :windowIfClosed, :timestamp
+
+  def initialize(id: nil, title: nil, location: 'center', styleIfClosed: '', windowIfClosed: 'main', timestamp: true)
+    @id = id
+    @title = title || @id.capitalize
+    @location = location || 'center'
+    @styleIfClosed = styleIfClosed || ''
+    @windowIfClosed = windowIfClosed || 'main'
+    @timestamp = timestamp || true
+  end
+
+  def getWindowXML
+    return "<streamWindow \
+            id='#{@id}' \
+            title='#{@title}' \
+            location='#{location}' \
+            styleIfClosed='#{styleIfClosed}' \
+            ifClosed='#{windowIfClosed}' \
+            timestamp='#{timestamp ? 'on' : 'off'}' \
+            save='true' \
+            resident='true'/>"
+  end
+end
+
 class SetupFiles
+  attr_accessor :load_message_extensions
+
   def initialize(debug)
     @debug = debug
     @load = true
+    @load_message_extensions = true
     @save = false
     @latest = false
     @settings = {}
@@ -781,6 +809,7 @@ class SetupFiles
     load_data_settings if @load
     load_settings if @load && !@data_load
     load_data if @load && @data_load
+    load_message_extension if @load_message_extensions
     save_settings if @save
   end
 
@@ -871,6 +900,25 @@ class SetupFiles
     end
     @settings = transform_settings(settings)
     @load = false
+  end
+
+  def load_message_extension
+    return if !self.loaded?
+    # merge user settings, but don't wipe out min required settings
+    UserVars.message_extensions = {}
+    UserVars.message_extensions['windows'] = @settings.base_message_extension['windows'].merge(@settings.custom_message_extension['windows'])
+    UserVars.message_extensions['severities'] = @settings.base_message_extension['severities'].merge(@settings.custom_message_extension['severities'])
+
+    # create / modify windows
+    UserVars.message_extensions['windows'].each do |window_id,window_details|
+      _respond CustomWindow.new(id: window_id, 
+                            title: window_details[:title], 
+                            location: window_details[:location], 
+                            styleIfClosed: window_details[:styleIfClosed], 
+                            windowIfClosed: window_details[:windowIfClosed], 
+                            timestamp: window_details[:timestamp]).getWindowXML
+    end
+    @load_message_extensions = false
   end
 
   def transform_settings(settings)
@@ -1316,6 +1364,15 @@ end
 
 def setup_data
   $manager.setup_data
+end
+
+def reload_message_extensions
+  # refresh cashed details in case of change
+  pause 0.05 while $setupfiles.pending?
+  $setupfiles.request_settings([])
+  pause 0.05 until $setupfiles.loaded?
+  # trigger load on next run_queue
+  $setupfiles.load_message_extensions = true
 end
 
 def supported_ruby_version?

--- a/dependency.lic
+++ b/dependency.lic
@@ -755,10 +755,10 @@ class CustomWindow
     return "<streamWindow \
             id='#{@id}' \
             title='#{@title}' \
-            location='#{location}' \
-            styleIfClosed='#{styleIfClosed}' \
-            ifClosed='#{windowIfClosed}' \
-            timestamp='#{timestamp ? 'on' : 'off'}' \
+            location='#{@location}' \
+            styleIfClosed='#{@styleIfClosed}' \
+            ifClosed='#{@windowIfClosed}' \
+            timestamp='#{@timestamp ? 'on' : 'off'}' \
             save='true' \
             resident='true'/>"
   end

--- a/dependency.lic
+++ b/dependency.lic
@@ -907,11 +907,11 @@ class SetupFiles
     return if !self.loaded?
     # merge user settings, but don't wipe out min required settings
     UserVars.message_extensions = {}
-    UserVars.message_extensions['windows'] = @settings.base_message_extension['windows']
-    UserVars.message_extensions['windows'].merge!(@settings.custom_message_extension['windows']) unless @settings.custom_message_extension['windows'] == nil
+    UserVars.message_extensions['windows'] = @base_files['base-message-extensions.yaml'][:base_message_windows]
+    UserVars.message_extensions['windows'].merge!(@settings.custom_message_windows) unless @settings.custom_message_windows == nil
 
-    UserVars.message_extensions['severities'] = @settings.base_message_extension['severities']
-    UserVars.message_extensions['severities'].merge!(@settings.custom_message_extension['severities']) unless @settings.custom_message_extension['severities'] == nil
+    UserVars.message_extensions['severities'] = @base_files['base-message-extensions.yaml'][:base_message_severities]
+    UserVars.message_extensions['severities'].merge!(@settings.custom_message_severities) unless @settings.custom_message_severities == nil
 
     $LEGACY_DRC_MESSAGE ||= @settings.legacy_drc_message 
 
@@ -925,6 +925,9 @@ class SetupFiles
                             timestamp: window_details[:timestamp]).getWindowXML
     end
 
+    @load_message_extensions = false
+  rescue
+    $LEGACY_DRC_MESSAGE = true
     @load_message_extensions = false
   end
 

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -108,3 +108,25 @@ empty_values:
   doublestrike_trainables: []
   battle_cries: []
   battle_cry_cycle: []
+  base_message_extension: 
+    windows:
+      log:                        # required - window id 
+        :title: Log               # optional - default: capitalization case of window id
+        :location: center         # optional - default: center, [left,center,right]
+        :styleIfClosed: ''        # optional - default: '', [select from presets - roomName, bold, monsterbold, speech, whisper, thought, watching, link, selectedLink, command, normal]
+        :windowIfClosed: main     # optional - default: '', window id of where to send text if this window is closed
+        :timestamp: true          # optional - default: true, use timestampes on this window
+    severities:
+      info:
+        :window: log
+        :highlight: none
+      warning:
+        :window: log
+        :highlight: bold
+      severe:
+        :window: log
+        :highlight: speech
+      fatal:
+        :window: log
+        :highlight: whisper
+  custom_message_extension: {}

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -108,27 +108,5 @@ empty_values:
   doublestrike_trainables: []
   battle_cries: []
   battle_cry_cycle: []
-  base_message_extension: 
-    windows:
-      log:                        # required - window id 
-        :title: Log               # optional - default: capitalization case of window id
-        :location: center         # optional - default: center, [left,center,right]
-        :styleIfClosed: ''        # optional - default: '', [select from presets - roomName, bold, monsterbold, speech, whisper, thought, watching, link, selectedLink, command, normal]
-        :windowIfClosed: main     # optional - default: '', window id of where to send text if this window is closed
-        :timestamp: true          # optional - default: true, use timestampes on this window
-    severities:
-      info:
-        :window: log
-        :highlight: none
-      warning:
-        :window: log
-        :highlight: bold
-      severe:
-        :window: log
-        :highlight: speech
-      fatal:
-        :window: log
-        :highlight: whisper
-  custom_message_extension:
-    windows: {}
-    severities: {}
+  custom_message_windows: {}
+  custom_message_severities: {}

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -129,4 +129,6 @@ empty_values:
       fatal:
         :window: log
         :highlight: whisper
-  custom_message_extension: {}
+  custom_message_extension:
+    windows: {}
+    severities: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -49,6 +49,8 @@ private_textsubs:
 #     fatal:
 #       window: log
 #       highlight: whisper
+# set to false to allow window redirect / highlighed DRC.message() output
+legacy_drc_message: true
 
 # Combat settings
 # https://elanthipedia.play.net/Lich_script_repository#combat-trainer

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -21,6 +21,35 @@ t2_avoids:
 private_textsubs:
   # old text: new text
 
+### controls custom formatting and window for output of all scripts which use DRC.message method
+### This will NOT auto update if you make changes, you need to run `;e reload_message_extensions` to reload
+###
+## windows: creates / modifies additional/existing windowss
+## classes: controls which window and how messages of particular severities are highlighted
+#           can be used to override the defaults listed below, or create your own custom ones for custom scripts
+# 
+# custom_message_extension:
+#   windows:  ### can be ussed to create new windows, overide behaviour of existing windows
+#     log:                        # required - window id 
+#       :title: Log               # optional - default: capitalization case of window id
+#       :location: center         # optional - default: center, [left,center,right]
+#       :styleIfClosed: ''        # optional - default: '', [select from presets - roomName, bold, monsterbold, speech, whisper, thought, watching, link, selectedLink, command, normal]
+#       :windowIfClosed: main     # optional - default: '', window id of where to send text if this window is closed
+#       :timestamp: true          # optional - default: true, use timestampes on this window
+#   severities:
+#     info:
+#       window: log
+#       highlight: none
+#     warning:
+#       window: log
+#       highlight: bold
+#     severe:
+#       window: log
+#       highlight: speech
+#     fatal:
+#       window: log
+#       highlight: whisper
+
 # Combat settings
 # https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 aim_fillers:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -25,30 +25,33 @@ private_textsubs:
 ### This will NOT auto update if you make changes, you need to run `;e reload_message_extensions` to reload
 ###
 ## windows: creates / modifies additional/existing windowss
-## classes: controls which window and how messages of particular severities are highlighted
-#           can be used to override the defaults listed below, or create your own custom ones for custom scripts
-# 
-# custom_message_extension:
-#   windows:  ### can be ussed to create new windows, overide behaviour of existing windows
-#     log:                        # required - window id 
-#       :title: Log               # optional - default: capitalization case of window id
-#       :location: center         # optional - default: center, [left,center,right]
-#       :styleIfClosed: ''        # optional - default: '', [select from presets - roomName, bold, monsterbold, speech, whisper, thought, watching, link, selectedLink, command, normal]
-#       :windowIfClosed: main     # optional - default: '', window id of where to send text if this window is closed
-#       :timestamp: true          # optional - default: true, use timestampes on this window
-#   severities:
-#     info:
-#       window: log
-#       highlight: none
-#     warning:
-#       window: log
-#       highlight: bold
-#     severe:
-#       window: log
-#       highlight: speech
-#     fatal:
-#       window: log
-#       highlight: whisper
+## severities: controls which window and how messages of particular severities are highlighted
+##             can be used to override the defaults listed below, or create your own custom ones for custom scripts
+
+## These are the defaults, they can be extended.  You only need to specify any of these if you want to override their default settings
+# custom_message_windows: ### can be ussed to create new windows, overide behaviour of existing windows
+#   log:                        # required - window id 
+#     :title: Log               # optional - default: capitalization case of window id
+#     :location: center         # optional - default: center, [left,center,right]
+#     :styleIfClosed: ''        # optional - default: '', [select from presets - roomName, bold, monsterbold, speech, whisper, thought, watching, link, selectedLink, command, normal]
+#     :windowIfClosed: main     # optional - default: '', window id of where to send text if this window is closed
+#     :timestamp: true          # optional - default: true, use timestampes on this window
+# custom_message_severities:
+#   info:
+#     window: log
+#     highlight: none
+#   warning:
+#     window: log
+#     highlight: bold
+#   severe:
+#     window: log
+#     highlight: speech
+#   fatal:
+#     window: log
+#     highlight: whisper
+custom_message_windows:
+custom_message_severities:
+
 # set to false to allow window redirect / highlighed DRC.message() output
 legacy_drc_message: true
 

--- a/validate.lic
+++ b/validate.lic
@@ -915,11 +915,11 @@ class DRYamlValidator
   def assert_that_message_extensions_are_valid(settings)
     supported_highlights = %w[roomName bold monsterbold speech whisper thought watching link selectedLink command none normal]
 
-    custom_windows = settings.base_message_extension['windows']
-    custom_windows.merge!(settings.custom_message_extension['windows']) unless settings.custom_message_extension['windows'] == nil
+    custom_windows = get_data('message-extensions').base_message_windows
+    custom_windows.merge!(@settings.custom_message_windows) unless @settings.custom_message_windows == nil
 
-    custom_severities = settings.base_message_extension['severities']
-    custom_severities.merge!(settings.custom_message_extension['severities']) unless settings.custom_message_extension['severities'] == nil
+    custom_severities = get_data('message-extensions').base_message_severities
+    custom_severities.merge!(@settings.custom_message_severities) unless @settings.custom_message_severities == nil
 
     custom_severities.each do |idx,severity|
       warn("custom_message_extension:severities:#{idx} uses a window (#{severity[:window]}) that does not exist in custom_message_extensions:windows.") if !custom_windows.include?(severity[:window])

--- a/validate.lic
+++ b/validate.lic
@@ -915,15 +915,14 @@ class DRYamlValidator
   def assert_that_message_extensions_are_valid(settings)
     supported_highlights = %w[roomName bold monsterbold speech whisper thought watching link selectedLink command none normal]
 
-    custom_windows = get_data('message-extensions').base_message_windows
-    custom_windows.merge!(@settings.custom_message_windows) unless @settings.custom_message_windows == nil
+    custom_windows = get_data('message-extensions').base_message_windows.merge(settings.custom_message_windows)
+    custom_severities = get_data('message-extensions').base_message_severities.merge(settings.custom_message_severities)
 
-    custom_severities = get_data('message-extensions').base_message_severities
-    custom_severities.merge!(@settings.custom_message_severities) unless @settings.custom_message_severities == nil
+    warn("Mismatch between UserVars and your YAML stetings.  You should consider running '#{$clean_lich_char}e reload_message_extensions' and rerunning validate.") if custom_windows != UserVars.message_extensions['windows'] || custom_severities != UserVars.message_extensions['severities']
 
     custom_severities.each do |idx,severity|
-      warn("custom_message_extension:severities:#{idx} uses a window (#{severity[:window]}) that does not exist in custom_message_extensions:windows.") if !custom_windows.include?(severity[:window])
-      error("custom_message_extension:severities:#{idx} uses a highlight (#{severity[:highlight]}) that is not supported.") if !supported_highlights.include?(severity[:highlight])
+      warn("custom_message_severities:#{idx} uses a window (#{severity[:window]}) that does not exist in custom_message_windows.") if !custom_windows.include?(severity[:window])
+      error("custom_message_severities:#{idx} uses a highlight (#{severity[:highlight]}) that is not supported.") if !supported_highlights.include?(severity[:highlight])
     end
   end
   private

--- a/validate.lic
+++ b/validate.lic
@@ -912,6 +912,16 @@ class DRYamlValidator
     warn('use_barrage_attacks is deprecated, please specify "barrage: true" in the spell configurations for the TM spells you want to use barrage attacks with.')
   end
 
+  def assert_that_message_extensions_are_valid(settings)
+    supported_highlights = %w[roomName bold monsterbold speech whisper thought watching link selectedLink command none normal]
+    custom_windows = settings.base_message_extension['windows'].merge(settings.custom_message_extension['windows'])
+    custom_severities = settings.base_message_extension['severities'].merge(settings.custom_message_extension['severities'])
+    
+    custom_severities.each do |idx,severity|
+      warn("custom_message_extension:severities:#{idx} uses a window (#{severity[:window]}) that does not exist in custom_message_extensions:windows.") if !custom_windows.include?(severity[:window])
+      error("custom_message_extension:severities:#{idx} uses a highlight (#{severity[:highlight]}) that is not supported.") if !supported_highlights.include?(severity[:highlight])
+    end
+  end
   private
 
   def warn(message)

--- a/validate.lic
+++ b/validate.lic
@@ -914,9 +914,13 @@ class DRYamlValidator
 
   def assert_that_message_extensions_are_valid(settings)
     supported_highlights = %w[roomName bold monsterbold speech whisper thought watching link selectedLink command none normal]
-    custom_windows = settings.base_message_extension['windows'].merge(settings.custom_message_extension['windows'])
-    custom_severities = settings.base_message_extension['severities'].merge(settings.custom_message_extension['severities'])
-    
+
+    custom_windows = settings.base_message_extension['windows']
+    custom_windows.merge!(settings.custom_message_extension['windows']) unless settings.custom_message_extension['windows'] == nil
+
+    custom_severities = settings.base_message_extension['severities']
+    custom_severities.merge!(settings.custom_message_extension['severities']) unless settings.custom_message_extension['severities'] == nil
+
     custom_severities.each do |idx,severity|
       warn("custom_message_extension:severities:#{idx} uses a window (#{severity[:window]}) that does not exist in custom_message_extensions:windows.") if !custom_windows.include?(severity[:window])
       error("custom_message_extension:severities:#{idx} uses a highlight (#{severity[:highlight]}) that is not supported.") if !supported_highlights.include?(severity[:highlight])


### PR DESCRIPTION
Adds support to allow to redirect output to customizable windows and highlight message based on FE presets
of DRC.message method.

This change introduces the following:
- Allows custom windows to be created, if the FE supports dynamic windows similar to SF and Genie.
- Allows modification of settings of the default windows (ex: allows to redirect output from one window to another)
- Allows DRC.message to direct it's output in (moderately) user customizable way.  (Existing scripts will need to be updated to take advantage of this).
  - If a script specifies a severity on DRC.message (and ensuring yaml settings for that severity exist) users can select which window and what kind of highlighting are applied to these messages.  
  - All DR preset highlighting are supported, but the FE must support this 
    - SF: as the Simutronics official one supports all
    - Genie: does not due to it's janky setup
    - Frostbite: Unknown
    - Profanity: Unknown
  - Scripts that have not been updated to take advantage of this will continue to operate as normal.

Notes:
- I'm not 100% on the naming of these settings/ methods / yaml setup.  If there are any suggestions for more clear naming/help text I'm more than willing to consider changes.  This is the best I could come up with but even then I'm not particularly happy with what I came up with.
- I'm not sure current changes to base-empty.yaml (adding default values instead of actual empty hash, and using merge in dependency) are the best way to accomplish having some defaults that users will not accidently remove completly.  Also open to suggestions here as well.
- As this is making some significant changes, having additional FE users test is strongly desired prior to merging.