### PR TITLE
[script] [transfer-items] Add match string when container can't be sorted

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -24,7 +24,7 @@ class ItemTransfer
     # If container is very full then LOOK may not list all of them.
     # If you're moving a specific item, then sort those to the top
     # to increase chances we find and move all of them in one go.
-    bput("sort #{noun} in my #{source}", "are now at the top", "What were you referring to", "Please rephrase that command") if noun
+    bput("sort #{noun} in my #{source}", "are now at the top", "What were you referring to", "Please rephrase that command", "You may only sort items in your inventory") if noun
     DRCI.get_item_list(source, 'look')
       .map { |full_name| full_name =~ /lot of other stuff/ ? full_name : full_name.split(' ').last }
       .select { |item| noun ? /\b#{noun}\b/ =~ item : true }


### PR DESCRIPTION
### Background
* When transfering a specific noun between containers, the script first does a `sort <item>` so that all of them appear first in the list of inventory. This mitigates when a container is super full and the items might be burried behind ", and a lot of other stuff.".
* The watery portal (eddy) container is not physically "on you" so you can't sort items within it, giving you the message "You may only sort items in your inventory."

### Changes
* Add match string for "You may only sort items in your inventory." so the `transfer-items` script doesn't hang