### PR TITLE
[script] [drinfomon] Add skillset property to DRSkill

### DIFF
--- a/data/base-skills.yaml
+++ b/data/base-skills.yaml
@@ -1,0 +1,112 @@
+---
+
+skillsets:
+  Armor:
+    - Shield Usage
+    - Light Armor
+    - Chain Armor
+    - Brigandine
+    - Plate Armor
+    - Defending
+    # Guild Skills
+    - Conviction # Paladin
+  Weapon:
+    - Parry Ability
+    - Small Edged
+    - Large Edged
+    - Twohanded Edged
+    - Small Blunt
+    - Large Blunt
+    - Twohanded Blunt
+    - Slings
+    - Bow
+    - Crossbow
+    - Staves
+    - Polearms
+    - Light Thrown
+    - Heavy Thrown
+    - Brawling
+    - Offhand Weapon
+    - Melee Mastery
+    - Missile Mastery
+    # Guild Skills
+    - Expertise # Barbarian
+  Magic:
+    - Primary Magic # See `guild_skill_aliases` section
+    - Arcana
+    - Attunement
+    - Augmentation
+    - Debilitation
+    - Targeted Magic
+    - Utility
+    - Warding
+    - Sorcery
+    # Guild Skills
+    - Astrology # Moon Mage
+    - Summoning # Warrior Mage
+    - Theurgy # Cleric
+    - Inner Magic # Thief
+    - Inner Fire # Barbarian
+    - Lunar Magic # Moon Mage, Trader
+    - Elemental Magic # Warrior Mage, Bard
+    - Holy Magic # Cleric, Paladin
+    - Life Magic # Empath, Ranger
+    - Arcane Magic # Necromancer
+  Survival:
+    - Evasion
+    - Athletics
+    - Perception
+    - Stealth
+    - Locksmithing
+    - Thievery
+    - First Aid
+    - Outdoorsmanship
+    - Skinning
+    # Guild Skills
+    - Scouting # Ranger
+    - Backstab # Thief
+    - Thanatology # Necromancer
+  Lore:
+    - Alchemy
+    - Appraisal
+    - Enchanting
+    - Engineering
+    - Forging
+    - Outfitting
+    - Performance
+    - Scholarship
+    - Tactics
+    # Guild Skills
+    - Empathy # Empath
+    - Bardic Lore # Bard
+    - Trading # Trader
+    # Deprecated Skills
+    - Mechanical Lore
+
+# Because the Primary Magic skill is labeled differently per guild...
+# In game, you'd type `exp primary magic` to see the rank, but the XML data
+# sent and parsed by Lich is the guild-specific label. Therefore, this cross-reference
+# helps scripts to determine the correct value to use with DRSkills.getxp('Skill Name').
+guild_skill_aliases:
+  Barbarian:
+    Primary Magic: Inner Fire
+  Bard:
+    Primary Magic: Elemental Magic
+  Cleric:
+    Primary Magic: Holy Magic
+  Empath:
+    Primary Magic: Life Magic
+  Moon Mage:
+    Primary Magic: Lunar Magic
+  Necromancer:
+    Primary Magic: Arcane Magic
+  Paladin:
+    Primary Magic: Holy Magic
+  Ranger:
+    Primary Magic: Life Magic
+  Thief:
+    Primary Magic: Inner Magic
+  Trader:
+    Primary Magic: Lunar Magic
+  Warrior Mage:
+    Primary Magic: Elemental Magic

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -605,7 +605,7 @@ vault_titles = {
   "Ratha"              => ["[[Ratha, Carousel Square]]"],
   "Riverhaven"         => ["[[Riverhaven, Carousel Chamber]]"],
   "Shard"              => ["[[Shard, Carousel Chamber]]"],
-  "Therenborough"      => ["[[Therenborough, Carousel Square]]"]
+  "Therenborough"      => ["[[Therenborough, Carousel Chamber]]"]
 }
 #
 # Register ;banks ;vault commands

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -283,11 +283,12 @@ class DRStats
 end
 
 class DRSkill
+  @@skills_data = nil
   @@gained_skills ||= []
   @@start_time ||= Time.now
   @@list ||= []
 
-  attr_reader :name, :rank, :exp, :percent, :current, :baseline
+  attr_reader :name, :rank, :exp, :percent, :current, :baseline, :skillset
   attr_writer :rank, :exp, :percent, :current, :baseline
 
   def initialize(name, rank, exp, percent)
@@ -297,6 +298,7 @@ class DRSkill
     @percent = percent
     @baseline = rank.to_i + (percent.to_i / 100.0)
     @current = rank.to_i + (percent.to_i / 100.0)
+    @skillset = lookup_skillset(@name)
     @@list.push(self) unless @@list.find { |skill| skill.name == @name }
   end
 
@@ -315,66 +317,81 @@ class DRSkill
   end
 
   def self.gained_exp(val)
-    ary = @@list.collect(&:name)
-    if i = ary.index(val)
-      return @@list[i].current ? (@@list[i].current - @@list[i].baseline).round(2) : 0.00
+    skill = self.find_skill(val)
+    if skill
+      return skill.current ? (skill.current - skill.baseline).round(2) : 0.00
     end
   end
 
   def self.include?(val)
-    ary = @@list.collect(&:name)
-    ary.include?(val)
+    !self.find_skill(val).nil?
   end
 
