### PR TITLE
[script] [combat-trainer]  breakfix for warhorns due to DR's terrible parser

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -43,7 +43,7 @@ class SetupProcess
     if @warhorn.casecmp('egg').zero?
       @warhon_activation_command = "invoke my #{@warhorn}"
     else
-      @warhon_activation_command = "exhale my #{@warhorn} lure"
+      @warhon_activation_command = "exhale #{@warhorn} lure"
     end
 
     if DRCI.wearing?(@warhorn)


### PR DESCRIPTION
Remove my in warhorn activation.

```[combat-trainer]>get my warhorn

You get a sparkling diamondique warhorn adorned with platinum bells from inside your engineer's satchel.
> 
[combat-trainer]>exhale my warhorn lure

Smoking commands are:
Inhale - to draw smoke into your mouth.
Tap - to tap ashes off a cigar.
Clean - to clean out a pipe.
Smoke - to puff a cigar or pipe.
Smoke List - to list the smoke images you have learned.
Exhale - to exhale inhaled smoke.
Exhale (Rings|Balls|Lines) - to exhale rings, balls or a line of smoke.
Exhale (<player>|<creature>|<object>) - to exhale smoke at a player, creature or object.
Exhale Line <image name> - create a smoke image from one of your known images.```