### PR TITLE
[script] [common-arcana] sort skills to train by learning rate then by rank

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -849,7 +849,10 @@ module DRCA
     needs_training = %w[Warding Utility Augmentation]
     needs_training.append("Sorcery") if (settings.crafting_training_spells_enable_sorcery && !Script.running?('forge')) ||
                                         (settings.crafting_training_spells_enable_sorcery && settings.crafting_training_spells_enable_sorcery_forging)
-    needs_training = needs_training .select { |skill| training_spells[skill] } .select { |skill| DRSkill.getxp(skill) < 31 } .sort_by { |skill| DRSkill.getxp(skill) }.first
+    needs_training = needs_training.select { |skill| training_spells[skill] }
+                                   .select { |skill| DRSkill.getxp(skill) < 31 }
+                                   .sort_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
+                                   .first
 
     return unless needs_training
 


### PR DESCRIPTION
### Background
* Similar logic was implemented in combat-trainer in https://github.com/rpherbig/dr-scripts/pull/4686 to help ensure the lowest rate/rank skill gets the most attention

### Changes
* Sort crafting training spells by learning rate then by rank