### PR TITLE
[script] [transfer-items] add missing DRC prefix

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -33,7 +33,7 @@ class ItemTransfer
     # If container is very full then LOOK may not list all of them.
     # If you're moving a specific item, then sort those to the top
     # to increase chances we find and move all of them in one go.
-    bput("sort #{noun} in my #{source}", "are now at the top", "What were you referring to", "Please rephrase that command", "You may only sort items in your inventory") if noun
+    DRC.bput("sort #{noun} in my #{source}", "are now at the top", "What were you referring to", "Please rephrase that command", "You may only sort items in your inventory") if noun
     DRCI.get_item_list(source, 'look')
       .map { |full_name| full_name =~ /lot of other stuff/ ? full_name : full_name.split(' ').last }
       .select { |item| noun ? /\b#{noun}\b/ =~ item : true }


### PR DESCRIPTION
### Background
* mea culpa, I missed this in a recent update

### Changes
* Use `DRC` prefix for common methods now that `include DRC` was removed