### PR TITLE
stopping crystals from messing up magic training time

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1751,6 +1751,7 @@ sanowret_no_use_scripts: # Don't try to use crystal while these scripts are acti
 - buff
 - burgle
 - go2
+- magic-training
 sanowret_no_use_rooms: # Don't try to use crystal while in these rooms.
 - Carousel Chamber     # Room with vault
 - Carousel Booth       # Room just before vault


### PR DESCRIPTION
What it says on the title. magic-training is from the base lich repo.