### PR TITLE
[script] [buff-watcher] support 'recast' config on spell data

### DIFF
--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -95,14 +95,14 @@ class BuffWatcher
 
   def buffs_active?
     if DRStats.thief?
-      # Elements in the buff are ability names (strings) without the Khri prefix
-      return @settings.waggle_sets[@buff_set_name].all? { |spell| DRSpells.active_spells["Khri #{spell}"] }
+      # Elements in the waggle set are ability names (strings) without the Khri prefix
+      return @settings.waggle_sets[@buff_set_name].all? { |name| DRSpells.active_spells["Khri #{name}"] }
     elsif DRStats.barbarian?
-      # Elements in the buff are ability names (strings)
-      return @settings.waggle_sets[@buff_set_name].all? { |spell| DRSpells.active_spells[spell] }
+      # Elements in the waggle set are ability names (strings)
+      return @settings.waggle_sets[@buff_set_name].all? { |name| DRSpells.active_spells[name] }
     else
-      # Elements in the buff are maps of spell name to spell data
-      return @settings.waggle_sets[@buff_set_name].all? { |spell, data| DRSpells.active_spells[spell] }
+      # Elements in the waggle set are maps of spell name to spell data
+      return @settings.waggle_sets[@buff_set_name].all? { |name, data| DRSpells.active_spells[name] && (data['recast'].nil? || DRSpells.active_spells[name].to_i > data['recast']) }
     end
   end
 


### PR DESCRIPTION
### Background
* Requested by Xelten in [Discord](https://discord.com/channels/745675889622384681/745675890242879671/932074274003484783)
* `buff-watcher` waits until a spell is not active before recasting; some users want the `recast` property to be respected so that the spell is recast when there's X or fewer minutes remaining so that the buff is always up

### Changes
* If a spell is active and there's `recast` number of minutes or fewer remaining then recast the buff