### PR TITLE
Update SampleMoonMage-setup.yaml

### DIFF
--- a/profiles/SampleMoonMage-setup.yaml
+++ b/profiles/SampleMoonMage-setup.yaml
@@ -148,6 +148,18 @@ crossing_training:
 - Athletics
 - Perception
 - Mechanical Lore
+
+# Astrology settings
+# divination_bones_storage:
+#   container: forging kit
+#   tied: false
+# astrology_training:
+# - observe
+# - rtr
+# astral_plane_training:
+#   train_destination: Shard
+#   train_source: Crossing
+# astrology_use_full_pools: false # Helps maximize tool bonding rate when using max pools
 have_telescope: false
 
 safe_room: 19162


### PR DESCRIPTION
After some user confusion of yaml setting formats, added some astrology settings examples in the SampleMoonMage yaml. Commented all of it out so that the functionality of the sample yaml doesn't change, but the format of the additional examples is there to use.