### PR TITLE
Add: force_crafting_hometown > Forging

### DIFF
--- a/alchemy.lic
+++ b/alchemy.lic
@@ -29,7 +29,7 @@ class Alchemy
     exit if args.craft && (args.forage || args.prepare)
 
     settings = get_settings
-    @hometown = settings.hometown
+    @hometown = @settings.force_crafting_town || @settings.hometown
     @alchemy_herb_quantity = settings.alchemy_herb_quantity
     @alchemy_herb_storage = settings.alchemy_herb_storage
     @herb_container = settings.herb_container

--- a/alchemy.lic
+++ b/alchemy.lic
@@ -29,7 +29,7 @@ class Alchemy
     exit if args.craft && (args.forage || args.prepare)
 
     settings = get_settings
-    @hometown = @settings.force_crafting_town || @settings.hometown
+    @hometown = settings.hometown
     @alchemy_herb_quantity = settings.alchemy_herb_quantity
     @alchemy_herb_storage = settings.alchemy_herb_storage
     @herb_container = settings.herb_container

--- a/craft.lic
+++ b/craft.lic
@@ -20,7 +20,7 @@ class Craft
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town || @settings.hometown
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
     @training_room = (@settings.training_rooms || [@settings.safe_room]).sample

--- a/forge.lic
+++ b/forge.lic
@@ -51,7 +51,7 @@ class Forge
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town || @settings.hometown
     @stamp = @settings.mark_crafted_goods
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container

--- a/makesteel.lic
+++ b/makesteel.lic
@@ -24,9 +24,10 @@ class MakeSteel
     total_count = args.count.to_i
     type = args.type || 'h'
     @settings = get_settings
-    @stock_room = get_data('crafting')['blacksmithing'][@settings.hometown]['stock-room']
+    @hometown = @settings.force_crafting_town || @settings.hometown
+    @stock_room = get_data('crafting')['blacksmithing'][@hometown]['stock-room']
 
-    ensure_copper_on_hand(2000 * total_count, @settings)
+    ensure_copper_on_hand(2000 * total_count, @settings, @hometown)
 
     combine = total_count > 6
     remaining_count = total_count
@@ -48,8 +49,8 @@ class MakeSteel
   end
 
   def refine
-    DRCT.order_item(get_data('crafting')['blacksmithing'][@settings.hometown]['finisher-room'], 9) unless exists?('flux')
-    find_empty_crucible(@settings.hometown)
+    DRCT.order_item(get_data('crafting')['blacksmithing'][@hometown]['finisher-room'], 9) unless exists?('flux')
+    find_empty_crucible(@hometown)
     until bput('get my steel ingot', 'You get', 'What were') == 'What were'
       bput('put ingot in cruc', 'You put')
     end
@@ -65,7 +66,7 @@ class MakeSteel
       order_stow(2) if type == 'h'
     end
 
-    find_empty_crucible(@settings.hometown)
+    find_empty_crucible(@hometown)
 
     multiplier = case type
                  when 'l'

--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -19,6 +19,7 @@ class SmeltDeeds
     alloys = %w[steel bronze pewter brass]
     all_metals = get_data('items').metal_types - alloys
     all_metals += [args.material] if args.material && alloys.include?(args.material)
+    @hometown = get_settings.force_crafting_hometown || get_settings.hometown
 
     unless %w[rod bellows shovel].all? { |tool| exists?(tool) }
       echo 'A TOOL WAS MISSING. FIND IT AND RESTART'
@@ -48,9 +49,7 @@ class SmeltDeeds
   end
 
   def smelt(metal)
-    settings = get_settings
-
-    find_empty_crucible(settings.hometown)
+    find_empty_crucible(@hometown)
 
     prepare_crucible(metal)
 

--- a/smelt.lic
+++ b/smelt.lic
@@ -12,6 +12,7 @@ class Smelt
     EquipmentManager.new.empty_hands
 
     settings = get_settings
+    @hometown = settings.force_crafting_town || settings.hometown
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container
     @belt = settings.forging_belt

