### PR TITLE
[script][clean-leather] Fix supplies ordering

### DIFF
--- a/clean-leather.lic
+++ b/clean-leather.lic
@@ -27,7 +27,7 @@ class CleanLeather
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.outfitting_belt
 
-    @stock_room = args.noun =~ /^bones?$/i ? get_data('crafting')['engineering'][@settings.hometown]['tool-room'] : get_data('crafting')['tailoring'][@settings.hometown]['tool-room']
+    @stock_room = args.noun =~ /^bones?$/i ? get_data('crafting')['shaping'][@settings.hometown]['tool-room'] : get_data('crafting')['tailoring'][@settings.hometown]['tool-room']
 
     ensure_copper_on_hand(2000, @settings)
 

--- a/clean-leather.lic
+++ b/clean-leather.lic
@@ -32,7 +32,7 @@ class CleanLeather
     ensure_copper_on_hand(2000, @settings)
 
     @preservative = args.noun =~ /^bones?$/i ? 'bleaching solution' : 'tanning lotion'
-    @item = args.noun =~ /^bones?$/i ? '8' : '7'
+    @item = args.noun =~ /^bones?$/i ? '7' : '8'
     @speed = args.speed || ''
 
     while bput("get #{args.noun} from my #{args.source}", 'You get', 'You carefully remove', 'What were you') != 'What were you'


### PR DESCRIPTION
This PR fixes a failure [reported by Rohk](https://discordapp.com/channels/745675889622384681/745762398056612020/916558926173044756) in Discord.

The script was improperly accessing common-crafting to order bleaching solution from the Engineering Society, causing it to not pull a restock room number and thus failing to move to the room and order. It also had the catalog order numbers switched between Engineering (bones need bleaching solution) and Outfitting (hides/pelts/etc. need tanning lotion).

Note: this script will need quite a bit of additional work that I don't yet have time to handle. This gets it semi-functioning by cleaning a single set of hides or bones, but there are a number of other failure modes that currently exist. I think the main code block that handles the cleaning function probably needs a rewrite.

Additional failures I noticed when testing these fixes:

- If hands are full when script starts, it hangs
- bput match failure when done applying solution to hides/bones, then an infinite loop