### PR TITLE
[script] [sell-loot] Support new setting pick.component_container

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -58,7 +58,7 @@ class SellLoot
 
     sell_bundle if @settings.sell_loot_bundle
 
-    sell_traps(@settings.component_container) if @settings.sell_loot_traps
+    sell_traps(@settings.pick['component_container'] || @settings.component_container) if @settings.sell_loot_traps
 
     return if skip_bank && !@bankbot_enabled
     return if @bankbot_enabled && (@bankbot_name.nil? || @bankbot_room_id.nil?)


### PR DESCRIPTION
### Background
* With the [rewrite](https://github.com/rpherbig/dr-scripts/pull/5167) of `pick` script, the new setting for storing harvested trap components is the nested `pick.component_container` property.
* The original `component_container` property is still supported for backwards compatibility, but if you've moved to the new setting then `sell-loot` was not selling your traps.

### Changes
* Check for the old and new settings just like the `pick` script does