### PR TITLE
Temporary Map Fix

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -187,6 +187,12 @@ class ScriptManager
     @enable_fork = LICH_VERSION =~ /f/
 
     @versions = nil
+    
+    ## Temporary Map Fix dated 8/10/21 - be removed once map is unlocked/migrated
+    Room["1544"].title = ["[[Randal's Repairs, Work Room]]"] 
+    Room["19270"].title = ["[[Waystation, Ylono's Repairs]]"]
+    Room["9639"].title = ["[[Steelclaw Clan, Granzer's Repairs]]"]
+    Room["12174"].title = ["[[Gudthar's Repairs]]"]   
   end
 
   def updated_dependency?


### PR DESCRIPTION
Today Simu updated repair shops and broke their titles so ;go2 cannot function.  The map is currently locked and  has been for months with no solution in place.  This is obviously not an ideal fix but it will at least get folks moving when they are otherwise at a standstill.  If there is a place that would be better, I'm happy to edit.  @rcuhljr  @rpherbig   

Otherwise if this is good, can we get it pushed ASAP?