### PR TITLE
Fix common-arcana telescope storage

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1814,7 +1814,7 @@ class SpellProcess
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
 
-    data = update_astral_data(data)
+    data = update_astral_data(data, @settings)
     if data # update_astral_data returns nil on failure
       check_invoke(game_state)
       ritual(data, @settings)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -518,21 +518,21 @@ module DRCA
     end
   end
 
-  def update_astral_data(data)
+  def update_astral_data(data, settings)
     if data['moon']
       data = set_moon_data(data)
     elsif data['stats']
-      data = set_planet_data(data)
+      data = set_planet_data(data, settings)
     end
     data
   end
 
-  def find_visible_planets(planets)
+  def find_visible_planets(planets, settings)
+    return unless settings.have_telescope
     return if DRC.bput('get my telescope', 'You get', 'What were you', 'You are already') == 'What were you'
 
     Flags.add('planet-not-visible', 'turns up fruitless')
     observed_planets = []
-
     planets.each do |planet|
       case DRC.bput("center telescope on #{planet}", 'You put your eye', 'The pain is too much', "That's a bit tough to do when you can't see the sky")
       when 'The pain is too much', "That's a bit tough to do when you can't see the sky"
@@ -541,18 +541,19 @@ module DRCA
       observed_planets << planet unless Flags['planet-not-visible']
       Flags.reset('planet-not-visible')
     end
-
     Flags.delete('planet-not-visible')
-    DRC.bput('stow telescope', 'You put')
+
+    DRCI.put_away_item?('telescope', settings.telescope_storage ? settings.telescope_storage['container'] : nil)
+
     observed_planets
   end
 
-  def set_planet_data(data)
+  def set_planet_data(data, settings)
     return data unless data['stats']
 
     planets = get_data('constellations')[:constellations].select { |planet| planet['stats'] }
     planet_names = planets.map { |planet| planet['name'] }
-    visible_planets = find_visible_planets(planet_names)
+    visible_planets = find_visible_planets(planet_names, settings)
     data['stats'].each do |stat|
       cast_on = planets.map { |planet| planet['name'] if planet['stats'].include?(stat) && visible_planets.include?(planet['name']) }.compact.first
       next unless cast_on
@@ -596,7 +597,7 @@ module DRCA
     return unless data
     return unless settings
 
-    data = update_astral_data(data)
+    data = update_astral_data(data, settings)
     return unless data # update_astral_data returns nil on failure
 
     if (data['abbrev'] =~ /locat/i) && !DRSpells.active_spells['Clear Vision']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -560,7 +560,7 @@ module DRCA
       data['cast'] = "cast #{cast_on}"
       return data
     end
-    echo 'Could not find any planets to cast on'
+    DRC.message('Could not find any planets to cast on. Do you have a telescope configured?')
     nil
   end
 

--- a/test/test_common_arcana.rb
+++ b/test/test_common_arcana.rb
@@ -37,9 +37,26 @@ class TestDRCA < Minitest::Test
     @test = run_script_with_proc(['common', 'common-items', 'common-arcana'], proc do
       DRCA.const_set("DRC", DRC) unless defined?(DRCA::DRC)
       DRCA.const_set("DRCI", DRCI) unless defined?(DRCA::DRCI)
+      $test_settings.have_telescope = true
 
-      seen_planets = DRCA.find_visible_planets(['a planet', 'another planet'])
+      seen_planets = DRCA.find_visible_planets(['a planet', 'another planet'], $test_settings)
       assert_empty(seen_planets)
+    end)
+  end
+
+  def test_find_visible_planets_while_indoors
+    $history = [
+      'You get an ivory telescope inlaid with a ruby-eyed golden dragon from inside your hunting pack.',
+      "That's a bit tough to do when you can't see the sky.",
+      'You put your telescope in your hunting pack.'
+    ]
+    @test = run_script_with_proc(['common', 'common-items', 'common-arcana'], proc do
+      DRCA.const_set("DRC", DRC) unless defined?(DRCA::DRC)
+      DRCA.const_set("DRCI", DRCI) unless defined?(DRCA::DRCI)
+      $test_settings.have_telescope = false
+
+      seen_planets = DRCA.find_visible_planets(['a planet', 'another planet'], $test_settings)
+      assert_nil(seen_planets)
     end)
   end
 


### PR DESCRIPTION
common-arcana uses 'stow' instead of correctly putting things back where it should, which then makes my other scripts very angry.