### PR TITLE
[script] [combat-trainer] Mitigate accidentally dropping items after script unpaused

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -595,21 +595,24 @@ class LootProcess
       game_state.wield_whirlwind_offhand
     end
     return unless tried_loot
-    # Mitigating a race condition when wand-watcher or another script pauses
-    # combat-trainer while it's looting, then resumes in the middle of this function.
-    # Occassionally, the thread hasn't updated the left_hand/right_hand variables
-    # to know what's currently in your hand and will trash what's in your hand!
     pause 1
-    bput('glance', 'You glance .*')
-    if left_hand != pair.first && !@equipment_manager.is_listed_item?(left_hand)
-      echo("out of room, failed to store #{left_hand}")
-      game_state.unlootable(GameObj.left_hand.noun.downcase)
-      dispose_trash(left_hand)
+    if DRC.left_hand != pair.first || DRC.right_hand != pair.last
+      # Mitigating a race condition when wand-watcher or another script pauses
+      # combat-trainer while it's looting, then resumes in the middle of this function.
+      # Occassionally, the thread hasn't updated the left_hand/right_hand variables
+      # to know what's currently in your hand and will trash what's in your hand!
+      # Do a glance to force the variables to be refreshed before we take action.
+      DRC.bput('glance', 'You glance .*')
     end
-    if right_hand != pair.last && !@equipment_manager.is_listed_item?(right_hand)
-      echo("out of room, failed to store #{right_hand}")
-      game_state.unlootable(GameObj.right_hand.noun.downcase)
-      dispose_trash(right_hand)
+    if DRC.left_hand != pair.first && !@equipment_manager.is_listed_item?(DRC.left_hand)
+      DRC.message("Out of room, failed to store: #{DRC.left_hand}")
+      game_state.unlootable(DRC.left_hand_noun.downcase)
+      DRCI.dispose_trash(DRC.left_hand)
+    end
+    if DRC.right_hand != pair.last && !@equipment_manager.is_listed_item?(DRC.right_hand)
+      DRC.message("Out of room, failed to store: #{DRC.right_hand}")
+      game_state.unlootable(DRC.right_hand_noun.downcase)
+      DRCI.dispose_trash(DRC.right_hand)
     end
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -584,7 +584,12 @@ class LootProcess
       game_state.wield_whirlwind_offhand
     end
     return unless tried_loot
+    # Mitigating a race condition when wand-watcher or another script pauses
+    # combat-trainer while it's looting, then resumes in the middle of this function.
+    # Occassionally, the thread hasn't updated the left_hand/right_hand variables
+    # to know what's currently in your hand and will trash what's in your hand!
     pause 1
+    bput('glance', 'You glance .*')
     if left_hand != pair.first && !@equipment_manager.is_listed_item?(left_hand)
       echo("out of room, failed to store #{left_hand}")
       game_state.unlootable(GameObj.left_hand.noun.downcase)


### PR DESCRIPTION
### Background
* [Naimo](https://discord.com/channels/745675889622384681/745678330933805157/917646189032263700) and others were sharing in Lich Discord that `combat-trainer` would occassionally [drop items](https://pastebin.com/amKRSMwt) if the script was paused/unpaused (usually be `wand-watcher`, but could have been `almanac` or other script) in the middle of the stow loot routine.
* The issue is a race condition between `combat-trainer` becoming unpaused and the Lich thread catching up with what's currently in your hand isn't still the wand or almanac the pausing script just had in your hands.

### Changes
* In an effort to ensure the Lich thread synchronously parses the game output to know what's in your hands before `combat-trainer` does the logic to determine if it should trash what's in your hand, add a `glance` action.

