### PR TITLE
Hunting-Buddy.lic allow the threshold for stop_on to be specified

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -20,6 +20,7 @@ class HuntingBuddy
     @escort_zones = data.escort_zones
     @hunting_zones = data.hunting_zones
     @stop_on_low_threshold = @settings.stop_on_low_threshold
+    @stop_on_threshold = @settings.stop_on_threshold || 32
     @magic_exp_threshold = @settings.magic_exp_training_max_threshold
     @magic_skills = ['Arcane Magic', 'Holy Magic', 'Life Magic', 'Elemental Magic',\
                      'Lunar Magic', 'Attunement', 'Arcana', 'Targeted Magic', 'Inner Fire',\
@@ -245,7 +246,7 @@ class HuntingBuddy
   end
 
   def all_skills_at_cap?(stop_on_skills)
-    stop_on_skills && !stop_on_skills.empty? && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }
+    stop_on_skills && !stop_on_skills.empty? && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : @stop_on_threshold) }
   end
 
   def stop_on_low_skills_too_low?(stop_on_low_skills)

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -20,7 +20,7 @@ class HuntingBuddy
     @escort_zones = data.escort_zones
     @hunting_zones = data.hunting_zones
     @stop_on_low_threshold = @settings.stop_on_low_threshold
-    @stop_on_threshold = @settings.stop_on_threshold || 32
+    @stop_on_high_threshold = @settings.stop_on_high_threshold
     @magic_exp_threshold = @settings.magic_exp_training_max_threshold
     @magic_skills = ['Arcane Magic', 'Holy Magic', 'Life Magic', 'Elemental Magic',\
                      'Lunar Magic', 'Attunement', 'Arcana', 'Targeted Magic', 'Inner Fire',\
@@ -246,7 +246,7 @@ class HuntingBuddy
   end
 
   def all_skills_at_cap?(stop_on_skills)
-    stop_on_skills && !stop_on_skills.empty? && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : @stop_on_threshold) }
+    stop_on_skills && !stop_on_skills.empty? && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : @stop_on_high_threshold) }
   end
 
   def stop_on_low_skills_too_low?(stop_on_low_skills)

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -20,7 +20,7 @@ class HuntingBuddy
     @escort_zones = data.escort_zones
     @hunting_zones = data.hunting_zones
     @stop_on_low_threshold = @settings.stop_on_low_threshold
-    @stop_on_threshold = @settings.stop_on_threshold
+    @stop_on_threshold = @settings.stop_on_threshold || 32
     @magic_exp_threshold = @settings.magic_exp_training_max_threshold
     @magic_skills = ['Arcane Magic', 'Holy Magic', 'Life Magic', 'Elemental Magic',\
                      'Lunar Magic', 'Attunement', 'Arcana', 'Targeted Magic', 'Inner Fire',\

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -20,7 +20,7 @@ class HuntingBuddy
     @escort_zones = data.escort_zones
     @hunting_zones = data.hunting_zones
     @stop_on_low_threshold = @settings.stop_on_low_threshold
-    @stop_on_threshold = @settings.stop_on_threshold || 32
+    @stop_on_threshold = @settings.stop_on_threshold
     @magic_exp_threshold = @settings.magic_exp_training_max_threshold
     @magic_skills = ['Arcane Magic', 'Holy Magic', 'Life Magic', 'Elemental Magic',\
                      'Lunar Magic', 'Attunement', 'Arcana', 'Targeted Magic', 'Inner Fire',\

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -402,6 +402,8 @@ hunting_room_strict_mana: false
 hunting_room_max_searches: 30
 hunting_file_list:
 stop_on_low_threshold: 2
+# sets a default stop_on threshold for hunting-buddy.lic 
+stop_on_threshold: 32
 
 
 ## Repair settings

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -402,8 +402,8 @@ hunting_room_strict_mana: false
 hunting_room_max_searches: 30
 hunting_file_list:
 stop_on_low_threshold: 2
-# sets a default stop_on threshold for hunting-buddy.lic 
-stop_on_threshold: 32
+# sets the mindstates required for hunting-buddy.lic's stop_on skills
+stop_on_high_threshold: 32
 
 
 ## Repair settings


### PR DESCRIPTION
replaced huntig-buddy.lic's default of 32 when checking stop_on skills to now use stop_on_threshold to allow stopping on lower mindstates. 

Added to base.yaml with a default of 32 as specified in the original hunting-buddy.