### PR TITLE
[script] [magic-training] Support both `magic_training` and `training_spells`

### DIFF
--- a/magic-training.lic
+++ b/magic-training.lic
@@ -52,7 +52,8 @@ class MagicTraining
     @exp_threshold = @settings.magic_exp_training_max_threshold
 
     # Hash of magic skill (e.g. Warding) to spell to train with (same config as spells in waggle sets)
-    @training_spells = @settings.training_spells
+    @training_spells = @settings.magic_training # original value from `;repos download magic-training`
+    @training_spells = @settings.training_spells if @training_spells.nil? || @training_spells.empty?
 
     @force_cambrinth = @settings.waggle_force_cambrinth
 


### PR DESCRIPTION
### Background
* Today I learned that Lich repo has two magic training scripts: magic-trainer, magic-training
* `magic-trainer` uses `training_spells:` setting and `magic_training` uses `magic_training:` setting
* The two scripts do pretty much the same thing... cast spells to train magic
* In https://github.com/rpherbig/dr-scripts/pull/5393 I was not aware of the two separate settings and brought over support for only `training_spells`, which broke a few people today

### Changes
* Support `magic_training:` as list of magic skills/spells to train
* Fallback to `training_spells:` if the other setting is not defined or empty