### PR TITLE
Add arg to check song and exit

### DIFF
--- a/performance.lic
+++ b/performance.lic
@@ -12,7 +12,8 @@ class Performance
     start_time = Time.new.to_i
     arg_definitions = [
       [
-        { name: 'noclean', regex: /noclean/i, optional: true, description: 'Skip cleaning your instrument' }
+        { name: 'noclean', regex: /noclean/i, optional: true, description: 'Skip cleaning your instrument' },
+        { name: 'checksong', regex: /checksong/i, optional: true, description: 'Only check what song to play for best learning then exit.' }
       ]
     ]
 
@@ -21,6 +22,7 @@ class Performance
     @settings = get_settings
     @song_list = get_data('perform').perform_options
     skip_clean = args.noclean
+    check_song_only = args.checksong
 
     instrument = @settings.instrument
     is_instrument_worn = instrument.nil?
@@ -37,6 +39,7 @@ class Performance
     end
 
     return unless DRC.play_song?(@settings, @song_list, is_instrument_worn, skip_clean)
+    exit if check_song_only
 
     loop do
       run_time = Time.new.to_i - start_time


### PR DESCRIPTION
Many people use UserVars.song to train performance in a variety of scripts these days but still have to run ;performance from time to time in order to check their song choice.  This allows the user to leverage the common method (which is awesome) and exit immediately instead of having to sit through an entire song first.