### PR TITLE
[data] [base-spells] Default `recast` and `prep` properties

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -484,7 +484,7 @@ spell_data:
     cyclic: true
     mana: 7
     mana_type: elemental
-    recast: 1
+    recast: -1
   Absolution:
     skill: Utility
     harmless: true
@@ -525,7 +525,7 @@ spell_data:
     prep: prepare
     cyclic: true
     mana: 5
-    recast: 1
+    recast: -1
     mana_type: life
     harmless: true
   Aesrela Everild:
@@ -543,7 +543,7 @@ spell_data:
     cyclic: true
     mana: 4
     mana_type: elemental
-    recast: 1
+    recast: -1
   Aether Spheres:
     skill: cantrip
     abbrev: C AE S
@@ -562,7 +562,7 @@ spell_data:
     cyclic: true
     mana: 2
     mana_type: elemental
-    recast: 1
+    recast: -1
   Aethereal Image:
     skill: cantrip
     abbrev: C AE I
@@ -637,7 +637,7 @@ spell_data:
     cyclic: true
     mana: 5
     mana_type: elemental
-    recast: 1
+    recast: -1
   Anther's Call:
     skill: Debilitation
     abbrev: ANC
@@ -661,7 +661,7 @@ spell_data:
     prep: prepare
     starlight_threshold: 0
     mana_type: lunar
-    recast: 1
+    recast: -1
   Arc Light:
     skill: Debilitation
     harmless: true
@@ -735,7 +735,7 @@ spell_data:
     mana: 5
     mana_type: life
     prep: prepare
-    recast: 1
+    recast: -1
   Banner of Truce:
     skill: Utility
     abbrev: BOT
@@ -750,7 +750,7 @@ spell_data:
     mana: 5
     mana_type: life
     prep: prepare
-    recast: 1
+    recast: -1
   Beckon the Naga:
     skill: Targeted Magic
     heavy: true
@@ -788,7 +788,7 @@ spell_data:
     mana: 5
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Bloodthorns:
     skill: Warding
     abbrev: blood
@@ -923,7 +923,7 @@ spell_data:
     mana: 2
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Carrion Call:
     skill: Targeted Magic
     abbrev: CAC
@@ -952,7 +952,7 @@ spell_data:
     mana: 5
     mana_type: life
     prep: prepare
-    recast: 1
+    recast: -1
   Chill Spirit:
     skill: Targeted Magic
     abbrev: CHS
@@ -1083,7 +1083,7 @@ spell_data:
     mana: 6
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Dazzle: # Requires either the sun or moons to be visible and being outdoors
     skill: Debilitation
     harmless: true
@@ -1273,7 +1273,7 @@ spell_data:
     mana: 6
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Emuin's Candlelight:
     skill: Augmentation # Also Warding
     abbrev: EMC
@@ -1324,7 +1324,7 @@ spell_data:
     mana: 3
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Eyes of the Blind:
     skill: Utility
     abbrev: EOTB
@@ -1347,7 +1347,7 @@ spell_data:
     mana: 2
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Fire Ball:
     skill: Targeted Magic
     abbrev: FB
@@ -1362,7 +1362,7 @@ spell_data:
     mana: 7
     prep: prepare
     mana_type: elemental
-    recast: 1
+    recast: -1
   Fire Shards:
     skill: Targeted Magic
     abbrev: FS
@@ -1517,7 +1517,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
-    recast: 1
+    recast: -1
   Gift of Life:
     skill: Augmentation
     abbrev: GOL
@@ -1540,7 +1540,7 @@ spell_data:
     mana: 5
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Grizzly Claws:
     skill: Debilitation
     abbrev: GRIZ
@@ -1564,7 +1564,7 @@ spell_data:
     mana: 5
     mana_type: life
     harmless: true
-    recast: 1
+    recast: -1
   Gust of Wind:
     skill: cantrip
     abbrev: C G O W
@@ -1696,7 +1696,7 @@ spell_data:
     mana: 5
     mana_type: elemental
     prep: prepare
-    recast: 1
+    recast: -1
   Holy Warrior:
     skill: Warding
     abbrev: HOW
@@ -1704,7 +1704,7 @@ spell_data:
     cyclic: true
     mana_type: holy
     prep: prepare
-    recast: 1
+    recast: -1
   Horn of the Black Unicorn:
     skill: Targeted Magic
     abbrev: HORN
@@ -1729,7 +1729,7 @@ spell_data:
     mana: 6
     mana_type: holy
     prep: prepare
-    recast: 1
+    recast: -1
   Ice Patch:
     skill: Debilitation
     harmless: true
@@ -1745,7 +1745,7 @@ spell_data:
     mana: 15
     mana_type: life
     prep: target
-    recast: 1
+    recast: -1
   Idon's Theft:
     skill: Debilitation # Also Utility
     abbrev: IT
@@ -1942,7 +1942,7 @@ spell_data:
     mana: 5
     moon: true
     skill: Warding
-    recast: 1
+    recast: -1
     mana_type: lunar
     prep: prepare
   Mass Rejuvenation:
@@ -2032,7 +2032,7 @@ spell_data:
     mana: 5
     mana_type: lunar
     prep: prepare
-    recast: 1
+    recast: -1
   Murrula's Flames:
     skill: Utility
     abbrev: MF
@@ -2195,7 +2195,7 @@ spell_data:
     prep: prepare
     triggers_justice: true
     mana_type: elemental
-    recast: 1
+    recast: -1
   Platinum Hands of Kertigen:
     abbrev: PHK
     mana: 15
@@ -2310,7 +2310,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
-    recast: 1
+    recast: -1
   Reinforce Stone:
     skill: cantrip
     abbrev: C R S
@@ -2356,7 +2356,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
-    recast: 1
+    recast: -1
   Revelation:
     skill: Utility
     abbrev: revelation
@@ -2364,7 +2364,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
-    recast: 1
+    recast: -1
   Reverse Putrefaction:
     skill: Augmentation
     abbrev: RPU
@@ -2393,7 +2393,7 @@ spell_data:
     cyclic: true
     mana: 6
     mana_type: elemental
-    recast: 1
+    recast: -1
   Ring of Spears:
     skill: Targeted Magic
     abbrev: ROS
@@ -2401,7 +2401,7 @@ spell_data:
     cyclic: true
     mana: 7
     mana_type: elemental
-    recast: 1
+    recast: -1
   Rising Mists:
     skill: Utility
     harmless: true
@@ -2418,7 +2418,7 @@ spell_data:
     mana: 5
     mana_type: arcane
     prep: prepare
-    recast: 1
+    recast: -1
   Rite of Forebearance:
     skill: Utility # Also Debilitation
     abbrev: RoF
@@ -2426,7 +2426,7 @@ spell_data:
     mana: 5
     mana_type: arcane
     prep: prepare
-    recast: 1
+    recast: -1
   Rite of Grace:
     skill: Utility
     abbrev: ROG
@@ -2434,7 +2434,7 @@ spell_data:
     mana: 5
     mana_type: arcane
     prep: prepare
-    recast: 1
+    recast: -1
   River in the Sky:
     skill: Warding
     abbrev: rits
@@ -2468,7 +2468,7 @@ spell_data:
     abbrev: SANCTUARY
     cyclic: true
     mana: 5
-    recast: 1
+    recast: -1
     mana_type: elemental
     prep: prepare
   Sanyu Lyba:
@@ -2570,7 +2570,7 @@ spell_data:
     mana: 6
     mana_type: lunar
     prep: prepare
-    recast: 1
+    recast: -1
   Shatter:
     skill: Debilitation
     harmless: true
@@ -2664,7 +2664,7 @@ spell_data:
     cyclic: true
     mana: 6
     prep: target
-    recast: 1
+    recast: -1
   Soul Bonding:
     skill: Debilitation
     abbrev: SB
@@ -2728,7 +2728,7 @@ spell_data:
     night: true
     mana: 6
     mana_type: lunar
-    recast: 1
+    recast: -1
   Stellar Collector:
     abbrev: STC
     mana: 30
@@ -2744,7 +2744,7 @@ spell_data:
     invisibility: true
     mana_type: lunar
     prep: prepare
-    recast: 1
+    recast: -1
   Stone Seat:
     skill: cantrip
     abbrev: C S S
@@ -2925,7 +2925,7 @@ spell_data:
     cyclic: true
     mana_type: holy
     prep: prepare
-    recast: 1
+    recast: -1
   Turmar Illumination:
     abbrev: TU IL
     mana: 5
@@ -2948,7 +2948,7 @@ spell_data:
     prep: prepare
     mana: 7
     mana_type: arcane
-    recast: 1
+    recast: -1
   Unleash:
     skill: Utility
     abbrev: unleash

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -484,6 +484,7 @@ spell_data:
     cyclic: true
     mana: 7
     mana_type: elemental
+    recast: 1
   Absolution:
     skill: Utility
     harmless: true
@@ -504,6 +505,7 @@ spell_data:
     prep: target
     mana: 1
     mana_type: arcane
+    recast: 1
   Aegis of Granite:
     skill: Augmentation
     abbrev: AEG
@@ -532,6 +534,7 @@ spell_data:
     prep: target
     mana: 15
     mana_type: holy
+    recast: 1
   Aether Cloak:
     skill: Warding
     harmless: true
@@ -540,6 +543,7 @@ spell_data:
     cyclic: true
     mana: 4
     mana_type: elemental
+    recast: 1
   Aether Spheres:
     skill: cantrip
     abbrev: C AE S
@@ -558,6 +562,7 @@ spell_data:
     cyclic: true
     mana: 2
     mana_type: elemental
+    recast: 1
   Aethereal Image:
     skill: cantrip
     abbrev: C AE I
@@ -574,6 +579,7 @@ spell_data:
     prep: target
     mana: 2
     mana_type: arcane
+    recast: 1
   Avren Aevareae:
     skill: Debilitation
     harmless: true
@@ -582,6 +588,7 @@ spell_data:
     moon: true
     abbrev: AVA
     mana_type: lunar
+    recast: 1
   Aggressive Stance:
     skill: Augmentation
     abbrev: AGS
@@ -613,6 +620,7 @@ spell_data:
     prep: target
     mana: 1
     mana_type: elemental
+    recast: 1
   Alamhif's Gift:
     skill: Utility
     abbrev: AG
@@ -629,6 +637,7 @@ spell_data:
     cyclic: true
     mana: 5
     mana_type: elemental
+    recast: 1
   Anther's Call:
     skill: Debilitation
     abbrev: ANC
@@ -636,6 +645,7 @@ spell_data:
     mana: 1
     harmless: true
     mana_type: elemental
+    recast: 1
   Anti-Stun:
     skill: Utility
     abbrev: AS
@@ -651,6 +661,7 @@ spell_data:
     prep: prepare
     starlight_threshold: 0
     mana_type: lunar
+    recast: 1
   Arc Light:
     skill: Debilitation
     harmless: true
@@ -658,6 +669,7 @@ spell_data:
     mana: 1
     mana_type: elemental
     prep: prepare
+    recast: 1
   Artificer's Eye:
     skill: Augmentation
     abbrev: ART
@@ -672,6 +684,7 @@ spell_data:
     ritual: true
     mana_type: arcane
     prep: prepare
+    recast: 2
   Aspirant's Aegis:
     skill: Warding
     abbrev: AA
@@ -722,6 +735,7 @@ spell_data:
     mana: 5
     mana_type: life
     prep: prepare
+    recast: 1
   Banner of Truce:
     skill: Utility
     abbrev: BOT
@@ -736,6 +750,7 @@ spell_data:
     mana: 5
     mana_type: life
     prep: prepare
+    recast: 1
   Beckon the Naga:
     skill: Targeted Magic
     heavy: true
@@ -743,6 +758,7 @@ spell_data:
     abbrev: BTN
     prep: prepare
     mana_type: elemental
+    recast: 1
   Benediction:
     skill: Augmentation
     abbrev: Benediction
@@ -772,6 +788,7 @@ spell_data:
     mana: 5
     mana_type: elemental
     prep: prepare
+    recast: 1
   Bloodthorns:
     skill: Warding
     abbrev: blood
