### PR TITLE
[script] [combat-trainer] Use DRCMM utility to hold moon weapon instead of bput

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1,7 +1,7 @@
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 =end
-custom_require.call(%w[common common-arcana common-healing common-items common-summoning drinfomon equipmanager events spellmonitor common-moonmage])
+custom_require.call(%w[common common-arcana common-healing common-items common-summoning common-moonmage common-travel drinfomon equipmanager events spellmonitor])
 
 class SetupProcess
   include DRC
@@ -948,7 +948,7 @@ class LootProcess
         dispose_trash(right_hand) if snap.last != right_hand && !@equipment_manager.is_listed_item?(right_hand)
       end
       game_state.need_bundle = false
-      unless stored_moon && bput('get moon', 'you grab', 'What were') == 'you grab'
+      unless stored_moon && DRCMM.hold_moon_weapon?
         if summoned
           game_state.prepare_summoned_weapon(false)
         else
@@ -2424,7 +2424,7 @@ class TrainerProcess
     echo("  @prayer_mat: #{@prayer_mat}") if $debug_mode_ct
 
     @prayer_mat_container = settings.prayer_mat_container || settings.theurgy_supply_container
-    echo("  @prayer_mat_container: #{@prayer_mat_container}") if $debug_mode_ct    
+    echo("  @prayer_mat_container: #{@prayer_mat_container}") if $debug_mode_ct
 
     @dirt_stacker = settings.dirt_stacker
     echo("  @dirt_stacker: #{@dirt_stacker}") if $debug_mode_ct


### PR DESCRIPTION
### Background
* Pulled out of https://github.com/rpherbig/dr-scripts/pull/5319#discussion_r777283108 into its own PR

### Changes
* Replace `bput` with `DRCMM.hold_moon_weapon?` to remove duplicate logic
* Sort `common-*` scripts together in the `custom_require`
* Add `common-travel` to `custom_require` -- without it if this is the first script you run upon logging in then may get error about symbol `DRCT` is not yet defined