### PR TITLE
[script] [buff-watcher] wait til know the guild, else buffing fails

### DIFF
--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -5,7 +5,7 @@
 no_kill_all
 no_pause_all
 
-custom_require.call(%w[common common-arcana common-items spellmonitor])
+custom_require.call(%w[common common-arcana common-items drinfomon spellmonitor])
 
 class BuffWatcher
 
@@ -60,7 +60,7 @@ class BuffWatcher
   end
 
   def should_activate_buffs?
-    !(hidden? || invisible? || running_no_use_scripts? || inside_no_use_room? || need_inner_fire? || buffs_active?)
+    !(hidden? || invisible? || running_no_use_scripts? || inside_no_use_room? || need_inner_fire? || buffs_active? || DRStats.guild.nil?)
   end
 
   def activate_buffs


### PR DESCRIPTION
### Background
* Race condition when this script starts and DRStats.guild hasn't been populated yet

### Changes
* Don't try to buff unless we know the guild, otherwise the code goes down the wrong paths and errors