### PR TITLE
Updated Dragon Spine for TT82

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1285,6 +1285,26 @@ hunting_zones:
   - 2763
   - 2764
   - 2740
+  # https://elanthipedia.play.net/Snowbeast                               80-105
+  # Separated from granite gargoyles on Tuesday Tidings 82
+  snowbeasts_dragonspine:
+  - 2912
+  - 2914
+  - 2915
+  - 2920
+  - 2921
+  - 2919
+  - 2923
+  - 2924
+  - 2925
+  # https://elanthipedia.play.net/Snowbeast                               80-105
+  # Estate Holder Only
+  snowbeasts_grove:
+  - 9621
+  - 9627
+  - 9622
+  - 9625
+  - 9626
   # https://elanthipedia.play.net/Skeletal_kobold_savage                  85-110
   # https://elanthipedia.play.net/Skeletal_Kobold_Headhunter              85-110
   # https://elanthipedia.play.net/Zombie_Kobold_Savage                    85-110
@@ -1296,23 +1316,24 @@ hunting_zones:
   - 8114
   - 8113
   - 8108
-  - 8110
-  # https://elanthipedia.play.net/Snowbeast                               75-105
+  - 8110  
   # https://elanthipedia.play.net/Granite_gargoyle                        95-125
-  # Empath Caution: These are mixed live snowbeasts and construct gargoyles.
+  # Empaths: No longer mixed with snowbeasts and are now shock-free constructs
   granite_gargoyles:
-  - 2908
-  - 2909
-  - 2910
-  - 2911
-  - 2915
-  - 2919
-  - 2916
   - 2917
   - 2918
   - 2926
   - 2927
   - 2928
+  - 2929
+  - 2930
+  - 2933
+  - 2932
+  - 2931
+  - 2934
+  - 2935
+  - 2936
+  - 2937
   # https://elanthipedia.play.net/Blue-belly_crocodile                   100-140
   # Near Shard (Ilithi Province), NOT Zoluren Province
   blue_belly_crocs_shard:
@@ -1354,6 +1375,13 @@ hunting_zones:
   young_prereni_stones:
   - 12276
   - 12277
+  # https://elanthipedia.play.net/Frostweaver                            180-260
+  # Estate Holder Only
+  frostweaver_den:
+  - 9630  
+  - 9631
+  - 9632
+  - 9633  
   # https://elanthipedia.play.net/Blue-dappled_prereni_(1)               180-225
   # Crazy swarm, packed
   blue_dappled_prereni:


### PR DESCRIPTION
Area reworked by Tuesday Tidings.  Premie threshold fixed to make snowbeasts and frostweavers rooms viable plus standard live snowbeasts separated from gargoyle constructs.