### PR TITLE
[script] [almanac] Add `almanac_no_use_rooms` setting, other refactorings

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -5,28 +5,26 @@
 custom_require.call(%w[common common-items])
 
 class Almanac
-  include DRC
-  include DRCI
 
   def initialize
     settings = get_settings
     UserVars.almanac_last_use ||= Time.now - 600
     @no_use_scripts = settings.almanac_no_use_scripts
+    @no_use_rooms = settings.almanac_no_use_rooms
     @almanac_skills = settings.almanac_skills
     @almanac = settings.almanac_noun
 
     passive_loop
   end
 
-  def use_almanac
-    return if Time.now - UserVars.almanac_last_use < 600
-    return if @no_use_scripts.any? { |name| Script.running?(name) }
-    return if XMLData.room_title.include? 'Carousel Chamber'
-    return if XMLData.room_title.include? 'Carousel Booth'
-    return if XMLData.room_title.include? 'Family Vault'
-    return if hidden?
-    return if checkleft
+  def passive_loop
+    loop do
+      use_almanac if should_use_almanac?
+      pause 20
+    end
+  end
 
+  def use_almanac
     unless @almanac_skills.empty?
       training_skill = @almanac_skills
                        .select { |skill| DRSkill.getxp(skill) < 18 }
@@ -34,35 +32,61 @@ class Almanac
       return unless training_skill
     end
 
-    pause 1 until pause_all
+    # Pause scripts to prevent interference
+    scripts_to_unpause = []
+    scripts_to_unpause = DRC.smart_pause_all
     waitrt?
-    case bput("get my #{@almanac}", 'You get', 'What were', 'You are already', 'You need a free')
-    when 'What were'
-      echo('Almanac not found, exiting.')
-      unpause_all
+
+    # Wait for any last output from paused scripts to resolve
+    # to mitigate things like combat-trainer doing `loot treasure`
+    # and getting a "I could not find what you were referring to" response
+    # (because no critter to loot) before the response to "get my almanac".
+    # In that race condition, we think we didn't get your almanac and
+    # the script exits, but that leaves you with an almanac in your hand
+    # and can cause combat-trainer to hang if it's trying to use a twohanded weapon.
+    pause 1
+    clear
+
+    unless DRCI.get_item_if_not_held?(@almanac) && DRCI.in_hands?(@almanac)
+      DRC.message('Almanac not found, exiting')
+      DRC.unpause_all_list(scripts_to_unpause)
       exit
-    when 'You need a free'
-      unless DRCI.in_hands?(@almanac)
-        unpause_all
-        return
-      end
     end
+
     if training_skill
-      bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
+      DRC.bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
     end
-    bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what', 'interrupt your research')
+
+    DRC.bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what', 'interrupt your research')
     waitrt?
-    bput("stow my #{@almanac}", 'You put', 'Stow what', 'You hold out')
+
+    DRCI.put_away_item?(@almanac)
+
     UserVars.almanac_last_use = Time.now
-    unpause_all
+
+    DRC.unpause_all_list(scripts_to_unpause)
   end
 
-  def passive_loop
-    loop do
-      use_almanac
-      pause 20
-    end
+  def should_use_almanac?
+    !(hidden? || invisible? || almanac_on_cooldown? || hands_full? || running_no_use_scripts? || inside_no_use_room?)
   end
+
+  def running_no_use_scripts?
+    @no_use_scripts.any? { |name| Script.running?(name) }
+  end
+
+  def inside_no_use_room?
+    @no_use_rooms.any? { |room| room === DRRoom.title.to_s()[2..-3] || room == Room.current.id }
+  end
+
+  def almanac_on_cooldown?
+    (Time.now - UserVars.almanac_last_use) < 600
+  end
+
+  def hands_full?
+    DRC.left_hand && DRC.right_hand && !DRCI.in_hands?(@almanac)
+  end
+
 end
 
 Almanac.new

--- a/almanac.lic
+++ b/almanac.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#almanac
 =end
 
-custom_require.call(%w[common common-items])
+custom_require.call(%w[common common-items drinfomon])
 
 class Almanac
 

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -70,6 +70,8 @@ empty_values:
   caravan_training_skills: {}
   caravan_recipes: {}
   almanac_skills: []
+  almanac_no_use_scripts: []
+  almanac_no_use_rooms: []
   held_athletics_items: []
   training_list: []
   t2_avoids: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -811,7 +811,7 @@ crafting_training_spells:
 crafting_training_spells_enable_sorcery: false
 # enable sorcery casting during forging specifically. Requires above setting to be true as well
 crafting_training_spells_enable_sorcery_forging: false
