### PR TITLE
[script] [transfer-items] [offload-items] [pawn-items] reverting emptying hands at script start

### DIFF
--- a/offload-items.lic
+++ b/offload-items.lic
@@ -25,13 +25,6 @@ class OffloadItems
     # Invisibility sometimes impedes getting/stowing items.
     DRC.release_invisibility
 
-    # Put away items in hands to mitigate accidentally moving the wrong ones.
-    EquipmentManager.new.empty_hands
-    if DRC.right_hand || DRC.left_hand
-      DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
-      exit
-    end
-
     # Warn the script user that this is designed to offload items off your person
     warn_before_offload(args.source, args.preposition, args.destination, args.noun)
 

--- a/pawn-items.lic
+++ b/pawn-items.lic
@@ -42,13 +42,6 @@ class PawnItems
     # and invisibility sometimes impedes getting/stowing items.
     DRC.release_invisibility
 
-    # Put away items in hands to mitigate accidentally selling them
-    EquipmentManager.new.empty_hands
-    if DRC.right_hand || DRC.left_hand
-      DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
-      exit
-    end
-
     # Warn the script user that this is designed to sell items off your person
     warn_before_sell(args.source, args.noun)
 

--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -19,13 +19,6 @@ class ItemTransfer
     # Invisibility sometimes impedes getting/stowing items.
     DRC.release_invisibility
 
-    # Put away items in hands to mitigate accidentally moving the wrong ones.
-    EquipmentManager.new.empty_hands
-    if DRC.right_hand || DRC.left_hand
-      DRC.message("Exited due to item that could not be stowed.  Please check your hands and gear settings then try again.")
-      exit
-    end
-
     transfer_items(args.source, args.destination, args.noun)
   end
 


### PR DESCRIPTION
### Background
* Recently, I updated these scripts to empty your hands before it begin moving items from the source contrainer as a precaution when the script gets to the "put my {item} ..." that there could not be any ambiguity of which item in your hands to move in the chance that you were holding an item that would match that phrase and that wasn't what you wanted to move.
* At the time, the simplest safety check was just empty your hands, regardless what you're holding, that included the source and/or destination containers.
* Some folks relied on, or preferred, the original behavior of letting the containers stay in your hands.
* Instead of adding more code and making the scripts more complex to figure out what to keep in your hands vs. not, I'm just reverting the empty hands check. People know these scripts move items, they should be careful with what's in their hands, and the two scripts that could lead to item loss have big warnings already.

### Changes
* Remove the "empty hands" logic at script start, reverting to their original behaviors.