### PR TITLE
[script][common-items] Adding tie/untie predicates, first draft

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -123,6 +123,7 @@ module DRCI
 
   @@tie_item_failure_patterns = [
     /^There's no more free ties/,
+    /^You must be holding/,
     /^Tie what/
   ]
 

--- a/common-items.lic
+++ b/common-items.lic
@@ -122,7 +122,8 @@ module DRCI
   ]
 
   @@tie_item_failure_patterns = [
-    /^There's no more free ties/
+    /^There's no more free ties/,
+    /^Tie what/
   ]
 
   @@untie_item_success_patterns = [
@@ -130,7 +131,8 @@ module DRCI
   ]
 
   @@untie_item_failure_patterns = [
-    /^You fumble with the ties/
+    /^You fumble with the ties/,
+    /^Untie what/
   ]
 
   @@remove_item_success_patterns = [
@@ -655,7 +657,7 @@ module DRCI
   #########################################
 
   def tie_item?(item, container)
-    case DRC.bput("tie #{item} to my #{container}", @@tie_item_success_patterns, @@tie_item_failure_patterns)
+    case DRC.bput("tie my #{item} to my #{container}", @@tie_item_success_patterns, @@tie_item_failure_patterns)
     when *@@tie_item_success_patterns
       return true
     else
@@ -664,7 +666,7 @@ module DRCI
   end
 
   def untie_item?(item, container)
-    case DRC.bput("untie #{item} from my #{container}", @@untie_item_success_patterns, @@untie_item_failure_patterns)
+    case DRC.bput("untie my #{item} from my #{container}", @@untie_item_success_patterns, @@untie_item_failure_patterns)
     when *@@untie_item_success_patterns
       return true
     else

--- a/common-items.lic
+++ b/common-items.lic
@@ -116,6 +116,23 @@ module DRCI
     /^What were you/
   ]
 
+  @@tie_item_success_patterns = [
+    /^You .* tie/,
+    /^You attach/
+  ]
+
+  @@tie_item_failure_patterns = [
+    /^There's no more free ties/
+  ]
+
+  @@untie_item_success_patterns = [
+    /you untie/
+  ]
+
+  @@untie_item_failure_patterns = [
+    /^You fumble with the ties/
+  ]
+
   @@remove_item_success_patterns = [
     /^Dropping your shoulder/,
     /^The .* slide/,
@@ -627,6 +644,28 @@ module DRCI
     from = "from #{container}" if container && !(container =~ /^(in|on|under|behind|from) /i)
     case DRC.bput("get #{item} #{from}", @@get_item_success_patterns, @@get_item_failure_patterns)
     when *@@get_item_success_patterns
+      return true
+    else
+      return false
+    end
+  end
+
+  #########################################
+  # TIE/UNTIE ITEM
+  #########################################
+
+  def tie_item?(item, container)
+    case DRC.bput("tie #{item} to my #{container}", @@tie_item_success_patterns, @@tie_item_failure_patterns)
+    when *@@tie_item_success_patterns
+      return true
+    else
+      return false
+    end
+  end
+
+  def untie_item?(item, container)
+    case DRC.bput("untie #{item} from my #{container}", @@untie_item_success_patterns, @@untie_item_failure_patterns)
+    when *@@untie_item_success_patterns
       return true
     else
       return false


### PR DESCRIPTION
Very basic first draft, and they work.

```
2022-02-07 08:57:47 UTC: --- Lich: test-tie active.
2022-02-07 08:57:47 UTC: [test-tie]>tie sword to my rucksack
2022-02-07 08:57:47 UTC: >;test-tie
2022-02-07 08:57:48 UTC: You securely tie your bastard sword to a rucksack.
2022-02-07 08:57:48 UTC: <pushBold/>| tied sword to rucksack<popBold/>
2022-02-07 08:57:48 UTC: --- Lich: test-tie has exited.
2022-02-07 08:57:59 UTC: >;test-tie
2022-02-07 08:57:59 UTC: [test-tie]>untie sword from my rucksack
2022-02-07 08:58:00 UTC: Loosening the straps, you untie a bastard sword from your rucksack.
2022-02-07 08:58:00 UTC: <pushBold/>| untied sword from rucksack<popBold/>
2022-02-07 08:58:00 UTC: --- Lich: test-tie has exited.
```

We need to collect more success/failure patterns as we go, but this is the first step towards fixing up telescope storage defs! (I jokingly told @KatoakDR I just wanted to make a small change... and now I'm collecting success/failure patterns for tying items. sigh.)