### PR TITLE
duplicate stop play has no match, and causes hangs whilst trying to b…

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -237,7 +237,7 @@ class Burgle
     get_entry(@entry_type) unless @follow
 
     #prevent race condition that can occur with bput and invisibility/stealth and playing music
-    bput('stop play','In the name of love','You stop playing') if (Script.running?('performance') || Script.running?('play'))
+    bput('stop play','In the name of love','You stop playing','But you're not performing anything') if (Script.running?('performance') || Script.running?('play'))
 
     wait_for_script_to_complete('buff', ['burgle']) if @settings.waggle_sets['burgle']
 

--- a/burgle.lic
+++ b/burgle.lic
@@ -237,7 +237,7 @@ class Burgle
     get_entry(@entry_type) unless @follow
 
     #prevent race condition that can occur with bput and invisibility/stealth and playing music
-    bput('stop play','In the name of love','You stop playing','But you're not performing anything') if (Script.running?('performance') || Script.running?('play'))
+    bput('stop play','In the name of love','You stop playing','But you\'re not performing anything') if (Script.running?('performance') || Script.running?('play'))
 
     wait_for_script_to_complete('buff', ['burgle']) if @settings.waggle_sets['burgle']
 


### PR DESCRIPTION
…urgle someone's house

Adding match for this so it won't hang when burgling.

` [burgle]>stop play                                                                                                                                                                                                                           
 But you're not performing anything!                                                                                                                                                                                                          
 >                                                                                                                                                                                                                                            
 [burgle: *** No match was found after 15 seconds, dumping info]                                                                                                                                                                              
 [burgle: messages seen length: 2]                                                                                                                                                                                                            
 [burgle: checked against [/In the name of love/i, /You stop playing/i]]                                                                                                                                                                      
 [burgle: for command stop play]                                               `