### PR TITLE
[script] [common] Rename hometown global variable; add another that is union of the regexes

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -3,12 +3,13 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common
 =end
 
-# The regular expressions supports colloquial shorthands.
+# Map of canonical town names to regular expressions that matches them.
+# The regular expressions support colloquial shorthands.
 # Utility to help identify the canonical town name based on arbitrary text.
 # For example, "Theren" for "Therenborough" and "Haven" for "Riverhaven".
 # It also handles missing apostrophes and the occasional space between names
 # like "merkresh" or "Mer'Kresh" or "ainghazal" or "Ain Ghazal".
-$HOMETOWN_REGEX = {
+$HOMETOWN_REGEX_MAP = {
   "Arthe Dale" => /^(arthe( dale)?)$/i,
   "Crossing" => /^(cross(ing)?)$/i,
   "Darkling Wood" => /^(darkling( wood)?)$/i,
@@ -38,7 +39,11 @@ $HOMETOWN_REGEX = {
   "Ain Ghazal" => /^(ain( )?ghazal)$/i
 }
 
-$HOMETOWN_LIST = $HOMETOWN_REGEX.keys
+# List of canonical town names, like 'Therenborough' and 'Langenfirth'.
+$HOMETOWN_LIST = $HOMETOWN_REGEX_MAP.keys
+
+# Union of regular expressions that match town names, like /^(theren(borough)?)$/i
+$HOMETOWN_REGEX = Regexp.union($HOMETOWN_REGEX_MAP.values)
 
 $ORDINALS = %w[first second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth sixteenth seventeenth eighteenth nineteenth twentieth]
 

--- a/common.lic
+++ b/common.lic
@@ -407,7 +407,7 @@ module DRC
   # like "merkresh" or "Mer'Kresh" or "ainghazal" or "Ain Ghazal".
   # Returns nil if unable to find a match.
   def get_town_name(text)
-    towns = $HOMETOWN_REGEX.select { |town, regex| regex =~ text }.keys
+    towns = $HOMETOWN_REGEX_MAP.select { |town, regex| regex =~ text }.keys
     if towns.length > 1
       DRC.message("Found multiple towns that match '#{text}': #{towns}")
       DRC.message("Using first town that matched: #{towns.first}")


### PR DESCRIPTION
### Background
* Per [feedback](https://github.com/rpherbig/dr-scripts/pull/5324/files#r775606933), want to reference a variable like `$HOMETOWN_REGEX` that is a regex that matches town names and their colloquialisms.

### Changes
* Rename `$HOMETOWN_REGEX` to `$HOMETOWN_REGEX_MAP`
* Add `$HOMETOWN_REGEX = Regexp.union($HOMETOWN_REGEX_MAP.values)`
* Add comments about purpose of the variables

### Tests
```
> ,e echo $HOMETOWN_LIST

--- Lich: exec1 active.

[exec1: ["Arthe Dale", "Crossing", "Darkling Wood", "Dirge", "Fayrin's Rest", "Leth Deriel", "Shard", "Steelclaw Clan", "Stone Clan", "Tiger Clan", "Wolf Clan", "Riverhaven", "Rossman's Landing", "Therenborough", "Langenfirth", "Fornsted", "Hvaral", "Ratha", "Aesry", "Mer'Kresh", "Throne City", "Hibarnhvidar", "Raven's Point", "Boar Clan", "Fang Cove", "Muspar'i", "Ain Ghazal"]]

--- Lich: exec1 has exited.
```
```
> ,e echo $HOMETOWN_REGEX

--- Lich: exec1 active.

[exec1: (?-mix:(?i-mx:^(arthe( dale)?)$)|(?i-mx:^(cross(ing)?)$)|(?i-mx:^(darkling( wood)?)$)|(?i-mx:^(dirge)$)|(?i-mx:^(fayrin'?s?( rest)?)$)|(?i-mx:^(leth( deriel)?)$)|(?i-mx:^(shard)$)|(?i-mx:^(steel( )?claw( clan)?)$)|(?i-mx:^(stone( clan)?)$)|(?i-mx:^(tiger( clan)?)$)|(?i-mx:^(wolf( clan)?)$)|(?i-mx:^(river|haven|riverhaven)$)|(?i-mx:^(rossman'?s?( landing)?)$)|(?i-mx:^(theren(borough)?)$)|(?i-mx:^(lang(enfirth)?)$)|(?i-mx:^(fornsted)$)|(?i-mx:^(hvaral)$)|(?i-mx:^(ratha)$)|(?i-mx:^(aesry)$)|(?i-mx:^(mer'?kresh)$)|(?i-mx:^(throne( city)?)$)|(?i-mx:^(hib(arnhvidar)?)$)|(?i-mx:^(raven'?s?( point)?)$)|(?i-mx:^(boar( clan)?)$)|(?i-mx:^(fang( cove)?)$)|(?i-mx:^(muspar'?i)$)|(?i-mx:^(ain( )?ghazal)$))]

--- Lich: exec1 has exited.
```
```
> ,e echo $HOMETOWN_REGEX_MAP

--- Lich: exec1 active.

[exec1: {"Arthe Dale"=>/^(arthe( dale)?)$/i, "Crossing"=>/^(cross(ing)?)$/i, "Darkling Wood"=>/^(darkling( wood)?)$/i, "Dirge"=>/^(dirge)$/i, "Fayrin's Rest"=>/^(fayrin'?s?( rest)?)$/i, "Leth Deriel"=>/^(leth( deriel)?)$/i, "Shard"=>/^(shard)$/i, "Steelclaw Clan"=>/^(steel( )?claw( clan)?)$/i, "Stone Clan"=>/^(stone( clan)?)$/i, "Tiger Clan"=>/^(tiger( clan)?)$/i, "Wolf Clan"=>/^(wolf( clan)?)$/i, "Riverhaven"=>/^(river|haven|riverhaven)$/i, "Rossman's Landing"=>/^(rossman'?s?( landing)?)$/i, "Therenborough"=>/^(theren(borough)?)$/i, "Langenfirth"=>/^(lang(enfirth)?)$/i, "Fornsted"=>/^(fornsted)$/i, "Hvaral"=>/^(hvaral)$/i, "Ratha"=>/^(ratha)$/i, "Aesry"=>/^(aesry)$/i, "Mer'Kresh"=>/^(mer'?kresh)$/i, "Throne City"=>/^(throne( city)?)$/i, "Hibarnhvidar"=>/^(hib(arnhvidar)?)$/i, "Raven's Point"=>/^(raven'?s?( point)?)$/i, "Boar Clan"=>/^(boar( clan)?)$/i, "Fang Cove"=>/^(fang( cove)?)$/i, "Muspar'i"=>/^(muspar'?i)$/i, "Ain Ghazal"=>/^(ain( )?ghazal)$/i}]

--- Lich: exec1 has exited.
```