### PR TITLE
[script][common]Adding a common method for ouutputting atmospheric messages

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -750,6 +750,11 @@ module DRC
     DRC.bput("stance set #{stance}", /Setting your/)
   end
 
+  def atmo(text)
+    string = "<pushStream id=\"atmospherics\"/>" + text
+    _respond(string, "<popStream id=\"atmospherics\" /><prompt time =\"#{Time.now.to_i}\">&gt;</prompt>")
+  end
+
   def message(text)
     string = ''
     $fake_stormfront ? string.concat("\034GSL\r\n ") : string.concat("<pushBold\/>")


### PR DESCRIPTION
I removed this method from tarantula.lic in the recent rewrite, and someone asked me to put it back in. Makes more sense here, than in the tarantula script itself. Thoughts?