### PR TITLE
[script][tip.lic] Allow decimals when tipping

### DIFF
--- a/tip.lic
+++ b/tip.lic
@@ -15,7 +15,7 @@ class Tip
       # Mirrors DR's mechanics of "tip <person> 10000 kron", and also allows "tip <person> 10000" and assumes coppers
       [
         { name: 'recipient', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'The recipent of your tip. Abbreviations ok.' },
-        { name: 'amount', regex: /^\d+$/i, variable: true, description: 'Numeric amount to tip, no commas (e.g. the number "100" in 100 kronars)' },
+        { name: 'amount', regex: /^([0-9]+(\.[0-9]*)?|\.[0-9]+)$/i, variable: true, description: 'Numeric amount to tip, no commas (e.g. the number "100" in 100 kronars)' },
         { name: 'currency', regex: Regexp.union($CURRENCY_REGEX_MAP.values), optional: true, variable: true, description: 'Optional currency. Abbreviations ok: kron, lirums, dokor' }         
       ],
       # Three required arguments - recipient, amount, denomination - plus a fourth optional argument - currency
@@ -23,7 +23,7 @@ class Tip
       # or "tip person 10 plat kron"
       [
         { name: 'recipient', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'The recipent of your tip. Abbreviations ok.' },
-        { name: 'amount', regex: /^\d+$/i, variable: true, description: 'Numeric amount to tip, no commas (e.g. the number "100" in 100 kronars)' },
+        { name: 'amount', regex: /^([0-9]+(\.[0-9]*)?|\.[0-9]+)$/i, variable: true, description: 'Numeric amount to tip, no commas (e.g. the number "100" in 100 kronars)' },
         { name: 'denomination', regex: Regexp.union($DENOMINATION_REGEX_MAP.values), variable: true, description: 'The denomination. Abbrevations ok. (e.g. plat, gold, silv)' },
         { name: 'currency', regex: Regexp.union($CURRENCY_REGEX_MAP.values), optional: true, variable: true, description: 'Optional currency. Abbreviations ok: kron, lirums, dokor' }
       ]

--- a/tip.lic
+++ b/tip.lic
@@ -15,7 +15,7 @@ class Tip
       # Mirrors DR's mechanics of "tip <person> 10000 kron", and also allows "tip <person> 10000" and assumes coppers
       [
         { name: 'recipient', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'The recipent of your tip. Abbreviations ok.' },
-        { name: 'amount', regex: /^([0-9]+(\.[0-9]*)?|\.[0-9]+)$/i, variable: true, description: 'Numeric amount to tip, no commas (e.g. the number "100" in 100 kronars)' },
+        { name: 'amount', regex: /^([0-9]+(\.[0-9]*)?|\.[0-9]+)$/i, variable: true, description: 'Numeric amount to tip, no commas, decimals ok (e.g. the number "100" in 100 kronars)' },
         { name: 'currency', regex: Regexp.union($CURRENCY_REGEX_MAP.values), optional: true, variable: true, description: 'Optional currency. Abbreviations ok: kron, lirums, dokor' }         
       ],
       # Three required arguments - recipient, amount, denomination - plus a fourth optional argument - currency
@@ -23,7 +23,7 @@ class Tip
       # or "tip person 10 plat kron"
       [
         { name: 'recipient', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'The recipent of your tip. Abbreviations ok.' },
-        { name: 'amount', regex: /^([0-9]+(\.[0-9]*)?|\.[0-9]+)$/i, variable: true, description: 'Numeric amount to tip, no commas (e.g. the number "100" in 100 kronars)' },
+        { name: 'amount', regex: /^([0-9]+(\.[0-9]*)?|\.[0-9]+)$/i, variable: true, description: 'Numeric amount to tip, no commas, decimals ok (e.g. the number "100" in 100 kronars)' },
         { name: 'denomination', regex: Regexp.union($DENOMINATION_REGEX_MAP.values), variable: true, description: 'The denomination. Abbrevations ok. (e.g. plat, gold, silv)' },
         { name: 'currency', regex: Regexp.union($CURRENCY_REGEX_MAP.values), optional: true, variable: true, description: 'Optional currency. Abbreviations ok: kron, lirums, dokor' }
       ]


### PR DESCRIPTION
When reviewing @KatoakDR 's update to `DRCM.convert_to_copper` to handle decimals, realized my `;tip` script also didn't handle decimals. Updated to accept decimal tip amounts. Katoak's adjustment to `convert_to_copper` allows us to do nothing more than allowing decimal amounts in the script.

I did structure the regex such that it can accept most formats of integer or float. 

Examples:

```
>;tip gild 1 bronze dok
--- Lich: tip active.
>
[tip]>tip gild 10 dokoras
```

```
>;tip gild 1. bronze dok
--- Lich: tip active.
>
[tip]>tip gild 10 dokoras
```

```
>;tip gild .01 plat
--- Lich: tip active.
[tip]>wealth

Debt:
  You owe 3 silver, 4 bronze, and 6 copper Dokoras to the Domain of Ilithi. (346 copper Dokoras)
  [You can pay off this debt in person at the respective provincial debt office or by calling for an urchin runner with BANK DEBT.]

Wealth:
  No Kronars.
  No Lirums.
  1 gold, 6 silver, 12 bronze, and 10 copper Dokoras (1,730 copper Dokoras).
>
[tip]>tip gild 100 dokoras
```

```
>;tip gild 0.10 plat dok
--- Lich: tip active.
[tip]>tip gild 1000 dokoras
```