### PR TITLE
Update common.lic

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -155,7 +155,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/, /^You can't do that while (sitting|kneeling|lying)/
+      when /^You must be standing/, /^You should stand up first/, /You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /You should be sitting up/
         fix_standing
         waitrt?
         put message

--- a/common.lic
+++ b/common.lic
@@ -159,7 +159,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/, /You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /You should be sitting up/, /You really should be standing to play/
+      when /^You must be standing/, /^You should stand up first/, /You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/
         fix_standing
         waitrt?
         put message

--- a/common.lic
+++ b/common.lic
@@ -155,7 +155,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/
+      when /^You must be standing/, /^You should stand up first/, /^You can't do that while (sitting|kneeling|lying)/
         fix_standing
         waitrt?
         put message

--- a/common.lic
+++ b/common.lic
@@ -159,7 +159,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/, /You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/
+      when /^You must be standing/, /^You should stand up first/, /^You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/
         fix_standing
         waitrt?
         put message

--- a/common.lic
+++ b/common.lic
@@ -155,6 +155,12 @@ module DRC
         put message
         timer = Time.now
         next
+      when /^You must be standing/, /^You should stand up first/
+        fix_standing
+        waitrt?
+        put message
+        timer = Time.now
+        next
       end
 
       matches.each do |match|

--- a/common.lic
+++ b/common.lic
@@ -94,6 +94,10 @@ module DRC
   # Like `fput` but better because will wait for RT
   # before performing command and do smart retries.
   # Will wait for matching text up to 15 seconds then timeout.
+  # Also recovers from some limited failures wherein we want to 
+  # simply fix the issue and retry the bput, like when we're prone
+  # and need to be standing. Complex handling should be done within
+  # the calling script.
   def bput(message, *matches)
     options = (matches.shift if matches.first.is_a?(Hash)) || {}
     options['timeout'] ||= 15

--- a/common.lic
+++ b/common.lic
@@ -155,7 +155,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/, /You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /You should be sitting up/
+      when /^You must be standing/, /^You should stand up first/, /You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /You should be sitting up/, /You really should be standing to play/
         fix_standing
         waitrt?
         put message


### PR DESCRIPTION
Addressing original issue #5242 , in which parts of combat-trainer fail when your character is unexpectedly prone.

We were originally addressing this directly within combat-trainer via #5245 which is now closed without merging.

After additional discussion we've decided this is best handled within DRC.bput itself, which already handles some limited conditions wherein we have a common failure condition and want to simply fix that condition and re-input the same exact bput without any complex handling.

Thus, this PR edits bput to handle standing you up when you are prone. Separately, I'll do another PR to combat-trainer to remove the redundant failure output for standing since it'll now be handled in DRC.bput.

@vtcifer @Dartellum @KatoakDR 