### PR TITLE
[script] [combat-trainer] Switch to predicate `wield_weapon?` methods

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -313,7 +313,7 @@ class SetupProcess
       game_state.prepare_summoned_weapon(last_summoned)
     else
       bput('aim stop', "But you're not aiming", 'You stop concentrating', 'You are already') if game_state.aimed_skill?
-      @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
       if game_state.whirlwind_trainable?
         game_state.currently_whirlwinding = true
         determine_whirlwind_weapon(game_state)
@@ -359,7 +359,7 @@ class SetupProcess
     @cycle_regalia = nil
     Flags.reset('ct-regalia-expired')
     @equipment_manager.wear_equipment_set?('standard')
-    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if @gearsets['standard'].include?(game_state.weapon_name) # The above will put away worn weapons
+    @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill) if @gearsets['standard'].include?(game_state.weapon_name) # The above will put away worn weapons
   end
 end
 
@@ -760,7 +760,7 @@ class LootProcess
     end
 
     do_necro_ritual(mob_noun, 'dissect', game_state) if @dissect_and_butcher && !@ritual_type.eql?('butcher')
-    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+    @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
   end
 
   def necro_harvest_check
@@ -952,7 +952,7 @@ class LootProcess
         if summoned
           game_state.prepare_summoned_weapon(false)
         else
-          @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+          @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
         end
       end
     end
@@ -1026,7 +1026,7 @@ class SafetyProcess
       Flags.reset('ct-itemdropped')
       # If put an item away then get it back out.
       if temp_item
-        @equipment_manager.wield_weapon(temp_item) || DRCI.get_item?(temp_item)
+        @equipment_manager.wield_weapon?(temp_item) || DRCI.get_item?(temp_item)
         # In case the items end up in opposite hands, swap.
         # This may do nothing if you have only one usable hand.
         fput('swap') if (DRC.left_hand != temp_left_item && DRC.right_hand != temp_right_item)
@@ -1501,7 +1501,7 @@ class SpellProcess
       if result.empty? # if not wearing a regalia, retreat, swap to regalia gearset, then cast
         DRC.retreat
         @equipment_manager.wear_equipment_set?('regalia')
-        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if @settings.gear_sets['regalia'].include?(game_state.weapon_name)
+        @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill) if @settings.gear_sets['regalia'].include?(game_state.weapon_name)
       else # otherwise break what you're already wearing then cast.
         DRCA.shatter_regalia?(result)
       end
@@ -1547,7 +1547,7 @@ class SpellProcess
     game_state.casting_cyclic = false
     if game_state.casting_sorcery
       game_state.casting_sorcery = false
-      @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
     end
 
     if game_state.casting_moonblade
@@ -1749,7 +1749,7 @@ class SpellProcess
       if Flags['ct-starlight-depleted'] # In some conditions, regalia can run out of starlight partway through creation.  Don't want a partial regalia on.
         DRCA.shatter_regalia?
         @equipment_manager.wear_equipment_set?('standard')
-        @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill) if @settings.gear_sets['standard'].include?(game_state.weapon_name)
+        @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill) if @settings.gear_sets['standard'].include?(game_state.weapon_name)
         game_state.last_regalia_type = nil
         game_state.swap_regalia_type = nil
       end
@@ -1864,7 +1864,7 @@ class SpellProcess
     if summoned
       game_state.prepare_summoned_weapon(false)
     else
-      @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
     end
     game_state.reset_stance = true
   end
@@ -2424,7 +2424,7 @@ class TrainerProcess
     echo("  @prayer_mat: #{@prayer_mat}") if $debug_mode_ct
 
     @prayer_mat_container = settings.prayer_mat_container || settings.theurgy_supply_container
-    echo("  @prayer_mat_container: #{@prayer_mat_container}") if $debug_mode_ct    
+    echo("  @prayer_mat_container: #{@prayer_mat_container}") if $debug_mode_ct
 
     @dirt_stacker = settings.dirt_stacker
     echo("  @dirt_stacker: #{@dirt_stacker}") if $debug_mode_ct