-# Disable the warning you get with ;validate when you enable sorcery. 
+# Disable the warning you get with ;validate when you enable sorcery.
 crafting_training_spells_enable_sorcery_squelch_warning: false
 # mindstate craft.lic will skip making an item at
 craft_max_mindstate: 31
@@ -1077,7 +1077,7 @@ pick:
   # optional container for storing boxes with blacklisted traps for manual picking later, if blank will drop
   blacklist_container:
   # list of trap types to automatically disarm careful regardless of identified difficulty; trap names can be seen in base-picking
-  trap_greylist:  
+  trap_greylist:
   # list of containers to pick boxes from, will fall back to old 'picking_box_source' if not present
   picking_box_sources:
   # try to harvest trap components after each disarm
@@ -1800,12 +1800,49 @@ spell_cycle:
 
 restock_shop:
 
-#custom almanac noun
+# The noun of your almanac (e.g. almanac, tome, treatise, monograph, etc)
 almanac_noun: almanac
-# For almanacs that let you pick which skill to use
+
+# List of skills to turn almanac to train.
+# Leave blank unless you have a "pick a skill" almanac.
 almanac_skills:
 
+# List of scripts that when running then almanac script won't run.
+almanac_no_use_scripts:
+- sew
+- carve
+- tinker
+- forge
+- remedy
+- shape
+- enchant
+- combat-trainer
+- stabbity
+- feed-cloak
+- go2
+- get2
+- bescort
+- steal
+- pick
+- locksmithing
+- astrology
+- clean-leather
+- clean-lumber
+- craft
+- scouting
+- athletics
+- outdoorsmanship
+- mech-lore
+- corn-maze
+- burgle
+
+# List of room titles or room ids or regular expressions
+# that if matches the current room then almanac script won't run.
+almanac_no_use_rooms:
+  - !ruby/regexp /\b(Carousel|Vault|Item Registration Office|Registrar's Office)\b/
+
 sanowret_adjective: sanowret
+
 sanowret_no_use_scripts: # Don't try to use crystal while these scripts are active.
 - sew
 - carve
@@ -1821,34 +1858,11 @@ sanowret_no_use_scripts: # Don't try to use crystal while these scripts are acti
 - go2
 - magic-training
 - astrology
+
 sanowret_no_use_rooms: # Don't try to use crystal while in these rooms.
 - Carousel Chamber     # Room with vault
 - Carousel Booth       # Room just before vault
 - 1900                 # You can specify room ids, too
-
-almanac_no_use_scripts:
-- sew
-- carve
-- tinker
-- forge
-- remedy
-- shape
-- enchant
-- combat-trainer
-- go2
-- get2
-- bescort
-- steal
-- astrology
-- clean-leather
-- clean-lumber
-- craft
-- scouting
-- athletics
-- outdoorsmanship
-- mech-lore
-- corn-maze
-- burgle
 
 walkingastro_no_use_scripts:
 - sew


### PR DESCRIPTION
### Background
* Similar run-in-the-background scripts like `wand-watcher` and `buff-watcher` support a list of exclusion rooms where not to try and run the script, either out of preference or because the room won't allow it, as well as follow a particular _template_ for how the class is structured.
* This pull request brings `almanac` more in line with them for consistency.

### Changes
* Remove `include` in favor of using `DRC` and `DRCI` prefixed methods
* Create individual methods for checking specific criteria on when it's ok to use the almanac
* Use `DRC.smart_pause_all` to only pause _pausable_ scripts, and to remember which scripts were paused by this script so that at the end only those are the ones that are unpauased and not _every_ paused script suddenly is unpaused. You might have paused an unrelated script and didn't want it unpaused yet.
* Add a slight delay after pausing scripts to handle a race condition where `combat-trainer` or `almanac` may get confused when parsing game output and mistake what's actually in your hands.
* In addition to not using an almanac when hidden, don't while invisible either.
* Group almanac yaml settings together (they were split by sanowret settings)

### Configuration
_existing settings_
```yaml
# The noun of your almanac (e.g. almanac, tome, treatise, monograph, etc)
almanac_noun: almanac

# List of skills to turn almanac to train.
# Leave blank unless you have a "pick a skill" almanac.
almanac_skills:
  - Scholarship
  - Appraisal
  - ...

# List of scripts that when running then almanac script won't run.
almanac_no_use_scripts:
  - athletics
  - burgle
  - steal
  - ...
```
_new settings_
```yaml
# List of room titles or room ids or regular expressions
# that if matches the current room then almanac script won't run.
almanac_no_use_rooms:
  - !ruby/regexp /\b(Carousel|Vault|Item Registration Office|Registrar's Office)\b/
```