### PR TITLE
[script] [appraisal] Skip items that aren't found

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -96,11 +96,12 @@ class Appraisal
   end
 
   def appraise_item?(item)
-    @equipment_manager.get_item?(item)
-    bput("appraise #{item.short_name} quick", 'Roundtime')
-    waitrt?
-    pause 1
-    @equipment_manager.empty_hands
+    if @equipment_manager.get_item?(item)
+      bput("appraise #{item.short_name} quick", 'Roundtime')
+      waitrt?
+      pause 1
+      @equipment_manager.empty_hands
+    end
     DRSkill.getxp('Appraisal') < 30
   end
 
@@ -121,7 +122,7 @@ class Appraisal
   end
 
   def appraise_focus(item)
-    focus_concepts = ["defense", "arcane", "recall", "logic", "offense", "magic", "khri", "inner fire"] 
+    focus_concepts = ["defense", "arcane", "recall", "logic", "offense", "magic", "khri", "inner fire"]
     if focus_concepts.include?(item)
       focus_concept(item)
     else
@@ -143,7 +144,7 @@ class Appraisal
 
     exit
   end
-  
+
   def focus_concept(item)
     waitrt?
     case bput("appraise focus #{item}", 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem', 'You will lose your progress')


### PR DESCRIPTION
### Background
* When using `appraisal_training: [gear]` then the script iterates all items in your `gear_set:`
* If you have items listed that are not currently on your person then the script tries (and fails) to appraise something that you didn't get.

### Changes
* If don't get item then skip it and move on to the next item.