### PR TITLE
[script][common-arcana] Honor settings.telescope_storage

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-arcana
 =end
 
-custom_require.call(%w[common common-items events spellmonitor drinfomon])
+custom_require.call(%w[common common-items common-moonmage events spellmonitor drinfomon])
 
 $MANA_MAP = {
   'weak' => %w[dim glowing bright],
@@ -518,16 +518,17 @@ module DRCA
     end
   end
 
-  def update_astral_data(data)
+  def update_astral_data(data, settings)
     if data['moon']
       data = set_moon_data(data)
     elsif data['stats']
-      data = set_planet_data(data)
+      data = set_planet_data(data, settings)
     end
     data
   end
 
-  def find_visible_planets(planets)
+  def find_visible_planets(planets, settings)
+    return unless settings.have_telescope
     return if DRC.bput('get my telescope', 'You get', 'What were you', 'You are already') == 'What were you'
 
     Flags.add('planet-not-visible', 'turns up fruitless')
@@ -543,16 +544,16 @@ module DRCA
     end
 
     Flags.delete('planet-not-visible')
-    DRC.bput('stow telescope', 'You put')
+    DRCMM.store_telescope(settings.telescope_storage)
     observed_planets
   end
 
-  def set_planet_data(data)
+  def set_planet_data(data, settings)
     return data unless data['stats']
 
     planets = get_data('constellations')[:constellations].select { |planet| planet['stats'] }
     planet_names = planets.map { |planet| planet['name'] }
-    visible_planets = find_visible_planets(planet_names)
+    visible_planets = find_visible_planets(planet_names, settings)
     data['stats'].each do |stat|
       cast_on = planets.map { |planet| planet['name'] if planet['stats'].include?(stat) && visible_planets.include?(planet['name']) }.compact.first
       next unless cast_on
@@ -596,7 +597,7 @@ module DRCA
     return unless data
     return unless settings
 
-    data = update_astral_data(data)
+    data = update_astral_data(data, settings)
     return unless data # update_astral_data returns nil on failure
 
     if (data['abbrev'] =~ /locat/i) && !DRSpells.active_spells['Clear Vision']


### PR DESCRIPTION
Issue first reported by @MahtraDR [in Discord](https://discordapp.com/channels/745675889622384681/912127186419482664/917606108410032158). Special thanks to him for helping test these changes.

Basically, sometimes ;buff and ;combat-trainer will not honor your telescope storage case. Each seems to _eventually_ rely on `DRCA.find_visible_planets`, which in its un-revised state uses a simple stow instead of using telescope storage. There is an existing, but stalled, PR #5207 which attempts to update both the common-* and other files in a single PR.

This PR overlaps that one. But also, instead of storing your telescope via `bput`, utilizes the `DRCMM.store_telescope` method. All we need to do is properly pass a settings args to access.

This will support another PR, eventually, to `combat-trainer`, which passes the @settings arg through to also now utilize `DRCA.store_telescope`.

@MahtraDR has tested this change on his MM, but we welcome others.