### PR TITLE
Update base-hunting.yaml

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1338,13 +1338,13 @@ hunting_zones:
   young_prereni_stones:
   - 12276
   - 12277
-  # https://elanthipedia.play.net/Blue-dappled_prereni                   180-225
+  # https://elanthipedia.play.net/Blue-dappled_prereni_(1)                   180-225
   # Crazy swarm, packed
   blue_dappled_prereni:
   - 10148
   - 10149
   - 10151
-  # https://elanthipedia.play.net/Blue-dappled_prereni                   190-250
+  # https://elanthipedia.play.net/Blue-dappled_prereni_(2)                  190-250
   # premie only rooms, slightly higher level than the standard ones
   blue_prereni_stones:
   - 12278


### PR DESCRIPTION
starting at line 1341 base-hunting.yaml
 
 
  # https://elanthipedia.play.net/Blue-dappled_prereni                   180-225
  # Crazy swarm, packed
  blue_dappled_prereni:
  - 10148
  - 10149
  - 10151
  # https://elanthipedia.play.net/Blue-dappled_prereni                   190-250
  # premie only rooms, slightly higher level than the standard ones
  blue_prereni_stones:
  - 12278
  - 12279
 
 
 
 
  change to 
 
   # https://elanthipedia.play.net/Blue-dappled_prereni_(1)                   180-225
  # Crazy swarm, packed
  blue_dappled_prereni:
  - 10148
  - 10149
  - 10151
  # https://elanthipedia.play.net/Blue-dappled_prereni_(2)                   190-250
  # premie only rooms, slightly higher level than the standard ones
  blue_prereni_stones:
  - 12278
  - 12279