### PR TITLE
[script] [healme] track when get disease/poisoned and when its healed over time

### DIFF
--- a/healme.lic
+++ b/healme.lic
@@ -79,6 +79,8 @@ class HealMe
             echo "@tended_wounds[#{body_part}] = #{@tended_wounds[body_part]}" if $debug_mode_healme
           end
       end
+      @diseased = false if Flags['healme-cured-disease']
+      @poisoned = false if Flags['healme-flushed-poisons']
       server_string
     end
 
@@ -169,10 +171,10 @@ class HealMe
       # Using these variable names to not conflict with
       # implicit 'health' variable that tells your vitality.
       @health_data = get_health_data
+      @diseased = @health_data['diseased']
+      @poisoned = @health_data['poisoned']
       break unless wounds_to_heal?(@health_data)
       attend_vitals
-      flush_poisons if @health_data['poisoned']
-      cure_diseases if @health_data['diseased']
       # Address the most severe wounds for a given category each loop iteration.
       # This heals the most severe bleeders first, then restarts the loop.
       # If there are more bleeders, it heals the next severity level, then restarts the loop.
@@ -227,6 +229,8 @@ class HealMe
       cast_regenerate if @spells['Regenerate']
       cast_heal if @spells['Heal']
     end
+    cure_diseases if diseased?
+    flush_poisons if poisoned?
   end
 
   # Removes wounds from the wounds map that are
@@ -570,6 +574,20 @@ class HealMe
     # becomes worse the next due to disease, poison, or other cause.
     @healed_wounds = Hash.new { |h, k| h[k] = false }
     @tended_wounds = Hash.new { |h, k| h[k] = false }
+    Flags.add('healme-cured-disease', 'You feel completely cured of all disease')
+    Flags.add('healme-flushed-poison', 'your spell flushes all poison from your body')
+  end
+
+  # The method by similar name in lich.rbw does not support DR
+  # so relying on our own variable based on parsing health output.
+  def diseased?
+    @diseased
+  end
+
+  # The method by similar name in lich.rbw does not support DR
+  # so relying on our own variable based on parsing health output.
+  def poisoned?
+    @poisoned
   end
 
   # Returns true if the argument is nil or empty.
@@ -580,6 +598,8 @@ end
 
 before_dying do
   DownstreamHook.remove('wounds_healed_hook')
+  Flags.delete('healme-cured-disease')
+  Flags.delete('healme-flushed-poison')
 end
 
 HealMe.new


### PR DESCRIPTION
### Background
* As an Empath, if you know [Adaptive Curing](https://elanthipedia.play.net/Adaptive_Curing) then you may already have the healing effect of Cure Disease or Flush Poisons active and a pulse may heal the issue when the script tries to do it, too.
* The script can be optimized to monitor for being cured of disease/poison and skip casting the spells individually.

### Changes
* Use `Flags` to detect when your disease/poisons are cured
* Check if your diseased/poisoned when checking vitals instead of each time you perceive health so that such things don't linger longer than necessary