### PR TITLE
Quick Fix: Empath Healing + Shock Guards

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1599,7 +1599,7 @@ class SpellProcess
 
     if DRSpells.active_spells['Regeneration']
       if @empath_spells['VH'] && DRStats.health <= 95
-        data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1] }
+        data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1], 'harmless' => true }
         prepare_spell(data, game_state)
       end
       return
@@ -1613,14 +1613,14 @@ class SpellProcess
     echo('Healing') if $debug_mode_ct
     if @wounds.any?
       if @empath_spells['FOC']
-        data = { 'abbrev' => 'foc', 'mana' => @empath_spells['FOC'].first, 'cambrinth' => @empath_spells['FOC'][1..-1] }
+        data = { 'abbrev' => 'foc', 'mana' => @empath_spells['FOC'].first, 'cambrinth' => @empath_spells['FOC'][1..-1], 'harmless' => true }
       elsif @empath_spells['HEAL']
-        data = { 'abbrev' => 'heal', 'mana' => @empath_spells['HEAL'].first, 'cambrinth' => @empath_spells['HEAL'][1..-1] }
+        data = { 'abbrev' => 'heal', 'mana' => @empath_spells['HEAL'].first, 'cambrinth' => @empath_spells['HEAL'][1..-1], 'harmless' => true }
       end
       @wounds = {}
       prepare_spell(data, game_state, true) if data
     elsif @empath_spells['VH']
-      data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1] }
+      data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1], 'harmless' => true }
       prepare_spell(data, game_state, true)
     end
   end


### PR DESCRIPTION
Marking the spell data for "on the fly" generated heal spells as 'harmless' so that the shock guards don't drop the spells