### PR TITLE
Register.lic - Detect steel type when labeling

### DIFF
--- a/register.lic
+++ b/register.lic
@@ -93,7 +93,7 @@ class Register
   end
 
   def label_page
-    quality, volume, pure, mix, type = nil
+    quality, volume, pure, mix, type, steel, hardness = nil
     fput('read my register')
     loop do
       line = get
@@ -113,12 +113,16 @@ class Register
         volume = 4
       when /A deed for.+boulder reads/
         volume = 5
+      when /A deed for a steel ingot reads/
+        steel = true
       when /Metallurgical Properties/
         type = 'metal'
       when /Quality:\s+(\d+)/
         quality = Regexp.last_match(1).to_i
       when /(?:Volume:|Yards:|Pieces:|Amount:)\s+(\d+)/
         volume = Regexp.last_match(1).to_i
+      when /(?:Hardness:)\s+(\d+)/
+        hardness = Regexp.last_match(1).to_i
       when /This ingot is certified pure/
         pure = true
       when /The metal appears to be composed of: (.*)\.$/
@@ -129,6 +133,16 @@ class Register
     end
     write = "#{volume}V #{quality}Q"
     write << " - pure" if pure
+    if steel
+      case hardness
+      when 90
+        write << " HCS"
+      when 85
+        write << " MCS"
+      when 80
+        write << " LCS"
+      end
+    end
     write << " - #{sort_mix(mix)}" if mix
     write << " - unknown mix" if type == 'metal' && !pure && mix.nil?
     fput("write #{write}")


### PR DESCRIPTION
The script will now label steel with HCS, MCS, or LCS when the ingot is pure.

Old labeling:
`81 -- a deed for a steel ingot (51V 99Q - pure --Binu)`

New labeling:
`81 -- a deed for a steel ingot (51V 99Q - pure HCS --Binu)`