### PR TITLE
[script][dependency] Removing DRC references in dependency

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1191,9 +1191,9 @@ def verify_script(script_names)
   script_names
     .reject { |name| Script.exists?(name) }
     .each do |name|
-      DRC.message("Failed to find a script named '#{name}'")
-      DRC.message("Please report this to https://github.com/rpherbig/dr-scripts/issues")
-      DRC.message("or to Discord https://discord.gg/ffcEAYfK")
+      echo "Failed to find a script named '#{name}'"
+      echo "Please report this to <https://github.com/rpherbig/dr-scripts/issues>"
+      echo "or to Discord <https://discord.gg/ffcEAYfK>"
       state = false
     end
   state


### PR DESCRIPTION
When I switched out from Etreu's name to point to discord, I added DRC.message, which is entirely not appropriate for dependency, since it needs to be able to run entirely before any scripts exist... 