### PR TITLE
Commenting out 19193 in the Cave Troll area, it has too few trolls...

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1044,7 +1044,7 @@ hunting_zones:
   - 19195
   - 19196
   - 19204
-  - 19193
+# - 19193
   # https://elanthipedia.play.net/Giant_bear                             210-290
   # Super high spawn
   giant_bears:


### PR DESCRIPTION
This comes up a lot for empaths and manipulation. The area isn't big, and whilst this room has the best mana, it has horrible spawn rates...