### PR TITLE
[script][burgle.lic] Add match phrase when putting item away

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -456,7 +456,7 @@ class Burgle
 
   #ripped out of steal.lic
   def put_item?(item)
-    case bput("put my #{item} in my #{@loot_container}", 'What were you', 'You put', "You can't do that", 'no matter how you arrange it', 'even after stuffing', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again')
+    case bput("put my #{item} in my #{@loot_container}", 'What were you', 'You put', "You can't do that", 'no matter how you arrange it', 'even after stuffing', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again', 'That\'s too heavy to go in there')
     when 'perhaps try doing that again'
       return put_item?(item)
     when 'You put'


### PR DESCRIPTION
Reported by DantiaDR [in Disord](https://discordapp.com/channels/745675889622384681/912127186419482664/917887603926265967).

15 second bput match failure for 'That's too heavy to go in there!'. Log here: https://pastebin.com/SK9g5QJX

Added the match phrase to bput. The method should properly drop the item with the rest of it as-is.