### PR TITLE
[data] [base-town] Add leather repair for SCC

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -633,6 +633,9 @@ Steelclaw Clan:
   metal_repair:
     id: 9639
     name: Granzer
+  leather_repair:
+    id: 9639
+    name: Granzer
   deposit: *shard_deposit
 Stone Clan:
   currency: kronars


### PR DESCRIPTION
### Background
* Continuation of https://github.com/rpherbig/dr-scripts/pull/5464

### Changes
* Add explicit entry for `leather_repair` because `crossing-repair` script looks for leather or metal repair entries in town data based on gear using `is_leather` property. This is parity with how Ylono is configured in Shard, and an interim solution until or if we consolidate code/data to one repairer per town.