### PR TITLE
[script] [common-items] Look in watery portal if fail to get item from the container the first time

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -557,6 +557,23 @@ module DRCI
     when *@@get_item_success_patterns
       return true
     else
+      if container =~ /\bportal\b/i
+        return get_item_from_eddy_portal?(item, container)
+      else
+        return false
+      end
+    end
+  end
+
+  # Workaround to game changes where you must periodically look in
+  # the portal for the contents to be available.
+  # http://forums.play.net/forums/DragonRealms/Discussions%20with%20DragonRealms%20Staff%20and%20Players/Game%20Master%20and%20Official%20Announcements/view/1899
+  def get_item_from_eddy_portal?(item, container)
+    DRCI.look_in_container(container)
+    case DRC.bput("get #{item} #{container}", @@get_item_success_patterns, @@get_item_failure_patterns)
+    when *@@get_item_success_patterns
+      return true
+    else
       return false
     end
   end

--- a/common-items.lic
+++ b/common-items.lic
@@ -570,7 +570,9 @@ module DRCI
   # http://forums.play.net/forums/DragonRealms/Discussions%20with%20DragonRealms%20Staff%20and%20Players/Game%20Master%20and%20Official%20Announcements/view/1899
   def get_item_from_eddy_portal?(item, container)
     DRCI.look_in_container(container)
-    case DRC.bput("get #{item} #{container}", @@get_item_success_patterns, @@get_item_failure_patterns)
+    from = container
+    from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
+    case DRC.bput("get #{item} #{from}", @@get_item_success_patterns, @@get_item_failure_patterns)
     when *@@get_item_success_patterns
       return true
     else

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -91,6 +91,15 @@ class TestDRCI < Minitest::Test
   # GET ITEM
   #########################################
 
+  def test_get_item__should_look_in_eddy_portal_then_get_branch_from_portal
+    run_drci_command(
+      ["You get a bloodwood branch from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame."],
+      'get_item?',
+      ["bloodwood branch", "watery portal"],
+      [assert_result]
+    )
+  end
+
   def test_get_item__should_get_crystal_from_backpack
     run_drci_command(
       ["You get a sanowret crystal from inside your hitman's backpack."],

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -93,7 +93,14 @@ class TestDRCI < Minitest::Test
 
   def test_get_item__should_look_in_eddy_portal_then_get_branch_from_portal
     run_drci_command(
-      ["You get a bloodwood branch from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame."],
+      [
+        # Don't see it the first time, so the script will need to look in the portal
+        "What were you referring to?",
+        # You look in the portal
+        "In the swirling eddy you see a bloodwood branch.",
+        # The retry attempt now gets the item
+        "You get a bloodwood branch from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame."
+      ],
       'get_item?',
       ["bloodwood branch", "watery portal"],
       [assert_result]


### PR DESCRIPTION
### Background
* For some reason the GameMasters [changed](http://forums.play.net/forums/DragonRealms/Discussions%20with%20DragonRealms%20Staff%20and%20Players/Game%20Master%20and%20Official%20Announcements/view/1899
) how the watery portal (eddy) from Hollow Eve 2020 works and it now requires you to periodically `LOOK` in the container before you can get items from it.

### Changes
* In `common-items`, when fail to get an item from the container and that container includes the word `portal` then retry once after looking in the portal.

### Tests
* See `test/test_common_items.rb`

```
> get bloodwood branch from my watery portal
What were you referring to?

> look in my watery portal
[Assuming you mean a swirling eddy of incandescent light bound by a gold-striated coralite frame.]
In the swirling eddy you see ...

> get bloodwood branch from my watery portal
You get a curving bloodwood branch from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame.
```