### PR TITLE
[script][circlecheck] - Bugfix, visual updates

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -542,8 +542,8 @@ def display_requirements(requirements, level_target, brief, pretty_print)
     # This outputs the beginning section of circle check, which
     # gives your current circle and your TDPs at next level.
     DRC.message("___________________________________________________________")
-    _respond "            Current Circle:  <pushBold/>#{DRStats.circle}<popBold/>" + 
-      "    |    Next Level TDPs:  #{DRStats.tdps} <pushBold/>+ #{tdps}<popBold/> = #{DRStats.tdps + tdps}"
+    _respond " Current Circle:  <pushBold/>#{DRStats.circle}<popBold/>" + 
+      " | Next Level TDPs:  #{DRStats.tdps} <pushBold/>+ #{tdps}<popBold/> = #{DRStats.tdps + tdps}"
     respond("")
     
     # Set column headings for later display for prettyprint

--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -611,7 +611,11 @@ def display_requirements(requirements, level_target, brief, pretty_print)
 
       # Formulate the needed ranks to target circle including 
       # fractional amount. Also prep total target ranks for proper display.
-      subtraction == 1.0 ? needed_ranks = missing_ranks : needed_ranks = missing_ranks - 1
+      if subtraction == 1.0
+        needed_ranks = missing_ranks
+      else
+        needed_ranks = missing_ranks - 1
+      end
       needed_ranks = needed_ranks.to_s + percent_remaining.to_s
       missing_ranks_plus_ranks = "(" + (missing_ranks + ranks).to_s + ")"
 

--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -542,7 +542,8 @@ def display_requirements(requirements, level_target, brief, pretty_print)
     # This outputs the beginning section of circle check, which
     # gives your current circle and your TDPs at next level.
     DRC.message("___________________________________________________________")
-    respond("CURRENT CIRCLE:" + "#{DRStats.circle}" + " | Next level TDPS: " + "#{tdps}")
+    _respond "            Current Circle:  <pushBold/>#{DRStats.circle}<popBold/>" + 
+      "    |    Next Level TDPs:  #{DRStats.tdps} <pushBold/>+ #{tdps}<popBold/> = #{DRStats.tdps + tdps}"
     respond("")
     
     # Set column headings for later display for prettyprint
@@ -570,7 +571,7 @@ def display_requirements(requirements, level_target, brief, pretty_print)
       echo("met_circle: #{met_circle} circle: #{DRStats.circle}") if $debug_mode_cc
       can_circle = true
       new_target = first_circle_seen + 1
-      DRC.message("***You're ready to circle!***")
+      DRC.message("***You're ready to circle!***\n")
     end
 
     # If we're in the first iteration of this loop, and user has
@@ -604,17 +605,14 @@ def display_requirements(requirements, level_target, brief, pretty_print)
 
       # Calculate the percent remaining to next skill rank
       # so we can display fractional amounts. Format so 
-      # we can easily append to current rank.
-      percent_remaining = 100 - DRSkill.getpercent(sub_skill).to_i
-      if percent_remaining.to_s.size < 2
-        percent_remaining = "0" + percent_remaining.to_s
-      elsif percent_remaining == 100
-        percent_remaining = 00
-      end
+      # we can easily append decimal to current rank.
+      subtraction = (100 - DRSkill.getpercent(sub_skill).to_f)/100.00
+      percent_remaining = format('%.2f', subtraction).sub(/^./, '')
 
       # Formulate the needed ranks to target circle including 
       # fractional amount. Also prep total target ranks for proper display.
-      needed_ranks = (missing_ranks -1).to_s + "." + percent_remaining.to_s
+      subtraction == 1.0 ? needed_ranks = missing_ranks : needed_ranks = missing_ranks - 1
+      needed_ranks = needed_ranks.to_s + percent_remaining.to_s
       missing_ranks_plus_ranks = "(" + (missing_ranks + ranks).to_s + ")"
 
       # Handle formatting circlecheck output in column formatting.
