### PR TITLE
[script][heal-remedy][update]Changed catch messages to @@<name>, exam…

### DIFF
--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -16,6 +16,33 @@ arg_definitions = [
   ]
 ]
 
+@@drink_remedy_success_patterns = [
+  /You drink/,
+  /You take a drink/
+]
+
+@@remedy_inhale_patterns = [
+  /^You'd be better off trying to inhale/
+]
+
+@@drink_remedy_eat_patterns = [
+  /can't drink/
+]
+
+@@remedy_failure_patterns = [
+  /Drink what?/,
+  /you referring to?/
+]
+
+@@eat_remedy_success_patterns = [
+  /You eat/
+]
+
+@@eat_remedy_drink_patterns = [
+  /^You'd be better off trying to drink/,
+  /you should try drinking that?/
+]
+
 args = parse_args(arg_definitions)
 $debug_mode_hr = args.debug
 $nohands_mode = args.nohands
@@ -175,14 +202,14 @@ end
 
 def drink_remedy?(remedy)
   DRC.message("In drink_remedy function and remedy is #{remedy}") if $debug_mode_hr
-  result = DRC.bput("drink my #{remedy}", /You drink/, /Drink what?/, /can't drink/, /^You'd be better off trying to inhale/,/You take a drink/)
+  result = DRC.bput("drink my #{remedy}", @@drink_remedy_success_patterns, @@drink_remedy_eat_patterns, @@remedy_inhale_patterns, @@remedy_failure_patterns)
   DRC.message("drink_remedy function result is #{result}.") if $debug_mode_hr
   case result
-  when /You drink/,/You take a drink/
+  when *@@drink_remedy_success_patterns
     true
-  when /^You'd be better off trying to inhale/
+  when *@@remedy_inhale_patterns
     inhale_remedy?(remedy)
-  when /can't drink/
+  when *@@drink_remedy_eat_patterns
     eat_remedy?(remedy)
   else
     false
@@ -191,14 +218,14 @@ end
 
 def eat_remedy?(remedy)
   DRC.message("In eat_remedy function and remedy is #{remedy}") if $debug_mode_hr
-  result = DRC.bput("eat my #{remedy}", /You eat/, /you referring to?/, /^You'd be better off trying to inhale/, /^You'd be better off trying to drink/, /you should try drinking that?/)
+  result = DRC.bput("eat my #{remedy}", @@eat_remedy_success_patterns, @@remedy_inhale_patterns, @@eat_remedy_drink_patterns, @@remedy_failure_patterns)
   DRC.message("eat_remedy function result is #{result}.") if $debug_mode_hr
   case result
-  when /You eat/
+  when *@@eat_remedy_success_patterns
     true
-  when /^You'd be better off trying to inhale/
+  when *@@remedy_inhale_patterns
     inhale_remedy?(remedy)
-  when /^You'd be better off trying to drink/, /you should try drinking that?/
+  when *@@eat_remedy_drink_patterns
     drink_remedy?(remedy)
   else
     false


### PR DESCRIPTION
…ple: @@drink_remedy_success_patterns, etc. This will allow easier additions of messages later instead of requiring two places to edit. Just add the message to the correct @@<name>.

Was suggested in the last update to this script. 