### PR TITLE
[script] [favor] Favordotlic fix for using bad immortals

### DIFF
--- a/favor.lic
+++ b/favor.lic
@@ -110,19 +110,35 @@ class CrossingFavor
   def use_puzzle
     walk_to @hometown_data['favor_puzzle']['id']
 
-    case bput('pray', 'You feel a sense of peace settle over you', 'The gods ignore the pleas of your decaying spirit')
-    when 'The gods ignore the pleas of your decaying spirit'
-      echo '***CANNOT GET A FAVOR YOU HEATHEN!***'
-      return
+    loop do
+      case bput("pray",
+        /^You feel a sense of peace settle over you/,
+        /^The gods ignore the pleas of your decaying spirit/,
+        /^You close your eyes and pray/,
+        /^As you continue to pray/,
+        /if you have come seeking the favor of your God, declare that name now/)
+      when /^You close your eyes and pray/, /^As you continue to pray/, /^You feel a sense of peace settle over you/
+        next
+      when 'The gods ignore the pleas of your decaying spirit'
+        DRC.message("***CANNOT GET A FAVOR YOU HEATHEN!***")
+        exit
+        break
+      when /if you have come seeking the favor of your God, declare that name now/
+        break
+      end
     end
-    fput 'pray'
-    fput 'pray'
-    fput "say #{@settings.favor_god}"
-    fix_standing
-    fput "get #{@settings.favor_god} orb from altar"
-    bput("go arch", /^You step through the granite arch/)
-    do_puzzle
+
+    case bput("say #{@settings.favor_god}", /^The voice speaks to you again saying, \"You have indicated an unknown God with the name/, /rise and seek your favor/)
+    when /^The voice speaks to you again saying, \"You have indicated an unknown God with the name/
+      DRC.message("***Only neutral aspects can be used with favor puzzles***")
+      exit
+    when /rise and seek your favor/
+      fix_standing
+      fput "get #{@settings.favor_god} orb from altar"
+    end
+    start_puzzle('arch')
   end
+
 
   def do_puzzle
     pause 1

--- a/favor.lic
+++ b/favor.lic
@@ -122,7 +122,6 @@ class CrossingFavor
       when 'The gods ignore the pleas of your decaying spirit'
         DRC.message("***CANNOT GET A FAVOR YOU HEATHEN!***")
         exit
-        break
       when /if you have come seeking the favor of your God, declare that name now/
         break
       end

--- a/favor.lic
+++ b/favor.lic
@@ -131,6 +131,7 @@ class CrossingFavor
     case bput("say #{@settings.favor_god}", /^The voice speaks to you again saying, \"You have indicated an unknown God with the name/, /rise and seek your favor/)
     when /^The voice speaks to you again saying, \"You have indicated an unknown God with the name/
       DRC.message("***Only neutral aspects can be used with favor puzzles***")
+      DRC.message("Check https://elanthipedia.play.net/Category:Immortals names of Neutral aspects")
       exit
     when /rise and seek your favor/
       fix_standing


### PR DESCRIPTION
As reported by @kaesken on Discord. 

When an immortal is listed for which the maze doesn't work, throws a more informative error and exits out.
![favor_error](https://user-images.githubusercontent.com/93822896/147172662-c6c67132-0533-427d-9140-429d590c0a6f.png)
