### PR TITLE
[data] [base-town] Add vault and family vault rooms

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -9,6 +9,10 @@ Arthe Dale:
     id: 1073
 Crossing:
   currency: kronars
+  vault:
+    id: 8285
+  family_vault:
+    id: 15016
   leather_repair:
     id: 1544
     name: Randal
@@ -265,6 +269,8 @@ Darkling Wood:
   trader_outpost:
     id: 2702
 Dirge:
+  vault:
+    id: 14633
   trade_minister:
     id: 15175
   currency: kronars
@@ -299,6 +305,8 @@ Fayrin's Rest:
     id: 2840
 Leth Deriel:
   currency: kronars
+  vault:
+    id: 4488
   leather_repair:
     id: 1544
     name: Randal
@@ -354,6 +362,10 @@ Leth Deriel:
     << : *zoluren_guild_leaders
 Shard:
   currency: dokoras
+  vault:
+    id: 19282
+  family_vault:
+    id: 15681
   deposit:
     id: 19276
   exchange:
@@ -644,6 +656,8 @@ Wolf Clan:
     id: 1533
 Riverhaven:
   currency: lirums
+  vault:
+    id: 11476
   shipment_clerk:
     id: 13751
   trade_minister:
@@ -789,6 +803,8 @@ Rossman's Landing:
     - 12416
 Therenborough:
   currency: lirums
+  vault:
+    id: 8501
   shipment_clerk:
     id: 3232
   trade_minister:
@@ -935,6 +951,8 @@ Hvaral:
     id: 3751
 Ratha:
   currency: lirums
+  vault:
+    id: 14433
   leather_repair:
     id: 10752
     name: Raven
@@ -1032,6 +1050,8 @@ Ratha:
       id: 12687
 Aesry:
   currency: lirums
+  vault:
+    id: 14625
   leather_repair:
     id: 7229
     name: Sefu
@@ -1121,6 +1141,8 @@ Aesry:
       id:
 Mer'Kresh:
   currency: lirums
+  vault:
+    id: 11833
   deposit:
     id: 8834
   exchange:
@@ -1195,6 +1217,8 @@ Throne City:
   npc_empath: # None
 Hibarnhvidar:
   currency: dokoras
+  vault:
+    id: 13744
   shipment_clerk:
     id: 7412
   trade_minister:
@@ -1331,6 +1355,8 @@ Raven's Point:
     id: 4440
 Boar Clan:
   currency: dokoras
+  vault:
+    id: 13689
   shipment_clerk:
     id: 13675
   trade_minister:
@@ -1401,6 +1427,10 @@ Boar Clan:
       - 4194
 Fang Cove:
   currency: dokoras
+  vault:
+    id: 13507
+  family_vault:
+    id: 15875
   exchange:
     id: 8389
     fee: 0.03
@@ -1422,6 +1452,8 @@ Fang Cove:
     id: 8393
 Muspar'i:
   currency: Lirums
+  vault:
+    id: 15110
   shipment_clerk:
     id: 14289
   trade_minister:


### PR DESCRIPTION
### Background
* I'm tinkering with a script to take me to where my actual vault is located.
* Some of my characters use Fang Cove, some use one in their local hometown, either way `,go vault` is insufficient for my purposes because that only goes to the nearest vault.

### Changes
* Add vault rooms to towns