### PR TITLE
[script][common-money] Broaden common money

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -137,26 +137,18 @@ module DRCM
     # each line after we recognize we've hit the Wealth block.
     wealth_lines.each do |line|
       case line
-      when  /^Wealth:/i
+      when /^Wealth:/i
         # This is the start of our Wealth lines.
         # We don't need to parse this line. Break out of loop.
         break
-      when /\(\d+ copper Kronars\)|^No Kronars/i
-        kronars_line = line
-      when /\(\d+ copper Lirums\)|^No Lirums/i
-        lirums_line = line
-      when /\(\d+ copper Dokoras\)|^No Dokoras/i
-        dokoras_line = line
+      when /\(\d+ copper Kronars\)/i
+        kronars = line.scan(\d+).first.to_i
+      when /\(\d+ copper Lirums\)/i
+        lirums = line.scan(\d+).first.to_i
+      when /\(\d+ copper Dokoras\)/i
+        dokoras = line.scan(\d+).first.to_i
       end
     end
-
-    # Scan each wealth line for the value in coppers,
-    # capture that numeric value, then integerize.
-    # If the line indicates no wealth of that currency, accept
-    # the instantiated value of 0 for that currency.
-    kronars = kronars_line.scan(/\((\d+) copper Kronars\)/i).first.first.to_i unless kronars_line =~ /^No/    
-    lirums = lirums_line.scan(/\((\d+) copper lirums\)/i).first.first.to_i unless lirums_line =~ /^No/        
-    dokoras = dokoras_line.scan(/\((\d+) copper dokoras\)/i).first.first.to_i unless dokoras_line =~ /^No/
     
     # Set up a hash of currency and corresponding value
     # in coppers. Return the hash for future use.

--- a/common-money.lic
+++ b/common-money.lic
@@ -138,7 +138,7 @@ module DRCM
         # We don't need to parse this line. Break out of loop.
         break
       when /\(\d+ copper Kronars\)/i
-        kronars = line.scan(/\((\d+) copper Kronars\)/i).first.first.to_i
+        kronars = line.scan(/\((\d+) copper kronars\)/i).first.first.to_i
       when /\(\d+ copper Lirums\)/i
         lirums = line.scan(/\((\d+) copper lirums\)/i).first.first.to_i
       when /\(\d+ copper Dokoras\)/i

--- a/common-money.lic
+++ b/common-money.lic
@@ -138,11 +138,11 @@ module DRCM
         # We don't need to parse this line. Break out of loop.
         break
       when /\(\d+ copper Kronars\)/i
-        kronars = line.scan(/\d+/).first.to_i
+        kronars = line.scan(/\((\d+) copper Kronars\)/i).first.first.to_i
       when /\(\d+ copper Lirums\)/i
-        lirums = line.scan(/\d+/).first.to_i
+        lirums = line.scan(/\((\d+) copper lirums\)/i).first.first.to_i
       when /\(\d+ copper Dokoras\)/i
-        dokoras = line.scan(/\d+/).first.to_i
+        dokoras = line.scan(/\((\d+) copper dokoras\)/i).first.first.to_i
       end
     end
     

--- a/common-money.lic
+++ b/common-money.lic
@@ -42,7 +42,8 @@ module DRCM
   def convert_to_copper(amount, denomination)
     # Convert to copper given denomination (abbreviation permitted)
     # If no denomination specified, return the integer amount (assumed to be coppers)
-    if denomination
+    denomination = denomination.strip # trim whitespace and also convert nil to empty string
+    if !denomination.empty?
       return (amount.to_i * 10_000) if 'platinum'.start_with?(denomination.downcase)
       return (amount.to_i *   1000) if 'gold'.start_with?(denomination.downcase)
       return (amount.to_i *    100) if 'silver'.start_with?(denomination.downcase)

--- a/common-money.lic
+++ b/common-money.lic
@@ -49,10 +49,9 @@ module DRCM
       return (amount.to_i *    100) if 'silver'.start_with?(denomination.downcase)
       return (amount.to_i *     10) if 'bronze'.start_with?(denomination.downcase)
       return (amount.to_i *      1) if 'copper'.start_with?(denomination.downcase)
-    else
-      DRC.message("Unknown denomination, assuming coppers: #{denomination}")
-      amount.to_i
     end
+    DRC.message("Unknown denomination, assuming coppers: #{denomination}")
+    amount.to_i
   end
 
   # Returns full canonical currency if given an abbreviation

--- a/common-money.lic
+++ b/common-money.lic
@@ -8,6 +8,25 @@ custom_require.call(%w[common common-travel drinfomon])
 module DRCM
   module_function
 
