### PR TITLE
[script][drinfomon]Removing troublesome non-ascii characters

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -384,7 +384,7 @@ class DRSkill
   # This is an instance method, do not prefix with `self`.
   # It is called from the initialize method (constructor).
   # When it was defined as a class method then the initialize method
-  # complained that this method didn't yet exist. ¯\_(ツ)_/¯
+  # complained that this method didn't yet exist.
   def lookup_skillset(skill)
     # To mitigate slowing down drinfomon loading up, the skills
     # data is lazily loaded instead of loaded as part of the class variable


### PR DESCRIPTION
Spent most of today troubleshooting, and thinking I was going insane. No, turns out non-ascii on the ruby with Fedora is bad.

it's the two outter, upper dashes, and the smiley in the middle. Any of them causes this.

```
 --- Lich: error: invalid byte sequence in US-ASCII                                                                                                                                                                                           
         /home/grocha/lich/lich.rbw:2944:in `block in initialize'                                                                                                                                                                             
         /home/grocha/lich/lich.rbw:2943:in `each'                                                                                                                                                                                            
         /home/grocha/lich/lich.rbw:2943:in `initialize'                                                                                                                                                                                      
         /home/grocha/lich/lich.rbw:2504:in `new'                                                                                                                                                                                             
         /home/grocha/lich/lich.rbw:2504:in `block in <class:Script>'                                                                                                                                                                         
         /home/grocha/lich/lich.rbw:2710:in `start'                                                                                                                                                                                           
         /home/grocha/lich/lich.rbw:6918:in `do_client'                                                                                                                                                                                       
         /home/grocha/lich/lich.rbw:12676:in `block (3 levels) in <main>'                                                                                                                                                                     
         /home/grocha/lich/lich.rbw:12621:in `loop'                                                                                                                                                                                           
         /home/grocha/lich/lich.rbw:12621:in `block (2 levels) in <main>'
```