@@ -791,6 +808,7 @@ spell_data:
     mana: 15
     mana_type: arcane
     prep: target
+    recast: 1
   Blood Staunching:
     skill: Utility
     abbrev: BS
@@ -805,6 +823,7 @@ spell_data:
     mana: 30
     mana_type: elemental
     prep: target
+    recast: 1
   Blur:
     skill: Augmentation
     mana: 5
@@ -827,12 +846,14 @@ spell_data:
     ritual: true
     mana_type: lunar
     prep: prepare
+    recast: 2
   Breath of Storms:
     skill: Targeted Magic
     abbrev: BOS
     mana: 2
     mana_type: elemental
     prep: target
+    recast: 1
   Burden:
     skill: Debilitation
     abbrev: BURDEN
@@ -840,12 +861,14 @@ spell_data:
     harmless: true
     mana_type: ap
     prep: prepare
+    recast: 1
   Burn:
     skill: Targeted Magic
     abbrev: burn
     mana: 7
     mana_type: lunar
     prep: target
+    recast: 1
   Burning Touch:
     skill: cantrip
     abbrev: C B T
@@ -892,6 +915,7 @@ spell_data:
     mana: 1
     mana_type: lunar
     prep: prepare
+    recast: 1
   Caress of the Sun:
     skill: Utility
     abbrev: CARE
@@ -899,12 +923,14 @@ spell_data:
     mana: 2
     mana_type: elemental
     prep: prepare
+    recast: 1
   Carrion Call:
     skill: Targeted Magic
     abbrev: CAC
     mana: 2
     mana_type: life
     prep: target
+    recast: 1
   Centering:
     skill: Augmentation
     abbrev: centering
@@ -918,6 +944,7 @@ spell_data:
     mana: 15
     mana_type: elemental
     prep: target
+    recast: 1
   Cheetah Swiftness:
     skill: Augmentation
     abbrev: CS
@@ -925,12 +952,14 @@ spell_data:
     mana: 5
     mana_type: life
     prep: prepare
+    recast: 1
   Chill Spirit:
     skill: Targeted Magic
     abbrev: CHS
     mana: 7
     mana_type: holy
     prep: target
+    recast: 1
   Circle of Sympathy:
     skill: Utility
     abbrev: COS
@@ -939,6 +968,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 2
   Clarity:
     skill: Augmentation
     abbrev: clarity
@@ -967,12 +997,14 @@ spell_data:
     mana: 15
     mana_type: life
     prep: prepare
+    recast: 1
   Compost:
     skill: Utility
     abbrev: COMPOST
     mana: 1
     mana_type: life
     prep: prepare
+    recast: 1
   Consume Flesh:
     skill: Utility
     abbrev: CF
@@ -986,6 +1018,7 @@ spell_data:
     abbrev: CONTINGENCY
     mana_type: lunar
     prep: prepare
+    recast: 1
   Courage:
     skill: Augmentation
     abbrev: CO
@@ -1000,6 +1033,7 @@ spell_data:
     starlight_threshold: 0
     mana_type: lunar
     prep: target
+    recast: 1
   Crystalize Ice:
     skill: cantrip
     abbrev: C Crystalize Ice
@@ -1024,6 +1058,7 @@ spell_data:
     mana: 15
     mana_type: life
     prep: prepare
+    recast: 1
   Curse of the Wilds:
     skill: Debilitation
     harmless: true
@@ -1031,6 +1066,7 @@ spell_data:
     mana: 10
     mana_type: life
     prep: prepare
+    recast: 1
   Curse of Zachriedek:
     skill: Debilitation
     abbrev: COZ
@@ -1038,6 +1074,7 @@ spell_data:
     harmless: true
     mana_type: holy
     prep: prepare
+    recast: 1
   Damaris' Lullaby:
     skill: Debilitation
     harmless: true
@@ -1046,6 +1083,7 @@ spell_data:
     mana: 6
     mana_type: elemental
     prep: prepare
+    recast: 1
   Dazzle: # Requires either the sun or moons to be visible and being outdoors
     skill: Debilitation
     harmless: true
@@ -1053,6 +1091,7 @@ spell_data:
     mana: 1
     mana_type: lunar
     prep: prepare
+    recast: 1
   Deadfall:
     skill: Debilitation
     harmless: true
@@ -1060,6 +1099,7 @@ spell_data:
     mana: 1
     mana_type: life
     prep: prepare
+    recast: 1
   Demrris' Resolve:
     skill: Debilitation
     harmless: true
@@ -1067,6 +1107,7 @@ spell_data:
     mana: 3
     mana_type: elemental
     prep: prepare
+    recast: 1
   Desert's Maelstrom:
     skill: Debilitation
     abbrev: DEMA
@@ -1074,6 +1115,7 @@ spell_data:
     harmless: true
     mana_type: elemental
     prep: prepare
+    recast: 1
   Destiny Cipher:
     skill: Utility
     abbrev: DC
@@ -1081,12 +1123,14 @@ spell_data:
     ritual: true
     mana_type: lunar
     prep: prepare
+    recast: 2
   Devitalize:
     skill: Targeted Magic
     abbrev: DEVI
     mana: 10
     mana_type: life
     prep: target
+    recast: 1
   Devolve:
     skill: Debilitation
     abbrev: DE
@@ -1094,6 +1138,7 @@ spell_data:
     harmless: true
     mana_type: life
     prep: prepare
+    recast: 1
   Devour:
     skill: Utility
     abbrev: devour
@@ -1107,6 +1152,7 @@ spell_data:
     mana: 15
     mana_type: ap
     prep: prepare
+    recast: 1
   Distant Gaze:
     skill: Utility
     abbrev: DG
@@ -1120,6 +1166,7 @@ spell_data:
     mana: 2
     mana_type: lunar
     prep: target
+    recast: 1
   Divine Armor:
     skill: Utility
     abbrev: DA
@@ -1140,6 +1187,7 @@ spell_data:
     mana: 2
     mana_type: holy
     prep: prepare
+    recast: 1
   Dragon's Breath:
     skill: Targeted Magic
     heavy: true
@@ -1162,12 +1210,14 @@ spell_data:
     mana_type: ap
     harmless: true
     prep: prepare
+    recast: 1
   Eagle's Cry:
     skill: Targeted Magic
     mana: 1
     abbrev: EC
     mana_type: life
     prep: target
+    recast: 1
   Earth Meld:
     skill: Augmentation
     abbrev: EM
@@ -1187,6 +1237,7 @@ spell_data:
     abbrev: ECHO
     mana_type: elemental
     prep: prepare
+    recast: 2
   Eillie's Cry:
     skill: Augmentation
     abbrev: ECRY
@@ -1199,7 +1250,7 @@ spell_data:
     skill: Warding
     ritual: true
     abbrev: ELI
-    recast: 1
+    recast: 2
     starlight_threshold: 0
     mana_type: lunar
     prep: prepare
@@ -1222,6 +1273,7 @@ spell_data:
     mana: 6
     mana_type: elemental
     prep: prepare
+    recast: 1
   Emuin's Candlelight:
     skill: Augmentation # Also Warding
     abbrev: EMC
@@ -1257,6 +1309,7 @@ spell_data:
     expire: fissure collapses in on itself, winking out of existence
     mana_type: elemental
     prep: prepare
+    recast: 1
   Ethereal Shield:
     skill: Warding
     abbrev: ES
@@ -1271,6 +1324,7 @@ spell_data:
     mana: 3
     mana_type: elemental
     prep: prepare
+    recast: 1
   Eyes of the Blind:
     skill: Utility
     abbrev: EOTB
@@ -1285,6 +1339,7 @@ spell_data:
     mana: 15
     mana_type: holy
     prep: prepare
+    recast: 1
   Faenella's Grace:
     skill: Augmentation
     abbrev: FAE
@@ -1292,12 +1347,14 @@ spell_data:
     mana: 2
     mana_type: elemental
     prep: prepare
+    recast: 1
   Fire Ball:
     skill: Targeted Magic
     abbrev: FB
     mana: 15
     mana_type: elemental
     prep: target
+    recast: 1
   Fire Rain:
     skill: Targeted Magic
     abbrev: FR
@@ -1305,24 +1362,28 @@ spell_data:
     mana: 7
     prep: prepare
     mana_type: elemental
+    recast: 1
   Fire Shards:
     skill: Targeted Magic
     abbrev: FS
     mana: 1
     mana_type: elemental
     prep: target
+    recast: 1
   Fire of Ushnish:
     skill: Targeted Magic
     abbrev: FOU
     mana: 30
     mana_type: holy
     prep: target
+    recast: 1
   Fists of Faenella:
     skill: Targeted Magic
     abbrev: FF
     mana: 2
     mana_type: holy
     prep: target
+    recast: 1
   Finesse:
     abbrev: FIN
     mana: 5
@@ -1358,6 +1419,7 @@ spell_data:
     starlight_threshold: 0
     mana_type: lunar
     prep: prepare
+    recast: 1
   Flush Poisons:
     skill: Utility
     abbrev: FP
@@ -1380,12 +1442,14 @@ spell_data:
     mana: 2
     mana_type: holy
     prep: target
+    recast: 1
   Forestwalker's Boon:
     skill: Warding
     abbrev: FWB
     mana: 15
     mana_type: life
     prep: prepare
+    recast: 1
   Fortress of Ice:
     skill: Utility
     abbrev: FOI
@@ -1401,6 +1465,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 1
   Frostbite:
     skill: Debilitation
     harmless: true
@@ -1408,12 +1473,14 @@ spell_data:
     mana: 15
     mana_type: elemental
     prep: prepare
+    recast: 1
   Frost Scythe:
     skill: Targeted Magic
     abbrev: FRS
     mana: 7
     mana_type: elemental
     prep: target
+    recast: 1
   Gam Irnan:
     skill: Warding
     abbrev: GI
@@ -1428,18 +1495,21 @@ spell_data:
     mana_type: ap
     harmless: true
     prep: prepare
+    recast: 1
   Gar Zeng:
     skill: Targeted Magic
     abbrev: GZ
     mana: 1
     mana_type: elemental
     prep: target
+    recast: 1
   Geyser:
     skill: Targeted Magic
     abbrev: geyser
     mana: 1
     mana_type: elemental
     prep: target
+    recast: 1
   Ghost Shroud:
     skill: Warding
     abbrev: GHS
@@ -1447,6 +1517,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
+    recast: 1
   Gift of Life:
     skill: Augmentation
     abbrev: GOL
@@ -1469,6 +1540,7 @@ spell_data:
     mana: 5
     mana_type: elemental
     prep: prepare
+    recast: 1
   Grizzly Claws:
     skill: Debilitation
     abbrev: GRIZ
@@ -1476,6 +1548,7 @@ spell_data:
     harmless: true
     mana_type: life
     prep: prepare
+    recast: 1
   Grounding Field:
     skill: Warding
     abbrev: GF
@@ -1491,6 +1564,7 @@ spell_data:
     mana: 5
     mana_type: life
     harmless: true
+    recast: 1
   Gust of Wind:
     skill: cantrip
     abbrev: C G O W
@@ -1508,6 +1582,7 @@ spell_data:
     harmless: false
     mana_type: holy
     prep: prepare
+    recast: 1
   Halt:
     skill: Debilitation
     harmless: true
@@ -1515,12 +1590,14 @@ spell_data:
     mana: 1
     mana_type: holy
     prep: prepare
+    recast: 1
   Hand of Tenemlor:
     skill: Targeted Magic
     abbrev: HOT
     mana: 7
     mana_type: holy
     prep: target
+    recast: 1
   Hands of Justice:
     skill: Utility
     abbrev: HOJ
@@ -1542,18 +1619,21 @@ spell_data:
     mana: 3
     mana_type: life
     prep: prepare
+    recast: 1
   Harm Evil:
     skill: Targeted Magic
     abbrev: HE
     mana: 2
     mana_type: holy
     prep: target
+    recast: 1
   Harm Horde:
     skill: Targeted Magic
     abbrev: HH
     mana: 15
     mana_type: holy
     prep: target
+    recast: 1
   Harmony:
     skill: Augmentation
     abbrev: Harmony
