### PR TITLE
[script] [burgle] add burgle_settings.rope_adjective

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -62,9 +62,10 @@ class Burgle
     @settings = get_settings
     @burgle_settings = @settings.burgle_settings
     @loot_container = @burgle_settings['loot_container']
-    @use_lockpick_ring =  @burgle_settings['use_lockpick_ring']
+    @use_lockpick_ring = @burgle_settings['use_lockpick_ring']
     @lockpick_container =  @burgle_settings['lockpick_container']
     @max_priority_mindstate = @burgle_settings['max_priority_mindstate'] || 26
+    @rope_adjective = @burgle_settings['rope_adjective'] || 'heavy'
     @loot_room_id = nil
 
     #set yaml settings unless being overridden from the command line arguments
@@ -185,7 +186,7 @@ class Burgle
         end
       when /rope/i
         if !check_entry?(@entry_type)
-          message("Couldn't find entry item: heavy rope")
+          message("Couldn't find entry item: #{@rope_adjective} rope")
           exit
         end
       when /lockpick/i
@@ -300,7 +301,7 @@ class Burgle
   def check_entry?(entry_type)
     case entry_type
     when /rope/i
-      return exists?("heavy rope")
+      return exists?("#{@rope_adjective} rope")
     when /lockpick/i
       if @use_lockpick_ring
         return exists?(@lockpick_container)

--- a/burgle.lic
+++ b/burgle.lic
@@ -349,8 +349,8 @@ class Burgle
   def get_entry(entry_type)
     case entry_type
     when /rope/i
-      if bput('get my heavy rope', 'You get', 'You are already holding' ,'What were you') =~ /What were you/
-        message("Couldn't find entry item: heavy rope")
+      if bput("get my #{@rope_adjective} rope", 'You get', 'You are already holding' ,'What were you') =~ /What were you/
+        message("Couldn't find entry item: #{@rope_adjective} rope")
         exit
       end
     when /lockpick/i


### PR DESCRIPTION
### Background
* Feature requested by [Tekhelet](https://discord.com/channels/745675889622384681/912127186419482664/913561525170606090)

> Please add a burgle rope adjective.
There are [some available](https://elanthipedia.play.net/Item:Supple_rope_of_plaited_fabric) that work for burgling in the crowns game at fest.

### Changes
* Add new setting `rope_adjective` (string) that defaults to `heavy`, the previously hardcoded value

### Example Config
_The default adjective is heavy (i.e. heavy rope)._
_Now players can override the rope adjective._
```yaml
burgle_settings:
    rope_adjective: supple
```

## Tests

### Burgle cannot find your custom rope adjective
```
[burgle]>tap my supple rope 
I could not find what you were referring to.
| Couldn't find entry item: supple rope

(script exits or switches to attempt using lockpicks)
```

### Burgle can find your custom rope adjective
```
[burgle]>tap my supple rope 
You tap a supple black rope of plaited spidersilk.

[burgle]>get my supple rope
You get a supple black rope of plaited spidersilk from inside your backpack.
```

FYI @vtcifer @Dartellum @wstampley 