### PR TITLE
Allow bypassing worn_trashcan_verb

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -309,8 +309,10 @@ module DRCI
       when *@@drop_trash_retry_patterns
         return true if dispose_trash(item, worn_trashcan, worn_trashcan_verb)
       when *@@drop_trash_success_patterns
-        DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *@@worn_trashcan_verb_patterns)
-        DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *@@worn_trashcan_verb_patterns)
+        if worn_trashcan_verb
+          DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *@@worn_trashcan_verb_patterns)
+          DRC.bput("#{worn_trashcan_verb} my #{worn_trashcan}", *@@worn_trashcan_verb_patterns)
+        end
         return true
       end
     end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1041,7 +1041,7 @@ consumable_lockboxes:
 
 # can be set to the adj. + noun for a wearable trash container, some scripts will use it
 worn_trashcan:
-# can be set to the verb that empties your trash container for scripts that use it
+# can be set to the verb that empties your trash container for scripts that use it.  Leave blank to skip this automatic step for more control on frequency.
 worn_trashcan_verb:
 
 # pick.lic settings for live boxes


### PR DESCRIPTION
This action after ever single dispose can be extremely scroll-inducing.  Allowing the user to skip that step gives them control on when to dump the trash and avoid many extra actions.