### PR TITLE
Update to allow Forage Toggle

### DIFF
--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -52,7 +52,7 @@ class Outdoorsmanship
     start_exp = DRSkill.getxp(@skill_name)
     @end_exp = [start_exp + @targetxp, 34].min
 
-    DRCT.walk_to(@outdoors_room) if @outdoors_room
+    DRCT.walk_to(@outdoors_room)
     train_outdoorsmanship
   end
 

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -27,8 +27,6 @@ class Outdoorsmanship
     @training_spells = @settings.crafting_training_spells
     @targetxp = 4
     @targetxp = args.mindstates.to_i if args.mindstates
-    @worn_trashcan = @settings.worn_trashcan
-    @worn_trashcan_verb = @settings.worn_trashcan_verb
     @outdoors_room = @settings.outdoors_room
     if args.room
       room = args.room.split('=')[1]
@@ -64,7 +62,7 @@ class Outdoorsmanship
       if DRSkill.getrank('Outdoorsmanship') < 20 || @train_method == 'forage' 
         crafting_magic_routine(@settings)
         forage?(@forage_item)
-        DRCI.dispose_trash(@forage_item, @worn_trashcan, @worn_trashcan_verb)
+        DRCI.dispose_trash(@forage_item)
       else
         item = @forage_item
         crafting_magic_routine(@settings)

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -14,9 +14,10 @@ class Outdoorsmanship
       [
         { name: 'perception', regex: /perception/, optional: true, description: 'Optional: Check Perception skill in place of Outdoorsmanship' },
         { name: 'mindstates', regex: /^\d+/, optional: true, description: 'Optional: Number of mindstates or collection attempts to perform before exiting. Defaults to 3' },
-        { name: 'room', regex: /(room=(\d+))/, optional: true, description: 'Optional: Specific room to forage in - primarily used to locate a trash bin. Syntax:  room=1234'  },        
-        { name: 'collect_item', regex: /\w+/i, optional: true, description: 'Optional: Item to collect. Will use forage_item if not set. Wrap "multiple words" in double quotes.' },
-        { name: 'forage', regex: /forage/, optional: true, description: 'Optional: Default method is collect, specify forage to override. Forage is best used with a trash bin.' }
+        { name: 'room', regex: /(room=(\d+))/, optional: true, description: 'Optional: Specific room to forage in - primarily used to locate a trash bin. Syntax:  room=1234'  }, 
+        { name: 'forage', regex: /forage/, optional: true, description: 'Optional: Default method is collect, specify forage to override. Forage is best used with a trash bin.' },
+        { name: 'collect_item', regex: /\w+/i, optional: true, description: 'Optional: Item to collect. Will use forage_item if not set. Wrap "multiple words" in double quotes.' }
+        
       ]
     ]
     args = parse_args(arg_definitions)

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -27,6 +27,8 @@ class Outdoorsmanship
     @training_spells = @settings.crafting_training_spells
     @targetxp = 4
     @targetxp = args.mindstates.to_i if args.mindstates
+    @worn_trashcan = @settings.worn_trashcan
+    @worn_trashcan_verb = @settings.worn_trashcan_verb    
     @outdoors_room = @settings.outdoors_room
     if args.room
       room = args.room.split('=')[1]
@@ -62,7 +64,7 @@ class Outdoorsmanship
       if DRSkill.getrank('Outdoorsmanship') < 20 || @train_method == 'forage' 
         crafting_magic_routine(@settings)
         forage?(@forage_item)
-        DRCI.dispose_trash(@forage_item)
+        DRCI.dispose_trash(@forage_item, @worn_trashcan, @worn_trashcan_verb)
       else
         item = @forage_item
         crafting_magic_routine(@settings)

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#outdoorsmanship
 =end
 
-custom_require.call(%w[common common-items drinfomon common-arcana events])
+custom_require.call(%w[common common-items drinfomon common-arcana events common-travel])
 
 class Outdoorsmanship
   include DRC
