### PR TITLE
[script][combat-trainer][update] Add picking during combat back in with consumables.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2761,11 +2761,11 @@ class TrainerProcess
   def pickbox(game_state, number='first')
     DRC.message("@pet_count is #{@pet_count}.") if $debug_mode_ct
     return unless @pet_box_source && @pet_count > 0
-    return if @use_lockpick_ring == 'false' && !DRCI.exists?('lockpick')
+    return if @use_lockpick_ring = 'false' && !DRCI.exists?('lockpick')
     return if game_state.loaded || game_state.offhand?
     return if left_hand && !game_state.currently_whirlwinding
 
-    if @use_lockpick_ring == 'false'
+    if @use_lockpick_ring = 'false'
       if right_hand
         if game_state.weapon_is_summoned?
           echo 'combat-trainer::pickbox: weapon summoned' if $debug_mode_ct
@@ -2780,8 +2780,9 @@ class TrainerProcess
         end
         had_weapon = true
       end
+      game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
+      DRCI.get_item?('lockpick')
     end
-    game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
 
     num = 1
     picked = false
@@ -2829,8 +2830,9 @@ class TrainerProcess
     DRCI.put_away_item?(box, @pet_box_source)
 
     if had_weapon
+      DRCI.put_away_item?('lockpick')
       if game_state.weapon_is_summoned?
-        DRCI.recover_item(game_state, game_state.weapon_name, 'pickup')
+        recover_item(game_state, game_state.weapon_name, 'pickup')
         pause 0.5
       else
         @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2445,6 +2445,9 @@ class TrainerProcess
 
     @worn_trashcan_verb = settings.worn_trashcan_verb
     echo("  @worn_trashcan_verb: #{@worn_trashcan_verb}") if $debug_mode_ct
+
+    @use_lockpick_ring = settings.use_lockpick_ring
+    echo("  @use_lockpick_ring : #{@use_lockpick_ring }") if $debug_mode_ct
   end
 
   def execute(game_state)
@@ -2758,8 +2761,27 @@ class TrainerProcess
   def pickbox(game_state, number='first')
     DRC.message("@pet_count is #{@pet_count}.") if $debug_mode_ct
     return unless @pet_box_source && @pet_count > 0
+    return if @use_lockpick_ring == 'false' && !DRCI.exists?('lockpick')
     return if game_state.loaded || game_state.offhand?
     return if left_hand && !game_state.currently_whirlwinding
+
+    if @use_lockpick_ring == 'false'
+      if right_hand
+        if game_state.weapon_is_summoned?
+          echo 'combat-trainer::pickbox: weapon summoned' if $debug_mode_ct
+          if DRStats.warrior_mage?
+            DRCI.lower_item?(game_state.weapon_name)
+          else
+            DRCMM.wear_moon_weapon?
+          end
+        else
+          echo 'combat-trainer::pickbox: weapon NOT summoned' if $debug_mode_ct
+          @equipment_manager.stow_weapon(game_state.weapon_name)
+        end
+        had_weapon = true
+      end
+    end
+    game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
 
     num = 1
     picked = false
@@ -2805,6 +2827,16 @@ class TrainerProcess
     DRC.message("@pet_count is #{@pet_count}.") if $debug_mode_ct
     waitrt?
     DRCI.put_away_item?(box, @pet_box_source)
+
+    if had_weapon
+      if game_state.weapon_is_summoned?
+        DRCI.recover_item(game_state, game_state.weapon_name, 'pickup')
+        pause 0.5
+      else
+        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      end
+      game_state.wield_whirlwind_offhand if game_state.currently_whirlwinding
+    end
   end
 
   def analyze(game_state, fail_count)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2812,9 +2812,6 @@ class TrainerProcess
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
     case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip', 'You should stand up first') # unless
-    when 'You must be standing', 'You should stand up first'
-      DRC.fix_standing
-      analyze(game_state, fail_count + 1)
     when 'Analyze what'
       case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
       when 'There is nothing else', 'What are you trying'
@@ -4627,7 +4624,7 @@ class GameState
     return false if combo_type != 'flame' && !Flags["ct-#{combo_type}-ready"] && DRStats.barbarian?
     return false if DRSkill.getrank('Expertise') < expertise_requirement
 
-    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?', 'You should stand up first', 'You must be standing')
+    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?')
     waitrt?
 
     case result
