### PR TITLE
thief backtraining feature for combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3009,7 +3009,7 @@ class AttackProcess
 
     # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
     unless maneuver_success
-      if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush?
+      if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush? || game_state.ambush_stun_training?
         hide?(@hide_type)
       end
 
@@ -3017,15 +3017,17 @@ class AttackProcess
 
       command = game_state.offhand? ? "#{verb} left" : verb
 
-      if (game_state.backstab? || game_state.ambush?) && hiding?
+      if (game_state.backstab? || game_state.ambush? || game_state.ambush_stun_training?) && hiding?
         if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
           command += " #{@ambush_location}"
+        elsif (game_state.ambush_stun_training?)
+          command = command.sub(verb, 'ambush stun')
         else
           command = command.sub(verb, 'backstab')
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip', 'You can not slam with that')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
     pause
@@ -3730,6 +3732,8 @@ class GameState
     @backstab_past_mindlock = settings.backstab_past_mindlock
     echo("  @backstab: #{@backstab}") if $debug_mode_ct
 
+    @ambush_stun_weapons = settings.ambush_stun_weapons
+
     @charged_maneuvers = settings.charged_maneuvers
     echo("  @charged_maneuvers: #{@charged_maneuvers}") if $debug_mode_ct
     # Initialize the maneuver timers. This avoids a later issue where a number
@@ -4126,6 +4130,10 @@ class GameState
   def backstab?
     return @backstab.include?(weapon_skill) if @backstab_past_mindlock
     @backstab.include?(weapon_skill) && DRSkill.getxp('Backstab') < 34
+  end
+
+  def ambush_stun_training?
+    return @ambush_stun_weapons.include?(weapon_skill)
   end
 
   def dancing?


### PR DESCRIPTION
This change gives Thief characters the ability to list melee weapon skills under a new 'ambush_stun_weapons:' yaml setting. Those weapon skills will be trained using stealth and the ambush stun attack command. The benefit of this change is that it allows targeted backtraining for lower rank weapons within an otherwise normal hunt where those weapons would not be able to train using standard attacks.

I'm going to submit this as a draft, because this is my first time and I know it's ambitious to be messing with combat-trainer.

There may be some missing matches (line 3030) for cases where a weapon is not valid for use with ambush stun, I'll try to find and add those.