@@ -12,9 +12,11 @@ class Outdoorsmanship
   def initialize
     arg_definitions = [
       [
-        { name: 'perception', regex: /perception/, optional: true, description: 'Check Perception skill in place of Outdoorsmanship' },
-        { name: 'mindstates', regex: /\d+/, optional: true, description: 'Number of mindstates or collection attempts to perform before exiting. Defaults to 3' },
-        { name: 'collect_item', regex: /\w+/i, optional: true, description: 'Item to collect. Will use forage_item if not set' }
+        { name: 'perception', regex: /perception/, optional: true, description: 'Optional: Check Perception skill in place of Outdoorsmanship' },
+        { name: 'mindstates', regex: /^\d+/, optional: true, description: 'Optional: Number of mindstates or collection attempts to perform before exiting. Defaults to 3' },
+        { name: 'room', regex: /(room=(\d+))/, optional: true, description: 'Optional: Specific room to forage in - primarily used to locate a trash bin. Syntax:  room=1234'  },        
+        { name: 'collect_item', regex: /\w+/i, optional: true, description: 'Optional: Item to collect. Will use forage_item if not set. Wrap "multiple words" in double quotes.' },
+        { name: 'forage', regex: /forage/, optional: true, description: 'Optional: Default method is collect, specify forage to override. Forage is best used with a trash bin.' }
       ]
     ]
     args = parse_args(arg_definitions)
@@ -24,30 +26,42 @@ class Outdoorsmanship
     @training_spells = @settings.crafting_training_spells
     @targetxp = 4
     @targetxp = args.mindstates.to_i if args.mindstates
+    @outdoors_room = @settings.outdoors_room
+    if args.room
+      room = args.room.split('=')[1]
+      @outdoors_room = room
+    end
+
+    @train_method = args.forage || @settings.outdoors_method
 
     @forage_item = if args.collect_item
                      args.collect_item
-                   else
+                   elsif @settings.forage_item
                      @settings.forage_item
+                   elsif DRSkill.getrank('Outdoorsmanship') < 20
+                     'rock'
                    end
+
     if args.perception
       @skill_name = 'Perception'
     else
       @skill_name = 'Outdoorsmanship'
     end
-    start_exp = DRSkill.getxp(@skill_name)
-    @end_exp = [start_exp + @targetxp, 29].min
 
+    start_exp = DRSkill.getxp(@skill_name)
+    @end_exp = [start_exp + @targetxp, 34].min
+
+    DRCT.walk_to(@outdoors_room) if @outdoors_room
     train_outdoorsmanship
   end
 
   def train_outdoorsmanship
     attempt = 0 # Failsafe counter to prevent an infinite loop if item isn't collectable in the room
     while (DRSkill.getxp(@skill_name) < @end_exp) && (attempt < @targetxp)
-      if DRSkill.getrank('Outdoorsmanship') < 20
+      if DRSkill.getrank('Outdoorsmanship') < 20 || @train_method == 'forage' 
         crafting_magic_routine(@settings)
-        forage?('rock')
-        dispose_trash 'rock'
+        forage?(@forage_item)
+        dispose_trash(@forage_item)
       else
         item = @forage_item
         crafting_magic_routine(@settings)

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -12,12 +12,11 @@ class Outdoorsmanship
   def initialize
     arg_definitions = [
       [
-        { name: 'perception', regex: /perception/, optional: true, description: 'Optional: Check Perception skill in place of Outdoorsmanship' },
-        { name: 'mindstates', regex: /^\d+/, optional: true, description: 'Optional: Number of mindstates or collection attempts to perform before exiting. Defaults to 3' },
-        { name: 'room', regex: /(room=(\d+))/, optional: true, description: 'Optional: Specific room to forage in - primarily used to locate a trash bin. Syntax:  room=1234'  }, 
-        { name: 'forage', regex: /forage/, optional: true, description: 'Optional: Default method is collect, specify forage to override. Forage is best used with a trash bin.' },
-        { name: 'collect_item', regex: /\w+/i, optional: true, description: 'Optional: Item to collect. Will use forage_item if not set. Wrap "multiple words" in double quotes.' }
-        
+        { name: 'perception', regex: /perception/, optional: true, description: 'Check Perception skill in place of Outdoorsmanship' },
+        { name: 'mindstates', regex: /^\d+/, optional: true, description: 'Number of mindstates or collection attempts to perform before exiting. Defaults to 3' },
+        { name: 'room', regex: /(room=(\d+))/, optional: true, description: 'Specific room to forage in - primarily used to locate a trash bin. Syntax:  room=1234'  },        
+        { name: 'forage', regex: /forage|collect/, optional: true, description: 'Default method is collect, specify forage to override. Forage is best used with a trash bin.' },
+        { name: 'collect_item', regex: /\w+/i, optional: true, description: 'Item to collect. Will use forage_item if not set. Wrap "multiple words" in double quotes.' }        
       ]
     ]
     args = parse_args(arg_definitions)
