### PR TITLE
[script] [safe-room] Support custom bank amounts (withdraw/deposits) and bug fix

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -469,6 +469,13 @@ safe_room_tip_amount:
 safe_room_empath:
 safe_room_empaths:
 
+# override the npc healer to use from hometown
+force_healer_town:
+# Amount to withdraw from bank for healing
+safe_room_withdraw_amount: 4_000
+# Amount to deposit back in back after healing (only used if force_healer_town is set)
+safe_room_keep_bank_amount:
+
 
 # Spellcasting (and Khri) settings
 use_harness_when_arcana_locked: false
@@ -1705,8 +1712,6 @@ holy_weapon:
 # https://elanthipedia.play.net/Lich_script_repository#fill-dirt
 dirt_stacker:
 
-# override the npc healer to use
-force_healer_town:
 shard_thief_password:
 forge_container:
 spell_cycle:

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -23,6 +23,8 @@ class SafeRoom
     args = parse_args(arg_definitions)
     settings = get_settings
     @health_threshold = settings.saferoom_health_threshold
+    @withdraw_amount = settings.safe_room_withdraw_amount
+    @keep_bank_amount = settings.safe_room_keep_bank_amount 
 
     return unless args.force || need_healing?
 
@@ -50,7 +52,7 @@ class SafeRoom
         'go have yourself a birthday party',
         'you are well',
         'have other patients',
-        'you look fine and healthy',
+        /Arthianna says "#{Regexp.quote(checkname)}, you look fine and healthy to me/,
         'A little rest and exercise',
         'There is nothing I can do for you',
         'Up and out',
@@ -72,11 +74,16 @@ class SafeRoom
         hometown = town_data[settings.hometown]
       end
 
-      ensure_copper_on_hand(4_000, settings, hometown_name)
+      ensure_copper_on_hand(@withdraw_amount, settings, hometown_name)
       wait_at_empath(hometown['npc_empath']['id'])
       fix_standing
       if (settings.hometown != hometown_name)
-        deposit_coins(0, settings, hometown_name)
+        bank_amount, bank_currency = deposit_coins(0, settings, hometown_name)
+        if @keep_bank_amount && bank_amount > @keep_bank_amount
+          DRCM.minimize_coins(bank_amount-@keep_bank_amount).each { |amount| 
+            DRCM.withdraw_exact_amount?(amount, settings,hometown_name) 
+            }
+        end
       end
     elsif settings.necro_safe_room_use_devour
       @health_threshold = 0 if args.force


### PR DESCRIPTION
- Adds support to customize withdraw amount when healing by NPCs
- Adds support to keep a max amount of coin in bank (only if using force_healer_town:)
- Minor clean up in base.yaml to put settings near rest of safe-room settings.

Relies upon changes in #5228 