### PR TITLE
[script] [common-summoning] fix issue with identifying summoned weapons

### DIFF
--- a/common-summoning.lic
+++ b/common-summoning.lic
@@ -55,7 +55,7 @@ module DRCS
       end
     elsif DRStats.warrior_mage?
       get_ingot(ingot, false)
-      case DRC.bput("shape my #{identify_summoned_weapon} to #{skill}", 'You lack the elemental charge', 'You reach out', 'You fumble around')
+      case DRC.bput("shape my #{identify_summoned_weapon} to #{skill}", 'You lack the elemental charge', 'You reach out', 'You fumble around', "You don't know how to manipulate your weapon in that way")
       when 'You lack the elemental charge'
         summon_admittance
         shape_summoned_weapon(skill, nil)
@@ -75,14 +75,14 @@ module DRCS
       return DRC.right_hand if DRCMM.is_moon_weapon?(DRC.right_hand)
       return DRC.left_hand  if DRCMM.is_moon_weapon?(DRC.left_hand)
     elsif DRStats.warrior_mage?
-      weapon_regex = /^You tap (?:a|an|some) ((stone|fiery|icy|electric) [\w\s\-]+) that you are holding.$/
+      weapon_regex = /^You tap (?:a|an|some)(?:[\w\s\-]+)((stone|fiery|icy|electric) [\w\s\-]+) that you are holding.$/
       # For a two-worded weapon like 'short sword' the only way to know
       # which element it was summoned with is by tapping it. That's the only
       # way we can infer if it's a summoned sword or a regular one.
       # However, the <adj> <noun> of the item we return must be what's in
       # their hands, not what the regex matches in the tap.
-      return DRC.right_hand if DRC.right_hand && DRCI.tap(DRC.right_hand) =~ weapon_regex
-      return DRC.left_hand  if DRC.left_hand  && DRCI.tap(DRC.left_hand)  =~ weapon_regex
+      return DRC.right_hand if DRCI.tap(DRC.right_hand) =~ weapon_regex
+      return DRC.left_hand if DRCI.tap(DRC.left_hand) =~ weapon_regex
     else
       echo "Unable to summon weapons as a #{DRStats.guild}"
     end


### PR DESCRIPTION
### Dependencies
* https://github.com/rpherbig/dr-scripts/pull/5492

### Background
* [Zauper](https://discord.com/channels/745675889622384681/745676299594629272/938120440155615282) reported in Lich discord errors trying to shape summoned elemental weapons.

```
[combat-trainer]>tap my marauder blade 

You tap a stone marauder blade that you are holding.
> 
[combat-trainer]>shape my  to Large Edged

You fumble around but can't seem to make that work.
```

### Changes
* Updated regular expression to match multi-word elemental weapons
* Simplify logic when to return left_hand or right_hand by deferring to `DRCI.tap`