### PR TITLE
clean-leather.lic - re-declaration of @bag causing errors

### DIFF
--- a/clean-leather.lic
+++ b/clean-leather.lic
@@ -35,8 +35,6 @@ class CleanLeather
     @item = args.noun =~ /^bones?$/i ? '8' : '7'
     @speed = args.speed || ''
 
-    @bag = @settings.crafting_items_in_container
-
     while bput("get #{args.noun} from my #{args.source}", 'You get', 'You carefully remove', 'What were you') != 'What were you'
       fput('stow left') if left_hand == 'bundling rope'
       fput('stow right') if right_hand == 'bundling rope'


### PR DESCRIPTION
removed line 38 
``@bag = @settings.crafting_items_in_container``
as this was causing ``stow_crafting_item`` to incorrectly try and put items into the ``crafting_items_in_container`` list

Example:
``[clean-leather]>put my scraper in my [["knitting needles", "sewing needles", "polished slickstone", "detailed yardstick", "serrated scissors"]]``