### PR TITLE
[script] [common-arcana, validate]  [data] [base.yaml] - Crafting training spells enable sorcery

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -819,8 +819,8 @@ module DRCA
     return if checkcastrt > 0
 
     needs_training = %w[Warding Utility Augmentation]
-    needs_training.append("Sorcery") if settings.crafting_training_spells_enable_sorcery && !Script.running?('forge')
-    needs_training.append("Sorcery") if settings.crafting_training_spells_enable_sorcery && settings.crafting_training_spells_enable_sorcery_forging
+    needs_training.append("Sorcery") if (settings.crafting_training_spells_enable_sorcery && !Script.running?('forge')) ||
+                                        (settings.crafting_training_spells_enable_sorcery && settings.crafting_training_spells_enable_sorcery_forging)
     needs_training = needs_training .select { |skill| training_spells[skill] } .select { |skill| DRSkill.getxp(skill) < 31 } .sort_by { |skill| DRSkill.getxp(skill) }.first
  
     return unless needs_training

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -805,6 +805,7 @@ module DRCA
 
   def crafting_magic_routine(settings)
     training_spells = settings.crafting_training_spells
+
     return if training_spells.empty?
     return if DRStats.mana <= settings.waggle_spells_mana_threshold
 
@@ -816,10 +817,11 @@ module DRCA
     end
 
     return if checkcastrt > 0
+
     needs_training = %w[Warding Utility Augmentation]
-                     .select { |skill| training_spells[skill] }
-                     .select { |skill| DRSkill.getxp(skill) < 31 }
-                     .sort_by { |skill| DRSkill.getxp(skill) }.first
+    needs_training.append("Sorcery") if settings.crafting_training_spells_enable_sorcery
+    needs_training = needs_training .select { |skill| training_spells[skill] } .select { |skill| DRSkill.getxp(skill) < 31 } .sort_by { |skill| DRSkill.getxp(skill) }.first
+ 
     return unless needs_training
 
     crafting_prepare_spell(training_spells[needs_training], settings)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -819,7 +819,8 @@ module DRCA
     return if checkcastrt > 0
 
     needs_training = %w[Warding Utility Augmentation]
-    needs_training.append("Sorcery") if settings.crafting_training_spells_enable_sorcery
+    needs_training.append("Sorcery") if settings.crafting_training_spells_enable_sorcery && !Script.running?('forge')
+    needs_training.append("Sorcery") if settings.crafting_training_spells_enable_sorcery && settings.crafting_training_spells_enable_sorcery_forging
     needs_training = needs_training .select { |skill| training_spells[skill] } .select { |skill| DRSkill.getxp(skill) < 31 } .sort_by { |skill| DRSkill.getxp(skill) }.first
  
     return unless needs_training

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -792,6 +792,10 @@ use_own_ingot_type:
 deed_own_ingot: false
 # spells that get woven in to various scripts, do not use cambrinth
 crafting_training_spells:
+# enable the use of Sorcery during crafting spell training. Don't blow up your hands...
+crafting_training_spells_enable_sorcery: false
+# Disable the warning you get with ;validate when you enable sorcery. 
+crafting_training_spells_enable_sorcery_squelch_warning: false
 # mindstate craft.lic will skip making an item at
 craft_max_mindstate: 31
 # amount of yarn to keep on hand for craft.lic, don't exceed 300

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -794,6 +794,8 @@ deed_own_ingot: false
 crafting_training_spells:
 # enable the use of Sorcery during crafting spell training. Don't blow up your hands...
 crafting_training_spells_enable_sorcery: false
+# enable sorcery casting during forging specifically. Requires above setting to be true as well
+crafting_training_spells_enable_sorcery_forging: false
 # Disable the warning you get with ;validate when you enable sorcery. 
 crafting_training_spells_enable_sorcery_squelch_warning: false
 # mindstate craft.lic will skip making an item at

--- a/validate.lic
+++ b/validate.lic
@@ -76,6 +76,15 @@ class DRYamlValidator
     warn("You have the following invalid appraisal_training settings: #{bad_settings}\nValid appraisal_training settings are: #{valid_settings}")
   end
 
+  def assert_that_sorcery_is_dangerous(settings)
+    return unless settings.crafting_training_spells_enable_sorcery
+    return if settings.crafting_training_spells_enable_sorcery_squelch_warning
+
+    warn('You have Sorcery casting whilst crafting, check JUSTICE in your crafting room')
+    warn('Set crafting_training_spells_enable_sorcery_squelch_warning: true to make this message go away')
+  end
+
+
   def assert_that_pouch_appraisal_has_defined_container(settings)
     return unless settings.appraisal_training.include?('pouches')
     return if settings.full_pouch_container
@@ -158,7 +167,8 @@ class DRYamlValidator
   def assert_that_crafting_training_spells_are_skills(settings)
     return unless settings.crafting_training_spells
 
-    valid_crafting_training_spells_skills = %w[Augmentation Utility Warding]
+    valid_crafting_training_spells_skills = %w[Augmentation Utility Warding] 
+    valid_crafting_training_spells_skills.append("Sorcery") if settings.crafting_training_spells_enable_sorcery
 
     settings.crafting_training_spells
             .keys


### PR DESCRIPTION
…, with accompanying validat ewarnings, and settings for base.yaml

This defaults to off, has entries in base.yaml, and gets checked for in ;validate

```
crafting_training_spells_enable_sorcery: false # simple toggle to enable for all crafting, other that forging
crafting_training_spells_enable_sorcery_squelch_warning: false # disable the extra validate warning
crafting_training_spells_enable_sorcery_forging: false # enable sorcery during forging too 
```
results in 

```
[validate: ERROR:< Invalid crafting_training_spells: skill name 'Sorcery'. Valid skill names are '["Augmentation", "Utility", "Warding"]'  >]
 ```

enable the main setting and you get this 

```
[validate: WARNING:< You have Sorcery casting whilst crafting, check JUSTICE in your crafting room  >]
 [validate: WARNING:< Set crafting_training_spells_enable_sorcery_squelch_warning: true to make this message go away  >]
```

enable both

```   WARNINGS:0 ERRORS:0```