### PR TITLE
[data] [crafting] remove crossing anvil room outside society

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -20,7 +20,7 @@ blacksmithing:
       - 8911
       - 8777
       - 8778
-      - 760
+      # - 760  # do not add back in - removed because it is outside the forging society and prone to getting stolen from
       - 19_252
       - 19_211
       - 50_270
@@ -2023,3 +2023,226 @@ recipe_parts:
     Fang Cove:
       part-room: 14784
       part-number:
+
+herbs:
+  details:
+    aloe:
+      name: aloe leaves
+      process type: dry
+      output: dried aloe
+    blocil:
+      name: blocil berries
+      process type: dry
+      output: dried blocil
+    cebi:
+      name: cebi root
+      process type: dried
+      output: dried cebi
+    dioica:
+      name: dioica sap
+      process type: dry
+      output: dried dioica
+    genich:
+      name: genich stem
+      process type: dry
+      output: dried genich
+    georin:
+      name: georin grass
+      process type: dry
+      output: dried georin
+    hulnik:
+      name: hulnik grass
+      process type: dry
+      output: dried hulnik
+    jadice: 
+      name: jadice flower
+      process type: dry
+      output: dried jadice
+    nemoih: 
+      name: nemoih root
+      process type: dry
+      output: dried nemoih
+    nilos:
+      name: nilos grass
+      process type: dry
+      output: dried nilos
+    plovik:
+      name: plovik leaves
+      process type: dry
+      output: dried plovik
+    qun:
+      name: qun pollen
+      process type: dry
+      output: dried qun
+    red flower:
+      name: red flower
+      process type: dry
+      output: dried flower
+    sufil: 
+      name: sufil sap
+      process type: dry
+      output: dried sufil
+    aevaes:
+      name: aevaes leaves
+      process type: crush
+      output: crushed aevaes
+    belradi:
+      name: belradi moss
+      process type: crush
+      output: crushed belradi
+    blue flower:
+      name: blue flower
+      process type: crush
+      output: crushed flower
+    eghmok:
+      name: eghmok moss
+      process type: crush
+      output: crushed eghmok
+    hisan:
+      name: hisan flower
+      process type: crush
+      output: crushed hisan
+    hulij:
+      name: hulij leaves
+      process type: crush
+      output: crushed hulij
+    ithor:
+      name: ithor root
+      process type: crush
+      output: crushed ithor
+    junliar:
+      name: junliar stem
+      process type: crush
+      output: crushed junliar
+    lujeakave:
+      name: lujeakave root
+      process type: crush
+      output: crushed lujeakave
+    muljin:
+      name: muljin sap
+      process type: crush
+      output: crushed muljin
+    nuloe:
+      name: nuloe stem
+      process type: crush
+      output: crushed nuloe
+    ojhenik:
+      name: ojhenik root
+      process type: crush
+      output: crushed ojhenik
+    riolur:
+      name: riolur leaves
+      process type: crush
+      output: crushed riolur
+    yelith:
+      name: yelith root
+      process type: crush
+      output: crushed yelith
+    seolarn:
+      name: seolarn weed
+      process type: crush
+      output: crushed seolarn
+  Crossing: &crossing_herbs
+    aloe:                   
+    blocil: 8243
+    cebi: 793
+    dioica: 
+    genich: 
+    georin: 1130
+    hulnik: 8243
+    jadice: 8243
+    nemoih: 8243
+    nilos: 793
+    plovik: 14156
+    qun: 
+    red flower: 8243
+    sufil: 8243
+    aevaes: 
+    belradi: 
+    blue flower: 8243
+    eghmok: 992
+    hisan: 1130
+    hulij: 
+    ithor: 
+    junliar: 
+    lujeakave: 
+    muljin: 1130
+    nuloe: 
+    ojhenik: 8243
+    riolur: 1130
+    yelith: 1348
+    seolarn: 8243
+  Arthe Dale:
+    << : *crossing_herbs
+  Dirge:
+    << : *crossing_herbs
+  Stone Clan:
+    << : *crossing_herbs
+  Tiger Clan:
+    << : *crossing_herbs
+  Wolf Clan:
+    << : *crossing_herbs
+  Leth Deriel:
+    aloe:
+    blocil:
+    cebi:
+    dioica:
+    genich:
+    georin:
+    hulnik:
+    jadice: 
+    nemoih: 
+    nilos:
+    plovik:
+    qun:
+    red flower:
+    sufil: 
+    aevaes:
+    belradi:
+    blue flower:
+    eghmok:
+    hisan:
+    hulij:
+    ithor:
+    junliar:
+    lujeakave:
+    muljin:
+    nuloe:
+    ojhenik:
+    riolur:
+    yelith:
+    seolarn:
+  #P2
+  Riverhaven:
+  Therenborough: &therenborough_herbs
+  Rossman's Landing:
+    << : *therenborough_herbs
+  Langenfirth:
+    << : *therenborough_herbs
+  Fornsted:
+    << : *therenborough_herbs
+  Hvaral:
+    << : *therenborough_herbs
+  Throne City:
+  Muspar'i:
+  #P2
+  Shard: &shard_herbs
+  Darkling Wood:
+    << : *shard_herbs
+  Fayrin's Rest:
+    << : *shard_herbs
+  Steelclaw Clan:
+    << : *shard_herbs
+  #P4
+  Ratha:
+  Aesry:
+  Mer'Kresh:
+  #P5
+  Raven's Point:
+    << : *shard_herbs
+  Hibarnhvidar: &hibarnhvidar_herbs
+  Boar Clan:
+    << : *shard_herbs
+  Ain Ghazal:
+  #Premie:
+  Fang Cove:


### PR DESCRIPTION
Removed 760 from crossing anvils due to it being outside not in no-stealing room, and thus prone to getting stolen from