### PR TITLE
[script][log]adding this to revert to default behaviour

### DIFF
--- a/log.lic
+++ b/log.lic
@@ -5,11 +5,9 @@
 
 	 author: Tillmen (tillmen@lichproject.org)
 	   game: any
-	version: 0.3
+	version: 0.2
 
 	changelog:
-		0.3 (2022-01-04):
-			prepend datetime stamps to logged lines
 		0.2 (2015-01-13):
 			create log directory if needed
 
@@ -55,8 +53,8 @@ loop {
 	begin
 		30000.times {
 			line = get
- 			unless line =~ /^<(?:push|pop)Stream/
-				file.puts "#{Time.now.strftime("%F %T %Z")}: #{line}"
+			unless line =~ /^<(?:push|pop)Stream/
+				file.puts line
 			end
 		}
 		file.puts "#{Time.now.strftime("%Y-%m-%d %I:%M%P").sub(/0([0-9]+\:)/) {"#{$1}"}}\n"


### PR DESCRIPTION
I should have added this with a different name. Someone objects to log datetimestamps and we can't do args on startup scripts, so reverting this. I'll submit datetimestamped log.lic as a different named file.