@@ -4646,9 +4643,6 @@ class GameState
       return true
     when 'What are you trying to attack?'
       return true
-    when 'You should stand up first', 'You must be standing'
-      DRC.fix_standing
-      perform_analyze?(combo_type, expertise_requirement)
     end
 
     text = result.match(/by landing an? (.*)\.$/).to_a[1]

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2811,7 +2811,7 @@ class TrainerProcess
     return if game_state.npcs.empty?
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
-    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip', 'You should stand up first') # unless
+    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
     when 'Analyze what'
       case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
       when 'There is nothing else', 'What are you trying'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -473,7 +473,6 @@ class LootProcess
     if settings.box_loot_limit
       @box_nouns = get_data('items').box_nouns
       @box_loot_limit = settings.box_loot_limit
-      #@current_box_count = count_boxes(settings)
       @current_box_count = DRCI.count_all_boxes(settings)
       echo("  @current_box_count: #{@current_box_count}")
       echo("  @box_loot_limit: #{@box_loot_limit}")
@@ -840,7 +839,8 @@ class LootProcess
     when 'would probably object', "should be left alone."
       fput ('dissect')
     when "That's going to be hard"
-      fput ('unhide')
+      DRC.release_invisibility if invisible?
+      fput ('unhide') if hidden?
       dissected?(mob_noun, game_state)
     end
     return false
@@ -2403,8 +2403,11 @@ class TrainerProcess
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
 
-    @pet_count = @skill_map.include?('Locks') ? DRCI.count_items_in_container("box", @pet_box_source) : 0
-    @pet_count = @skill_map.include?('Locks') ? @pet_count + DRCI.count_items_in_container("pouch", @pet_box_source) : 0
+    @pet_count = 0
+
+    if @skill_map.include?('Locks')
+      @pet_count = DRCI.count_items_in_container("box", @pet_box_source) + DRCI.count_items_in_container("pouch", @pet_box_source)
+    end
     echo("  @pet_count: #{@pet_count}") if $debug_mode_ct
 
     @combat_trainer_herbs_allowhands = settings.combat_trainer_herbs_allowhands
@@ -2488,7 +2491,7 @@ class TrainerProcess
         bput("teach #{@combat_teaching_skill} to #{character}", 'You begin to', 'is already listening to you', 'is listening to someone else', 'I could not find who you were referring to', 'You have already offered', 'That person is too busy teaching', 'You are already teaching', 'You cannot teach two different classes at the same time', 'is not paying attention to you', 'You cannot listen to a teacher and teach', 'already trying to teach you something', 'trying to teach someone else')
       end
     when /^Pray$/i
-      bput('pray meraud', 'You glance')
+      bput("pray #{@favor_god}", 'You offer a quiet prayer', 'Clasping your hands humbly', 'You hum under your breath', 'You murmur under your breath', 'You proclaim cheerfully', 'You raise your voice', 'You glance heavenward', 'You quietly go over the mantra', 'Immersing yourself in your faith', 'You bow your head', 'You murmur softly to yourself', 'You pray in susurration', 'You raise your fist', 'You lift your chin proudly', 'Feeling your blood boiling', 'You sigh and say softly', 'You open your arms', 'You glance at your surroundings', 'You mutter a prayer', 'Aligning your thoughts', 'You grumble ominously', 'You offer a prayer', 'You pray quietly', 'You throw your head back', 'With a mirthful laugh', 'Smiling joyously', 'You chant solemnly', 'You roll your eyes heavenward', 'You intone serenely', 'You narrow your eyes', 'You take a deep breath', 'You recite fervently', 'With an exultant grin', 'With renewed purpose', 'Drawing your fist to your heart', 'Glancing furtively at the comforting', 'You close your eyes and slow', 'You still your thoughts and whisper', 'You prepare to take lives', 'You raise your hands lightly', 'Bristling up against a sudden', 'You slowly square your shoulders', 'You tap the center of your forehead', 'You whisper your prayer', 'With a pat you double-check', 'Quietly touching your lips')
     when /^Scream$/i
       bput('Scream conc', 'Inhaling deeply', 'There is nothing', 'You open your mouth, then close it suddenly, looking somewhat like a fish') unless game_state.npcs.empty?
     when /^Khri Prowess$/i
