### PR TITLE
Fixing IZ prep: line since it doesn't use target

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1744,7 +1744,7 @@ spell_data:
     cyclic: true
     mana: 15
     mana_type: life
-    prep: target
+    prep: prepare 
     recast: -1
   Idon's Theft:
     skill: Debilitation # Also Utility

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1744,7 +1744,7 @@ spell_data:
     cyclic: true
     mana: 15
     mana_type: life
-    prep: prepare 
+    prep: prepare
     recast: -1
   Idon's Theft:
     skill: Debilitation # Also Utility


### PR DESCRIPTION
IZ had an incorrect "prep: target" line added. This is simply fixing that one spell.

2021-12-09 15:00:25 +1300:>target iz
2021-12-09 15:00:25 +1300:This spell cannot be targeted.
2021-12-09 15:00:29 +1300:>prep iz
2021-12-09 15:00:29 +1300:Since you're not feeding enough power into the spell pattern to make it coherent, you quickly work your way to the minimum required.
2021-12-09 15:00:29 +1300:With tense movements you prepare your body for the Icutu Zaharenela spell.
