### PR TITLE
[script] [equipmanager] Handle if item is already in your hands

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -218,6 +218,7 @@ class EquipmentManager
   end
 
   def get_item?(item)
+    return true if DRCI.in_hands?(item)
     if item.wield
       bput("wield my #{item.short_name}", 'You draw', 'You deftly remove', 'You slip', 'Wield what', 'With a flick of your wrist you stealthily unsheathe') != 'Wield what'
     elsif item.transforms_to

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -320,12 +320,15 @@ class EquipmentManager
   end
 
   def get_item_helper(item, type)
+    return false unless item
     data = verb_data(item)[type]
     snapshot = [left_hand, right_hand]
     waitrt?
     response = bput("#{data[:verb]} my #{item.short_name}", *data[:matches])
     waitrt?
     case response
+    when 'You are already holding'
+      return true
     when *data[:exhausted]
       return false
     when *data[:failures]


### PR DESCRIPTION
### Background
* If the item is in your hands and you try to get it, equipment manager may fail to find it and hang.

### Changes
* If the item to get is already in your hands then just return `true`.

Example of issue:
```  
 [combat-trainer]>get my Damaris.sledgehammer from my war.belt                                                                                                                                                                                
 What were you referring to?                                                                                                                                                                                                                  
 [combat-trainer]>get my Damaris.sledgehammer                                                                                                                                                                                                 
 >                                                                                                                                                                                                                                            
 You are already holding that. 

(hangs)
```