### PR TITLE
[script] [faskinner] stop training when mind locked

### DIFF
--- a/faskinner.lic
+++ b/faskinner.lic
@@ -10,7 +10,6 @@ fa_skinning_priority: Skinning
 custom_require.call(%w[common events drinfomon equipmanager])
 
 class FaSkinner
-  include DRC
 
   def initialize
     @settings = get_settings
@@ -27,22 +26,22 @@ class FaSkinner
     get_item(@knife, @knife_container) if @knife
 
     if @priority == 'First Aid' && DRSkill.getxp('First Aid') < @target_mindstate
-      until DRSkill.getxp('First Aid') > @target_mindstate
+      until DRSkill.getxp('First Aid') >= @target_mindstate
         train_skills
       end
       echo ("Exiting because First Aid locked!")
     elsif @priority == 'Skinning' && DRSkill.getxp('Skinning') < @target_mindstate
-      until DRSkill.getxp('Skinning') > @target_mindstate
+      until DRSkill.getxp('Skinning') >= @target_mindstate
         train_skills
       end
       echo ("Exiting because Skinning target reached!")
     elsif @priority == 'Both' || @priority == 'both'
-      until DRSkill.getxp('First Aid') > @target_mindstate  && DRSkill.getxp('Skinning') > @target_mindstate
+      until DRSkill.getxp('First Aid') >= @target_mindstate  && DRSkill.getxp('Skinning') >= @target_mindstate
         train_skills
       end
       echo ("Exiting because First Aid AND Skinning target reached!")
     else
-      until DRSkill.getxp('First Aid') > @target_mindstate  || DRSkill.getxp('Skinning') > @target_mindstate
+      until DRSkill.getxp('First Aid') >= @target_mindstate  || DRSkill.getxp('Skinning') >= @target_mindstate
         train_skills
       end
       echo ("Exiting because First Aid OR Skinning target reached!")
@@ -59,7 +58,7 @@ class FaSkinner
   end
 
   def train_skills
-    case bput("skin my #{@trainer}",'You skillfully','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears','need to have a bladed instrument')
+    case DRC.bput("skin my #{@trainer}",'You skillfully','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears','need to have a bladed instrument')
     when /You must be holding/
       get_item(@trainer, @trainer_container)
     when /The leather looks frayed/
@@ -70,7 +69,7 @@ class FaSkinner
       do_exit
     end
 
-    case bput("repair my #{@trainer}",'With some needle and thread','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears')
+    case DRC.bput("repair my #{@trainer}",'With some needle and thread','A small blue-belly crocodile with prominently','You must be holding','The leather looks frayed','A small fuzzy caracal with tufted ears')
     when /You must be holding/
       get_item(@trainer, @trainer_container)
     when /The leather looks frayed/


### PR DESCRIPTION
### Background
* The script will stop training when your First Aid or Skinning exceed the `fa_skinning_mindstate_target` yaml setting
* `base.yaml` defaults to `fa_skinning_mindstate_target: 34`
* The current logic stops if your learning rate **is greater than** that threshold, but if you're already at 34 and can't increase then the script continues until it wears out the training device

### Changes
* Change greater than `>` comparisons to greater or equal `>=`
* Remove `include DRC` and instead use `DRC` prefix on those methods (bput) instead per general refactoring conventions

FYI @Hiinky 