### PR TITLE
Improving handling for harvest + no component container

### DIFF
--- a/data/base-picking.yaml
+++ b/data/base-picking.yaml
@@ -176,21 +176,19 @@ picking:
   - steel striker
   - black cube
   - chitinous leg
-  - spring
+  - coiled spring
   - brown clay
   - animal bladder
   - sharp blade
   - tiny hammer
   - sealed vial
   - stoppered vial
+  - metal spring
+  - metal lever
   - iron disc
-  - spring
-  - lever
-  - striker
-  - needle
+  - broken needle
   - curved blade
   - silver studs
-  - striker
   - metal circle
   - steel pin
   - broken rune
@@ -200,6 +198,7 @@ picking:
   - bronze face
   - black crystal
   - capillary tube
+  - short needle
 
   lockpick_costs:
     Crossing:

--- a/pick.lic
+++ b/pick.lic
@@ -575,10 +575,13 @@ class Pick
       @trap_sprung_matches,
       @pick_identify_messages,
       @pick_retry,
+      'better have an empty hand first',
       /Find a more appropriate tool and try again/,
       /It's not even locked, why bother/)
 
     case pick_identify_match
+    when 'better have an empty hand first'
+      stow_hands_except(box['noun'])
     when *@trap_sprung_matches
       handle_trap_sprung(nil)
     when /Find a more appropriate tool and try again/
@@ -622,15 +625,17 @@ class Pick
     Flags.reset('more-traps')
     locked = true
 
-    case DRC.bput("pick my #{box['noun']} #{speed}", @trap_sprung_matches, 'not even locked',
-                  'you remove your lockpick and open and remove the lock', 'You discover another lock protecting',
-                  'You are unable to make any progress towards opening the lock', 'Find a more appropriate tool and try again',
-                  /If you're going to use a lockpick from the lockpick ring/,
-                  /Pick what/)
+    pick_result = DRC.bput("pick my #{box['noun']} #{speed}", @trap_sprung_matches, 'not even locked',
+                      'you remove your lockpick and open and remove the lock', 'You discover another lock protecting',
+                      'You are unable to make any progress towards opening the lock', 'Find a more appropriate tool and try again',
+                      'better have an empty hand first', /Pick what/)
+    echo "Pick Result: #{pick_result}" if @debug
+
+    case pick_result
     when 'Find a more appropriate tool and try again'
       @use_lockpick_ring = false
-    when /If you're going to use a lockpick from the lockpick ring/
-      @use_lockpick_ring = true
+    when 'better have an empty hand first'
+      stow_hands_except(box['noun'])
     when *@trap_sprung_matches
       handle_trap_sprung(nil)
     when 'you remove your lockpick and open and remove the lock', 'not even locked'
@@ -793,17 +798,19 @@ class Pick
   end
 
   def harvest(box)
-    echo "Harvesting: #{box}" if @debug
+    echo "Harvesting: #{box} - container: #{@component_container}" if @debug
 
     harvest_result = DRC.bput("disarm my #{box['noun']} harvest",
       /You fumble around with the trap apparatus/, /much for it to be successfully harvested/,
       /completely unsuitable for harvesting/, /previous trap have already been completely harvested/, 'Roundtime')
+    echo "Harvest Result: #{harvest_result}" if @debug
 
     case harvest_result
     when /You fumble around with the trap apparatus/
       harvest(box)
     when 'Roundtime'
-      waitrt?
+      echo "Harvested item: #{DRC.left_hand} - trap part? #{@trap_parts.include?(DRC.left_hand)}" if @debug
+
       DRCI.put_away_item?(DRC.left_hand, @component_container) if @component_container
       DRCI.dispose_trash(DRC.left_hand, @worn_trashcan, @worn_trashcan_verb) if @trap_parts.include?(DRC.left_hand)
     end


### PR DESCRIPTION
The data in base-picking for trap parts wasn't specific enough for people who are harvesting but not keeping trap components, which would leave them holding a trap part in their left hand, and cause problems picking the box.

This PR:
- Fixes the base-picking data based on the table here: https://elanthipedia.play.net/Locksmithing_skill (which could still be wrong? we'll see)
- Adds an error handling path in `pick identify` that clears your off hand and continues
- Adds more debugging lines for future use