### PR TITLE
[script] [common-items] Add get_item failure match "You can't reach that from here"

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -66,19 +66,20 @@ module DRCI
   ]
 
   @@get_item_failure_patterns = [
-    /already in your inventory/,
     /^You need a free hand/,
-    /needs to be tended to be removed/,
     /^You can't pick that up with your hand that damaged/,
     /^Your (left|right) hand is too injured/,
     /^You just can't/,
-    /push you over the item limit/,
     /^You stop as you realize the .* is not yours/,
+    /^You can't reach that from here/, # on a mount like a flying carpet
     /^Get what/,
     /^I could not/,
     /^What were you/,
-    /rapidly decays away/,
-    /cracks and rots away/
+    /already in your inventory/, # wearing it
+    /needs to be tended to be removed/, # ammo lodged in you
+    /push you over the item limit/, # you're at item capacity
+    /rapidly decays away/, # item disappears when try to get it
+    /cracks and rots away/ # item disappears when try to get it
   ]
 
   @@wear_item_success_patterns = [


### PR DESCRIPTION
### Background
* Encountered this while on my flying carpet and `wand-watcher` tried to get my wand from my portal.

### Changes
* Add `^/You can't reach that from here/` to get item failure matches
* Reorganize the match strings so that anchored ones start first then the unanchored ones, for my personal preference