### PR TITLE
[script] [common-travel] add `sell_item` to support new pawn script

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -8,6 +8,30 @@ custom_require.call(%w[common common-items common-arcana events drinfomon])
 module DRCT
   module_function
 
+  def sell_item(room, item)
+    return false unless DRCI.in_hands?(item)
+
+    walk_to(room)
+
+    success_patterns = [
+      /hands? you \d+ (kronars|lirums|dokoras)/i
+    ]
+
+    failure_patterns = [
+      /I need to examine the merchandise first/,
+      /That's not worth anything/,
+      /I only deal in pelts/,
+      /There's folk around here that'd slit a throat for this/
+    ]
+
+    case DRC.bput("sell my #{item}", *success_patterns, *failure_patterns)
+    when *success_patterns
+      true
+    when *failure_patterns
+      false
+    end
+  end
+
   def buy_item(room, item)
     walk_to(room)
 


### PR DESCRIPTION
### Background
* I'm working on [a pawn script](https://github.com/rpherbig/dr-scripts/pull/5434) to sell lots of junk from a container in much the same way `offload-items` moves things from your container to another container

### Changes
* Add `sell_item(room, item)` to walk somewhere and sell the item in your hand to the merchant (e.g. pawn shop)