### PR TITLE
[script] [equipmanager] Add `turn_to_weapon?` for Damaris weapons support

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -194,7 +194,7 @@ class EquipmentManager
     end
 
     get_item?(weapon)
-    swap_to_skill(weapon.name, skill) if skill && weapon.swappable
+    swap_to_skill?(weapon.name, skill) if skill && weapon.swappable
   end
 
   def wield_weapon(description, skill = nil)
@@ -213,7 +213,7 @@ class EquipmentManager
 
     get_item?(weapon)
 
-    swap_to_skill(weapon.name, skill) if skill && weapon.swappable
+    swap_to_skill?(weapon.name, skill) if skill && weapon.swappable
     bput('swap', 'You move') if offhand && right_hand
   end
 
@@ -335,7 +335,23 @@ class EquipmentManager
     end
   end
 
-  def swap_to_skill(noun, skill)
+  # Turns a weapon so that it can be used as a different weapon.
+  # Examples include Damaris weapons.
+  def turn_to_weapon?(old_noun, new_noun)
+    return true if old_noun == new_noun
+    result = DRC.bput("turn my #{old_noun} to #{new_noun}", /^Turn what?/i, /^Which weapon did you want to pull out/i, /^Your .*\b#{old_noun}.* shifts .*/i)
+    waitrt? # turning may incur roundtime
+    case result
+    when /^Your .*\b#{old_noun}.* shifts .* before resolving itself into .*\b#{new_noun}/i
+      true
+    else
+      false
+    end
+  end
+
+  # Swaps a weapon so that it can be used for a different skill.
+  # Examples include bastard swords, bar maces, and ristes.
+  def swap_to_skill?(noun, skill)
     if noun =~ /\bfan\b/i
       command = skill =~ /edged/i ? 'open' : 'close'
       bput("#{command} my fan", 'you snap', 'already')


### PR DESCRIPTION
### Background
* For some upcoming changes to `combat-trainer` to support [Damaris weapons](https://elanthipedia.play.net/Category:Damaris_weapons), need way to turn weapon to desired noun.

### Changes
* Add `turn_to_weapon?(old_noun, new_noun)` method with initial support for Damaris weapons
* Rename `swap_to_skill` to include `?` predicate suffix to match convention; updated the 2 other spots where that method was used

## Tests

### successfully turns weapon to new noun
```
You get a Damaris falchion from inside your thornweave lootsack.
> ,e echo EquipmentManager.new.turn_to_weapon?('falchion', 'mace')

[exec1]>turn my falchion to mace

Your Damaris falchion shifts and momentarily becomes a blurry mass of shadows before resolving itself into a Damaris mace.
Roundtime: 1 sec.

[exec1: true]
```

### unable to turn weapon to new noun
```
> ,e echo EquipmentManager.new.turn_to_weapon?('mace', 'sword')

[exec1]>turn my mace to sword

Which weapon did you want to pull out of the shadows?

[exec1: false]
```

### optimization to avoid roundtime if old and new noun are the same
```
> tap mace
You tap a Damaris mace that you are holding.

> ,e echo EquipmentManager.new.turn_to_weapon?('mace', 'mace')

[exec1: true]
```