### PR TITLE
[script] [tendme] support tending internal bleeders

### DIFF
--- a/tendme.lic
+++ b/tendme.lic
@@ -44,8 +44,8 @@ class TendMe
   # Monitor for wounds to begin bleeding again then tend them.
   def monitor_health(train)
     Flags.add('tendme-bind-lodged', /You feel a slight pain from the (?<item>.*) lodged in your (?<body_part>.*)\./)
-    Flags.add('tendme-bind-wound', /The bandages binding your (?<body_part>.*) (become|come|soak)/)
-    Flags.add('tendme-rewrap-wound', /You feel like now might be a good time to change the bandages on your (?<body_part>.*)\./)
+    Flags.add('tendme-bind-wound', /The bandages (binding|compressing) your (?<body_part>.*) (become|come|soak)/)
+    Flags.add('tendme-rewrap-wound', /You feel like now might be a good time to change the (bandages|bindings) on your (?<body_part>.*)\./)
 
     loop do
       pause 0.5

--- a/tendme.lic
+++ b/tendme.lic
@@ -26,18 +26,11 @@ class TendMe
       health_data['parasites'].values.flatten +
       health_data['bleeders'].values.flatten
     )
-    .reject { |wound| !wound.tendable? || wound.bleeding_rate =~ /tended|clotted/ } # untendable
-    .select do |wound|
-      if wound.bleeding? && !DRCH.skilled_to_tend_wound?(wound.bleeding_rate)
-        DRC.message("You are not skilled enough to tend a #{wound.bleeding_rate.upcase} bleeder on a #{wound.body_part.upcase}, skipping")
-        false
-      else
-        # the wound is either a tendable bleeder, parasite, or lodged item
-        true
-      end
-    end
+    .select { |wound| wound.tendable? }
     .sort_by { |wound| wound.severity * -1 } # sort descending
-    .each { |wound| tended_wounds = DRCH.bind_wound(wound.body_part) || tended_wounds }
+    .map { |wound| wound.body_part }
+    .uniq
+    .each { |body_part| tended_wounds = DRCH.bind_wound(body_part) || tended_wounds }
     return tended_wounds
   end
 


### PR DESCRIPTION
### Background
* Part of the solution for https://github.com/rpherbig/dr-scripts/issues/5440
* Courtesy of @Kaesken

### Changes
* Update match string to detect bandages for internal bleeders coming off
* Remove unnecessary code that duplicates logic of `wound.tendable?`
* Because `DRCH.bind_wound(..)` recursively calls itself to remove all lodged items/parasites on a body part, added a `uniq` filter to the list of tendable wounds so that we don't redundantly try to tend the same spot after there's nothing left to tend.