### PR TITLE
[script] [common-items] more concise way to convert text to Item instance

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -418,13 +418,7 @@ module DRCI
   # Hand options are: left, right, either, both.
   def in_hand?(item, which_hand = 'either')
     return false unless item
-    if item.is_a?(String)
-      if item.split.size > 1
-        item = DRC::Item.new(adjective: item.split.first, name: item.split.last)
-      else
-        item = DRC::Item.new(name: item)
-      end
-    end
+    item = DRC::Item.from_text(item) if item.is_a?(String)
     case which_hand.downcase
     when 'left'
       DRC.left_hand =~ item.short_regex


### PR DESCRIPTION
### Changes
* Consolidate code to one line by using `DRC::Item.from_text(text)` method instead of `DRC::Item.new(...)`