### PR TITLE
[data] [base-spells] Add new spell preps from Elven arachnomancer

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -120,6 +120,10 @@ prep_messages:
 - Invoke what
 - You have yet to receive any training in the magical arts
 - You have no idea how to cast that spell
+- You weave delicate lines of light
+- Kaleidoscopic ribbons of light swirl between your outstretched hands
+- You bring your hands together and slowly spread them apart
+- Focusing intently, you trace a
 
 cast_messages:
 - You clench your fists


### PR DESCRIPTION
New spell preps taught by [Eleven arachnomancer](https://elanthipedia.play.net/Elven_arachnomancer) at Hollow Eve 2021

Requested by [Allye](https://discord.com/channels/745675889622384681/912127186419482664/915784988971106314)