### PR TITLE
Make gem_pouch_adjective Optional

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -14,7 +14,9 @@ class Appraisal
         { name: 'focus', regex: /focus/i, description: 'Perform appraise focus on an item.' },
         { name: 'item', regex: /\w+/i, description: 'Item to use appraise focus with.' }
       ],
-      []
+      [ 
+        { name: 'nonspecific', regex: /nonspecific/i, optional: true, description: 'Toggle off specific gem_pouch_adjective' }
+      ]
     ]
 
     args = parse_args(arg_definitions)
@@ -22,6 +24,12 @@ class Appraisal
     @equipment_manager = EquipmentManager.new
     settings = get_settings
     train_list = settings.appraisal_training
+
+    if args.nonspecific
+      pouch_adjective = nil
+    else
+      pouch_adjective = settings.gem_pouch_adjective
+    end
 
     if args.focus
       if DRSkill.getrank('Appraisal') < 200
@@ -37,7 +45,7 @@ class Appraisal
         when 'zills'
           assess_zills
         when 'pouches'
-          train_appraisal_with_pouches(settings.full_pouch_container, settings.gem_pouch_adjective, settings.gem_pouch_noun)
+          train_appraisal_with_pouches(settings.full_pouch_container, pouch_adjective, settings.gem_pouch_noun)
         when 'gear'
           train_appraisal_with_gear
         when 'bundle'


### PR DESCRIPTION
Not everyone uses the exact same pouch for appraisal training and are severely limited by enforcing use of said variable.