### PR TITLE
[script] [common-items] Add optional `container` argument so can check watery portals

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -350,8 +350,8 @@ module DRCI
   end
 
   # Taps an item to confirm it exists.
-  def exists?(item)
-    tap(item) =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
+  def exists?(item, container = nil)
+    tap(item, container) =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
   end
 
   # Taps an item and returns the match string.


### PR DESCRIPTION
### Background
* For some upcoming changes to `combat-trainer` to support [Damaris weapons](https://elanthipedia.play.net/Category:Damaris_weapons), wanting a more reliable way to know if common-items was able to tap an item
* Since items in your [watery portal](https://elanthipedia.play.net/Item:Swirling_eddy_of_incandescent_light_bound_by_a_gold-striated_coralite_frame) is not "on" your person, simply tapping an item will not find it. You must specify that you want to tap the item that's in your watery portal.

### Changes
* Add optional `container` argument to `DRCI.exists?` function so that we can ask if the item exists _in_ a container (e.g. the watery portal).

### Example Planned Usage
```ruby
item = @equipment_manager.item_by_desc(weapon)
if DRCI.exists?(item.name, item.container)
  ...
end
```

## Tests

### does not tap item without container suffix
```
> ,e echo DRCI.exists?("khor'vela riste")

[exec1]>tap my khor'vela riste 

I could not find what you were referring to.

[exec1: ]
```

### taps item with container suffix
```
> ,e echo DRCI.exists?("khor'vela riste", "watery portal")

[exec1]>tap my khor'vela riste from watery portal

You tap a savage khor'vela riste affixed with jagged obsidian blades inside a swirling eddy.

[exec1: 0]
```