### PR TITLE
[script] [common-items] handle opening or checking inventory on invalid items

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -256,7 +256,8 @@ module DRCI
     /^It would be a shame to disturb the silence of this place for that/,
     /^This is probably not the time nor place for that/,
     /^There is no way to do that/,
-    /^You can't do that/
+    /^You can't do that/,
+    /^Open what/
   ]
 
   @@close_container_success_patterns = [
@@ -749,8 +750,8 @@ module DRCI
   # Where <type> can be armor, weapon, fluff, container, or combat.
   # Where <slot> can be any phrase from INV SLOTS LIST command.
   def get_inventory_by_type(type = 'combat', line_count = 40)
-    case DRC.bput("inventory #{type}", "Use INVENTORY HELP for more options.", "The INVENTORY command is the best way")
-    when "The INVENTORY command is the best way"
+    case DRC.bput("inventory #{type}", /Use INVENTORY HELP for more options/, /The INVENTORY command is the best way/, /You can't do that/)
+    when /The INVENTORY command is the best way/, /You can't do that/
       DRC.message("Unrecognized inventory type: #{type}. Valid options are ARMOR, WEAPON, FLUFF, CONTAINER, COMBAT, or any slot from INVENTORY SLOTS LIST.")
       return []
     end


### PR DESCRIPTION
### Changes
* Add match string for `Open what?` when try to open a container but no container was specified or found
* Add match string for `You can't do that` when try to call `inventory <type>` on an invalid container
* Don't try to open a closed container if the original command was `stow <item>` and there is no known container to open