@@ -1568,6 +1648,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 1
   Heal Scars:
     skill: Utility
     abbrev: HS
@@ -1575,6 +1656,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 1
   Heal Wounds:
     skill: Utility
     mana: 1
@@ -1582,6 +1664,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 1
   Heart Link:
     skill: Utility
     mana: 15
@@ -1589,6 +1672,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 1
   Heighten Pain:
     skill: Debilitation
     harmless: true
@@ -1597,6 +1681,7 @@ spell_data:
     expire: The reddish-green arcs surrounding .+ fade away
     mana_type: arcane
     prep: prepare
+    recast: 1
   Heroic Strength:
     skill: Augmentation
     abbrev: HES
@@ -1611,6 +1696,7 @@ spell_data:
     mana: 5
     mana_type: elemental
     prep: prepare
+    recast: 1
   Holy Warrior:
     skill: Warding
     abbrev: HOW
@@ -1618,12 +1704,14 @@ spell_data:
     cyclic: true
     mana_type: holy
     prep: prepare
+    recast: 1
   Horn of the Black Unicorn:
     skill: Targeted Magic
     abbrev: HORN
     mana: 2
     mana_type: holy
     prep: target
+    recast: 1
   Huldah's Pall:
     skill: Debilitation
     abbrev: HULP
@@ -1631,6 +1719,7 @@ spell_data:
     harmless: true
     mana_type: holy
     prep: prepare
+    recast: 1
   Hydra Hex:
     skill: Debilitation
     harmless: true
@@ -1640,6 +1729,7 @@ spell_data:
     mana: 6
     mana_type: holy
     prep: prepare
+    recast: 1
   Ice Patch:
     skill: Debilitation
     harmless: true
@@ -1647,6 +1737,7 @@ spell_data:
     mana: 1
     mana_type: elemental
     prep: prepare
+    recast: 1
   Icutu Zaharenela:
     skill: Targeted Magic
     abbrev: IZ
@@ -1654,12 +1745,14 @@ spell_data:
     mana: 15
     mana_type: life
     prep: target
+    recast: 1
   Idon's Theft:
     skill: Debilitation # Also Utility
     abbrev: IT
     mana: 20
     harmless: true
     prep: prepare
+    recast: 1
   Ignite:
     skill: Utility
     abbrev: ignite
@@ -1673,6 +1766,7 @@ spell_data:
     abbrev: IMBUE
     mana_type: ap
     prep: prepare
+    recast: 1
   Innocence:
     skill: Utility
     abbrev: INNOCENCE
@@ -1698,7 +1792,7 @@ spell_data:
     abbrev: IOTS
     mana: 300
     ritual: true
-    recast: 0
+    recast: 0 # Don't recast while it's up to prevent incineration
     stats:
     - Discipline
     - Agility
@@ -1759,12 +1853,14 @@ spell_data:
     mana: 1
     mana_type: life
     prep: prepare
+    recast: 1
   Lightning Bolt:
     skill: Targeted Magic
     abbrev: LB
     mana: 7
     mana_type: elemental
     prep: target
+    recast: 1
   Locate:
     skill: Utility
     abbrev: locate
@@ -1786,6 +1882,7 @@ spell_data:
     expire: A heavy earthen ballista loses its cohesion and crumples into a pile of debris.
     mana_type: elemental
     prep: prepare
+    recast: 1
   Major Physical Protection:
     skill: Augmentation
     abbrev: MAPP
@@ -1801,6 +1898,7 @@ spell_data:
     expire: malevolent darkness wane
     mana_type: holy
     prep: prepare
+    recast: 1
   Manifest Force:
     skill: Warding
     abbrev: MAF
@@ -1830,6 +1928,7 @@ spell_data:
     mana: 1
     mana_type: elemental
     prep: prepare
+    recast: 1
   Marshal Order:
     skill: Augmentation
     abbrev: MO
@@ -1875,6 +1974,7 @@ spell_data:
     mana: 20
     mana_type: lunar
     prep: prepare
+    recast: 1
   Mental Focus:
     skill: Augmentation
     abbrev: MEF
@@ -1890,6 +1990,7 @@ spell_data:
     harmless: false
     mana_type: holy
     prep: prepare
+    recast: 1
   Mind Shout:
     skill: Debilitation
     harmless: true
@@ -1900,6 +2001,7 @@ spell_data:
     triggers_justice: true
     mana_type: lunar
     prep: prepare
+    recast: 1
   Minor Physical Protection:
     skill: Warding
     abbrev: MPP
@@ -1922,6 +2024,7 @@ spell_data:
     moon: true
     mana_type: lunar
     prep: prepare
+    recast: 1
   Moongate:
     skill: Utility
     abbrev: MG
@@ -1929,12 +2032,13 @@ spell_data:
     mana: 5
     mana_type: lunar
     prep: prepare
+    recast: 1
   Murrula's Flames:
     skill: Utility
     abbrev: MF
     mana: 300
     ritual: true
-    recast: 1
+    recast: 2
     mana_type: holy
     prep: prepare
   Naming of Tears:
@@ -1958,6 +2062,7 @@ spell_data:
     expire: the music nears the end, finishing with a lone tambourine to conclude the theme
     mana_type: elemental
     prep: prepare
+    recast: 1
   Nissa's Binding:
     skill: Debilitation
     harmless: true
@@ -1965,6 +2070,7 @@ spell_data:
     mana: 10
     mana_type: life
     prep: prepare
+    recast: 1
   Nonchalance:
     abbrev: NON
     mana: 5
@@ -1999,12 +2105,14 @@ spell_data:
     abbrev: OM
     mana_type: holy
     prep: prepare
+    recast: 1
   Paeldryth's Wrath:
     skill: Targeted Magic
     abbrev: PW
     mana: 7
     mana_type: elemental
     prep: target
+    recast: 1
   Paralysis:
     skill: Targeted Magic
     abbrev: PARALYSIS
@@ -2012,12 +2120,14 @@ spell_data:
     mana_type: life
     harmless: true
     prep: target
+    recast: 1
   Partial Displacement:
     skill: Targeted Magic
     abbrev: PD
     mana: 2
     mana_type: lunar
     prep: target
+    recast: 1
   Pattern Hues:
     skill: cantrip
     abbrev: C P H
@@ -2053,6 +2163,7 @@ spell_data:
     expire: no longer seems petrified
     mana_type: arcane
     prep: prepare
+    recast: 1
   Phelim's Sanction:
     skill: Debilitation
     harmless: true
@@ -2061,6 +2172,7 @@ spell_data:
     triggers_justice: true
     mana_type: holy
     prep: prepare
+    recast: 1
   Philosopher's Preservation:
     skill: Augmentation
     abbrev: PHP
@@ -2083,6 +2195,7 @@ spell_data:
     prep: prepare
     triggers_justice: true
     mana_type: elemental
+    recast: 1
   Platinum Hands of Kertigen:
     abbrev: PHK
     mana: 15
@@ -2096,6 +2209,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
+    recast: 1
   Psychic Shield:
     skill: Warding
     abbrev: PSY
@@ -2149,12 +2263,14 @@ spell_data:
     expire: The world dulls almost imperceptibly as the last remnants of the Read the Ripples ritual fade from your mind's eye
     mana_type: lunar
     prep: prepare
+    recast: 2
   Rebuke:
     skill: Targeted Magic
     abbrev: REB
     mana: 10
     mana_type: holy
     prep: target
+    recast: 1
   Redeemer's Pride:
     abbrev: REPR
     skill: Warding
@@ -2194,6 +2310,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 1
   Reinforce Stone:
     skill: cantrip
     abbrev: C R S
@@ -2210,12 +2327,14 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
+    recast: 1
   Rend:
     skill: Utility
     abbrev: rend
     mana: 5
     mana_type: lunar
     prep: prepare
+    recast: 1
   Researcher's Insight:
     skill: Augmentation
     abbrev: REI
@@ -2237,6 +2356,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
+    recast: 1
   Revelation:
     skill: Utility
     abbrev: revelation
@@ -2244,6 +2364,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
+    recast: 1
   Reverse Putrefaction:
     skill: Augmentation
     abbrev: RPU
@@ -2257,6 +2378,7 @@ spell_data:
     mana: 40
     mana_type: lunar
     prep: prepare
+    recast: 1
   Righteous Wrath:
     skill: Augmentation
     abbrev: RW
@@ -2271,6 +2393,7 @@ spell_data:
     cyclic: true
     mana: 6
     mana_type: elemental
+    recast: 1
   Ring of Spears:
     skill: Targeted Magic
     abbrev: ROS
@@ -2278,6 +2401,7 @@ spell_data:
     cyclic: true
     mana: 7
     mana_type: elemental
+    recast: 1
   Rising Mists:
     skill: Utility
     harmless: true
@@ -2286,6 +2410,7 @@ spell_data:
     expire: The unnatural fog breaks apart
     mana_type: elemental
     prep: prepare
+    recast: 1
   Rite of Contrition:
     skill: Utility
     abbrev: ROC
@@ -2293,6 +2418,7 @@ spell_data:
     mana: 5
     mana_type: arcane
     prep: prepare
+    recast: 1
   Rite of Forebearance:
     skill: Utility # Also Debilitation
     abbrev: RoF
@@ -2300,6 +2426,7 @@ spell_data:
     mana: 5
     mana_type: arcane
     prep: prepare
+    recast: 1
   Rite of Grace:
     skill: Utility
     abbrev: ROG
@@ -2307,12 +2434,14 @@ spell_data:
     mana: 5
     mana_type: arcane
     prep: prepare
+    recast: 1
   River in the Sky:
     skill: Warding
     abbrev: rits
     mana: 15
     mana_type: life
     prep: prepare
+    recast: 1
   Rutilor's Edge:
     skill: Utility
     abbrev: RUE
@@ -2356,6 +2485,7 @@ spell_data:
     abbrev: SEC
     mana_type: ap
     prep: prepare
+    recast: 2
   Seer's Sense:
     skill: Augmentation # Also Utility
     abbrev: SEER
@@ -2391,18 +2521,21 @@ spell_data:
     harmless: true
     mana_type: lunar
     prep: prepare
+    recast: 1
   Shadewatch Mirror:
     skill: Utility
     abbrev: SHM
     mana: 30
     mana_type: lunar
     prep: prepare
+    recast: 1
   Shadow Servant:
     skill: Utility
     abbrev: SS
     mana: 30
     mana_type: lunar
     prep: prepare
+    recast: 1
   Shadowling:
     skill: Utility
     abbrev: shadowling
@@ -2437,6 +2570,7 @@ spell_data:
     mana: 6
     mana_type: lunar
     prep: prepare
+    recast: 1
   Shatter:
     skill: Debilitation
     harmless: true
@@ -2444,6 +2578,7 @@ spell_data:
     mana: 1
     mana_type: holy
     prep: prepare
+    recast: 1
   Shear:
     skill: Warding
     abbrev: shear
@@ -2471,12 +2606,14 @@ spell_data:
     mana: 30
     mana_type: elemental
     prep: target
+    recast: 1
   Siphon Vitality:
     skill: Targeted Magic
     abbrev: SV
     mana: 10
     mana_type: arcane
     prep: target
+    recast: 1
   Skein of Shadows:
     skill: Augmentation # Also Utility
     abbrev: SKS
@@ -2491,12 +2628,14 @@ spell_data:
     mana: 1
     mana_type: lunar
     prep: prepare
+    recast: 1
   Smite Horde:
     skill: Targeted Magic
     abbrev: SMH
     mana: 30
     mana_type: holy
     prep: target
+    recast: 1
   Soldier's Prayer:
     skill: Warding
     abbrev: SP
@@ -2518,18 +2657,21 @@ spell_data:
     ritual: true
     mana_type: elemental
     prep: prepare
+    recast: 2
   Soul Attrition:
     skill: Targeted Magic
     abbrev: SA
     cyclic: true
     mana: 6
     prep: target
+    recast: 1
   Soul Bonding:
     skill: Debilitation
     abbrev: SB
     mana_type: holy
     mana: 1
     prep: prepare
+    recast: 1
   Soul Shield:
     skill: Warding
     abbrev: SOS
