### PR TITLE
[script] [combat-trainer] Exclude swappable and summonable weapons from offhand dual wield attacks

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4560,6 +4560,8 @@ class GameState
     options -= $melee_skills if weapon_skill.eql?('Bow') || (weapon_skill.eql?('Crossbow') && !@using_light_crossbow) # can't aim with weapon in your offhand
     options -= $thrown_skills if (weapon_skill.eql?('Bow') && @left_hand_free)
     options -= weapon_training.select { |skill, weapon| weapon == weapon_training[weapon_skill] }.keys # can't be same weapon that's equipped in your mainhand
+    options -= weapon_training.select { |skill, weapon| swappable_weapon?(weapon) }.keys # remove swappable weapons because they might be swapped into a two-handed state
+    options -= @summoned_weapons.map { |info| info['name'] } # remove summoned weapons because they may not exist for offhand use
     echo "determine_aiming_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
   end
@@ -4572,6 +4574,8 @@ class GameState
     options -= $aim_skills # can't use aimable weapons in your offhand
     options -= $martial_skills # shouldn't be brawling, you need a weapon in your offhand
     options -= weapon_training.select { |skill, weapon| weapon == weapon_training[weapon_skill] }.keys # can't be same weapon that's equipped in your mainhand
+    options -= weapon_training.select { |skill, weapon| swappable_weapon?(weapon) }.keys # remove swappable weapons because they might be swapped into a two-handed state
+    options -= @summoned_weapons.map { |info| info['name'] } # remove summoned weapons because they may not exist for offhand use
     echo "determine_doublestrike_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
   end
@@ -4591,10 +4595,12 @@ class GameState
   # Determine the weapon skill to equip offhand to use while whirlwinding.
   def determine_whirlwind_weapon_skill
     return if twohanded_weapon_skill?
-    options = whirlwind_trainables
+    options = @whirlwind_trainables
     options -= [weapon_skill] # can't be your main hand skill, it's in your main hand
     options -= $twohanded_skills # can't be a twohanded skill, you need both hands
     options -= weapon_training.select { |skill, weapon| weapon == weapon_training[weapon_skill] }.keys # can't be same weapon that's equipped in your mainhand
+    options -= weapon_training.select { |skill, weapon| swappable_weapon?(weapon) }.keys # remove swappable weapons because they might be swapped into a two-handed state
+    options -= @summoned_weapons.map { |info| info['name'] } # remove summoned weapons because they may not exist for offhand use
     echo "determine_whirlwind_weapon_skill::options: #{options}" if $debug_mode_ct
     sort_by_rate_then_rank(options).first
   end


### PR DESCRIPTION
### Background
* Pulled out of https://github.com/rpherbig/dr-scripts/pull/5319#discussion_r777283280 into its own PR

### Changes
* When determining an aiming trainable, doublestrike trainable, or a whirlwind trainable skill to offhand, exclude swappable and summoned weapons
  - Swappable weapons (like ristes, bastard swords, and bar maces) might be in their twohanded variant and thus not compatible
  - Summoned weapons might not exist at the time, they tend to be summoned and dismissed as needed for mainhand use