### PR TITLE
[script] [steal.lic] minor qol updates

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -300,7 +300,7 @@ module DRCT
     target_id = hometown_data[target] && hometown_data[target]['id']
     #try twice with pause if failed the first time, because sometimes data doesn't get loaded correctly
     if !target_id
-      echo("*** get_hometown_target_id failed first attmpt for #{target} in #{hometown}. Trying again:") if $common_travel_debug
+      echo("*** get_hometown_target_id failed first attempt for #{target} in #{hometown}. Trying again:") if $common_travel_debug
       pause 2
       hometown_data = get_data('town')[hometown]
       target_id = hometown_data[target] && hometown_data[target]['id']
@@ -308,7 +308,7 @@ module DRCT
         echo("*** get_hometown_target_id failed second attempt for #{target} in #{hometown}.  Likely target doesn't exist") if $common_travel_debug
         target_id = nil
       else
-        echo("*** get_hometown_target_id succedeed second attempt for #{target} in #{hometown}.") if $common_travel_debug
+        echo("*** get_hometown_target_id succeeded second attempt for #{target} in #{hometown}.") if $common_travel_debug
       end
     end
     echo("*** target_id = #{target_id}") if $common_travel_debug

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -657,7 +657,8 @@ hide_to_steal: true
 bin_stolen: false
 # slow down how fast you put items into bins
 slow_bin_speed: false
-
+# force binning in hometown other than your hometown
+force_bin_town:
 
 # Crafting settings
 crafting_container: backpack

--- a/steal.lic
+++ b/steal.lic
@@ -18,23 +18,19 @@ class Steal
     @stealing_bag = settings.stealing_bag
     stealing_hometown = settings.hometown 
     stealing_hometown = settings.force_bin_town if settings.force_bin_town
-    hometown_data = get_data('town')[stealing_hometown]
-    @bin_id = hometown_data['thief_bin'] && hometown_data['thief_bin']['id']
     @stealing_towns = settings.stealing_towns
     @bin_stolen = settings.bin_stolen
-    if @bin_stolen && !@bin_id
-      DRC.message("*** Binning check failed first attempt for #{stealing_hometown}. Trying again:")
-      pause 2
-      hometown_data = get_data('town')[stealing_hometown]
-      @bin_id = hometown_data['thief_bin'] && hometown_data['thief_bin']['id']
-      if !@bin_id
+    if DRStats.thief?
+      @bin_id = get_hometown_target_id(@hometown,'thief_bin')
+      if !(@bin_id)
+        message("Binning not supported in #{@hometown}.  You should turn it off or change hometown.")
         @bin_stolen = false
-        DRC.message("*** Binning check failed second attempt.  Binning is not yet supported in #{settings.hometown}")
-        pause 10 
-      else
-        DRC.message("*** Binning check succeeded second attempt.  Binning supported in #{settings.hometown}")
-        pause 10 
+        pause 5
       end
+    else
+      message("You are not a thief.  You can't use thief bins.  You should turn it off.")
+      @bin_stolen = false
+      pause 5
     end
     @hide_to_steal = settings.hide_to_steal
     @stealing_low_acceptable_count = settings.stealing_low_acceptable_count
@@ -97,12 +93,12 @@ class Steal
 
     # close stealing container before getting re-dressed 
     # in case you stole something with same name as your equipment
-    fput ("close my #{@stealing_bag}") if @bin_stolen
+    fput("close my #{@stealing_bag}") if @bin_stolen
 
     @equipment_manager.wear_equipment_set?('standard')
 
     # reopen stealing container after getting re-dressed 
-    fput ("open my #{@stealing_bag}") if @bin_stolen
+    fput("open my #{@stealing_bag}") if @bin_stolen
 
     # As is done when `burgle` script finishes, release invisibility
     # because it can interfere with other actions like using banks.

--- a/steal.lic
+++ b/steal.lic
@@ -16,13 +16,25 @@ class Steal
 
     @stealing_options = get_data('stealing').stealing_options.reject { |target| settings.dont_steal_list.include?(target['id'].to_i) }
     @stealing_bag = settings.stealing_bag
