### PR TITLE
[new script][log]Adding a version for us here. Modified from the original to prepend d…

### DIFF
--- a/log.lic
+++ b/log.lic
@@ -1,0 +1,66 @@
+=begin
+
+	logs the game to lich\logs\<game code>-<char name>\<date>-<number>.log
+	starts a new file after 30,000 lines (somewhere around 1mb)
+
+	 author: Tillmen (tillmen@lichproject.org)
+	   game: any
+	version: 0.3
+
+	changelog:
+		0.3 (2022-01-04):
+			prepend datetime stamps to logged lines
+		0.2 (2015-01-13):
+			create log directory if needed
+
+=end
+
+unless defined?(script.want_script_output)
+	echo 'your version of Lich is too old for this script'
+	exit
+end
+
+unless $SAFE == 0
+	echo 'this script must be trusted to work (;trust log)'
+	exit
+end
+
+hide_me
+
+script.want_script_output = true
+script.want_upstream = true
+
+Thread.new {
+	begin
+		loop {
+			script.downstream_buffer.push ">#{upstream_get.sub(/^<c>/, '')}"
+		}
+	rescue
+		echo $!
+	end
+}
+
+Dir.mkdir("#{$lich_dir}logs") unless File.exists?("#{$lich_dir}logs")
+dir = "#{$lich_dir}logs/#{XMLData.game}-#{XMLData.name}"
+Dir.mkdir(dir) unless File.exists?(dir)
+
+loop {
+	num = 1
+	filename = "#{dir}/#{Time.now.strftime("%Y-%m-%d")}-#{num}.log"
+	filename = "#{dir}/#{Time.now.strftime("%Y-%m-%d")}-#{num+=1}.log" while File.exists?(filename)
+	file = File.open(filename, 'a')
+	file.sync = true
+	file.puts "#{Time.now.strftime("%Y-%m-%d %I:%M%P").sub(/0([0-9]+\:)/) {"#{$1}"}}\n"
+	file.puts(reget) if (Time.now - $login_time) < 30
+	begin
+		30000.times {
+			line = get
+ 			unless line =~ /^<(?:push|pop)Stream/
+				file.puts "#{Time.now.strftime("%F %T %Z")}: #{line}"
+			end
+		}
+		file.puts "#{Time.now.strftime("%Y-%m-%d %I:%M%P").sub(/0([0-9]+\:)/) {"#{$1}"}}\n"
+	ensure
+		file.close rescue()
+	end
+}


### PR DESCRIPTION
…ate/time stamps to every line

It''s the same one from ;repos, but with date/time stamps prepended to every line. It's a nicer way to log than what profanity/front ends do, I think, since the logging is in lich itself now, and you can run headless.