### PR TITLE
[script] [transfer-items] Mirror updates to `pawn-items` script

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -2,11 +2,9 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#transfer-items
 =end
 
-custom_require.call %w[common common-items]
+custom_require.call %w[common common-items equipmanager]
 
 class ItemTransfer
-  include DRC
-  include DRCI
 
   def initialize
     arg_definitions = [
@@ -17,6 +15,17 @@ class ItemTransfer
       ]
     ]
     args = parse_args(arg_definitions)
+
+    # Invisibility sometimes impedes getting/stowing items.
+    DRC.release_invisibility
+
+    # Put away items in hands to mitigate accidentally moving the wrong ones.
+    EquipmentManager.new.empty_hands
+    if DRC.right_hand || DRC.left_hand
+      DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
+      exit
+    end
+
     transfer_items(args.source, args.destination, args.noun)
   end
 


### PR DESCRIPTION
### Related
* https://github.com/rpherbig/dr-scripts/pull/5434
* https://github.com/rpherbig/dr-scripts/pull/5448

### Background
* Code review feedback, https://github.com/rpherbig/dr-scripts/pull/5434#discussion_r786896366
* Related code-style commit, https://github.com/rpherbig/dr-scripts/pull/5434/commits/07330816fbc7c07ddab7d53f24862e00a79304b3

### Changes
* Remove `include` in favor of using module prefixes
* Stow items in hands to avoid ambiguity of which items are being transferred