@@ -2545,6 +2687,7 @@ spell_data:
     expire: The spiritual weight lifts off
     mana_type: holy
     prep: prepare
+    recast: 1
   Sovereign Destiny:
     skill: Debilitation
     mana: 5
@@ -2552,6 +2695,7 @@ spell_data:
     harmless: true
     mana_type: lunar
     prep: prepare
+    recast: 1
   Spite of Dergati:
     skill: Debilitation # Also Warding
     harmless: true
@@ -2560,12 +2704,14 @@ spell_data:
     triggers_justice: true
     mana_type: holy
     prep: prepare
+    recast: 1
   Stampede:
     skill: Targeted Magic
     abbrev: STAMPEDE
     mana: 2
     mana_type: life
     prep: target
+    recast: 1
   Starcrash:
     skill: Targeted Magic
     abbrev: starcrash
@@ -2573,6 +2719,7 @@ spell_data:
     starlight_threshold: 0
     mana_type: lunar
     prep: prepare
+    recast: 1
   Starlight Sphere:
     skill: Targeted Magic
     abbrev: SLS
@@ -2581,6 +2728,7 @@ spell_data:
     night: true
     mana: 6
     mana_type: lunar
+    recast: 1
   Stellar Collector:
     abbrev: STC
     mana: 30
@@ -2596,6 +2744,7 @@ spell_data:
     invisibility: true
     mana_type: lunar
     prep: prepare
+    recast: 1
   Stone Seat:
     skill: cantrip
     abbrev: C S S
@@ -2612,12 +2761,14 @@ spell_data:
     mana: 1
     mana_type: elemental
     prep: target
+    recast: 1
   Strange Arrow:
     skill: Targeted Magic
     abbrev: STRA
     mana: 1
     mana_type: ap
     prep: target
+    recast: 1
   Stun Foe:
     skill: Debilitation
     abbrev: SF
@@ -2625,6 +2776,7 @@ spell_data:
     harmless: true
     mana_type: holy
     prep: prepare
+    recast: 1
   Substratum:
     skill: Augmentation
     abbrev: substratum
@@ -2646,6 +2798,7 @@ spell_data:
     harmless: true
     mana_type: life
     prep: prepare
+    recast: 1
   Swirling Winds:
     skill: Augmentation
     abbrev: SW
@@ -2675,6 +2828,7 @@ spell_data:
     abbrev: TF
     mana_type: lunar
     prep: prepare
+    recast: 1
   Telekinetic Shield:
     skill: Warding
     abbrev: TKSH
@@ -2688,18 +2842,21 @@ spell_data:
     mana: 15
     mana_type: lunar
     prep: target
+    recast: 1
   Telekinetic Throw:
     skill: Targeted Magic
     abbrev: TKT
     mana: 1
     mana_type: lunar
     prep: target
+    recast: 1
   Teleport:
     skill: Utility
     abbrev: TELEPORT
     mana: 5
     mana_type: lunar
     prep: prepare
+    recast: 1
   Tenebrous Sense:
     skill: Augmentation
     abbrev: TS
@@ -2713,6 +2870,7 @@ spell_data:
     abbrev: TV
     mana_type: lunar
     prep: prepare
+    recast: 1
   Thoughtcast:
     skill: Utility
     abbrev: TH
@@ -2727,6 +2885,7 @@ spell_data:
     mana: 10
     mana_type: elemental
     prep: prepare
+    recast: 1
   Tingle:
     skill: Debilitation
     harmless: true
@@ -2734,6 +2893,7 @@ spell_data:
     mana: 5
     mana_type: elemental
     prep: prepare
+    recast: 1
   Trabe Chalice:
     skill: Warding
     mana: 1
@@ -2757,6 +2917,7 @@ spell_data:
     mana: 10
     mana_type: elemental
     prep: prepare
+    recast: 1
   Truffenyi's Rally:
     skill: Augmentation # Also Utility
     abbrev: TR
@@ -2764,6 +2925,7 @@ spell_data:
     cyclic: true
     mana_type: holy
     prep: prepare
+    recast: 1
   Turmar Illumination:
     abbrev: TU IL
     mana: 5
@@ -2777,6 +2939,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
+    recast: 1
   Universal Solvent:
     skill: Targeted Magic
     abbrev: USOL
@@ -2785,6 +2948,7 @@ spell_data:
     prep: prepare
     mana: 7
     mana_type: arcane
+    recast: 1
   Unleash:
     skill: Utility
     abbrev: unleash
@@ -2806,6 +2970,7 @@ spell_data:
     mana: 15
     mana_type: elemental
     prep: prepare
+    recast: 1
   Vessel of Salvation:
     skill: Utility
     abbrev: VOS
@@ -2819,6 +2984,7 @@ spell_data:
     mana: 5
     mana_type: holy
     prep: prepare
+    recast: 1
   Vigor:
     skill: Augmentation
     abbrev: VIGOR
@@ -2834,6 +3000,7 @@ spell_data:
     mana: 10
     mana_type: arcane
     prep: prepare
+    recast: 1
   Visions of Darkness:
     skill: Debilitation
     harmless: true
@@ -2841,6 +3008,7 @@ spell_data:
     mana: 5
     mana_type: arcane
     prep: prepare
+    recast: 1
   Vitality Healing:
     skill: Utility
     mana: 5
@@ -2848,6 +3016,7 @@ spell_data:
     mana_type: life
     harmless: true
     prep: prepare
+    recast: 1
   Vivisection:
     skill: Targeted Magic
     abbrev: vivisection
@@ -2855,6 +3024,7 @@ spell_data:
     use_stealth: true
     mana_type: arcane
     prep: target
+    recast: 1
   Ward Break:
     skill: Debilitation
     harmless: true
@@ -2862,6 +3032,7 @@ spell_data:
     mana: 1
     mana_type: elemental
     prep: prepare
+    recast: 1
   Water Globe:
     skill: cantrip
     abbrev: C Water Globe
@@ -2894,6 +3065,7 @@ spell_data:
     ritual: true
     mana_type: elemental
     prep: prepare
+    recast: 2
   Will O Wisp:
     skill: cantrip
     abbrev: C W O W
@@ -2926,6 +3098,7 @@ spell_data:
     ritual: true
     mana_type: elemental
     prep: prepare
+    recast: 2
   Worm's Mist:
     skill: Warding
     abbrev: WORM
@@ -2947,6 +3120,7 @@ spell_data:
     expire: the breeze fades from the area
     mana_type: elemental
     prep: prepare
+    recast: 1
 
 rituals:
   preserve: Unseen energies seep into the creature's fluids, suspending the corpse in unnatural stasis for a time

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -475,7 +475,7 @@ spell_data:
   Abandoned Heart:
     skill: Targeted Magic
     abbrev: ABAN
-    prep_type: prepare
+    prep: prepare
     cyclic: true
     mana: 7
     mana_type: elemental
@@ -483,6 +483,7 @@ spell_data:
     skill: Utility
     harmless: true
     abbrev: Absolution
+    prep: prepare
     mana: 150
     before:
     - message: release gol
@@ -495,11 +496,13 @@ spell_data:
   Acid Splash:
     skill: Targeted Magic
     abbrev: ACS
+    prep: target
     mana: 1
     mana_type: arcane
   Aegis of Granite:
     skill: Augmentation
     abbrev: AEG
+    prep: prepare
     ritual: true
     mana: 300
     before:
@@ -512,6 +515,7 @@ spell_data:
   Aesandry Darlaeth:
     skill: Augmentation
     abbrev: AD
+    prep: prepare
     cyclic: true
     mana: 5
     recast: 1
@@ -520,18 +524,21 @@ spell_data:
   Aesrela Everild:
     skill: Targeted Magic
     abbrev: AE
+    prep: target
     mana: 15
     mana_type: holy
   Aether Cloak:
     skill: Warding
     harmless: true
     abbrev: AC
+    prep: prepare
     cyclic: true
     mana: 4
     mana_type: elemental
   Aether Spheres:
     skill: cantrip
     abbrev: C AE S
+    prep: prepare
     prep_time: 0
     cast: gesture
     harmless: true
@@ -542,12 +549,14 @@ spell_data:
     skill: Debilitation
     harmless: true
     abbrev: AEWO
+    prep: prepare
     cyclic: true
     mana: 2
     mana_type: elemental
   Aethereal Image:
     skill: cantrip
     abbrev: C AE I
+    prep: prepare
     prep_time: 0
     cast: gesture
     harmless: true
@@ -557,11 +566,13 @@ spell_data:
   Aethrolysis:
     skill: Targeted Magic
     abbrev: Aethrolysis
+    prep: target
     mana: 2
     mana_type: arcane
   Avren Aevareae:
     skill: Debilitation
     harmless: true
+    prep: prepare
     mana: 10
     moon: true
     abbrev: AVA
@@ -569,6 +580,7 @@ spell_data:
   Aggressive Stance:
     skill: Augmentation
     abbrev: AGS
+    prep: prepare
     mana: 5
     recast: 1
     mana_type: life
@@ -576,6 +588,7 @@ spell_data:
   Air Blast:
     skill: cantrip
     abbrev: C AI B
+    prep: prepare
     prep_time: 0
     cast: gesture
     harmless: true
@@ -585,17 +598,20 @@ spell_data:
   Air Bubble:
     skill: Utility
     abbrev: AB
+    prep: prepare
     mana: 5
     recast: 1
     mana_type: elemental
   Air Lash:
     skill: Targeted Magic
     abbrev: ALA
+    prep: target
     mana: 1
     mana_type: elemental
   Alamhif's Gift:
     skill: Utility
     abbrev: AG
+    prep: prepare
     ritual: true
     mana: 300
     recast: 2
@@ -604,12 +620,14 @@ spell_data:
     skill: Debilitation
     harmless: true
     abbrev: ALB
+    prep: prepare
     cyclic: true
     mana: 5
     mana_type: elemental
   Anther's Call:
     skill: Debilitation
     abbrev: ANC
+    prep: prepare
     mana: 1
     harmless: true
     mana_type: elemental
@@ -619,6 +637,7 @@ spell_data:
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Arbiter's Stylus:
     skill: Targeted Magic
     cyclic: true
@@ -633,48 +652,56 @@ spell_data:
     abbrev: AL
     mana: 1
     mana_type: elemental
+    prep: prepare
   Artificer's Eye:
     skill: Augmentation
     abbrev: ART
     mana: 5
     recast: 1
     mana_type: lunar
+    prep: prepare
   Aspects of the All-God:
-    skill: Augmentation  # Also utility
+    skill: Augmentation # Also Utility
     abbrev: ALL
     mana: 50
     ritual: true
     mana_type: arcane
+    prep: prepare
   Aspirant's Aegis:
     skill: Warding
     abbrev: AA
     mana: 1
     recast: 1
     mana_type: holy
+    prep: prepare
   Athleticism:
     skill: Augmentation
     abbrev: ATHLETICISM
     mana: 1
     recast: 1
     mana_type: life
+    prep: prepare
   Aura Sight:
     skill: Augmentation
     abbrev: AUS
     mana: 5
     recast: 1
     mana_type: lunar
+    prep: prepare
   Aura of Tongues:
     skill: Utility
     abbrev: AOT
     mana: 1
     recast: 1
     mana_type: elemental
+    prep: prepare
   Auspice:
     skill: Augmentation
     abbrev: Auspice
     recast: 1
     mana: 5
     mana_type: holy
+    prep: prepare
   Awaken:
     skill: Utility
     abbrev: AWAKEN
@@ -682,30 +709,34 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Awaken Forest:
     skill: Utility
     abbrev: AF
     cyclic: true
     mana: 5
     mana_type: life
+    prep: prepare
   Banner of Truce:
     skill: Utility
     abbrev: BOT
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Bear Strength:
     skill: Augmentation
     abbrev: BES
     cyclic: true
     mana: 5
     mana_type: life
+    prep: prepare
   Beckon the Naga:
     skill: Targeted Magic
     heavy: true
     mana: 30
     abbrev: BTN
-    prep_type: prepare
+    prep: prepare
     mana_type: elemental
   Benediction:
     skill: Augmentation
@@ -713,6 +744,7 @@ spell_data:
     recast: 1
     mana: 15
     mana_type: holy
