### PR TITLE
[data] [base-spells] match string for elemental barrage

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -211,7 +211,7 @@ module DRCA
     before.each { |action| DRC.bput(action['message'], action['matches']) }
 
     Flags.add('unknown-command', "Please rephrase that command")
-    Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that")
+    Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that", "You do not know how to manipulate that pathway.")
     Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell', 'There is nothing else to face')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -220,6 +220,7 @@ cast_messages:
 - You must have a fully developed target matrix to make a barrage attack.
 - You are unable to muster the energy to do that.
 # Elemental Barrage cast messages
+- You do not know how to manipulate that pathway.
 - Heatless orange flames climb your .* before winking out of existance.
 - A shimmering silvery-blue glow quickly spreads from your hand to the tip of your .*, then quickly fades.
 - Tiny fingers of lightning course rapidly along your .*, disappearing almost immediately.


### PR DESCRIPTION
My newbie warrior mage encountered this using a more advanced character's yaml and tried to use a barrage attack but doesn't know that ability yet.

```
[combat-trainer]>barrage feint
You do not know how to manipulate that pathway.
...
[combat-trainer: *** No match was found after 15 seconds, dumping info]
```