### PR TITLE
[data] [base-spells] Add missing 'recast' property to Gam Irnan

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1295,6 +1295,7 @@ spell_data:
     skill: Warding
     abbrev: GI
     mana: 5
+    recast: 1
     mana_type: elemental
   Gauge Flow:
     skill: Utility


### PR DESCRIPTION
### Background
* `combat-trainer` [recasts buff spells](https://github.com/rpherbig/dr-scripts/blob/master/combat-trainer.lic#L1608) when they wear off _if_ the spell data has either the `recast`, `recast_every`, or `expire` properties set.
* As a new spell recently added to `base-spells.yaml`, Gam Irnan is missing one of those properties and thus `combat-trainer` is not recasting it.

### Changes
* Add `recast: 1` to the Gam Irnan spell data, which aligns with most other non-battle spells, particularly Manifest Force (a similar warding spell).