### PR TITLE
[script] [combat-trainer] QOL updates: warhorns and weapon cycling at max training

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -34,11 +34,17 @@ class SetupProcess
     @gearsets = settings.gear_sets
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
-    @last_warhorn = Time.now - 305
+    @next_warhorn = Time.now
 
     validate_regalia(settings)
 
     return unless @warhorn
+
+    if @warhorn.casecmp('egg').zero?
+      @warhon_activation_command = "invoke my #{@warhorn}"
+    else
+      @warhon_activation_command = "exhale my #{@warhorn} lure"
+    end
 
     if DRCI.wearing?(@warhorn)
       @warhorn_get_verb = 'remove'
@@ -95,18 +101,17 @@ class SetupProcess
 
   def blow_warhorn(game_state)
     return unless @warhorn
-    return if Time.now - @last_warhorn < 300
+    return if Time.now < @next_warhorn
 
     game_state.sheath_whirlwind_offhand
 
     case bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'You take', 'What were you referring to', 'You need a free hand', 'Remove what')
     when 'You get', 'You remove', 'You take'
-      if @warhorn.casecmp('egg').zero?
-        bput("invoke my #{@warhorn}", 'light envelops the area briefly', 'light within the egg', 'Something about the area inhibits')
+      if /The red light within the egg is dim and moves about sluggishly|Your lungs are tired from having sounded a/ =~ bput(@warhon_activation_command,'light envelops the area briefly', 'The red light within the egg is dim and moves about sluggishly', 'Something about the area inhibits','You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
+        @next_warhorn = Time.now + 60
       else
-        bput("exhale #{@warhorn} lure", 'You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
+        @next_warhorn = Time.now + 300
       end
-      @last_warhorn = Time.now
       waitrt?
       bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when 'What were you referring to'
@@ -188,6 +193,11 @@ class SetupProcess
 
   def determine_next_to_train(game_state, weapon_training, ending_ranged)
     return unless game_state.skill_done? || !weapon_training[game_state.weapon_skill] || ending_ranged
+    #check if all weapons are maxed exp to prevent rapid cycling
+    if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
+      echo 'all weapons locked, not switching' if $debug_mode_ct
+      return
+    end
 
     echo('new skill needed for training') if $debug_mode_ct
 
@@ -844,7 +854,7 @@ class LootProcess
       elsif DRSkill.getxp('First Aid') < DRSkill.getxp('Skinning')
         return if dissected?(mob_noun, game_state)
       elsif !game_state.skinnable?(mob_noun) && DRSkill.getxp('First Aid') <= 32
-        return if dissected?(mob_noun, game_state)      
+        return if dissected?(mob_noun, game_state)
       end
     end
 


### PR DESCRIPTION
- Change up how warhorn time is tracked to allow variable activation time:
  - Allows for better usage of warhorns in cases where hunts are back to back
- Stop switching weapons due to exp if all weapons are maxed