### PR TITLE
craft.lic - fix for enchanting tier 5

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -344,7 +344,7 @@ class Craft
     elsif rank <= 300 # Tier 5 - Basic
       # Buy an abolition and congruence sigils and bone totem
       ensure_copper_on_hand(2000, @settings)
-      DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 3) unless DRCI.exists?("induction sigil-scroll")
+      DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 3) unless DRCI.exists?("congruence sigil-scroll")
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 2) unless DRCI.exists?("abolition sigil-scroll")
       stow_item(right_hand)
       stow_item(left_hand)

--- a/craft.lic
+++ b/craft.lic
@@ -342,7 +342,7 @@ class Craft
       wait_for_script_to_complete('enchant', [2, 'an earth trinket', 'totem'])
       dispose_trash('totem', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 300 # Tier 5 - Basic
-      # Buy an abolition and induction sigils and bone totem
+      # Buy an abolition and congruence sigils and bone totem
       ensure_copper_on_hand(2000, @settings)
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 3) unless DRCI.exists?("induction sigil-scroll")
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 2) unless DRCI.exists?("abolition sigil-scroll")

--- a/craft.lic
+++ b/craft.lic
@@ -344,7 +344,7 @@ class Craft
     elsif rank <= 300 # Tier 5 - Basic
       # Buy an abolition and induction sigils and bone totem
       ensure_copper_on_hand(2000, @settings)
-      DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 1) unless DRCI.exists?("induction sigil-scroll")
+      DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 3) unless DRCI.exists?("induction sigil-scroll")
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 2) unless DRCI.exists?("abolition sigil-scroll")
       stow_item(right_hand)
       stow_item(left_hand)


### PR DESCRIPTION
Updated the tier 5 enchant recipe to buy the correct sigils that base-recipes.yaml now uses.

Fixes this issue: https://github.com/rpherbig/dr-scripts/issues/5216