### PR TITLE
Update Osrel infuse mana check

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -23,7 +23,7 @@ module DRCA
     failure = ['as if it hungers for more', 'Your infusion fails completely', 'You don\'t have enough harnessed mana to infuse that much', 'You have no harnessed']
 
     loop do
-      pause 5 while mana <= amount
+      pause 5 while mana <= 40
       harness_mana([amount]) if harness
       break if success.include?(DRC.bput("infuse om #{amount}", success, failure))
       pause 0.5


### PR DESCRIPTION
Original `pause 5 while mana <= amount` can cause combat trainer to pause indefinitely with no error message if the infuse amount is at 100 or greater.  
- The mana pool is a percentage not an actual mana amount so `infuse om 100` is asking to infuse exactly 100 streams not 100% and is possible.  
- Updating to 40 makes it check 40% which is likely going to be more than 100 streams for any cleric that already manage to harness/use 100 streams at once.
- Worst case a too-large infuse will trigger an actionable game message for the user to address instead of the absolutely nothing that currently causes much frustration.