### PR TITLE
Stop unhelpful 'tendme' spam in combat

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -942,10 +942,21 @@ class SafetyProcess
     @equipment_manager = equipment_manager
     @health_threshold = settings.health_threshold
     echo("  @health_threshold: #{@health_threshold}") if $debug_mode_ct
+    @untendable_counter = 0
   end
 
   def execute(game_state)
-    custom_require.call('tendme') if bleeding? && !Script.running?('tendme')
+    if @untendable_counter > 0
+      @untendable_counter -= 1
+    elsif bleeding? && !Script.running?('tendme')
+      if DRCH.has_tendable_bleeders?
+        custom_require.call('tendme')
+      else
+        # Don't spam tendme, as it makes it take longer to actually get out of combat / cast spells, etc.
+        @untendable_counter = 10
+      end
+    end
+
     fput 'exit' if DRStats.health < @health_threshold
     fix_standing
     check_item_recovery(game_state)
@@ -1026,6 +1037,7 @@ class SafetyProcess
     bput("#{Flags['active-mitigation'][:action]} #{Flags['active-mitigation'][:obstacle]}", 'You manage to', "You've got to", 'Please rephrase', 'You jump back', "You can't do")
     Flags.reset('active-mitigation')
   end
+
   def in_danger?(danger)
     return false if DRStats.health >= 75
 

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -7,6 +7,12 @@ custom_require.call(%w[common common-items common-healing-data])
 module DRCH
   module_function
 
+  def has_tendable_bleeders?
+    health_data = check_health
+    return true if health_data['bleeders'].values.flatten.any? { |wound| wound.tendable? }
+    return false
+  end
+
   # Uses HEALTH command to check for poisons, diseases, bleeders, parasites, and lodged items.
   # Based on this diagnostic information, you should be able to prioritize how you heal
   # yourself with medicinal potions and salves, or healing spells.


### PR DESCRIPTION
Adding logic to not blindly spam tendme after EVERY command if you have ONLY un-tendable wounds left, as this drastically slows down getting out of combat / casting heals / etc.

Would love some testers, as it's an edge case that I've only had a couple cases of.