### PR TITLE
[script] [common-healing] Fix for skin bleeders

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -194,7 +194,7 @@ module DRCH
   # are the severity and the values are the list of bleeding wounds.
   def parse_bleeders(health_lines)
     bleeders = Hash.new { |h, k| h[k] = [] }
-    bleeder_line_regex = /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg|tail)\b/
+    bleeder_line_regex = /^\b(inside\s+)?((l\.|r\.|left|right)\s+)?(head|eye|neck|chest|abdomen|back|arm|hand|leg|tail|skin)\b/
     if health_lines.grep(/^Bleeding|^\s*\bArea\s+Rate\b/).any?
       health_lines
         .drop_while { |line| !(bleeder_line_regex =~ line) }
@@ -208,7 +208,7 @@ module DRCH
           # Internal bleeders use the abbreviations.
           body_part = body_part.gsub('l.', 'left').gsub('r.', 'right')
           # Check for the bleeding severity.
-          bleed_rate = /(?:head|eye|neck|chest|abdomen|back|arm|hand|leg|tail)\s+(.+)/.match(line)[1]
+          bleed_rate = /(?:head|eye|neck|chest|abdomen|back|arm|hand|leg|tail|skin)\s+(.+)/.match(line)[1]
           severity = $DRCH_BLEED_RATE_TO_SEVERITY_MAP[bleed_rate][:severity]
           # Check if internal or not. Want an actual boolean result here, not just "truthy/falsey".
           is_internal = line =~ /^inside/ ? true : false

--- a/test/test_check_health.rb
+++ b/test/test_check_health.rb
@@ -181,4 +181,33 @@ class TestCheckHealth < Minitest::Test
     end
   end
 
+  def test_see_both_internal_and_external_bleeders
+    messages = [
+      "Your body feels in bad shape.",
+      "Your spirit feels full of life.",
+      "You have a severely swollen and deeply bruised right leg compounded by deep cuts across the right leg, a severely swollen and deeply bruised left leg compounded by deep slashes across the left leg, open and bleeding sores all over the skin.",
+      "",
+      "Bleeding",
+      "            Area       Rate              ",
+      "-----------------------------------------",
+      "       right leg       slight",
+      "        left leg       light",
+      "            skin       slight",
+      "   inside r. leg       slight",
+      "   inside l. leg       light"
+    ]
+
+    check_health_with_buffer(messages, [
+      proc do |health|
+        bleeders = health['bleeders'].values.flatten
+        assert_equal(5, bleeders.length)
+        assert_equal(true, bleeders.any? { |wound| wound.body_part == 'right leg' && !wound.internal?  && wound.bleeding_rate == 'slight' } )
+        assert_equal(true, bleeders.any? { |wound| wound.body_part == 'left leg'  && !wound.internal?  && wound.bleeding_rate == 'light' } )
+        assert_equal(true, bleeders.any? { |wound| wound.body_part == 'skin'      && !wound.internal?  && wound.bleeding_rate == 'slight' } )
+        assert_equal(true, bleeders.any? { |wound| wound.body_part == 'right leg' &&  wound.internal?  && wound.bleeding_rate == 'slight' } )
+        assert_equal(true, bleeders.any? { |wound| wound.body_part == 'left leg'  &&  wound.internal?  && wound.bleeding_rate == 'light' } )
+      end
+    ])
+  end
+
 end


### PR DESCRIPTION
### Background
* `DRCH.parse_bleeders` method was stopping prematurely when it hit 'skin' wounds and so not seeing all the bleeders

### Changes
* Add the word `skin` as a valid body part that could be bleeding

### Tests
* See `test/test_check_health.rb`