-  def self.update(name, ra, xp, per)
-    ary = @@list.collect(&:name)
-    if i = ary.index(name)
-      @@list[i].rank = ra
-      @@list[i].exp = xp
-      @@list[i].percent = per
-      @@list[i].current = ra.to_i + (per.to_i / 100.0)
+  def self.update(name, rank, exp, percent)
+    skill = self.find_skill(name)
+    if skill
+      skill.rank = rank
+      skill.exp = exp
+      skill.percent = percent
+      skill.current = rank.to_i + (percent.to_i / 100.0)
     end
   end
 
-  def self.clear_mind(name)
-    ary = @@list.collect(&:name)
-    if i = ary.index(name)
-      @@list[i].exp = 0
-    end
+  def self.clear_mind(val)
+    self.find_skill(val).exp = 0
   end
 
   def self.getrank(val)
-    ary = @@list.collect(&:name)
-    if i = ary.index(val)
-      return @@list[i].rank.to_i
-    end
-    0
+    self.find_skill(val).rank.to_i
   end
 
   def self.getxp(val)
-    ary = @@list.collect(&:name)
-    return 34 if getrank(val) == 1750
-    if i = ary.index(val)
-      return @@list[i].exp.to_i
-    end
-    0
+    skill = self.find_skill(val)
+    skill.rank.to_i >= 1750 ? 34 : skill.exp.to_i
   end
 
   def self.getpercent(val)
-    ary = @@list.collect(&:name)
-    if i = ary.index(val)
-      return @@list[i].percent
-    end
+    self.find_skill(val).percent
+  end
+
+  def self.getskillset(val)
+    self.find_skill(val).skillset
   end
 
   def self.listall
     @@list.each do |i|
-      puts i.name + ': ' + i.rank + '.' + i.percent + '% [' + i.exp + '/34] --'
+      echo "#{i.name}: #{i.rank}.#{i.percent}% [#{i.exp}/34]"
     end
   end
 
   def self.list
     @@list
+  end
+
+  private
+
+  def self.find_skill(val)
+    @@list.find { |data| data.name == self.lookup_alias(val) }
+  end
+
+  # Some guilds rename skills, like Barbarians call "Primary Magic" as "Inner Fire".
+  # Given the canonical or colloquial name, this method returns the value
+  # that's usable with the other methods like `getxp(skill)` and `getrank(skill)`.
+  def self.lookup_alias(skill)
+    @@skills_data.guild_skill_aliases[DRStats.guild][skill] || skill
+  end
+
+  # This is an instance method, do not prefix with `self`.
+  # It is called from the initialize method (constructor).
+  # When it was defined as a class method then the initialize method
+  # complained that this method didn't yet exist. ¯\_(ツ)_/¯
+  def lookup_skillset(skill)
+    # To mitigate slowing down drinfomon loading up, the skills
+    # data is lazily loaded instead of loaded as part of the class variable
+    # initialization. The delay caused other scripts to complain that `DRRoom`
+    # had not been initialized yet.
+    @@skills_data ||= get_data('skills')
+    @@skills_data.skillsets.find { |skillset, skills| skills.include?(skill) }.first
   end
 end
 
@@ -588,7 +605,7 @@ vault_titles = {
   "Ratha"              => ["[[Ratha, Carousel Square]]"],
   "Riverhaven"         => ["[[Riverhaven, Carousel Chamber]]"],
   "Shard"              => ["[[Shard, Carousel Chamber]]"],
-  "Therenborough"      => ["[[Therenborough, Carousel Chamber]]"]
+  "Therenborough"      => ["[[Therenborough, Carousel Square]]"]
 }
 #
 # Register ;banks ;vault commands
@@ -819,7 +836,7 @@ premiumcheck_silence = proc do |server_string|
 end
 
 DownstreamHook.add('premiumcheck_silence', premiumcheck_silence)
-fput 'ltb info'
+fput('ltb info')
 
 while line = script.gets
   begin


### PR DESCRIPTION
### Background
* I'm working on some new scripts that will take advantage of knowing the skillset of skills you're training, and rather than do that lookup in all those scripts I'd rather just consult the DRSkill class centrally

### Changes
* Add new `data/base-skills.yaml` file that lists skillsets and their skills
* Refactor `DRSkill` class to track new `skillset` property
* Add support for skill aliases, like asking for details about "Primary Magic" but would only be known as the guild alias like "Inner Fire" or "Lunar Magic" etc
* Code clean up by adding `find_skill` method that the other methods use to identify the record for a given skill name rather than every method doing the same loops
* Fix concatenation issue in `DRSkill.listall` where a nil value would cause errors

### Tests
```
> exp athletics

          SKILL: Rank/Percent towards next rank/Amount learning/Mindstate fraction
       Athletics:    464 20.46% understanding (14/34)

```
```
> ,e echo DRSkill.getrank('Athletics')

--- Lich: exec1 active.

[exec1: 464]

--- Lich: exec1 has exited.
```
```
> ,e echo DRSkill.getxp('Athletics')

--- Lich: exec1 active.

[exec1: 14]

--- Lich: exec1 has exited.
```
```
,e echo DRSkill.getpercent('Athletics')
--- Lich: exec1 active.

[exec1: 20]

--- Lich: exec1 has exited.
```
```
> ,e echo DRSkill.getskillset('Athletics')

--- Lich: exec1 active.

[exec1: Survival]

--- Lich: exec1 has exited.
```