### PR TITLE
Add toggle to release cyclic spells on low mana

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1583,12 +1583,8 @@ class SpellProcess
     return if game_state.casting
     return unless @training_spells
     return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
-    if DRStats.mana < @release_cyclic_threshold && @release_cyclic_on_low_mana == true
-      release_cyclics
-      return
-    elsif DRStats.mana < @training_spell_mana_threshold 
-      return      
-    end
+    release_cyclics if @release_cyclic_on_low_mana && DRStats.mana < @release_cyclic_threshold
+    return if DRStats.mana < @training_spell_mana_threshold 
 
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
                      .select { |skill| @training_spells[skill] }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1159,6 +1159,12 @@ class SpellProcess
 
     @training_spell_mana_threshold = settings.training_spell_mana_threshold
     echo("  @training_spell_mana_threshold: #{@training_spell_mana_threshold}") if $debug_mode_ct
+    
+    @release_cyclic_on_low_mana = settings.release_cyclic_on_low_mana
+    echo("  @release_cyclic_on_low_mana: #{@release_cyclic_on_low_mana}") if $debug_mode_ct
+
+    @release_cyclic_threshold = settings.release_cyclic_threshold
+    echo("  @release_cyclic_threshold: #{@release_cyclic_threshold}") if $debug_mode_ct
 
     @buff_spell_mana_threshold = settings.buff_spell_mana_threshold
     echo("  @buff_spell_mana_threshold: #{@buff_spell_mana_threshold}") if $debug_mode_ct
@@ -1577,7 +1583,12 @@ class SpellProcess
     return if game_state.casting
     return unless @training_spells
     return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
-    return if DRStats.mana < @training_spell_mana_threshold
+    if DRStats.mana < @release_cyclic_threshold && @release_cyclic_on_low_mana == true
+      release_cyclics
+      return
+    elsif DRStats.mana < @training_spell_mana_threshold 
+      return      
+    end
 
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
                      .select { |skill| @training_spells[skill] }

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -384,6 +384,10 @@ combat_spell_timer: 45
 offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50
 buff_spell_mana_threshold: 40
+# release any cyclic on low mana
+release_cyclic_on_low_mana: false
+# release any cyclic when below this mana threshold
+release_cyclic_threshold: 30
 # don't cast ;buff waggles without this much mana or concentration
 waggle_spells_mana_threshold: 40
 # concentration can be 0 to remove the conc check but it cannot be blank.  Must be an integer.


### PR DESCRIPTION
Low mana can seriously hinder training or survivability.  One of the biggest offenders for bad mana are mana-heavy cyclics.  This feature allows to the user to toggle off the drain.

-  Updated to combat-trainer training section.  
  -  Chose this location because it triggers often and is the section most impacted by low mana.
-  Add default values to base.
  -  `release_cyclic_on_low_mana` default toggle is false to mimic current behavior.
  -  `release_cyclic_threshold` default value set to 30 to allow some margin of flexibility of account for the initial mana cost of a buff or training spell.
