### PR TITLE
[script] [common-travel] add method to ask merchant for something

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -8,6 +8,8 @@ custom_require.call(%w[common common-items common-arcana events drinfomon])
 module DRCT
   module_function
 
+  # Visit a merchant and sell an item.
+  # Usually to sell junk at pawn shops.
   def sell_item(room, item)
     return false unless DRCI.in_hands?(item)
 
@@ -32,6 +34,8 @@ module DRCT
     end
   end
 
+  # Visit a merchant and buy an item by offering their asking price.
+  # Usually for restocking ammunition or other misc items.
   def buy_item(room, item)
     walk_to(room)
 
@@ -69,6 +73,31 @@ module DRCT
     fput("offer #{amount}") if amount
   end
 
+  # Visit a merchant and ask for an item.
+  # Usually this is for bundling ropes or gem pouches.
+  def ask_for_item?(room, name, item)
+    walk_to(room)
+
+    success_patterns = [
+      /hands you/
+    ]
+
+    failure_patterns = [
+      /does not seem to know anything about that/,
+      /All I know about/,
+      /To whom are you speaking/,
+      /Usage: ASK/
+    ]
+
+    case DRC.bput("ask #{name} for #{item}", *success_patterns, *failure_patterns)
+    when /hands you/
+      true
+    else
+      false
+    end
+  end
+
+  # Visit a merchant and order from a menu.
   def order_item(room, item_number)
     walk_to(room)
 


### PR DESCRIPTION
### Background
* While working on `hunting-buddy` script, saw an opportunity to create `DRCT.ask_for_item?(room, npc, item)` to consolidate logic for getting bundling ropes and gem pouches

### Changes
* Add `DRCT.ask_for_item?(room, npc, item)` method to complement the existing `buy_item`, `order_item` and `sell_item` methods 