### PR TITLE
[script] [textsubs] Add option to textsubs to group at plat level

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -23,10 +23,6 @@ t2_after_shutdown:
   - sell-loot
   - gosafe
 
-# TextSubs
-private_textsubs:
-  # old text: new text
-
 # Combat settings
 # https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 aim_fillers:
@@ -1807,9 +1803,15 @@ sorter:
 
 stabbity:
 
+# TextSubs
+private_textsubs:
+  # old text: new text
 # For use with shitlist and textsubs
 # Will allow textsubs to put an (SL) at the end of the names of people on your list
 integrate_shit_list_with_textsubs: false
+#turn on heal/remedy text subs by ingredient name: yelith (limb-IW) tonic
+herb_textsubs: false
+textsubs_use_plat_grouping: false
 
 # Settings for smoke script
 smoke:
@@ -1866,9 +1868,6 @@ suhelmas:
     # If you are not an Empath then you'll need a weapon to smite the Seed of Entropy.
     # Specify the weapon's <adjective> <noun> as listed in your gear config.
     weapon:
-
-#turn on heal/remedy text subs by ingredient name: yelith (limb-IW) tonic
-herb_textsubs: false
 
 # Settings used for wand-watcher, which uses 'wands' (ex: bloodwood branch) based on timers
 # See: https://elanthipedia.play.net/Lich_script_repository#wand-watcher for details

--- a/textsubs.lic
+++ b/textsubs.lic
@@ -805,7 +805,11 @@ if DRStats.barbarian?
 end
 
 # Commas when dealing with coins
-TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')
+if settings.textsubs_use_plat_grouping
+  TextSubs.add('(?!.*>)\d{1,3}(?=(\d{4})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')
+else
+  TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')
+end
 
 # Subs to add guild name to scroll spells
 scroll_label = '^(It is labeled)'


### PR DESCRIPTION
Allows users to group money at plat level, isntead of just based on thousands.  Ex:

Default (currenty):
`textsubs_use_plat_grouping: false`
 > 1219 platinum, 56 gold, 64 silver, 59 bronze, and 56 copper Kronars (12,253,046 copper Kronars).
  No Lirums.


New:
`textsubs_use_plat_grouping: true`
 > 1219 platinum, 56 gold, 64 silver, 59 bronze, and 56 copper Kronars (1,225,3046 copper Kronars).
  No Lirums.


Also groups textsubs settings in base.yaml together.