### PR TITLE
[script] [magic-training] new script, supercedes what's in Lich 'repository'

### DIFF
--- a/magic-training.lic
+++ b/magic-training.lic
@@ -1,0 +1,126 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#magic-training
+=end
+
+custom_require.call(%w[common common-arcana common-healing drinfomon])
+
+# Track how long we've been training and how many mindstates we increase at the end.
+# These are defined with @@ so that they can be referenced in before_dying block.
+@@time_in = Time.now
+@@aug_in = DRSkill.getxp('Augmentation')
+@@ward_in = DRSkill.getxp('Warding')
+@@util_in = DRSkill.getxp('Utility')
+@@sorc_in = DRSkill.getxp('Sorcery')
+
+class MagicTraining
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'max_time', regex: /\d+/, optional: true, description: 'Max time, in minutes, spent training. (Optional)' },
+        { name: 'training_skills', regex: /^((Augmentation|Warding|Utility|Sorcery)((\s*,\s*)(Augmentation|Warding|Utility|Sorcery))*)$/i, optional: true, description: 'Override which magic skills to train, as a comma-separated list. (Optional)' }
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
+
+    load_settings
+
+    @max_time = ((args.max_time || 60).to_i * 60) # convert to seconds
+    @training_skills = args.training_skills.split(',').map { |skill| skill.strip.downcase.capitalize }
+    @training_skills = %w[Utility Warding Augmentation Sorcery] if @training_skills.nil? || @training_skills.empty?
+
+    echo "Max training time: #{@max_time} seconds"
+    echo "Training skills: #{@training_skills}"
+
+    loop do
+      if (Time.now - @@time_in) > @max_time
+        echo "Max time alloted for Magic Training reached. Now exiting..."
+        exit
+      end
+      unless train_magics
+        echo "Done training magics"
+        exit
+      end
+    end
+  end
+
+  def load_settings
+    @settings = get_settings
+
+    # If mana drops below this level then script will pause training and wait for it to regenerate
+    @mana_threshold = @settings.training_spell_mana_threshold || @settings.waggle_spells_mana_threshold || 40
+
+    # If concentration drops below this level then script will pause training and wait for it to regenerate
+    @conc_threshold = @settings.training_spell_concentration_threshold || @settings.waggle_spells_concentration_threshold || 80
+
+    # Stops training a specfic skill after reaching this mindstate threshold, and quits program when all skills are above
+    @exp_threshold = @settings.magic_exp_training_max_threshold || 32
+
+    # Hash of magic skill (e.g. Warding) to spell to train with (same config as spells in waggle sets)
+    @training_spells = @settings.training_spells
+
+    @force_cambrinth = @settings.waggle_force_cambrinth
+
+    @health_threshold = @settings.health_threshold # vitaltiy percentage
+    @saferoom_health_threshold = @settings.saferoom_health_threshold # wound severity threshold
+  end
+
+  def train_magics
+    load_settings # This is done purposely so you can adjust settings on the fly, it's great for finding mana values
+
+    magic_skills = @training_spells.keys
+    skills_to_train = magic_skills
+      .select { |skill| @training_skills.include?(skill) } # filter to skills you want to train
+      .select { |skill| DRCA.update_astral_data(@training_spells[skill]) } # filter to spells you can cast now
+      .reject { |skill| DRSkill.getxp(skill) > @exp_threshold } # filter out skills you don't need to train
+      .sort_by do |skill|
+        [
+          DRSkill.getxp(skill),   # choose first by skills with lowest learning rate
+          DRSkill.getrank(skill)  # then choose by skills with lowest ranks
+        ]
+      end
+
+    # Attained desired learning threshold in all magic skills to train
+    return false if skills_to_train.empty?
+
+    skills_to_train.each do |skill|
+      echo "Next skill to train: #{skill}"
+      before_xp = DRSkill.getxp(skill)
+      DRCA.check_discern(@training_spells[skill], @settings) if @training_spells[skill]['use_auto_mana']
+      DRCA.cast_spells({ spell_name: @training_spells[skill] }, @settings, @force_cambrinth)
+      echo("#{skill} gains: #{DRSkill.getxp(skill) - before_xp}")
+      waitrt?
+      check_health
+    end
+
+    return true
+  end
+
+  # Needed when training sorcery as you may experience sorcerous backlash
+  def check_health
+    pause 0.5 while stunned?
+    health_data = DRCH.check_health
+    if bleeding? || health_data['score'] >= @saferoom_health_threshold || DRStats.health < [50, @health_threshold].max || health_data['poisoned'] || health_data['diseased']
+      DRC.message("You're injured! Stopping training")
+      DRC.wait_for_script_to_complete('safe-room', ['force'])
+      exit
+    end
+  end
+
+end
+
+before_dying do
+  fput('release spell')
+  fput('release mana')
+  fput('release symbiosis')
+
+  total_time = (Time.now - @@time_in) / 60
+  echo "Total time in Magic-Training: #{total_time.to_i} minutes"
+  echo "Total xp gained in Augmentation: #{DRSkill.getxp('Augmentation') - @@aug_in}"
+  echo "Total xp gained in Warding: #{DRSkill.getxp('Warding') - @@ward_in}"
+  echo "Total xp gained in Utility: #{DRSkill.getxp('Utility') - @@util_in}"
+  echo "Total xp gained in Sorcery: #{DRSkill.getxp('Sorcery') - @@sorc_in}"
+end
+
+MagicTraining.new

