### PR TITLE
appraisal.lic use drci.get/pull for pouches

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -77,21 +77,17 @@ class Appraisal
     end
     pause 1
     $ORDINALS.each do |ordinal|
-      case bput("get #{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun} from my #{full_pouch_container}", '^You get ', '^What were you referring')
-      when /^You get /
-        case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./)
-        when /You.ll need to open the .* to examine its contents./
-          bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .* ./, /That is already open/)
-          bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')
-          bput("close my #{gem_pouch_adjective} #{gem_pouch_noun}", /You close your/, /That is already closed/)
-        end
-        waitrt?
-        bput("put my #{gem_pouch_adjective} #{gem_pouch_noun} in my #{full_pouch_container}", 'You put')
-        pause 1
-      else
-        break
+    break unless DRCI.get_item?( "#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )  
+      case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./)
+      when /You.ll need to open the .* to examine its contents./
+        bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .* ./, /That is already open/)
+        bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')
+        bput("close my #{gem_pouch_adjective} #{gem_pouch_noun}", /You close your/, /That is already closed/)
       end
-      break if DRSkill.getxp('Appraisal') >= 30
+      waitrt?
+      DRCI.put_away_item?( "#{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )
+      pause 1
+    break if DRSkill.getxp('Appraisal') >= 30
     end
   end
 

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -77,17 +77,17 @@ class Appraisal
     end
     pause 1
     $ORDINALS.each do |ordinal|
-    break unless DRCI.get_item?( "#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )  
-      case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./)
-      when /You.ll need to open the .* to examine its contents./
-        bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .* ./, /That is already open/)
-        bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')
-        bput("close my #{gem_pouch_adjective} #{gem_pouch_noun}", /You close your/, /That is already closed/)
-      end
-      waitrt?
-      DRCI.put_away_item?( "#{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )
-      pause 1
-    break if DRSkill.getxp('Appraisal') >= 30
+      break unless DRCI.get_item?( "#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )  
+        case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./)
+        when /You.ll need to open the .* to examine its contents./
+          bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .* ./, /That is already open/)
+          bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')
+          bput("close my #{gem_pouch_adjective} #{gem_pouch_noun}", /You close your/, /That is already closed/)
+        end
+        waitrt?
+        DRCI.put_away_item?( "#{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )
+        pause 1
+      break if DRSkill.getxp('Appraisal') >= 30
     end
   end
 


### PR DESCRIPTION
Appraisal.lic was failing to find full pouches contained in Eddy's.

Updated to use common-items ``get_item?`` and ``put_away_item?``