### PR TITLE
[script] [combat-trainer] Ensure hands are empty at script start

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3580,6 +3580,7 @@ class CombatTrainer
   def initialize
     settings = set_args
     @equipment_manager = EquipmentManager.new(settings)
+    @equipment_manager.empty_hands
     setup(settings)
     settings.storage_containers.each { |container| fput("open my #{container}") }
     @equipment_manager.wear_equipment_set?('standard') if settings.cycle_armors_regalia.nil? || DRCA.parse_regalia.empty?


### PR DESCRIPTION
### Background
* When the CombatTrainer class starts the combat routine, it will [return gear in your hands](https://github.com/rpherbig/dr-scripts/blob/d951e69ada529320fc02a65af679e0233d7f12ca/combat-trainer.lic#L3643) to their stow locations. However, this happens _after_ all the sub-processes like SafetyProcess, SpellProcess, AttackProcess, etc get initialized.
* #5319 in the GameState class taps items to identify the current state of your Damaris weapons, and if the item is expected to be in a container then the script tries to tap the item _in_ that container and no where else.
* If you're holding your Damaris weapon then this leads to combat-trainer to not identify it, aside from the fact that gear is out of place for the outset of combat.

### Changes
* Ensure hands are empty and gear put away before processes even start to ensure Damaris weapons (or anything else) are found in their respective "containers".