### PR TITLE
Add a skill check to one room north of the gondola

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -370,7 +370,7 @@ class Athletics
   def climb_wyvern
     walk_to(19_464)
     until done_training?
-      walk_to(2245)
+      walk_to(2245) if UserVars.athletics > 540
       walk_to(9607)
       walk_to(11_126)
       walk_to(19_464)


### PR DESCRIPTION
Apparently you can safely climb wyvern mountain before 540 but not the gondola branch so this skill check allows the daring to brave the mountain and avoid the silly gondola.