### PR TITLE
[script][common-money] Add match phrase when withdrawing

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -194,12 +194,21 @@ module DRCM
     DRCT.walk_to(get_data('town')[hometown]['deposit']['id'])
     DRC.release_invisibility
     loop do
-      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells', 'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands', 'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account', /The clerk says, "I'm afraid you can't withdraw that much at once/)
+      case DRC.bput("withdraw #{amount_as_string}", 'The clerk counts', 'The clerk tells',
+        'The clerk glares at you.', 'You count out', 'find a new deposit jar', 'If you value your hands',
+        'Hey!  Slow down!', "You must be at a bank teller's window to withdraw money",
+        "You don't have that much money", 'have an account',
+        /The clerk says, "I'm afraid you can't withdraw that much at once/,
+        /^How much do you wish to withdraw/i
+      )
       when 'The clerk counts', 'You count out'
         break true
       when 'The clerk glares at you.', 'Hey!  Slow down!'
         pause 15
-      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar', "You must be at a bank teller's window to withdraw money", "You don't have that much money", 'have an account', /The clerk says, "I'm afraid you can't withdraw that much at once/
+      when 'The clerk tells', 'If you value your hands', 'find a new deposit jar',
+        "You must be at a bank teller's window to withdraw money", "You don't have that much money",
+        'have an account', /The clerk says, "I'm afraid you can't withdraw that much at once/,
+        /^How much do you wish to withdraw/i
         break false
       else
         break false
@@ -224,8 +233,7 @@ module DRCM
       return
     end
     minimize_coins(keep_copper).each { |amount| withdraw_exact_amount?(amount, settings) } if settings.hometown == hometown
-    case DRC.bput('check balance',
-                /current balance is .*? (?:Kronars?|Dokoras?|Lirums?)\."$/,
+    case DRC.bput('check balance', /current balance is .*? (?:Kronars?|Dokoras?|Lirums?)\."$/,
                 /If you would like to open one, you need only deposit a few (?:Kronars?|Dokoras?|Lirums?)\."$/,
                 /As expected, there are .*? (?:Kronars?|Dokoras?|Lirums?)\.$/,
                 'Perhaps you should find a new deposit jar for your financial needs.  Be sure to mark it with your name')


### PR DESCRIPTION
Reported by [Xelten on Discord](https://discordapp.com/channels/745675889622384681/745675890242879671/931550450417823775).

Adds a match phrase when withdrawing money from the bank. The actual reason for this match failure is because `;herb-restock` doesn't use the right helper methods and sometimes tries to withdraw 0 copper from the teller. But I'm adding this match phrase for completeness sake.