### PR TITLE
[script] [combat-trainer] support loading energy bows

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3278,7 +3278,8 @@ class AttackProcess
         /in your hand/,
         /A rapid series of clicks/,
         /into firing position/,
-        /You realize readying/
+        /You realize readying/,
+        /As you draw back the string/
       ]
 
       load_weapon_failure = [
@@ -3286,9 +3287,11 @@ class AttackProcess
         /You don't have the proper ammunition/,
         /You don't have enough .* to load two at once/,
         /What weapon are you trying to load/,
-        /Such a feat would be impossible without the winds to guide/,
-        /but are unable to draw upon its majesty/,
-        /without steadier hands/,
+        /You can't do that .* because you aren't trained in the ways of magic/, # energy bow that requires mana
+        /you probably need to be more specific on what you are loading/, # energy bows require `load <weapon>` syntax, set `dual_load: false`
+        /Such a feat would be impossible without the winds to guide/, # unable to dual load without ability
+        /but are unable to draw upon its majesty/, # unable to dual load without ability
+        /without steadier hands/, # unable to dual load without ability
         /You can not load .* in your left hand/,
         /You attempt to ready your/,
         /Push what?/,
@@ -3319,8 +3322,8 @@ class AttackProcess
         Flags.reset('ct-ranged-loaded')
         Flags.reset('ct-using-repeating-crossbow')
 
-        load_weapon_result = bput('load', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
-        load_weapon_result = bput('load', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        load_weapon_result = bput("load my #{game_state.weapon_name}", { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
+        load_weapon_result = bput("load my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
         waitrt?
 
         case load_weapon_result


### PR DESCRIPTION
### Background
* https://elanthipedia.play.net/Category:Energy_bow

### Changes
* Add new success/failure match strings for loading energy bows. Both bows and crossbows have the same load success message prefix, "As you draw back the string", so that made that piece easy.
* Change `load` to `load my {weapon}` because energy bows require the specific syntax, thankfully, it works for regular weapons too

### Tests
_load without specifying the weapon_
```
[combat-trainer]>load
The light crossbow seems different than a standard weapon, you probably need to be more specific on what you are loading.
(LOAD crossbow)
```
_load with specifying the weapon_
```
[combat-trainer]>load my light crossbow
As you draw back the string of your light crossbow, you feel a tugging sensation before an incandescent ethereal mist coalesces into a white bolt, loading the weapon!
Roundtime: 6 sec.
```