### PR TITLE
[script] [t2] option to skip skills that require moons

### DIFF
--- a/t2.lic
+++ b/t2.lic
@@ -5,11 +5,9 @@
         and thresholds in which the scripts should be started
 =end
 
-custom_require.call(%w[common drinfomon equipmanager common-arcana])
+custom_require.call(%w[common common-arcana drinfomon equipmanager])
 
 class T2
-  # include DRC for various common calls below
-  # include DRCA for the cyclic release handling at script exit
 
   def initialize
     @shutdown = false
@@ -35,13 +33,19 @@ class T2
       EquipmentManager.new.empty_hands
 
       trainables.each do |trainable|
-        if trainable['skill'].is_a? Array
+        # Skip if learning rate is above start threshold for this trainable
+        if trainable['skill'].is_a?(Array)
           next if trainable['skill'].each.reject { |skill| DRSkill.getxp(skill) >= trainable['start'] }.empty?
         elsif DRSkill.getxp(trainable['skill']) >= trainable['start']
           next
-        elsif has_cooldown? trainable['skill']
-          next unless cooldown_expired? trainable['skill']
         end
+
+        # Skip if the skill is still on cooldown between trainings
+        next unless has_cooldown?(trainable['skill']) && cooldown_expired?(trainable['skill'])
+
+        # Skip if no moons are available
+        # Lunar mages can use this setting to skip skills that require moons
+        next unless trainable['moons'] && DRC.moons_visible?
 
         # At this point we know that we need to train the skill
         if trainable['name'].nil?
@@ -61,7 +65,7 @@ class T2
   end
 
   def has_cooldown?(skill)
-    @settings.exp_timers.keys.include? skill
+    @settings.exp_timers.keys.include?(skill)
   end
 
   def cooldown_expired?(skill)
@@ -82,7 +86,7 @@ class T2
     end
   end
 
-  def shutdown 
+  def shutdown
     if @shutdown
       DRC.message("T2 already set to shutdown.  Use '#{$clean_lich_char}e $T2.noshutdown' to cancel.")
     else
@@ -91,7 +95,7 @@ class T2
     end
   end
 
-  def noshutdown 
+  def noshutdown
     if @shutdown
       @shutdown = false
       DRC.message('Canceling shutdown of T2.')
@@ -104,7 +108,7 @@ class T2
     temp_settings = get_settings
 
     if temp_settings.training_list.nil? ||
-       temp_settings.training_list.class != Array || 
+       temp_settings.training_list.class != Array ||
        temp_settings.training_list.empty?
       DRC.message("Detected invalid T2 settings - please double check your config")
       return

--- a/t2.lic
+++ b/t2.lic
@@ -41,11 +41,15 @@ class T2
         end
 
         # Skip if the skill is still on cooldown between trainings
-        next unless has_cooldown?(trainable['skill']) && cooldown_expired?(trainable['skill'])
+        if has_cooldown?(trainable['skill'])
+          next unless cooldown_expired?(trainable['skill'])
+        end
 
         # Skip if no moons are available
         # Lunar mages can use this setting to skip skills that require moons
-        next unless trainable['moons'] && DRC.moons_visible?
+        if trainable['moons']
+          next unless DRC.moons_visible?
+        end
 
         # At this point we know that we need to train the skill
         if trainable['name'].nil?

--- a/t2.lic
+++ b/t2.lic
@@ -41,15 +41,11 @@ class T2
         end
 
         # Skip if the skill is still on cooldown between trainings
-        if has_cooldown?(trainable['skill'])
-          next unless cooldown_expired?(trainable['skill'])
-        end
+        next if has_cooldown?(trainable['skill']) && !cooldown_expired?(trainable['skill'])
 
         # Skip if no moons are available
         # Lunar mages can use this setting to skip skills that require moons
-        if trainable['moons']
-          next unless DRC.moons_visible?
-        end
+        next if trainable['moons'] && !DRCA.moons_visible?
 
         # At this point we know that we need to train the skill
         if trainable['name'].nil?


### PR DESCRIPTION
### Dependencies
* https://github.com/rpherbig/dr-scripts/pull/5408

### Background
* I've been playing my Moon Mage lately and the moons have not been visible for long stretches of time while I'm in the game.
* T2 doesn't currently have a way to skip training certain skills/sections if moons aren't visible so I get in loops where I can't get past my combat-block (which bails when no moons) to do other tedious things like train scholarship or first aid, etc
* I'd rather not re-order my T2 section, I like hunting first then diving in to other things
* What I'm looking for is for T2 to skip whole sections if moons aren't visible to avoid these hangups

### Changes
* 🆕 Support new property when defining a training section: `moons: boolean` much like how `hunting-buddy` does
* 🧹 Reorder custom_require imports to sort `common-*` scripts first
* 🧹 Trim whitespace on file save
* 🧹 Add parens to method calls