### PR TITLE
[script] [common-arcana] new methods to check currently preparing spell

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -167,23 +167,21 @@ module DRCA
   end
 
   # Returns true if preparing a spell, false otherwise.
-  # For the name of the spell, see `get_preparing_spell`
-  def preparing_spell?
-    !XMLData.prepared_spell.nil? &&
-    !XMLData.prepared_spell.empty? &&
-    !XMLData.prepared_spell.eql?('None')
+  def spell_preparing?
+    !spell_preparing.nil?
   end
 
   # Returns true if you're prepared to cast your spell.
   # Infers this if you're preparing a spell and there's no more prep time to wait.
   def spell_prepared?
-    preparing_spell? && checkcastrt <= 0
+    spell_preparing? && checkcastrt <= 0
   end
 
   # Returns name of the spell being prepared, or nil if not preparing one.
   def spell_preparing
-    return nil unless preparing_spell?
-    XMLData.prepared_spell
+    name = XMLData.prepared_spell
+    name = nil if name.empty? || name.eql?('None')
+    name
   end
 
   def ritual(spell, settings)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -166,6 +166,26 @@ module DRCA
     match
   end
 
+  # Returns true if preparing a spell, false otherwise.
+  # For the name of the spell, see `get_preparing_spell`
+  def preparing_spell?
+    !XMLData.prepared_spell.nil? &&
+    !XMLData.prepared_spell.empty? &&
+    !XMLData.prepared_spell.eql?('None')
+  end
+
+  # Returns true if you're prepared to cast your spell.
+  # Infers this if you're preparing a spell and there's no more prep time to wait.
+  def spell_prepared?
+    preparing_spell? && checkcastrt <= 0
+  end
+
+  # Returns name of the spell being prepared, or nil if not preparing one.
+  def spell_preparing
+    return nil unless preparing_spell?
+    XMLData.prepared_spell
+  end
+
   def ritual(spell, settings)
     DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
     DRC.release_invisibility


### PR DESCRIPTION
### Background
* I want easier ways to check if you're currently preparing a spell and what spell that is and whether you're likely ready to cast
* Building blocks to greater awesomeness

### Changes
* Add three new methods:
  - `DRCA.spell_preparing?` _are you preparing a spell?_
  - `DRCA.spell_prepared?` _are you prepared to cast the spell you're preparing, i.e. no more cast wait time_
  - `DRCA.spell_preparing` _returns name of spell currently being prepared_

### Tests
_when not preparing a spell_
```
> ,e echo "spell=#{DRCA.spell_preparing}, prepared=#{DRCA.spell_prepared?}, preparing=#{DRCA.spell_preparing?}, waitcastrt=#{checkcastrt}"

[exec1: spell=, prepared=false, preparing=false, waitcastrt=0]
```
_when preparing a spell_
```
> prepare cv 10
You raise your palms skyward, chanting the equation of the Clear Vision spell.

> ,e echo "spell=#{DRCA.spell_preparing}, prepared=#{DRCA.spell_prepared?}, preparing=#{DRCA.spell_preparing?}, waitcastrt=#{checkcastrt}"

[exec1: spell=Clear Vision, prepared=false, preparing=true, waitcastrt=15.854858016967775]
```
_when spell is ready to cast_
```
You feel fully prepared to cast your spell.

> ,e echo "spell=#{DRCA.spell_preparing}, prepared=#{DRCA.spell_prepared?}, preparing=#{DRCA.spell_preparing?}, waitcastrt=#{checkcastrt}"

[exec1: spell=Clear Vision, prepared=true, preparing=true, waitcastrt=0]
```
_after casting spell_
```
> cast
You gesture.
You briefly feel less aware of your environment, then feel more aware again.

> ,e echo "spell=#{DRCA.spell_preparing}, prepared=#{DRCA.spell_prepared?}, preparing=#{DRCA.spell_preparing?}, waitcastrt=#{checkcastrt}"

[exec1: spell=, prepared=false, preparing=false, waitcastrt=0]
```