### PR TITLE
Remove requirement for empty remedies grinder room

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -102,7 +102,7 @@ module DRCC
     return unless DRC.bput('tap grinder', 'I could not', 'You tap.*grinder') == 'I could not'
     pressgrinderrooms = get_data('crafting')['remedies'][hometown]['press-grinder-rooms']
     idle_room = get_data('crafting')['remedies'][hometown]['idle-room']
-    DRCT.find_sorted_empty_room(pressgrinderrooms, idle_room)
+    DRTC.walk_to(pressgrinderrooms[0])
   end
 
   def find_enchanting_room(hometown, override = nil)


### PR DESCRIPTION
Supercedes #4952.  Good update, we need this.  Adding here so we can complete the edit.