### PR TITLE
[script] [athletics] delete flags

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -176,10 +176,6 @@ class Athletics
         bput("get #{@settings.climbing_rope_adjective} rope", 'You are already holding that', 'You get', 'What were you')
       end
     end
-    Flags.delete('climbing-finished')
-    Flags.delete('climbing-too-easy')
-    Flags.delete('climbing-too-hard')
-    Flags.delete('climbing-dead-rope')
     bput('stop climb', 'You stop practicing your climbing skills.', "You weren't practicing your climbing skills anyway.")
     DRC.stop_playing
     fix_standing
@@ -397,6 +393,11 @@ end
 before_dying do
   stop_script('performance') if Script.running?('performance')
   put('stop climb')
+  Flags.delete('climbing-finished')
+  Flags.delete('climbing-too-easy')
+  Flags.delete('climbing-too-hard')
+  Flags.delete('climbing-dead-rope')
+  Flags.delete('climbing-live-rope')
   Flags.delete('ct-climbing-finished')
   Flags.delete('ct-climbing-combat')
 end

--- a/athletics.lic
+++ b/athletics.lic
@@ -46,7 +46,7 @@ class Athletics
     elsif args.xalas || (@settings.climbing_target == 'xalas')
       climb_xalas
     elsif args.cliffs || (@settings.climbing_target == 'cliffs')
-      climb_cliffs  
+      climb_cliffs
     elsif have_climbing_rope
       train_with_rope(args.stationary)
     elsif @swimming_target
@@ -397,6 +397,8 @@ end
 before_dying do
   stop_script('performance') if Script.running?('performance')
   put('stop climb')
+  Flags.delete('ct-climbing-finished')
+  Flags.delete('ct-climbing-combat')
 end
 
 Athletics.new


### PR DESCRIPTION
### Background
* Two flags are added at lines 312-313 but are never deleted

### Changes
* Delete flags as part of script cleanup: `ct-climbing-finished` and `ct-climbing-combat`
* Moved all calls to `Flags.delete(..)` to `before_dying` to ensure they happen regardless how script exits