### PR TITLE
[data] [crafting] remove crossing anvil room outside society

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -20,7 +20,7 @@ blacksmithing:
       - 8911
       - 8777
       - 8778
-      - 760
+      # - 760  # do not add back in - removed because it is outside the forging society and prone to getting stolen from
       - 19_252
       - 19_211
       - 50_270


### PR DESCRIPTION
Removed 760 from crossing anvils due to it being outside not in no-stealing room, and thus prone to getting stolen from