### PR TITLE
[script][common-items] Fix improper parsing of item list when rummaging a container

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -753,9 +753,18 @@ module DRCI
       return nil unless open_container?(container)
       rummage_container(container)
     else
-      contents
-        .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
-        .split(/(?:, | and )?(?:a|an|some) /)
+      # Get string of just the comma separated item list
+      contents = contents.match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]      
+      
+      # Strip a, an, or some, and leading spaces from each item, split into array of items
+      # The last two items in the rummage list are not comma delimited, handle below
+      contents = contents.split(/, (?:a|an|some) /)      
+      
+      # Grab the last array element which is the final two item, split them
+      sub_contents = contents.last.split(/ and (?:a|an|some) /)
+      
+      # Tack those last two items back onto our item list array
+      contents = contents.concat(sub_contents)
     end
   end
 

--- a/common-items.lic
+++ b/common-items.lic
@@ -762,7 +762,7 @@ module DRCI
       
       # Grab the last array element which is the final two items that are never comma
       # delimited in game output, split them into their item descriptions
-      sub_contents = contents.last.split(/ and (?:a|an|some) /)
+      sub_contents = contents.pop.split(/ and (?:a|an|some) /)
       
       # Tack those last two items back onto our item list array
       contents = contents.concat(sub_contents)

--- a/common-items.lic
+++ b/common-items.lic
@@ -756,11 +756,12 @@ module DRCI
       # Get string of just the comma separated item list
       contents = contents.match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]      
       
-      # Strip a, an, or some, and leading spaces from each item, split into array of items
-      # The last two items in the rummage list are not comma delimited, handle below
+      # Split at a, an, or some, but only when it follows a comma
+      # The last two items in the rummage list are never comma delimited, handle shortly
       contents = contents.split(/, (?:a|an|some) /)      
       
-      # Grab the last array element which is the final two item, split them
+      # Grab the last array element which is the final two items that are never comma
+      # delimited in game output, split them into their item descriptions
       sub_contents = contents.last.split(/ and (?:a|an|some) /)
       
       # Tack those last two items back onto our item list array


### PR DESCRIPTION
Addresses issue #4972 where sell-loot was identifying metal/stone deeds as sellable stones when the yaml setting `sell_loot_metals_and_stones` is true. As indicated in the issue comments, the problem was in DRCI's methods to obtain a list of items from rummaging a container.

Steps to recreate the issue:

1. Visit the forging society, buy a packet of deed claim forms and a small oravir nugget. Push the nugget to the deed packet to create `a deed for a tiny oravir nugget`.
2. Make sure your `sell_loot_metals_and_stones` yaml setting is true and set a metals/stones container via yaml setting `sell_loot_metals_and_stones_container`.
3. Activate `;sell-loot` and watch as the script tries to sell `a tiny oravir nugget`.

The `;sell-loot` script utilizes DRCI's `get_item_list` to get a list of items in containers and then try to match for sellable stones or metals. 

With the deed in my backpack, a quick run of `;e echo DRCI.get_item_list('backpack')` shows the issue:

```
>;e echo DRCI.get_item_list('backpack')
--- Lich: exec1 active.
[exec1]>rummage my backpack
You rummage through a sturdy backpack and see a shining calavarite runestone marked with a 
symbol for Arc Light, <SNIP> a deed for a tiny oravir nugget, a shiny blue xibaryl runestone marked with 
a symbol for Calm and an apple.

[exec1: ["shining calavarite runestone marked with ", <SNIP> "deed for ", 
"tiny oravir nugget", "shiny blue xibaryl runestone marked with ", "symbol for Calm", "apple"]]
```

There are also other parsing issues in the same output.  The item `an ilmenite runestone marked with a symbol for Clear Vision` becomes:

```
"ilmenite runestone marked with ", "symbol for Clear Vision"
```

The issue is the array .split in DRCI's helper method `rummage_container`, which brute-forces a split of the container contents string at _any_ instances of `a|an|some`. This was likely done to split the last two items in the list, which are never comma-delimited in the game output, but here we need another way in order to avoid errors in parsing in the rest of the list.

```ruby
else
      contents
        .match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
        .split(/(?:, | and )?(?:a|an|some) /)
end
```

I am not super awesome at regex but I settled on the following:

```ruby
else
      # Get string of just the comma separated item list
      contents = contents.match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]      
      
      # Strip a, an, or some, and leading spaces from each item only if it follows a comma, split into array of items
      # The last two items in the rummage list are not comma delimited, handle below
      contents = contents.split(/, (?:a|an|some) /)      
      
      # Grab the last array element which is the final two items, split them
      sub_contents = contents.last.split(/ and (?:a|an|some) /)
      
      # Tack those last two items back onto our item list array
      contents = contents.concat(sub_contents)
end
```

Testing again with these changes:

```
[exec1: ["ilmenite runestone marked with a symbol for Clear Vision", "deed for a tiny oravir nugget"]]
```

A quick glance at `sell-loot`'s parsing of the return of DRCI's item list shows that it will only attempt to sell stones when the item starts with the size:

```ruby
materials_regex = /^(?<size>\w+) (?<material>#{(material_types).join('|')}) (?<noun>nugget|bar)$/i
```

And because we've properly captured the item now as a `deed for a tiny oravir nugget`, a test confirms it no longer tries to sell this item.

If someone wants to grab this file and just run it for a while to make sure no issues. I'm running it fine.