### PR TITLE
[script][shape.lic] Fix stamp match failure.

### DIFF
--- a/shape.lic
+++ b/shape.lic
@@ -256,7 +256,7 @@ class Shape
   def stamp
     return unless @stamp
     get_item('stamp')
-    bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that')
+    bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
     pause
     waitrt?
     stow_item('stamp')


### PR DESCRIPTION
15 second match failure [reported by B-Money420](https://discordapp.com/channels/745675889622384681/912127186419482664/917161412445503589) in Discord. There is match failure in the `stamp` method when the stamp is too damaged to mark the product. He/she just wants to avoid the 15 second match failure.

```
[shape]>mark my crown with my stamp
The stamp is too badly damaged to be used for that.
```

Added match phrase to the `stamp` method bput.