@@ -2758,22 +2761,6 @@ class TrainerProcess
     return if game_state.loaded || game_state.offhand?
     return if left_hand && !game_state.currently_whirlwinding
 
-    if right_hand
-      if game_state.weapon_is_summoned?
-        echo 'combat-trainer::pickbox: weapon summoned' if $debug_mode_ct
-        if DRStats.warrior_mage?
-          bput("lower #{game_state.weapon_name} to ground", 'You lower')
-        else
-          bput("wear my #{game_state.weapon_name}", 'telekinetic force')
-        end
-      else
-        echo 'combat-trainer::pickbox: weapon NOT summoned' if $debug_mode_ct
-        @equipment_manager.stow_weapon(game_state.weapon_name)
-      end
-      had_weapon = true
-    end
-    game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
-
     num = 1
     picked = false
     while !picked
@@ -2817,23 +2804,16 @@ class TrainerProcess
     DRC.message("@pet_count is #{@pet_count}.") if $debug_mode_ct
     waitrt?
     DRCI.put_away_item?(box, @pet_box_source)
-
-    if had_weapon
-      if game_state.weapon_is_summoned?
-        bput("get my #{game_state.weapon_name}", 'You pick up', 'from the air')
-        pause 0.5
-      else
-        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
-      end
-      game_state.wield_whirlwind_offhand if game_state.currently_whirlwinding
-    end
   end
 
   def analyze(game_state, fail_count)
     return if game_state.npcs.empty?
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
-    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
+    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip', 'You should stand up first') # unless
+    when 'You must be standing', 'You should stand up first'
+      DRC.fix_standing
+      analyze(game_state, fail_count + 1)
     when 'Analyze what'
       case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
       when 'There is nothing else', 'What are you trying'
@@ -3238,7 +3218,7 @@ class AttackProcess
       game_state.action_taken
     when /you (fire|poach|snipe)/i
       #Successful fire, increment action_taken
-      game_state.action_taken    
+      game_state.action_taken
     end
 
     # If detected that you shot, then stow any non-lodged ammo.
@@ -4646,7 +4626,7 @@ class GameState
     return false if combo_type != 'flame' && !Flags["ct-#{combo_type}-ready"] && DRStats.barbarian?
     return false if DRSkill.getrank('Expertise') < expertise_requirement
 
-    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?')
+    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?', 'You should stand up first', 'You must be standing')
     waitrt?
 
     case result
@@ -4665,6 +4645,9 @@ class GameState
       return true
     when 'What are you trying to attack?'
       return true
+    when 'You should stand up first', 'You must be standing'
+      DRC.fix_standing
+      perform_analyze?(combo_type, expertise_requirement)
     end
 
     text = result.match(/by landing an? (.*)\.$/).to_a[1]

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2782,6 +2782,7 @@ class TrainerProcess
         num += 1
         DRCI.put_away_item?(box, @pet_box_source)
         @pet_count -= 1
+        # Grab the next training box in the container
         if num == 2
           ord = 'second'
         elsif num == 3

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2761,11 +2761,11 @@ class TrainerProcess
   def pickbox(game_state, number='first')
     DRC.message("@pet_count is #{@pet_count}.") if $debug_mode_ct
     return unless @pet_box_source && @pet_count > 0
-    return if @use_lockpick_ring = 'false' && !DRCI.exists?('lockpick')
+    return if !@use_lockpick_ring && !DRCI.exists?('lockpick')
     return if game_state.loaded || game_state.offhand?
     return if left_hand && !game_state.currently_whirlwinding
 
-    if @use_lockpick_ring = 'false'
+    if !@use_lockpick_ring
       if right_hand
         if game_state.weapon_is_summoned?
           echo 'combat-trainer::pickbox: weapon summoned' if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -43,7 +43,7 @@ class SetupProcess
     if @warhorn.casecmp('egg').zero?
       @warhon_activation_command = "invoke my #{@warhorn}"
     else
-      @warhon_activation_command = "exhale #{@warhorn} lure"
+      @warhon_activation_command = "exhale my #{@warhorn} lure"
     end
 
     if DRCI.wearing?(@warhorn)
@@ -193,8 +193,8 @@ class SetupProcess
 
   def determine_next_to_train(game_state, weapon_training, ending_ranged)
     return unless game_state.skill_done? || !weapon_training[game_state.weapon_skill] || ending_ranged
