### PR TITLE
[script][herb-stock] Use common-money method

### DIFF
--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -37,8 +37,9 @@ class Herbstock
       item['buy_num'] = buy_num
       items_to_restock.push(item)
     end
-    get_money_from_bank("#{coin_needed / 1000} gold", "#{town_currency(town)}", "#{town}") if (coin_needed / 1000) > 0
-    get_money_from_bank("#{coin_needed % 1000} copper", "#{town_currency(town)}", "#{town}") if coin_needed > 0
+
+    DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
+
     items_to_restock.each do |item|
       item['buy_num'].times do
         stow_hands


### PR DESCRIPTION
Utilizes DRCM's helper method instead of handling depositing coins manually. Prevents [occasionally trying to withdraw 0 copper](https://discordapp.com/channels/745675889622384681/745675890242879671/931550450417823775) when the math in the method works out a certain way.