### PR TITLE
[script] [combat-trainer] use DRCMM instead of DRCS in prep for #5424

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -211,7 +211,7 @@ class SetupProcess
 
     # If you're training with summoned moon weapons but you haven't cast the moonblade spell yet
     # then skip those weapon skills and train something else while we wait for moonblade spell to be cast.
-    if DRStats.moon_mage? && !game_state.summoned_weapons.empty? && DRCS.moon_used_to_summon_weapon.nil?
+    if DRStats.moon_mage? && !game_state.summoned_weapons.empty? && DRCMM.moon_used_to_summon_weapon.nil?
       echo('skipping summoned weapons because no moonblade available') if $debug_mode_ct
       weapon_training = weapon_training.reject { |skill, _| game_state.summoned_info(skill) }
     end
@@ -1921,7 +1921,7 @@ class SpellProcess
       end
       if data['abbrev'] == 'moonblade'
         game_state.casting_moonblade = true
-        last_moon = DRCS.moon_used_to_summon_weapon
+        last_moon = DRCMM.moon_used_to_summon_weapon
         # Determine if we can just refresh the currently summoned weapon.
         # Doing so can save us some RT by not needing to shape a new summoned weapon again.
         # We'll only do this if the last moon used is expected to stay visible for a decent amount of time.


### PR DESCRIPTION
### Background
* #5425 moved `moon_used_to_summon_weapon` to DRCMM
* #5424 will remove `moon_used_to_summon_weapon` from DRCS

### Changes
* To enable #5424, switch reference from DRCS to DRCMM