+    prep: prepare
   Blend:
     skill: Utility
     abbrev: Blend
@@ -720,18 +752,21 @@ spell_data:
     mana: 15
     recast: 1
     mana_type: life
+    prep: prepare
   Bless:
     skill: Utility
     abbrev: bless
     mana: 1
     recast: 1
     mana_type: holy
+    prep: prepare
   Blessing of the Fae:
     skill: Augmentation
     abbrev: BOTF
     cyclic: true
     mana: 5
     mana_type: elemental
+    prep: prepare
   Bloodthorns:
     skill: Warding
     abbrev: blood
@@ -744,11 +779,13 @@ spell_data:
       - Release what?
     recast: 2
     mana_type: life
+    prep: prepare
   Blood Burst:
     skill: Targeted Magic
     abbrev: BLB
     mana: 15
     mana_type: arcane
+    prep: target
   Blood Staunching:
     skill: Utility
     abbrev: BS
@@ -756,11 +793,13 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Blufmor Garaen:
     skill: Targeted Magic
     abbrev: BG
     mana: 30
     mana_type: elemental
+    prep: target
   Blur:
     skill: Augmentation
     mana: 5
@@ -768,34 +807,40 @@ spell_data:
     recast: 1
     starlight_threshold: 0
     mana_type: lunar
+    prep: prepare
   Bond Armaments:
     skill: Utility
     abbrev: BA
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Braun's Conjecture:
     skill: Utility
     abbrev: BC
     mana: 150
     ritual: true
     mana_type: lunar
+    prep: prepare
   Breath of Storms:
     skill: Targeted Magic
     abbrev: BOS
     mana: 2
     mana_type: elemental
+    prep: target
   Burden:
     skill: Debilitation
     abbrev: BURDEN
     mana: 1
     harmless: true
     mana_type: ap
+    prep: prepare
   Burn:
     skill: Targeted Magic
     abbrev: burn
     mana: 7
     mana_type: lunar
+    prep: target
   Burning Touch:
     skill: cantrip
     abbrev: C B T
@@ -805,12 +850,14 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Butcher's Eye:
     skill: Augmentation
     abbrev: BUE
     mana: 5
     recast: 1
     mana_type: arcane
+    prep: prepare
   Cage of Light:
     skill: Warding
     abbrev: CoL
@@ -818,57 +865,67 @@ spell_data:
     moon: true
     recast: 1
     mana_type: lunar
+    prep: prepare
   Calcified Hide:
     skill: Warding
     abbrev: CH
     mana: 15
     recast: 1
     mana_type: arcane
+    prep: prepare
   Call from Beyond:
     skill: Utility
     abbrev: CFB
     mana: 15
     recast: 1
     mana_type: arcane
+    prep: prepare
   Calm:
     skill: Debilitation
     harmless: true
     abbrev: calm
     mana: 1
     mana_type: lunar
+    prep: prepare
   Caress of the Sun:
     skill: Utility
     abbrev: CARE
     cyclic: true
     mana: 2
     mana_type: elemental
+    prep: prepare
   Carrion Call:
     skill: Targeted Magic
     abbrev: CAC
     mana: 2
     mana_type: life
+    prep: target
   Centering:
     skill: Augmentation
     abbrev: centering
     mana: 1
     recast: 1
     mana_type: holy
+    prep: prepare
   Chain Lightning:
     skill: Targeted Magic
     abbrev: CL
     mana: 15
     mana_type: elemental
+    prep: target
   Cheetah Swiftness:
     skill: Augmentation
     abbrev: CS
     cyclic: true
     mana: 5
     mana_type: life
+    prep: prepare
   Chill Spirit:
     skill: Targeted Magic
     abbrev: CHS
     mana: 7
     mana_type: holy
+    prep: target
   Circle of Sympathy:
     skill: Utility
     abbrev: COS
@@ -876,58 +933,68 @@ spell_data:
     ritual: true
     mana_type: life
     harmless: true
+    prep: prepare
   Clarity:
     skill: Augmentation
     abbrev: clarity
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Claws of the Cougar:
     skill: Augmentation
     abbrev: COTC
     mana: 15
     recast: 1
     mana_type: life
+    prep: prepare
   Clear Vision:
     skill: Augmentation
     abbrev: CV
     mana: 1
     recast: 1
     mana_type: lunar
+    prep: prepare
   Compel:
     skill: Debilitation
     harmless: true
     abbrev: COMPEL
     mana: 15
     mana_type: life
+    prep: prepare
   Compost:
     skill: Utility
     abbrev: COMPOST
     mana: 1
     mana_type: life
+    prep: prepare
   Consume Flesh:
     skill: Utility
     abbrev: CF
     mana: 15
     recast: 1
     mana_type: arcane
+    prep: prepare
   Contingency:
     skill: Utility
     mana: 15
     abbrev: CONTINGENCY
     mana_type: lunar
+    prep: prepare
   Courage:
     skill: Augmentation
     abbrev: CO
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Crystal Dart:
     skill: Targeted Magic
     abbrev: CRD
     mana: 2
     starlight_threshold: 0
     mana_type: lunar
+    prep: target
   Crystalize Ice:
     skill: cantrip
     abbrev: C Crystalize Ice
@@ -937,30 +1004,35 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Crusader's Challenge:
     skill: Augmentation # Also Utility
     abbrev: CRC
     mana: 30
     recast: 1
     mana_type: holy
+    prep: prepare
   Cure Disease:
     skill: Utility
     harmless: true
     abbrev: CD
     mana: 15
     mana_type: life
+    prep: prepare
   Curse of the Wilds:
     skill: Debilitation
     harmless: true
     abbrev: COTW
     mana: 10
     mana_type: life
+    prep: prepare
   Curse of Zachriedek:
     skill: Debilitation
     abbrev: COZ
     mana: 5
     harmless: true
     mana_type: holy
+    prep: prepare
   Damaris' Lullaby:
     skill: Debilitation
     harmless: true
@@ -968,86 +1040,101 @@ spell_data:
     cyclic: true
     mana: 6
     mana_type: elemental
+    prep: prepare
   Dazzle: # Requires either the sun or moons to be visible and being outdoors
     skill: Debilitation
     harmless: true
     abbrev: dazzle
     mana: 1
     mana_type: lunar
+    prep: prepare
   Deadfall:
     skill: Debilitation
     harmless: true
     abbrev: DF
     mana: 1
     mana_type: life
+    prep: prepare
   Demrris' Resolve:
     skill: Debilitation
     harmless: true
     abbrev: DMRS
     mana: 3
     mana_type: elemental
+    prep: prepare
   Desert's Maelstrom:
     skill: Debilitation
     abbrev: DEMA
     mana: 20
     harmless: true
     mana_type: elemental
+    prep: prepare
   Destiny Cipher:
     skill: Utility
     abbrev: DC
     mana: 50
     ritual: true
     mana_type: lunar
+    prep: prepare
   Devitalize:
     skill: Targeted Magic
     abbrev: DEVI
     mana: 10
     mana_type: life
+    prep: target
   Devolve:
     skill: Debilitation
     abbrev: DE
     mana: 5
     harmless: true
     mana_type: life
+    prep: prepare
   Devour:
     skill: Utility
     abbrev: devour
     mana: 30
     recast: 1
     mana_type: arcane
+    prep: prepare
   Dispel:
     skill: Utility
     abbrev: DISPEL
     mana: 15
     mana_type: ap
+    prep: prepare
   Distant Gaze:
     skill: Utility
     abbrev: DG
     mana: 15
     recast: 1
     mana_type: lunar
+    prep: prepare
   Dinazen Olkar:
     skill: Targeted Magic
     abbrev: DO
     mana: 2
     mana_type: lunar
+    prep: target
   Divine Armor:
     skill: Utility
     abbrev: DA
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Divine Guidance:
     skill: Augmentation
     abbrev: DIG
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Divine Radiance:
     skill: Utility
     abbrev: DR
     mana: 2
     mana_type: holy
+    prep: prepare
   Dragon's Breath:
     skill: Targeted Magic
     heavy: true
@@ -1055,23 +1142,27 @@ spell_data:
     mana: 15
     mana_type: elemental
     recast: 1
+    prep: target
   Drums of the Snake:
     skill: Augmentation
     mana: 15
     abbrev: DRUM
     recast: 1
     mana_type: elemental
+    prep: prepare
   Ease Burden:
     skill: Augmentation
     abbrev: EASE
     mana: 1
     mana_type: ap
     harmless: true
+    prep: prepare
   Eagle's Cry:
     skill: Targeted Magic
     mana: 1
     abbrev: EC
     mana_type: life
+    prep: target
   Earth Meld:
     skill: Augmentation
     abbrev: EM
@@ -1083,18 +1174,21 @@ spell_data:
       - You come out of hiding
       - But you are not
     mana_type: life
+    prep: prepare
   Echoes of Aether:
     skill: Augmentation
     ritual: true
     mana: 150
     abbrev: ECHO
     mana_type: elemental
+    prep: prepare
   Eillie's Cry:
     skill: Augmentation
     abbrev: ECRY
     mana: 1
     recast: 1
     mana_type: elemental
+    prep: prepare
   Elision:
     mana: 400
     skill: Warding
@@ -1103,6 +1197,7 @@ spell_data:
     recast: 1
     starlight_threshold: 0
     mana_type: lunar
+    prep: prepare
   Electric Charge:
     skill: cantrip
     abbrev: C E C
@@ -1112,6 +1207,7 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Electrostatic Eddy:
     skill: Debilitation
     harmless: true
@@ -1120,12 +1216,14 @@ spell_data:
     triggers_justice: true
     mana: 6
     mana_type: elemental
+    prep: prepare
   Emuin's Candlelight:
     skill: Augmentation # Also Warding
     abbrev: EMC
     mana: 15
     recast: 1
     mana_type: arcane
+    prep: prepare
   Enrichment:
     skill: Augmentation
     abbrev: ENRICH
@@ -1133,12 +1231,14 @@ spell_data:
     recast: -1
     starlight_threshold: 3
     mana_type: lunar
+    prep: prepare
   Essence of Yew:
     skill: Warding
     abbrev: EY
     mana: 5
     recast: 1
     mana_type: life
+    prep: prepare
   Ethereal Fissure:
     skill: Utility
     abbrev: ETF
@@ -1151,18 +1251,21 @@ spell_data:
       - What do you want to close?
     expire: fissure collapses in on itself, winking out of existence
     mana_type: elemental
+    prep: prepare
   Ethereal Shield:
     skill: Warding
     abbrev: ES
     mana: 1
     recast: 1
     mana_type: elemental
+    prep: prepare
   Eye of Kertigen:
     skill: Utility
     abbrev: EYE
     cyclic: true
     mana: 3
     mana_type: elemental
+    prep: prepare
   Eyes of the Blind:
     skill: Utility
     abbrev: EOTB
@@ -1170,50 +1273,58 @@ spell_data:
     mana: 5
     recast: 1
     mana_type: arcane
+    prep: prepare
   Eylhaar's Feast:
     skill: Utility
     abbrev: EF
     mana: 15
     mana_type: holy
+    prep: prepare
   Faenella's Grace:
     skill: Augmentation
     abbrev: FAE
     cyclic: true
     mana: 2
     mana_type: elemental
+    prep: prepare
   Fire Ball:
     skill: Targeted Magic
     abbrev: FB
     mana: 15
     mana_type: elemental
+    prep: target
   Fire Rain:
     skill: Targeted Magic
     abbrev: FR
     cyclic: true
     mana: 7
-    prep_type: prepare
+    prep: prepare
     mana_type: elemental
   Fire Shards:
     skill: Targeted Magic
     abbrev: FS
     mana: 1
     mana_type: elemental
+    prep: target
   Fire of Ushnish:
     skill: Targeted Magic
     abbrev: FOU
     mana: 30
     mana_type: holy
+    prep: target
   Fists of Faenella:
     skill: Targeted Magic
     abbrev: FF
     mana: 2
     mana_type: holy
+    prep: target
   Finesse:
     abbrev: FIN
     mana: 5
     skill: Augmentation
     recast: 1
     mana_type: lunar
