### PR TITLE
Fixing BG prep: line since it doesn't use target

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -822,7 +822,7 @@ spell_data:
     abbrev: BG
     mana: 30
     mana_type: elemental
-    prep: target
+    prep: prepare
     recast: 1
   Blur:
     skill: Augmentation


### PR DESCRIPTION
Same deal as IZ was. This spell uses "prep" not "target"