@@ -626,25 +624,25 @@ def display_requirements(requirements, level_target, brief, pretty_print)
         needed_ranks_plus = "+" + needed_ranks.to_s
 
         respond(
-          "#{sub_skill.center(column_spacing[1])}" +                             # Column 1 - Skill
-          "#{category.center(column_spacing[2])}" +                              # Column 2 - Category
-          "#{met_circle.to_s.rjust(column_spacing[3])}  " +                      # Column 3 - Met circle
-          "-".center(column_spacing[4]) +                                        # Column 4 - and need
-          "#{needed_ranks_plus.to_s.rjust(column_spacing[5])}" +                 # Column 5 - Needed Ranks
-          "#{missing_ranks_plus_ranks.to_s.rjust(column_spacing[6])} " +         # Column 6 - Total Target Ranks
-          "|".ljust(column_spacing[7]) +                                         # Column 7 - for
-          "#{met_circle.to_s.rjust(column_spacing[8])}"                          # Column 8 - Target circle
+          "#{sub_skill.center(column_spacing[1])}" +                            # Column 1 - Skill
+          "#{category.center(column_spacing[2])}" +                             # Column 2 - Category
+          "#{met_circle.to_s.rjust(column_spacing[3])}  " +                     # Column 3 - Met circle
+          "-".center(column_spacing[4]) +                                       # Column 4 - and need
+          "#{needed_ranks_plus.to_s.rjust(column_spacing[5])}" +                # Column 5 - Needed Ranks
+          "#{missing_ranks_plus_ranks.to_s.rjust(column_spacing[6])} " +        # Column 6 - Total Target Ranks
+          "|".ljust(column_spacing[7]) +                                        # Column 7 - for
+          "#{met_circle.to_s.rjust(column_spacing[8])}"                         # Column 8 - Target circle
         )
       else
         respond(
-          "#{sub_skill.center(column_spacing[1])}" +                               # Column 1 - Skill
-          "#{category.center(column_spacing[2])}" +                                # Column 2 - Category
-          "#{met_circle.to_s.rjust(column_spacing[3])}  " +                        # Column 3 - Met circle
-          "-".center(column_spacing[4]) +                                          # Column 4 - and need
-          "#{needed_ranks.to_s.rjust(column_spacing[5])}" +                        # Column 5 - Needed Ranks
-          "#{missing_ranks_plus_ranks.to_s.rjust(column_spacing[6])} " +           # Column 6 - Total Target Ranks
-          "|".ljust(column_spacing[7]) +                                           # Column 7 - for
-          "#{[met_circle + 1, level_target].max.to_s.rjust(column_spacing[8])}"    # Column 8 - Target circle
+          "#{sub_skill.center(column_spacing[1])}" +                            # Column 1 - Skill
+          "#{category.center(column_spacing[2])}" +                             # Column 2 - Category
+          "#{met_circle.to_s.rjust(column_spacing[3])}  " +                     # Column 3 - Met circle
+          "-".center(column_spacing[4]) +                                       # Column 4 - and need
+          "#{needed_ranks.to_s.rjust(column_spacing[5])}" +                     # Column 5 - Needed Ranks
+          "#{missing_ranks_plus_ranks.to_s.rjust(column_spacing[6])} " +        # Column 6 - Total Target Ranks
+          "|".ljust(column_spacing[7]) +                                        # Column 7 - for
+          "#{[met_circle + 1, level_target].max.to_s.rjust(column_spacing[8])}" # Column 8 - Target circle
         )
       end # Prettyprint display section
 
@@ -656,6 +654,8 @@ def display_requirements(requirements, level_target, brief, pretty_print)
       end
     end
   end
+  # Line delimiter for visual separation from game spam
+  DRC.message("___________________________________________________________")
 end
 
 def all_requirements(level_target)


### PR DESCRIPTION
Fixed a bug where the `pretty_print` version of `;circlecheck` reported the wrong needed ranks for next circle when the current rank was exactly 0% to next rank and at the same time made the calculation code a bit more efficient. Also some visual updates and a bit more info on TDPs - listing your current TDPs, the amount of TDPs you'll earn next level, and the resulting total.

![image](https://user-images.githubusercontent.com/6467969/147399196-918e279b-427b-4132-a671-ab2d683ec7ce.png)

Note: Still requires yaml `circlecheck_prettyprint: true` to display new format.

Here is a log of the error:

![image](https://user-images.githubusercontent.com/6467969/147399290-f43d8892-74fb-4d73-9c44-13939cfbd84f.png)