--- a/smith.lic
+++ b/smith.lic
@@ -29,8 +29,8 @@ class Smith
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
-    @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town || @settings.hometown
+    discipline = get_data('crafting')['blacksmithing'][@hometown]
     @container = get_settings.crafting_container
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = recipe_lookup(recipes, args.item_name)
@@ -61,7 +61,7 @@ class Smith
   end
 
   def buy_parts(parts)
-    ensure_copper_on_hand(700, @settings)
+    ensure_copper_on_hand(700, @settings, @hometown)
     stow_hands
 
     parts.each do |part|
@@ -78,7 +78,7 @@ class Smith
   end
 
   def buy_ingot(discipline)
-    ensure_copper_on_hand(700, @settings)
+    ensure_copper_on_hand(700, @settings, @hometown)
     DRCT.order_item(discipline['stock-room'], discipline['stock-number'])
     bput("put ingot in my #{@container}", 'You put')
     stow_hands
@@ -103,7 +103,7 @@ class Smith
       end
     end
 
-    ensure_copper_on_hand(1000, @settings)
+    ensure_copper_on_hand(1000, @settings, @hometown)
     DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
     bput("put oil in my #{@container}", 'You put')
     stow_hands

--- a/workorders.lic
+++ b/workorders.lic
@@ -30,7 +30,7 @@ class WorkOrders
     @recipe_parts = crafting_data['recipe_parts']
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @hometown = @settings.hometown
+    @hometown = @settings.force_crafting_town || @settings.hometown
     @use_own_ingot_type = @settings.use_own_ingot_type
     @deed_own_ingot = @settings.deed_own_ingot
     deeds_data = get_data('crafting').deeds[@hometown]
@@ -220,7 +220,7 @@ class WorkOrders
   end
 
   def carve_items(info, item, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
     material_noun = %w[deed pebble stone rock rock boulder]
     material_volume = 0
@@ -302,7 +302,7 @@ class WorkOrders
   end
 
   def shape_items(info, item, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 10_000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 10_000, @settings, @hometown)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
 
     quantity.times do |count|
@@ -421,7 +421,7 @@ class WorkOrders
   end
 
   def sew_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
 
     existing = if bput("get #{info['sew-stock-name']} cloth from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
@@ -452,7 +452,7 @@ class WorkOrders
   end
 
   def knit_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
 
     existing = if bput("get yarn from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
@@ -576,7 +576,7 @@ class WorkOrders
   end
 
   def remedy_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
     herb2_needed = ''
     liquid_used = ''
 
@@ -635,7 +635,7 @@ class WorkOrders
     recipe, = find_recipe(info, item, quantity)
     remaining_volume = 0
 
-    ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
 
     quantity.times do
       if remaining_volume < recipe['volume']
@@ -722,7 +722,7 @@ class WorkOrders
 
     return unless @deed_own_ingot
     unless DRC.bput('look my deed packet', /You count \d+ deed claim forms remaining/, /I could not find what you were referring to/) =~ /You count \d+ deed claim forms remaining/
-      ensure_copper_on_hand(@cash_on_hand || 10_000, @settings)
+      ensure_copper_on_hand(@cash_on_hand || 10_000, @settings, @hometown)
       DRCT.order_item(@deeds_room, @deeds_number)
       fput('stow my packet')
     end
@@ -734,7 +734,7 @@ class WorkOrders
   end
 
   def enchanting_items(info, recipe, quantity)
-    ensure_copper_on_hand(@cash_on_hand || 20_000, @settings)
+    ensure_copper_on_hand(@cash_on_hand || 20_000, @settings, @hometown)
     # Enchant Sigil #1
     order_enchant(info['stock-room'], quantity, recipe['enchant_stock1'], @bag, @belt)
 


### PR DESCRIPTION
This is very similar to a draft @vtcifer had started ages ago then tons of things changed and some of the commons have been updated for other PRs but are applied very effectively here.

Purpose: Allow user to set `force_crafting_town:` similar to force_healer_town to utilize less-busy locations.  Most users would really only need this for forging but for the sake on uniformity and future-proofing, I am adding support to all of the craft scripts.