+    prep: prepare
   Flame Shockwave:
     abbrev: FLS
     prep_time: 0
@@ -1223,6 +1334,7 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Flash Point:
     skill: cantrip
     abbrev: C F
@@ -1232,6 +1344,7 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Fluoresce:
     abbrev: fluoresce
     mana: 1
@@ -1239,6 +1352,7 @@ spell_data:
     harmless: true
     starlight_threshold: 0
     mana_type: lunar
+    prep: prepare
   Flush Poisons:
     skill: Utility
     abbrev: FP
@@ -1246,6 +1360,7 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Focus Moonbeam:
     skill: Utility
     abbrev: FM
@@ -1253,22 +1368,26 @@ spell_data:
     moon: true
     recast: 1
     mana_type: lunar
+    prep: prepare
   Footman's Strike:
     skill: Targeted Magic
     abbrev: FST
     mana: 2
     mana_type: holy
+    prep: target
   Forestwalker's Boon:
     skill: Warding
     abbrev: FWB
     mana: 15
     mana_type: life
+    prep: prepare
   Fortress of Ice:
     skill: Utility
     abbrev: FOI
     mana: 30
     recast: 1
     mana_type: elemental
+    prep: prepare
   Fountain of Creation:
     skill: Utility
     abbrev: FOC
@@ -1276,44 +1395,52 @@ spell_data:
     expire: You no longer feel especially strained from invoking the Fountain of Creation
     mana_type: life
     harmless: true
+    prep: prepare
   Frostbite:
     skill: Debilitation
     harmless: true
     abbrev: frostbite
     mana: 15
     mana_type: elemental
+    prep: prepare
   Frost Scythe:
     skill: Targeted Magic
     abbrev: FRS
     mana: 7
     mana_type: elemental
+    prep: target
   Gam Irnan:
     skill: Warding
     abbrev: GI
     mana: 5
     mana_type: elemental
+    prep: prepare
   Gauge Flow:
     skill: Utility
     mana: 5
     abbrev: GAF
     mana_type: ap
     harmless: true
+    prep: prepare
   Gar Zeng:
     skill: Targeted Magic
     abbrev: GZ
     mana: 1
     mana_type: elemental
+    prep: target
   Geyser:
     skill: Targeted Magic
     abbrev: geyser
     mana: 1
     mana_type: elemental
+    prep: target
   Ghost Shroud:
     skill: Warding
     abbrev: GHS
     cyclic: true
     mana: 5
     mana_type: holy
+    prep: prepare
   Gift of Life:
     skill: Augmentation
     abbrev: GOL
@@ -1321,35 +1448,40 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Glythtide's Gift:
     skill: Augmentation
     abbrev: GG
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Glythtide's Joy:
     skill: Warding
     abbrev: GJ
     cyclic: true
     mana: 5
     mana_type: elemental
+    prep: prepare
   Grizzly Claws:
     skill: Debilitation
     abbrev: GRIZ
     mana: 10
     harmless: true
     mana_type: life
+    prep: prepare
   Grounding Field:
     skill: Warding
     abbrev: GF
     mana: 30
     recast: 1
     mana_type: elemental
+    prep: prepare
   Guardian Spirit:
     skill: Utility
     abbrev: GS
     cyclic: true
-    prep_type: prepare
+    prep: prepare
     mana: 5
     mana_type: life
     harmless: true
@@ -1362,81 +1494,95 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Halo:
-    skill: Debilitation # Also warding
+    skill: Debilitation # Also Warding
     abbrev: HALO
     mana: 30
     harmless: false
     mana_type: holy
+    prep: prepare
   Halt:
     skill: Debilitation
     harmless: true
     abbrev: halt
     mana: 1
     mana_type: holy
+    prep: prepare
   Hand of Tenemlor:
     skill: Targeted Magic
     abbrev: HOT
     mana: 7
     mana_type: holy
+    prep: target
   Hands of Justice:
     skill: Utility
     abbrev: HOJ
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Hands of Lirisa:
     skill: Augmentation
     abbrev: HOL
     mana: 5
     recast: 1
     mana_type: life
+    prep: prepare
   Harawep's Bonds:
     skill: Debilitation
     harmless: true
     abbrev: HB
     mana: 3
     mana_type: life
+    prep: prepare
   Harm Evil:
     skill: Targeted Magic
     abbrev: HE
     mana: 2
     mana_type: holy
+    prep: target
   Harm Horde:
     skill: Targeted Magic
     abbrev: HH
     mana: 15
     mana_type: holy
+    prep: target
   Harmony:
     skill: Augmentation
     abbrev: Harmony
     mana: 30
     recast: 1
     mana_type: elemental
+    prep: prepare
   Heal:
     skill: Utility
     mana: 15
     abbrev: heal
     mana_type: life
     harmless: true
+    prep: prepare
   Heal Scars:
     skill: Utility
     abbrev: HS
     mana: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Heal Wounds:
     skill: Utility
     mana: 1
     abbrev: HW
     mana_type: life
     harmless: true
+    prep: prepare
   Heart Link:
     skill: Utility
     mana: 15
     abbrev: HL
     mana_type: life
     harmless: true
+    prep: prepare
   Heighten Pain:
     skill: Debilitation
     harmless: true
@@ -1444,35 +1590,41 @@ spell_data:
     mana: 1
     expire: The reddish-green arcs surrounding .+ fade away
     mana_type: arcane
+    prep: prepare
   Heroic Strength:
     skill: Augmentation
     abbrev: HES
     mana: 1
     recast: 1
     mana_type: holy
+    prep: prepare
   Hodierna's Lilt:
     skill: Utility
     abbrev: HODI
     cyclic: true
     mana: 5
     mana_type: elemental
+    prep: prepare
   Holy Warrior:
     skill: Warding
     abbrev: HOW
     mana: 5
     cyclic: true
     mana_type: holy
+    prep: prepare
   Horn of the Black Unicorn:
     skill: Targeted Magic
     abbrev: HORN
     mana: 2
     mana_type: holy
+    prep: target
   Huldah's Pall:
     skill: Debilitation
     abbrev: HULP
     mana: 10
     harmless: true
     mana_type: holy
+    prep: prepare
   Hydra Hex:
     skill: Debilitation
     harmless: true
@@ -1481,34 +1633,40 @@ spell_data:
     triggers_justice: true
     mana: 6
     mana_type: holy
+    prep: prepare
   Ice Patch:
     skill: Debilitation
     harmless: true
     abbrev: IP
     mana: 1
     mana_type: elemental
+    prep: prepare
   Icutu Zaharenela:
     skill: Targeted Magic
     abbrev: IZ
     cyclic: true
     mana: 15
     mana_type: life
+    prep: target
   Idon's Theft:
-    skill: Debilitation  # Also utility
+    skill: Debilitation # Also Utility
     abbrev: IT
     mana: 20
     harmless: true
+    prep: prepare
   Ignite:
     skill: Utility
     abbrev: ignite
     mana: 5
     recast: -1
     mana_type: elemental
+    prep: prepare
   Imbue:
     skill: Utility
     mana: 15
     abbrev: IMBUE
     mana_type: ap
+    prep: prepare
   Innocence:
     skill: Utility
     abbrev: INNOCENCE
@@ -1521,12 +1679,14 @@ spell_data:
         - Release what?
     mana_type: life
     harmless: true
+    prep: prepare
   Instinct:
     skill: Augmentation
     abbrev: INST
     mana: 5
     recast: 1
     mana_type: life
+    prep: prepare
   Invocation of the Spheres:
     skill: Augmentation
     abbrev: IOTS
@@ -1550,6 +1710,7 @@ spell_data:
         - You draw your hand
         - Invoke what
     mana_type: lunar
+    prep: prepare
   Iron Constitution:
     skill: Warding
     abbrev: IC
@@ -1557,22 +1718,26 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Ivory Mask:
     skill: Augmentation
     abbrev: IVM
     mana: 5
     recast: 1
+    prep: prepare
   Kura-Silma:
     skill: Augmentation
     abbrev: KS
     mana: 5
     recast: 1
+    prep: prepare
   Last Gift of Vithwok IV:
     abbrev: LGV
     mana: 5
     skill: Augmentation
     recast: 1
     mana_type: lunar
+    prep: prepare
   Lay Ward:
     skill: Warding
     abbrev: LW
@@ -1580,41 +1745,48 @@ spell_data:
     recast: 1
     mana_type: ap
     harmless: true
+    prep: prepare
   Lethargy:
     skill: Debilitation
     harmless: true
     abbrev: LETHARGY
     mana: 1
     mana_type: life
+    prep: prepare
   Lightning Bolt:
     skill: Targeted Magic
     abbrev: LB
     mana: 7
     mana_type: elemental
+    prep: target
   Locate:
     skill: Utility
     abbrev: locate
     mana: 15
     recast: 1
     mana_type: lunar
+    prep: prepare
   Machinist's Touch:
     skill: Augmentation
     abbrev: MT
     mana: 15
     recast: 1
     mana_type: lunar
+    prep: prepare
   Magnetic Ballista:
     skill: Utility
     abbrev: MAB
     mana: 15
     expire: A heavy earthen ballista loses its cohesion and crumples into a pile of debris.
     mana_type: elemental
+    prep: prepare
   Major Physical Protection:
     skill: Augmentation
     abbrev: MAPP
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Malediction:
     skill: Debilitation
     mana: 5
@@ -1622,6 +1794,7 @@ spell_data:
     harmless: true
     expire: malevolent darkness wane
     mana_type: holy
+    prep: prepare
   Manifest Force:
     skill: Warding
     abbrev: MAF
@@ -1629,6 +1802,7 @@ spell_data:
     recast: 1
     mana_type: ap
     harmless: true
+    prep: prepare
   Mantle of Flame:
     skill: Augmentation
     harmless: true
@@ -1642,18 +1816,21 @@ spell_data:
       - Release what?
     recast: 2
     mana_type: elemental
+    prep: prepare
   Mark of Arhat:
     skill: Debilitation
     harmless: true
     abbrev: MOA
     mana: 1
     mana_type: elemental
+    prep: prepare
   Marshal Order:
     skill: Augmentation
     abbrev: MO
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Mask of the Moons:
     abbrev: MOM
     cyclic: true
@@ -1662,18 +1839,21 @@ spell_data:
     skill: Warding
     recast: 1
     mana_type: lunar
+    prep: prepare
   Mass Rejuvenation:
     skill: Utility
     abbrev: MRE
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Membrach's Greed:
     abbrev: MEG
     mana: 5
     skill: Augmentation
     recast: 1
     mana_type: lunar
+    prep: prepare
   Memory of Nature:
     skill: Utility
     abbrev: MON
@@ -1681,12 +1861,14 @@ spell_data:
     ritual: true
     recast: 2
     mana_type: life
+    prep: prepare
   Mental Blast:
     skill: Debilitation
     harmless: true
     abbrev: MB
     mana: 20
     mana_type: lunar
+    prep: prepare
   Mental Focus:
     skill: Augmentation
     abbrev: MEF
@@ -1694,12 +1876,14 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Meraud's Cry:
     skill: Debilitation
     abbrev: MC
     mana: 10
     harmless: false
     mana_type: holy
+    prep: prepare
   Mind Shout:
     skill: Debilitation
     harmless: true
@@ -1709,31 +1893,36 @@ spell_data:
     expire: recovered to craft another major manifestation of offensive magic
     triggers_justice: true
     mana_type: lunar
+    prep: prepare
   Minor Physical Protection:
     skill: Warding
     abbrev: MPP
     mana: 1
     recast: 1
     mana_type: holy
+    prep: prepare
   Misdirection:
-    skill: Augmentation # Also debilitation
+    skill: Augmentation # Also Debilitation
     harmless: true
     abbrev: MIS
     mana: 10
     recast: 1
     mana_type: elemental
+    prep: prepare
   Moonblade:
     skill: Utility
     abbrev: moonblade
     mana: 15
     moon: true
     mana_type: lunar
+    prep: prepare
   Moongate:
     skill: Utility
     abbrev: MG
     cyclic: true
     mana: 5
     mana_type: lunar
+    prep: prepare
   Murrula's Flames:
     skill: Utility
     abbrev: MF
