### PR TITLE
[script] [pawn-items] 🆕 pawn items in a container

### DIFF
--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -1,0 +1,84 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#pawn-items
+=end
+
+custom_require.call %w[common common-items common-travel equipmanager]
+
+class PawnItems
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'source', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'Source container' },
+        { name: 'noun', regex: /^[A-z\.\s\-]+$/i, optional: true, variable: true, description: 'If specified, only items with this noun will be sold.' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
+
+    # Put away items in hands to mitigate accidentally selling them
+    EquipmentManager.new.return_held_gear
+    # Warn the script user that this is designed to sell items off your person
+    warn_before_sell(args.source, args.noun)
+    # Turn items into coins
+    sell_items(args.source, args.noun)
+  end
+
+  def sell_items(source, noun)
+    # If container is very full then LOOK may not list all of them.
+    # If you're moving a specific item, then sort those to the top
+    # to increase chances we find and sell all of them in one go.
+    DRC.bput("sort #{noun} in my #{source}", "are now at the top", "What were you referring to", "Please rephrase that command", "You may only sort items in your inventory") if noun
+    DRCI.get_item_list(source, 'look')
+      .map { |full_name| full_name =~ /lot of other stuff/ ? full_name : full_name.split(' ').last }
+      .select { |item| noun ? /\b#{noun}\b/ =~ item : true }
+      .each do |item|
+        # This indicates there is more items than LOOK can show
+        # and we've reached the end of what we last saw.
+        # We need to look again to see what we can now see.
+        # Keep doing this until exhaust source.
+        if item =~ /lot of other stuff/
+          sell_items(source, noun)
+          return
+        end
+        # Attempt to get the item from the source container.
+        if DRCI.get_item?(item, source)
+          unless DRCT.sell_item(Room.current.id, item)
+            # Failed. Message user and return item to source container.
+            DRC.message("Unable to sell #{item}. The merchant may not accept these items.")
+            DRCI.put_away_item?(item, source)
+            exit
+          end
+        else
+          DRC.message("Unable to get #{item} from #{source}.")
+          DRC.message("Your hands are full!") if (DRC.left_hand && DRC.right_hand)
+          exit
+        end
+      end
+  end
+
+  def warn_before_sell(source, noun)
+    # Pause script and warn that it is designed to sell items
+    # from your person to somewhere else. Item loss may occur.
+    DRC.message("WARNING: This script is designed to sell items from YOU to an NPC merchant.")
+    DRC.message("WARNING: It also has the ability to sell every item from the source container.")
+    DRC.message("WARNING: Item loss may occur. Use with caution.")
+    DRC.message("WARNING: If you want to sell loot like gems and bundles, use ;sell-loot instead.")
+    DRC.message("WARNING: If you want to transfer items between containers, use ;transfer-items or ;offload-items instead.")
+    DRC.message("\n")
+
+    unless noun
+      DRC.message("You are about to sell EVERY SINGLE ITEM from #{source}.")
+      DRC.message("Unpause the script to continue. Otherwise, ;kill the script to stop.")
+      pause_script
+      DRC.message("Are you SURE you want to sell EVERY SINGLE ITEM from YOUR #{source}?")
+      pause_script
+    else
+      DRC.message("You are about to sell all #{noun.upcase}s from #{source}.")
+      DRC.message("Unpause the script to continue. Otherwise, ;kill the script to stop.")
+      pause_script
+    end
+  end
+
+end
+
+PawnItems.new

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -11,19 +11,45 @@ class PawnItems
       [
         { name: 'source', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'Source container' },
         { name: 'noun', regex: /^[A-z\.\s\-]+$/i, optional: true, variable: true, description: 'If specified, only items with this noun will be sold.' }
+      ],
+      [
+        { name: 'source', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'Source container' },
+        { name: 'noun', regex: /^[A-z\.\s\-]+$/i, variable: true, description: 'If specified, only items with this noun will be sold.' },
+        { name: 'town', regex: $HOMETOWN_REGEX, variable: true, description: 'Override the town to pawn in.' }
       ]
     ]
     args = parse_args(arg_definitions)
 
+    settings = get_settings
+
+    # Identify which pawnshop to go to
+    hometown = DRC.get_town_name(args.town || settings.sell_loot_town || settings.hometown)
+    pawnshop_room_id = DRCT.get_hometown_target_id(hometown, 'pawnshop')
+
+    if pawnshop_room_id.nil?
+      DRC.message("Pawning not supported in #{hometown}.")
+      exit
+    end
+
+    # You can't sell to a merchant if you're invisible,
+    # and invisibility sometimes impedes getting/stowing items.
+    DRC.release_invisibility
+
     # Put away items in hands to mitigate accidentally selling them
     EquipmentManager.new.return_held_gear
+    if DRC.right_hand || DRC.left_hand
+      DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
+      exit
+    end
+
     # Warn the script user that this is designed to sell items off your person
     warn_before_sell(args.source, args.noun)
+
     # Turn items into coins
-    sell_items(args.source, args.noun)
+    sell_items(pawnshop_room_id, args.source, args.noun)
   end
 
-  def sell_items(source, noun)
+  def sell_items(pawnshop_room_id, source, noun)
     # If container is very full then LOOK may not list all of them.
     # If you're moving a specific item, then sort those to the top
     # to increase chances we find and sell all of them in one go.
@@ -42,7 +68,7 @@ class PawnItems
         end
         # Attempt to get the item from the source container.
         if DRCI.get_item?(item, source)
-          unless DRCT.sell_item(Room.current.id, item)
+          unless DRCT.sell_item(pawnshop_room_id, item)
             # Failed. Message user and return item to source container.
             DRC.message("Unable to sell #{item}. The merchant may not accept these items.")
             DRCI.put_away_item?(item, source)
@@ -62,19 +88,19 @@ class PawnItems
     DRC.message("WARNING: This script is designed to sell items from YOU to an NPC merchant.")
     DRC.message("WARNING: It also has the ability to sell every item from the source container.")
     DRC.message("WARNING: Item loss may occur. Use with caution.")
-    DRC.message("WARNING: If you want to sell loot like gems and bundles, use ;sell-loot instead.")
-    DRC.message("WARNING: If you want to transfer items between containers, use ;transfer-items or ;offload-items instead.")
+    DRC.message("WARNING: If you want to sell loot like gems and bundles, use #{$clean_lich_char}sell-loot instead.")
+    DRC.message("WARNING: If you want to transfer items between containers, use #{$clean_lich_char}transfer-items or #{$clean_lich_char}offload-items instead.")
     DRC.message("\n")
 
-    unless noun
-      DRC.message("You are about to sell EVERY SINGLE ITEM from #{source}.")
-      DRC.message("Unpause the script to continue. Otherwise, ;kill the script to stop.")
-      pause_script
-      DRC.message("Are you SURE you want to sell EVERY SINGLE ITEM from YOUR #{source}?")
+    if noun
+      DRC.message("You are about to sell all #{noun.upcase} from #{source}.")
+      DRC.message("Unpause the script to continue. Otherwise, #{$clean_lich_char}kill the script to stop.")
       pause_script
     else
-      DRC.message("You are about to sell all #{noun.upcase}s from #{source}.")
-      DRC.message("Unpause the script to continue. Otherwise, ;kill the script to stop.")
+      DRC.message("You are about to sell EVERY SINGLE ITEM from #{source}.")
+      DRC.message("Unpause the script to continue. Otherwise, #{$clean_lich_char}kill the script to stop.")
+      pause_script
+      DRC.message("Are you SURE you want to sell EVERY SINGLE ITEM from YOUR #{source}?")
       pause_script
     end
   end

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -36,7 +36,7 @@ class PawnItems
     DRC.release_invisibility
 
     # Put away items in hands to mitigate accidentally selling them
-    EquipmentManager.new.return_held_gear
+    EquipmentManager.new.empty_hands
     if DRC.right_hand || DRC.left_hand
       DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
       exit

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -2,6 +2,11 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#pawn-items
 =end
 
+# This script pauses itself to warn user before proceeding with item-losing actions.
+# Flag this script as not eligible for generic "unpause all" commands so that
+# only if the player explicitly unpauses this script does it unpause.
+no_pause_all
+
 custom_require.call %w[common common-items common-travel equipmanager]
 
 class PawnItems

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -88,17 +88,17 @@ class PawnItems
     DRC.message("WARNING: This script is designed to sell items from YOU to an NPC merchant.")
     DRC.message("WARNING: It also has the ability to sell every item from the source container.")
     DRC.message("WARNING: Item loss may occur. Use with caution.")
-    DRC.message("WARNING: If you want to sell loot like gems and bundles, use #{$clean_lich_char}sell-loot instead.")
-    DRC.message("WARNING: If you want to transfer items between containers, use #{$clean_lich_char}transfer-items or #{$clean_lich_char}offload-items instead.")
+    DRC.message("WARNING: If you want to sell loot like gems and bundles then use #{$clean_lich_char}sell-loot instead.")
+    DRC.message("WARNING: If you want to transfer items between containers then use #{$clean_lich_char}transfer-items or #{$clean_lich_char}offload-items instead.")
     DRC.message("\n")
 
     if noun
-      DRC.message("You are about to sell all #{noun.upcase} from #{source}.")
-      DRC.message("Unpause the script to continue. Otherwise, #{$clean_lich_char}kill the script to stop.")
+      DRC.message("You are about to sell all #{noun.upcase}s from #{source}.")
+      DRC.message("Unpause the script to continue or #{$clean_lich_char}kill the script to stop.")
       pause_script
     else
       DRC.message("You are about to sell EVERY SINGLE ITEM from #{source}.")
-      DRC.message("Unpause the script to continue. Otherwise, #{$clean_lich_char}kill the script to stop.")
+      DRC.message("Unpause the script to continue or #{$clean_lich_char}kill the script to stop.")
       pause_script
       DRC.message("Are you SURE you want to sell EVERY SINGLE ITEM from YOUR #{source}?")
       pause_script

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -100,6 +100,7 @@ class PawnItems
       DRC.message("You are about to sell EVERY SINGLE ITEM from #{source}.")
       DRC.message("Unpause the script to continue or #{$clean_lich_char}kill the script to stop.")
       pause_script
+      DRCI.rummage_container(source)
       DRC.message("Are you SURE you want to sell EVERY SINGLE ITEM from YOUR #{source}?")
       pause_script
     end

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -15,12 +15,8 @@ class PawnItems
     arg_definitions = [
       [
         { name: 'source', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'Source container' },
+        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, variable: true, description: 'Override the town to pawn in.' },
         { name: 'noun', regex: /^[A-z\.\s\-]+$/i, optional: true, variable: true, description: 'If specified, only items with this noun will be sold.' }
-      ],
-      [
-        { name: 'source', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'Source container' },
-        { name: 'noun', regex: /^[A-z\.\s\-]+$/i, variable: true, description: 'If specified, only items with this noun will be sold.' },
-        { name: 'town', regex: $HOMETOWN_REGEX, variable: true, description: 'Override the town to pawn in.' }
       ]
     ]
     args = parse_args(arg_definitions)

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -23,9 +23,15 @@ class PawnItems
 
     settings = get_settings
 
