### PR TITLE
combat-trainer.lic - tend_lodged fails when whirlwinding

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1060,7 +1060,9 @@ class SafetyProcess
 
   def tend_lodged
     return unless Flags['ct-lodged']
+    game_state.sheath_whirlwind_offhand
     bind_wound(Flags['ct-lodged'][:body_part])
+    game_state.wield_whirlwind_offhand
     Flags.reset('ct-lodged')
   end
 


### PR DESCRIPTION
Added the standard sheath/wield whirlwind_offhand commands to the tend_lodged method. Without this when whirlwinding, tend_lodged will fail due to hands being full.