### PR TITLE
[script][crossing-repair] Rework, smarten

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -164,8 +164,9 @@ class CrossingRepair
 
     # If we've not exited above, we're validated ready to repair.
     # Populate a hash of items to repair at either leather or metal repairer, or both.
-    repair_info = { leather_repairer => leather_items_to_repair }
-                    .merge(metal_repairer => metal_items_to_repair) { |_key, old, new| old + new }
+    leather_repair_info = { leather_repairer => leather_items_to_repair }
+    metal_repair_info = { metal_repairer => metal_items_to_repair }
+    repair_info = leather_repair_info.merge(metal_repair_info) { |key, old, new| old + new }
 
     # Return our above repair info hash: leather, metal, or both.
     return repair_info
@@ -186,7 +187,7 @@ class CrossingRepair
 
     DRC.release_invisibility
     if repeat
-      fput('swap') unless right_hand
+      fput('swap') unless DRC.right_hand
       command = "give #{repairer}"
     else
       return unless @equipment_manager.get_item?(item)
@@ -219,7 +220,7 @@ class CrossingRepair
 
   def turn_in_ticket(repairer, failed = false)
     if failed
-      fput('swap') unless right_hand
+      fput('swap') unless DRC.right_hand
       command = "give #{repairer}"
     else
       command = "give my ticket to #{repairer}"

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -5,9 +5,6 @@
 custom_require.call(%w[common common-money common-travel equipmanager])
 
 class CrossingRepair
