### PR TITLE
Add base_noun to handle materials that change noun during crafting

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -18,11 +18,14 @@ class Enchant
     @bag = @settings.crafting_container
     @stamp = @settings.mark_crafted_goods
 
+
     arg_definitions = [
       [
-        { name: 'chapter', regex: /\d+/i, variable: true, description: 'Chapter containing the item.' },
-        { name: 'recipe', display: 'recipe name', regex: /^[A-z\s\-']+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
-        { name: 'noun', regex: /\w+/i, variable: true }
+        { name: 'chapter', regex: /\d+/i, variable: true, description: 'Required: Chapter containing the item.' },
+        { name: 'recipe', display: 'recipe name', regex: /^[A-z\s\-']+$/i, variable: true, description: 'Required: Name of the recipe, wrap in double quotes if this is multiple words.' },
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Required: Noun of finished product, can wrap in double quotes if this is multiple words. Example: "small brazier"' },
+        { name: 'base_noun', regex: /\w+/i, variable: true, optional: true, description: 'Optional: Noun of base item that will change once started.  Example: short pole turns into a loop once placed on brazier.'  }
+
       ]
     ]
 
@@ -50,7 +53,8 @@ class Enchant
     end
 
     args = parse_args(arg_definitions)
-
+    
+    @baseitem = args.base_noun || args.noun
     @item = args.noun
     @chapter = args.chapter
     @recipe = args.recipe
@@ -91,23 +95,23 @@ class Enchant
     stow_item("#{@book_type} book")
     get_item(@brazier) if @use_own_brazier
 
-    case bput("get my #{@item} from my #{@bag}", 'You get a', 'That is far too dangerous')
+    case bput("get my #{@baseitem} from my #{@bag}", 'You get a', 'That is far too dangerous')
     when 'That is far too dangerous'
       clean_brazier
       empty_brazier
-      bput("get my #{@item} from my #{@bag}", 'You get a')
+      bput("get my #{@baseitem} from my #{@bag}", 'You get a')
     end
     2.times do
-      case bput("put my #{@item} on #{@brazier}", 'You glance down', 'With a flick', 'You must first clean', 'You put')
+      case bput("put my #{@baseitem} on #{@brazier}", 'You glance down', 'With a flick', 'You must first clean', 'You put')
       when 'With a flick', 'You put'
         waitrt?
         break
       when 'You must first clean'
         clean_brazier
         empty_brazier
-        bput("get my #{@item} from my #{@bag}", 'You get a')
+        bput("get my #{@baseitem} from my #{@bag}", 'You get a')
         2.times do
-          case bput("put my #{@item} on #{@brazier}", 'You glance down', 'With a flick', 'You put')
+          case bput("put my #{@baseitem} on #{@brazier}", 'You glance down', 'With a flick', 'You put')
           when 'With a flick', 'You put'
             waitrt?
             break


### PR DESCRIPTION
Some artificing products change names as they progress.  For example to make an augmenting loop you put a `short pole` on the brazier and with the first action, it immediately turns in to a `loop` for the remainder of the process.