@@ -1741,75 +1930,88 @@ spell_data:
     ritual: true
     recast: 1
     mana_type: holy
+    prep: prepare
   Naming of Tears:
     abbrev: NAME
     skill: Warding
     mana: 30
     recast: 1
     mana_type: elemental
+    prep: prepare
   Necrotic Reconstruction:
     skill: Utility
     abbrev: NR
     mana: 15
     recast: 1
     mana_type: arcane
+    prep: prepare
   Nexus:
     skill: Utility
     abbrev: NEXUS
     mana: 30
     expire: the music nears the end, finishing with a lone tambourine to conclude the theme
     mana_type: elemental
+    prep: prepare
   Nissa's Binding:
-    skill: Debilitation # area of effect
+    skill: Debilitation
     harmless: true
     abbrev: NB
     mana: 10
     mana_type: life
+    prep: prepare
   Nonchalance:
     abbrev: NON
     mana: 5
     skill: Warding
     recast: 1
     mana_type: lunar
+    prep: prepare
   Noumena:
     mana: 1
     skill: Utility
     abbrev: NOU
     recast: 1
     mana_type: lunar
+    prep: prepare
   Oath of the Firstborn:
     skill: Augmentation
     abbrev: OATH
     mana: 15
     recast: 1
     mana_type: life
+    prep: prepare
   Obfuscation:
     skill: Augmentation
     abbrev: obfuscation
     mana: 1
     recast: 1
     mana_type: arcane
+    prep: prepare
   Osrel Meraud:
     skill: Utility
     mana: 30
     abbrev: OM
     mana_type: holy
+    prep: prepare
   Paeldryth's Wrath:
     skill: Targeted Magic
     abbrev: PW
     mana: 7
     mana_type: elemental
+    prep: target
   Paralysis:
     skill: Targeted Magic
     abbrev: PARALYSIS
     mana: 2
     mana_type: life
     harmless: true
+    prep: target
   Partial Displacement:
     skill: Targeted Magic
     abbrev: PD
     mana: 2
     mana_type: lunar
+    prep: target
   Pattern Hues:
     skill: cantrip
     abbrev: C P H
@@ -1819,6 +2021,7 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Perseverance of Peri'el:
     skill: Warding
     abbrev: POP
@@ -1827,6 +2030,7 @@ spell_data:
     ritual: true
     mana_type: life
     harmless: true
+    prep: prepare
   Persistence of Mana:
     skill: Augmentation
     abbrev: POM
@@ -1834,6 +2038,7 @@ spell_data:
     mana: 150
     ritual: true
     mana_type: holy
+    prep: prepare
   Petrifying Visions:
     skill: Debilitation
     abbrev: PV
@@ -1841,31 +2046,35 @@ spell_data:
     harmless: true
     expire: no longer seems petrified
     mana_type: arcane
+    prep: prepare
   Phelim's Sanction:
-    skill: Debilitation # area of effect
+    skill: Debilitation
     harmless: true
     abbrev: PS
     mana: 10
     triggers_justice: true
     mana_type: holy
+    prep: prepare
   Philosopher's Preservation:
     skill: Augmentation
     abbrev: PHP
     mana: 5
     recast: 1
     mana_type: arcane
+    prep: prepare
   Piercing Gaze:
     skill: Utility
     abbrev: PG
     mana: 5
     recast: 1
     mana_type: lunar
+    prep: prepare
   Phoenix's Pyre:
     skill: Targeted Magic
     abbrev: PYRE
     cyclic: true
     mana: 7
-    prep_type: prepare
+    prep: prepare
     triggers_justice: true
     mana_type: elemental
   Platinum Hands of Kertigen:
@@ -1874,29 +2083,34 @@ spell_data:
     skill: Augmentation
     recast: 1
     mana_type: lunar
+    prep: prepare
   Protection from Evil:
     skill: Warding
     abbrev: PFE
     mana: 5
     mana_type: holy
+    prep: prepare
   Psychic Shield:
     skill: Warding
     abbrev: PSY
     mana: 5
     recast: 1
     mana_type: lunar
+    prep: prepare
   Quicken the Earth:
     skill: Utility
     abbrev: QE
     mana: 5
     recast: 1
     mana_type: arcane
+    prep: prepare
   Rage of the Clans:
     skill: Augmentation
     mana: 15
     abbrev: RAGE
     recast: 1
     mana_type: elemental
+    prep: prepare
   Raincloud:
     skill: cantrip
     abbrev: C Raincloud
@@ -1906,6 +2120,7 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Raise Power:
     skill: Utility
     abbrev: RP
@@ -1913,6 +2128,7 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Read the Ripples:
     skill: Utility
     abbrev: RtR
@@ -1926,17 +2142,20 @@ spell_data:
       - You are already sitting
     expire: The world dulls almost imperceptibly as the last remnants of the Read the Ripples ritual fade from your mind's eye
     mana_type: lunar
+    prep: prepare
   Rebuke:
     skill: Targeted Magic
     abbrev: REB
     mana: 10
     mana_type: holy
+    prep: target
   Redeemer's Pride:
     abbrev: REPR
     skill: Warding
     mana: 5
     recast: 1
     mana_type: elemental
+    prep: prepare
   Refractive Field:
     skill: Utility
     abbrev: RF
@@ -1944,6 +2163,7 @@ spell_data:
     invisibility: true
     recast: 1
     mana_type: lunar
+    prep: prepare
   Refresh:
     abbrev: Refresh
     skill: Augmentation
@@ -1951,6 +2171,7 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Regalia:
     abbrev: REGAL
     mana: 15
@@ -1958,6 +2179,7 @@ spell_data:
     recast: 1
     starlight_threshold: 0
     mana_type: lunar
+    prep: prepare
   Regenerate:
     skill: Utility
     abbrev: regenerate
@@ -1965,6 +2187,7 @@ spell_data:
     mana: 5
     mana_type: life
     harmless: true
+    prep: prepare
   Reinforce Stone:
     skill: cantrip
     abbrev: C R S
@@ -1974,68 +2197,78 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Rejuvenation:
     skill: Utility
     abbrev: REJUV
     mana: 5
     mana_type: holy
+    prep: prepare
   Rend:
     skill: Utility
     abbrev: rend
     mana: 5
     mana_type: lunar
+    prep: prepare
   Researcher's Insight:
     skill: Augmentation
     abbrev: REI
     mana: 15
     recast: 1
     mana_type: arcane
+    prep: prepare
   Resonance:
     skill: Utility
     mana: 15
     abbrev: RESONANCE
     recast: 1
     mana_type: elemental
+    prep: prepare
   Resurrection:
     skill: Utility
     abbrev: REZZ
     cyclic: true
     mana: 5
     mana_type: holy
+    prep: prepare
   Revelation:
     skill: Utility
     abbrev: revelation
     cyclic: true
     mana: 5
     mana_type: holy
+    prep: prepare
   Reverse Putrefaction:
     skill: Augmentation
     abbrev: RPU
     mana: 15
     recast: 1
     mana_type: arcane
+    prep: prepare
   Riftal Summons:
     skill: Utility
     abbrev: RS
     mana: 40
     mana_type: lunar
+    prep: prepare
   Righteous Wrath:
     skill: Augmentation
     abbrev: RW
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Rimefang:
     skill: Targeted Magic
     abbrev: RIM
-    prep_type: prepare
+    prep: prepare
     cyclic: true
     mana: 6
     mana_type: elemental
   Ring of Spears:
     skill: Targeted Magic
     abbrev: ROS
-    prep_type: prepare
+    prep: prepare
     cyclic: true
     mana: 7
     mana_type: elemental
@@ -2046,47 +2279,55 @@ spell_data:
     mana: 15
     expire: The unnatural fog breaks apart
     mana_type: elemental
+    prep: prepare
   Rite of Contrition:
     skill: Utility
     abbrev: ROC
     cyclic: true
     mana: 5
     mana_type: arcane
+    prep: prepare
   Rite of Forebearance:
     skill: Utility # Also Debilitation
     abbrev: RoF
     cyclic: true
     mana: 5
     mana_type: arcane
+    prep: prepare
   Rite of Grace:
     skill: Utility
     abbrev: ROG
     cyclic: true
     mana: 5
     mana_type: arcane
+    prep: prepare
   River in the Sky:
     skill: Warding
     abbrev: rits
     mana: 15
     mana_type: life
+    prep: prepare
   Rutilor's Edge:
     skill: Utility
     abbrev: RUE
     recast: -1
     mana: 15
     mana_type: holy
+    prep: prepare
   Saesordian Compass:
     skill: Augmentation
     abbrev: SCO
     mana: 30
     recast: 1
     mana_type: arcane
+    prep: prepare
   Sanctify Pattern:
     skill: Augmentation
     abbrev: SAP
     recast: 1
     mana: 5
     mana_type: holy
+    prep: prepare
   Sanctuary:
     skill: Utility
     abbrev: SANCTUARY
@@ -2094,58 +2335,68 @@ spell_data:
     mana: 5
     recast: 1
     mana_type: elemental
+    prep: prepare
   Sanyu Lyba:
     skill: Warding
     abbrev: SL
     mana: 30
     recast: 1
     mana_type: holy
+    prep: prepare
   Seal Cambrinth:
     skill: Utility
     ritual: true
     mana: 50
     abbrev: SEC
     mana_type: ap
+    prep: prepare
   Seer's Sense:
-    skill: Augmentation # It is also utility
+    skill: Augmentation # Also Utility
     abbrev: SEER
     mana: 15
     recast: 1
     mana_type: lunar
+    prep: prepare
   See the Wind:
     Skill: Augmentation
     abbrev: STW
     mana: 1
     recast: 1
     mana_type: life
+    prep: prepare
   Senses of the Tiger:
     skill: Augmentation
     abbrev: SOTT
     mana: 5
     recast: 1
     mana_type: life
+    prep: prepare
   Sentinel's Resolve:
     skill: Augmentation
     abbrev: SR
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Sever Thread:
     skill: Debilitation
     abbrev: SET
     mana: 3
     harmless: true
     mana_type: lunar
+    prep: prepare
   Shadewatch Mirror:
     skill: Utility
     abbrev: SHM
     mana: 30
     mana_type: lunar
+    prep: prepare
   Shadow Servant:
     skill: Utility
     abbrev: SS
     mana: 30
     mana_type: lunar
+    prep: prepare
   Shadowling:
     skill: Utility
     abbrev: shadowling
@@ -2164,12 +2415,14 @@ spell_data:
       - You gesture, adjusting the pattern that binds the shadowling to this plane
       - You're not sure what would happen
     mana_type: lunar
+    prep: prepare
   Shadows:
     skill: Augmentation
     abbrev: shadows
     mana: 1
     recast: 1
     mana_type: lunar
+    prep: prepare
   Shadow Web:
     skill: Debilitation
     harmless: true
@@ -2177,91 +2430,107 @@ spell_data:
     cyclic: true
     mana: 6
     mana_type: lunar
+    prep: prepare
   Shatter:
     skill: Debilitation
     harmless: true
     abbrev: shatter
     mana: 1
     mana_type: holy
+    prep: prepare
   Shear:
     skill: Warding
     abbrev: shear
     mana: 30
     recast: 1
     mana_type: lunar
+    prep: prepare
   Shield of Light:
     skill: Augmentation # Also Utility
     abbrev: SOL
     mana: 15
     recast: 3
     mana_type: holy
+    prep: prepare
   Shift Moonbeam:
     skill: Utility
     abbrev: SM
     mana: 15
     recast: 1
     mana_type: lunar
+    prep: prepare
   Shockwave:
     skill: Targeted Magic
     abbrev: shockwave
     mana: 30
     mana_type: elemental
+    prep: target
   Siphon Vitality:
     skill: Targeted Magic
     abbrev: SV
     mana: 10
     mana_type: arcane
+    prep: target
   Skein of Shadows:
-    skill: Augmentation # Utility
+    skill: Augmentation # Also Utility
     abbrev: SKS
     mana: 15
     recast: 1
     mana_type: life
+    prep: prepare
   Sleep:
     skill: Debilitation
     harmless: true
     abbrev: sleep
     mana: 1
     mana_type: lunar
