### PR TITLE
[script] [faux-atmo] missing `drinfomon` ; makes use of `DRRoom`

### DIFF
--- a/faux-atmo.lic
+++ b/faux-atmo.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#faux-atmo
 =end
 
-custom_require.call(%w[common events])
+custom_require.call(%w[common drinfomon events])
 
 class FauxAtmo
   include DRC


### PR DESCRIPTION
### Changes
* Require `drinfomon` since the code uses `DRRoom`
* If this script loads before `drinfomon` then error about unknown symbol occurs