### PR TITLE
[script][remedy.lic] Addresses #5179 - Fix script failure when yaml `crafting_items_in_container` setting include bowl/mortar, etc.

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -1,9 +1,10 @@
 =begin
-  Documentation: https://elanthipedia.play.net/mediawiki/index.php/Lich_script_development#remedy
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#remedy
 =end
 
 # ;remedy remedies 2 "blister cream" "red flower" nemoih bar mortar cream
 # ;remedy remedies 2 "blister cream" nemoih "not used" bar mortar cream  - for when only herb is required
+# ;remedy remedies 3 "limb salve" jadice none nugget mortar salve
 
 custom_require.call(%w[common common-arcana common-crafting common-items common-travel common-money events])
 
@@ -134,7 +135,7 @@ class Remedy
     create_item
   end
 
-  def get_item(name)
+  def get_item(name, at_feet = false)
     # added to check for herbs in special herb container, then check if herbs in crafting container, otherwise get normally
     # this is to prevent issues getting herbs if someone has less than 25 in @herb_container
     # there are still issues when herbs are in a different container (not @bag or @herb_container), script will still run fine
@@ -143,6 +144,8 @@ class Remedy
       get_crafting_item(name, @herb_container, true, @belt) # bag_items is TRUE to look for herbs in herb_container
     elsif (name == @herb1 || name == @herb2) && bput("tap #{name} in #{@bag}", 'You tap', 'I could not find what you were referring to.', 'You lightly tap') == 'You tap'
       get_crafting_item(name, @bag, true, @belt) # bag_items is TRUE to look for herbs in bag
+    elsif at_feet
+      get_crafting_item(name, @bag, false, @belt) # bag_items is FALSE to GET HERB without specifying a bag
     else
       get_crafting_item(name, @bag, @bag_items, @belt) # bag_items is FALSE to GET HERB without specifying a bag
       'none' # return specified to handle herbs differently for this option (to prevent a bug)
@@ -239,7 +242,7 @@ class Remedy
       stow_item(@herb1) # Added for when the herb is larger than 25 pieces
     end
 
-    get_item(@container) # pickup off ground
+    get_item(@container, true) # pickup off ground, at_feet = true
     get_item(@pestle)
 
     if /mort/ =~ @container

--- a/remedy.lic
+++ b/remedy.lic
@@ -4,7 +4,6 @@
 
 # ;remedy remedies 2 "blister cream" "red flower" nemoih bar mortar cream
 # ;remedy remedies 2 "blister cream" nemoih "not used" bar mortar cream  - for when only herb is required
-# ;remedy remedies 3 "limb salve" jadice none nugget mortar salve
 
 custom_require.call(%w[common common-arcana common-crafting common-items common-travel common-money events])
 

--- a/remedy.lic
+++ b/remedy.lic
@@ -144,7 +144,7 @@ class Remedy
     elsif (name == @herb1 || name == @herb2) && bput("tap #{name} in #{@bag}", 'You tap', 'I could not find what you were referring to.', 'You lightly tap') == 'You tap'
       get_crafting_item(name, @bag, true, @belt) # bag_items is TRUE to look for herbs in bag
     elsif at_feet
-      get_crafting_item(name, @bag, false, @belt) # bag_items is FALSE to GET HERB without specifying a bag
+      get_crafting_item(name, @bag, false, @belt) # This elsif used primarily to get bowl/mortar etc. from at our feet after lowering it.
     else
       get_crafting_item(name, @bag, @bag_items, @belt) # bag_items is FALSE to GET HERB without specifying a bag
       'none' # return specified to handle herbs differently for this option (to prevent a bug)


### PR DESCRIPTION
Addresses issue #5179 where the script fails to pick up the mortar from at your feet when the yaml `crafting_items_in_container` setting includes that item. This issue arises because the same method is used to get the mortar from the yaml-specified crafting container as well as when picking up the mortar from at your feet. The method honors the yaml setting and thus can't be used in its current form to also pick up a mortar at your feet because it explicitly tries to get the mortar from the crafting container.

Tried for the simplest fix possible so as not to change much of the code. Added a simple boolean for at_feet and we call the method with that set to true when necessary.