### PR TITLE
[script] [smith] - Fix for looking for oil, finding holy oil, and trying that...

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -26,6 +26,8 @@ class Smith
       ]
     ]
 
+_respond "<pushBold/>Mahtra's test version<popBold/>"
+
     args = parse_args(arg_definitions)
 
     @settings = get_settings
@@ -92,10 +94,10 @@ class Smith
 
   def check_oil(discipline)
     $ORDINALS.each do |ord|
-      case bput("look my #{ord} oil", /thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
+      case bput("look my #{ord} oil in #{@container}", /thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
       when /thick and syrupy substance that easily coats and lubricates metal/
         return if ord == 'first'
-        bput("get my #{ord} oil", /You get/)
+        bput("get my #{ord} oil in #{container}", /You get/)
         bput("put oil in my #{@container}", 'You put')
         return
       when /I could not find what you were referring to/

--- a/smith.lic
+++ b/smith.lic
@@ -26,8 +26,6 @@ class Smith
       ]
     ]
 
-_respond "<pushBold/>Mahtra's test version<popBold/>"
-
     args = parse_args(arg_definitions)
 
     @settings = get_settings


### PR DESCRIPTION
reported by @kaesken on discord, who also tested the fix for me.
```
[smith]>look my first oil

You see nothing unusual.
> 
[smith]>look my second oil

You see nothing unusual.
> 
[smith]>look my third oil

You see nothing unusual.
> 
[smith]>look my fourth oil

There are about 20 stones of holy oil left.
> 
[smith: *** No match was found after 15 seconds, dumping info]

[smith: messages seen length: 11]

[smith: message: Halo  (OM)]

[smith: message: Murrula's Flames  (OM)]

[smith: message: Osrel Meraud  (56%)]

[smith: message: Persistence of Mana  (OM)]

[smith: message: Divine Radiance  (OM)]

[smith: message: Halo  (OM)]

[smith: message: Murrula's Flames  (OM)]

[smith: message: Osrel Meraud  (56%)]

[smith: message: Persistence of Mana  (OM)]

[smith: message: Divine Radiance  (OM)]

[smith: message: There are about 20 stones of holy oil left.]

[smith: checked against [/thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/]]

[smith: for command look my fourth oil]

[smith]>look my fifth oil

There are about 20 stones of holy oil left.
> 
[smith: *** No match was found after 15 seconds, dumping info]
```

after change it looks inside crafting_container as expected

```
[smith]>look my first oil in duffel bag

A thick and syrupy substance that easily coats and lubricates metal.
> 
```