### PR TITLE
Update common items

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -804,7 +804,7 @@ module DRCI
   # Puts away an item, optionally into a specific container, optionally
   # using a container preposition (e.g. "ON shelf")
   # If no container specified then uses the default stow location.
-  # If no preposition specified, defaults to "in" (e.g. "IN shelf")
+  # If no preposition specified, defaults to "in" (e.g. "IN cabinet")
   def put_away_item_unsafe?(item, container = nil, preposition = "in")
     command = "put #{item} #{preposition} #{container}" if container
     command = "stow #{item}" unless container

--- a/common-items.lic
+++ b/common-items.lic
@@ -147,7 +147,11 @@ module DRCI
     /nods toward you as your .* falls into the .* bin/,
     /^You add/,
     /^You rearrange/,
-    /You combine the stacks/
+    /You combine the stacks/,
+    # The following are success messages for putting an item in a container OFF your person.
+    /^You drop/i,
+    /^You set/i,
+    /^You put/i
   ]
 
   @@put_away_item_failure_patterns = [
@@ -171,6 +175,7 @@ module DRCI
     /Perhaps you should be holding that first/,
     /Containers can't be placed in/,
     /The .* is not designed to carry anything/,
+    /You can't put that.*there/,
     # You may get the next message if you've been cursed and unable to let go of items.
     # Find a Cleric to uncurse you.
     /Oddly, when you attempt to stash it away safely/,
@@ -796,10 +801,12 @@ module DRCI
     put_away_item_unsafe?(item, container)
   end
 
-  # Puts away an item, optionally into a specific container.
+  # Puts away an item, optionally into a specific container, optionally
+  # using a container preposition (e.g. "ON shelf")
   # If no container specified then uses the default stow location.
-  def put_away_item_unsafe?(item, container = nil)
-    command = "put #{item} in #{container}" if container
+  # If no preposition specified, defaults to "in" (e.g. "IN shelf")
+  def put_away_item_unsafe?(item, container = nil, preposition = "in")
+    command = "put #{item} #{preposition} #{container}" if container
     command = "stow #{item}" unless container
     result = DRC.bput(command, @@container_is_closed_patterns, @@put_away_item_success_patterns, @@put_away_item_failure_patterns, @@put_away_item_retry_patterns)
     case result


### PR DESCRIPTION
Update method `put_away_item_unsafe?()` to avoid hard-coding the "in" preposition and allows to pass in a preposition of another type (e.g. "ON shelf"). Still defaults the preposition to "in" if no preposition is specified to avoid breaking scripts using this method as it exists. Also updates the success messaging to recognize when we've successfully put an item from our person to off our person.

This update will help support PR #5232 (in progress) which is a script to handle offloading items from our person to outside our person.