### PR TITLE
Update stowing of enchantables to be consistent

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -398,9 +398,10 @@ class Craft
       ensure_copper_on_hand(4000, @settings)
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 1) unless DRCI.exists?("induction sigil-scroll")
       DRCT.order_item(crafting_data['artificing'][@hometown]['stock-room'], 5) unless DRCI.exists?("rarefaction sigil-scroll")
-      stow_hands
+      stow_item(right_hand)
+      stow_item(left_hand)
       DRCT.buy_item(crafting_data['artificing'][@hometown]['stock-room'], 'runestone') unless DRCI.exists?("basic runestone")
-      stow_hands
+      stow_item('runestone')
       fount(crafting_data['artificing'][@hometown]['tool-room'],1,crafting_data['artificing'][@hometown]['fount'],2,@bag, @bag_items, @belt)
       walk_to(@training_room)
       wait_for_script_to_complete('enchant',[6,'lay ward runestone','runestone'])


### PR DESCRIPTION
stow_hands uses stow and stow_items honors crafting bag.  Will snag if crafting bag is not default container.  Other tiers are correct, just updating this last one to match.