+  # Map of regex abbreviations for coin denominations
+  # Supports abbreviations of input like DR
+  $DENOMINATION_REGEX_MAP = {
+    'platinum' =>   /\bp(l|la|lat|lati|latin|latinu|latinum)?\b/i,
+    'gold' =>       /\bg(o|ol|old)?\b/i,
+    'silver' =>     /\bs(i|il|ilv|ilve|ilver)?\b/i,
+    'bronze' =>     /\bb(r|ro|ron|ronz|ronze)?\b/i,
+    'copper' =>     /\bc(o|op|opp|oppe|opper)?\b/i
+  }
+
+  # Map of regex abbreviations for currency
+  # Supports abbreviations of input like DR
+  $CURRENCY_REGEX_MAP = {
+    'kronars' => /\bk(r|ro|ron|rona|ronar|ronars)?\b/i,
+    'lirums' => /\bl(i|ir|iru|irum|irums)?\b/i,
+    'dokoras' => /\bd(o|ok|oko|okor|okora|okoras)?\b/i
+  }
+
+
   def minimize_coins(copper)
     denominations = [[10_000, 'platinum'], [1000, 'gold'], [100, 'silver'], [10, 'bronze'], [1, 'copper']]
     denominations.inject([copper, []]) do |result, denomination|
@@ -21,11 +40,27 @@ module DRCM
   end
 
   def convert_to_copper(amount, denomination)
-    return (amount.to_i * 10_000) if 'platinum' =~ /^#{denomination}/
-    return (amount.to_i * 1000) if 'gold' =~ /^#{denomination}/
-    return (amount.to_i * 100) if 'silver' =~ /^#{denomination}/
-    return (amount.to_i * 10) if 'bronze' =~ /^#{denomination}/
-    amount.to_i
+    # Convert to copper given denomination (abbreviation permitted)
+    # If no denomination specified, return the integer amount (assumed to be coppers)
+    if denomination
+      return (amount.to_i * 10_000) if 'platinum'.start_with?(denomination.downcase)
+      return (amount.to_i *   1000) if 'gold'.start_with?(denomination.downcase)
+      return (amount.to_i *    100) if 'silver'.start_with?(denomination.downcase)
+      return (amount.to_i *     10) if 'bronze'.start_with?(denomination.downcase)
+      return (amount.to_i *      1) if 'copper'.start_with?(denomination.downcase)
+    else
+      amount.to_i
+    end
+  end
+
+  # Returns full canonical currency if given an abbreviation
+  def get_canonical_currency(currency)    
+    currencies = [
+      'kronars',
+      'lirums',
+      'dokoras'
+    ]    
+    return currencies.find { |x| x.start_with?(currency)}    
   end
 
   def convert_currency(amount, from, to, fee)
