### PR TITLE
Add optional prayer_mat_storage

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2423,8 +2423,8 @@ class TrainerProcess
     @prayer_mat = settings.prayer_mat
     echo("  @prayer_mat: #{@prayer_mat}") if $debug_mode_ct
 
-    @prayer_mat_storage = settings.prayer_mat_storage || settings.theurgy_supply_container
-    echo("  @prayer_mat_storage: #{@prayer_mat_storage}") if $debug_mode_ct    
+    @prayer_mat_container = settings.prayer_mat_container || settings.theurgy_supply_container
+    echo("  @prayer_mat_container: #{@prayer_mat_container}") if $debug_mode_ct    
 
     @dirt_stacker = settings.dirt_stacker
     echo("  @dirt_stacker: #{@dirt_stacker}") if $debug_mode_ct
@@ -2697,7 +2697,7 @@ class TrainerProcess
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     unless bput(
-      "get #{@prayer_mat} from my #{@prayer_mat_storage}",
+      "get #{@prayer_mat} from my #{@prayer_mat_container}",
       'You get', 'What were you referring to'
     ) == 'You get'
       message '*** Cannot run PrayerMat; no prayer mat in theurgy_supply_container'
@@ -2722,7 +2722,7 @@ class TrainerProcess
     bput("roll #{@prayer_mat}",
          'carefully gather up',
          'need to be holding that first', 'not on the ground')
-    bput("put #{@prayer_mat} in my #{@prayer_mat_storage}",
+    bput("put #{@prayer_mat} in my #{@prayer_mat_container}",
          'You put', 'What were you referring to')
     @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2424,7 +2424,7 @@ class TrainerProcess
     echo("  @prayer_mat: #{@prayer_mat}") if $debug_mode_ct
 
     @prayer_mat_storage = settings.prayer_mat_storage || settings.theurgy_supply_container
-    echo("  @prayer_mat_storage: #{@prayer_mat_storage}") #if $debug_mode_ct    
+    echo("  @prayer_mat_storage: #{@prayer_mat_storage}") if $debug_mode_ct    
 
     @dirt_stacker = settings.dirt_stacker
     echo("  @dirt_stacker: #{@dirt_stacker}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2423,6 +2423,9 @@ class TrainerProcess
     @prayer_mat = settings.prayer_mat
     echo("  @prayer_mat: #{@prayer_mat}") if $debug_mode_ct
 
+    @prayer_mat_storage = settings.prayer_mat_storage || settings.theurgy_supply_container
+    echo("  @prayer_mat_storage: #{@prayer_mat_storage}") #if $debug_mode_ct    
+
     @dirt_stacker = settings.dirt_stacker
     echo("  @dirt_stacker: #{@dirt_stacker}") if $debug_mode_ct
 
@@ -2694,7 +2697,7 @@ class TrainerProcess
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     unless bput(
-      "get #{@prayer_mat} from my #{@theurgy_supply_container}",
+      "get #{@prayer_mat} from my #{@prayer_mat_storage}",
       'You get', 'What were you referring to'
     ) == 'You get'
       message '*** Cannot run PrayerMat; no prayer mat in theurgy_supply_container'
@@ -2719,7 +2722,7 @@ class TrainerProcess
     bput("roll #{@prayer_mat}",
          'carefully gather up',
          'need to be holding that first', 'not on the ground')
-    bput("put #{@prayer_mat} in my #{@theurgy_supply_container}",
+    bput("put #{@prayer_mat} in my #{@prayer_mat_storage}",
          'You put', 'What were you referring to')
     @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
   end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -413,6 +413,8 @@ last_rites: false
 warhorn:
 # noun of the prayer mat to use in training_abilities
 prayer_mat:
+# optional container to bypass default mat storage in theurgy_supply_container
+prayer_mat_container:
 paladin_use_mana_glyph: false
 paladin_use_badge: false
 # allow throwing offhand weapons


### PR DESCRIPTION
A prayer mat is significantly larger and more valuable than most theurgy items.  This optional field defaults to the same theurgy container or allows the user to define a specific container for added security/QOL.