+    prep: prepare
   Smite Horde:
     skill: Targeted Magic
     abbrev: SMH
     mana: 30
     mana_type: holy
+    prep: target
   Soldier's Prayer:
     skill: Warding
     abbrev: SP
     mana: 15
     recast: 1
     mana_type: holy
+    prep: prepare
   Solace:
     skill: Warding
     abbrev: SOLACE
     mana: 5
     recast: 1
     mana_type: arcane
+    prep: prepare
   Soul Ablaze:
     skill: Augmentation
     abbrev: SOUL
     mana: 300
     ritual: true
     mana_type: elemental
+    prep: prepare
   Soul Attrition:
     skill: Targeted Magic
     abbrev: SA
     cyclic: true
     mana: 6
+    prep: target
   Soul Bonding:
     skill: Debilitation
     abbrev: SB
     mana_type: holy
     mana: 1
+    prep: prepare
   Soul Shield:
     skill: Warding
     abbrev: SOS
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Soul Sickness:
     skill: Debilitation
     harmless: true
@@ -2269,12 +2538,14 @@ spell_data:
     mana: 1
     expire: The spiritual weight lifts off
     mana_type: holy
+    prep: prepare
   Sovereign Destiny:
     skill: Debilitation
     mana: 5
     abbrev: SOD
     harmless: true
     mana_type: lunar
+    prep: prepare
   Spite of Dergati:
     skill: Debilitation # Also Warding
     harmless: true
@@ -2282,11 +2553,13 @@ spell_data:
     mana: 20
     triggers_justice: true
     mana_type: holy
+    prep: prepare
   Stampede:
     skill: Targeted Magic
     abbrev: STAMPEDE
     mana: 2
     mana_type: life
+    prep: target
   Starcrash:
     skill: Targeted Magic
     abbrev: starcrash
@@ -2298,7 +2571,7 @@ spell_data:
     skill: Targeted Magic
     abbrev: SLS
     cyclic: true
-    prep_type: prepare
+    prep: prepare
     night: true
     mana: 6
     mana_type: lunar
@@ -2308,6 +2581,7 @@ spell_data:
     skill: Utility
     recast: 1
     mana_type: lunar
+    prep: prepare
   Steps of Vuan:
     skill: Utility
     abbrev: SOV
@@ -2315,6 +2589,7 @@ spell_data:
     cyclic: true
     invisibility: true
     mana_type: lunar
+    prep: prepare
   Stone Seat:
     skill: cantrip
     abbrev: C S S
@@ -2324,46 +2599,54 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Stone Strike:
     skill: Targeted Magic
     abbrev: STS
     mana: 1
     mana_type: elemental
+    prep: target
   Strange Arrow:
     skill: Targeted Magic
     abbrev: STRA
     mana: 1
     mana_type: ap
+    prep: target
   Stun Foe:
     skill: Debilitation
     abbrev: SF
     mana: 1
     harmless: true
     mana_type: holy
+    prep: prepare
   Substratum:
     skill: Augmentation
     abbrev: substratum
     mana: 5
     recast: 1
     mana_type: elemental
+    prep: prepare
   Sure Footing:
     skill: Augmentation
     abbrev: SUF
     mana: 5
     recast: 1
     mana_type: elemental
+    prep: prepare
   Swarm:
     skill: Debilitation
     abbrev: SWARM
     mana: 10
     harmless: true
     mana_type: life
+    prep: prepare
   Swirling Winds:
     skill: Augmentation
     abbrev: SW
     mana: 5
     recast: 1
     mana_type: elemental
+    prep: prepare
   Syamelyo Kuniyo:
     skill: Augmentation
     abbrev: SK
@@ -2371,68 +2654,80 @@ spell_data:
     recast: -1
     expire: Your green-shadowed reveries grow distant
     mana_type: life
+    prep: prepare
   Tailwind:
     skill: Augmentation
     abbrev: TW
     mana: 5
     recast: 1
     mana_type: elemental
+    prep: prepare
   Tangled Fate:
-    skill: Debilitation # Also utility
+    skill: Debilitation # Also Utility
     mana: 5
     harmless: true
     abbrev: TF
     mana_type: lunar
+    prep: prepare
   Telekinetic Shield:
     skill: Warding
     abbrev: TKSH
     mana: 30
     mana_type: lunar
     recast: 1
+    prep: prepare
   Telekinetic Storm:
     skill: Targeted Magic
     abbrev: TKS
     mana: 15
     mana_type: lunar
+    prep: target
   Telekinetic Throw:
     skill: Targeted Magic
     abbrev: TKT
     mana: 1
     mana_type: lunar
+    prep: target
   Teleport:
     skill: Utility
     abbrev: TELEPORT
     mana: 5
     mana_type: lunar
+    prep: prepare
   Tenebrous Sense:
     skill: Augmentation
     abbrev: TS
     mana: 5
     recast: 1
     mana_type: lunar
+    prep: prepare
   Tezirah's Veil:
     skill: Augmentation
     mana: 15
     abbrev: TV
     mana_type: lunar
+    prep: prepare
   Thoughtcast:
     skill: Utility
     abbrev: TH
     mana: 15
     recast: 1
     mana_type: lunar
+    prep: prepare
   Thunderclap:
     skill: Debilitation
     harmless: true
     abbrev: TC
     mana: 10
     mana_type: elemental
+    prep: prepare
   Tingle:
     skill: Debilitation
     harmless: true
     abbrev: TI
     mana: 5
     mana_type: elemental
+    prep: prepare
   Trabe Chalice:
     skill: Warding
     mana: 1
@@ -2440,42 +2735,48 @@ spell_data:
     recast: 1
     starlight_threshold: 0
     mana_type: lunar
+    prep: prepare
   Tranquility:
-    skill: Warding # Augmentation
+    skill: Warding # Also Augmentation
     abbrev: TRANQUILITY
     mana: 15
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Tremor:
     skill: Debilitation
     harmless: true
     abbrev: tremor
     mana: 10
     mana_type: elemental
+    prep: prepare
   Truffenyi's Rally:
     skill: Augmentation # Also Utility
     abbrev: TR
     mana: 5
     cyclic: true
     mana_type: holy
+    prep: prepare
   Turmar Illumination:
     abbrev: TU IL
     mana: 5
     skill: Augmentation
     recast: 1
     mana_type: lunar
+    prep: prepare
   Uncurse:
     skill: Utility
     abbrev: UNCURSE
     mana: 5
     mana_type: holy
+    prep: prepare
   Universal Solvent:
     skill: Targeted Magic
     abbrev: USOL
     cyclic: true
     triggers_justice: true
-    prep_type: prepare
+    prep: prepare
     mana: 7
     mana_type: arcane
   Unleash:
@@ -2484,29 +2785,34 @@ spell_data:
     mana: 15
     recast: 1
     mana_type: lunar
+    prep: prepare
   Veil of Ice:
     skill: Warding
     abbrev: VOI
     mana: 15
     recast: 1
     mana_type: elemental
+    prep: prepare
   Vertigo:
     skill: Debilitation
     harmless: true
     abbrev: vertigo
     mana: 15
     mana_type: elemental
+    prep: prepare
   Vessel of Salvation:
     skill: Utility
     abbrev: VOS
     mana: 5
     recast: 1
     mana_type: holy
+    prep: prepare
   Vigil:
     skill: Utility
     abbrev: VIGIL
     mana: 5
     mana_type: holy
+    prep: prepare
   Vigor:
     skill: Augmentation
     abbrev: VIGOR
@@ -2514,36 +2820,42 @@ spell_data:
     recast: 1
     mana_type: life
     harmless: true
+    prep: prepare
   Viscous Solution:
     skill: Debilitation
     harmless: true
     abbrev: VS
     mana: 10
     mana_type: arcane
+    prep: prepare
   Visions of Darkness:
     skill: Debilitation
     harmless: true
     abbrev: VOD
     mana: 5
     mana_type: arcane
+    prep: prepare
   Vitality Healing:
     skill: Utility
     mana: 5
     abbrev: VH
     mana_type: life
     harmless: true
+    prep: prepare
   Vivisection:
     skill: Targeted Magic
     abbrev: vivisection
     mana: 20
     use_stealth: true
     mana_type: arcane
+    prep: target
   Ward Break:
     skill: Debilitation
     harmless: true
     abbrev: WB
     mana: 1
     mana_type: elemental
+    prep: prepare
   Water Globe:
     skill: cantrip
     abbrev: C Water Globe
@@ -2553,12 +2865,14 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Whispers of the Muse:
     skill: Augmentation
     abbrev: WOTM
     mana: 5
     recast: 1
     mana_type: elemental
+    prep: prepare
   Whole Displacement:
     skill: Warding
     abbrev: WD
@@ -2566,12 +2880,14 @@ spell_data:
     mana: 5
     recast: 1
     mana_type: lunar
+    prep: prepare
   Will of Winter:
     skill: Augmentation
     abbrev: WILL
     mana: 150
     ritual: true
     mana_type: elemental
+    prep: prepare
   Will O Wisp:
     skill: cantrip
     abbrev: C W O W
@@ -2581,6 +2897,7 @@ spell_data:
     mana:
     recast: 1
     mana_type: elemental
+    prep: prepare
   Wisdom of the Pack:
     skill: Augmentation
     abbrev: WOTP
@@ -2588,36 +2905,42 @@ spell_data:
     recast: 1
     expire: With a slight jolt, you suddenly feel disconnected from the pack.
     mana_type: life
+    prep: prepare
   Wolf Scent:
     skill: Augmentation
     abbrev: WS
     mana: 5
     recast: 1
     mana_type: life
+    prep: prepare
   Words of the Wind:
     skill: Augmentation
     abbrev: WORD
     mana: 50
     ritual: true
     mana_type: elemental
+    prep: prepare
   Worm's Mist:
     skill: Warding
     abbrev: WORM
     mana: 30
     recast: 1
     mana_type: arcane
+    prep: prepare
   Y'ntrel Sechra:
     skill: Augmentation
     abbrev: YS
     mana: 15
     recast: 1
     mana_type: elemental
+    prep: prepare
   Zephyr:
     skill: Utility
     abbrev: zephyr
     mana: 5
     expire: the breeze fades from the area
     mana_type: elemental
+    prep: prepare
 
 rituals:
   preserve: Unseen energies seep into the creature's fluids, suspending the corpse in unnatural stasis for a time

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1195,7 +1195,7 @@ spell_data:
     mana: 15
     mana_type: elemental
     recast: 1
-    prep: target
+    prep: prepare # This is a buff that trains TM, you 'spit' to use it
   Drums of the Snake:
     skill: Augmentation
     mana: 15


### PR DESCRIPTION
### Background
* `combat-trainer` will recast buffs defined in `buff_spells:` of your yaml if the spell data has either `recast`, `recast_every`, or `expire` properties.
* Not all spells in base data had one of those properties and so they weren't being cast in combat (e.g. [Gam Inran](https://github.com/rpherbig/dr-scripts/pull/5267) which was recently fixed, and [Aether Wolves](https://discord.com/channels/745675889622384681/745678330933805157/916347740252954635) as reported by Mahtra).
* `dependency` sets if doesn't exist a `prep: target` for `offensive_spells:` defined in your yaml if they are for the Targeted Magic skill, or if a Sorcery that refers to a Targeted Magic skill. However, if those spells are referenced in other yaml properties, like `combat_spell_training:` then that logic isn't being applied and leads to TM spells being prepared but never targeted and consequentially never cast. Rather than continue to play whack-a-mole in dependency, opting to ensure every spell has a default `prep` property.

### Changes
* For spells without a `recast` property:
  - Add `recast: 2` for ritual spells (to account for time needed to invoke the ritual focus)
  - Add `recast: 1` for all other spells
* For spells without a `prep` property:
  - Add `prep: prepare` for non-TM spells
  - Add `prep: target` for TM spells
* For consistency, and based on [this conversation](https://discord.com/channels/745675889622384681/745696628714897508/916461610598547558), cyclics use `recast: -1` to emphasize that their duration is as long as the spell is maintained.
* For consistency, renamed `prep_type` to `prep` for the handful of spells that used that alias