### PR TITLE
[script] [common-items] Cleanup code for some "count" methods

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -469,7 +469,7 @@ module DRCI
   end
 
   def count_items(item)
-    /inside your (.*).|I could not find/ =~ DRC.bput("tap my #{item}", 'inside your (.*).', 'atop your', 'I could not find')
+    /inside your (.*)/ =~ tap(item)
     container = Regexp.last_match(1)
     return 0 if container.nil?
     count_items_in_container(item, container)
@@ -777,16 +777,16 @@ module DRCI
       rummage_container(container)
     else
       # Get string of just the comma separated item list
-      contents = contents.match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]      
-      
+      contents = contents.match(/You rummage through .* and see (?:a|an|some) (?<items>.*)\./)[:items]
+
       # Split at a, an, or some, but only when it follows a comma
       # The last two items in the rummage list are never comma delimited, handle shortly
-      contents = contents.split(/, (?:a|an|some) /)      
-      
+      contents = contents.split(/, (?:a|an|some) /)
+
       # Grab the last array element which is the final two items that are never comma
       # delimited in game output, split them into their item descriptions
       sub_contents = contents.pop.split(/ and (?:a|an|some) /)
-      
+
       # Tack those last two items back onto our item list array
       contents = contents.concat(sub_contents)
     end

--- a/common-items.lic
+++ b/common-items.lic
@@ -468,6 +468,8 @@ module DRCI
     count
   end
 
+  # Counts items in a container that is inferred by first tapping the item.
+  # If you want to count items in a specific container, use `count_items_in_container(item, container)`
   def count_items(item)
     /inside your (.*)/ =~ tap(item)
     container = Regexp.last_match(1)
@@ -475,15 +477,20 @@ module DRCI
     count_items_in_container(item, container)
   end
 
+  # Counts items in a container.
+  # If you don't know which container the items are in, use `count_items(item)` to infer it.
   def count_items_in_container(item, container)
-    contents = DRC.bput("rummage /C #{item.split.last} IN MY #{container}", '^You rummage .*', 'That would accomplish nothing')
+    contents = DRC.bput("rummage /C #{item.split.last} in my #{container}", /^You rummage .*/, /That would accomplish nothing/)
     # This regexp avoids counting the quoted item name in the message, as
     # well as avoiding finding the item as a substring of other items.
     contents.scan(/ #{item}\W/).size
   end
 
+  # Identifies how many more lockpicks that the container can hold.
+  # Designed to work on lockpick stackers.
+  # https://elanthipedia.play.net/Lockpick_rings
   def count_lockpick_container(container)
-    count = DRC.bput("app my #{container}", 'and it appears to be full', 'and it might hold an additional \d+', '\d+ lockpicks would probably fit').scan(/\d+/).first.to_i
+    count = DRC.bput("appraise my #{container} quick", /it appears to be full/, /it might hold an additional \d+/, /\d+ lockpicks would probably fit/).scan(/\d+/).first.to_i
     waitrt?
     count
   end


### PR DESCRIPTION
### Background
* General code review and clean up

### Changes
* Added usage comments to `count_items`, `count_items_in_container`, and `count_lockpick_container`
* Appraise `quick` when identifying how many more lockpicks a lockpick stacker can hold to use less roundtime
* Line 472: Replaced code that duplicated functionality of `tap(item)` with a call to the method itself
* Lines below 700: Trimmed whitespace on file save

## Tests

### count items
```
> ,e echo DRCI.count_items('foo')

--- Lich: exec1 active.

[exec1]>tap my foo 

I could not find what you were referring to.

[exec1: 0]

--- Lich: exec1 has exited.
```
```
> ,e echo DRCI.count_items('bundling rope')

--- Lich: exec1 active.

[exec1]>tap my bundling rope 

You tap some bundling rope inside your encompassing shadows.

[exec1]>rummage /C rope IN MY encompassing shadows.

You rummage through some dark encompassing shadows of twilight dreamweave looking for something similar to "rope" and see a coil of heavy rope, some bundling rope and some bundling rope.

[exec1: 2]

--- Lich: exec1 has exited.
```
```
> ,e echo DRCI.count_items('silver razor')

--- Lich: exec1 active.

[exec1]>tap my silver razor 

You tap a silver razor inside your encompassing shadows.

[exec1]>rummage /C razor IN MY encompassing shadows.

You rummage through some dark encompassing shadows of twilight dreamweave looking for something similar to "razor" and see a silver razor, a silver razor, a silver razor and a silver razor.

[exec1: 4]

--- Lich: exec1 has exited.
```

### count_items_in_container
```
> ,e echo DRCI.count_items_in_container('rope', 'backpack')

--- Lich: exec1 active.

[exec1]>rummage /C rope in my backpack

You rummage through a rugged aqua backpack looking for something similar to "rope" but there is nothing in there like that.
 
[exec1: 0]

--- Lich: exec1 has exited.
```
```
> ,e echo DRCI.count_items_in_container('rope', 'shadows')

--- Lich: exec1 active.

[exec1]>rummage /C rope in my shadows

You rummage through some dark encompassing shadows of twilight dreamweave looking for something similar to "rope" and see a coil of heavy rope, some bundling rope and some bundling rope.
> 
[exec1: 3]

--- Lich: exec1 has exited.
```

### count_lockpick_container
_To prove that 'quick' didn't lose exactness, did appraisal on a Novice character with 0 ranks_
```
> ,e echo DRCI.count_lockpick_container('suede pouch')

--- Lich: exec1 active.

[exec1]>appraise my suede pouch quick

The suede pouch looks to be holding 12 lockpicks and it might hold an additional 38.
It appears that the suede pouch can be worn attached to a belt.
The suede pouch feels pretty light.
You believe that the suede pouch is probably worth around several thousand Kronars.
Roundtime: 5 seconds.

[exec1: 38]

--- Lich: exec1 has exited.
```