### PR TITLE
[script][apraisal]Appraisal add empty pouch handling

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -97,6 +97,7 @@ class Appraisal
         end
         waitrt?
         if pouch_empty
+          DRC.message("Empty pouch found, putting it into spare_gem_pouch_container")
           DRCI.put_away_item?("#{gem_pouch_adjective} #{gem_pouch_noun}", spare_gem_pouch_container)
           pouch_empty = false
         else

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -45,7 +45,7 @@ class Appraisal
         when 'zills'
           assess_zills
         when 'pouches'
-          train_appraisal_with_pouches(settings.full_pouch_container, pouch_adjective, settings.gem_pouch_noun)
+          train_appraisal_with_pouches(settings.full_pouch_container, pouch_adjective, settings.gem_pouch_noun, settings.spare_gem_pouch_container)
         when 'gear'
           train_appraisal_with_gear
         when 'bundle'
@@ -73,9 +73,10 @@ class Appraisal
     waitrt?
   end
 
-  def train_appraisal_with_pouches(full_pouch_container, gem_pouch_adjective, gem_pouch_noun)
+  def train_appraisal_with_pouches(full_pouch_container, gem_pouch_adjective, gem_pouch_noun, spare_gem_pouch_container)
+    pouch_empty = false
     if gem_pouch_adjective
-      case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', 'You can.t appraise the', 'Appraise what', /You.ll need to open the .* to examine its contents./)
+      case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', 'You can.t appraise the', 'Appraise what', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/)
       when /You.ll need to open the .* to examine its contents./
         bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .*./, /That is already open/)
         bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', 'You can.t appraise the', 'Appraise what')
@@ -85,15 +86,22 @@ class Appraisal
     end
     pause 1
     $ORDINALS.each do |ordinal|
-      break unless DRCI.get_item?( "#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )  
-        case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./)
+      break unless DRCI.get_item?("#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container)
+        case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/)
         when /You.ll need to open the .* to examine its contents./
           bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .* ./, /That is already open/)
           bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')
           bput("close my #{gem_pouch_adjective} #{gem_pouch_noun}", /You close your/, /That is already closed/)
+        when /There doesn.t appear to be anything in/
+          pouch_empty = true
         end
         waitrt?
