### PR TITLE
Add Segue Support for Bards

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1870,13 +1870,20 @@ class SpellProcess
       echo("  Target found: #{data['target_enemy']}") if $debug_mode_ct
       fput("face #{data['target_enemy']}")
     end
-    if data['cyclic']
-      release_cyclics
-      game_state.casting_cyclic = true
-    end
+
     command = 'prep'
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']
+
+    if command == 'segue'
+      return if segue?(data['abbrev'], data['mana'])
+      command = 'prep'
+    end
+
+    if data['cyclic']
+      release_cyclics
+      game_state.casting_cyclic = true
+    end 
 
     if data['recast_every']
       if data['pet_type']

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -674,11 +674,6 @@ module DRCA
       return false
     end
     true
-    case match
-    when 'You must be performing a cyclic spell to segue from','It is too soon to segue','You are lacking the bardic flair'
-      return false
-    end
-    match
   end
 
   def check_discern(data, settings)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -615,14 +615,15 @@ module DRCA
     end
 
     cast_lifecycle_lambda.call('pre-prep', data, settings) if cast_lifecycle_lambda != nil
-    
-    if data['prep'] == 'segue' || data['prep_type'] == 'segue'
-      return if segue?(data['abbrev'], data['mana'])
-    end
 
     command = 'prep'
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']     
+    
+    if data['prep'] == 'segue' || data['prep_type'] == 'segue'
+      return if segue?(data['abbrev'], data['mana'])
+      command = 'prep'
+    end
 
     release_cyclics if data['cyclic']
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -603,18 +603,10 @@ module DRCA
       cast_spell({ 'abbrev' => 'cv', 'mana' => 1, 'prep_time' => 5 }, settings)
     end
 
-    release_cyclics if data['cyclic']
-    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
-    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
-
     if data['ritual']
       ritual(data, settings)
       return
     end
-
-    command = 'prep'
-    command = data['prep'] if data['prep']
-    command = data['prep_type'] if data['prep_type']
 
     if data['runestone_name']
       if !prepare_to_cast_runestone?(data, settings)
@@ -623,6 +615,19 @@ module DRCA
     end
 
     cast_lifecycle_lambda.call('pre-prep', data, settings) if cast_lifecycle_lambda != nil
+    
+    if data['prep'] == 'segue' || data['prep_type'] == 'segue'
+      return if segue?(data['abbrev'], data['mana'])
+    end
+
+    command = 'prep'
+    command = data['prep'] if data['prep']
+    command = data['prep_type'] if data['prep_type']     
+
+    echo data['cyclic']
+    release_cyclics if data['cyclic']
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")    
 
     return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
     DRCI.put_away_item?(data['runestone_name'], settings.runestone_storage) if DRCI.in_hands?(data['runestone_name'])
@@ -661,6 +666,15 @@ module DRCA
     cast_lifecycle_lambda.call('post-cast', data, settings) if cast_lifecycle_lambda != nil
 
     return spell_cast
+  end
+
+  def segue?(abbrev,mana)
+    match = DRC.bput("segue #{abbrev} #{mana}", get_data('spells').segue_messages)
+    case match
+    when 'You must be performing a cyclic spell to segue from','It is too soon to segue','You are lacking the bardic flair'
+      return false
+    end
+    match
   end
 
   def check_discern(data, settings)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -624,7 +624,6 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']     
 
-    echo data['cyclic']
     release_cyclics if data['cyclic']
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
     DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")    

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -669,7 +669,11 @@ module DRCA
   end
 
   def segue?(abbrev,mana)
-    match = DRC.bput("segue #{abbrev} #{mana}", get_data('spells').segue_messages)
+    case DRC.bput("segue #{abbrev} #{mana}", get_data('spells').segue_messages)
+    when 'You must be performing a cyclic spell to segue from','It is too soon to segue','You are lacking the bardic flair'
+      return false
+    end
+    true
     case match
     when 'You must be performing a cyclic spell to segue from','It is too soon to segue','You are lacking the bardic flair'
       return false

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -620,7 +620,7 @@ module DRCA
     command = data['prep'] if data['prep']
     command = data['prep_type'] if data['prep_type']     
     
-    if data['prep'] == 'segue' || data['prep_type'] == 'segue'
+    if command == 'segue'
       return if segue?(data['abbrev'], data['mana'])
       command = 'prep'
     end

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -3161,10 +3161,10 @@ rituals:
 #bard ability only
 segue_messages:
 # failure
-- You must be performing a cyclic spell to segue from
-- It is too soon to segue
-- You are lacking the bardic flair
-- You are already performing
+- ^You must be performing a cyclic spell to segue from
+- ^It is too soon to segue
+- ^You are lacking the bardic flair
+- ^You are already performing
 #success
 - ^You let your voice fade even as the pace
 - ^You release an accompaniment of elemental

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -3157,3 +3157,20 @@ rituals:
   - much too battered and beat up to extract any body parts from
   - renders it useless for butchering
   - prevents a meaningful dissection
+
+#bard ability only
+segue_messages:
+# failure
+- You must be performing a cyclic spell to segue from
+- It is too soon to segue
+- You are lacking the bardic flair
+- You are already performing
+#success
+- ^You let your voice fade even as the pace
+- ^You release an accompaniment of elemental
+- ^A few fleeting, soporific notes
+- ^You sing, purposely warbling
+- ^The final, quiet notes
+- ^The final words of the
+- ^The aethereal static subsides
+- ^As your rendition of


### PR DESCRIPTION
Part 1 of 3 common-arcana  
- Rearrange the order of operations slightly to support normal casting if Segue fails for any reason.
- Add Segue action with handling for failure.