### PR TITLE
[script] [combat-trainer] wield from `doublestrike_trainables` when do doublestrike

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4546,13 +4546,13 @@ class GameState
 
   # Determine the weapon skill to equip offhand to perform a doublestrike maneuver.
   def determine_doublestrike_skill
-    options = @aiming_trainables
+    options = @doublestrike_trainables
     options -= [weapon_skill] # can't be your main hand skill, it's in your main hand
     options -= $twohanded_skills # can't be a twohanded skill, you need both hands
     options -= $aim_skills # can't use aimable weapons in your offhand
     options -= $martial_skills # shouldn't be brawling, you need a weapon in your offhand
-    echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
     options -= weapon_training.select { |skill, weapon| weapon == weapon_training[weapon_skill] }.keys # can't be same weapon that's equipped in your mainhand
+    echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -147,18 +147,23 @@ charged_maneuvers:
   Polearms: impale
   Dual Wield: doublestrike
 # If "Charged Maneuver" is set in your training_abilities, this setting
-# will prioritize dual wield attacks by temporarily wielding an "aiming trainable"
-# in your offhand when you're holding a one-handed weapon in your main hand.
-# If this is false then a charged manuever for your main hand weapon is used instead.
+# will attempt doublestrikes by temporarily wielding a "doublestrike trainable"
+# in your offhand when you're holding a "doublestrike trainable" in your main hand.
+# If this is false then doublestrikes are only attempted if you are a Barbarian using whirlwind.
+# If you already use "aiming trainables" to train multiple weapons when using a ranged weapon,
+# then this is a complementary setting to train multiple melee weapons.
 prioritize_maneuver_doublestrike: false
 # When prioritizing doublestrike maneuvers, this is the list
 # of melee one-handed skills that when equipped in your mainhand
-# you want to attempt a doublestrike with an aiming_trainables
-# weapon skill equipped in your offhand.
+# you want to attempt a doublestrike with another listed weapon skill
+# equipped in your offhand, assuming they aren't the same item (e.g. ristes).
 #
-# For example, if you use quarterstaves or polearms that require two hands
-# then those aren't suitable for doublestrikes. But if you use short staves
-# or short polearms like light spears then those are suitable for doublestrikes.
+# This setting is necessary if you use twohanded staves or polearms so
+# that you can opt them out of doublestrike attempts because they will
+# fail because the weapon itself requires two hands.
+# If you're able to use the weapon for an aiming trainable then it's
+# suitable to be a doublestrike trainable. This separate setting gives you control,
+# however, to use different weapons for aiming and doublestrike purposes.
 doublestrike_trainables:
   - Small Edged
   - Small Blunt


### PR DESCRIPTION
### Background
* Separated out from #5315
  - See comments [here](https://github.com/rpherbig/dr-scripts/pull/5315/commits/fbc1716093d8ffe83fb24a9c67e2de36e3774e84#r774010128) and [here](https://github.com/rpherbig/dr-scripts/pull/5315#issuecomment-1001705187)

### Changes
* Update `determine_doublestrike_skill` method to actually pick a skill from your `doublestrike_trainables:` setting (which often is the same as your `aimable_trainables:` but now the method ensures it's picking from your list of weapons you explicitly allowlisted for doublestrikes. The other method, `doublestrikable_weapon_skill?`, already was correctly looking at `doublestrike_trainables:`