### PR TITLE
Update combat-trainer.lic

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3118,13 +3118,13 @@ class AttackProcess
     # rather than relying on the first message returned from bput.
     Flags.reset('ct-ranged-ammo')
 
-    result = bput(command, /you (fire|poach|snipe)/i, 'isn\'t loaded', 'There is nothing', 'But your', 'I could not find', 'with no effect and falls (to the ground|to your feet)', 'Face what', 'How can you (poach|snipe)', /you don\'t feel like fighting right now/i, 'That weapon must be in your right hand to fire', 'But you don\'t have a ranged weapon in your hand to fire with')
+    result = bput(command, /you (fire|poach|snipe)/i, /isn't loaded/i, /There is nothing/i, /But your/i, /I could not find/i, /with no effect and falls (to the ground|to your feet)/i, /Face what/i, /How can you (poach|snipe)/i, /you don't feel like fighting right now/i, /That weapon must be in your right hand to fire/i, /But you don't have a ranged weapon in your hand to fire with/i)
     waitrt?
 
     case result
-    when /How can you (poach|snipe)/
+    when /How can you (poach|snipe)/i
       shoot_aimed('shoot', game_state)
-    when /That weapon must be in your right hand to fire|But you don't have a ranged weapon in your hand to fire with/
+    when /That weapon must be in your right hand to fire|But you don't have a ranged weapon in your hand to fire with/i
       # Explicitly say 'swap right' because if you're holding a swappable weapon (e.g. riste)
       # then just 'swap' will try to switch the weapon mode, not move it to other hand.
       if fput('swap right') =~ /You (swap|move)/i
@@ -3133,10 +3133,13 @@ class AttackProcess
     when /you don't feel like fighting right now/i
       pause 1
       shoot_aimed(command, game_state)
-    when /you (fire|poach|snipe)|with no effect and falls (to the ground|to your feet)/i
+    when /with no effect and falls (to the ground|to your feet)/i
       # If you fired without Bless at an incorporeal undead then it'll have no effect.
       # However, that's still considered an action taken, just you missed.
       game_state.action_taken
+    when /you (fire|poach|snipe)/i
+      #Successful fire, increment action_taken
+      game_state.action_taken    
     end
 
     # If detected that you shot, then stow any non-lodged ammo.


### PR DESCRIPTION
Attempts to address issue #5202 

Ranged attacks were not incrementing action_count and thus the script was not honoring the action count yaml setting threshold. Community help in Discord showed that the regex matching was wrong.

This is an attempt to fix that by using the regex case insensitivity flag where appropriate. I've done some basic testing with this PR and it increments the action count successfully now. I wasn't able to test it exhaustively.

I also added a debug echo in each of the three action_count code blocks so that we can see when action_count resets, increments, and decrements.

Special thanks to @BinuDR @wstampley and the Discord folks.