-        DRCI.put_away_item?( "#{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container )
+        if pouch_empty
+          DRCI.put_away_item?("#{gem_pouch_adjective} #{gem_pouch_noun}", spare_gem_pouch_container)
+          pouch_empty = false
+        else
+          DRCI.put_away_item?("#{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container)
+        end
         pause 1
       break if DRSkill.getxp('Appraisal') >= 30
     end

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -45,7 +45,7 @@ class Appraisal
         when 'zills'
           assess_zills
         when 'pouches'
-          train_appraisal_with_pouches(settings.full_pouch_container, pouch_adjective, settings.gem_pouch_noun, settings.spare_gem_pouch_container)
+          train_appraisal_with_pouches(settings.full_pouch_container, settings.spare_gem_pouch_container, pouch_adjective, settings.gem_pouch_noun)
         when 'gear'
           train_appraisal_with_gear
         when 'bundle'
@@ -73,8 +73,7 @@ class Appraisal
     waitrt?
   end
 
-  def train_appraisal_with_pouches(full_pouch_container, gem_pouch_adjective, gem_pouch_noun, spare_gem_pouch_container)
-    pouch_empty = false
+  def train_appraisal_with_pouches(full_pouch_container, spare_gem_pouch_container, gem_pouch_adjective, gem_pouch_noun)
     if gem_pouch_adjective
       case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', 'You can.t appraise the', 'Appraise what', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/)
       when /You.ll need to open the .* to examine its contents./
@@ -86,6 +85,7 @@ class Appraisal
     end
     pause 1
     $ORDINALS.each do |ordinal|
+      gem_pouch_container = full_pouch_container
       break unless DRCI.get_item?("#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container)
         case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/)
         when /You.ll need to open the .* to examine its contents./
@@ -93,16 +93,11 @@ class Appraisal
           bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')
           bput("close my #{gem_pouch_adjective} #{gem_pouch_noun}", /You close your/, /That is already closed/)
         when /There doesn.t appear to be anything in/
-          pouch_empty = true
+          gem_pouch_container = spare_gem_pouch_container
         end
         waitrt?
-        if pouch_empty
-          DRC.message("Empty pouch found, putting it into spare_gem_pouch_container")
-          DRCI.put_away_item?("#{gem_pouch_adjective} #{gem_pouch_noun}", spare_gem_pouch_container)
-          pouch_empty = false
-        else
-          DRCI.put_away_item?("#{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container)
-        end
+        DRC.message("Empty pouch found, putting it into spare_gem_pouch_container") if gem_pouch_container == spare_gem_pouch_container
+        DRCI.put_away_item?("#{gem_pouch_adjective} #{gem_pouch_noun}", gem_pouch_container)
         pause 1
       break if DRSkill.getxp('Appraisal') >= 30
     end

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -86,17 +86,17 @@ class Appraisal
     pause 1
     $ORDINALS.each do |ordinal|
       gem_pouch_container = full_pouch_container
-      break unless DRCI.get_item?("#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", full_pouch_container)
+      break unless DRCI.get_item?("#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", gem_pouch_container)
         case bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/)
         when /You.ll need to open the .* to examine its contents./
           bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .* ./, /That is already open/)
           bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')
           bput("close my #{gem_pouch_adjective} #{gem_pouch_noun}", /You close your/, /That is already closed/)
         when /There doesn.t appear to be anything in/
+          DRC.message("Empty pouch found, putting it into spare_gem_pouch_container")
           gem_pouch_container = spare_gem_pouch_container
         end
         waitrt?
-        DRC.message("Empty pouch found, putting it into spare_gem_pouch_container") if gem_pouch_container == spare_gem_pouch_container
         DRCI.put_away_item?("#{gem_pouch_adjective} #{gem_pouch_noun}", gem_pouch_container)
         pause 1
       break if DRSkill.getxp('Appraisal') >= 30


### PR DESCRIPTION
```
2022-02-07 05:12:18 UTC: [appraisal]>get my sixth  pouch from my portal
2022-02-07 05:12:18 UTC: [Assuming you mean an effervescent eddy of honey-hued light captured by a sungold frame.]
2022-02-07 05:12:18 UTC: You get a soft gem pouch from inside an effervescent eddy of honey-hued light captured by a sungold frame.
2022-02-07 05:12:18 UTC: [appraisal]>appraise my  pouch quick
2022-02-07 05:12:18 UTC: The soft gem pouch is a container, and can be opened and closed.
2022-02-07 05:12:18 UTC: The soft gem pouch is fairly soft.
2022-02-07 05:12:18 UTC: It appears that the soft gem pouch can be worn attached to a belt.
2022-02-07 05:12:18 UTC: You think it is likely that the soft gem pouch probably weighs a few stones.
2022-02-07 05:12:18 UTC: There doesn't appear to be anything in the soft gem pouch.
2022-02-07 05:12:18 UTC: Roundtime: 3 seconds.
2022-02-07 05:12:21 UTC: <pushBold/>| Empty pouch found, putting it into spare_gem_pouch_container<popBold/>
2022-02-07 05:12:21 UTC: [appraisal]>put my  pouch in my weapon.harness
2022-02-07 05:12:21 UTC: You put your pouch in your weapon harness.
2022-02-07 05:12:23 UTC: [appraisal]>get my seventh  pouch from my portal
2022-02-07 05:12:23 UTC: [Assuming you mean an effervescent eddy of honey-hued light captured by a sungold frame.]
2022-02-07 05:12:23 UTC: You get a black gem pouch from inside an effervescent eddy of honey-hued light captured by a sungold frame.
2022-02-07 05:12:23 UTC: [appraisal]>appraise my  pouch quick
2022-02-07 05:12:23 UTC: The black gem pouch is a container.
2022-02-07 05:12:23 UTC: The black gem pouch is fairly soft.
2022-02-07 05:12:23 UTC: It appears that the black gem pouch can be worn attached to a belt.
2022-02-07 05:12:23 UTC: You guess that the black gem pouch weighs around 165 stones.
2022-02-07 05:12:23 UTC: You sort through the gems and finally decide that they're worth a total of about 273992 Dokoras.
2022-02-07 05:12:23 UTC: Roundtime: 5 seconds.
2022-02-07 05:12:28 UTC: [appraisal]>put my  pouch in my portal
2022-02-07 05:12:29 UTC: [Assuming you mean an effervescent eddy of honey-hued light captured by a sungold frame.]
2022-02-07 05:12:29 UTC: [Assuming you mean an effervescent eddy of honey-hued light captured by a sungold frame.]
```

I had multiple people test, just in case, works as expected. It should be a non-issue of a change, fingers crossed...