### PR TITLE
[script][smith.lic] Fix instance variable

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -95,7 +95,7 @@ class Smith
       case bput("look my #{ord} oil in #{@container}", /thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
       when /thick and syrupy substance that easily coats and lubricates metal/
         return if ord == 'first'
-        bput("get my #{ord} oil in #{container}", /You get/)
+        bput("get my #{ord} oil in #{@container}", /You get/)
         bput("put oil in my #{@container}", 'You put')
         return
       when /I could not find what you were referring to/


### PR DESCRIPTION
Crafting container called as local instead of instance variable. Fixed.

Reported [by chawtlepot](https://discordapp.com/channels/745675889622384681/745678330933805157/926835146127179866) in Discord.