### PR TITLE
titlecheck.lic - added arguments to optionally list ALL titles and/or SORT them

### DIFF
--- a/titlecheck.lic
+++ b/titlecheck.lic
@@ -8,25 +8,36 @@ class TitleCheck
   def initialize
     arg_definitions = [
       [
-        { name: 'title_set', options: %w[blunt ranged brawling genedged specedged thrown pole shield slings weapons weaponmaster performer primarymagic magic money ownership survival1 survival2 survival3 lore criminal generic racial premium order religion novice practitioner dilettante aficionado adept expert professional authority genius savant master grandmaster guru legend cleric trader warmage necromancer empath ranger paladin bard barbarian thief moonmage], description: 'What set of titles are you checking?' }
+        { name: 'title_set', options: %w[blunt ranged brawling genedged specedged thrown pole shield slings weapons weaponmaster performer primarymagic magic money ownership survival1 survival2 survival3 lore criminal generic racial premium order religion novice practitioner dilettante aficionado adept expert professional authority genius savant master grandmaster guru legend cleric trader warmage necromancer empath ranger paladin bard barbarian thief moonmage], description: 'What set of titles are you checking?' },
+        { name: 'all', regex: /all/, optional: true, description: 'List all titles in the set'},
+        { name: 'sort', regex: /sort/, optional: true, description: 'Sort titles alphabetically'}
       ]
     ]
     args = parse_args(arg_definitions)
     UserVars.titles ||= {}
     titles = parse_titles(args.title_set)
-    new_titles = check_existing(args.title_set, titles)
-    print_new_titles(new_titles)
+
+    if args.sort
+       titles = titles.sort_by { |title| title }
+    end
+
+    if args.all
+      print_titles(titles, 'titles')
+    else
+      new_titles = check_existing(args.title_set, titles)
+      print_titles(new_titles, 'new titles')
+    end
   end
 
-  def print_new_titles(new_titles)
+  def print_titles(titles, descriptor)
     respond '-' * 10
     respond 'Title Check'
     respond '-' * 10
-    if new_titles.empty?
-      respond 'You have no new titles'
+    if titles.empty?
+      respond "You have no #{descriptor}"
     else
-      respond 'You have the following new titles: '
-      new_titles.each { |title| respond title }
+      respond "You have the following #{descriptor}: "
+      titles.each { |title| respond title }
     end
     respond '-' * 10
   end


### PR DESCRIPTION
I found that parsing the standard title output was challenging and wanted to see titles in a nice list. titlecheck provided that functionality, but only for titles new since the last run. I added some simple arguments that bypass checking the existing list and optionally sort the titles alphabetically.