### PR TITLE
[script][common-items] Adding pull to remove item success patterns

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -117,23 +117,23 @@ module DRCI
   ]
 
   @@remove_item_success_patterns = [
-    /^You remove/,
-    /^You detach/,
-    /^You sling/,
-    /^You slide/,
-    /^You take/,
-    /^You loosen/,
-    /^You untie/,
-    /^You pull/,
-    /^You tug/,
-    /^You struggle/,
-    /^The .* slide/,
-    /^You .* slide/,
     /^Dropping your shoulder/,
+    /^The .* slide/,
     /^Without any effort/,
+    /^You .* slide/,
+    /^You detach/,
+    /^You loosen/,
+    /^You pull/,
+    /^You remove/,
+    /^You slide/,
+    /^You sling/,
+    /^You struggle/,
+    /^You take/,
+    /^You tug/,
+    /^You untie/,
     /as you remove/,
-    /you manage to loosen/,
     /slide themselves off of your/
+    /you manage to loosen/,
   ]
 
   @@remove_item_failure_patterns = [

--- a/common-items.lic
+++ b/common-items.lic
@@ -124,6 +124,7 @@ module DRCI
     /^You take/,
     /^You loosen/,
     /^You untie/,
+    /^You pull/,
     /^You tug/,
     /^You struggle/,
     /^The .* slide/,


### PR DESCRIPTION
I've only added 'You slip" as a match pattern, but I also sorted the pattern list, which is why it looks like so many lines changed.

Added "You slip" to match this
```
 >wear my gloves
You slip some lumium lamellar gloves crafted from tempered bands onto your hands.
```