### PR TITLE
Deprecate id: <roomnumber> syntax for theurgy_prayer_mat_room, and make it work like other _room settings

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -392,7 +392,11 @@ class TheurgyActions
     return if @mat_unrolled
 
     if @prayer_mat
-      walk_to @prayer_mat_room if @prayer_mat_room
+      if @settings.theurgy_prayer_mat_room.is_a?(Hash)
+        walk_to @prayer_mat_room['id']
+      else @settings.theurgy_prayer_mat_room.is_a?(Integer)
+        walk_to @prayer_mat_room
+      end
       stow_hands
       DRCI.get_item_safe(@prayer_mat, @theurgy_supply_container)
       bput("unroll #{@prayer_mat}",

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -392,10 +392,12 @@ class TheurgyActions
     return if @mat_unrolled
 
     if @prayer_mat
-      if @settings.theurgy_prayer_mat_room.is_a?(Hash)
+      if @settings.theurgy_prayer_mat_room.is_a?(Hash) && @settings.theurgy_prayer_mat_room.has_key?('id')
         walk_to @prayer_mat_room['id']
-      else @settings.theurgy_prayer_mat_room.is_a?(Integer)
+      elsif @settings.theurgy_prayer_mat_room.is_a?(Integer)
         walk_to @prayer_mat_room
+      else 
+        echo "theurgy_prayer_mat_room does not contain valid settings. A valid setting looks like \"theurgy_prayer_mat_room: 1900\""
       end
       stow_hands
       DRCI.get_item_safe(@prayer_mat, @theurgy_supply_container)

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -45,6 +45,7 @@ class TheurgyActions
     end
   end
 
+
   def get_rituals
     rituals = all_rituals
     blacklist = @settings.theurgy_blacklist
@@ -391,7 +392,7 @@ class TheurgyActions
     return if @mat_unrolled
 
     if @prayer_mat
-      walk_to @prayer_mat_room['id'] if @prayer_mat_room
+      walk_to @prayer_mat_room if @prayer_mat_room
       stow_hands
       DRCI.get_item_safe(@prayer_mat, @theurgy_supply_container)
       bput("unroll #{@prayer_mat}",

--- a/validate.lic
+++ b/validate.lic
@@ -99,7 +99,7 @@ class DRYamlValidator
 
   def assert_that_theurgy_prayer_mat_room_should_be_an_int_and_warn_about_deprecation(settings)
       return if settings.theurgy_prayer_mat_room.is_a?(Integer) && !settings.theurgy_use_prayer_mat
-      return if not settings.theurgy_prayer_mat_room['id']
+      return if not settings.theurgy_prayer_mat_room.is_a?(Hash)
     
       warn("theurgy_prayer_mat_room is set as a key value pair id: #{settings.theurgy_prayer_mat_room['id']} this is deprecated. It should be set as a room number \"theurgy_prayer_mat_room: #{settings.theurgy_prayer_mat_room['id']}\" ")
   end

--- a/validate.lic
+++ b/validate.lic
@@ -98,10 +98,13 @@ class DRYamlValidator
   end
 
   def assert_that_theurgy_prayer_mat_room_should_be_an_int_and_warn_about_deprecation(settings)
-      return if settings.theurgy_prayer_mat_room.is_a?(Integer) && !settings.theurgy_use_prayer_mat
-      return if not settings.theurgy_prayer_mat_room.is_a?(Hash)
-    
-      warn("theurgy_prayer_mat_room is set as a key value pair id: #{settings.theurgy_prayer_mat_room['id']} this is deprecated. It should be set as a room number \"theurgy_prayer_mat_room: #{settings.theurgy_prayer_mat_room['id']}\" ")
+      return if settings.theurgy_prayer_mat_room.is_a?(Integer) || !settings.theurgy_use_prayer_mat
+
+      if settings.theurgy_prayer_mat_room.is_a?(Hash) && settings.theurgy_prayer_mat_room.key?('id')
+        warn("theurgy_prayer_mat_room is set as a key value pair id: #{settings.theurgy_prayer_mat_room['id']} this is deprecated. It should be set as a room number \"theurgy_prayer_mat_room: #{settings.theurgy_prayer_mat_room['id']}\" ")
+      else
+        warn("theurgy_prayer_mat_room does not contain valid settings. A valid setting looks like \"theurgy_prayer_mat_room: 1900\"")
+      end
   end
 
   def assert_that_hometown_has_altar_if_using_altars(settings)

--- a/validate.lic
+++ b/validate.lic
@@ -97,6 +97,13 @@ class DRYamlValidator
     error("The favor_god: #{settings.favor_god} you have set requires use_favor_altars: true, only neutral aspects can use the puzzle for orbs")
   end
 
+  def assert_that_theurgy_prayer_mat_room_should_be_an_int_and_warn_about_deprecation(settings)
+      return if settings.theurgy_prayer_mat_room.is_a?(Integer) && !settings.theurgy_use_prayer_mat
+      return if not settings.theurgy_prayer_mat_room['id']
+    
+      warn("theurgy_prayer_mat_room is set as a key value pair id: #{settings.theurgy_prayer_mat_room['id']} this is deprecated. It should be set as a room number \"theurgy_prayer_mat_room: #{settings.theurgy_prayer_mat_room['id']}\" ")
+  end
+
   def assert_that_hometown_has_altar_if_using_altars(settings)
     return if !settings.use_favor_altars
     return if settings.favor_goal == 0

--- a/validate.lic
+++ b/validate.lic
@@ -100,7 +100,7 @@ class DRYamlValidator
   def assert_that_theurgy_prayer_mat_room_should_be_an_int_and_warn_about_deprecation(settings)
       return if settings.theurgy_prayer_mat_room.is_a?(Integer) || !settings.theurgy_use_prayer_mat
 
-      if settings.theurgy_prayer_mat_room.is_a?(Hash) && settings.theurgy_prayer_mat_room.key?('id')
+      if settings.theurgy_prayer_mat_room.is_a?(Hash) && settings.theurgy_prayer_mat_room.has_key?('id')
         warn("theurgy_prayer_mat_room is set as a key value pair id: #{settings.theurgy_prayer_mat_room['id']} this is deprecated. It should be set as a room number \"theurgy_prayer_mat_room: #{settings.theurgy_prayer_mat_room['id']}\" ")
       else
         warn("theurgy_prayer_mat_room does not contain valid settings. A valid setting looks like \"theurgy_prayer_mat_room: 1900\"")


### PR DESCRIPTION
…rematurely

Prior to this small change, calling theurgy with a prayer mat defined caused it to exit prematurely:
with 

```
theurgy_use_prayer_mat: true
```
and with a theurgy_prayer_mat_room: defined prior to this fix, this happens

```
 --- Lich: error: no implicit conversion of String into Integer                                                                                                                                                                               
         theurgy:394:in `[]'                                                                                                                                                                                                                  
         theurgy:394:in `walk_to_altar_or_prayer_mat'                                                                                                                                                                                         
 --- Lich: theurgy has exited.   
```

It now no longer happens, and the script runs through to the end.

Thanks @asechrest for the help!