@@ -2658,7 +2658,7 @@ class TrainerProcess
     fput "get #{@water_holder} from my #{@theurgy_supply_container}"
     if /that/i =~ bput("sprinkle #{@water_holder} on #{checkname}", 'You sprinkle', 'Sprinkle what?', 'Sprinkle that')
       fput "put #{@water_holder} in my #{@theurgy_supply_container}"
-      @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
       @training_abilities.delete('Meraud')
       return
     end
@@ -2666,7 +2666,7 @@ class TrainerProcess
     fput "get #{@flint_lighter}", 'You get a', 'You are already'
     if bput("get incense from my #{@theurgy_supply_container}", 'You get', 'You are already', 'referring to') == 'referring to'
       fput "stow #{@flint_lighter}", 'You put your', 'Stow what'
-      @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
       @training_abilities.delete('Meraud')
       return
     end
@@ -2678,7 +2678,7 @@ class TrainerProcess
     bput("put incense in my #{@theurgy_supply_container}", 'You put', 'What were you referring to')
     fput "stow #{@flint_lighter}", 'You put your', 'Stow what'
     pause 1
-    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+    @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
     bput('commune meraud', 'Nothing happens.', 'you have attempted a commune too recently', 'You close your eyes and concentrate, letting your mind still and feeling your breathing grow shallow', 'the ground is already consecrated')
     pause
     waitrt?
@@ -2724,7 +2724,7 @@ class TrainerProcess
          'need to be holding that first', 'not on the ground')
     bput("put #{@prayer_mat} in my #{@prayer_mat_container}",
          'You put', 'What were you referring to')
-    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+    @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
   end
 
   def ambush_stun(game_state)
@@ -2733,7 +2733,7 @@ class TrainerProcess
     dead_count = DRRoom.dead_npcs.size
     unless game_state.weapon_name == @stun_weapon && !game_state.offhand?
       @equipment_manager.stow_weapon(game_state.weapon_name)
-      @equipment_manager.wield_weapon(@stun_weapon, @stun_weapon_skill)
+      @equipment_manager.wield_weapon?(@stun_weapon, @stun_weapon_skill)
     end
 
     if hide?
@@ -2744,7 +2744,7 @@ class TrainerProcess
 
     unless game_state.weapon_name == @stun_weapon && !game_state.offhand?
       @equipment_manager.stow_weapon(@stun_weapon)
-      @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+      @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
     end
     DRRoom.dead_npcs.size > dead_count
   end
@@ -2852,7 +2852,7 @@ class TrainerProcess
     else
       determine_time
     end
-    @equipment_manager.wield_weapon(game_state.weapon_name, game_state.weapon_skill)
+    @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
   end
 
   def determine_time
@@ -4061,14 +4061,14 @@ class GameState
     return if skill.eql?('Brawling')
     return if skill.eql?('Tactics')
 
-    @equipment_manager.wield_weapon_offhand(weapon_training[skill], skill)
+    @equipment_manager.wield_weapon_offhand?(weapon_training[skill], skill)
     weapon_training[skill]
   end
 
   def wield_whirlwind_offhand
     return if twohanded_weapon_skill?
     return unless currently_whirlwinding
-    @equipment_manager.wield_weapon_offhand(whirlwind_offhand_name)
+    @equipment_manager.wield_weapon_offhand?(whirlwind_offhand_name)
   end
 
   def determine_whirlwind_action


### PR DESCRIPTION
### Background
* Predicate-named methods for wielding weapons was introduced in https://github.com/rpherbig/dr-scripts/pull/5340
* The changes to use them in `combat-trainer` were in #5319 but were [requested](https://github.com/rpherbig/dr-scripts/pull/5319/files#r777283081) to move to their own pull request to reduce the diff.

### Changes
* Update calls to `@equipment_manager.wield_weapon` and `@equipment_manager.wield_offhand_weapon` to use the `?` predicate convention-named methods