### PR TITLE
Add Commune Selection + bug fixes

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1282,6 +1282,7 @@ theurgy_supply_container: backpack
 #    min: 3
 #    target: 4
 theurgy_supply_levels:
+communes: [Eluned Truffenyi Kertigen Tamsine]
 
 tithe: false
 tithe_almsbox:

--- a/theurgy.lic
+++ b/theurgy.lic
@@ -17,11 +17,9 @@ class TheurgyActions
     @hometown = @settings.hometown
     all_theurgy_data = get_data('theurgy')
     @data = all_theurgy_data[@hometown]
-
     @immortal_to_aspect = all_theurgy_data['immortal_to_aspect']
     @safe_room = @settings.safe_room
     @immortal_aspect = @settings.immortal_aspect
-
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
@@ -29,12 +27,11 @@ class TheurgyActions
     @prayer_mat_container = @settings.prayer_mat_container || @settings.theurgy_supply_container
     @water_holder = @settings.water_holder
     @flint_lighter = @settings.flint_lighter
-
-    (@prayer_mat = @settings.prayer_mat) if @settings.theurgy_use_prayer_mat
-    @prayer_mat_room = @settings.theurgy_prayer_mat_room
-
+    @prayer_mat = @settings.prayer_mat if @settings.theurgy_use_prayer_mat
+    @prayer_mat_room = @settings.theurgy_prayer_mat_room    
     @rituals = get_rituals
     @communes = get_communes
+    @chosen_communes = @settings.communes
 
     @item_info = collect_item_info(@rituals + @communes)
 
@@ -45,7 +42,6 @@ class TheurgyActions
       c[:items].any? { |i| !i[:on_hand] && !i[:shop] }
     end
   end
-
 
   def get_rituals
     rituals = all_rituals
@@ -73,7 +69,6 @@ class TheurgyActions
         method: :refectory
       }
     end
-
     if DRSkill.getrank('Engineering') > 140 && @immortal_aspect && @known_spells.include?('Bless')
       rituals << {
         method: :carve_bead
@@ -161,13 +156,13 @@ class TheurgyActions
 
   def get_communes
     communes = []
-    if DRStats.circle > 3 && DRSkill.getrank('Outdoorsmanship') > 20 && @data['dirt_foraging']
+    if DRStats.circle > 3 && DRSkill.getrank('Outdoorsmanship') > 20 && @data['dirt_foraging'] && @chosen_communes.include?('Eluned')
       communes << {
         name: :eluned,
         method: :commune_eluned
       }
     end
-    if DRStats.circle > 60
+    if DRStats.circle > 60 && @chosen_communes.include?('Truffenyi')
       truffenyi_commune = {
         name: :truffenyi,
         method: :commune_truffenyi,
@@ -181,13 +176,13 @@ class TheurgyActions
       end
       communes << truffenyi_commune
     end
-    if DRStats.circle > 2
+    if DRStats.circle > 2  && @chosen_communes.include?('Tamsine')
       communes << {
         name: :tamsine,
         method: :commune_tamsine
       }
     end
-    if DRStats.circle > 8
+    if DRStats.circle > 8  && @chosen_communes.include?('Kertigen')
       communes << {
         name: :kertigen,
         method: :commune_kertigen,
@@ -256,6 +251,7 @@ class TheurgyActions
   def holy_water?
     DRCI.get_item_safe(@water_holder, @theurgy_supply_container)
     DRCI.inside?('holy water', @water_holder)
+    DRCI.put_away_item?(@water_holder, @theurgy_supply_container)
   end
 
   def buy_supplies
@@ -729,12 +725,24 @@ class TheurgyActions
     else
       DRCI.get_item_safe('incense', @theurgy_supply_container)
     end
+    
+    unless exists?('flint')
+      bput('drop my incense','You')
+      DRCI.get_item_safe('flint', @theurgy_supply_container)
+      dropped = true
+    end
 
     waitrt? while bput('light my incense with flint',
                        'nothing happens',
                        'bursts into flames',
                        'much too dark in here to do that') == 'nothing happens'
     waitrt?
+
+    if dropped == true
+      DRCI.put_away_item?('flint', @theurgy_supply_container)
+      fput "get incense"
+    end
+    
     fput "wave incense at #{@prayer_mat || 'altar'}"
     fput 'snuff incense'
     DRCI.put_away_item?('incense', @theurgy_supply_container)
@@ -750,14 +758,12 @@ class TheurgyActions
       fix_standing
       bput("kneel #{@prayer_mat}", 'You humbly kneel')
     end
-
     complete_or_interrupt_research
     cast_spell({ 'abbrev' => 'bless',
                  'mana' => 1,
                  'prep_time' => 2,
                  'cast' => "cast my wine" }, @settings)
-    continue_research
-
+    continue_research    
     bput("pour wine on #{@prayer_mat || 'altar'}",
          'You quietly pour', 'Pour what')
     fix_standing
@@ -776,7 +782,11 @@ class TheurgyActions
     return false unless holy_water?
     safe_walk_to @data['altar']['id']
     DRCI.get_item_safe(@water_holder, @theurgy_supply_container)
-    fput 'clean altar with holy water'
+    case bput('clean altar with holy water','Roundtime','You are a bit too busy performing to do that')
+    when 'You are a bit too busy performing to do that'
+      fput('stop play')
+      fput('clean altar with holy water')
+    end
     waitfor 'You finish your job'
     DRCI.put_away_item?(@water_holder, @theurgy_supply_container)
     waitrt?


### PR DESCRIPTION
-- Add communes field to allow user to choose which communes to use.  Its very easy to bottom out devotion with badly timed communes.
-- Properly return water holder to theurgy container after checking so stow_hands can't accidentally stow it in the wrong place.
-- Add handling for flint in an eddy (must be in your hand to light incense) versus in a normal container (does not need to be in-hand)
-- Add handling for performance/play interfering with altar cleaning.