-    #check if all weapons are maxed exp to prevent rapid cycling
-    if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
+     #check if all weapons are maxed exp to prevent rapid cycling
+     if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
       echo 'all weapons locked, not switching' if $debug_mode_ct
       return
     end
@@ -365,7 +365,7 @@ class LootProcess
     echo("  @dissect: #{@dissect}") if $debug_mode_ct
 
     @dissect_priority = skinning['dissect_priority']
-    echo("  @dissect_priority: #{@dissect_priority}") if $debug_mode_ct    
+    echo("  @dissect_priority: #{@dissect_priority}") if $debug_mode_ct
 
     @arrange_all = skinning['arrange_all'] || false
     echo("  @arrange_all: #{@arrange_all}") if $debug_mode_ct
@@ -473,6 +473,7 @@ class LootProcess
     if settings.box_loot_limit
       @box_nouns = get_data('items').box_nouns
       @box_loot_limit = settings.box_loot_limit
+      #@current_box_count = count_boxes(settings)
       @current_box_count = DRCI.count_all_boxes(settings)
       echo("  @current_box_count: #{@current_box_count}")
       echo("  @box_loot_limit: #{@box_loot_limit}")
@@ -830,17 +831,14 @@ class LootProcess
 
   #not necromancer related - not to be confused with the necro rituals.  According to GMs this may change but for now they are two separate functions.
   def dissected?(mob_noun, game_state)
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge')
-    when 'You succeed in dissecting the corpse'  
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object','A skinned creature is worthless','You do not yet possess the knowledge required',"That'd be a waste of time")
+    when 'You succeed in dissecting the corpse'
       return true
-    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
+    when 'While likely a fascinating study','You do not yet possess the knowledge required',"That'd be a waste of time"
       game_state.undissectable(mob_noun)
       return false
-    when 'would probably object', "should be left alone."
+    when 'would probably object'
       fput ('dissect')
-    when "That's going to be hard"
-      fput ('unhide')
-      dissected?(mob_noun, game_state)
     end
     return false
   end
@@ -1483,9 +1481,9 @@ class SpellProcess
         end
       end
     else
-      DRC.message('Dropping spell: Offensive magic is not allowed right now...')
-      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+      echo('Dropping spell: Offensive magic is not allowed right now...')
+      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      bput('release mana', 'You release all', "You aren't harnessing any mana")
     end
 
     @custom_cast = nil
@@ -1897,9 +1895,9 @@ class SpellProcess
     DRCA.prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
 
     if Flags['ct-shock-warning'] && !game_state.is_permashocked?
-      DRC.message('Dropping spell: Got shock warning.')
-      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+      echo('Dropping spell: Got shock warning.')
+      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      bput('release mana', 'You release all', "You aren't harnessing any mana")
     end
 
     game_state.casting = true
@@ -2306,14 +2304,13 @@ class TrainerProcess
       'Barb Research Debilitation' => 'Debilitation',
       'Barb Research Utility' => 'Utility',
       'Barb Research Warding' => 'Warding',
-      'Berserk Landslide' => 'Warding',
-      'Berserk Avalanche' => 'Utility',
       'Charged Maneuver' => 'Expertise',
       'Collect' => 'Outdoorsmanship',
       'Favor Orb' => 'Anything',
       'Flee' => 'Athletics',
       'Hunt' => 'Perception',
       'Khri Prowess' => 'Debilitation',
+      'Locks' => 'Locksmithing',
       'Meraud' => 'Theurgy',
       'Perc Health' => 'Empathy',
       'Perc' => 'Attunement',
@@ -2384,6 +2381,9 @@ class TrainerProcess
     @forage_item = settings.forage_item
     echo("  @forage_item: #{@forage_item}") if $debug_mode_ct
 
+    @pet_box_source = settings.picking_pet_box_source
+    echo("  @pet_box_source: #{@pet_box_source}") if $debug_mode_ct
+
     @analyze_retry_count = settings.combat_analyze_retry_count
     echo("  @analyze_retry_count: #{@analyze_retry_count}") if $debug_mode_ct
 
@@ -2392,6 +2392,10 @@ class TrainerProcess
 
     @combat_training_abilities_target = settings.combat_training_abilities_target
     echo("  @combat_training_abilities_target: #{@combat_training_abilities_target}") if $debug_mode_ct
