### PR TITLE
Update Logic for using Crafted

### DIFF
--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -37,6 +37,9 @@ if @settings.herbs && !@override_mode
 elsif @override_mode
   $remedies = get_data('remedies')
   DRC.message("first remedies condition") if $debug_mode_hr
+else
+  $remedies = get_data('remedies')
+  DRC.message("first remedies condition") if $debug_mode_hr
 end
 
 @wounds_applied = FALSE

--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -34,9 +34,6 @@ DRC.message("@override_mode: #{@override_mode}") if $debug_mode_hr
 if @settings.herbs && !@override_mode
   $remedies = get_data('herbs')
   DRC.message("herbs") if $debug_mode_hr
-elsif @override_mode
-  $remedies = get_data('remedies')
-  DRC.message("first remedies condition") if $debug_mode_hr
 else
   $remedies = get_data('remedies')
   DRC.message("first remedies condition") if $debug_mode_hr


### PR DESCRIPTION
Previous logic excluded crafted remedies being called from ;combat  `wait_for_script_to_complete('heal-remedy', ['quick'])` because it doesn't/can't send the override arg without a fair bit of tinkering.  This returns to the previous functional conditions while including the override option for on-the-spot healing.