### PR TITLE
Update trade.lic

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -1341,7 +1341,7 @@ class Trade
   end
 
   def appraise_worn_pouch?
-    case bput("appraise my #{@gem_pouch_adjective} pouch", 'Roundtime', 'You can.t appraise the', 'Appraise what')
+    case bput("appraise my #{@gem_pouch_adjective} pouch quick", 'Roundtime', 'You can.t appraise the', 'Appraise what')
     when 'You can.t appraise the', 'Appraise what'
       @appraisal_queue -= ['pouch']
       false
@@ -1354,7 +1354,7 @@ class Trade
     @pouch_ordinal = 0 if @pouch_ordinal > 10
     case bput("get #{$ORDINALS[@pouch_ordinal]} pouch from my #{@full_pouch_container}", '^You get ', '^What were you referring')
     when /^You get /
-      bput('appraise my pouch', 'Roundtime')
+      bput('appraise my pouch quick', 'Roundtime')
       waitrt?
       bput("put my pouch in my #{@full_pouch_container}", 'You put')
       @pouch_ordinal += 1
@@ -1367,7 +1367,7 @@ class Trade
   end
 
   def appraise_bundle?
-    case bput('appraise my bundle', 'Roundtime', 'Appraise what', 'You cannot appraise')
+    case bput('appraise my bundle quick', 'Roundtime', 'Appraise what', 'You cannot appraise')
     when 'Appraise what', 'You cannot appraise'
       @appraisal_queue -= ['bundle']
       return false


### PR DESCRIPTION
tiny change but makes a huge difference with training for the few people using this script

When appraising a pouch solely for exp gain purposes it is always best to APPRAISE MY POUCH QUICK. This is true at any rank from 0-1750 for a pouch of any value. (26 years of Trader training to back this up)