### PR TITLE
[script] [drinfomon] Remove initial 30 sec delay before first info check

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -805,11 +805,9 @@ end
 
 fput('exp all')
 pause 0.25
-info_check_time = Time.now - 30
 unless dead?
   DownstreamHook.add('info_silence', info_silence) unless UserVars.drinfomon_debug
   fput('info')
-  info_check_time = Time.now
   pause 0.25
 end
 
@@ -837,6 +835,14 @@ end
 
 DownstreamHook.add('premiumcheck_silence', premiumcheck_silence)
 fput('ltb info')
+
+# To track when the last time was we checked experience/info.
+# The first time we check is to determine your guild and initial exp/stats.
+# For commoners, we continue to check on an interval so that when they
+# join a guild we will pick up their new info.
+# And for characters who play as commoners, the interval reduces spam.
+info_check_interval = 30 # seconds
+info_check_time = Time.now - info_check_interval
 
 while line = script.gets
   begin
@@ -987,7 +993,7 @@ while line = script.gets
         end
       end
     end
-    if DRStats.guild.nil? && !dead? && Time.now - info_check_time > 30
+    if DRStats.guild.nil? && !dead? && Time.now - info_check_time > info_check_interval
       UserVars.XPSquelch = true unless UserVars.drinfomon_debug
       DownstreamHook.add('info_silence', info_silence) unless UserVars.drinfomon_debug
       fput('exp all')


### PR DESCRIPTION
### Background
* Until `drinfomon` parses `info` then Lich doesn't know what guild you are.
* The script calls `info` in original line 811 then sets a timer variable so the next check doesn't happen for another 30 seconds.
* However, as of that first check, the code at line 841 hasn't been defined yet nor all the downstream hooks registered so not all the key information we need has been populated in `DRStats` or `DRSkill`.
* Due to race conditions with `drinfomon`, use of `custom_require`, and what other scripts do, occasionally scripts fail because data they relied on in `DRStats` just isn't defined yet. It eventually resolves itself after that initial 30 second wait, but it's not ideal on startup when scripts randomly fail.

### Changes
* Don't set the timer to start its 30 second interval before the second info check until after the code loop defined at line 841 is started, that way it and all the other downstream hooks will be registered and parse the output from `exp all` and `info`.
* This results in `DRStats` being populated much faster than the current design.