### PR TITLE
[script][circlecheck] Prettify output

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#circlecheck
 =end
 
-custom_require.call(%w[drinfomon])
+custom_require.call(%w[drinfomon common])
 
 $Skills = [
   { name: 'Scouting', type: 'Survival' },
@@ -514,6 +514,9 @@ def display_requirements(requirements, level_target, brief)
          else
            0
          end
+  
+  DRC.message("________________________________________________________________________________________________________________")
+  respond("CURRENT CIRCLE: #{DRStats.circle}")
   respond("Your next level will award: #{tdps} TDPs")
   new_target = 0
   requirements.each do |skill, met_circle, missing_ranks, ranks|
@@ -523,22 +526,51 @@ def display_requirements(requirements, level_target, brief)
       echo("met_circle: #{met_circle} circle: #{DRStats.circle}") if $debug_mode_cc
       can_circle = true
       new_target = first_circle_seen + 1
-      respond("***You're ready to circle!***")
+      DRC.message("***You're ready to circle!***")
+      respond('')
     end
 
     if met_circle >= [level_target, new_target].max && !spacer_displayed
       break if brief
       spacer_displayed = true
       respond('')
-      respond('')
     end
 
-    if met_circle == 200
-      respond("You have enough #{skill} for circle #{met_circle} and have exceeded it by #{missing_ranks} (#{ranks}) ranks")
+    if skill =~ /\(/i
+      sub_skill = skill.scan(/\(([A-z\.\s\-']+)\)/i).first.first
+      category = skill.split(/ \([A-z\.\s\-']+\)/i).first
     else
-      respond("You have enough #{skill} for circle #{met_circle} and need #{missing_ranks} (#{missing_ranks + ranks}) ranks for circle #{[met_circle + 1, level_target].max}")
+      sub_skill = skill
+      category = ' '
+    end
+
+    rank = DRSkill.getrank(sub_skill).to_s
+    percent_remaining = 100 - DRSkill.getpercent(sub_skill).to_i
+
+    if percent_remaining.to_s.size < 2
+      percent_remaining = "0" + percent_remaining.to_s
+    elsif percent_remaining == 100
+      percent_remaining = 00
+    end
+    
+    needed_ranks = (missing_ranks -1).to_s + "." + percent_remaining.to_s
+    missing_ranks_plus_ranks = "(" + (missing_ranks + ranks).to_s + ")"
+
+    # Handle formatting essentially into columns. Deal with lining
+    # up numbers properly. 
+    case
+    when met_circle == 200
+      respond("You have enough  #{sub_skill.ljust(15)} #{category.ljust(13)} for circle  #{met_circle}  and have exceeded it by  #{needed_ranks.rjust(7)} (#{ranks})  ranks")
+    when met_circle == 99
+      respond("You have enough  #{sub_skill.ljust(15)} #{category.ljust(13)} for circle   #{met_circle}  and need  #{needed_ranks.rjust(7)} #{missing_ranks_plus_ranks.rjust(7)}  ranks for circle #{[met_circle + 1, level_target].max.to_s.rjust(5)}")
+    when met_circle < 100
+      respond("You have enough  #{sub_skill.ljust(15)} #{category.ljust(13)} for circle   #{met_circle}  and need  #{needed_ranks.rjust(7)} #{missing_ranks_plus_ranks.rjust(7)}  ranks for circle #{[met_circle + 1, level_target].max.to_s.rjust(5)}")
+    else
+      respond("You have enough  #{sub_skill.ljust(15)} #{category.ljust(13)} for circle  #{met_circle}  and need  #{needed_ranks.rjust(7)} #{missing_ranks_plus_ranks.rjust(7)}  ranks for circle #{[met_circle + 1, level_target].max.to_s.rjust(5)}")
     end
   end
+
+  DRC.message("________________________________________________________________________________________________________________")
 end
 
 def all_requirements(level_target)

--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -544,7 +544,6 @@ def display_requirements(requirements, level_target, brief)
       category = ' '
     end
 
-    rank = DRSkill.getrank(sub_skill).to_s
     percent_remaining = 100 - DRSkill.getpercent(sub_skill).to_i
 
     if percent_remaining.to_s.size < 2


### PR DESCRIPTION
This revision prettifies the output of `;circlecheck`.

I took this on mainly as practice with formatting in Ruby. But I did add some additional output that I thought were nice quality of life updates. I use circle check via "cc" alias quite frequently. One thing I like to see at a glance is 1) my current circle and 2) my current progress to next rank in given skills.

So this PR does a few things:

1. Outputs your current circle
2. Defines, with yellow highlights, the beginning and end of the circle check
3. Organizes the sections in columns for easy at-a-glance interpretation
4. Changes the order of presentation of the SKILL (e.g. Small Blunt) with the category (e.g. 1st Weapon)
4. Lets you know, down to the remaining percentage, how much you have left to next level

I was able to test a number of output scenarios with the EXCEPTION of someone who is max 200 circle. If someone would offer to help me test the formatting of the output, I'd appreciate it. I think it will need some tweaking.

In a reply here I'll give some examples of old vs. new formatting. Thanks.