### PR TITLE
[script][common-items] Fix edge case match failure when tree is in the room

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -32,7 +32,8 @@ module DRCI
     /You really shouldn't be loitering/,
     # You may get the next message if you've been cursed and unable to let go of items.
     # Find a Cleric to uncurse you.
-    /Oddly, when you attempt to stash it away safely/
+    /Oddly, when you attempt to stash it away safely/,
+    /You need something in your right hand/
   ]
 
   # Messages that when trying to drop an item you're warned.


### PR DESCRIPTION
Ref Issue #5253 

This fixes an edge case match failure/timeout when player housing in the form of a tree is in the room. I discovered this when setting a new safe room in a room that has player housing in the form of a tree that can be interacted with and attempted to run `;craft alchemy`. Once your product is complete, the `;craft` script calls `DRCI.dispose_trash`, which sees a tree in the room and thinks it's a trash receptacle. Interestingly, because `;craft` ends with the final product in your LEFT hand, there is a unique failure message that results, per my submitted issue.

The simple fix is adding that failure pattern to DRCI, which will then handle the rest (dropping the item in this case).

Tested in room 6455, Shard area.