### PR TITLE
[data] [base-hunting] Separating Leth dryads

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -968,6 +968,10 @@ hunting_zones:
   - 9773
   - 9772
   - 9767
+  - 9768
+  - 9769
+  - 9770
+  - 9771
   # https://elanthipedia.play.net/Twisted_Dryad                          175-220
   # same dryads, premie only rooms
   twisted_dryads_premium:

--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -950,6 +950,17 @@ hunting_zones:
   - 1277
   - 1278
   # https://elanthipedia.play.net/Dryad_priestess                        175-220
+  dryad_priestess:
+  - 9768
+  - 9769
+  - 9770
+  - 9771
+  # https://elanthipedia.play.net/Dryad_priestess                        175-220
+  # same dryads, premie only rooms
+  dryad_priestess_premium:
+  - 15795
+  - 15794
+  - 15793 
   # https://elanthipedia.play.net/Twisted_Dryad                          175-220
   dryads:
   - 9766
@@ -957,22 +968,12 @@ hunting_zones:
   - 9773
   - 9772
   - 9767
-  - 9768
-  - 9769
-  - 9770
-  - 9771
   # https://elanthipedia.play.net/Twisted_Dryad                          175-220
   # same dryads, premie only rooms
   twisted_dryads_premium:
   - 15229
   - 15231
   - 15230
-  # https://elanthipedia.play.net/Dryad_priestess                        175-220
-  # same dryads, premie only rooms
-  dryad_priestess_premium:
-  - 15795
-  - 15794
-  - 15793
   # https://elanthipedia.play.net/Pale_Grey_Death_Spirit                 200-250
   # In the forest of night, uses silverclaw hub for day access
   leth_death_spirits:


### PR DESCRIPTION
The twisted dryads (36) and dryad priestesses (34) spawn in different areas and have different rank ranges. It could be useful for people dealing with the low-level hunting ladder to start at 34 and move up to 36 later. This change leaves the 'dryads' zone in place, and moves 4 of those rooms into a separate 'dryad_priestess' zone.