-    hometown_data = get_data('town')[settings.hometown]
+    stealing_hometown = settings.hometown 
+    stealing_hometown = settings.force_bin_town if settings.force_bin_town
+    hometown_data = get_data('town')[stealing_hometown]
     @bin_id = hometown_data['thief_bin'] && hometown_data['thief_bin']['id']
     @stealing_towns = settings.stealing_towns
     @bin_stolen = settings.bin_stolen
     if @bin_stolen && !@bin_id
-      DRC.message("*** Binning is not yet supported in #{settings.hometown}")
-      @bin_stolen = false
+      DRC.message("*** Binning check failed first attempt for #{stealing_hometown}. Trying again:")
+      pause 2
+      hometown_data = get_data('town')[stealing_hometown]
+      @bin_id = hometown_data['thief_bin'] && hometown_data['thief_bin']['id']
+      if !@bin_id
+        @bin_stolen = false
+        DRC.message("*** Binning check failed second attempt.  Binning is not yet supported in #{settings.hometown}")
+        pause 10 
+      else
+        DRC.message("*** Binning check succeeded second attempt.  Binning supported in #{settings.hometown}")
+        pause 10 
+      end
     end
     @hide_to_steal = settings.hide_to_steal
     @stealing_low_acceptable_count = settings.stealing_low_acceptable_count
@@ -74,8 +86,23 @@ class Steal
 
     start_script('performance', ['noclean']) unless settings.hide_to_steal
     npcs.each { |npc| steal_from_npc(npc, settings.npc_stealing_attempt_count) }
-    targets.each { |target| steal(target) }
+    
+    # make semi-intelligent choices about which order to steal things in:
+    # steal within one area before moving to next
+    @stealing_towns.each do |current_town|
+      targets.select { |target| target['town'] == current_town}
+      .each { |target| steal(target) }
+    end
+
+
+    # close stealing container before getting re-dressed 
+    # in case you stole something with same name as your equipment
+    fput ("close my #{@stealing_bag}") if @bin_stolen
+
     @equipment_manager.wear_equipment_set?('standard')
+
+    # reopen stealing container after getting re-dressed 
+    fput ("open my #{@stealing_bag}") if @bin_stolen
 
     # As is done when `burgle` script finishes, release invisibility
     # because it can interfere with other actions like using banks.

--- a/steal.lic
+++ b/steal.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#steal
 =end
 
-custom_require.call(%w[common common-arcana common-items common-travel drinfomon equipmanager])
+custom_require.call(%w[common common-arcana common-items common-travel drinfomon equipmanager skill-recorder])
 
 class Steal
 
@@ -21,14 +21,14 @@ class Steal
     @stealing_towns = settings.stealing_towns
     @bin_stolen = settings.bin_stolen
     if DRStats.thief?
-      @bin_id = get_hometown_target_id(@hometown,'thief_bin')
+      @bin_id = DRCT.get_hometown_target_id(stealing_hometown,'thief_bin')
       if !(@bin_id)
-        message("Binning not supported in #{@hometown}.  You should turn it off or change hometown.")
+        DRC.message("Binning not supported in #{stealing_hometown}.  You should turn it off or change hometown/force_bin_town.")
         @bin_stolen = false
         pause 5
       end
     else
-      message("You are not a thief.  You can't use thief bins.  You should turn it off.")
+      DRC.message("You are not a thief.  You can't use thief bins.  You should turn it off.")
       @bin_stolen = false
       pause 5
     end


### PR DESCRIPTION
For anyone who might still be using it (might still be useful for thieves repairing rep), I've had these in my working directory for a while.  

Minor updates:
 - allow hometown override for bin (force_bin_town)
 - retry getting bin settings to mitigate intermittent failure
 - change shop selection criteria to stick within a town before moving to next
 - close stealing bag before redressing to prevent issues caused by stealing an item with same name as your equipment