### PR TITLE
[script] [sell-loot] Add `sell_loot_town` setting

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1039,6 +1039,9 @@ bankbot_enabled: false
 
 # Sell loot settings
 sell_loot: true
+# Overrides `hometown` setting to specify where to sell items and deposit coins.
+# Can also override with script argument `;sell-loot <town>`
+sell_loot_town:
 # To sell gems from untied gem pouches.
 sell_loot_pouch: true
 # To sell worn bundle.

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -95,7 +95,7 @@ class SellLoot
     when 'There is no teller here', "We don't serve necromancers or sorcerers here."
       return
     end
-    minimize_coins(keep_copper).each { |amount| DRCM.withdraw_exact_amount?(amount, @settings) }
+    minimize_coins(keep_copper).each { |amount| DRCM.withdraw_exact_amount?(amount, @settings, @character_hometown) }
     DRC.bput('check balance', 'your current balance is', 'As expected, there are')
   end
 

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -13,14 +13,14 @@ class SellLoot
   def initialize
     arg_definitions = [
       [
-        { name: 'hometown', regex: /^([a-zA-Z\s']+)$/i, variable: true, description: 'Override the hometown to sell loot in.' }
+        { name: 'town', regex: /^([a-zA-Z\s']+)$/i, variable: true, description: 'Override the town to sell loot in.' }
       ],
       [
         { name: 'amount', regex: /\d+/i, variable: true, description: 'Number of coins to keep' },
         { name: 'type', regex: /\w+/i, variable: true, description: 'Type of coins to keep' }
       ],
       [
-        { name: 'hometown', regex: /^([a-zA-Z\s']+)$/i, variable: true, description: 'Override the hometown to sell loot in.' },
+        { name: 'town', regex: /^([a-zA-Z\s']+)$/i, variable: true, description: 'Override the town to sell loot in.' },
         { name: 'amount', regex: /\d+/i, variable: true, description: 'Number of coins to keep' },
         { name: 'type', regex: /\w+/i, variable: true, description: 'Type of coins to keep' }
       ],
@@ -36,7 +36,7 @@ class SellLoot
 
     @settings = get_settings
     town_data = get_data('town')
-    @character_hometown = DRC.get_town_name(args.hometown || @settings.hometown)
+    @character_hometown = DRC.get_town_name(args.town || @settings.sell_loot_town || @settings.hometown)
     @hometown = town_data[@character_hometown]
     @bankbot_name = @settings.bankbot_name
     @bankbot_room_id = @settings.bankbot_room_id


### PR DESCRIPTION
### Background
* Per https://github.com/rpherbig/dr-scripts/pull/5254, we added support for script argument to change the sell town at runtime.
* [Briarleigh](https://discord.com/channels/745675889622384681/745675890242879671/916478387369934908) then requested that there be a setting for the sell town instead of always needing to specify it at script runtime.

### Changes
* Add new setting `sell_loot_town:` that defaults blank (which the script `sell-loot` will then default to use `hometown`)
* Fix bug where if you had `sell_loot_money_on_hand:` setting to non-zero amount then you would go to the bank at `hometown` rather than the overriden town

### Example Config
_default, blank, will fallback to hometown_
```yaml
hometown: Shard

# Overrides `hometown` setting to specify where to sell items and deposit coins.
# Can also override with script argument `;sell-loot <town>`
sell_loot_town:
```
_always sell loot in Fang Cove, but your hometown for other things is Shard_
```yaml
hometown: Shard

# Overrides `hometown` setting to specify where to sell items and deposit coins.
# Can also override with script argument `;sell-loot <town>`
sell_loot_town: Fang Cove
```