### PR TITLE
[script] [combat-trainer] Add `strict_weapon_stance` setting

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -245,11 +245,22 @@ class SetupProcess
     points = override || previous.values.inject(&:+)
 
     priority = if game_state.current_weapon_stance
-                 game_state.sort_by_rate_then_rank(game_state.current_weapon_stance[0..1]) + [game_state.current_weapon_stance.last]
+                 if game_state.strict_weapon_stance
+                   # Player wants their weapon stance strictly adhered to, no change.
+                   game_state.current_weapon_stance
+                 else
+                   # Player has a preference for the first two stances for this weapon
+                   # and is open to having them dynamically prioritized to optimize learning.
+                   game_state.sort_by_rate_then_rank(game_state.current_weapon_stance[0..1]) + [game_state.current_weapon_stance.last]
+                 end
                elsif @priority_defense
+                 # Player does not have a weapon specific stance but does want
+                 # a preferred defense to always be 100%.
                  rest = ['Evasion', 'Parry Ability', 'Shield Usage'] - [@priority_defense]
                  [@priority_defense] + game_state.sort_by_rate_then_rank(rest)
                else
+                 # Player is a gambler and wants combat-trainer to dynamically
+                 # prioritize the stances with the lowest learning rates/ranks.
                  game_state.sort_by_rate_then_rank(['Evasion', 'Parry Ability', 'Shield Usage'])
                end
 
@@ -3727,6 +3738,9 @@ class GameState
     @target_increment = settings.combat_trainer_target_increment
     echo("  @target_increment: #{@target_increment}") if $debug_mode_ct
 
+    @strict_weapon_stance = settings.strict_weapon_stance
+    echo("  @strict_weapon_stance: #{@strict_weapon_stance}") if $debug_mode_ct
+
     @stances = settings.stances
     echo("  @stances: #{@stances}") if $debug_mode_ct
 
@@ -4073,6 +4087,10 @@ class GameState
 
   def update_target_weapon_skill
     @target_weapon_skill = [34, DRSkill.getxp(current_weapon_skill) + @target_increment].min
+  end
+
+  def strict_weapon_stance
+    @strict_weapon_stance
   end
 
   def current_weapon_stance

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -37,6 +37,9 @@ aim_fillers:
   - bob
   - bob
   - bob
+# Skill-specific stances when training these weapon types.
+# Uses same keys as `weapon_training:` setting.
+# Ignored if `stance_override:` is set.
 stances:
   Bow:
   - Evasion
@@ -54,9 +57,19 @@ stances:
   - Evasion
   - Shield Usage
   - Parry Ability
+# When true then weapon stances are strictly respected as listed in your yaml or base.yaml settings.
+# When false then combat-trainer will dynamically determine your stance
+# based on which of the first two listed skills has the lowest learning rate and rank.
+# For example, if Bow lists Evasion > Shield > Parry, when strict weapon stance is false
+# then combat-trainer may switch that to Shield > Evasion > Parry if shield
+# has the lower learning rate/rank than Evasion. This dynamic selection optimizes learning,
+# but may be dangerous for characters who are uphunting or have disparate defense ranks.
+# For historical reasons, this setting defaults to false although intuitively you'd expect it to be true.
+strict_weapon_stance: false
 # Stance combat-trainer will go into when first starting up, before combat logic starts
 default_stance: 100 0 80
-# Set a priority defense skill name (eg. Parry Ability) to always use 100% of that defense when it's legal for your weapon.
+# Set a priority defense skill name (Evasion, Shield Usage, or Parry Ability) to always use 100% of that defense when it's legal for your weapon.
+# Ignored if `stance_override:` is set.
 priority_defense:
 # Setting this will make you never change stances outside of whatever numerical values you set.
 stance_override:


### PR DESCRIPTION
### Background
* In the Lich Discord, a group of players have been discussing concerns about how `stances:` and `priority_defense` were not being respected by ranged weapons.
* After review of the code, we realized that even when a weapon stance is provided, combat-trainer will still dynamically choose between the first two preferred defenses and prioritize the one that has lower learning rate/rank (presumably to optimize learning).
* Some players shared that their characters get hurt bad if combat-trainer switches them into a Shield first stance.
* To provide people the option to opt-out of this dynamic stance logic, this PR introduces a new setting `strict_weapon_stance` (boolean) that defaults to `false` to preserve current behavior.

### Changes
* Add `strict_weapon_stance` to `base.yaml`, and update comments on the stance settings.
* Update the `check_stance` method in `combat-trainer` to use the exact weapon stance as configured in the yaml when `strict_weapon_stance: true`, otherwise do its current behavior.

### Example Config

_original behavior, no change necessary_
```yaml
stances:
  Bow:
  - Evasion
  - Shield Usage
  - Parry Ability

# If false then combat-trainer does its current behavior,
# it will dynamically choose between the first two listed defenses
# of the weapon (in this case between Evasion and Shield) and
# stance to the one that has lowest learning rate/rank of the two.
strict_weapon_stance: false
```

_new option_
```yaml
stances:
  Bow:
  - Evasion
  - Shield Usage
  - Parry Ability

# If true then combat-trainer will stance the character precisely
# as the defenses are listed in the weapon stance in the yaml.
# In this case, when training bows then the character will
# prioritize Evasion, allocate remaining to Shield, and any extra to Parry.
# The script would never dynamically decide to stance Shield before Evasion
# when training the bow weapon skill.
strict_weapon_stance: true
```