+
+    @pet_count = @skill_map.include?('Locks') ? DRCI.count_items_in_container("box", @pet_box_source) : 0
+    @pet_count = @skill_map.include?('Locks') ? @pet_count + DRCI.count_items_in_container("pouch", @pet_box_source) : 0
+    echo("  @pet_count: #{@pet_count}") if $debug_mode_ct
 
     @combat_trainer_herbs_allowhands = settings.combat_trainer_herbs_allowhands
     echo("  @combat_trainer_herbs_allowhands: #{@combat_trainer_herbs_allowhands}") if $debug_mode_ct
@@ -2417,11 +2421,11 @@ class TrainerProcess
     @almanac = settings.almanac_noun
     echo("  @almanac: #{@almanac}") if $debug_mode_ct
 
-    @barb_buffs_inner_fire_threshold = settings.barb_buffs_inner_fire_threshold
-    echo("  @barb_buffs_inner_fire_threshold: #{@barb_buffs_inner_fire_threshold}") if $debug_mode_ct
+    @worn_trashcan = settings.worn_trashcan
+    echo("  @worn_trashcan: #{@worn_trashcan}") if $debug_mode_ct
 
-    @always_use_maneuvers = settings.always_use_maneuvers
-    echo("  @always_use_maneuvers: #{@always_use_maneuvers}") if $debug_mode_ct
+    @worn_trashcan_verb = settings.worn_trashcan_verb
+    echo("  @worn_trashcan_verb: #{@worn_trashcan_verb}") if $debug_mode_ct
   end
 
   def execute(game_state)
@@ -2459,6 +2463,8 @@ class TrainerProcess
       bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
     when /^Analyze$/i
       analyze(game_state, 0)
+    when /^Locks$/i
+      pickbox(game_state, number='first')
     when /^Hunt$/i
       bput('hunt', 'You take note of ', 'You find yourself unable to hunt in this area') unless game_state.retreating?
     when /^Teach$/i
@@ -2511,14 +2517,6 @@ class TrainerProcess
       bput('meditate research earthquake', 'You clear ')
     when /^Barb Research Utility$/i
       bput('meditate research prediction', 'You clear ')
-    when /^Berserk Landslide$/i
-      if DRStats.mana >= @barb_buffs_inner_fire_threshold
-        DRCA.activate_barb_buff?('Landslide')
-      end
-    when /^Berserk Avalanche$/i
-      if DRStats.mana >= @barb_buffs_inner_fire_threshold
-        DRCA.activate_barb_buff?('Avalanche')
-      end
     when /^Collect$/i
       game_state.sheath_whirlwind_offhand
       retreat
@@ -2730,6 +2728,76 @@ class TrainerProcess
          'dumping some dirt', 'What were you referring')
   end
 
