### PR TITLE
[script] [sell-loot] add hometown argument

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -37,7 +37,7 @@ class SellLoot
     @settings = get_settings
     town_data = get_data('town')
     @character_hometown = args.hometown || @settings.hometown
-    @hometown = town_data[@settings.hometown]
+    @hometown = town_data[@character_hometown]
     @bankbot_name = @settings.bankbot_name
     @bankbot_room_id = @settings.bankbot_room_id
     @bankbot_deposit_threshold = @settings.bankbot_deposit_threshold

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -36,7 +36,7 @@ class SellLoot
 
     @settings = get_settings
     town_data = get_data('town')
-    @character_hometown = args.hometown || @settings.hometown
+    @character_hometown = DRC.get_town_name(args.hometown || @settings.hometown)
     @hometown = town_data[@character_hometown]
     @bankbot_name = @settings.bankbot_name
     @bankbot_room_id = @settings.bankbot_room_id

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -11,6 +11,23 @@ class SellLoot
   include DRCT
 
   def initialize
+    arg_definitions = [
+      [
+        { name: 'hometown', regex: /^([a-zA-Z\s']+)$/i, variable: true, description: 'Override the hometown to sell loot in.' }
+      ],
+      [
+        { name: 'amount', regex: /\d+/i, variable: true, description: 'Number of coins to keep' },
+        { name: 'type', regex: /\w+/i, variable: true, description: 'Type of coins to keep' }
+      ],
+      [
+        { name: 'hometown', regex: /^([a-zA-Z\s']+)$/i, variable: true, description: 'Override the hometown to sell loot in.' },
+        { name: 'amount', regex: /\d+/i, variable: true, description: 'Number of coins to keep' },
+        { name: 'type', regex: /\w+/i, variable: true, description: 'Type of coins to keep' }
+      ],
+      []
+    ]
+    args = parse_args(arg_definitions)
+
     EquipmentManager.new.empty_hands
 
     Flags.add('tip-accepted', '.* accepts your tip and slips it away with a smile')
@@ -19,7 +36,7 @@ class SellLoot
 
     @settings = get_settings
     town_data = get_data('town')
-    @character_hometown = @settings.hometown
+    @character_hometown = args.hometown || @settings.hometown
     @hometown = town_data[@settings.hometown]
     @bankbot_name = @settings.bankbot_name
     @bankbot_room_id = @settings.bankbot_room_id
@@ -28,7 +45,10 @@ class SellLoot
     @local_currency = town_data[@character_hometown]['currency']
     skip_bank = @settings.sell_loot_skip_bank
     skip_exchange = @settings.sell_loot_skip_exchange
-    keep_money_by_currency = @settings.sell_loot_money_on_hand
+    keep_money_by_currency = @settings.sell_loot_money_on_hand.split(' ')
+    keep_amount = args.amount || keep_money_by_currency[0] || 3
+    keep_denomination = args.type || keep_money_by_currency[1] || 'silver'
+    keep_coppers_bank = convert_to_copper(keep_amount, keep_denomination)
     @sort_auto_head = @settings.sort_auto_head
 
     sell_gems("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}") if @settings.sell_loot_pouch
@@ -43,8 +63,6 @@ class SellLoot
     return if skip_bank && !@bankbot_enabled
     return if @bankbot_enabled && (@bankbot_name.nil? || @bankbot_room_id.nil?)
 
-    keep_coppers_bank = parse(keep_money_by_currency.split(' '))
-
     if skip_bank && @bankbot_enabled
       $CURRENCIES.each do |currency|
         give_money_to_bankbot(currency, currency =~ /#{@local_currency}/i ? @bankbot_deposit_threshold : 0)
@@ -58,23 +76,6 @@ class SellLoot
     else
       deposit_coins(keep_coppers_bank)
     end
-  end
-
-  def parse(setting)
-    arg_definitions = [
-      [
-        { name: 'amount', regex: /\d+/i, variable: true, description: 'Number of coins to keep' },
-        { name: 'type', regex: /\w+/i, variable: true, description: 'Type of coins to keep' }
-      ],
-      []
-    ]
-
-    args = parse_args(arg_definitions)
-
-    keep_amount = args.amount || setting[0] || 3
-    keep_type = args.type || setting[1] || 'silver'
-
-    convert_to_copper(keep_amount, keep_type)
   end
 
   def exchange_coins


### PR DESCRIPTION
### Dependencies
* https://github.com/rpherbig/dr-scripts/pull/5256

### Background
* Feature requested by [Tirost](https://discord.com/channels/745675889622384681/912127186419482664/913661837462089788)

> I'm requesting being able to use `;sell-loot crossing` or `;sell-loot hib` and have the script take me to that hometown's gem appraiser, tanner and bank. My hope is to be able to use `sell-loot` in locations other than the hometown I use for training to sell off invasion spoils, money of a denomination I'd rather not pay exchange fees on or that's been acquired in an RP event, or return money after shopping or trading.

### Changes
* Add `hometown` as a new script argument to override that value from character's YAML

### Example Usage
_Original two options, and these still exist_
```
;sell-loot
;sell-loot 10 silver
```
_New options allow you to specify the hometown to use_
```
;sell-loot riverhaven
;sell-loot shard 5 gold
```

