### PR TITLE
[script] [common] avoid race condition of drinfomon updating DRStats

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -525,8 +525,15 @@ module DRC
   end
 
   def check_encumbrance(refresh = true)
-    bput('encumbrance', 'Encumbrance : .*') if refresh
-    $ENC_MAP[DRStats.encumbrance]
+    encumbrance = DRStats.encumbrance
+    if refresh
+      encumbrance_pattern = /(Encumbrance)\s:\s(?<encumbrance>.*)/
+      case bput('encumbrance', encumbrance_pattern)
+      when encumbrance_pattern
+        encumbrance = Regexp.last_match[:encumbrance]
+      end
+    end
+    $ENCUMBRANCE_MAP[encumbrance]
   end
 
   def retreat(ignored_npcs = [])

--- a/common.lic
+++ b/common.lic
@@ -533,7 +533,7 @@ module DRC
         encumbrance = Regexp.last_match[:encumbrance]
       end
     end
-    $ENCUMBRANCE_MAP[encumbrance]
+    $ENC_MAP[encumbrance]
   end
 
   def retreat(ignored_npcs = [])


### PR DESCRIPTION
### Background
* `drinfomon` will update `DRStats.encumbrance` to be the text value from `encumbrance` command
* We want `DRC.check_encumbrance` to give us the numeric result (0 to 11)
* Since `drinfomon` runs as a separate thread then there's a race condition between running the command and when DRStats gets updated where sometimes the method returns the outdated value

### Changes
* Don't wait for `drinfomon` before this method returns a value; go ahead and parse it to ensure we get the latest value