### PR TITLE
[script] [levelup] Accept any town arg that `DRC.get_town_name` supports

### DIFF
--- a/levelup.lic
+++ b/levelup.lic
@@ -9,7 +9,7 @@ class LevelUp
   def initialize
     arg_definitions = [
       [
-        { name: 'town', regex: /\w+/, optional: true, description: 'Town where to find guild' }
+        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town where to find guild' }
       ]
     ]
     args = parse_args(arg_definitions)

--- a/levelup.lic
+++ b/levelup.lic
@@ -5,36 +5,52 @@
 custom_require.call(%w[common common-travel drinfomon])
 
 class LevelUp
-  include DRC
-  include DRCT
-
-  def guildleader_info
-    settings = get_settings
-    hometown = settings.hometown
-    guild_leaders = get_data('town')[hometown]['guild_leaders']
-
-    guild_leaders[DRStats.guild]
-  end
 
   def initialize
-    info = guildleader_info
-    name = info['name']
-    room = info['id']
+    arg_definitions = [
+      [
+        { name: 'town', regex: /\w+/, optional: true, description: 'Town where to find guild' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
 
-    unless name
-      echo "Could not find a guild leader name for guild '#{DRStats.guild}'"
+    settings = get_settings
+
+    town = DRC.get_town_name(args.town || settings.hometown)
+    guild = DRStats.guild
+
+    guild_leader_info = get_guild_leader_info(town, guild)
+    guild_leader = guild_leader_info['name']
+    guild_room = guild_leader_info['id']
+
+    if args.town && !town
+      DRC.message("Could not identify town for argument: #{args.town}")
+      DRC.message("To avoid ambiguity, please use the town's full name: https://elanthipedia.play.net/Category:Cities")
       exit
     end
 
-    unless room
-      echo "Could not find a guild leader room for guild '#{DRStats.guild}'"
+    unless guild_leader
+      DRC.message("Could not find a guild leader name for guild '#{guild}' in town '#{town}'")
       exit
     end
 
-    walk_to(room)
+    unless guild_room
+      DRC.message("Could not find a guild leader room for guild '#{guild}' in town '#{town}'")
+      exit
+    end
 
+    DRCT.walk_to(guild_room)
+
+    ask_guild_leader_about_circle(guild_leader, guild)
+  end
+
+  def get_guild_leader_info(town, guild)
+    get_data('town')[town]['guild_leaders'][guild]
+  end
+
+  def ask_guild_leader_about_circle(guild_leader, guild)
     loop do
-      case bput("ask #{name} about circle",
+      case DRC.bput("ask #{guild_leader} about circle",
         'You are ready to train for your next level',
         'To whom are you speaking',
         'You have some work to do',
@@ -57,13 +73,14 @@ class LevelUp
         'You are ready for the next step down the road though',
         'Esuin starts to speak and then looks at you with concern',
         'Excellent.  The inner fire burns bright within',
-        'Anything to make a Dokora')
+        'Anything to make a Dokora',
+        'means to congratulate you for rising another circle'
+      )
       when 'you still have an outstanding task which you must complete', "you don't deserve to ever get promoted again"
-        echo '***Unable to circle, do you need to complete a quest?***'
+        DRC.message('*** Unable to circle, do you need to complete a quest? ***')
         break
       when 'To whom are you speaking'
-        echo "***Guild info is invalid for guild '#{DRStats.guild}'***"
-        echo 'Please file an issue on GitHub with a log of this problem: https://github.com/rpherbig/dr-scripts/issues'
+        DRC.message("*** Did not find #{guild} guild leader #{guild_leader}. This may be an issue with Lich base-town data. ***")
         break
       when 'You have some work to do', 'You have a bit more work to do', 'he shakes his head at you and says', 'you\'re just not quite ready', 'you have some work to do'
         break


### PR DESCRIPTION
### Background
* `levelup` uses your hometown setting to locate a guild leader and try to circle
* However, you may want to circle when you're traveling outside your hometown

### Changes
* Add an optional `town` argument to specify where you want to travel to circle
* Use `DRC.message` instead of `echo` to display warnings/errors
* Add match string `means to congratulate you for rising another circle` for Necromancer guild
* Remove `include` and instead qualify method calls with `DRC` or `DRCT`

### Usage
_Travel to your hometown and try to circle_
```
>,levelup
```
_Travel to specified town and try to circle there_
```
>,levelup haven
```