### PR TITLE
[script][hunting-buddy] Clearing all avoids when exiting due to low health

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -278,6 +278,7 @@ class HuntingBuddy
       clear
       if health < @settings.health_threshold
         message('***STATUS*** exiting due to low health')
+        fput('avoid all')
         fput('exit')
       end
       if @settings.stop_hunting_if_bleeding && bleeding?


### PR DESCRIPTION
When HB exits due to low health, in many cases a character will have their avoids set still, as they're set by t2. With this change, when a character logs back in, they can at least be dragged out immediately, instead of having to perform the manual action of clearing avoids first...