### PR TITLE
combat-trainer.lic - Added setting to allow herb healing to use herbs that allow handling

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2383,6 +2383,9 @@ class TrainerProcess
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
 
+    @combat_trainer_herbs_allowhands = settings.combat_trainer_herbs_allowhands
+    echo("  @combat_trainer_herbs_allowhands: #{@combat_trainer_herbs_allowhands}") if $debug_mode_ct
+
     @telescope_storage = settings.telescope_storage
     echo("  @telescope_storage: #{@telescope_storage}") if $debug_mode_ct
 
@@ -2520,7 +2523,7 @@ class TrainerProcess
     when /^Smite$/i
       smite(game_state)
     when /^Herbs$/i
-      if game_state.npcs.empty?
+      if game_state.npcs.empty? || @combat_trainer_herbs_allowhands
         game_state.sheath_whirlwind_offhand
         wait_for_script_to_complete('heal-remedy', ['quick'])
         game_state.wield_whirlwind_offhand

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1147,6 +1147,9 @@ restock:
 # restock equivalent for combinable herbs, see profiles/HerbUser-setup.yaml
 herbs:
 
+# Setting to override combat-trainer skipping herbs that require a hand to use while in combat
+combat_trainer_herbs_allowhands: false
+
 # Skip harnessing before infusing or not
 osrel_no_harness: false
 osrel_amount:


### PR DESCRIPTION
Added a new setting that allows the "herbs" section of combat-training to use herbs that require a hand to use. It happens super quickly, so I just like my characters to use all the herbs.