### PR TITLE
[script][combat-trainer][update] Fix multiple failures when prone

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4573,6 +4573,11 @@ class GameState
       fput('engage')
     when 'You fail to find any'
       perform_analyze?(combo_type, expertise_requirement)
+    when 'You should stand up first'
+      # We're somehow prone. Attempt to stand up and retry the maneuver.
+      DRC.fix_standing
+      waitrt?
+      perform_analyze?(combo_type, expertise_requirement)
     when 'Analyze what?'
       case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
       when 'You turn'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4550,7 +4550,7 @@ class GameState
     return false if combo_type != 'flame' && !Flags["ct-#{combo_type}-ready"] && DRStats.barbarian?
     return false if DRSkill.getrank('Expertise') < expertise_requirement
 
-    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?')
+    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any', 'What are you trying to attack\?', 'You should stand up first')
     waitrt?
 
     case result

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2461,7 +2461,7 @@ class TrainerProcess
       waitrt?
       fix_standing
     when /^Tactics$/i
-      bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
+      bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'You should stand up first') unless game_state.npcs.empty?
     when /^Analyze$/i
       analyze(game_state, 0)
     when /^Hunt$/i
@@ -2749,6 +2749,11 @@ class TrainerProcess
       analyze(game_state, fail_count)
     when 'You must be closer'
       fput('engage')
+    when 'You should stand up first'
+      # We're somehow prone. Attempt to stand up and retry the maneuver.
+      DRC.fix_standing
+      waitrt?
+      analyze(game_state, fail_count)
     when 'Your analysis reveals a massive opening'
       return
     when 'You fail to find any holes'
@@ -3436,7 +3441,9 @@ class AttackProcess
       # Maneuver requires a weapon but you're not wielding any
       /^With your fist?  That might hurt/,
       # You can't aim before powershot maneuver
-      /^You are unable to focus on performing a maneuver while aiming at an enemy/
+      /^You are unable to focus on performing a maneuver while aiming at an enemy/,
+      # Not standing
+      /^You must be standing/
     ]
 
     attempt = bput("maneuver #{action}", *maneuver_success_messages, *maneuver_failure_messages)
@@ -3453,6 +3460,11 @@ class AttackProcess
       # we'll wait another 15 seconds and retry.
       game_state.cooldown_timers[action] += 15
       return false
+    when /^You must be standing/
+      # We're somehow prone. Attempt to stand up and retry the maneuver.
+      DRC.fix_standing
+      waitrt?
+      use_charged_maneuver(action, game_state)
     when *maneuver_failure_messages
       return false
     when *maneuver_success_messages

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2739,7 +2739,7 @@ class TrainerProcess
     return if game_state.npcs.empty?
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
-    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
+    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip', 'You should stand up first') # unless
     when 'Analyze what'
       case bput('face next', 'There is nothing else', 'You turn', 'What are you trying')
       when 'There is nothing else', 'What are you trying'


### PR DESCRIPTION
Addressing issue #5242. Add a proper bput failure message for if you're knocked prone when trying Analyze. This failure message may need to be handled elsewhere. For now, handling the specific error case.