### PR TITLE
[script] [common-moonmage] add `is_moon_weapon?` and `moon_used_to_summon_weapon`

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -138,13 +138,12 @@ module DRCMM
   # Returns false if you're not holding a moon weapon, or you are but can't wear it.
   # https://elanthipedia.play.net/Shape_Moonblade
   def wear_moon_weapon?
-    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
     moon_wear_messages = ["You're already", "You can't wear", "Wear what", "telekinetic"]
     wore_it = false
-    if DRC.left_hand =~ moon_weapon_regex
+    if is_moon_weapon?(DRC.left_hand)
       wore_it = wore_it || DRC.bput("wear #{DRC.left_hand}", *moon_wear_messages) == "telekinetic"
     end
-    if DRC.right_hand =~ moon_weapon_regex
+    if is_moon_weapon?(DRC.right_hand)
       wore_it = wore_it || DRC.bput("wear #{DRC.right_hand}", *moon_wear_messages) == "telekinetic"
     end
     return wore_it
@@ -153,13 +152,12 @@ module DRCMM
   # Drops the moon weapon in your hands, if any.
   # Returns true if dropped something, false otherwise.
   def drop_moon_weapon?
-    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
     moon_drop_messages = ["As you open your hand", "What were you referring to"]
     dropped_it = false
-    if DRC.left_hand =~ moon_weapon_regex
+    if is_moon_weapon?(DRC.left_hand)
       dropped_it = dropped_it || DRC.bput("drop #{DRC.left_hand}", *moon_drop_messages) == "As you open your hand"
     end
-    if DRC.right_hand =~ moon_weapon_regex
+    if is_moon_weapon?(DRC.right_hand)
       dropped_it = dropped_it || DRC.bput("drop #{DRC.right_hand}", *moon_drop_messages) == "As you open your hand"
     end
     return dropped_it
@@ -167,8 +165,7 @@ module DRCMM
 
   # Is a moon weapon in your hands?
   def holding_moon_weapon?
-    moon_weapon_regex = /((black|red-hot|blue-white) moon[\w]+)/
-    return (DRC.left_hand =~ moon_weapon_regex || DRC.right_hand =~ moon_weapon_regex) != nil
+    return is_moon_weapon?(DRC.left_hand) || is_moon_weapon?(DRC.right_hand)
   end
 
   # Try to hold a moon weapon.
@@ -184,6 +181,30 @@ module DRCMM
       end
     end
     false
+  end
+
+  # Does the item appear to be a moon weapon?
+  def is_moon_weapon?(item)
+    return false unless item
+    !(item =~ /^((black|red-hot|blue-white) moon(blade|staff))$/i).nil?
+  end
+
+  def moon_used_to_summon_weapon
+    # Note, if you have more than one weapon summoned at a time
+    # then the results of this method are non-deterministic.
+    # For example, if you have 2+ moonblades/staffs cast on different moons.
+    ['moonblade', 'moonstaff'].each do |weapon|
+      glance = DRC.bput("glance my #{weapon}", "You glance at a .* (black|red-hot|blue-white) moon(blade|staff)", "I could not find")
+      case glance
+      when /black moon/
+        return 'katamba'
+      when /red-hot moon/
+        return 'yavash'
+      when /blue-white moon/
+        return 'xibar'
+      end
+    end
+    return nil
   end
 
 end


### PR DESCRIPTION
### Background
* The `moon_used_to_summon_weapon` method previously existed in `common-summoning` but is definitively moon mage specific

### Changes
* 🧹 Move `moon_used_to_summon_weapon` from `common-summoning` to `common-moonmage` (a subsequent pull request will refactor common-summoning to use this method)
* 🧹 Consolidate duplicated regex logic into `is_moon_weapon?` method

## Tests

### Moon Used To Summon Weapon
```
,e echo DRCMM.moon_used_to_summon_weapon

--- Lich: exec1 active.

[exec1]>glance my moonblade
You glance at a fiery red-hot moonblade.

[exec1: yavash]

--- Lich: exec1 has exited.
```
```
,e echo DRCMM.moon_used_to_summon_weapon

--- Lich: exec1 active.

[exec1]>glance my moonblade
You glance at a dull black moonblade.

[exec1: katamba]

--- Lich: exec1 has exited.
```
```
> ,e echo DRCMM.moon_used_to_summon_weapon

--- Lich: exec1 active.

[exec1]>glance my moonblade

I could not find what you were referring to.
> 
[exec1]>glance my moonstaff

I could not find what you were referring to.
> 
[exec1: ]

--- Lich: exec1 has exited.
```

### Holding Moon Weapon?
_when not holding items or none of them match the moon weapon regex_
```
> ,e echo DRCMM.holding_moon_weapon?

--- Lich: exec1 active.

[exec1: false]

--- Lich: exec1 has exited.
```
_when holding at least one item that matches the moon weapon regex_
```
> ,e echo DRCMM.holding_moon_weapon?

--- Lich: exec1 active.

[exec1: true]

--- Lich: exec1 has exited.
```