### PR TITLE
adding a validate error for cornmaze_container when it's a Hash, vers…

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -862,6 +862,21 @@ class DRYamlValidator
     end
   end
 
+  def assert_that_cornmaze_containers_is_an_array(settings)
+    return if settings.cornmaze_containers.empty? or settings.cornmaze_containers.is_a?(Array)
+
+    list = <<~END
+      cornmaze_containers:
+                 - haversack
+                 - portal
+                 - hip pouch
+
+    END
+
+    error("cornmaze_containers should be a list of containers like this works:")
+    echo("#{list}")
+  end
+
   def assert_that_crossing_training_config_is_valid(settings)
     return unless settings.crossing_training
     unless settings.crossing_training_max_threshold.is_a? Numeric


### PR DESCRIPTION
…us an Array https://github.com/rpherbig/dr-scripts/issues/4007

When
```
cornmaze_containers: foo
```
;validate returns
```
 [validate: ERROR:< cornmaze_containers should be a list of containers like this works:  >]
 [validate: cornmaze_containers:
            - haversack
            - portal
            - hip pouch
 ]
   WARNINGS:0 ERRORS:1
   All done!
```

when cornmaze_containers is empty, or contains an array, no such error occurs.
```
cornmaze_containers:
WARNINGS:0 ERRORS:0
```
```
cornmaze_containers:
- haversack
- portal
- hip pouch
WARNINGS:0 ERRORS:0
```
