### PR TITLE
[script] [combat-trainer] Barb maneuver toggle

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2413,6 +2413,9 @@ class TrainerProcess
 
     @barb_buffs_inner_fire_threshold = settings.barb_buffs_inner_fire_threshold
     echo("  @barb_buffs_inner_fire_threshold: #{@barb_buffs_inner_fire_threshold}") if $debug_mode_ct
+
+    @always_use_maneuvers = settings.always_use_maneuvers
+    echo("  @always_use_maneuvers: #{@always_use_maneuvers}") if $debug_mode_ct
   end
 
   def execute(game_state)
@@ -2949,6 +2952,9 @@ class TrainerProcess
     check = [check].flatten
     cooldown = ability_info.is_a?(Hash) ? ability_info[:cooldown] : ability_info.to_i
     expcheck = check.nil? || check.any? { |skill_to_check| DRSkill.getxp(skill_to_check) < @combat_training_abilities_target }
+    if name == 'Charged Maneuver' && @always_use_maneuvers
+      expcheck = true
+    end
     return expcheck unless game_state.cooldown_timers[name]
 
     Time.now - game_state.cooldown_timers[name] >= cooldown ? expcheck : false
@@ -3096,7 +3102,7 @@ class AttackProcess
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
     pause


### PR DESCRIPTION
This adds a setting to allow barbs to keep using the 'Charged Maneuver' training ability beyond the field exp threshold set for training abilities. It's nice for young barbs to benefit from the increased IF regen applied to maneuver killing blows, and doublestrike is a decent weapon training tool pre-whirlwind.

Also, there is a small fix that adds missing match strings for attack commands related to using ambush stun on flying creatures and undead (issue reported by user).