### PR TITLE
[script] [dependency] increase freq of not on min supported ruby version warning

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -174,6 +174,7 @@ class ScriptManager
     Settings['autostart'] = Settings['autostart'] - ['dependency']
 
     Settings['base_versions'] ||= {}
+    CharSettings['next_ruby_version_check_datetime'] = Time.now
 
     @developer = Settings['dependency-developer'] || false
     @ignore_dependency = Settings['ignore-dependency'] || false
@@ -235,6 +236,7 @@ class ScriptManager
   end
 
   def run_queue
+    validate_supported_ruby_version
     Settings['dependency-developer'] = @developer
     Settings['ignore-dependency'] = @ignore_dependency
     update = false
@@ -1324,9 +1326,9 @@ end
 
 def validate_supported_ruby_version
   # Get stored time for next check (or now if not stored yet)
-  next_check_datetime = Settings['next_ruby_version_check_datetime'] || Time.now
+  next_check_datetime = CharSettings['next_ruby_version_check_datetime'] || Time.now
 
-  # Don't spam user every time it starts up
+  # Don't spam user every iteration of run_queue
   return if next_check_datetime > Time.now
 
   #Check for supported version
@@ -1336,12 +1338,12 @@ def validate_supported_ruby_version
     echo "WARN: While many scripts may still continue to run, there are some that may not."
     echo "WARN: Please update to at least version #{$MIN_RUBY_VERSION} as soon as possible."
     echo "WARN: For further details / assistance, please join the dr-scripts Lich Discord: https://discord.gg/uxZWxuX."
-    echo "WARN: This warning will repeat on startup after 7 days."
+    echo "WARN: This warning will repeat on startup and every three hours."
     echo "*** WARN WARN WARN WARN WARN WARN WARN ***"
   end
 
-  # Set next check time to 7 days from now
-  Settings['next_ruby_version_check_datetime'] = Time.now + (60 * 60 * 24 * 7)
+  # Set next check time to 3 hours from now
+  CharSettings['next_ruby_version_check_datetime'] = Time.now + (60 * 60 * 3)
 end
 
 def remove_from_autostart(scripts)
@@ -1415,8 +1417,6 @@ if $manager.updated_dependency?
   echo('Update found for dependency.lic')
   update_d
 end
-
-validate_supported_ruby_version
 
 before_dying do
   $moon_watch = nil


### PR DESCRIPTION
- make the min check part of the run_queue so it will run more often than on start up
- change timing from 1/week per install to every 3 hours 8/day) per character (to more likely to catch user attention

Given that we're still getting users hitting problems with methods that don't exist prior to 2.5.5, I think we need to increase the frequency to more likely users will see this, and upgrade.