-    # Identify which pawnshop to go to
-    hometown = DRC.get_town_name(args.town || settings.sell_loot_town || settings.hometown)
-    pawnshop_room_id = DRCT.get_hometown_target_id(hometown, 'pawnshop')
+    # Identify which pawnshop to go to.
+    if DRCT.tag_to_id('pawnshop') == Room.current.id
+      # If you're already in the nearest pawnshop, sell there.
+      pawnshop_room_id = Room.current.id
+    else
+      # Otherwise, go to the one in your preferred town.
+      hometown = DRC.get_town_name(args.town || settings.sell_loot_town || settings.hometown)
+      pawnshop_room_id = DRCT.get_hometown_target_id(hometown, 'pawnshop')
+    end
 
     if pawnshop_room_id.nil?
       DRC.message("Pawning not supported in #{hometown}.")


### PR DESCRIPTION
### Dependencies
* https://github.com/rpherbig/dr-scripts/pull/5433

### Related
* https://github.com/rpherbig/dr-scripts/pull/5448
* https://github.com/rpherbig/dr-scripts/pull/5450

### Background
* My characters collect in Crossing pawnable items that have to be sold in other towns
* To cut down on travel, I move them all on to one character and make the trip periodically
* I want to automate selling all the items from my container to the pawn shop similar to how `sell-loot` sells gems/metals or `offload-items` moves items from a container to off your person

### Changes
* 🆕 Script modeled after `offload-items` that takes you to pawn shop and sells the items in the container. Uses same safety mechanisms to prompt user to confirm and they have to explicitly unpause the script 