--- a/magic-training.lic
+++ b/magic-training.lic
@@ -48,12 +48,6 @@ class MagicTraining
   def load_settings
     @settings = get_settings
 
-    # If mana drops below this level then script will pause training and wait for it to regenerate
-    @mana_threshold = @settings.training_spell_mana_threshold || @settings.waggle_spells_mana_threshold || 40
-
-    # If concentration drops below this level then script will pause training and wait for it to regenerate
-    @conc_threshold = @settings.training_spell_concentration_threshold || @settings.waggle_spells_concentration_threshold || 80
-
     # Stops training a specfic skill after reaching this mindstate threshold, and quits program when all skills are above
     @exp_threshold = @settings.magic_exp_training_max_threshold || 32
 


### PR DESCRIPTION
### Background
* Originated in Lich's repository and authored by the player of Chuno ([link to original](https://gist.github.com/KatoakDR/279a88bef9a802e02d926f6bca08ebee))
* Updated by Katoak as a magic training tool used with T2 or training-manager, etc

### Changes
* Update custom_require listings and remove `includes`
* Supports two arguments:
  - `max_time` (optional) number of minutes to limit training
  - `training_skills` (optional) comma-separated list of magic skills to train (Augmentation, Warding, Utility, Sorcery)
* Relies on many of the magic yaml settings that control mana and concentration thresholds and cambrinth, etc
* For lunar mages, updates astral data on the spells to be trained and filters them out if they can't be cast right now
* Remove checks for waiting on your mana level and instead delegate to `DRCA.cast_spells` to handle that
* To mitigate sorcerous backlash, checks health and heals you if you become sufficiently wounded, poisoned, or diseased.

### Config
_These are all pre-existing settings. This is how this script uses them._
```yaml
# Skips casting a spell if the magic skill is at or above this learning rate.
magic_exp_training_max_threshold: number

# Hash of magic skill (e.g. Warding) to spell to train with (same config as spells in waggle sets)
# Each magic skill is optional. To train it, then list the skill with the spell's config nested under it like a waggle.
training_spells:
  Utility:
    << : *seers_sense
  Warding:
    << : *cage_of_light
  Augmentation:
    << : *aura_sight
  Sorcery:
    << : *righteous_wrath

# If true, always uses cambrinth, else may harness if arcana is locked.
waggle_force_cambrinth: boolean

# When checking health for sorcerous backlash injuries,
# if your vitality falls below this percentage then runs `safe-room` script.
health_threshold: number

# When checking health for sorcerous backlash injuries,
# if the severity of your wounds exceeds this threshold then runs `safe-room` script.
saferoom_health_threshold: number
```

## Usage
_Default trains each magic skill listed in your training_spells until attains desired learning rates_
```
>;magic-training
```
_Same as above but stops after 10 minutes_
```
>;magic-training 10
```
_Only trains the augmentation and utility skills_
```
>;magic-training augmentation,utility
```
_Only trains the sorcery skill for up to 5 minutes or until reaches desired learning rate, whichever is first_
```
>;magic-training 5 sorcery
```