### PR TITLE
Update base-town.yaml to include Hib stat training sites

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -1239,6 +1239,30 @@ Hibarnhvidar:
     - 3831
     - 3832
     - 3833
+  strength:
+    outer_room: 13880
+    inner_room: 
+  agility:
+    outer_room: 12152
+    inner_room: 
+  discipline:
+    outer_room: 12153
+    inner_room: 
+  intelligence:
+    outer_room: 2494
+    inner_room:
+  wisdom:
+    outer_room: 12185
+    inner_room:
+  reflex:
+    outer_room: 13571
+    inner_room: 
+  charisma:
+    outer_room: 13878
+    inner_room: 
+  stamina:
+    outer_room: 13879
+    inner_room: 
   guild_leaders: &hib_guild_leaders
     Barbarian:
       name: Stumara


### PR DESCRIPTION
Added stat training sites in Hib for use with train.lic. Int is trained in Shard, because I couldn't find a way to enter Chedik Bridge, Engineer's Tower in Hib.