### PR TITLE
[script] [common-items] New helper method paradigm (rough draft, work in progress)

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -56,30 +56,32 @@ module DRCI
   ]
 
   @@get_item_success_patterns = [
-    /^You get/,
-    /^You pick/,
-    /^You pluck/,
-    /^You slip/,
-    /^You deftly remove/,
-    /^You are already holding/,
-    /^You fade in for a moment as you/
+    /^You get.*/,
+    /^You pick.*/,
+    /^You pluck.*/,
+    /^You slip.*/,
+    /^You deftly remove.*/,
+    /^You are already holding.*/,
+    /^You fade in for a moment as you.*/
   ]
 
   @@get_item_failure_patterns = [
-    /already in your inventory/,
-    /^You need a free hand/,
-    /needs to be tended to be removed/,
-    /^You can't pick that up with your hand that damaged/,
-    /^Your (left|right) hand is too injured/,
-    /^You just can't/,
-    /push you over the item limit/,
-    /^You stop as you realize the .* is not yours/,
-    /^Get what/,
-    /^I could not/,
-    /^What were you/,
-    /rapidly decays away/,
-    /cracks and rots away/
+    /.*already in your inventory.*/,
+    /^You need a free hand.*/,
+    /.*needs to be tended to be removed.*/,
+    /^You can't pick that up with your hand that damaged.*/,
+    /^Your (left|right) hand is too injured.*/,
+    /^You just can't.*/,
+    /.*push you over the item limit.*/,
+    /^You stop as you realize the .* is not yours.*/,
+    /^Get what.*/,
+    /^I could not.*/,
+    /^What were you.*/,
+    /.*rapidly decays away.*/,
+    /.*cracks and rots away.*/
   ]
+
+  @@get_item_retry_patterns = []
 
   @@wear_item_success_patterns = [
     /^You put/,
@@ -115,32 +117,34 @@ module DRCI
   ]
 
   @@remove_item_success_patterns = [
-    /^You remove/,
-    /^You detach/,
-    /^You sling/,
-    /^You slide/,
-    /^You take/,
-    /^You loosen/,
-    /^You untie/,
-    /^You tug/,
-    /^You struggle/,
-    /^The .* slide/,
-    /^You .* slide/,
-    /^Dropping your shoulder/,
-    /^Without any effort/,
-    /as you remove/,
-    /you manage to loosen/,
-    /slide themselves off of your/
+    /^You remove.*/,
+    /^You detach.*/,
+    /^You sling.*/,
+    /^You slide.*/,
+    /^You take.*/,
+    /^You loosen.*/,
+    /^You untie.*/,
+    /^You tug.*/,
+    /^You struggle.*/,
+    /^The .* slide.*/,
+    /^You .* slide.*/,
+    /^Dropping your shoulder.*/,
+    /^Without any effort.*/,
+    /.*as you remove.*/,
+    /.*you manage to loosen.*/,
+    /.*slide themselves off of your.*/
   ]
 
   @@remove_item_failure_patterns = [
-    /^You need a free hand/,
-    /^You aren't wearing/,
-    /^You don't seem to be able to move/,
-    /^Remove what/,
-    /^I could not/,
-    /^What were you/
+    /^You need a free hand.*/,
+    /^You aren't wearing.*/,
+    /^You don't seem to be able to move.*/,
+    /^Remove what.*/,
+    /^I could not.*/,
+    /^What were you.*/
   ]
