### PR TITLE
[script] [enchant] Updated cleanup section to make sure the item on the ground it picked up and not retrieved from container.

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -236,7 +236,11 @@ class Enchant
     stow_item(left_hand) if left_hand
     get_item(@fount) unless @item == 'fount'
     stow_item(@fount) unless @item == 'fount'
-    bput("get my #{@item}", 'You', 'What')
+    result = bput("get my #{@item}", 'You get', 'What', 'You pick up')
+    if result =~ /You get/
+      stow_item(@item)
+      bput("get #{@item}",'You get', 'What', 'You pick up')
+    end
   end
 
   def get_item(name)


### PR DESCRIPTION
Sometimes `get my #{@item}` would retrieve the item from the container instead of picking the item up from the feet location. This change tries both get ways to retrieve the item. This satisfies the second part of Issue https://github.com/rpherbig/dr-scripts/issues/4340. Putting in draft until some more can test, specifically KillashandreaDR. Yes, it works for me. 