### PR TITLE
Add Grey List of traps to always pick careful

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -364,8 +364,8 @@ class Pick
 
         while holding_box?(current_box) && current_box['trapped'] && !current_box['trap_difficulty'].nil?
           if current_box['trap'] && @trap_greylist.include?(current_box['trap'])
-            current_box['trap_difficulty'] = 17
-            #17 is one above the player input range to block potential yaml setting interference
+            current_box['trap_difficulty'] = 18
+            #18 is one above the player range to block potential yaml setting interference
           end        
           disarm_trap(current_box)
         end

--- a/pick.lic
+++ b/pick.lic
@@ -364,8 +364,8 @@ class Pick
 
         while holding_box?(current_box) && current_box['trapped'] && !current_box['trap_difficulty'].nil?
           if current_box['trap'] && @trap_greylist.include?(current_box['trap'])
-            current_box['trap_difficulty'] = 18
-            #18 is one above the player range to block potential yaml setting interference
+            # force disarm careful on specific trap_greylist of traps types.
+            current_box['trap_difficulty'] = @disarm_careful_threshold
           end        
           disarm_trap(current_box)
         end

--- a/pick.lic
+++ b/pick.lic
@@ -90,6 +90,8 @@ class Pick
 
     @trap_blacklist = @settings.pick['trap_blacklist'] || []
     @blacklist_container = @settings.pick['blacklist_container']
+    
+    @trap_greylist = @settings.pick['trap_greylist'] || []
 
     @all_trap_messages = picking_data['traps']
     @disarmed_trap_messages = picking_data['disarmed_traps']
@@ -125,6 +127,7 @@ class Pick
       echo "- too_hard_container: #{@too_hard_container}"
       echo "- trap_blacklist: #{@trap_blacklist}"
       echo "- blacklist_container: #{@blacklist_container}"
+      echo "- trap_greylist: #{@trap_greylist}"
       echo "- pick_quick: #{@pick_quick_threshold}"
       echo "- pick_normal: #{@pick_normal_threshold}"
       echo "- pick_careful: #{@pick_careful_threshold}"
@@ -360,6 +363,10 @@ class Pick
         end
 
         while holding_box?(current_box) && current_box['trapped'] && !current_box['trap_difficulty'].nil?
+          if current_box['trap'] && @trap_greylist.include?(current_box['trap'])
+            current_box['trap_difficulty'] = 17
+            #17 is one above the player input range to block potential yaml setting interference
+          end        
           disarm_trap(current_box)
         end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1076,6 +1076,8 @@ pick:
   trap_blacklist:
   # optional container for storing boxes with blacklisted traps for manual picking later, if blank will drop
   blacklist_container:
+  # list of trap types to automatically disarm careful regardless of identified difficulty; trap names can be seen in base-picking
+  trap_greylist:  
   # list of containers to pick boxes from, will fall back to old 'picking_box_source' if not present
   picking_box_sources:
   # try to harvest trap components after each disarm


### PR DESCRIPTION
Some traps have a very high mortality rate, no matter the difficulty identified.  This grey list allows the user to define specific traps to always disarm careful.
```yaml
pick:
  debug: false
  trash_empty_boxes: true
  pick_quick_threshold: 2
  pick_normal_threshold: 4
  pick_careful_threshold: 6
  disarm_quick_threshold: 1
  disarm_normal_threshold: 3
  disarm_careful_threshold: 5
  disarm_too_hard_threshold: 8
  trap_blacklist:
  trap_greylist:  [teleport, shrapnel, shocker, concussion, lightning, boomer]  
  picking_box_sources: [lootpouch,backpack]
```