### PR TITLE
[script] [common-items] Fix when item name includes 'my' prefix

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -369,13 +369,21 @@ module DRC
         .sub('.', ' ') # convert 'foo.bar' => 'foo bar' so more easily split into adjective and noun
         .squeeze(' ') # condense repeated runs of whitespace with a single space
         .strip # remove leading/trailing whitespace
+      has_my_prefix = text.start_with?('my ')
+      text = text.delete_prefix('my ')
       parts = text.split
       if text.nil? || text.empty?
         nil
       elsif parts.size > 1
-        DRC::Item.new(adjective: parts.first, name: parts.last)
+        DRC::Item.new(
+          adjective: "#{has_my_prefix ? 'my ' : ''}#{parts.first}",
+          name: parts.last
+        )
       else
-        DRC::Item.new(name: text)
+        DRC::Item.new(
+          adjective: has_my_prefix ? 'my' : nil,
+          name: text
+        )
       end
     end
   end


### PR DESCRIPTION
### Background
* Reported by [DMAN](https://discord.com/channels/745675889622384681/745675890242879671/864884343151132714) in the Lich discord
* Prior to https://github.com/rpherbig/dr-scripts/pull/5084, the `remove_item_unsafe?(item)` used the entire contents of `item` argument. That pull request incorrectly split the string and used the first/last words only. So when the phrase "my cambrinth armband" was given then the updated command operated on "my armband" which now ambiguously refers to "leather armbands" and "cambrinth armbands", etc.

### Changes
* Update `Item.from_text(text)` method to preserve the `my` prefix as part of the item object's adjective.

### Tests
```
> ,e echo i = DRC::Item.from_text('armband') ; echo "adj=#{i.adjective}, noun=#{i.name}"
[exec1: adj=, noun=armband]

> ,e echo i = DRC::Item.from_text('my armband') ; echo "adj=#{i.adjective}, noun=#{i.name}"
[exec1: adj=my, noun=armband]

> ,e echo i = DRC::Item.from_text('my cambrinth armband') ; echo "adj=#{i.adjective}, noun=#{i.name}"
[exec1: adj=my cambrinth, noun=armband]

> ,e echo i = DRC::Item.from_text('my cambrinth something armband') ; echo "adj=#{i.adjective}, noun=#{i.name}"
[exec1: adj=my cambrinth, noun=armband]
```