-  # include DRC
-  # include DRCM
-  # include DRCT
 
   def initialize
     arg_definitions = [

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -35,6 +35,7 @@ class CrossingRepair
       exit
     end
 
+    # If the user has specified a repair town via script call argument, set that here.
     settings['hometown'] = town if town
 
     @repair_heuristic_gear = settings.repair_heuristic_gear
@@ -42,6 +43,8 @@ class CrossingRepair
     @repair_timer = settings.repair_timer
     UserVars.repair_timer_snap ||= Time.now
 
+    # User has option via script arg to force repair and ignore any repair timers.
+    # Handle that here. Else, exit.
     unless args.force || should_repair?
       echo "Skipping repair" if $debug_mode_crossing_repair
       exit
@@ -51,23 +54,27 @@ class CrossingRepair
     @equipment_manager.wear_equipment_set?('standard')
     @equipment_manager.empty_hands
 
-    @skip_bank = settings.sell_loot_skip_bank
+    # @skip_bank = settings.sell_loot_skip_bank
     amount, denom = settings.sell_loot_money_on_hand.split(' ')
     @keep_copper = DRCM.convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
     @hometown_data = get_data('town')[settings.hometown]
 
     # Verify for the repair town specified, we have a bank, a leather repairer
-    # (if leather items exist), and a metal repairer (if metal items exist)
+    # (if leather items exist), and a metal repairer (if metal items exist).
+    # Returns hash of repair items, set to variable.
     repair_info = repair_prep(town, settings)
 
+    # Run through each item with respective metal or leather repairer, turning in items for repair.
     repair_info.each do |repairer, items|
       echo "Repairing at #{repairer}" if $debug_mode_crossing_repair
       repair_at(repairer['name'], repairer['id'], items)
     end
 
+    # Deposit remaining coins unless we have setting to skip.
     DRCM.deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
 
+    # Handle turning in tickets to get repaired items back.
     repair_info.to_a.reverse.each do |(repairer, _items)|
       while tickets_left?(repairer)
       end
@@ -97,7 +104,7 @@ class CrossingRepair
 
     # No bank specified in base-town.yaml for specified repair town? Message user. This method
     # both withdraws and deposits coins, so having a bank specified is requisite.
-    if !@hometown_data['deposit']
+    unless @hometown_data['deposit']
       DRC.message("No bank found for #{town} in base-town.yaml. Please submit an issue on GitHub:")
       DRC.message("https://github.com/rpherbig/dr-scripts/issues")
       exit
@@ -108,7 +115,7 @@ class CrossingRepair
     # If not, message user and direct to report issue.
     if leather_items_to_repair.any?
       echo "Leather items detected." if $debug_mode_crossing_repair
-      if !@hometown_data['leather_repair']
+      unless @hometown_data['leather_repair']
         DRC.message("No leather repairer specified in base-town.yaml. Please submita an issue on GitHub:")
         DRC.message("https://github.com/rpherbig/dr-scripts/issues")
         exit
@@ -120,7 +127,7 @@ class CrossingRepair
     # If not, message user and direct to report issue.
     if metal_items_to_repair.any?
       echo "Metal items detected." if $debug_mode_crossing_repair
-      if !@hometown_data['metal_repair']
+      unless @hometown_data['metal_repair']
         DRC.message("No metal repairer specified in base-town.yaml. Please submita an issue on GitHub:")
         DRC.message("https://github.com/rpherbig/dr-scripts/issues")
         exit

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -12,15 +12,14 @@ class CrossingRepair
   def initialize
     arg_definitions = [
       [
-        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town to sell in' },
+        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town to repair in' },
         { name: 'force', regex: /force/i, optional: true, description: 'Force repair gear, ignoring any wait timers' },
         { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug mode' }
       ]
     ]
+
     args = parse_args(arg_definitions)
-
     $debug_mode_crossing_repair = args.debug || UserVars.crossing_repair_debug
-
     town = DRC.get_town_name(args.town)
     settings = get_settings
 
@@ -36,33 +35,46 @@ class CrossingRepair
     end
 
     # If the user has specified a repair town via script call argument, set that here.
+    # This argument has already passed through the $HOMETOWN_REGEX check so we know it to be valid.
     settings['hometown'] = town if town
 
+    # Check if we have the repair_heuristic_gear yaml settings. This uses appraise to assess
+    # condition of listed items, and if damaged to a certain thresshold, then run crossing-repair
+    # on _all_ items. In other words, try to repair all your gear if some key items show wear and tear.
     @repair_heuristic_gear = settings.repair_heuristic_gear
     @repair_heuristic_threshold = settings.repair_heuristic_threshold
+
+    # Set up a repair timer so we can use this metric to know whether to repair.
+    # User has option via script arg to force repair and ignore any repair timers.
+    # Also handle that here.
     @repair_timer = settings.repair_timer
     UserVars.repair_timer_snap ||= Time.now
-
-    # User has option via script arg to force repair and ignore any repair timers.
-    # Handle that here. Else, exit.
     unless args.force || should_repair?
       echo "Skipping repair" if $debug_mode_crossing_repair
       exit
     end
 
+    # Set up equipment manager. Wear our standard equipment set. Empty our hands.
     @equipment_manager = EquipmentManager.new
     @equipment_manager.wear_equipment_set?('standard')
     @equipment_manager.empty_hands
 
+    # Handle some bank and money items. Set hometown data.
     @skip_bank = settings.sell_loot_skip_bank
     amount, denom = settings.sell_loot_money_on_hand.split(' ')
     @keep_copper = DRCM.convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
     @hometown_data = get_data('town')[settings.hometown]
 
-    # Verify for the repair town specified, we have a bank, a leather repairer
-    # (if leather items exist), and a metal repairer (if metal items exist).
-    # Returns hash of repair items, set to variable.
+    # Call our main repair handler function.
+    repair_handler(town, settings)
+  end
+
+  # This is the method that handles calls to our various repair methods
+  def repair_handler(town, settings)
+
+    # This grabs a hash of the items to repair at leather and metal, respectively. repair_prep also
+    # validates a number of things to be sure we can successfully repair.
     repair_info = repair_prep(town, settings)
 
     # Run through each item with respective metal or leather repairer, turning in items for repair.
@@ -72,7 +84,7 @@ class CrossingRepair
     end
 
     # Deposit remaining coins unless we have setting to skip.
-    DRCM.deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
+    DRCM.deposit_coins(@keep_copper, settings) unless @skip_bank
 
     # Handle turning in tickets to get repaired items back.
     repair_info.to_a.reverse.each do |(repairer, _items)|
@@ -102,63 +114,52 @@ class CrossingRepair
     leather_items_to_repair = @equipment_manager.items.select(&:leather).reject(&:skip_repair)
     metal_items_to_repair = @equipment_manager.items.reject(&:leather).reject(&:skip_repair)
 
-    # No bank specified in base-town.yaml for specified repair town? Message user. This method
-    # both withdraws and deposits coins, so having a bank specified is requisite.
+    # Updates to DR now allow all items to be repaired at any repairer - whether historically
+    # a metal or leather repairer. In order to maintain legacy code functionality, we'll still
+    # accept specification that an item is leather or metal, but we'll be smart about towns
+    # that have only one type of repairer, and repair all items when we can.
+    leather_repairer = @hometown_data['leather_repair'] || @hometown_data['metal_repair']
+    metal_repairer = @hometown_data['metal_repair'] || @hometown_data['leather_repair']
 
-    unless @skip_bank && DRCM.wealth(settings['hometown'])
+    # If we have @skip_bank specified in our yaml, we may not need a bank as long as we have
+    # enough money on hand to meet or exceed our yaml repair_withdrawal_amount. Otherwise,
+    # check for a bank in the specified town. Withdraw money if needed.
+    unless @skip_bank && (DRCM.wealth(settings['hometown']) >= @repair_withdrawal_amount)
       unless @hometown_data['deposit']
-        DRC.message("No bank found for #{town} in base-town.yaml. Please submit an issue on GitHub:")
+        DRC.message("No bank found for #{town} in base-town.yaml. Please choose a different town.")
+        DRC.message("To add a bank for this town, please submit an issue on GitHub:")
         DRC.message("https://github.com/rpherbig/dr-scripts/issues")
         exit
       end
+    else
+      DRCM.ensure_copper_on_hand(@repair_withdrawal_amount, settings)
     end
 
-    # Check if we have leather items specified in yaml. If so, verify we have a leather
-    # repair person specified in base-town.yaml for the user-specified repair town.
-    # If not, message user and direct to report issue.
-    if leather_items_to_repair.any?
-      echo "Leather items detected." if $debug_mode_crossing_repair
-      unless @hometown_data['leather_repair']
-        DRC.message("No leather repairer specified in base-town.yaml. Please submita an issue on GitHub:")
-        DRC.message("https://github.com/rpherbig/dr-scripts/issues")
-        exit
-      end
-    end
-
-    # Check if we have metal items specified in yaml. If so, verify we have a metal
-    # repair person specified in base-town.yaml for the user-specified repair town.
-    # If not, message user and direct to report issue.
-    if metal_items_to_repair.any?
-      echo "Metal items detected." if $debug_mode_crossing_repair
-      unless @hometown_data['metal_repair']
-        DRC.message("No metal repairer specified in base-town.yaml. Please submita an issue on GitHub:")
-        DRC.message("https://github.com/rpherbig/dr-scripts/issues")
-        exit
-      end
-    end
-
-    # Verify we have enough money as specified in the user's yaml
-    # Also start the performance script for some lovely extra exp = tdps
-    DRCM.ensure_copper_on_hand(@repair_withdrawal_amount, settings)
-    start_script('performance', ['noclean']) unless settings.instrument
-
-    # Display our metal and leather item hashes for repair if debug set
-    if $debug_mode_crossing_repair
-      DRC.message("Metal items hash:")
-      echo @hometown_data['metal_repair'] => metal_items_to_repair
-
-      DRC.message("Leather items hash:")
-      echo @hometown_data['leather_repair'] => leather_items_to_repair
+    # If we have no repairers specified for this town, message user to specify a different town.
+    # If they believe a repairer should exist for this town, direct them to submit an issue.
+    unless leather_repairer || metal_repairer
+      echo "No repair locations specified for this town." if $debug_mode_crossing_repair
+      DRC.message("No repairers found for #{town} in base-town.yaml. Please choose a different town.")
+      DRC.message("To add repairers for this town, please submit an issue on GitHub:")
+      DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+      exit
     end
 
     # If we've not exited above, we're validated ready to repair.
     # Populate a hash of items to repair at either leather or metal repairer.
     # Return this hash for future use.
-    repair_info = { @hometown_data['leather_repair'] => leather_items_to_repair }
-                    .merge(@hometown_data['metal_repair'] => metal_items_to_repair) { |_key, old, new| old + new }
+    repair_info = { leather_repairer => leather_items_to_repair }
+                    .merge(metal_repairer => metal_items_to_repair) { |_key, old, new| old + new }
 
     # Return our repair info hash, both leather and metal
     return repair_info
+  end
+
+  def repair_at(repairer, target_room, items)
+    return if items.nil? || items.empty?
+    return unless DRCT.walk_to(target_room)
+
+    items.each { |item| repair(repairer, item) }
   end
 
   def repair(repairer, item, repeat = false)
@@ -213,13 +214,6 @@ class CrossingRepair
       pause 30
       turn_in_ticket(repairer)
     end
-  end
-
-  def repair_at(repairer, target_room, items)
-    return if items.nil? || items.empty?
-    return unless DRCT.walk_to(target_room)
-
-    items.each { |item| repair(repairer, item) }
   end
 
   # Determines if you should go repair your gear,

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -2,12 +2,12 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#crossing-repair
 =end
 
-custom_require.call(%w[common common-money common-travel drinfomon equipmanager])
+custom_require.call(%w[common common-money common-travel equipmanager])
 
 class CrossingRepair
-  include DRC
-  include DRCM
-  include DRCT
+  # include DRC
+  # include DRCM
+  # include DRCT
 
   def initialize
     arg_definitions = [
@@ -35,7 +35,8 @@ class CrossingRepair
     end
 
     # If the user has specified a repair town via script call argument, set that here.
-    # This argument has already passed through the $HOMETOWN_REGEX check so we know it to be valid.
+    # This argument has already passed through the $HOMETOWN_REGEX check so we know it to be
+    # a valid town.
     settings['hometown'] = town if town
 
     # Check if we have the repair_heuristic_gear yaml settings. This uses appraise to assess
@@ -50,7 +51,7 @@ class CrossingRepair
     @repair_timer = settings.repair_timer
     UserVars.repair_timer_snap ||= Time.now
     unless args.force || should_repair?
-      echo "Skipping repair" if $debug_mode_crossing_repair
+      DRC.message("Skipping repair") if $debug_mode_crossing_repair
       exit
     end
 
@@ -66,20 +67,23 @@ class CrossingRepair
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
     @hometown_data = get_data('town')[settings.hometown]
 
+    # Start performance script for some sweet TDPs.
+    start_script('performance', ['noclean']) unless settings.instrument
+
     # Call our main repair handler function.
     repair_handler(town, settings)
   end
 
-  # This is the method that handles calls to our various repair methods
+  # Handler method to do our repairs.
   def repair_handler(town, settings)
 
-    # This grabs a hash of the items to repair at leather and metal, respectively. repair_prep also
-    # validates a number of things to be sure we can successfully repair.
+    # Calls the repair prep and validation method. Makes sure we're ready and able to repair.
+    # Grabs a hash of the items to repair at leather and metal, respectively.
     repair_info = repair_prep(town, settings)
 
     # Run through each item with respective metal or leather repairer, turning in items for repair.
     repair_info.each do |repairer, items|
-      echo "Repairing at #{repairer}" if $debug_mode_crossing_repair
+      DRC.message("Repairing at #{repairer}") if $debug_mode_crossing_repair
       repair_at(repairer['name'], repairer['id'], items)
     end
 
@@ -87,12 +91,12 @@ class CrossingRepair
     DRCM.deposit_coins(@keep_copper, settings) unless @skip_bank
 
     # Handle turning in tickets to get repaired items back.
-    repair_info.to_a.reverse.each do |(repairer, _items)|
+    repair_info.to_a.reverse.each do |repairer, _items|
       while tickets_left?(repairer)
       end
     end
 
-    # update when last repair completed
+    # Update when last repair completed
     UserVars.repair_timer_snap = Time.now
 
     # don't wear your boots on your head, silly
@@ -106,7 +110,7 @@ class CrossingRepair
   # Returns: the hash of items to repair at either metal/leather repairer.
   def repair_prep(town, settings)
 
-    DRC.message("Validating bank and repairers...") if $debug_mode_crossing_repair
+    DRC.message("Validating currency, bank and repairers...") if $debug_mode_crossing_repair
 
     # Populate a hash of leather items to repair, and metal items to repair, based on user's
     # yaml list of equipment. While having to repair different items at leather vs. metal
@@ -117,28 +121,44 @@ class CrossingRepair
     # Updates to DR now allow all items to be repaired at any repairer - whether historically
     # a metal or leather repairer. In order to maintain legacy code functionality, we'll still
     # accept specification that an item is leather or metal, but we'll be smart about towns
-    # that have only one type of repairer, and repair all items when we can.
+    # that have only one type of repairer, and repair all items when we can, even if only one
+    # repair type is specified for the target town.
     leather_repairer = @hometown_data['leather_repair'] || @hometown_data['metal_repair']
     metal_repairer = @hometown_data['metal_repair'] || @hometown_data['leather_repair']
 
-    # If we have @skip_bank specified in our yaml, we may not need a bank as long as we have
-    # enough money on hand to meet or exceed our yaml repair_withdrawal_amount. Otherwise,
-    # check for a bank in the specified town. Withdraw money if needed.
-    unless @skip_bank && (DRCM.wealth(settings['hometown']) >= @repair_withdrawal_amount)
-      unless @hometown_data['deposit']
-        DRC.message("No bank found for #{town} in base-town.yaml. Please choose a different town.")
-        DRC.message("To add a bank for this town, please submit an issue on GitHub:")
-        DRC.message("https://github.com/rpherbig/dr-scripts/issues")
-        exit
-      end
+    # If we have no currency listed for our target town in base-town, we can't do anything, not even
+    # check if we have enough coin to exceed our yaml-specified repair_withdrawl_amount, since
+    # we don't know the requisite currency for the repair shop! Otherwise, if we know the currency,
+    # check if we have sell_loot_skip_bank set in our yaml AND we have enough coin on hand to exceed
+    # our yaml specifications. If so, don't care whether a bank is specified for this town.
+    # Otherwise we must do banking, and need the appropriate checks.
+    if !@hometown_data['currency']
+      DRC.message("No known currency for target town. Exiting.")
+      DRC.message("To add a currency for this town, please submit an issue on GitHub:")
+      DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+      exit
     else
-      DRCM.ensure_copper_on_hand(@repair_withdrawal_amount, settings)
+      if DRCM.wealth(settings['hometown']) >= @repair_withdrawal_amount && @skip_bank
+        DRC.message("We have enough money and our yaml specifies not to deposit coins after repair.") if $debug_mode_crossing_repair
+        DRC.message("Continuing...") if $debug_mode_crossing_repair
+      else
+        DRC.message("Either we don't have enough money on hand, or we don't specify sell_loot_skip_bank.") if $debug_mode_crossing_repair
+        DRC.message("Must bank...") if $debug_mode_crossing_repair
+        if @hometown_data['deposit']
+          DRCM.ensure_copper_on_hand(@repair_withdrawal_amount, settings)
+        else
+          DRC.message("No bank specified for this town, AND we don't have enough money on hand,")
+          DRC.message("and/or we have not specified to skip depositing excess coins after repair.")
+          DRC.message("To add a bank for this town, please submit an issue on GitHub:")
+          DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+          exit
+        end
+      end
     end
 
     # If we have no repairers specified for this town, message user to specify a different town.
-    # If they believe a repairer should exist for this town, direct them to submit an issue.
+    # If they believe a repairer should exist for this town, direct them to submit an issue. Exit.
     unless leather_repairer || metal_repairer
-      echo "No repair locations specified for this town." if $debug_mode_crossing_repair
       DRC.message("No repairers found for #{town} in base-town.yaml. Please choose a different town.")
       DRC.message("To add repairers for this town, please submit an issue on GitHub:")
       DRC.message("https://github.com/rpherbig/dr-scripts/issues")
@@ -146,21 +166,22 @@ class CrossingRepair
     end
 
     # If we've not exited above, we're validated ready to repair.
-    # Populate a hash of items to repair at either leather or metal repairer.
-    # Return this hash for future use.
+    # Populate a hash of items to repair at either leather or metal repairer, or both.
     repair_info = { leather_repairer => leather_items_to_repair }
                     .merge(metal_repairer => metal_items_to_repair) { |_key, old, new| old + new }
 
-    # Return our repair info hash, both leather and metal
+    # Return our above repair info hash: leather, metal, or both.
     return repair_info
   end
 
+  # Head to the appropriate repair spot. Return if we can't get there. Call the repair method.
   def repair_at(repairer, target_room, items)
     return if items.nil? || items.empty?
     return unless DRCT.walk_to(target_room)
 
     items.each { |item| repair(repairer, item) }
   end
+
 
   def repair(repairer, item, repeat = false)
     return unless repairer
@@ -175,7 +196,7 @@ class CrossingRepair
       command = "give my #{item.short_name} to #{repairer}"
     end
 
-    case bput(command, "There isn't a scratch on that", "I don't work on those here", "I don't repair those here", 'Just give it to me again', "If you agree, give it to me again", "You don't need to specify the object", "I will not repair something that isn't broken", "Please don't lose this ticket!", "You hand.*#{repairer}", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!', "You can't hand this weapon to another person!")
+    case DRC.bput(command, "There isn't a scratch on that", "I don't work on those here", "I don't repair those here", 'Just give it to me again', "If you agree, give it to me again", "You don't need to specify the object", "I will not repair something that isn't broken", "Please don't lose this ticket!", "You hand.*#{repairer}", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!', "You can't hand this weapon to another person!")
     when "There isn't a scratch on that", "I will not repair something that isn't broken", "Lucky for you!  That isn't damaged!", 'You will need more coin if I am to be repairing that!', "I don't repair those here", "You can't hand this weapon to another person!"
       @equipment_manager.empty_hands
     when "I don't work on those here"
@@ -184,12 +205,12 @@ class CrossingRepair
     when "You don't need to specify the object", 'Just give it to me again'
       repair(repairer, item, true)
     when "Please don't lose this ticket!", "You hand.*#{repairer}"
-      bput('stow my ticket', 'You put')
+      DRC.bput('stow my ticket', 'You put')
     end
   end
 
   def tickets_left?(repairer)
-    if bput("get my #{repairer['name']} ticket", 'What were you referring', 'You get') == 'What were you referring'
+    if DRC.bput("get my #{repairer['name']} ticket", 'What were you referring', 'You get') == 'What were you referring'
       return false
     end
 
@@ -207,7 +228,7 @@ class CrossingRepair
       command = "give my ticket to #{repairer}"
     end
 
-    case bput(command, 'You hand', 'takes your ticket', "You don't need to specify the object", 'almost done', "Well that isn't gonna be done")
+    case DRC.bput(command, 'You hand', 'takes your ticket', "You don't need to specify the object", 'almost done', "Well that isn't gonna be done")
     when "You don't need to specify the object"
       turn_in_ticket(repairer, true)
     when 'almost done', "Well that isn't gonna be done"
@@ -235,11 +256,11 @@ class CrossingRepair
     should_repair = elapsed_time >= @repair_timer
 
     if $debug_mode_crossing_repair
-      echo "last repair time: #{last_repair_time}"
-      echo "current time: #{current_repair_time}"
-      echo "elapsed time (seconds): #{elapsed_time}"
-      echo "repair timer (seconds): #{@repair_timer}"
-      echo "does elapsed time exceed repair timer? #{should_repair}"
+      DRC.message("last repair time: #{last_repair_time}")
+      DRC.message("current time: #{current_repair_time}")
+      DRC.message("elapsed time (seconds): #{elapsed_time}")
+      DRC.message("repair timer (seconds): #{@repair_timer}")
+      DRC.message("does elapsed time exceed repair timer? #{should_repair}")
     end
 
     return should_repair
@@ -288,10 +309,10 @@ class CrossingRepair
       condition_value = conditions.index(condition_match) + 1
       should_repair = condition_value <= @repair_heuristic_threshold
       if $debug_mode_crossing_repair
-        echo "item: #{item}"
-        echo "condition: #{condition_value} (#{condition_match})"
-        echo "threshold: #{@repair_heuristic_threshold}"
-        echo "should repair? #{should_repair}"
+        DRC.message("item: #{item}")
+        DRC.message("condition: #{condition_value} (#{condition_match})")
+        DRC.message("threshold: #{@repair_heuristic_threshold}")
+        DRC.message("should repair? #{should_repair}")
       end
       should_repair
     end

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -54,7 +54,7 @@ class CrossingRepair
     @equipment_manager.wear_equipment_set?('standard')
     @equipment_manager.empty_hands
 
-    # @skip_bank = settings.sell_loot_skip_bank
+    @skip_bank = settings.sell_loot_skip_bank
     amount, denom = settings.sell_loot_money_on_hand.split(' ')
     @keep_copper = DRCM.convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
@@ -87,12 +87,12 @@ class CrossingRepair
     fput('sort auto head') if settings.sort_auto_head
   end
 
+  # This method is designed to prep for repair by checking if we have a bank specified for the
+  # town in base-town.yaml, and checking if we have leather and/or metal items to repair and if
+  # there is a requisite metal or leather repair person specified in base-town.yaml.
+  # If we don't have the proper specifications in base-town.yaml, warn user, direct to submit issue.
+  # Returns: the hash of items to repair at either metal/leather repairer.
   def repair_prep(town, settings)
-    # This method is designed to prep for repair by checking if we have a bank specified for the
-    # town in base-town.yaml, and checking if we have leather and/or metal items to repair and if
-    # there is a requisite metal or leather repair person specified in base-town.yaml.
-    # If we don't have the proper specifications in base-town.yaml, warn user, direct to submit issue.
-    # Returns: the hash of items to repair at either metal/leather repairer.
 
     DRC.message("Validating bank and repairers...") if $debug_mode_crossing_repair
 
@@ -104,10 +104,13 @@ class CrossingRepair
 
     # No bank specified in base-town.yaml for specified repair town? Message user. This method
     # both withdraws and deposits coins, so having a bank specified is requisite.
-    unless @hometown_data['deposit']
-      DRC.message("No bank found for #{town} in base-town.yaml. Please submit an issue on GitHub:")
-      DRC.message("https://github.com/rpherbig/dr-scripts/issues")
-      exit
+
+    unless @skip_bank && DRCM.wealth(settings['hometown'])
+      unless @hometown_data['deposit']
+        DRC.message("No bank found for #{town} in base-town.yaml. Please submit an issue on GitHub:")
+        DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+        exit
+      end
     end
 
     # Check if we have leather items specified in yaml. If so, verify we have a leather

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -10,18 +10,65 @@ class CrossingRepair
   include DRCT
 
   def initialize
-    settings = setup
+    arg_definitions = [
+      [
+        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town to sell in' },
+        { name: 'force', regex: /force/i, optional: true, description: 'Force repair gear, ignoring any wait timers' },
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug mode' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
 
-    start_script('performance', ['noclean']) unless settings.instrument
+    $debug_mode_crossing_repair = args.debug || UserVars.crossing_repair_debug
 
-    @repair_info.each do |repairer, items|
+    town = DRC.get_town_name(args.town)
+    settings = get_settings
+
+    # If town argument is not recognized, choosing to exit the script with error
+    # instead of continue with the character's hometown because if the player
+    # wanted to repair in a specific town then they might be far away from their
+    # hometown and not want the script to suddenly rush them off,
+    # especially if it was a simple typo or the player suffers social outrage.
+    if args.town && !town
+      DRC.message("Could not identify town for argument: #{args.town}")
+      DRC.message("To avoid ambiguity, please use the town's full name: https://elanthipedia.play.net/Category:Cities")
+      exit
+    end
+
+    settings['hometown'] = town if town
+
+    @repair_heuristic_gear = settings.repair_heuristic_gear
+    @repair_heuristic_threshold = settings.repair_heuristic_threshold
+    @repair_timer = settings.repair_timer
+    UserVars.repair_timer_snap ||= Time.now
+
+    unless args.force || should_repair?
+      echo "Skipping repair" if $debug_mode_crossing_repair
+      exit
+    end
+
+    @equipment_manager = EquipmentManager.new
+    @equipment_manager.wear_equipment_set?('standard')
+    @equipment_manager.empty_hands
+
+    @skip_bank = settings.sell_loot_skip_bank
+    amount, denom = settings.sell_loot_money_on_hand.split(' ')
+    @keep_copper = DRCM.convert_to_copper(amount, denom)
+    @repair_withdrawal_amount = settings.repair_withdrawal_amount
+    @hometown_data = get_data('town')[settings.hometown]
+
+    # Verify for the repair town specified, we have a bank, a leather repairer
+    # (if leather items exist), and a metal repairer (if metal items exist)
+    repair_info = repair_prep(town, settings)
+
+    repair_info.each do |repairer, items|
       echo "Repairing at #{repairer}" if $debug_mode_crossing_repair
       repair_at(repairer['name'], repairer['id'], items)
     end
 
     DRCM.deposit_coins(@keep_copper, settings) unless settings.sell_loot_skip_bank
 
-    @repair_info.to_a.reverse.each do |(repairer, _items)|
+    repair_info.to_a.reverse.each do |(repairer, _items)|
       while tickets_left?(repairer)
       end
     end
@@ -31,6 +78,77 @@ class CrossingRepair
 
     # don't wear your boots on your head, silly
     fput('sort auto head') if settings.sort_auto_head
+  end
+
+  def repair_prep(town, settings)
+    # This method is designed to prep for repair by checking if we have a bank specified for the
+    # town in base-town.yaml, and checking if we have leather and/or metal items to repair and if
+    # there is a requisite metal or leather repair person specified in base-town.yaml.
+    # If we don't have the proper specifications in base-town.yaml, warn user, direct to submit issue.
+    # Returns: the hash of items to repair at either metal/leather repairer.
+
+    DRC.message("Validating bank and repairers...") if $debug_mode_crossing_repair
+
+    # Populate a hash of leather items to repair, and metal items to repair, based on user's
+    # yaml list of equipment. While having to repair different items at leather vs. metal
+    # repair is deprecated, we still need to support the legacy settings.
+    leather_items_to_repair = @equipment_manager.items.select(&:leather).reject(&:skip_repair)
+    metal_items_to_repair = @equipment_manager.items.reject(&:leather).reject(&:skip_repair)
+
+    # No bank specified in base-town.yaml for specified repair town? Message user. This method
+    # both withdraws and deposits coins, so having a bank specified is requisite.
+    if !@hometown_data['deposit']
+      DRC.message("No bank found for #{town} in base-town.yaml. Please submit an issue on GitHub:")
+      DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+      exit
+    end
+
+    # Check if we have leather items specified in yaml. If so, verify we have a leather
+    # repair person specified in base-town.yaml for the user-specified repair town.
+    # If not, message user and direct to report issue.
+    if leather_items_to_repair.any?
+      echo "Leather items detected." if $debug_mode_crossing_repair
+      if !@hometown_data['leather_repair']
+        DRC.message("No leather repairer specified in base-town.yaml. Please submita an issue on GitHub:")
+        DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+        exit
+      end
+    end
+
+    # Check if we have metal items specified in yaml. If so, verify we have a metal
+    # repair person specified in base-town.yaml for the user-specified repair town.
+    # If not, message user and direct to report issue.
+    if metal_items_to_repair.any?
+      echo "Metal items detected." if $debug_mode_crossing_repair
+      if !@hometown_data['metal_repair']
+        DRC.message("No metal repairer specified in base-town.yaml. Please submita an issue on GitHub:")
+        DRC.message("https://github.com/rpherbig/dr-scripts/issues")
+        exit
+      end
+    end
+
+    # Verify we have enough money as specified in the user's yaml
+    # Also start the performance script for some lovely extra exp = tdps
+    DRCM.ensure_copper_on_hand(@repair_withdrawal_amount, settings)
+    start_script('performance', ['noclean']) unless settings.instrument
+
+    # Display our metal and leather item hashes for repair if debug set
+    if $debug_mode_crossing_repair
+      DRC.message("Metal items hash:")
+      echo @hometown_data['metal_repair'] => metal_items_to_repair
+
+      DRC.message("Leather items hash:")
+      echo @hometown_data['leather_repair'] => leather_items_to_repair
+    end
+
+    # If we've not exited above, we're validated ready to repair.
+    # Populate a hash of items to repair at either leather or metal repairer.
+    # Return this hash for future use.
+    repair_info = { @hometown_data['leather_repair'] => leather_items_to_repair }
+                    .merge(@hometown_data['metal_repair'] => metal_items_to_repair) { |_key, old, new| old + new }
+
+    # Return our repair info hash, both leather and metal
+    return repair_info
   end
 
   def repair(repairer, item, repeat = false)
@@ -173,62 +291,6 @@ class CrossingRepair
       end
       should_repair
     end
-  end
-
-  def setup
-    arg_definitions = [
-      [
-        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town to sell in' },
-        { name: 'force', regex: /force/i, optional: true, description: 'Force repair gear, ignoring any wait timers' },
-        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug mode' }
-      ]
-    ]
-    args = parse_args(arg_definitions)
-
-    $debug_mode_crossing_repair = args.debug || UserVars.crossing_repair_debug
-
-    town = DRC.get_town_name(args.town)
-    settings = get_settings
-
-    # If town argument is not recognized, choosing to exit the script with error
-    # instead of continue with the character's hometown because if the player
-    # wanted to repair in a specific town then they might be far away from their
-    # hometown and not want the script to suddenly rush them off,
-    # especially if it was a simple typo or the player suffers social outrage.
-    if args.town && !town
-      DRC.message("Could not identify town for argument: #{args.town}")
-      DRC.message("To avoid ambiguity, please use the town's full name: https://elanthipedia.play.net/Category:Cities")
-      exit
-    end
-
-    settings['hometown'] = town if town
-
-    @repair_heuristic_gear = settings.repair_heuristic_gear
-    @repair_heuristic_threshold = settings.repair_heuristic_threshold
-    @repair_timer = settings.repair_timer
-    UserVars.repair_timer_snap ||= Time.now
-
-    unless args.force || should_repair?
-      echo "Skipping repair" if $debug_mode_crossing_repair
-      exit
-    end
-
-    @equipment_manager = EquipmentManager.new
-    @equipment_manager.wear_equipment_set?('standard')
-    @equipment_manager.empty_hands
-
-    @skip_bank = settings.sell_loot_skip_bank
-    amount, denom = settings.sell_loot_money_on_hand.split(' ')
-    @keep_copper = DRCM.convert_to_copper(amount, denom)
-    @repair_withdrawal_amount = settings.repair_withdrawal_amount
-    hometown_data = get_data('town')[settings.hometown]
-
-    DRCM.ensure_copper_on_hand(@repair_withdrawal_amount, settings)
-
-    # Merge, do not overwrite
-    @repair_info = { hometown_data['leather_repair'] => @equipment_manager.items.select(&:leather).reject(&:skip_repair) }
-                   .merge(hometown_data['metal_repair'] => @equipment_manager.items.reject(&:leather).reject(&:skip_repair)) { |_key, old, new| old + new }
-    settings
   end
 end
 


### PR DESCRIPTION
Designed to rework the code a bit. Reorganize to follow convention of other scripts, robust comments, smart and communicative failures to user when it does fail. Primarily, we had silent failures when specifying via arg a repair town, but said repair town had no bank, no leather repair, or no metal repair, specified.

Posting as a draft while I work on this. I've been busy with family stuff in the last week or so, so this may take a little more time.

@MahtraDR @KatoakDR 