### PR TITLE
Move check_slivers to drcs for use elsewhere.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1238,7 +1238,7 @@ class SpellProcess
       Flags.reset('need-tkt-ammo')
       drop_tkt_ammo
     end
-    check_slivers(game_state)
+    DRCS.check_slivers(game_state)
     check_regalia(game_state)
     check_consume(game_state)
     check_cfb(game_state)
@@ -1272,46 +1272,6 @@ class SpellProcess
   end
 
   private
-
-  def check_slivers(game_state)
-    return unless DRStats.moon_mage?
-    return if game_state.casting
-    return if @tk_ammo
-    return unless @tk_spell
-    return if DRSpells.slivers
-    return if UserVars.moons['visible'].empty?
-    # With low skill you may fail to create the slivers
-    # when breaking your moonblade. If so, keep retrying.
-    retry_count = 0
-    max_retries = 3
-    created_slivers = false
-    # We don't need to cast the spell a fancy way
-    # so rather than asking users to define a new waggle
-    # then simply cast the spell at minimum prep.
-    moonblade_spell = get_data('spells').spell_data['Moonblade'].dup
-    # Minimally prepare the spell so we can cast it quickly.
-    moonblade_spell['mana'] = 1
-    # Try, try, try to break moonblade into slivers.
-    # For novices, this may fail a couple times.
-    while !created_slivers && retry_count < max_retries
-      # For skilled mages, try to snap cast
-      # unless we failed the first time.
-      if retry_count == 0
-        case DRSkill.getrank('Lunar Magic')
-        when 200..299
-          moonblade_spell['prep_time'] = 3
-        when 300..399
-          moonblade_spell['prep_time'] = 2
-        when 400..Float::INFINITY
-          moonblade_spell['prep_time'] = 1
-        end
-      end
-      DRCA.cast_spell(moonblade_spell, @settings)
-      created_slivers = bput("break moonblade", "The slivers drift about", "dissipate without any benefit", "Break what?") == "The slivers drift about"
-      retry_count = retry_count + 1
-    end
-    DRC.message("Failed to create slivers for telekinetic ammo after #{retry_count} attempts") unless created_slivers
-  end
 
   def check_osrel(game_state)
     return if game_state.casting

--- a/common-summoning.lic
+++ b/common-summoning.lic
@@ -90,6 +90,46 @@ module DRCS
     return nil
   end
 
+  def check_slivers(game_state)
+    return unless DRStats.moon_mage?
+    return if game_state.casting
+    return if @tk_ammo
+    return unless @tk_spell
+    return if DRSpells.slivers
+    return if UserVars.moons['visible'].empty?
+    # With low skill you may fail to create the slivers
+    # when breaking your moonblade. If so, keep retrying.
+    retry_count = 0
+    max_retries = 3
+    created_slivers = false
+    # We don't need to cast the spell a fancy way
+    # so rather than asking users to define a new waggle
+    # then simply cast the spell at minimum prep.
+    moonblade_spell = get_data('spells').spell_data['Moonblade'].dup
+    # Minimally prepare the spell so we can cast it quickly.
+    moonblade_spell['mana'] = 1
+    # Try, try, try to break moonblade into slivers.
+    # For novices, this may fail a couple times.
+    while !created_slivers && retry_count < max_retries
+      # For skilled mages, try to snap cast
+      # unless we failed the first time.
+      if retry_count == 0
+        case DRSkill.getrank('Lunar Magic')
+        when 200..299
+          moonblade_spell['prep_time'] = 3
+        when 300..399
+          moonblade_spell['prep_time'] = 2
+        when 400..Float::INFINITY
+          moonblade_spell['prep_time'] = 1
+        end
+      end
+      DRCA.cast_spell(moonblade_spell, @settings)
+      created_slivers = bput("break moonblade", "The slivers drift about", "dissipate without any benefit", "Break what?") == "The slivers drift about"
+      retry_count = retry_count + 1
+    end
+    DRC.message("Failed to create slivers for telekinetic ammo after #{retry_count} attempts") unless created_slivers
+  end
+
   def turn_summoned_weapon
     case DRC.bput("turn my #{GameObj.right_hand.noun}", 'You lack the elemental charge', 'You reach out')
     when 'You lack the elemental charge'


### PR DESCRIPTION
This can be used downstream for sliver management in the future.