### PR TITLE
[script] [hunting-buddy] Do not run 'before:' if stop_on skills are a…

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -89,7 +89,9 @@ class HuntingBuddy
       end
 
       # Execute scripts to run before the hunt
-      execute_actions(before_actions)
+      if !all_skills_at_cap?(stop_on_skills)
+        execute_actions(before_actions)
+      end
 
       if stop_on_no_moons
         DRCA.check_moonwatch


### PR DESCRIPTION
…lready above threshold

This change prevents hunting-buddy from running a 'before:' section when started, if the hunt is going to be immediately ended due to capped skills. In this case the hunt is skipped but the 'after:' section will still run.

I feel like this makes sense, but I do wonder if some people have placed training scripts or other tasks in their 'before:' which they would want to run anyways. For me, it made sense to prevent a bunch of stuff that would only have been needed if I were actually going to make the hunt.