### PR TITLE
[script][bescort]Removing stowing into containers, as that can cause problems getting …

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -969,7 +969,6 @@ class Bescort
     EquipmentManager.new.empty_hands
     settings = get_settings
     footwear = settings.footwear
-    containers = settings.storage_containers
     move_fast = false
     footwear_removed = false
     skates_worn = false
@@ -977,7 +976,7 @@ class Bescort
     if DRCI.exists?("skates")
       # If I don't have footwear, or I removed them, then they're off
       footwear_removed = !footwear || DRCI.remove_item?(footwear)
-      DRCI.put_away_item?(footwear, containers) # may fail, but they'll just be in our hands until the end
+      DRCI.put_away_item?(footwear) # may fail, but they'll just be in our hands until the end
   
       # Nothing on out feet, try to get and wear the skates
       if footwear_removed
@@ -987,7 +986,7 @@ class Bescort
           else
             # Couldn't wear them for some reason
             # You might be wearing something and `footwear:` config is incorrect
-            DRCI.put_away_item?("skates", containers)
+            DRCI.put_away_item?("skates")
           end
         end
       end
@@ -1006,7 +1005,7 @@ class Bescort
 
     if skates_worn
       DRCI.remove_item?("skates")
-      DRCI.put_away_item?("skates", containers)
+      DRCI.put_away_item?("skates")
     end
 
     if footwear && footwear_removed


### PR DESCRIPTION
…them back from an eddy

So, turns out if we require containers we run into a few problems. Number 1 being that they default to empty, not nil, as expected. Number 2, that if we specify an eddy to put skates into because someone uses that in their storage_container, we can't get the skates back out of the eddy... We're fixing problem 1, somehow. But problem 2 is an issue because we don't have a skate_storage_container, nor do I think we need one, so let's just stow it.