### PR TITLE
[script] [ combat-trainer] Added Debilitation and Targeted Magic to cyclic training list.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1488,7 +1488,7 @@ class SpellProcess
     return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
     return if DRStats.mana < @training_spell_mana_threshold
 
-    needs_training = %w[Warding Utility Augmentation Sorcery]
+    needs_training = %w[Warding Utility Augmentation Sorcery Debilitation Targeted\ Magic]
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| game_state.is_offense_allowed? || @training_spells[skill]['harmless'] }
                      .select { |skill| DRSkill.getxp(skill) < @magic_exp_training_max_threshold }
@@ -1497,13 +1497,16 @@ class SpellProcess
                      .select { |skill| @training_spells[skill]['day'] ? UserVars.sun['day'] : true }
     needs_training = game_state.sort_by_rate_then_rank(needs_training).first
     return unless needs_training
+    DRC.message "needs_training: #{needs_training}"
 
     data = @training_spells[needs_training]
     @training_cast_timer = Time.now + @training_spells_wait
     if data['cyclic']
       @training_cyclic_timer = Time.now + 325
+      DRC.message "@training_cyclic_timer of Time.now + 325: #{@training_cyclic_timer}"
     elsif @training_cyclic_timer < @training_cast_timer
       @training_cyclic_timer = @training_cast_timer
+      DRC.message "@training_cyclic_timer less than @training_cast_timer: #{@training_cyclic_timer}"
     end
 
     game_state.hide_on_cast = true if data['use_stealth']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1488,7 +1488,6 @@ class SpellProcess
     return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
     return if DRStats.mana < @training_spell_mana_threshold
 
-    #needs_training = %w[Warding Utility Augmentation Sorcery Debilitation Targeted\ Magic]
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| game_state.is_offense_allowed? || @training_spells[skill]['harmless'] }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1488,7 +1488,8 @@ class SpellProcess
     return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
     return if DRStats.mana < @training_spell_mana_threshold
 
-    needs_training = %w[Warding Utility Augmentation Sorcery Debilitation Targeted\ Magic]
+    #needs_training = %w[Warding Utility Augmentation Sorcery Debilitation Targeted\ Magic]
+    needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| game_state.is_offense_allowed? || @training_spells[skill]['harmless'] }
                      .select { |skill| DRSkill.getxp(skill) < @magic_exp_training_max_threshold }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1497,16 +1497,16 @@ class SpellProcess
                      .select { |skill| @training_spells[skill]['day'] ? UserVars.sun['day'] : true }
     needs_training = game_state.sort_by_rate_then_rank(needs_training).first
     return unless needs_training
-    DRC.message "needs_training: #{needs_training}"
+    DRC.message "needs_training: #{needs_training}" if $debug_mode_ct
 
     data = @training_spells[needs_training]
     @training_cast_timer = Time.now + @training_spells_wait
     if data['cyclic']
       @training_cyclic_timer = Time.now + 325
-      DRC.message "@training_cyclic_timer of Time.now + 325: #{@training_cyclic_timer}"
+      DRC.message "@training_cyclic_timer of Time.now + 325: #{@training_cyclic_timer}" if $debug_mode_ct
     elsif @training_cyclic_timer < @training_cast_timer
       @training_cyclic_timer = @training_cast_timer
-      DRC.message "@training_cyclic_timer less than @training_cast_timer: #{@training_cyclic_timer}"
+      DRC.message "@training_cyclic_timer less than @training_cast_timer: #{@training_cyclic_timer}" if $debug_mode_ct
     end
 
     game_state.hide_on_cast = true if data['use_stealth']


### PR DESCRIPTION
Nothing Earthshattering here with this change, just the ability to swap between two additional cyclic spells during combat-trainer. Note, it will not stop a running one if the other cyclic skills do not need training regardless of timer. For example, I have EE and Rimefang defined in `combat_spell_training:`. If Debilitation needs training, combat-trainer will start EE and then run the 5 minutes and 25 seconds before, if TM training is needed, it will switch to Rimefang. If TM did not need training, EE would keep running. I see nothing wrong with it running as, if the hunt is long enough, Debil will drain to below the threshold for it to require training again, and then the switch will occur. 

The three messages were added to make sure the skill was reading and when the timer was set to change if needed.