### PR TITLE
[script] [offload-items] Mirror updates to `pawn-items` script

### DIFF
--- a/offload-items.lic
+++ b/offload-items.lic
@@ -92,6 +92,7 @@ class OffloadItems
       DRC.message("You are about to move EVERY SINGLE ITEM from #{source} to #{preposition} #{destination}.")
       DRC.message("Unpause the script to continue or #{$clean_lich_char}kill the script to stop.")
       pause_script
+      DRCI.rummage_container(source)
       DRC.message("Are you SURE you want to offload EVERY SINGLE ITEM from YOUR #{source} to #{preposition} #{destination}?")
       pause_script
     end

--- a/offload-items.lic
+++ b/offload-items.lic
@@ -2,11 +2,9 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#offload-items
 =end
 
-custom_require.call %w[common common-items]
+custom_require.call %w[common common-items equipmanager]
 
 class OffloadItems
-  include DRC
-  include DRCI
 
   def initialize
     arg_definitions = [
@@ -14,13 +12,24 @@ class OffloadItems
         { name: 'source', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'Source container' },
         { name: 'preposition', options: %w[in on under behind], variable: true, description: 'Preposition to use with the destination' },
         { name: 'destination', regex: /^[A-z\.\s\-']+$/i, variable: true, description: 'Destination container' },
-        { name: 'noun', regex: /^[A-z\.\s\-]+$/i, optional: true, variable: true, description: 'If specified, only items with this noun will be transferred.' }         
+        { name: 'noun', regex: /^[A-z\.\s\-]+$/i, optional: true, variable: true, description: 'If specified, only items with this noun will be transferred.' }
       ]
     ]
     args = parse_args(arg_definitions)
 
+    # Invisibility sometimes impedes getting/stowing items.
+    DRC.release_invisibility
+
+    # Put away items in hands to mitigate accidentally moving the wrong ones.
+    EquipmentManager.new.return_held_gear
+    if DRC.right_hand || DRC.left_hand
+      DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
+      exit
+    end
+
     # Warn the script user that this is designed to offload items off your person
     warn_before_offload(args.source, args.preposition, args.destination, args.noun)
+
     # Call the main method. If no preposition was specified, default to "in"
     offload_items(args.source, args.preposition, args.destination, args.noun)
   end
@@ -29,7 +38,7 @@ class OffloadItems
     # If container is very full then LOOK may not list all of them.
     # If you're moving a specific item, then sort those to the top
     # to increase chances we find and move all of them in one go.
-    bput("sort #{noun} in my #{source}", "are now at the top", "What were you referring to", "Please rephrase that command", "You may only sort items in your inventory") if noun
+    DRC.bput("sort #{noun} in my #{source}", "are now at the top", "What were you referring to", "Please rephrase that command", "You may only sort items in your inventory") if noun
     DRCI.get_item_list(source, 'look')
       .map { |full_name| full_name =~ /lot of other stuff/ ? full_name : full_name.split(' ').last }
       .select { |item| noun ? /\b#{noun}\b/ =~ item : true }
@@ -47,7 +56,7 @@ class OffloadItems
           if destination == 'trash'
             trash_item(item)
           else
-            unless put_away_item_unsafe?(item, destination, preposition)
+            unless DRCI.put_away_item_unsafe?(item, destination, preposition)
               # Failed. Message user and return item to source container.
               DRC.message("Unable to offload #{item} to #{preposition} #{destination}. It may not accept items, or you may need to change the preposition (e.g. 'on' vs. 'in')")
               DRCI.put_away_item?(item, source)
@@ -61,7 +70,7 @@ class OffloadItems
         end
       end
   end
- 
+
   def trash_item(item)
     DRCI.dispose_trash(item)
   end
@@ -72,22 +81,21 @@ class OffloadItems
     DRC.message("WARNING: This script is designed to offload items from YOU to somewhere ELSE.")
     DRC.message("WARNING: It also has the ability to move every item from the source container.")
     DRC.message("WARNING: Item loss may occur. Use with caution.")
-    DRC.message("WARNING: If you want to transfer items between containers you own, use ;transfer-items instead.")
+    DRC.message("WARNING: If you want to transfer items between containers you own then use #{$clean_lich_char}transfer-items instead.")
     DRC.message("\n")
-    
-    unless noun
+
+    if noun
+      DRC.message("You are about to move all #{noun.upcase}s from #{source} to #{preposition} #{destination}.")
+      DRC.message("Unpause the script to continue or #{$clean_lich_char}kill the script to stop.")
+      pause_script
+    else
       DRC.message("You are about to move EVERY SINGLE ITEM from #{source} to #{preposition} #{destination}.")
-      DRC.message("Unpause the script to continue. Otherwise, ;kill the script to stop.")
+      DRC.message("Unpause the script to continue or #{$clean_lich_char}kill the script to stop.")
       pause_script
       DRC.message("Are you SURE you want to offload EVERY SINGLE ITEM from YOUR #{source} to #{preposition} #{destination}?")
       pause_script
-    else
-      DRC.message("You are about to move all #{noun.upcase}s from #{source} to #{preposition} #{destination}.")
-      DRC.message("Unpause the script to continue. Otherwise, ;kill the script to stop.")
-      pause_script
     end
   end
-
 
 end
 

--- a/offload-items.lic
+++ b/offload-items.lic
@@ -2,6 +2,11 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#offload-items
 =end
 
+# This script pauses itself to warn user before proceeding with item-losing actions.
+# Flag this script as not eligible for generic "unpause all" commands so that
+# only if the player explicitly unpauses this script does it unpause.
+no_pause_all
+
 custom_require.call %w[common common-items equipmanager]
 
 class OffloadItems

--- a/offload-items.lic
+++ b/offload-items.lic
@@ -21,7 +21,7 @@ class OffloadItems
     DRC.release_invisibility
 
     # Put away items in hands to mitigate accidentally moving the wrong ones.
-    EquipmentManager.new.return_held_gear
+    EquipmentManager.new.empty_hands
     if DRC.right_hand || DRC.left_hand
       DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
       exit


### PR DESCRIPTION
### Related
* https://github.com/rpherbig/dr-scripts/pull/5434
* https://github.com/rpherbig/dr-scripts/pull/5450

### Background
* Code review feedback, https://github.com/rpherbig/dr-scripts/pull/5434#discussion_r786896366
* Related code-style commit, https://github.com/rpherbig/dr-scripts/pull/5434/commits/07330816fbc7c07ddab7d53f24862e00a79304b3

### Changes
* Remove `include` in favor of using module prefixes
* Stow items in hands to avoid ambiguity of which items are being transferred
* Update "warn message" verbiage per code review feedback in `pawn-items`
* Update "warn message" to avoid commas to avoid ambiguity with Lich script character