+
+  @@remove_item_retry_patterns = []
 
   @@put_away_item_success_patterns = [
     /^You put your .* in/,
@@ -563,55 +567,92 @@ module DRCI
   #
   # Returns true if the item is in your hand
   # or we were able to get it to your hand.
-  def get_item_if_not_held?(item, container = nil)
+  def get_item_if_not_held?(item, container = nil, detailed = false)
     return false unless item
     return true if in_hands?(item)
-    return get_item(item, container)
+    return get_item(item, container, detailed)
   end
 
   # Provide a predicate-named method to follow convention.
-  def get_item?(item, container = nil)
-    get_item(item, container)
+  def get_item?(item, container = nil, detailed = false)
+    get_item(item, container, detailed)
   end
 
   # Gets an item, optionally from a specific container.
   # If no container specified then generically grabs from the room/your person.
   # Can provide an array of containers to try, too, in case some might be empty.
-  def get_item(item, container = nil)
+  def get_item(item, container = nil, detailed = false)
     if container.is_a?(Array)
       container.each do |c|
-        return true if get_item_safe(item, c)
+        return true if get_item_safe(item, c, detailed)
       end
       return false
     end
-    get_item_safe(item, container)
+    get_item_safe(item, container, detailed)
   end
 
   # Same as 'get_item_unsafe' but ensures that
   # the container argument is prefixed with 'my' qualifier.
-  def get_item_safe?(item, container = nil)
+  def get_item_safe?(item, container = nil, detailed = false)
     item = "my #{item}" if item && !(item =~ /^my /i)
     container = "my #{container}" if container && !(container =~ /^((in|on|under|behind|from) )?my /i)
-    get_item_unsafe(item, container)
+    get_item_unsafe?(item, container, detailed)
   end
 
-  def get_item_safe(item, container = nil)
-    get_item_safe?(item, container)
+  def get_item_safe(item, container = nil, detailed = false)
+    get_item_safe?(item, container, detailed)
   end
 
   # Gets an item, optionally from a specific container.
   # If no container specified then generically grabs from the room/your person.
+  def get_item_unsafe?(item, container = nil, detailed = false)
+    result = get_item_unsafe(item, container)
+
+    unless detailed
+      return result.success
+    else
+      return result
+    end
+    # from = container
+    # from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
+    # case DRC.bput("get #{item} #{from}", @@get_item_success_patterns, @@get_item_failure_patterns)
+    # when *@@get_item_success_patterns
+    #   return true
+    # else
+    #   if container =~ /\bportal\b/i
+    #     return get_item_from_eddy_portal?(item, container)
+    #   else
+    #     return false
+    #   end
+    # end
+  end
+
   def get_item_unsafe(item, container = nil)
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
-    case DRC.bput("get #{item} #{from}", @@get_item_success_patterns, @@get_item_failure_patterns)
+    game_output = DRC.bput("get #{item} #{from}", @@get_item_success_patterns,
+      @@get_item_failure_patterns)
+
+    case game_output
     when *@@get_item_success_patterns
-      return true
+      return OpenStruct.new(
+        success: true,
+        output: game_output,
+        success_patterns: @@get_item_success_patterns,
+        failure_patterns: @@get_item_failure_patterns,
+        retry_patterns: @@get_item_retry_patterns
+      )
     else
       if container =~ /\bportal\b/i
-        return get_item_from_eddy_portal?(item, container)
+        return get_item_from_eddy_portal?(item, container, detailed)
       else
-        return false
+        return OpenStruct.new(
+          success: false,
+          output: game_output,
+          success_patterns: @@get_item_success_patterns,
+          failure_patterns: @@get_item_failure_patterns,
+          retry_patterns: @@get_item_retry_patterns
+        )
       end
     end
   end
@@ -619,7 +660,7 @@ module DRCI
   # Workaround to game changes where you must periodically look in
   # the portal for the contents to be available.
   # http://forums.play.net/forums/DragonRealms/Discussions%20with%20DragonRealms%20Staff%20and%20Players/Game%20Master%20and%20Official%20Announcements/view/1899
-  def get_item_from_eddy_portal?(item, container)
+  def get_item_from_eddy_portal?(item, container, detailed = false)
     # Ensure the eddy is open then look in it to force the contents to be loaded.
     return false unless DRCI.open_container?('my eddy') && DRCI.look_in_container(container)
     from = container
@@ -630,6 +671,10 @@ module DRCI
     else
       return false
     end
+  end
+
+  def get_item_from_eddy_portal(item, container)
+
   end
 
   #########################################
@@ -663,24 +708,49 @@ module DRCI
   #########################################
 
   # Removes an item you're wearing.
-  def remove_item?(item)
-    remove_item_safe?(item)
+  def remove_item?(item, detailed = false)
+    remove_item_safe?(item, detailed)
   end
 
   # Same as 'remove_item_unsafe?' but ensures that
   # the item name is prefixed with 'my' qualifier.
-  def remove_item_safe?(item)
+  def remove_item_safe?(item, detailed = false)
     item = "my #{item}" if item && !(item =~ /^my /i)
-    remove_item_unsafe?(item)
+    remove_item_unsafe?(item, detailed)
   end
 
   # Removes an item you're wearing.
-  def remove_item_unsafe?(item)
-    case DRC.bput("remove #{item}", @@remove_item_success_patterns, @@remove_item_failure_patterns)
-    when *@@remove_item_success_patterns
-      return true
+  def remove_item_unsafe?(item, detailed = false)
+    result = remove_item_unsafe(item)
+    unless detailed
+      return result.success
     else
-      return false
+      return result
+    end
+  end
+
+  def remove_item_unsafe(item)
+
+    game_output = DRC.bput("remove #{item}", @@remove_item_success_patterns,
+      @@remove_item_failure_patterns)
+
+    case game_output
+    when *@@remove_item_success_patterns
+      return OpenStruct.new(
+        success: true,
+        output: game_output,
+        success_patterns: @@remove_item_success_patterns,
+        failure_patterns: @@remove_item_failure_patterns,
+        retry_patterns: @@remove_item_retry_patterns
+      )
+    else
+      return OpenStruct.new(
+        success: false,
+        output: game_output,
+        success_patterns: @@remove_item_success_patterns,
+        failure_patterns: @@remove_item_failure_patterns,
+        retry_patterns: @@remove_item_retry_patterns
+      )
     end
   end
 
@@ -688,13 +758,13 @@ module DRCI
   # STOW ITEM
   #########################################
 
-  # Stows an item into its default container. See STORE HELP for details.
+  # Stows an item into its default container. See STORE HELP for detailed.
   # Same as 'stow_item_safe?'.
   def stow_item?(item)
     stow_item_safe?(item)
   end
 
-  # Stows an item into its default container. See STORE HELP for details.
+  # Stows an item into its default container. See STORE HELP for detailed.
   # Same as 'stow_item_unsafe?' but ensures that
   # the item argument is prefixed with 'my '.
   def stow_item_safe?(item)
@@ -702,7 +772,7 @@ module DRCI
     stow_item_unsafe?(item)
   end
 
-  # Stows an item into its default container. See STORE HELP for details.
+  # Stows an item into its default container. See STORE HELP for detailed.
   # Unless you include the 'my ' prefix in the item then this may
   # try to stow an item on the ground rather than something in your inventory.
   def stow_item_unsafe?(item)

--- a/common-items.lic
+++ b/common-items.lic
@@ -758,13 +758,13 @@ module DRCI
   # STOW ITEM
   #########################################
 
-  # Stows an item into its default container. See STORE HELP for detailed.
+  # Stows an item into its default container. See STORE HELP for details.
   # Same as 'stow_item_safe?'.
   def stow_item?(item)
     stow_item_safe?(item)
   end
 
-  # Stows an item into its default container. See STORE HELP for detailed.
+  # Stows an item into its default container. See STORE HELP for details.
   # Same as 'stow_item_unsafe?' but ensures that
   # the item argument is prefixed with 'my '.
   def stow_item_safe?(item)
@@ -772,7 +772,7 @@ module DRCI
     stow_item_unsafe?(item)
   end
 
-  # Stows an item into its default container. See STORE HELP for detailed.
+  # Stows an item into its default container. See STORE HELP for details.
   # Unless you include the 'my ' prefix in the item then this may
   # try to stow an item on the ground rather than something in your inventory.
   def stow_item_unsafe?(item)


### PR DESCRIPTION
I've really enjoyed learning the Lich code base. It's an impressive open-source project and for some reason is imminently approachable for someone like me who doesn't code for a living. Maybe it's the Ruby language, or how well-built the code base is. Either way, I'm enjoying it.

This draft is not close to complete and is not meant to be, but I wanted to put something up as a concept for discussion among contributors. I've tossed this around with some other contributors and we at least judged it worthy of discussion. **_I am soliciting comments and suggestions on this idea._**

**Background:**
I love the compartmentalization of the helper methods in the `common`s. It allows us to centralize the details of game input actions that are extraordinarily common. We centralize the game input and regex recognition, aggregate game output messages, make game actions "safe" so we don't lose items, handle common and benign failures and retry the input, and more. 

**Current Paradigm:**
By and large, the current paradigm is that the helper methods take some input, try some action, and return either true or false -- whether the action succeeded or failed. This serves a great purpose - offload the action and the details thereof, and tell us whether we succeeded. Then, the script calling the helper method can take action on a pass or fail basis.

**An Example:**
Let's take an easy example. Currently, `common-items` has a series of methods that wear an item. It is currently 3 methods, called in a hierarchical pattern, accepting as input the item we want to wear, helping make our input safe by appending "my" to the item, utilizing `bput` to perform the action, and aggregating all known success and failure patterns for wearing an item. It returns `true` if we successfully wore the item, and `false` if we didn't. A calling script can use `DRCI.wear_item("boots")` and not have to worry about the details of doing so.

**The Problem:**
Not really a problem, but an opportunity. We regularly want to perform a common game action within a script. And the `common` helper methods are good for this task. But, rather than understanding whether the action simply succeeded or failed, we often want to to understand what the game feedback is and perhaps take specific action _within the script calling the helper method_. In the example above, the calling script only has knowledge of whether the action succeeded or failed. It has no ability to understand what the game output was, and to take action on certain output. In essence, we have these beautiful centralized helper methods, but they don't help us do what we so often _need_ to do -- understand what the game output was, and handle various different output....differently.

**Current Scenario:**
Where does this leave us? We have a plethora of `common-*` helper scripts that are great to utilize. But any time we want a calling script to take a common game action and custom handle game output, we're left RE-creating the wheel via a `bput`, even when that action is something incredibly simple like getting an item. And because we're constantly re-creating the wheel and we have dozens of contributors trying to re-create success and failure messages, we have dozens of places where we have to fix things.

**The Idea - 10k Foot View:**
The idea is to maintain legacy functionality but allow a new paradigm -- create helper methods that _still_ centralize all the details of common game actions but allow a calling script to access the game output, if desired, and take specific action on that output. Instead of simply returning true or false when calling a helper method like `DRCI.wear_item`, we'll now allow the option to return the full game output line that matched. What does this get us? It still allows us to:

- Centralize the bput and success/failure match strings for common game actions
- Maintain the regular details of very common actions within a single method or set of methods in a Module
- Still allowing flexibility to parse different outputs within a script utilizing said Modules, without needing to recreate the wheel via `bput` any time we need to take custom action on game output

**Concrete Example:**
```ruby
    detailed_output = DRCI.get_item?(item, container, detailed = true)

    case detailed_output.output
    when /already in your inventory/
        echo "Do custom thing in our calling script based on this regex match to game output."
    end
```
What we're seeing here is that we're utilizing a new paradigm - calling `DRCI.get_item` with a new arg `detailed = true`, which exposes the full line of game output that matched the helper method, and allows us to take custom action on it in the calling script. 

As a real current example where this would be useful, `combat-trainer` currently has a match failure in its `stow_ammo` method when your hands are too full to stow something. The missing match phrase actually exists in the success/failure patterns of `DRCI.stow_item`, so if we could call that helper method here it would be properly handled. But we can't use the helper method here, because `combat-trainer` takes specific action on certain feedback to the stow action:

```ruby
    case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
    when 'You pick up', 'You put your'
      stow_ammo(ammo, quantity - 1)
    when 'Stow what'
      # Bug fix for typo with burgled arrows.
      # Messaging will say "you fire a blunt-tipped arrows" (note the trailing 's')
      # when you actually only shot a singular arrow and the item itself
      # only responds to 'stow arrow' (no 's').
      stow_ammo(ammo.slice(0..-2), quantity) if ammo.end_with?('s')
```
**_What if we could utilize `DRCI.stow_item`, where all our regex patterns are aggregated, while _still_ being able to take action on certain game output in our case/when statement in the calling script? That's where this idea comes in._**
--
**In summary:**
We have these great helper methods that are very useful. Yet our codebase is peppered with `bput`s that completely overlap with the helper methods _because_ they take some custom action on specific game output and the helper methods don't expose the game output to us.

The idea here is to add a new paradigm -- utilize all the good stuff of the centralized methods, while still allowing custom actions on the resulting game output. As a last note, here is a screenshot of a calling-script utilizing the new paradigm of a helper method, echoing the exposed game output, and taking some custom action on it, while also still functioning as expected using the old paradigm.

![image](https://user-images.githubusercontent.com/6467969/148718011-a6cf4797-ee3b-4ff4-80de-f2f9c3ce61f3.png)




