### PR TITLE
[script] [common-arcana] handle spells that don't support `barrage` attack

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -211,7 +211,7 @@ module DRCA
     before.each { |action| DRC.bput(action['message'], action['matches']) }
 
     Flags.add('unknown-command', "Please rephrase that command")
-    Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that", "You do not know how to manipulate that pathway.")
+    Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that", "You do not know how to manipulate that pathway.", "You cannot BARRAGE with that spell.")
     Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell', 'There is nothing else to face')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -225,8 +225,9 @@ cast_messages:
 - You'll need to be using a weapon to BARRAGE your target.
 - You must have a fully developed target matrix to make a barrage attack.
 - You are unable to muster the energy to do that.
-# Elemental Barrage cast messages
 - You do not know how to manipulate that pathway.
+- You cannot BARRAGE with that spell.
+# Elemental Barrage cast messages
 - Heatless orange flames climb your .* before winking out of existance.
 - A shimmering silvery-blue glow quickly spreads from your hand to the tip of your .*, then quickly fades.
 - Tiny fingers of lightning course rapidly along your .*, disappearing almost immediately.


### PR DESCRIPTION
### Background
* Players can set `barrage: true` on TM spells they want to use a [barrage](https://elanthipedia.play.net/Elemental_barrage) attack with. However, not all spells support that attack and we're missing a match string for it.
* `common-arcana` doesn't interpret the message and so never casts the spell and subsequently leads to `combat-trainer` trying to prepare the next spell (which it can't because you're sitting there with the prior non-barrage-cast spell still preparing).

### Changes
* Add match when warrior mage tries to use barrage attack with a spell that doesn't support it: `You cannot BARRAGE with that spell.`