### PR TITLE
[script] [hunting-buddy] stop searching for room if you're too injured

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -221,20 +221,30 @@ class HuntingBuddy
           # No visible friends in the room and no visible people
           UserVars.friends.each { |friend| Flags.add("room-check-#{friend}", friend) }
           Flags.add('room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
-          bput('search', 'roundtime')
-          data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
-          if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
-            pause
-            waitrt?
-            return UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
+          case bput('search', 'roundtime', "You're not in any condition to be searching around")
+          when /roundtime/i
+            data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
+            if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
+              pause
+              waitrt?
+              return UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
+            end
+            fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
+            20.times do |_|
+              pause 0.5
+              return true if UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
+              return false if Flags['room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+            end
+            true
+          when /You're not in any condition to be searching around/i
+            DRC.message("You're too injured to hunt!")
+            @stop_hunting = true
+            @stopped_for_bleeding = bleeding?
+            # Ironically, return true so the search for a suitable hunting room
+            # stops and then the hunting buddy loop will detect that you need help
+            # sooner rather than later.
+            true
           end
-          fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
-          20.times do |_|
-            pause 0.5
-            return true if UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
-            return false if Flags['room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
-          end
-          true
         end,
         @settings.hunting_room_min_mana,
         @settings.hunting_room_strict_mana,

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -221,7 +221,7 @@ class HuntingBuddy
           # No visible friends in the room and no visible people
           UserVars.friends.each { |friend| Flags.add("room-check-#{friend}", friend) }
           Flags.add('room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
-          case bput('search', 'roundtime', "You're not in any condition to be searching around")
+          case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
           when /roundtime/i
             data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
             if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?


### PR DESCRIPTION
### Background
* When buffing before combat, I blew my hand off due to sorcerous backlash
* One of the first things `hunting-buddy` does is go search for a room then does it's pre-combat steps
* The script hangs with a "no match found" error if you're too hurt to be searching

### Changes
* Add match string that you're too injured to search
* End combat so that the script heals you sooner rather than later

```
[buff]>cast
You gesture.
Your cambrinth armband emits a loud *snap* as it discharges all its power to aid your spell.
The spell pattern resists the influx of Life mana, and a strange burning sensation backwashes from the spell pattern into your body.
An instant rush of black and blue fire explodes into being, consuming your left hand and turning it into ash!
!> 
--- Lich: buff has exited.

[hunting-buddy]>encumbrance
  Encumbrance : None

[hunting-buddy: *** Search attempt 1 of 30 to find a suitable room ***]

--- Lich: go2 active.
[go2]>north
You wander north.
... snip ...
[go2: travel time: 0:00:02]
--- Lich: go2 has exited.

[hunting-buddy]>search
You're not in any condition to be searching around!

[hunting-buddy: *** No match was found after 15 seconds, dumping info]
... snip ...
[hunting-buddy: message: You're not in any condition to be searching around!]
[hunting-buddy: checked against [/roundtime/i]]
[hunting-buddy: for command search]
```