@@ -64,9 +99,72 @@ module DRCM
   def check_wealth(currency)
     DRC.bput("wealth #{currency}", /\(\d+ copper #{currency}\)/i, /No #{currency}/i).scan(/\d+/).first.to_i
   end
-
+  
   def wealth(hometown)
     check_wealth(hometown_currency(hometown))
+  end
+
+  def get_total_wealth
+    # This method captures your current total on-hand wealth
+    # and returns a hash representing the numerical value in
+    # coppers of each currency.    
+
+    # Set up variables to capture each line of wealth output by currency
+    kronars_line = nil
+    lirums_line = nil
+    dokoras_line = nil
+
+    # Set up variables to capture the value in coppers of each currency
+    # Set to zero so that, if we have, for example, "No Lirums"
+    # we simply return 0 for that value.
+    kronars = 0
+    lirums = 0
+    dokoras = 0
+
+    # Grab the character's wealth, pausing a bit
+    # then grabbing a sufficient number of lines
+    # to ensure we get all the output taking into
+    # account other random scroll text.
+    # Reversing the lines ensures we are processing
+    # the most recent output from 'wealth', in case
+    # reget were to grab output from back-to-back calls.
+    DRC.bput("wealth", "Wealth")
+    pause 0.5
+    wealth_lines = reget(10).map(&:strip).reverse
+
+    # We've reversed the reget array Now we'll iterate over it and capture
+    # each line after we recognize we've hit the Wealth block.
+    wealth_lines.each do |line|
+      case line
+      when  /^Wealth:/i
+        # This is the start of our Wealth lines.
+        # Break out of loop.
+        break
+      when /\(\d+ copper Kronars\)|^No Kronars/i
+        kronars_line = line
+      when /\(\d+ copper Lirums\)|^No Lirums/i
+        lirums_line = line
+      when /\(\d+ copper Dokoras\)|^No Dokoras/i
+        dokoras_line = line
+      end
+    end
+
+    # Scan each wealth line for the value in coppers,
+    # capture that numeric value, then integerize.
+    # If the line indicates no wealth of that currency, accept
+    # the instantiated value of 0 for that currency.
+    kronars = kronars_line.scan(/\((\d+) copper Kronars\)/i).first.first.to_i unless kronars_line =~ /^No/    
+    lirums = lirums_line.scan(/\((\d+) copper lirums\)/i).first.first.to_i unless lirums_line =~ /^No/        
+    dokoras = dokoras_line.scan(/\((\d+) copper dokoras\)/i).first.first.to_i unless dokoras_line =~ /^No/
+    
+    # Set up a hash of currency and corresponding value
+    # in coppers. Return the hash for future use.
+    total_wealth = {
+      'kronars' => kronars,
+      'lirums' => lirums,
+      'dokoras' => dokoras
+    }
+    return total_wealth
   end
 
   def ensure_copper_on_hand(copper, settings, hometown = nil)

--- a/common-money.lic
+++ b/common-money.lic
@@ -110,11 +110,6 @@ module DRCM
     # and returns a hash representing the numerical value in
     # coppers of each currency.    
 
-    # Set up variables to capture each line of wealth output by currency
-    kronars_line = nil
-    lirums_line = nil
-    dokoras_line = nil
-
     # Set up variables to capture the value in coppers of each currency
     # Set to zero so that, if we have, for example, "No Lirums"
     # we simply return the initialized value of 0.

--- a/common-money.lic
+++ b/common-money.lic
@@ -116,7 +116,7 @@ module DRCM
 
     # Set up variables to capture the value in coppers of each currency
     # Set to zero so that, if we have, for example, "No Lirums"
-    # we simply return 0 for that value.
+    # we simply return the initialized value of 0.
     kronars = 0
     lirums = 0
     dokoras = 0
@@ -132,13 +132,13 @@ module DRCM
     pause 0.5
     wealth_lines = reget(10).map(&:strip).reverse
 
-    # We've reversed the reget array Now we'll iterate over it and capture
+    # We've reversed the reget array. Now we'll iterate over it and capture
     # each line after we recognize we've hit the Wealth block.
     wealth_lines.each do |line|
       case line
       when  /^Wealth:/i
         # This is the start of our Wealth lines.
-        # Break out of loop.
+        # We don't need to parse this line. Break out of loop.
         break
       when /\(\d+ copper Kronars\)|^No Kronars/i
         kronars_line = line

--- a/common-money.lic
+++ b/common-money.lic
@@ -101,6 +101,7 @@ module DRCM
   def check_wealth(currency)
     DRC.bput("wealth #{currency}", /\(\d+ copper #{currency}\)/i, /No #{currency}/i).scan(/\d+/).first.to_i
   end
+
   def wealth(hometown)
     check_wealth(hometown_currency(hometown))
   end
@@ -137,11 +138,11 @@ module DRCM
         # We don't need to parse this line. Break out of loop.
         break
       when /\(\d+ copper Kronars\)/i
-        kronars = line.scan(\d+).first.to_i
+        kronars = line.scan(/\d+/).first.to_i
       when /\(\d+ copper Lirums\)/i
-        lirums = line.scan(\d+).first.to_i
+        lirums = line.scan(/\d+/).first.to_i
       when /\(\d+ copper Dokoras\)/i
-        dokoras = line.scan(\d+).first.to_i
+        dokoras = line.scan(/\d+/).first.to_i
       end
     end
     

--- a/common-money.lic
+++ b/common-money.lic
@@ -101,7 +101,6 @@ module DRCM
   def check_wealth(currency)
     DRC.bput("wealth #{currency}", /\(\d+ copper #{currency}\)/i, /No #{currency}/i).scan(/\d+/).first.to_i
   end
-  
   def wealth(hometown)
     check_wealth(hometown_currency(hometown))
   end

--- a/common-money.lic
+++ b/common-money.lic
@@ -50,6 +50,7 @@ module DRCM
       return (amount.to_i *     10) if 'bronze'.start_with?(denomination.downcase)
       return (amount.to_i *      1) if 'copper'.start_with?(denomination.downcase)
     else
+      DRC.message("Unknown denomination, assuming coppers: #{denomination}")
       amount.to_i
     end
   end


### PR DESCRIPTION
This PR makes a few updates to common-money. The impetus for this was separate PR #5259 which is a smart tipping script. These updates centralize and revise some of the money handling and may be useful for future use.

1. Adds global regex maps for use in parsing denominations and currencies and abbreviations thereof. I'm using this in my tip script to limit arg inputs.
2. Revises the `convert_to_copper` method to handle conversion if the denomination has been abbreviated. Now also handles conversion if the denomination is given explicitly as copper.
3. Adds method `get_canonical_currency`, which takes an abbreviated currency and returns the full canonical currency name.
4. Adds a `get_total_wealth method`, which returns a hash of the character's current total wealth in copper by currency.

Special thanks to @KatoakDR for significant Ruby help.