### PR TITLE
rezz.lic update - Find bodies with roombrief on

### DIFF
--- a/rezz.lic
+++ b/rezz.lic
@@ -66,7 +66,7 @@ class Rezz
 
   def find_dead
     /You take a moment to look for everybody in the area and see (.*)/ =~ bput('look people', "You look around and notice that you're the only one in the area", /You take a moment to look for everybody in the area and see (.*)/)
-    Regexp.last_match(1).sub(/ and /, ', ').scan(/the body of (.+?(?=who))/i).flatten.map { |obj| obj.split.last }
+    Regexp.last_match(1).sub(/ and /, ', ').scan(/the body of (.+?(?=who|\())/i).flatten.map { |obj| obj.split.last }
   end
 
   def rejuv(player, quick = false)


### PR DESCRIPTION
The script doesn't detect dead people if you have RoomBrief on.

[rezz]>look people
You take a moment to look for everybody in the area and see the body of Tohaka (prone).

I've updated the regex to deal with this.