### PR TITLE
[data] [base-hunting] Removing 8355 because the room description causes a loot action on th…

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -3168,7 +3168,7 @@ hunting_zones:
   - 8325
   # https://elanthipedia.play.net/Suw_bizar                                70-90
   suw_bizar:
-  - 8355
+# - 8355 # because room has "stones" in the description
   - 8364
   - 8362
   - 8360


### PR DESCRIPTION
…e word stones

As reported on Discord.