+  def pickbox(game_state, number='first')
+    DRC.message("@pet_count is #{@pet_count}.") if $debug_mode_ct
+    return unless @pet_box_source && @pet_count > 0
+    return if game_state.loaded || game_state.offhand?
+    return if left_hand && !game_state.currently_whirlwinding
+
+    if right_hand
+      if game_state.weapon_is_summoned?
+        echo 'combat-trainer::pickbox: weapon summoned' if $debug_mode_ct
+        if DRStats.warrior_mage?
+          bput("lower #{game_state.weapon_name} to ground", 'You lower')
+        else
+          bput("wear my #{game_state.weapon_name}", 'telekinetic force')
+        end
+      else
+        echo 'combat-trainer::pickbox: weapon NOT summoned' if $debug_mode_ct
+        @equipment_manager.stow_weapon(game_state.weapon_name)
+      end
+      had_weapon = true
+    end
+    game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
+
+    picked = false
+    while !picked
+      box = "box"
+      if !DRCI.in_hands?(box) && !DRCI.get_item?("#{number} #{box}", @pet_box_source)
+        box = "pouch"
+        DRCI.get_item?("#{number} #{box}", @pet_box_source) unless DRCI.in_hands?(box)
+      end
+      case bput("pick my #{box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm', 'The lock looks weak, and rather than risk breaking it', /It's not even locked, why bother?/)
+      when /it opens/
+        waitrt?
+        bput("lock my #{box}", 'You quickly lock', 'already locked')
+        picked = true
+      when /isn't locked/
+        bput("close my #{box}", "You close", "That is already closed")
+        bput("lock my #{box}", "You quickly lock", "already locked")
+        picked = false
+      when /The lock feels warm/
+        DRCI.put_away_item?(box, @pet_box_source)
+        @pet_count -= 1
+        #break if !DRCI.get_item?("second #{box}", @pet_box_source)
+        return pickbox(game_state, number='second')
+      when /The lock looks weak, and rather than risk breaking it/
+        DRCI.dispose_trash(box, @worn_trashcan, @worn_trashcan_verb)
+        @pet_count -= 1
+        pick = false
+      when /It's not even locked, why bother?/
+        # Box is not a trainer box. Putting away in default container.
+        DRCI.put_away_item?(box)
+        @pet_count -= 1
+        pick = false
+      end
+      break if @pet_count == 0
+    end
+    DRC.message("@pet_count is #{@pet_count}.") if $debug_mode_ct
+    waitrt?
+    DRCI.put_away_item?(box, @pet_box_source)
+
+    if had_weapon
+      if game_state.weapon_is_summoned?
+        bput("get my #{game_state.weapon_name}", 'You pick up', 'from the air')
+        pause 0.5
+      else
+        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      end
+      game_state.wield_whirlwind_offhand if game_state.currently_whirlwinding
+    end
+  end
+
   def analyze(game_state, fail_count)
     return if game_state.npcs.empty?
     return if fail_count > @analyze_retry_count
@@ -2900,9 +2968,6 @@ class TrainerProcess
     check = [check].flatten
     cooldown = ability_info.is_a?(Hash) ? ability_info[:cooldown] : ability_info.to_i
     expcheck = check.nil? || check.any? { |skill_to_check| DRSkill.getxp(skill_to_check) < @combat_training_abilities_target }
-    if name == 'Charged Maneuver' && @always_use_maneuvers
-      expcheck = true
-    end
     return expcheck unless game_state.cooldown_timers[name]
 
     Time.now - game_state.cooldown_timers[name] >= cooldown ? expcheck : false
@@ -3050,7 +3115,7 @@ class AttackProcess
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
     pause
@@ -3200,6 +3265,8 @@ class AttackProcess
           # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work
           bput("get #{weapon_name}", 'You pick up', 'You get', 'What were')
         end
+        # Added because sometimes the prior bput is not done due to roundtime, even the retries.
+        bput("get #{weapon_name}", 'You pick up', 'You get', 'What were') unless DRCI.in_left_hand?(weapon_name)
       end
 
       game_state.sheath_offhand_weapon(skill)
@@ -4081,12 +4148,12 @@ class GameState
 
   def dissectable?(mob_noun)
     !@no_dissect.include?(mob_noun)
-  end  
+  end
 
   def undissectable(mob_noun)
     echo("adding #{mob_noun} to no dissect list: #{@no_dissect}") if $debug_mode_ct
     @no_dissect.push(mob_noun)
-  end   
+  end
 
   def construct?(mob_noun)
     @constructs.include?(mob_noun)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -958,13 +958,15 @@ class SafetyProcess
 
   def execute(game_state)
     if @untendable_counter > 0
+      echo('Skipping tendme check due to untendable backoff') if $debug_mode_ct
       @untendable_counter -= 1
     elsif bleeding? && !Script.running?('tendme')
+      echo('Checking for tendable bleeders...') if $debug_mode_ct
       if DRCH.has_tendable_bleeders?
         custom_require.call('tendme')
       else
-        # Don't spam tendme, as it makes it take longer to actually get out of combat / cast spells, etc.
-        @untendable_counter = 10
+        echo('Setting untendable wound backoff to prevent tendme spam...') if $debug_mode_ct
+        @untendable_counter = 20
       end
     end
 
@@ -2769,6 +2771,7 @@ class TrainerProcess
     end
     game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
 
+    num = 1
     picked = false
     while !picked
       box = "box"
@@ -2786,16 +2789,22 @@ class TrainerProcess
         bput("lock my #{box}", "You quickly lock", "already locked")
         picked = false
       when /The lock feels warm/
+        num += 1
         DRCI.put_away_item?(box, @pet_box_source)
         @pet_count -= 1
-        #break if !DRCI.get_item?("second #{box}", @pet_box_source)
-        return pickbox(game_state, number='second')
+        if num == 2
+          ord = 'second'
+        elsif num == 3
+          ord = 'third'
+        elsif num = 4
+          ord = 'fourth'
+        end
+        return pickbox(game_state, number=ord)
       when /The lock looks weak, and rather than risk breaking it/
         DRCI.dispose_trash(box, @worn_trashcan, @worn_trashcan_verb)
         @pet_count -= 1
         pick = false
       when /It's not even locked, why bother?/
-        # Box is not a trainer box. Putting away in default container.
         DRCI.put_away_item?(box)
         @pet_count -= 1
         pick = false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -43,7 +43,7 @@ class SetupProcess
     if @warhorn.casecmp('egg').zero?
       @warhon_activation_command = "invoke my #{@warhorn}"
     else
-      @warhon_activation_command = "exhale my #{@warhorn} lure"
+      @warhon_activation_command = "exhale #{@warhorn} lure"
     end
 
     if DRCI.wearing?(@warhorn)
@@ -193,8 +193,8 @@ class SetupProcess
 
   def determine_next_to_train(game_state, weapon_training, ending_ranged)
     return unless game_state.skill_done? || !weapon_training[game_state.weapon_skill] || ending_ranged
-     #check if all weapons are maxed exp to prevent rapid cycling
-     if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
+    #check if all weapons are maxed exp to prevent rapid cycling
+    if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
       echo 'all weapons locked, not switching' if $debug_mode_ct
       return
     end
@@ -831,14 +831,17 @@ class LootProcess
 
   #not necromancer related - not to be confused with the necro rituals.  According to GMs this may change but for now they are two separate functions.
   def dissected?(mob_noun, game_state)
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object','A skinned creature is worthless','You do not yet possess the knowledge required',"That'd be a waste of time")
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge')
     when 'You succeed in dissecting the corpse'
       return true
-    when 'While likely a fascinating study','You do not yet possess the knowledge required',"That'd be a waste of time"
+    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
       game_state.undissectable(mob_noun)
       return false
-    when 'would probably object'
+    when 'would probably object', "should be left alone."
       fput ('dissect')
+    when "That's going to be hard"
+      fput ('unhide')
+      dissected?(mob_noun, game_state)
     end
     return false
   end
@@ -1481,9 +1484,9 @@ class SpellProcess
         end
       end
     else
-      echo('Dropping spell: Offensive magic is not allowed right now...')
-      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      bput('release mana', 'You release all', "You aren't harnessing any mana")
+      DRC.message('Dropping spell: Offensive magic is not allowed right now...')
+      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     end
 
     @custom_cast = nil
@@ -1895,9 +1898,9 @@ class SpellProcess
     DRCA.prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
 
     if Flags['ct-shock-warning'] && !game_state.is_permashocked?
-      echo('Dropping spell: Got shock warning.')
-      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      bput('release mana', 'You release all', "You aren't harnessing any mana")
+      DRC.message('Dropping spell: Got shock warning.')
+      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     end
 
     game_state.casting = true
@@ -2304,6 +2307,8 @@ class TrainerProcess
       'Barb Research Debilitation' => 'Debilitation',
       'Barb Research Utility' => 'Utility',
       'Barb Research Warding' => 'Warding',
+      'Berserk Landslide' => 'Warding',
+      'Berserk Avalanche' => 'Utility',
       'Charged Maneuver' => 'Expertise',
       'Collect' => 'Outdoorsmanship',
       'Favor Orb' => 'Anything',
@@ -2421,6 +2426,12 @@ class TrainerProcess
     @almanac = settings.almanac_noun
     echo("  @almanac: #{@almanac}") if $debug_mode_ct
 
+    @barb_buffs_inner_fire_threshold = settings.barb_buffs_inner_fire_threshold
+    echo("  @barb_buffs_inner_fire_threshold: #{@barb_buffs_inner_fire_threshold}") if $debug_mode_ct
+
+    @always_use_maneuvers = settings.always_use_maneuvers
+    echo("  @always_use_maneuvers: #{@always_use_maneuvers}") if $debug_mode_ct
+
     @worn_trashcan = settings.worn_trashcan
     echo("  @worn_trashcan: #{@worn_trashcan}") if $debug_mode_ct
 
@@ -2517,6 +2528,14 @@ class TrainerProcess
       bput('meditate research earthquake', 'You clear ')
     when /^Barb Research Utility$/i
       bput('meditate research prediction', 'You clear ')
+    when /^Berserk Landslide$/i
+      if DRStats.mana >= @barb_buffs_inner_fire_threshold
+        DRCA.activate_barb_buff?('Landslide')
+      end
+    when /^Berserk Avalanche$/i
+      if DRStats.mana >= @barb_buffs_inner_fire_threshold
+        DRCA.activate_barb_buff?('Avalanche')
+      end
     when /^Collect$/i
       game_state.sheath_whirlwind_offhand
       retreat
@@ -2968,6 +2987,9 @@ class TrainerProcess
     check = [check].flatten
     cooldown = ability_info.is_a?(Hash) ? ability_info[:cooldown] : ability_info.to_i
     expcheck = check.nil? || check.any? { |skill_to_check| DRSkill.getxp(skill_to_check) < @combat_training_abilities_target }
+    if name == 'Charged Maneuver' && @always_use_maneuvers
+      expcheck = true
+    end
     return expcheck unless game_state.cooldown_timers[name]
 
     Time.now - game_state.cooldown_timers[name] >= cooldown ? expcheck : false
@@ -3115,7 +3137,7 @@ class AttackProcess
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
     pause

--- a/common-items.lic
+++ b/common-items.lic
@@ -61,7 +61,8 @@ module DRCI
     /You slip/,
     /You deftly remove/,
     /You are already holding/,
-    /You fade in for a moment as you/
+    /You fade in for a moment as you/,
+    /from the air/
   ]
 
   @@get_item_failure_patterns = [

--- a/locksmithing.lic
+++ b/locksmithing.lic
@@ -14,6 +14,7 @@ class Locksmithing
     @daily_trainer = settings.have_training_box
     @box = settings.picking_lockbox
     @worn_lockbox = settings.picking_worn_lockbox
+    @picking_lockbox_container = settings.picking_lockbox_container
     @box_locked = false
     @liveboxes = settings.pick_live_boxes
     @consumable_trainers = settings.consumable_lockboxes
@@ -44,7 +45,7 @@ class Locksmithing
         end
         DRC.bput("close my #{@box}", 'You close', 'That is already', "You can't close that")
       else
-        case DRC.bput("get my #{@box}", 'You get a', 'What were')
+        case DRC.bput("get my #{@box} from #{@picking_lockbox_container}", 'You get a', 'What were')
         when 'What were'
           DRC.message('Daily Trainer not found! Where is it?')
           return
@@ -57,7 +58,8 @@ class Locksmithing
         DRC.bput("pick my #{@box}", 'not making any progress', 'it opens.', "isn't locked", 'The lock feels warm')
         DRC.bput("wear my #{@box}", 'You put', 'You sling', 'You attach')
       else
-        @equipment_manager.empty_hands
+        #@equipment_manager.empty_hands
+        DRC.bput("put #{@box} in #{@picking_lockbox_container}", 'You put')
       end
     end
     DRC.bput("open my #{@box}", 'You open',"You can't open that", 'It is locked')

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -954,6 +954,10 @@ have_training_box: false
 # name of the picking training container
 picking_lockbox: training box
 picking_worn_lockbox: false
+# location of picking_lockbox if not worn
+picking_lockbox_container:
+# Used for location of consumables for picking in combat.
+picking_pet_box_source:
 # consumable boxes will be pulled from your burgle loot_container and should be kept separate from live boxes.
 # list as many as you want - though it will try from the top down.
 consumable_lockboxes:


### PR DESCRIPTION
Consumables include keepsake and jewelry boxes picked up during burgle and pouches from various events. Reusing the `picking_pet_box_source:` setting. Will not try if none found and will stop trying to get one once runs out. 

Can use daily trainers too but `;locksmithing` expects those stowed presently. 

~~Putting in draft mode to correct settings I missed adding.~~ Done!

Added in worn trashcans variable - useful for disposing of the spent keepsake|jewelry|other box|pouch. 

Added in the following because a few of my chars were not getting the weapon due to round time (3290 is the comment for why):
3291: `bput("get #{weapon_name}", 'You pick up', 'You get', 'What were') unless DRCI.in_left_hand?(weapon_name)`