### PR TITLE
center telescope on spider defaults to the tarantula noun, and there'…

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -62,6 +62,7 @@ module DRCMM
              'open it to make any use of it',
              'The pain is too much',
              "That's a bit tough to do when you can't see the sky",
+             "You would probably need a periscope to do that",
              'Your search for',
              'Your vision is too fuzzy')
   end


### PR DESCRIPTION
…s nothing you can do about it...

This doesn't fix anything, but it prevents a 15 second hang. The new tarantula is a spider, and the parser defaults to it. You can't center telescope on spider in the sky either. Conceivably we could make the spider come off, and go back on, but that sounds silly to me, when we can just match the response and chug along.

 [astrology]>center telescope on Spider                                                                                                                                                                                                       
 You would probably need a periscope to do that.                                                                                                                                                                                              

 [astrology: *** No match was found after 15 seconds, dumping info]                                                                                                                                                                           
<snip>
 [astrology: for command center telescope on Spider]                                                                                                                                                                                          
