### PR TITLE
[script] [common-items] treat empty containers array as nil

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -557,6 +557,7 @@ module DRCI
   # If no container specified then generically grabs from the room/your person.
   # Can provide an array of containers to try, too, in case some might be empty.
   def get_item(item, container = nil)
+    container = nil if container.empty? # treat empty arrays as no container
     if container.is_a?(Array)
       container.each do |c|
         return true if get_item_safe(item, c)
@@ -820,6 +821,7 @@ module DRCI
   # If no container specified then uses the default stow location.
   # Can provide an array of containers to try, too, in case some might be full.
   def put_away_item?(item, container = nil)
+    container = nil if container.empty? # treat empty arrays as no container
     if container.is_a?(Array)
       container.each do |c|
         return true if put_away_item_safe?(item, c)


### PR DESCRIPTION
### Background
* A change to `bescort` was recently [reverted](https://github.com/rpherbig/dr-scripts/pull/5374) because the `common-items` methods to `get_item?(item, containers)` and `put_away_item?(item, containers)` did not handle empty arrays as nil, causing players to misplace or unable to get or put away their skates to travel the icy road between Shard and Hib

### Changes
* Treat `[]` as `nil` to mitigate code that calls `DRCI.put_away_item?(item, settings.storage_containers)` (or similar) with an empty array (as is often defaulted by `base-empty.yaml`) so that the code behaves as expected -- just get/stow the item.

### Tests
_get from empty array_
```
,e echo DRCI.get_item?('razor', [])
--- Lich: exec1 active.

[exec1]>get my razor 

You are already holding that.
> 
[exec1: true]

--- Lich: exec1 has exited.
```
_put in empty array_
```
> ,e echo DRCI.put_away_item?('razor', [])

--- Lich: exec1 active.

[exec1]>stow my razor

You put your razor in your encompassing shadows.
> 
[exec1: true]

--- Lich: exec1 has exited.
```
_get from nil_
```
> ,e echo DRCI.get_item?('razor', nil)

--- Lich: exec1 active.

[exec1]>get my razor 

You get a silver razor from inside your encompassing shadows.
> 
[exec1: true]

--- Lich: exec1 has exited.
```
_put in nil_
```
,e echo DRCI.put_away_item?('razor', nil)
--- Lich: exec1 active.

[exec1]>stow my razor

You put your razor in your encompassing shadows.
> 
[exec1: true]

--- Lich: exec1 has exited.
```
_get from non-empty array_
```
> ,e echo DRCI.get_item?('razor', ['foo', 'shadows'])

--- Lich: exec1 active.

[exec1]>get my razor from my foo

What were you referring to?
> 
[exec1]>get my razor from my shadows

You get a silver razor from inside your encompassing shadows.
> 
[exec1: true]

--- Lich: exec1 has exited.
```
_put in non-empty array_
```
> ,e echo DRCI.put_away_item?('razor', ['foo', 'shadows'])

--- Lich: exec1 active.

[exec1]>put my razor in my foo

What were you referring to?
> 
[exec1]>put my razor in my shadows

You put your razor in your encompassing shadows.
> 
[exec1: true]

--- Lich: exec1 has exited.
```