### PR TITLE
pick.lic - Added args to ignore exp mindstate limits and skip perception checks

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -107,7 +107,7 @@ class LockPicker
   end
 
   def stop_picking?
-    @stop_pick_on_mindlock && DRSkill.getxp('Locksmithing') >= 30
+    @stop_pick_on_mindlock && !@force_repair && DRSkill.getxp('Locksmithing') >= 30
   end
 
   def setup
@@ -116,12 +116,16 @@ class LockPicker
         { name: 'pets', regex: /pets/, optional: true, description: 'Disarm boxes and place them in the pet box container.' },
         { name: 'count', regex: /\d+/, optional: true, description: 'How many pet boxes to make.' },
         { name: 'refill', regex: /refill/, optional: true, description: 'Refills your lockpick ring.' },
-        { name: 'source', regex: /(source=(\w+))/, optional: true, description: 'Container with boxes to pick.'}
+        { name: 'source', regex: /(source=(\w+))/, optional: true, description: 'Container with boxes to pick.'},
+        { name: 'force', regex: /force/i, optional: true, description: 'Force picking, ignoring any experience mindstate limits' },
+        { name: 'perception', regex: /perception/i, optional: true, description: 'Skip perception checks' }
       ]
     ]
 
     args = parse_args(arg_definitions, true)
-
+	
+    @skip_identify = args.perception
+    @force_repair = args.force
     @make_pets = args.pets
     @pet_goal = args.count.to_i
     @pet_count = 0
@@ -369,24 +373,29 @@ class LockPicker
   def pick(box)
     waitrt?
     check_danger
-    case bput("pick my #{box} ident", @pick_careful, @pick_quick, @pick_blind, @pick_retry, /Find a more appropriate tool and try again/, /It's not even locked, why bother/)
-    when /Find a more appropriate tool and try again/
-      find_lockpick
-      pick(box)
-    when /It's not even locked, why bother/
-      return false
-    when *@pick_careful
-      pick_speed(box, 'careful')
-    when *@pick_quick
-      pick_speed(box, 'quick')
-    when *@pick_blind
-      if @never_pick_blind
-        pick_speed(box, 'quick')
-      else
-        pick_speed(box, 'blind')
-      end
-    when *@pick_retry
-      pick(box)
+
+    if @skip_identify
+      pick_speed(box, 'careful')  
+    else
+	    case bput("pick my #{box} ident", @pick_careful, @pick_quick, @pick_blind, @pick_retry, /Find a more appropriate tool and try again/, /It's not even locked, why bother/)
+	    when /Find a more appropriate tool and try again/
+	      find_lockpick
+	      pick(box)
+	    when /It's not even locked, why bother/
+	      return false
+	    when *@pick_careful
+	      pick_speed(box, 'careful')
+	    when *@pick_quick
+	      pick_speed(box, 'quick')
+	    when *@pick_blind
+	      if @never_pick_blind
+	        pick_speed(box, 'quick')
+	      else
+	        pick_speed(box, 'blind')
+	      end
+	    when *@pick_retry
+	      pick(box)
+	    end
     end
   end
 
@@ -440,23 +449,28 @@ class LockPicker
     waitrt?
     check_danger
     echo "disarm?(#{box})" if UserVars.lockpick_debug
-    case bput("disarm my #{box} identify", @disarm_identify_failed, @disarm_too_hard, @disarm_careful, @disarm_quick, @disarm_normal, 'Roundtime')
-    when 'Roundtime', *@disarm_careful
+
+    if @skip_identify
       disarm_speed?(box, 'careful')
-    when *@disarm_quick
-      speed = @settings.lockpick_force_disarm_careful ? 'careful' : 'quick'
-      disarm_speed?(box, speed)
-    when *@disarm_normal
-      speed = @settings.lockpick_force_disarm_careful ? 'careful' : 'normal'
-      disarm_speed?(box, speed)
-    when *@disarm_identify_failed
-      disarm?(box)
-    when *@disarm_too_hard
-      if @settings.lockpick_ignore_difficulty
-        disarm_speed?(box, 'careful')
-      else
-        false
-      end
+    else	
+	    case bput("disarm my #{box} identify", @disarm_identify_failed, @disarm_too_hard, @disarm_careful, @disarm_quick, @disarm_normal, 'Roundtime')
+	    when 'Roundtime', *@disarm_careful
+	      disarm_speed?(box, 'careful')
+	    when *@disarm_quick
+	      speed = @settings.lockpick_force_disarm_careful ? 'careful' : 'quick'
+	      disarm_speed?(box, speed)
+	    when *@disarm_normal
+	      speed = @settings.lockpick_force_disarm_careful ? 'careful' : 'normal'
+	      disarm_speed?(box, speed)
+	    when *@disarm_identify_failed
+	      disarm?(box)
+	    when *@disarm_too_hard
+	      if @settings.lockpick_ignore_difficulty
+	        disarm_speed?(box, 'careful')
+	      else
+	        false
+	      end
+	    end
     end
   end
 

--- a/pick.lic
+++ b/pick.lic
@@ -68,7 +68,7 @@ class LockPicker
     @harvest_traps = false
 
     boxes.each do |box|
-      if DRSkill.getxp('Locksmithing') >= 30
+      if DRSkill.getxp('Locksmithing') >= 30 && !force_picking
         echo '***STOPPING DUE TO MINDLOCK***'
         break
       end
@@ -107,7 +107,7 @@ class LockPicker
   end
 
   def stop_picking?
-    @stop_pick_on_mindlock && !@force_repair && DRSkill.getxp('Locksmithing') >= 30
+    @stop_pick_on_mindlock && !@force_picking && DRSkill.getxp('Locksmithing') >= 30
   end
 
   def setup
@@ -125,7 +125,7 @@ class LockPicker
     args = parse_args(arg_definitions, true)
 	
     @skip_identify = args.perception
-    @force_repair = args.force
+    @force_picking = args.force
     @make_pets = args.pets
     @pet_goal = args.count.to_i
     @pet_count = 0


### PR DESCRIPTION
Two new arguments, "force" and "perception"

Force: ignore experience mindstate limits that would normally stop picking
Perception: Skip identify checks (for when perception skill is insufficient)