### PR TITLE
[script][combat-trainer] Add support for sling ammo void-black spiral

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2980,9 +2980,9 @@ class AttackProcess
     @firing_check = 0
 
     # Monitor for ammo falling to ground after firing your ranged weapon.
-    # Tests: https://regex101.com/r/J5RsYD/8/
+    # Tests: https://regex101.com/r/HkIa8j/1
     # IMPORTANT: 'stone shard' must be listed before 'shard' and 'stone' in the pattern else won't match 'senci stone shard' correctly.
-    ammo_pattern = "(?<ammo>arrow|bolt|stone shard|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|blowgun dart|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment|talon|cork|button|core|pebble|geode|stub|pit|thimble|doorknob|cone|bell|hunk|piece|present|sleighbell|sprig|star|toy)s?"
+    ammo_pattern = "(?<ammo>arrow|bolt|stone shard|shard|rock|sphere|clump|coral|fist|holder|lump|patella|pellet|pulzone|quadrello|quarrel|quill|stone|stopper|verretto|blowgun dart|crumb|spine|mantrap spike|tiny dragon|icicle|fang|scale|grey-black spike|bacon strip|page|naga|thorn|fragment|talon|cork|button|core|pebble|geode|stub|pit|thimble|doorknob|cone|bell|hunk|piece|present|sleighbell|sprig|star|toy|spiral)s?"
     Flags.add('ct-ranged-ammo', "(you (?<action>fire|poach|snipe) an?|your) (?<prefix>[^\.!]*? )?#{ammo_pattern}(?<suffix> [^\.!]*?)?? (at|passes through)")
     Flags.add('ct-powershot-ammo', "With a loud twang, you let fly your #{ammo_pattern}!")
     Flags.add('ct-ranged-loaded', 'You reach into', 'You load', 'You carefully load', 'already loaded', 'in your hand')


### PR DESCRIPTION
Issue reported by Xelten [in Discord](https://discordapp.com/channels/745675889622384681/745675890242879671/926139424981549156).

Adding support for sling ammo `void-black spiral`. Updated regex Tests link.