### PR TITLE
combat-trainer.lic - Added threshold setting for casting VH

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1111,6 +1111,9 @@ class SpellProcess
     @empath_spells = settings.empath_healing
     echo("  @empath_spells: #{@empath_spells}") if $debug_mode_ct
 
+    @empath_vitality_threshold = settings.empath_vitality_threshold
+    echo("  @empath_vitality_threshold: #{@empath_vitality_threshold}") if $debug_mode_ct
+
     @osrel_timer = Time.now - 1000
     echo("  @osrel_timer: #{@osrel_timer}") if $debug_mode_ct
 
@@ -1652,10 +1655,10 @@ class SpellProcess
   end
 
   def check_health_empath(game_state)
-    return if DRStats.health > 95 && @wounds.empty?
+    return if DRStats.health > @empath_vitality_threshold && @wounds.empty?
 
     if DRSpells.active_spells['Regeneration']
-      if @empath_spells['VH'] && DRStats.health <= 95
+      if @empath_spells['VH'] && DRStats.health <= @empath_vitality_threshold
         data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1], 'harmless' => true }
         prepare_spell(data, game_state)
       end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1119,6 +1119,9 @@ empath_healing:
 #   - 5       # 1st cambrinth amount
 #   - 5       # 2nd cambrinth amount
 
+# Setting to control the health threshold for casting Vitality Healing (if defined)
+empath_vitality_threshold: 95
+
 # healme script specific settings for empaths.
 # Highly recommend that you define a 'healing' waggle set
 # for maximum control over how you cast your healing spells.


### PR DESCRIPTION
Added a setting to control threshold for casting VH as an empath. Default value is 95 to align with previously hardcoded value.