### PR TITLE
[script] [equipmanager] Explicit true/false return value when wield weapon

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -184,37 +184,51 @@ class EquipmentManager
     return false
   end
 
+  # Unlike `wield_weapon`, does NOT stow what's in your hands (not sure if that's on purpose or not).
+  # Handles swapping the weapon to desired weapon skill (e.g. bastard swords, bar maces, ristes).
+  # Will ensure the item ends up in your left hand.
   def wield_weapon_offhand(description, skill = nil)
     return if description.empty?
 
     weapon = item_by_desc(description)
     unless weapon
-      echo("failed to match a weapon for #{description}")
-      return
+      DRC.message("Failed to match a weapon for #{description}:#{skill}")
+      return false
     end
 
-    get_item?(weapon)
-    swap_to_skill(weapon.name, skill) if skill && weapon.swappable
+    if get_item?(weapon)
+      swap_to_skill?(weapon.name, skill) if skill && weapon.swappable
+      DRC.bput('swap', 'You move') if DRCI.in_right_hand?(weapon)
+      return true
+    end
+
+    return false
   end
 
+  # Stows any items in your hands then wields the requested item to your right hand.
+  # Handles swapping the weapon to desired weapon skill (e.g. bastard swords, bar maces, ristes).
+  # If the skill to swap to is 'Offhand Weapon' then will swap it to your left hand.
   def wield_weapon(description, skill = nil)
     return if description.empty?
 
     offhand = skill == 'Offhand Weapon'
     weapon = item_by_desc(description)
     unless weapon
-      echo("failed to match a weapon for #{description}:#{skill}")
-      return
+      DRC.message("Failed to match a weapon for #{description}:#{skill}")
+      return false
     end
 
     if [left_hand, right_hand].grep(weapon.short_regex).any?
       stow_weapon
     end
 
-    get_item?(weapon)
+    if get_item?(weapon)
+      swap_to_skill?(weapon.name, skill) if skill && weapon.swappable
+      DRC.bput('swap', 'You move') if offhand && right_hand
+      return true
+    end
 
-    swap_to_skill(weapon.name, skill) if skill && weapon.swappable
-    bput('swap', 'You move') if offhand && right_hand
+    return false
   end
 
   def get_item?(item)


### PR DESCRIPTION
### Background
* For some upcoming changes to `combat-trainer` to support [Damaris weapons](https://elanthipedia.play.net/Category:Damaris_weapons), wanting a more reliable way to know if equipmanager was able to find and wield the weapon or not.

### Changes
* If able to get the weapon into your hands, returns `true`, else `false`
* Use `DRC` module prefix
* Use `DRC.message` instead of echo for the warning message
* Added method comments

## Tests

### wield weapon offhand, swaps to left hand
```
> ,e echo EquipmentManager.new.wield_weapon_offhand('Damaris mace')

[exec1]>get Damaris.mace from my thornweave.lootsack

You get a Damaris mace from inside your thornweave lootsack.

[exec1]>swap

You move a Damaris mace to your left hand.

[exec1: true]

--- Lich: exec1 has exited.
```

### wield weapon to offhand skill
```
> ,e echo EquipmentManager.new.wield_weapon('Damaris mace', 'Offhand Weapon')

--- Lich: exec1 active.

[exec1]>get Damaris.mace from my thornweave.lootsack

You get a Damaris mace from inside your thornweave lootsack.

[exec1]>swap

You move a Damaris mace to your left hand.

[exec1: true]

--- Lich: exec1 has exited.
```

### wield riste and swap to 2HB
```
> ,e echo EquipmentManager.new.wield_weapon("khor'vela riste", 'Twohanded Blunt')

--- Lich: exec1 active.

[exec1]>get khor'vela.riste from my watery portal

You get a savage khor'vela riste affixed with jagged obsidian blades from inside a swirling eddy of incandescent light bound by a gold-striated coralite frame.
> 
[exec1]>swap my riste

You fiercely switch your grip so that your riste can be used as a heavy blunt weapon.

[exec1]>swap my riste

You fiercely switch your grip so that your riste can be used as a heavy edged weapon.

[exec1]>swap my riste

You fiercely switch your grip so that your riste can be used as a two-handed blunt weapon.

[exec1: true]

--- Lich: exec1 has exited.
```

### fail to wield weapon
```
> ,e echo EquipmentManager.new.wield_weapon("khor'vela riste", 'Twohanded Blunt')

--- Lich: exec1 active.

[exec1]>get khor'vela.riste from my watery portal

> 
What were you referring to?
> 
[exec1]>open my eddy

That is already open.
> 
[exec1]>look in my watery portal

In the swirling eddy you see a curving bloodwood branch, a curving bloodwood branch, an agonite great helm, a serrated Imperial spear, a leather sling, a diamondwood belaying pin, a massive hammer, a flame-bladed zweihander, a hefty hunting bola, a crimson glaes flamberge, a crimson glaes flamberge, a crimson glaes flamberge and a rugged black backpack.
> 
[exec1]>get khor'vela.riste from watery portal

What were you referring to?
> 
[exec1]>get my khor'vela.riste

What were you referring to?
> 
[exec1]>get my khor'vela.riste

What were you referring to?
> 
| Could not find khor'vela.riste anywhere.

[exec1: false]

--- Lich: exec1 has exited.
```