### PR TITLE
[script] [T2] Following up on the conversation started in https://github.com/rpherb…

### DIFF
--- a/t2.lic
+++ b/t2.lic
@@ -121,7 +121,6 @@ before_dying do
   scripts.each do |script_name|
     stop_script(script_name) if Script.running?(script_name)
   end
-  # Don't bother releasing cyclic for NMU guilds
   DRCA.release_cyclics
 end
 

--- a/t2.lic
+++ b/t2.lic
@@ -122,7 +122,7 @@ before_dying do
     stop_script(script_name) if Script.running?(script_name)
   end
   # Don't bother releasing cyclic for NMU guilds
-  DRCA.release_cyclics unless %w[Commoner Barbarian Thief].include?(DRStats.guild)
+  DRCA.release_cyclics
 end
 
 $T2 = T2.new


### PR DESCRIPTION
…ig/dr-scripts/pull/5331, removing this check, as it's not used

The check in common-arcana already only releases cyclics active on a character. If no cyclic is active, no cyclic will be released in any case.