### PR TITLE
[script] [t2] Allow reload of settings on the fly

### DIFF
--- a/t2.lic
+++ b/t2.lic
@@ -17,11 +17,9 @@ class T2
 
     @counter = 0
     @settings = get_settings
-    @after_shutdown = @settings.t2_after_shutdown
     UserVars.t2_timers ||= {}
 
-    t2_avoids = @settings.t2_avoids
-    t2_avoids.each do |avoid|
+    @settings.t2_avoids.each do |avoid|
       if avoid['state']
         fput("avoid !#{avoid['type']}")
       else
@@ -56,9 +54,9 @@ class T2
         break
       end
     end
-    if !@after_shutdown.empty?
+    if !@settings.t2_after_shutdown.empty?
       echo '***STATUS*** Controlled shutdown, executing shutdown actions.'
-      execute_actions(@after_shutdown) 
+      execute_actions(@settings.t2_after_shutdown)
     end
   end
 
@@ -100,6 +98,20 @@ class T2
     else
       DRC.message("T2 not set to shutdown.  Use '#{$clean_lich_char}e $T2.shutdown' to shutdown.")
     end
+  end
+
+  def reload_settings(debug = false)
+    temp_settings = get_settings
+
+    if temp_settings.training_list.nil? ||
+       temp_settings.training_list.class != Array || 
+       temp_settings.training_list.empty?
+      DRC.message("Detected invalid T2 settings - please double check your config")
+      return
+    end
+    @settings = temp_settings
+    DRC.message("T2 training_list reloaded.")
+    echo @settings.training_list.to_yaml if debug
   end
 
 end


### PR DESCRIPTION
Adds the ability to reload t2 settings (really `training_list:` and `t2_after_shutdown:` settings).

`;e $T2.reload_settings` - Will reload, no output.

`;e $T2.reload_settings(true)` - Will reload, and output the `training_list:` settings in yaml format.

It does some basic checks to ensure not reloading malformed settings, regardless of above.

(It is recommended to setup an alias).