### PR TITLE
[script] [common-items] handle when moonblades dissipate when leave your hand

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -17,7 +17,7 @@ module DRCI
     /^You put/,
     /^You spread .* on the ground/,
     /smashing it to bits/,
-    # The next message is when item crumbles when dropped, like a moonblade.
+    # The next message is when item crumbles when leaves your hand, like a moonblade.
     /^As you open your hand to release the/
   ]
 
@@ -281,6 +281,19 @@ module DRCI
     /^But that's closed/,
     /^That is closed/,
     /^While it's closed/
+  ]
+
+  @@lower_success_patterns = [
+    /^You lower/,
+    # The next message is when item crumbles when leaves your hand, like a moonblade.
+    /^As you open your hand to release the/
+  ]
+
+  @@lower_failure_patterns = [
+    /^But you aren't holding anything/,
+    /^Please rephrase that command/,
+    /^What were you referring to/,
+    /^I could not find what you were referring to/
   ]
 
   #########################################
@@ -705,7 +718,12 @@ module DRCI
     return false unless in_hands?(item)
     item_regex = /\b#{item}\b/
     hand = (DRC.left_hand =~ item_regex) ? 'left' : 'right'
-    DRC.bput("lower ground #{hand}", "You lower", "But you aren't holding anything") =~ /You lower/
+    case DRC.bput("lower ground #{hand}", *@@lower_success_patterns, *@@lower_failure_patterns)
+    when *@@lower_success_patterns
+      true
+    else
+      false
+    end
   end
 
   #########################################


### PR DESCRIPTION
### Background
* Missing match string when lower a moon weapon (do match for this when drop items)
* Encountered this when `wand-watcher` ran in combat and lowered my moon weapon to free up my hands (for a future PR, perhaps had logic to scripts like wand-watcher that lower generic items to use `DRCMM.wear_moon_weapon?` for Moon Mages)

```
As you open your hand to release the moonblade, it dissipates into the shadows from whence it came.
```

### Changes
* Refactor `lower_item?` to use new success/failure regex patterns per convention of the other methods

### Tests
```
> ,e echo DRCI.lower_item?('black moonblade')

--- Lich: exec1 active.

[exec1]>lower ground right

As you open your hand to release the moonblade, it dissipates into the shadows from whence it came.

[exec1: true]

--- Lich: exec1 has exited.
```