### PR TITLE
[script] [common-items] Add match for stowing gems

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -136,6 +136,7 @@ module DRCI
     /^You put your .* in/,
     /^You hold out/,
     /^You tuck/,
+    /^You open your pouch and put/,
     # The next message is when item crumbles when stowed, like a moonblade.
     /^As you open your hand to release the/,
     # You're a thief and you binned a stolen item.
@@ -448,8 +449,8 @@ module DRCI
   #########################################
 
   def stow_hands
-    stow_hand('right') if DRC.right_hand
-    stow_hand('left') if DRC.left_hand
+    (!DRC.left_hand  || stow_hand('left')) &&
+    (!DRC.right_hand || stow_hand('right'))
   end
 
   def stow_hand(hand)

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -323,6 +323,46 @@ class TestDRCI < Minitest::Test
   end
 
   #########################################
+  # STOW HANDS
+  #########################################
+
+  def test_stow_hands__open_pouch_for_gem_in_left_hand
+    $left_hand = 'crystal'
+    $right_hand = nil
+
+    run_drci_command(
+      ["You open your pouch and put the icy blue crystal inside, closing it once more."],
+      'stow_hands',
+      [],
+      [assert_result]
+    )
+  end
+
+  def test_stow_hands__open_pouch_for_gem_in_right_hand
+    $left_hand = nil
+    $right_hand = 'crystal'
+
+    run_drci_command(
+      ["You open your pouch and put the icy blue crystal inside, closing it once more."],
+      'stow_hands',
+      [],
+      [assert_result]
+    )
+  end
+
+  def test_stow_hands__skip_if_hands_empty
+    $left_hand = nil
+    $right_hand = nil
+
+    run_drci_command(
+      [],
+      'stow_hands',
+      [],
+      [assert_result]
+    )
+  end
+
+  #########################################
   # DISPOSE TRASH
   #########################################
 

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Harness
   # Lich global for the last time a user sent a command to the game
   $_IDLETIMESTAMP_ = Time.now
@@ -375,6 +377,26 @@ module Harness
     end
   end
 
+  class GameObj
+    def self.left_hand
+      item = Harness.left_hand || 'Empty'
+      OpenStruct.new({ name: item, noun: item })
+    end
+
+    def self.left_hand=(val)
+      Harness.left_hand(val)
+    end
+
+    def self.right_hand
+      item = Harness.right_hand || 'Empty'
+      OpenStruct.new({ name: item, noun: item })
+    end
+
+    def self.right_hand=(val)
+      Harness.right_hand(val)
+    end
+  end
+
   class Flags
     @@flags = {}
     @@matchers = {}
@@ -624,6 +646,9 @@ module Harness
     $dead = false
     $hidden = false
     $invisible = false
+
+    $left_hand = nil
+    $right_hand = nil
 
     Flags._reset
     DRSpells._reset


### PR DESCRIPTION
### Background
* Encountered a "no match string" when stowing a gem

### Changes
* Add `You open your pouch and put` to success messages when put an item away
* Refactor `stow_hands` such that it always returns a boolean result (this aided in tests, has practical value, too)
* Add `GameObj` stub to `test_harness` because the object is called from `common` script to check your hands

### Tests
* See `test/test_common_items.rb`