### PR TITLE
[script][almanac]Adding startup delay to almanac

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -14,6 +14,9 @@ class Almanac
     @almanac_skills = settings.almanac_skills
     @almanac = settings.almanac_noun
 
+    @startup_delay = settings.almanac_startup_delay || 15
+
+    pause @startup_delay
     passive_loop
   end
 

--- a/almanac.lic
+++ b/almanac.lic
@@ -14,9 +14,9 @@ class Almanac
     @almanac_skills = settings.almanac_skills
     @almanac = settings.almanac_noun
 
-    @startup_delay = settings.almanac_startup_delay || 15
+    startup_delay = settings.almanac_startup_delay
 
-    pause @startup_delay
+    pause startup_delay
     passive_loop
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1813,6 +1813,9 @@ restock_shop:
 # The noun of your almanac (e.g. almanac, tome, treatise, monograph, etc)
 almanac_noun: almanac
 
+# Wait this many seconds before reading almanac
+almanac_startup_delay: 15
+
 # List of skills to turn almanac to train.
 # Leave blank unless you have a "pick a skill" almanac.
 almanac_skills:


### PR DESCRIPTION
Without a startup delay, if you have almanac in autostarts you lose the mindstate when the game logs you in and clears mindstates from rested exp. Copied the syntax from tarantula.lic