### PR TITLE
Adding match for when the looted item is itself a container, and can'…

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -456,7 +456,7 @@ class Burgle
 
   #ripped out of steal.lic
   def put_item?(item)
-    case bput("put my #{item} in my #{@loot_container}", 'What were you', 'You put', "You can't do that", 'no matter how you arrange it', 'even after stuffing', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again', 'That\'s too heavy to go in there')
+    case bput("put my #{item} in my #{@loot_container}", 'What were you', 'You put', "You can't do that", 'no matter how you arrange it', 'even after stuffing', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again', 'That\'s too heavy to go in there', "^Weirdly, you can't manage")
     when 'perhaps try doing that again'
       return put_item?(item)
     when 'You put'


### PR DESCRIPTION
Adding a match for the case when you burgle a container, and have a hold-any container as your loot_container and get specific messaging.

```
2021-12-13 20:20:25 +1300:[burgle]>put my worn book in my hip pouch
2021-12-13 20:20:25 +1300:Weirdly, you can't manage to get the worn book to fit.
2021-12-13 20:20:25 +1300:[Containers can't be placed in the hip pouch, sorry!]
2021-12-13 20:20:26 +1300:Footsteps nearby make you wonder if you're pushing your luck.
2021-12-13 20:20:40 +1300:[burgle: *** No match was found after 15 seconds, dumping info]
<snip>
2021-12-13 20:20:40 +1300:[burgle: message: Footsteps nearby make you wonder if you're pushing your luck.]
2021-12-13 20:20:40 +1300:[burgle: message: [Containers can't be placed in the hip pouch, sorry!]]
2021-12-13 20:20:40 +1300:[burgle: message: Weirdly, you can't manage to get the worn book to fit.]
2021-12-13 20:20:40 +1300:[burgle: checked against [/What were you/i, /You put/i, /You can't do that/i, /no matter how you arrange it/i, /even after stuffing/i, /The .* is *.* too \w+ to fit in/i, /There isn't any more room/i, /perhaps tr
y doing that again/i]]
2021-12-13 20:20:40 +1300:[burgle: for command put my worn book in my hip pouch]
```
