### PR TITLE
[script] [common-summoning] identify summoned weapon

### DIFF
--- a/common-summoning.lic
+++ b/common-summoning.lic
@@ -3,17 +3,13 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-summoning
 =end
 
-custom_require.call(%w[common common-travel drinfomon])
+custom_require.call(%w[common common-moonmage drinfomon])
 
 module DRCS
   module_function
 
   def summon_weapon(moon = nil, element = nil, ingot = nil, skill = nil)
     if DRStats.moon_mage?
-      unless moon
-        echo "Couldn't find any moons to cast moonblade with"
-        return
-      end
       DRCMM.hold_moon_weapon?
     elsif DRStats.warrior_mage?
       get_ingot(ingot, true)
@@ -47,7 +43,7 @@ module DRCS
   def break_summoned_weapon(item)
     return if item.nil?
 
-    DRC.bput("break my #{item}", 'Focusing your will', 'disrupting its matrix', "You can't break")
+    DRC.bput("break my #{item}", 'Focusing your will', 'disrupting its matrix', "You can't break", "Break what")
   end
 
   def shape_summoned_weapon(skill, ingot = nil)
@@ -55,11 +51,11 @@ module DRCS
       skill_to_shape = { 'Staves' => 'blunt', 'Twohanded Edged' => 'huge', 'Large Edged' => 'heavy', 'Small Edged' => 'normal' }
       shape = skill_to_shape[skill]
       if DRCMM.hold_moon_weapon?
-        DRC.bput("shape #{GameObj.right_hand.noun} to #{shape}", 'you adjust the magic that defines its shape', 'already has')
+        DRC.bput("shape #{identify_summoned_weapon} to #{shape}", 'you adjust the magic that defines its shape', 'already has', 'You fumble around')
       end
     elsif DRStats.warrior_mage?
       get_ingot(ingot, false)
-      case DRC.bput("shape my #{GameObj.right_hand.noun} to #{skill}", 'You lack the elemental charge', 'You reach out')
+      case DRC.bput("shape my #{identify_summoned_weapon} to #{skill}", 'You lack the elemental charge', 'You reach out', 'You fumble around')
       when 'You lack the elemental charge'
         summon_admittance
         shape_summoned_weapon(skill, nil)
@@ -72,22 +68,24 @@ module DRCS
     waitrt?
   end
 
-  def moon_used_to_summon_weapon
-    # Note, if you have more than one weapon summoned at a time
-    # then the results of this method are non-deterministic.
-    # For example, if you have 2+ moonblades/staffs cast on different moons.
-    ['moonblade', 'moonstaff'].each do |weapon|
-      glance = DRC.bput("glance my #{weapon}", "You glance at a .* (black|red-hot|blue-white) moon(blade|staff)", "I could not find")
-      case glance
-      when /black moon[\w]+/
-        return 'katamba'
-      when /red-hot moon[\w]+/
-        return 'yavash'
-      when /blue-white moon[\w]+/
-        return 'xibar'
-      end
+  # Returns what kind of summoned weapon you're holding.
+  # Will be the <adj> <noun> like 'red-hot moonblade' or 'electric sword.
+  def identify_summoned_weapon
+    if DRStats.moon_mage?
+      return DRC.right_hand if DRCMM.is_moon_weapon?(DRC.right_hand)
+      return DRC.left_hand  if DRCMM.is_moon_weapon?(DRC.left_hand)
+    elsif DRStats.warrior_mage?
+      weapon_regex = /^You tap (?:a|an|some) ((stone|fiery|icy|electric) [\w\s\-]+) that you are holding.$/
+      # For a two-worded weapon like 'short sword' the only way to know
+      # which element it was summoned with is by tapping it. That's the only
+      # way we can infer if it's a summoned sword or a regular one.
+      # However, the <adj> <noun> of the item we return must be what's in
+      # their hands, not what the regex matches in the tap.
+      return DRC.right_hand if DRC.right_hand && DRCI.tap(DRC.right_hand) =~ weapon_regex
+      return DRC.left_hand  if DRC.left_hand  && DRCI.tap(DRC.left_hand)  =~ weapon_regex
+    else
+      echo "Unable to summon weapons as a #{DRStats.guild}"
     end
-    return nil
   end
 
   def turn_summoned_weapon


### PR DESCRIPTION
### Dependencies
* (forthcoming)

### Changes
* 🧹 Update `custom_require`; removed common-travel (unused) and added common-moonmage (missing)
* 🧹 Move `moon_used_to_summon_weapon` to `common-moonmage`
* 🆕 Add `identify_summoned_weapon` method to infer the summoned weapon in your hands