@@ -28,14 +27,18 @@ class Outdoorsmanship
     @targetxp = 4
     @targetxp = args.mindstates.to_i if args.mindstates
     @worn_trashcan = @settings.worn_trashcan
-    @worn_trashcan_verb = @settings.worn_trashcan_verb    
+    @worn_trashcan_verb = @settings.worn_trashcan_verb
     @outdoors_room = @settings.outdoors_room
     if args.room
       room = args.room.split('=')[1]
       @outdoors_room = room
     end
 
-    @train_method = args.forage || @settings.outdoors_method
+    @train_method = if DRSkill.getrank('Outdoorsmanship') < 20
+                      'forage'
+                    else
+                      args.forage || @settings.outdoors_method
+                    end
 
     @forage_item = if args.collect_item
                      args.collect_item
@@ -61,7 +64,7 @@ class Outdoorsmanship
   def train_outdoorsmanship
     attempt = 0 # Failsafe counter to prevent an infinite loop if item isn't collectable in the room
     while (DRSkill.getxp(@skill_name) < @end_exp) && (attempt < @targetxp)
-      if DRSkill.getrank('Outdoorsmanship') < 20 || @train_method == 'forage' 
+      if @train_method == 'forage' 
         crafting_magic_routine(@settings)
         forage?(@forage_item)
         DRCI.dispose_trash(@forage_item, @worn_trashcan, @worn_trashcan_verb)

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -27,6 +27,8 @@ class Outdoorsmanship
     @training_spells = @settings.crafting_training_spells
     @targetxp = 4
     @targetxp = args.mindstates.to_i if args.mindstates
+    @worn_trashcan = @settings.worn_trashcan
+    @worn_trashcan_verb = @settings.worn_trashcan_verb
     @outdoors_room = @settings.outdoors_room
     if args.room
       room = args.room.split('=')[1]

--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -62,7 +62,7 @@ class Outdoorsmanship
       if DRSkill.getrank('Outdoorsmanship') < 20 || @train_method == 'forage' 
         crafting_magic_routine(@settings)
         forage?(@forage_item)
-        dispose_trash(@forage_item)
+        DRCI.dispose_trash(@forage_item, @worn_trashcan, @worn_trashcan_verb)
       else
         item = @forage_item
         crafting_magic_routine(@settings)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -647,6 +647,12 @@ performance_pause: 3
 performance_mindstate_goal: 31
 # what item to forage/collect with ;outdoorsmanship
 forage_item: rock
+# Define as `forage` to override outdoorsmanship gathering method.  Leave blank to collect.
+outdoors_method: 
+# If you choose forage method, you'll want a room with a trash bin!  Leave blank to not set a default room.
+outdoors_room: 
+# If you choose forage method, you'll want to select a custom item for best learning rate.
+forage_item: rock
 # what item to braid in ;mech-lore
 braid_item:
 training_spells:


### PR DESCRIPTION
With new foraging items released recently, it much more effective to train with `forage` instead of collect but it is largely dependent on a trash bin nearby.  It is also quite handy to be able to change your room/item/method on the fly based on where you might be so it can be set by yaml or by args.  All args work independently or together in any combination so long as they're sent in correct order.
Defaults mirror existing behavior
```yaml
# Define as `forage` to override outdoorsmanship gathering method.  Leave blank to collect.
outdoors_method: 
# If you choose forage method, you'll want a room with a trash bin!  Leave blank to not set a default room.
outdoors_room: 
# If you choose forage method, you'll want to select a custom item for best learning rate.
forage_item: rock
```