### PR TITLE
NEW SCRIPT - sort-scrolls.lic

### DIFF
--- a/sort-scrolls.lic
+++ b/sort-scrolls.lic
@@ -1,0 +1,520 @@
+custom_require.call(%w[common])
+
+class ScrollSorter
+  include DRC
+  
+  def initialize
+    $ALL_SPELLS =
+    [
+      ["Abandoned Heart", "Bard"],
+      ["Aether Wolves", "Bard"],
+      ["Albreda's Balm", "Bard"],
+      ["Aura of Tongues", "Bard"],
+      ["Beckon the Naga", "Bard"],
+      ["Blessing of the Fae", "Bard"],
+      ["Breath of Storms", "Bard"],
+      ["Caress of the Sun", "Bard"],
+      ["Damaris' Lullaby", "Bard"],
+      ["Demrris' Resolve", "Bard"],
+      ["Desert's Maelstrom", "Bard"],
+      ["Drums of the Snake", "Bard"],
+      ["Echoes of Aether", "Bard"],
+      ["Eillie's Cry", "Bard"],
+      ["Eye of Kertigen", "Bard"],
+      ["Faenella's Grace", "Bard"],
+      ["Glythtide's Joy", "Bard"],
+      ["Harmony", "Bard"],
+      ["Hodierna's Lilt", "Bard"],
+      ["Misdirection", "Bard"],
+      ["Naming of Tears", "Bard"],
+      ["Nexus", "Bard"],
+      ["Phoenix's Pyre", "Bard"],
+      ["Rage of the Clans", "Bard"],
+      ["Redeemer's Pride", "Bard"],
+      ["Resonance", "Bard"],
+      ["Sanctuary", "Bard"],
+      ["Soul Ablaze", "Bard"],
+      ["Whispers of the Muse", "Bard"],
+      ["Will of Winter", "Bard"],
+      ["Words of the Wind", "Bard"],
+      ["Aesrela Everild", "Cleric"],
+      ["Aspects of the All-God", "Cleric"],
+      ["Auspice", "Cleric"],
+      ["Benediction", "Cleric"],
+      ["Bitter Feast", "Cleric"],
+      ["Bless", "Cleric"],
+      ["Centering", "Cleric"],
+      ["Chill Spirit", "Cleric"],
+      ["Curse of Zachriedek", "Cleric"],
+      ["Divine Radiance", "Cleric"],
+      ["Eylhaar's Feast", "Cleric"],
+      ["Fire of Ushnish", "Cleric"],
+      ["Fists of Faenella", "Cleric"],
+      ["Ghost Shroud", "Cleric"],
+      ["Glythtide's Gift", "Cleric"],
+      ["Halo", "Cleric"],
+      ["Hand of Tenemlor", "Cleric"],
+      ["Harm Evil", "Cleric"],
+      ["Harm Horde", "Cleric"],
+      ["Heavenly Fires", "Cleric"],
+      ["Horn of the Black Unicorn", "Cleric"],
+      ["Huldah's Pall", "Cleric"],
+      ["Hydra Hex", "Cleric"],
+      ["Idon's Theft", "Cleric"],
+      ["Major Physical Protection", "Cleric"],
+      ["Malediction", "Cleric"],
+      ["Mass Rejuvenation", "Cleric"],
+      ["Meraud's Cry", "Cleric"],
+      ["Minor Physical Protection", "Cleric"],
+      ["Murrula's Flames", "Cleric"],
+      ["Osrel Meraud", "Cleric"],
+      ["Persistence of Mana", "Cleric"],
+      ["Phelim's Sanction", "Cleric"],
+      ["Protection from Evil", "Cleric"],
+      ["Rejuvenation", "Cleric"],
+      ["Resurrection", "Cleric"],
+      ["Revelation", "Cleric"],
+      ["Sanctify Pattern", "Cleric"],
+      ["Sanyu Lyba", "Cleric"],
+      ["Shield of Light", "Cleric"],
+      ["Soul Attrition", "Cleric"],
+      ["Soul Bonding", "Cleric"],
+      ["Soul Shield", "Cleric"],
+      ["Soul Sickness", "Cleric"],
+      ["Spite of Dergati", "Cleric"],
+      ["Time of the Red Spiral", "Cleric"],
+      ["Uncurse", "Cleric"],
+      ["Vigil", "Cleric"],
+      ["Absolution", "Empath"],
+      ["Adaptive Curing", "Empath"],
+      ["Aesandry Darlaeth", "Empath"],
+      ["Aggressive Stance", "Empath"],
+      ["Awaken", "Empath"],
+      ["Blood Staunching", "Empath"],
+      ["Circle of Sympathy", "Empath"],
+      ["Compel", "Empath"],
+      ["Cure Disease", "Empath"],
+      ["Flush Poisons", "Empath"],
+      ["Fountain of Creation", "Empath"],
+      ["Gift of Life", "Empath"],
+      ["Guardian Spirit", "Empath"],
+      ["Heal", "Empath"],
+      ["Heal Scars", "Empath"],
+      ["Heal Wounds", "Empath"],
+      ["Heart Link", "Empath"],
+      ["Icutu Zaharenela", "Empath"],
+      ["Innocence", "Empath"],
+      ["Iron Constitution", "Empath"],
+      ["Lethargy", "Empath"],
+      ["Mental Focus", "Empath"],
+      ["Nissa's Binding", "Empath"],
+      ["Paralysis", "Empath"],
+      ["Perseverance of Peri'el", "Empath"],
+      ["Raise Power", "Empath"],
+      ["Refresh", "Empath"],
+      ["Regenerate", "Empath"],
+      ["Tranquility", "Empath"],
+      ["Vigor", "Empath"],
+      ["Vitality Healing", "Empath"],
+      ["Artificer's Eye", "Moon Mage"],
+      ["Aura Sight", "Moon Mage"],
+      ["Braun's Conjecture", "Moon Mage"],
+      ["Burn", "Moon Mage"],
+      ["Cage of Light", "Moon Mage"],
+      ["Calm", "Moon Mage"],
+      ["Clear Vision", "Moon Mage"],
+      ["Contingency", "Moon Mage"],
+      ["Dazzle", "Moon Mage"],
+      ["Destiny Cipher", "Moon Mage"],
+      ["Dinazen Olkar", "Moon Mage"],
+      ["Distant Gaze", "Moon Mage"],
+      ["Empower Moonblade", "Moon Mage"],
+      ["Focus Moonbeam", "Moon Mage"],
+      ["Hypnotize", "Moon Mage"],
+      ["Invocation of the Spheres", "Moon Mage"],
+      ["Iyqaromos Fire-Lens", "Moon Mage"],
+      ["Locate", "Moon Mage"],
+      ["Machinist's Touch", "Moon Mage"],
+      ["Mental Blast", "Moon Mage"],
+      ["Mind Shout", "Moon Mage"],
+      ["Moonblade", "Moon Mage"],
+      ["Moongate", "Moon Mage"],
+      ["Partial Displacement", "Moon Mage"],
+      ["Piercing Gaze", "Moon Mage"],
+      ["Psychic Shield", "Moon Mage"],
+      ["Read the Ripples", "Moon Mage"],
+      ["Refractive Field", "Moon Mage"],
+      ["Rend", "Moon Mage"],
+      ["Riftal Summons", "Moon Mage"],
+      ["Ripplegate Theory", "Moon Mage"],
+      ["Saesordian Compass", "Moon Mage"],
+      ["Seer's Sense", "Moon Mage"],
+      ["Sever Thread", "Moon Mage"],
+      ["Shadewatch Mirror", "Moon Mage"],
+      ["Shadow Servant", "Moon Mage"],
+      ["Shadow Web", "Moon Mage"],
+      ["Shadowling", "Moon Mage"],
+      ["Shadows", "Moon Mage"],
+      ["Shape Moonblade", "Moon Mage"],
+      ["Shear", "Moon Mage"],
+      ["Shift Moonbeam", "Moon Mage"],
+      ["Sleep", "Moon Mage"],
+      ["Sovereign Destiny", "Moon Mage"],
+      ["Starlight Sphere", "Moon Mage"],
+      ["Steps of Vuan", "Moon Mage"],
+      ["Tangled Fate", "Moon Mage"],
+      ["Telekinetic Storm", "Moon Mage"],
+      ["Telekinetic Throw", "Moon Mage"],
+      ["Teleport", "Moon Mage"],
+      ["Tenebrous Sense", "Moon Mage"],
+      ["Tezirah's Veil", "Moon Mage"],
+      ["Thoughtcast", "Moon Mage"],
+      ["Unleash", "Moon Mage"],
+      ["Whole Displacement", "Moon Mage"],
+      ["Acid Splash", "Necromancer"],
+      ["Alkahest Edge", "Necromancer"],
+      ["Blood Burst", "Necromancer"],
+      ["Butcher's Eye", "Necromancer"],
+      ["Calcified Hide", "Necromancer"],
+      ["Call from Beyond", "Necromancer"],
+      ["Chirurgia", "Necromancer"],
+      ["Consume Flesh", "Necromancer"],
+      ["Covetous Rebirth", "Necromancer"],
+      ["Devour", "Necromancer"],
+      ["Ebon Blood of the Scorpion", "Necromancer"],
+      ["Emuin's Candlelight", "Necromancer"],
+      ["Eyes of the Blind", "Necromancer"],
+      ["Heighten Pain", "Necromancer"],
+      ["Ivory Mask", "Necromancer"],
+      ["Kura-Silma", "Necromancer"],
+      ["Liturgy", "Necromancer"],
+      ["Necrotic Reconstruction", "Necromancer"],
+      ["Obfuscation", "Necromancer"],
+      ["Petrifying Visions", "Necromancer"],
+      ["Philosopher's Preservation", "Necromancer"],
+      ["Quicken the Earth", "Necromancer"],
+      ["Researcher's Insight", "Necromancer"],
+      ["Reverse Putrefaction", "Necromancer"],
+      ["Rite of Contrition", "Necromancer"],
+      ["Rite of Forbearance", "Necromancer"],
+      ["Rite of Grace", "Necromancer"],
+      ["Siphon Vitality", "Necromancer"],
+      ["Solace", "Necromancer"],
+      ["Spiteful Rebirth", "Necromancer"],
+      ["Universal Solvent", "Necromancer"],
+      ["Viscous Solution", "Necromancer"],
+      ["Visions of Darkness", "Necromancer"],
+      ["Vivisection", "Necromancer"],
+      ["Worm's Mist", "Necromancer"],
+      ["Alamhif's Gift", "Paladin"],
+      ["Anti-Stun", "Paladin"],
+      ["Aspirant's Aegis", "Paladin"],
+      ["Banner of Truce", "Paladin"],
+      ["Bond Armaments", "Paladin"],
+      ["Clarity", "Paladin"],
+      ["Courage", "Paladin"],
+      ["Crusader's Challenge", "Paladin"],
+      ["Divine Armor", "Paladin"],
+      ["Divine Guidance", "Paladin"],
+      ["Footman's Strike", "Paladin"],
+      ["Halt", "Paladin"],
+      ["Hands of Justice", "Paladin"],
+      ["Heroic Strength", "Paladin"],
+      ["Holy Warrior", "Paladin"],
+      ["Marshal Order", "Paladin"],
+      ["Rebuke", "Paladin"],
+      ["Righteous Wrath", "Paladin"],
+      ["Rutilor's Edge", "Paladin"],
+      ["Sentinel's Resolve", "Paladin"],
+      ["Shatter", "Paladin"],
+      ["Smite Horde", "Paladin"],
+      ["Soldier's Prayer", "Paladin"],
+      ["Stun Foe", "Paladin"],
+      ["Truffenyi's Rally", "Paladin"],
+      ["Vessel of Salvation", "Paladin"],
+      ["Veteran Insight", "Paladin"],
+      ["Athleticism", "Ranger"],
+      ["Awaken Forest", "Ranger"],
+      ["Bear Strength", "Ranger"],
+      ["Blend", "Ranger"],
+      ["Carrion Call", "Ranger"],
+      ["Cheetah Swiftness", "Ranger"],
+      ["Claws of the Cougar", "Ranger"],
+      ["Compost", "Ranger"],
+      ["Curse of the Wilds", "Ranger"],
+      ["Deadfall", "Ranger"],
+      ["Devitalize", "Ranger"],
+      ["Devolve", "Ranger"],
+      ["Eagle's Cry", "Ranger"],
+      ["Earth Meld", "Ranger"],
+      ["Essence of Yew", "Ranger"],
+      ["Forestwalker's Boon", "Ranger"],
+      ["Grizzly Claws", "Ranger"],
+      ["Hands of Lirisa", "Ranger"],
+      ["Harawep's Bonds", "Ranger"],
+      ["Instinct", "Ranger"],
+      ["Memory of Nature", "Ranger"],
+      ["Oath of the Firstborn", "Ranger"],
+      ["Plague of Scavengers", "Ranger"],
+      ["See the Wind", "Ranger"],
+      ["Senses of the Tiger", "Ranger"],
+      ["Skein of Shadows", "Ranger"],
+      ["Stampede", "Ranger"],
+      ["Swarm", "Ranger"],
+      ["Syamelyo Kuniyo", "Ranger"],
+      ["Wisdom of the Pack", "Ranger"],
+      ["Wolf Scent", "Ranger"],
+      ["Arbiter's Stylus", "Trader"],
+      ["Avren Aevareae", "Trader"],
+      ["Avtalia Array", "Trader"],
+      ["Bespoke Regalia", "Trader"],
+      ["Blur", "Trader"],
+      ["Crystal Dart", "Trader"],
+      ["Elision", "Trader"],
+      ["Enrichment", "Trader"],
+      ["Finesse", "Trader"],
+      ["Fluoresce", "Trader"],
+      ["Last Gift of Vithwok IV", "Trader"],
+      ["Mask of the Moons", "Trader"],
+      ["Membrach's Greed", "Trader"],
+      ["Nonchalance", "Trader"],
+      ["Noumena", "Trader"],
+      ["Platinum Hands of Kertigen", "Trader"],
+      ["Regalia", "Trader"],
+      ["Resumption", "Trader"],
+      ["Starcrash", "Trader"],
+      ["Stellar Collector", "Trader"],
+      ["Trabe Chalice", "Trader"],
+      ["Turmar Illumination", "Trader"],
+      ["Aegis of Granite", "Warrior Mage"],
+      ["Aether Cloak", "Warrior Mage"],
+      ["Aethrolysis", "Warrior Mage"],
+      ["Air Bubble", "Warrior Mage"],
+      ["Air Lash", "Warrior Mage"],
+      ["Anther's Call", "Warrior Mage"],
+      ["Arc Light", "Warrior Mage"],
+      ["Blufmor Garaen", "Warrior Mage"],
+      ["Chain Lightning", "Warrior Mage"],
+      ["Dragon's Breath", "Warrior Mage"],
+      ["Electrostatic Eddy", "Warrior Mage"],
+      ["Elementalism", "Warrior Mage"],
+      ["Ethereal Fissure", "Warrior Mage"],
+      ["Ethereal Shield", "Warrior Mage"],
+      ["Expansive Infusions", "Warrior Mage"],
+      ["Fiery Infusions", "Warrior Mage"],
+      ["Fire Ball", "Warrior Mage"],
+      ["Fire Rain", "Warrior Mage"],
+      ["Fire Shards", "Warrior Mage"],
+      ["Flame Shockwave", "Warrior Mage"],
+      ["Fortress of Ice", "Warrior Mage"],
+      ["Frost Scythe", "Warrior Mage"],
+      ["Frostbite", "Warrior Mage"],
+      ["Gar Zeng", "Warrior Mage"],
+      ["Geyser", "Warrior Mage"],
+      ["Grounding Field", "Warrior Mage"],
+      ["Ice Patch", "Warrior Mage"],
+      ["Icy Infusions", "Warrior Mage"],
+      ["Ignite", "Warrior Mage"],
+      ["Ignition Point", "Warrior Mage"],
+      ["Lightning Bolt", "Warrior Mage"],
+      ["Magnetic Ballista", "Warrior Mage"],
+      ["Mantle of Flame", "Warrior Mage"],
+      ["Mark of Arhat", "Warrior Mage"],
+      ["Paeldryth's Wrath", "Warrior Mage"],
+      ["Quick Infusions", "Warrior Mage"],
+      ["Reinforced Infusions", "Warrior Mage"],
+      ["Rimefang", "Warrior Mage"],
+      ["Ring of Spears", "Warrior Mage"],
+      ["Rising Mists", "Warrior Mage"],
+      ["Shocking Infusions", "Warrior Mage"],
+      ["Shockwave", "Warrior Mage"],
+      ["Stone Strike", "Warrior Mage"],
+      ["Substratum", "Warrior Mage"],
+      ["Sure Footing", "Warrior Mage"],
+      ["Swirling Winds", "Warrior Mage"],
+      ["Tailwind", "Warrior Mage"],
+      ["Thunderclap", "Warrior Mage"],
+      ["Tingle", "Warrior Mage"],
+      ["Tremor", "Warrior Mage"],
+      ["Veil of Ice", "Warrior Mage"],
+      ["Vertigo", "Warrior Mage"],
+      ["Ward Break", "Warrior Mage"],
+      ["Y'ntrel Sechra", "Warrior Mage"],
+      ["Zephyr", "Warrior Mage"],
+      ["Burden", "Analogous"],
+      ["Dispel", "Analogous"],
+      ["Ease Burden", "Analogous"],
+      ["Gauge Flow", "Analogous"],
+      ["Imbue", "Analogous"],
+      ["Lay Ward", "Analogous"],
+      ["Manifest Force", "Analogous"],
+      ["Seal Cambrinth", "Analogous"],
+      ["Strange Arrow", "Analogous"]
+    ]
+    @settings = get_settings
+    @default_container = @settings.default_container
+    @stacker = get_settings.scroll_sorter['stacker']
+    @stacker_container = get_settings.scroll_sorter['stacker_container']
+    @custom_nouns = get_settings.scroll_sorter['scroll_nouns']
+    @scroll_nouns = Array.new
+    @scroll_nouns.push(*get_data('items').scroll_nouns)
+    @scroll_nouns.push(*@custom_nouns)
+
+    arg_definitions =
+      [
+        [
+          { name: 'container', regex: /\w+/, optional: true, description: 'The container to collect scrolls from' }
+        ],
+        
+        [
+          { name: 'find', regex: /find/i },
+          { name: 'spell', regex: /\w+/i, variable: true, description: 'Name of spell to find' }
+        ]
+      ]
+    
+    args = parse_args(arg_definitions)
+    @default_container = args.container ? args.container : @default_container
+    @cases = populate_cases
+    
+    if args.find
+      find_spell(args.spell)
+    else
+      sort_scrolls
+    end
+    fput "close my #{@stacker_container}" if @settings.scroll_sorter['close_container']
+  end
+
+  def populate_cases
+    c = Array.new
+    fput "open my #{@stacker_container}"
+    fput "inv #{@stacker_container}"
+    pause 1
+
+    loop do
+      line = get
+      if line.include?(@stacker)
+        /labeled "(.*)"/ =~ line
+        guild = Regexp.last_match(1).to_s
+        c << guild
+      end
+      break if line.include?('INVENTORY HELP')
+    end
+    return c
+  end
+  
+  def unknown
+    DRC.message("Spell not found.  Either a new spell was released and it hasn't been added to the script yet, or you misspelled the spell you're searching for.")
+    exit
+  end
+
+  def find_scrolls(container)
+    x = Array.new
+    put "inv #{container}"
+    loop do
+      line = get
+      @scroll_nouns.each do |n|
+        x << n if line =~ / #{n}/
+      end
+      break if line.include?('INVENTORY HELP')
+    end
+    x
+  end
+  
+  def get_scroll(scroll)
+    case bput("get #{scroll} in my #{@default_container}", /You get/, /What were you referring/)
+    when /What were you referring/
+      message("  Can't find #{scroll} in your #{@default_container}!")
+      return false
+    end
+    return true
+  end
+  
+  def check_scroll(scroll)
+    case bput("look my #{scroll}", /It is labeled "(.*)\."/, /Illustrations of complex/)
+    when /Illustrations of complex/
+      message('Not labeled yet!')
+      /of the (.*) spell/ =~ bput("read my #{scroll}", 'The .* contains a complete description of the .* spell')
+      spell = Regexp.last_match(1)
+      guild = $ALL_SPELLS.select{ |s,g| s == spell }.flatten[1]
+      return guild
+    when /It is labeled "(.*)\."/
+      spell = Regexp.last_match(1).to_s
+      guild = $ALL_SPELLS.select{ |s,g| s == spell }.flatten[1]
+      return guild
+    end
+    return nil
+  end
+  
+  def find_case(guild)
+    @cases.each{ |c| return $ORDINALS[@cases.index(c)] if c.include?(guild) }
+  end
+  
+  def stack_scroll(scroll, guild)
+    if guild == 'Analogous'
+      message("Analogous pattern scroll, dropping it.")
+      bput("drop my #{scroll}", /You drop/)
+      return
+    end
+    ord = find_case(guild)
+    bput("get #{ord} #{@stacker} in my #{@stacker_container}", /You get/)
+    case bput("push my #{@stacker} with my #{scroll}", /you find room in a matching section/, /flip to an empty section/, /you realize there's no more room/, /you need to open the #{@stacker.split.last} first/)
+    when /you find room in a matching section/, /flip to an empty section/
+      stow_and_refactor_cases(guild)
+    when /you need to open the #{@stacker.split.last} first/
+      bput("open my #{@stacker}", /You open your #{@stacker.split.last} to the first section/)
+      stow_and_refactor_cases(guild)
+      stack_scroll(scroll, guild)
+    when /you realize there's no more room/
+      stow_and_refactor_cases(guild)
+      stack_scroll(scroll, "Extras")
+    end
+  end
+  
+  def stow_and_refactor_cases(guild)
+    bput("put my #{@stacker} in my #{@stacker_container}", /You put your/)
+    @cases.delete(guild)
+    @cases.unshift(guild)
+  end
+  
+  def sort_scrolls
+    scrolls = find_scrolls(@default_container)
+    scrolls.each do |s|
+      next unless get_scroll(s)
+      guild = check_scroll(s)
+      unknown if guild.nil?
+      stack_scroll(s, guild)
+    end
+  end
+  
+  def find_spell(name)
+    guild = $ALL_SPELLS.select{ |s,g| s =~ /#{name}/i }.flatten[1]
+    unknown if guild.nil?
+    ord = find_case(guild)
+    bput("get #{ord} #{@stacker} in my #{@stacker_container}", /You get/)
+    spells = Array.new
+    start = Time.now
+    fput("flip my #{@stacker}")
+    
+    loop do
+      line = get?
+      break if (Time.now-start) > 2
+      case line
+      when /The (.+) section/
+        spells.push(Regexp.last_match(1))
+      when /Section \d+ is empty/
+        spells.push('BlankSection')
+      end
+    end
+    num = spells.index{ |i| i =~ /#{name}/i }
+    if num.nil?
+      DRC.message("You have no copies of #{name}!")
+    else
+      fput("open my #{@stacker}")
+      num.times{ fput "turn my #{stacker}"; pause 0.1 }
+      fput("pull my #{@stacker}")
+    end
+    bput("put my #{@stacker} in my #{@stacker_container}", /You put your/)
+  end
+end
+
+ScrollSorter.new


### PR DESCRIPTION
This is an alternative to stack-scrolls because that script requires that you have different nouns for each case.

I've written this script so that you have all of your cases with the same noun, but you have to put a wax label on each of them and label them with guild names.  Currently the search is case sensitive, and spaces work so they need to be labeled like this: 
"Bard"
"Warrior Mage"
etc.

There is also a 10th case needed and that one should be labeled "Extras" for overflow if any of the other cases get full.

Here are all of the yaml settings used in the script:

```
scroll_sorter:
  stacker: scroll folio
  stacker_container: haversack
  scroll_nouns: ['cerulean scroll', 'glittery-pink scroll', 'silver-stippled scroll', 'gold-stippled scroll']
  close_container: false
```

`stacker:` is the noun or adjective and noun of the case type you're using.
`stacker_container:` is where you have your cases stored, and the script will put them back there as well.  If you don't specify this setting, it will use `default_container:` instead.
`scroll_nouns:` is where you specify any custom scroll types that come from different cases and also from custom papers you can use.
`close_container:` will close the container when the script ends if you set this to true.  If you don't include this setting, it won't close the container.

The script can be run in 3 ways.
Run with no arguments:  It will search for scrolls in your `default_container:` and put them into the correct cases.
Run with a container argument:  It will search for scrolls in the container you specify.  (;sort-scrolls backpack)
The third method will search for a scroll and remove a copy if you have one.  You can search for partial names, but if it matches more than 1 spell (like telekinetic), it will pick the first one alphabetically.
`;sort-scrolls find <spell name>`