### PR TITLE
[script] [crossing-training] misc. qol updates

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -81,10 +81,10 @@ class CrossingTraining
 
   def main
     walk_to(@training_room)
-    if @settings.waggle_sets['town-training']
-      wait_for_script_to_complete('buff', ['town-training'])
-    end
     loop do
+      if @settings.waggle_sets['town-training']
+        wait_for_script_to_complete('buff', ['town-training'])
+      end
       event_loop
       if @idling
         pause 30
@@ -200,7 +200,7 @@ class CrossingTraining
     when 'Outfitting'
       train_outfitting
     when 'Perception'
-      train_outdoorsmanship
+      train_perception
     when 'Performance'
       train_performance
     when 'Scholarship'
@@ -448,6 +448,9 @@ class CrossingTraining
     echo("using ability: #{ability}") if UserVars.crossing_trainer_debug
     if ability.include?('Khri')
       activate_khri?(@settings.kneel_khri, ability)
+    elsif ability.include?('berserk')
+      fput ability
+      fput 'berserk stop'
     else
       fput ability
     end
@@ -582,8 +585,14 @@ class CrossingTraining
 
   def train_outdoorsmanship
     return if @researching && @settings.crafting_training_spells
-
+    walk_to(@training_room)
     wait_for_script_to_complete('outdoorsmanship')
+  end
+
+  def train_perception
+    return if @researching && @settings.crafting_training_spells
+    walk_to(@training_room)
+    wait_for_script_to_complete('outdoorsmanship', ['perception'])
   end
 
   def train_first_aid
@@ -613,6 +622,7 @@ class CrossingTraining
       bput("turn my book to page #{count + 1}", 'You turn your book to page', 'You are already on')
       bput('study my book', 'roundtime')
       waitrt?
+	  break if DRSkill.getxp('Scholarship') >= 30
     end
     fput 'stow my book'
   end
@@ -687,7 +697,7 @@ class CrossingTraining
 
   def train_appraisal
     return if @researching
-
+    walk_to(@training_room)
     play_song? if DRSkill.getrank('Appraisal') >= 250
     wait_for_script_to_complete('appraisal')
   end


### PR DESCRIPTION
- move town-training waggle set casting to within the loop (helps with timing issues on buffs)
- switch perception training over to use new option on outdoorsmanship
- don't leave berserks running to drain IF as they only teach on start up
- walk to training rooms for outdoorsmanship/perception/app training
- stop training scholarship if > 30 learning rate