### PR TITLE
[script][common-healing][update] Added worn trash parameters to dispo…

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -330,8 +330,8 @@ module DRCH
     waitrt?
     case result
     when *tend_dislodge
-      DRCI.dispose_trash(DRC.left_hand) if DRC.left_hand != snap.first
-      DRCI.dispose_trash(DRC.right_hand) if DRC.right_hand != snap.last
+      DRCI.dispose_trash(DRC.left_hand, get_settings.worn_trashcan, get_settings.worn_trashcan_verb) if DRC.left_hand != snap.first
+      DRCI.dispose_trash(DRC.right_hand, get_settings.worn_trashcan, get_settings.worn_trashcan_verb) if DRC.right_hand != snap.last
       bind_wound(body_part, person)
     when *tend_failure
       false


### PR DESCRIPTION
…se call. If no worn trash parameters are in yaml, the default (old) action occurs. The option for worn trash is already present in `common-items.` 