### PR TITLE
[script] [common-items] Update regex patterns with anchors

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -22,120 +22,124 @@ module DRCI
   ]
 
   @@drop_trash_failure_patterns = [
-    /What were you referring to/,
-    /I could not find/,
-    /But you aren't holding that/,
-    /You're kidding, right/,
-    /You can't do that/,
-    /No littering/,
-    /Where do you want to put that/,
-    /You really shouldn't be loitering/,
+    /^What were you referring to/,
+    /^I could not find/,
+    /^But you aren't holding that/,
+    /^You're kidding, right/,
+    /^You can't do that/,
+    /^No littering/,
+    /^Where do you want to put that/,
+    /^You really shouldn't be loitering/,
     # You may get the next message if you've been cursed and unable to let go of items.
     # Find a Cleric to uncurse you.
-    /Oddly, when you attempt to stash it away safely/,
-    /You need something in your right hand/
+    /^Oddly, when you attempt to stash it away safely/,
+    /^You need something in your right hand/
   ]
 
   # Messages that when trying to drop an item you're warned.
   # To continue you must retry the command.
   @@drop_trash_retry_patterns = [
     # You may get the next message if the item would be damaged upon dropping.
-    /If you still wish to drop it/,
+    /^If you still wish to drop it/,
     /would damage it/,
     # You may get the next messages when an outdated item is updated upon use.
     # "Something appears different about the <item>, perhaps try doing that again."
     # Example: https://elanthipedia.play.net/Item:Leather_lotion
-    /Something appears different about/,
+    /^Something appears different about/,
     /perhaps try doing that again/
   ]
 
   @@worn_trashcan_verb_patterns = [
-    /You drum your fingers/,
-    /You pull a lever/,
-    /You poke your finger around/
+    /^You drum your fingers/,
+    /^You pull a lever/,
+    /^You poke your finger around/
   ]
 
   @@get_item_success_patterns = [
-    /You get/,
-    /You pick/,
-    /You pluck/,
-    /You slip/,
-    /You deftly remove/,
-    /You are already holding/,
-    /You fade in for a moment as you/
+    /^You get/,
+    /^You pick/,
+    /^You pluck/,
+    /^You slip/,
+    /^You deftly remove/,
+    /^You are already holding/,
+    /^You fade in for a moment as you/
   ]
 
   @@get_item_failure_patterns = [
     /already in your inventory/,
-    /You need a free hand/,
+    /^You need a free hand/,
     /needs to be tended to be removed/,
-    /You can't pick that up with your hand that damaged/,
-    /Your (left|right) hand is too injured/,
-    /You just can't/,
+    /^You can't pick that up with your hand that damaged/,
+    /^Your (left|right) hand is too injured/,
+    /^You just can't/,
     /push you over the item limit/,
-    /You stop as you realize the .* is not yours/,
-    /Get what/,
-    /I could not/,
-    /What were you/,
+    /^You stop as you realize the .* is not yours/,
+    /^Get what/,
+    /^I could not/,
+    /^What were you/,
     /rapidly decays away/,
     /cracks and rots away/
   ]
 
   @@wear_item_success_patterns = [
-    /You put/,
-    /You pull/,
-    /You sling/,
-    /You attach/,
-    /You strap/,
-    /You slide/,
-    /You spin/,
-    /You slip/,
-    /You place/,
-    /You hang/,
-    /You tug/,
-    /You toss one strap/,
-    /You carefully loop/,
-    /You work your way into/,
-    /slide effortlessly onto your/,
-    /You are already wearing/,
-    /You squeeze/,
-    /Gritting your teeth, you grip/
+    /^You put/,
+    /^You pull/,
+    /^You sling/,
+    /^You attach/,
+    /^You strap/,
+    /^You slide/,
+    /^You spin/,
+    /^You slip/,
+    /^You place/,
+    /^You hang/,
+    /^You tug/,
+    /^You struggle/,
+    /^You squeeze/,
+    /^You manage/,
+    /^You toss one strap/,
+    /^You carefully loop/,
+    /^You work your way into/,
+    /^You are already wearing/,
+    /^Gritting your teeth, you grip/,
+    /slide effortlessly onto your/
   ]
 
   @@wear_item_failure_patterns = [
-    /You can't wear/,
-    /You (need to|should) unload/,
+    /^You can't wear/,
+    /^You (need to|should) unload/,
     /close the fan/,
-    /You don't seem to be able to move/,
-    /Wear what/,
-    /I could not/,
-    /What were you/
+    /^You don't seem to be able to move/,
+    /^Wear what/,
+    /^I could not/,
+    /^What were you/
   ]
 
   @@remove_item_success_patterns = [
-    /You remove/,
-    /You detach/,
-    /You sling/,
-    /You slide/,
-    /You take off/,
-    /You loosen/,
-    /You untie/,
-    /You tug/,
+    /^You remove/,
+    /^You detach/,
+    /^You sling/,
+    /^You slide/,
+    /^You take/,
+    /^You loosen/,
+    /^You untie/,
+    /^You tug/,
+    /^You struggle/,
+    /^The .* slide/,
+    /^You .* slide/,
+    /^Dropping your shoulder/,
+    /^Without any effort/,
     /as you remove/,
-    /Dropping your shoulder/,
-    /The leather gauntlets slide/,
-    /Without any effort/,
     /you manage to loosen/,
     /slide themselves off of your/
   ]
 
   @@remove_item_failure_patterns = [
-    /You need a free hand/,
-    /You aren't wearing/,
-    /You don't seem to be able to move/,
-    /Remove what/,
-    /I could not/,
-    /What were you/
+    /^You need a free hand/,
+    /^You aren't wearing/,
+    /^You don't seem to be able to move/,
+    /^Remove what/,
+    /^I could not/,
+    /^What were you/
   ]
 
   @@put_away_item_success_patterns = [
@@ -149,7 +153,7 @@ module DRCI
     /nods toward you as your .* falls into the .* bin/,
     /^You add/,
     /^You rearrange/,
-    /You combine the stacks/,
+    /^You combine the stacks/,
     # The following are success messages for putting an item in a container OFF your person.
     /^You drop/i,
     /^You set/i,
@@ -161,23 +165,23 @@ module DRCI
     /^Please rephrase that command/,
     /^What were you referring to/,
     /^I could not find what you were referring to/,
+    /^There isn't any more room in/,
+    /^There's no room/,
+    /^(The|That).* too heavy to go in there/,
+    /^You (need to|should) unload/,
+    /^You can't do that/,
+    /^You just can't get/,
+    /^You can't put items/,
+    /^You can only take items out/,
+    /^Perhaps you should be holding that first/,
+    /^Containers can't be placed in/,
+    /^The .* is not designed to carry anything/,
+    /^You can't put that.*there/,
     /even after stuffing it/,
     /is too .* to (fit|hold)/,
-    /close the fan/,
     /no matter how you arrange it/,
-    /There isn't any more room in/,
-    /There's no room/,
+    /close the fan/,
     /to fit in the/,
-    /too heavy to go in there/,
-    /You (need to|should) unload/,
-    /You can't do that/,
-    /You just can't get/,
-    /You can't put items/,
-    /You can only take items out/,
-    /Perhaps you should be holding that first/,
-    /Containers can't be placed in/,
-    /The .* is not designed to carry anything/,
-    /You can't put that.*there/,
     # You may get the next message if you've been cursed and unable to let go of items.
     # Find a Cleric to uncurse you.
     /Oddly, when you attempt to stash it away safely/,
@@ -211,15 +215,28 @@ module DRCI
   ]
 
   @@rummage_success_patterns = [
-    /You rummage through .* and see (.*)\./,
-    /In the .* you see (.*)\./,
+    /^You rummage through .* and see (.*)\./,
+    /^In the .* you see (.*)\./,
     /there is nothing/i
   ]
 
   @@rummage_failure_patterns = [
-    /I could not find/,
-    /I don't know what you are referring to/,
-    /What were you referring to/
+    /^I could not find/,
+    /^I don't know what you are referring to/,
+    /^What were you referring to/
+  ]
+
+  @@tap_success_patterns = [
+    /^You tap .*/, # The `.*` is needed to capture entire phrase. Methods parse it to know if an item is worn, stowed, etc.
+    /^You (thump|drum) your finger/, # You tapped an item with fancy verbiage, ohh la la!
+    /^The orb is delicate/, # You tapped a favor orb
+    /^You .* on the shoulder/ # You tapped someone
+  ]
+
+  @@tap_failure_patterns = [
+    /^I could not find/,
+    /^I don't know what you are referring to/,
+    /^What were you referring to/
   ]
 
   @@open_container_success_patterns = [
@@ -337,7 +354,7 @@ module DRCI
   #########################################
 
   def search?(item)
-    /Your .* is in/ =~ DRC.bput("inv search #{item}", 'You can\'t seem to find anything that looks like that', 'Your .* is in')
+    /Your .* is in/ =~ DRC.bput("inv search #{item}", /^You can't seem to find anything/, /Your .* is in/)
   end
 
   # Taps items to check if you're wearing it.
@@ -352,7 +369,12 @@ module DRCI
 
   # Taps an item to confirm it exists.
   def exists?(item, container = nil)
-    tap(item, container) =~ /You tap|You (thump|drum) your fingers|The orb is delicate/
+    case tap(item, container)
+    when *@@tap_success_patterns
+      true
+    else
+      false
+    end
   end
 
   # Taps an item and returns the match string.
@@ -360,7 +382,7 @@ module DRCI
   def tap(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
-    DRC.bput("tap my #{item} #{from}", 'You tap .*', 'atop your', 'I could not find', 'on the shoulder', '^You (thump|drum) your fingers', 'The orb is delicate')
+    DRC.bput("tap my #{item} #{from}", *@@tap_success_patterns, *@@tap_failure_patterns)
   end
 
   def in_hands?(item)
@@ -407,8 +429,8 @@ module DRCI
     item = item.delete_prefix('my ')
     preposition = 'in my' if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
 
-    case DRC.bput("look at my #{item} #{preposition} #{container}", "#{item}", 'You see nothing unusual', 'I could not find', 'What were you referring to')
-    when 'You see nothing unusual', "#{item}"
+    case DRC.bput("look at my #{item} #{preposition} #{container}", item, /^You see nothing unusual/, /^I could not find/, /^What were you referring to/)
+    when /You see nothing unusual/, item
       true
     else
       false
@@ -633,8 +655,8 @@ module DRCI
 
   # Removes an item you're wearing.
   def remove_item_unsafe?(item)
-    case DRC.bput("remove #{item}", /You .*#{item}/i, @@remove_item_success_patterns, @@remove_item_failure_patterns)
-    when /You .*#{item}/i, *@@remove_item_success_patterns
+    case DRC.bput("remove #{item}", @@remove_item_success_patterns, @@remove_item_failure_patterns)
+    when *@@remove_item_success_patterns
       return true
     else
       return false

--- a/test/test_common_items.rb
+++ b/test/test_common_items.rb
@@ -96,6 +96,8 @@ class TestDRCI < Minitest::Test
       [
         # Don't see it the first time, so the script will need to look in the portal
         "What were you referring to?",
+        # You open the portal
+        "You open your swirling eddy.",
         # You look in the portal
         "In the swirling eddy you see a bloodwood branch.",
         # The retry attempt now gets the item


### PR DESCRIPTION
### Background
* General code review and cleanup
* Fix missing match string when remove item for `You take some`

### Changes
* Add start anchor to most regex matches where applicable
* Add some missing match strings for wearing/removing items
* Remove unnecessary code by removing `/You .*#{item}/i` from `remove_item_unsafe?` as the pattern was never matching to begin with when invoked from `remove_item_safe?` because the item was prefixed with "my" (e.g. `You .*my boots`) _and_ so the `@@remove_item_success_patterns` is what actually matches
* Consolidate duplicated code by creating `@@tap_success_patterns` and `@@tap_failure_patterns`