### PR TITLE
[script] [t2] QOL Updates: controlled shutdown, 'naming' of sections

### DIFF
--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -73,6 +73,7 @@ empty_values:
   held_athletics_items: []
   training_list: []
   t2_avoids: []
+  t2_after_shutdown: []
   stabbity: {}
   telescope_storage: {}
   smoke: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -17,6 +17,12 @@ t2_avoids:
   - type: drag
     state: true
 
+#Scripts to run after *controlled* shutdown of T2
+t2_after_shutdown:
+  - gosafe
+  - sell-loot
+  - gosafe
+
 # TextSubs
 private_textsubs:
   # old text: new text

--- a/t2.lic
+++ b/t2.lic
@@ -12,10 +12,12 @@ class T2
   include DRCT
 
   def initialize
+    @shutdown = false
     fput('awaken')
 
     @counter = 0
     @settings = get_settings
+    @after_shutdown = @settings.t2_after_shutdown
     UserVars.t2_timers ||= {}
 
     t2_avoids = @settings.t2_avoids
@@ -26,8 +28,11 @@ class T2
         fput("avoid #{avoid['type']}")
       end
     end
+  end
 
+  def run
     loop do
+      break if @shutdown
       trainables = @settings['training_list']
       EquipmentManager.new.empty_hands
 
@@ -41,12 +46,17 @@ class T2
         end
 
         # At this point we know that we need to train the skill
-        echo "***STATUS*** Starting #{trainable['skill']}"
+        if trainable['name'].nil?
+          echo "***STATUS*** Starting (#{trainable['start']}) #{trainable['skill']}"
+        else
+          echo "***STATUS*** Starting (#{trainable['start']}) #{trainable['name']}"
+        end
         execute_actions(trainable['scripts'])
-        update_cooldown trainable['skill'] if has_cooldown? trainable['skill']
+        update_cooldown(trainable['skill']) if has_cooldown?(trainable['skill'])
         break
       end
     end
+    execute_actions(@after_shutdown) unless @after_shutdown.nil?
   end
 
   def has_cooldown?(skill)
@@ -70,6 +80,25 @@ class T2
       wait_for_script_to_complete(script_name, action_parts)
     end
   end
+
+  def shutdown 
+    if @shutdown == false
+      @shutdown = true
+      DRC.message("Shutting down T2 on next check.  Use '#{$clean_lich_char}e $T2.noshutdown' to cancel.")
+    else
+      DRC.message("T2 already set to shutdown.  Use '#{$clean_lich_char}e $T2.noshutdown' to cancel.")
+    end
+  end
+
+  def noshutdown 
+    if @shutdown == true
+      @shutdown = false
+      DRC.message('Canceling shutdown of T2.')
+    else
+      DRC.message("T2 not set to shutdown.  Use '#{$clean_lich_char}e $T2.shutdown' to shutdown.")
+    end
+  end
+
 end
 
 before_dying do
@@ -81,4 +110,6 @@ before_dying do
   fput('release cyclic') unless %w[Commoner Barbarian Thief].include?(DRStats.guild)
 end
 
-T2.new
+$T2 = T2.new
+$T2.run
+$T2 = nil


### PR DESCRIPTION
- Adds the ability to gracefully shutdown/cancel shutdown of  T2 at next section, using:
   `;e $T2.shutdown` / `;e $T2.noshutdown`
  (It is recommended to setup an alias)
  - After shutdown, will run list of scripts defined by `t2_after_shutdown:`, which defaults to
      ```yaml
      t2_after_shutdown:
        - gosafe
        - sell-loot
        - gosafe
      ```
- Adds the ability to name sections, so shorter output is generated when starting up sections:
    ```yaml
    training_list:
      - skill:                  # Combat - main hunt
        - Targeted Magic
        - Debilitation
        - Small Edged
        - Large Edged
        - Shield Usage
        - Chain Armor
        # [SNIP - shortened to not take up space]
        name: Combat - Main Hunt
        start: 9
        scripts:
          - hunting-buddy setup
          - crossing-repair
    ```
    If no name is specified, will default to old style list from `skill:`