### PR TITLE
[script] [validate] Deprecate `component_container` setting, use pick: settings

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -704,6 +704,12 @@ class DRYamlValidator
     warn('***YOU HAVE OUTDATED SETTINGS*** THE SETTING lockpick_buffs IS NO LONGER USED. Please make a waggle_set called \'pick\'')
   end
 
+  def assert_that_component_container_is_deprecated(settings)
+    return if !settings.component_container || settings.component_container.empty?
+
+    warn('component_container is deprecated, please nest the setting under pick settings. https://elanthipedia.play.net/Lich_script_repository#pick')
+  end
+
   def assert_that_sell_loot_money_on_hand_is_correct(settings)
     settings.sell_loot_money_on_hand =~ /(\d+) (\w+)/
     amount = Regexp.last_match(1)


### PR DESCRIPTION
### Background
* Addresses https://github.com/rpherbig/dr-scripts/pull/5275#issuecomment-986882733

### Tests

_no error if setting doesn't exist or is blank_
```yaml
component_container:
```
```
--- Lich: validate active.
  Checking 97 different potential errors
> 
  WARNINGS:0 ERRORS:0
  All done!
--- Lich: validate has exited.
```

_warning if setting is nonblank_
```yaml
component_container: pouch
```
```
--- Lich: validate active.
  Checking 97 different potential errors
>
[validate: WARNING:< component_container is deprecated, please nest the setting under pick settings. https://elanthipedia.play.net/Lich_script_repository#pick  >]

  WARNINGS:1 ERRORS:0
  All done!
--- Lich: validate has exited.
```