### PR TITLE
[script] [spellmonitor] Handle when only know one cantrip

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -234,7 +234,7 @@ known_spells_hook = proc do |server_string|
         .each { |feat| DRSpells.known_feats[feat] = true }
     end
     server_string = nil if DRSpells.silence_known_spells_hook
-  when /^You have \d+ spell slots? available|You do not know any magic feats|You know the following .* cantrips/
+  when /^You have \d+ spell slots? available|You do not know any magic feats|You know the following .* cantrips?/
     server_string = nil if DRSpells.silence_known_spells_hook
   when /^You can use SPELL STANCE|^You have (no|yet to receive any) training in the magical arts|You have no desire to soil yourself with magical trickery|^You really shouldn't be loitering here|\(Use SPELL|\(Use PREPARE/
     DRSpells.grabbing_known_spells = false


### PR DESCRIPTION
When spellmonitor checks for your known spells and cantrips, it silences output for certain matched strings to avoid spamming the player.

The regex pattern handled if you knew multiple cantrips but not if you only knew one, so the message of the one cantrip you knew was not being slienced.

```
You know the following Aether cantrip: Aether Spheres.
```

This PR fixes that.