### PR TITLE
[script] [healme] Add `max_wounds_to_heal_between_perceives` setting

### DIFF
--- a/healme.lic
+++ b/healme.lic
@@ -32,6 +32,9 @@ class HealMe
     @max_wounds_to_tend_while_prep_spells = (@settings['healme']['max_wounds_to_tend_while_prep_spells'] || 1).to_i
     echo "max_wounds_to_tend_while_prep_spells = #{@max_wounds_to_tend_while_prep_spells}" if $debug_mode_healme
 
+    @max_wounds_to_heal_between_perceives = (@settings['healme']['max_wounds_to_heal_between_perceives'] || 3).to_i
+    echo "max_wounds_to_heal_between_perceives = #{@max_wounds_to_heal_between_perceives}" if $debug_mode_healme
+
     @health_data = {}
     @spells = load_healing_waggle_set
     @cast_spell_lambda = build_cast_spell_lambda
@@ -179,13 +182,13 @@ class HealMe
       # This continues until no more bleeders and then it begins to triage the next wound types.
       # This ensures minor scratches aren't attended to before bleeders, lodged items, parasites, etc.
       if @health_data['bleeders'].length > 0
-        heal_wounds(@health_data['bleeders'])
+        heal_wounds(@health_data['bleeders'], @max_wounds_to_heal_between_perceives)
       elsif @health_data['lodged'].length > 0
-        tend_wounds(@health_data['lodged'])
+        tend_wounds(@health_data['lodged'], @max_wounds_to_heal_between_perceives)
       elsif @health_data['parasites'].length > 0
-        tend_wounds(@health_data['parasites'])
+        tend_wounds(@health_data['parasites'], @max_wounds_to_heal_between_perceives)
       elsif @health_data['wounds'].length > 0
-        heal_wounds(@health_data['wounds'])
+        heal_wounds(@health_data['wounds'], @max_wounds_to_heal_between_perceives)
       elsif health < 100
         heal_vitality
       end
@@ -374,15 +377,19 @@ class HealMe
   # Similar to 'heal_wounds' except instead of casting a spell on the wound
   # this method tends the wound to remove parasites or lodged items.
   # This method is not intended for bleeders, use `heal_wound` method for those.
-  def tend_wounds(wounds_by_severity)
+  def tend_wounds(wounds_by_severity, max_wounds_to_tend = 3)
     wounds = get_wounds_in_priority_order(wounds_by_severity)
     return if wounds.empty?
+    # Tend the needful
+    count_of_wounds_tended = 0
     wounds.each do |wound|
       # Before we try to tend a wound, check if it's already been healed, either
       # from a previous, potent cast or from heal over time spells like Heal or Regenerate.
       next if wound_tended?(wound)
       tend_wound(wound)
       attend_vitals
+      count_of_wounds_tended = count_of_wounds_tended + 1
+      break if count_of_wounds_tended >= max_wounds_to_tend
     end
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -811,7 +811,7 @@ crafting_training_spells:
 crafting_training_spells_enable_sorcery: false
 # enable sorcery casting during forging specifically. Requires above setting to be true as well
 crafting_training_spells_enable_sorcery_forging: false
-# Disable the warning you get with ;validate when you enable sorcery. 
+# Disable the warning you get with ;validate when you enable sorcery.
 crafting_training_spells_enable_sorcery_squelch_warning: false
 # mindstate craft.lic will skip making an item at
 craft_max_mindstate: 31
@@ -1077,7 +1077,7 @@ pick:
   # optional container for storing boxes with blacklisted traps for manual picking later, if blank will drop
   blacklist_container:
   # list of trap types to automatically disarm careful regardless of identified difficulty; trap names can be seen in base-picking
-  trap_greylist:  
+  trap_greylist:
   # list of containers to pick boxes from, will fall back to old 'picking_box_source' if not present
   picking_box_sources:
   # try to harvest trap components after each disarm
@@ -1229,6 +1229,12 @@ healme:
   # between preparing and casting a spell.
   # Default is 1.
   max_wounds_to_tend_while_prep_spells: 1
+  # How many wounds to heal or tend between perceiving your health
+  # to check on remaining wounds and their severities?
+  # Increasing this number will reduce how often you perceive health,
+  # and may reduce your overall time to heal by cutting out those roundtimes.
+  # Default is 3.
+  max_wounds_to_heal_between_perceives: 3
 
 # Uses a scoring based system to determine when to go get healed after combat, 0 means always. 10 is 10 minor abraisions or 5 tiny scratches, etc
 # Run ;en echo DRCH.check_health to see your current wound value


### PR DESCRIPTION
### Background
* Some players are comfortable performing 1 or 2 `perceive health` when running `healme` and want to cut out the overhead of those roundtimes

### Changes
* Expose setting to let players "throttle" how often they `perceive health`. The default has always been 3, but now people can increase or reduce that number.

### Configuration
```yaml
# healme script specific settings for empaths.
# Highly recommend that you define a 'healing' waggle set
# for maximum control over how you cast your healing spells.
# If no 'healing' waggle set is defined then healme script
# will use 'empath_healing:' settings as backup.
healme:
  # Toggle debug mode. Can also use `debug` script argument.
  # Default is false.
  debug: false
  # Wound severities below this threshold will be ignored.
  # Range is 0 to 13 based on 'perceive health self'.
  # If you have HEAL or REGENERATE, then you may choose
  # to set a low threshold (1 or 2) since those can be healed over time
  # rather than waiting for the script to heal them all in one sitting.
  # Default is 0.
  severity_threshold: 0
  # When waiting for a spell to be prepared and if you have wounds to tend,
  # such as bleeders or lodged ammo or parasites, then this is the max
  # number of those wounds to tend before casting to be efficient.
  # Even if you set this to 0, healme script will tend wounds just not
  # between preparing and casting a spell.
  # Default is 1.
  max_wounds_to_tend_while_prep_spells: 1
  # How many wounds to heal or tend between perceiving your health
  # to check on remaining wounds and their severities?
  # Increasing this number will reduce how often you perceive health,
  # and may reduce your overall time to heal by cutting out those roundtimes.
  # Default is 3.
  max_wounds_to_heal_between_perceives: 3
```