### PR TITLE
[script] [common-items] don't tap if nothing to tap

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -398,6 +398,7 @@ module DRCI
   # Taps an item and returns the match string.
   # If no container specified then generically taps whatever's in your immediate inventory.
   def tap(item, container = nil)
+    return nil unless item
     from = container
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
     DRC.bput("tap my #{item} #{from}", *@@tap_success_patterns, *@@tap_failure_patterns)


### PR DESCRIPTION
### Changes
* Updated to be consistent with the other methods that handle a `nil` argument (for example, when called `DRCI.tap(DRC.right_hand)` and there's nothing in your hand to avoid a "tap my " command)

