### PR TITLE
[script] [hunting-buddy] [8] refactor parsing multiple hunt configs

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -11,20 +11,33 @@ class HuntingBuddy
     args = parse_args(arg_definitions, true)
 
     @settings = get_settings
+
+    @town_data = get_data('town')[@settings.hometown]
+    @hunting_data = get_data('hunting')
+    @escort_zones = @hunting_data.escort_zones
+    @hunting_zones = @hunting_data.hunting_zones
+
     @stop_on_familiar_drag = @settings.stop_on_familiar_drag
-    data = get_data('hunting')
-    @escort_zones = data.escort_zones
-    @hunting_zones = data.hunting_zones
+    echo("  @stop_on_familiar_drag: #{@stop_on_familiar_drag}") if $debug_mode_hunting
+
     @stop_on_low_threshold = @settings.stop_on_low_threshold
+    echo("  @stop_on_low_threshold: #{@stop_on_low_threshold}") if $debug_mode_hunting
+
     @stop_on_high_threshold = @settings.stop_on_high_threshold
+    echo("  @stop_on_high_threshold: #{@stop_on_high_threshold}") if $debug_mode_hunting
+
     @magic_exp_threshold = @settings.magic_exp_training_max_threshold
     @magic_skills = ['Arcane Magic', 'Holy Magic', 'Life Magic', 'Elemental Magic',\
                      'Lunar Magic', 'Attunement', 'Arcana', 'Targeted Magic', 'Inner Fire',\
                      'Inner Magic', 'Augmentation', 'Debilitation', 'Utility', 'Warding', 'Sorcery']
+    echo("  @magic_exp_threshold: #{@magic_exp_threshold}") if $debug_mode_hunting
+
     @hunting_buddies_max = @settings.hunting_buddies_max
+    echo("  @hunting_buddies_max: #{@hunting_buddies_max}") if $debug_mode_hunting
 
     # Will deprecate prehunt_buffs tag as a room
-    @buff_room = @settings.prehunt_buffing_room || @settings.prehunt_buffs
+    @prehunt_buffing_room = @settings.prehunt_buffing_room || @settings.prehunt_buffs
+    echo("  @prehunt_buffing_room: #{@prehunt_buffing_room}") if $debug_mode_hunting
 
     hunting_info = []
     if @settings.hunting_file_list || args.flex.any?
@@ -57,7 +70,35 @@ class HuntingBuddy
     check_bundling_rope
     DRC.wait_for_script_to_complete('restock') unless @settings.sell_loot_skip_bank
 
-    @hunting_info.each do |info|
+    @hunting_info.each_with_index do |info, index|
+
+      args = info['args'] # list of args to pass to combat-trainer
+      before_actions = info['before'] # list of script names
+      after_actions = info['after'] # list of script names
+      during_actions = info['during'] # list of script names
+      duration = info[:duration] # number of minutes to hunt
+      stop_on_high_skills = info['stop_on'] # list of skill names
+      stop_on_low_skills = info['stop_on_low'] # list of skill names
+      stop_on_boxes = info['boxes'] || info['stop_on_boxes'] # boolean
+      stop_on_no_moons = info['moons'] || info['stop_on_moons'] # boolean
+      hunting_zones = [info[:zone]].flatten.compact # string or list of hunting zones
+      waiting_room = info['full_waiting_room'] || @settings.safe_room # room id
+
+      if $debug_mode_hunting
+        echo("Processing hunting info number #{index + 1}")
+        echo("  args: #{args}")
+        echo("  before_actions: #{before_actions}")
+        echo("  after_actions: #{after_actions}")
+        echo("  during_actions: #{during_actions}")
+        echo("  duration: #{duration}")
+        echo("  stop_on_high_skills: #{stop_on_high_skills}")
+        echo("  stop_on_low_skills: #{stop_on_low_skills}")
+        echo("  stop_on_boxes: #{stop_on_boxes}")
+        echo("  stop_on_no_moons: #{stop_on_no_moons}")
+        echo("  hunting_zones: #{hunting_zones}")
+        echo("  waiting_room: #{waiting_room}")
+      end
+
       if @stop_hunting
         DRC.message("***STATUS*** Stopping all hunting because manual intervention")
         stop_actions(during_actions)
@@ -72,17 +113,6 @@ class HuntingBuddy
         execute_actions(after_actions)
         break
       end
-
-      args = info['args']
-      before_actions = info['before']
-      after_actions = info['after']
-      during_actions = info['during']
-      duration = info[:duration]
-      stop_on_skills = info['stop_on']
-      stop_on_low_skills = info['stop_on_low']
-      stop_on_boxes = info['boxes']
-      stop_on_no_moons = info['moons']
-      waiting_room = info['full_waiting_room'] || @settings.safe_room
 
       if stop_on_boxes && !need_boxes?
         DRC.message("***STATUS*** Skipping hunt because have enough boxes")
@@ -101,15 +131,15 @@ class HuntingBuddy
           next
         end
 
-      if all_skills_at_cap?(stop_on_skills)
-        DRC.message("***STATUS*** Skipping hunt because skills reached learning threshold")
+      if all_skills_at_cap?(stop_on_high_skills)
+        DRC.message("***STATUS*** Skipping hunt because skills reached learning threshold: #{stop_on_high_skills}")
         stop_actions(during_actions)
         execute_actions(after_actions)
         next
       end
 
       if stop_on_low_skills_too_low?(stop_on_low_skills)
-        DRC.message("***STATUS*** Skipping hunt because skills dropped below learning threshold")
+        DRC.message("***STATUS*** Skipping hunt because skills dropped below learning threshold: #{stop_on_low_skills}")
         stop_actions(during_actions)
         execute_actions(after_actions)
         next
@@ -117,7 +147,7 @@ class HuntingBuddy
 
       check_prehunt_buffs
 
-      next unless find_hunting_room?(info[:zone], waiting_room)
+      next unless find_hunting_room?(hunting_zones, waiting_room)
 
       args.each_with_index do |arg, index|
         if @stopped_for_bleeding
@@ -133,7 +163,7 @@ class HuntingBuddy
         hunt(
           arg,
           duration ? duration[index] : nil,
-          stop_on_skills ? stop_on_skills[index] : nil,
+          stop_on_high_skills ? stop_on_high_skills[index] : nil,
           stop_on_low_skills ? stop_on_low_skills[index] : nil,
           stop_on_boxes ? stop_on_boxes[index] : nil,
           stop_on_no_moons ? stop_on_no_moons[index] : nil
@@ -191,9 +221,8 @@ class HuntingBuddy
     return if DRCI.wearing?('bundle')
     return if DRCI.exists?('bundling rope')
 
-    tannery_data = get_data('town')[@settings.hometown]['tannery']
-    tanner_room = tannery_data['id']
-    tanner_name = tannery_data['name']
+    tanner_room = @town_data['tannery']['id'],
+    tanner_name = @town_data['tannery']['name'],
 
     DRCT.walk_to(tanner_room)
     DRC.bput("ask #{tanner_name} for bundling rope", 'hands you')
@@ -203,7 +232,7 @@ class HuntingBuddy
   def check_prehunt_buffs
     return unless @settings.waggle_sets['prehunt_buffs']
 
-    DRCT.walk_to(@buff_room)
+    DRCT.walk_to(@prehunt_buffing_room)
 
     DRC.wait_for_script_to_complete('buff', ['prehunt_buffs'])
   end
@@ -271,8 +300,8 @@ class HuntingBuddy
     true
   end
 
-  def all_skills_at_cap?(stop_on_skills)
-    stop_on_skills && !stop_on_skills.empty? && stop_on_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : @stop_on_high_threshold) }
+  def all_skills_at_cap?(stop_on_high_skills)
+    stop_on_high_skills && !stop_on_high_skills.empty? && stop_on_high_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : @stop_on_high_threshold) }
   end
 
   def stop_on_low_skills_too_low?(stop_on_low_skills)
@@ -283,7 +312,7 @@ class HuntingBuddy
     $COMBAT_TRAINER.get_process('loot').at_box_limit?
   end
 
-  def hunt(args, duration, stop_on_skills, stop_on_low_skills, stop_on_boxes, stop_on_no_moons)
+  def hunt(args, duration, stop_on_high_skills, stop_on_low_skills, stop_on_boxes, stop_on_no_moons)
     $COMBAT_TRAINER = nil
     hunting_room = Room.current.id
     Flags.add('hunting-buddy-familiar-drag', /^Your .+ grabs ahold of you and drags you .+, out of combat.+$/)
@@ -320,8 +349,8 @@ class HuntingBuddy
         DRC.message("***STATUS*** Stopping because no moons")
         break
       end
-      if all_skills_at_cap?(stop_on_skills)
-        DRC.message("***STATUS*** Stopping because skills reached learning threshold: #{stop_on_skills}")
+      if all_skills_at_cap?(stop_on_high_skills)
+        DRC.message("***STATUS*** Stopping because skills reached learning threshold: #{stop_on_high_skills}")
         break
       end
       if stop_on_low_skills_too_low?(stop_on_low_skills)
@@ -351,13 +380,13 @@ class HuntingBuddy
       end
       if (counter % 60).zero?
         if duration
-          if stop_on_skills
-            DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining or waiting on #{stop_on_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
+          if stop_on_high_skills
+            DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining or waiting on #{stop_on_high_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
           else
             DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining")
           end
         else
-          DRC.message("***STATUS*** #{counter / 60} minutes of hunting, still waiting on #{stop_on_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
+          DRC.message("***STATUS*** #{counter / 60} minutes of hunting, still waiting on #{stop_on_high_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
         end
       end
       counter += 1

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -11,7 +11,7 @@ class HuntingBuddy
     args = parse_args(arg_definitions, true)
 
     @settings = get_settings
-    @bail_on_familiar = @settings.stop_on_familiar_drag
+    @stop_on_familiar_drag = @settings.stop_on_familiar_drag
     data = get_data('hunting')
     @escort_zones = data.escort_zones
     @hunting_zones = data.hunting_zones
@@ -235,21 +235,21 @@ class HuntingBuddy
           # Skip if anyone not in your group is in the room
           return false if (DRRoom.pcs - DRRoom.group_members).any?
           # No visible friends in the room and no visible people
-          UserVars.friends.each { |friend| Flags.add("room-check-#{friend}", friend) }
-          Flags.add('room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
+            UserVars.friends.each { |friend| Flags.add("hunting-buddy-room-check-#{friend}", friend) }
+            Flags.add('hunting-buddy-room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
           case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
           when /roundtime/i
             data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
             if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
               pause
               waitrt?
-              return UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
+                return UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
             end
             fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
             20.times do |_|
               pause 0.5
-              return true if UserVars.friends.find { |friend| Flags["room-check-#{friend}"] }
-              return false if Flags['room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+                return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
+                return false if Flags['hunting-buddy-room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
             end
             true
           when /You're not in any condition to be searching around/i
@@ -286,7 +286,7 @@ class HuntingBuddy
   def hunt(args, duration, stop_on_skills, stop_on_low_skills, stop_on_boxes, stop_on_no_moons)
     $COMBAT_TRAINER = nil
     hunting_room = Room.current.id
-    Flags.add('familiar_drag', /^Your .+ grabs ahold of you and drags you .+, out of combat.+$/)
+    Flags.add('hunting-buddy-familiar-drag', /^Your .+ grabs ahold of you and drags you .+, out of combat.+$/)
 
     DRC.message("***STATUS*** Beginning hunt '#{args}' for '#{duration}' minutes")
 
@@ -337,17 +337,17 @@ class HuntingBuddy
         DRC.message("***STATUS*** Stopping because time")
         break
       end
-      if Flags['familiar_drag'] && @bail_on_familiar
+      if Flags['hunting-buddy-familiar-drag'] && @stop_on_familiar_drag
         DRC.message("***STATUS*** Stopping because familiar drug while stunned")
-        Flags.reset('familiar_drag')
+        Flags.reset('hunting-buddy-familiar-drag')
         break
       end
-      if Flags['familiar_drag'] && !@bail_on_familiar
+      if Flags['hunting-buddy-familiar-drag'] && !@stop_on_familiar_drag
         DRC.message("***STATUS*** Heading back to room because familiar drug while stunned")
         pause_script('combat-trainer') if Script.running?('combat-trainer')
         DRCT.walk_to(hunting_room)
         unpause_script('combat-trainer') if Script.running?('combat-trainer')
-        Flags.reset('familiar_drag')
+        Flags.reset('hunting-buddy-familiar-drag')
       end
       if (counter % 60).zero?
         if duration
@@ -411,8 +411,13 @@ before_dying do
     stop_script(script_name) if Script.running?(script_name)
   end
   DRCA.release_cyclics(get_settings.cyclic_no_release)
-  Flags.delete('room-check')
-  Flags.delete('familiar_drag')
+  flags_to_delete = [
+    'hunting-buddy-room-check', # there are multiple flags with this prefix, one per friend
+    'hunting-buddy-familiar-drag'
+  ]
+  Flags.flags.keys
+    .select { |flag_name| flags_to_delete.any? { |name| flag_name.start_with?(name) } }
+    .each   { |flag_name| Flags.delete(flag_name) }
 end
 
 $HUNTING_BUDDY = HuntingBuddy.new

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -38,30 +38,32 @@ class HuntingBuddy
     @hunting_buddies_max = @settings.hunting_buddies_max
     echo("  @hunting_buddies_max: #{@hunting_buddies_max}") if $debug_mode_hunting
 
-    # Will deprecate prehunt_buffs tag as a room
     @prehunt_buffing_room = @settings.prehunt_buffing_room || @settings.prehunt_buffs
     echo("  @prehunt_buffing_room: #{@prehunt_buffing_room}") if $debug_mode_hunting
 
-    hunting_info = []
-    if @settings.hunting_file_list || args.flex.any?
-      (args.flex.any? ? args.flex : @settings.hunting_file_list).each do |file|
-        if file == 'setup'
-          hunting_info += get_settings.hunting_info
-        else
-          # Hunting info from extra config needs the config name passed on in args.
-          infos = get_settings([file]).hunting_info
-          infos.each do |info|
-            info['args'] = info['args'] || []
-            (info['args'] << file) unless info['args'].include? file
-          end
-          hunting_info += infos
+    # After checking all hunting files to use, this array
+    # will be the combined set of hunting infos to execute.
+    @hunting_info = []
+
+    # Identify any other files to parse for hunting info.
+    # The values in `hunting_file_list` or `args.flex` are the suffixes
+    # in filename patterns that match "{character}-{suffix}.yaml" format.
+    hunting_files = args.flex.any? ? args.flex : @settings.hunting_file_list
+    hunting_files << 'setup' if hunting_files.empty?
+    echo("  hunting_files: #{hunting_files}") if $debug_mode_hunting
+
+    hunting_files.each do |character_file_suffix|
+      infos = get_settings([character_file_suffix]).hunting_info
+      infos.each do |info|
+        info['args'] ||= []
+        # Hunting info from extra config needs the config name passed on in args
+        # so that it can be further passed to other scripts like combat-trainer.
+        if character_file_suffix != 'setup' && !info['args'].include?(character_file_suffix)
+          info['args'] << character_file_suffix
         end
       end
-    else
-      hunting_info = @settings.hunting_info
+      @hunting_info += infos
     end
-
-    @hunting_info = format_hunting_info(hunting_info)
   end
 
   def main
@@ -108,6 +110,7 @@ class HuntingBuddy
 
       if @stopped_for_bleeding
         DRC.message("***STATUS*** Stopping all hunting because bleeding")
+        DRC.retreat
         stop_script('tendme') if Script.running?('tendme')
         stop_actions(during_actions)
         execute_actions(after_actions)
@@ -154,29 +157,35 @@ class HuntingBuddy
 
       check_prehunt_buffs
 
-      next unless find_hunting_room?(hunting_zones, waiting_room)
-
-      args.each_with_index do |arg, index|
-        if @stopped_for_bleeding
-          DRC.message("***STATUS*** Stopping all hunting because bleeding")
-          DRC.retreat
-          stop_script('tendme') if Script.running?('tendme')
-          break
-        end
-
-        # Execute background scripts to run during the hunt
-        execute_nonblocking_actions(during_actions)
-
-        hunt(
-          arg,
-          duration ? duration[index] : nil,
-          stop_on_high_skills ? stop_on_high_skills[index] : nil,
-          stop_on_low_skills ? stop_on_low_skills[index] : nil,
-          stop_on_boxes ? stop_on_boxes[index] : nil,
-          stop_on_no_moons ? stop_on_no_moons[index] : nil,
-          stop_on_encumbrance ? stop_on_encumbrance[index] : nil
-        )
+      # We need to find a hunting room when we start our first hunt
+      # or on subsequent hunts if where we currently are isn't where
+      # that next hunt wants to be. These checks help reduce moving
+      # around if it's be fine for us to start the next hunt in same spot.
+      if index == 0 || !hunting_zones.include?(current_hunting_zone)
+        next unless find_hunting_room?(hunting_zones, waiting_room)
       end
+
+      if @stopped_for_bleeding
+        DRC.message("***STATUS*** Stopping all hunting because bleeding")
+        DRC.retreat
+        stop_script('tendme') if Script.running?('tendme')
+        stop_actions(during_actions)
+        execute_actions(after_actions)
+        break
+      end
+
+      # Execute background scripts to run during the hunt
+      execute_nonblocking_actions(during_actions)
+
+      hunt(
+        args,
+        duration,
+        stop_on_high_skills,
+        stop_on_low_skills,
+        stop_on_boxes,
+        stop_on_no_moons,
+        stop_on_encumbrance
+      )
 
       # Stop background scripts that ran during the hunt
       stop_actions(during_actions)
@@ -224,17 +233,20 @@ class HuntingBuddy
     end
   end
 
+  # ------------------------------------------------------------
+
+  # Ensures you have a bundling rope unless you're not skinning.
   def check_bundling_rope
     return unless @settings.skinning['skin']
     return if DRCI.wearing?('bundle')
     return if DRCI.exists?('bundling rope')
 
-    tanner_room = @town_data['tannery']['id'],
-    tanner_name = @town_data['tannery']['name'],
-
-    DRCT.walk_to(tanner_room)
-    DRC.bput("ask #{tanner_name} for bundling rope", 'hands you')
-    DRC.stow_item?('bundling rope')
+    DRCT.ask_for_item?(
+      @town_data['tannery']['id'],
+      @town_data['tannery']['name'],
+      'bundling rope'
+    )
+    DRCI.stow_item?('bundling rope')
   end
 
   def check_prehunt_buffs
@@ -245,67 +257,78 @@ class HuntingBuddy
     DRC.wait_for_script_to_complete('buff', ['prehunt_buffs'])
   end
 
-  def find_hunting_room?(zone_name, waiting_room)
+  # ------------------------------------------------------------
+
+  # Returns the hunting zone that you are currently in.
+  # If you aren't in a known hunting zone then returns nil.
+  def current_hunting_zone(room_id = Room.current.id)
+    # Returns a list with only the key-value pairs that meet the criteria.
+    zones = @hunting_zones.select { |name, rooms| rooms.include?(room_id) }
+    # Get the first matching result.
+    zone = zones.first
+    # As a list of data, a hash becomes a list of two-element arrays [key, value].
+    # Return the first element to return the key, which is the zone name.
+    zone_name = zone.first
+  end
+
+  def find_hunting_room?(zones_to_search, waiting_room)
     UserVars.friends = @settings.hunting_buddies || []
     UserVars.hunting_nemesis = @settings.hunting_nemesis || []
-    zones = Array(zone_name).flatten.compact
-    rooms = @hunting_zones.values_at(*zones.select { |name| @hunting_zones.include?(name) }).flatten.compact unless @escort_zones.include?(zones.first)
-    if rooms.empty? || rooms.nil?
-      escort_info = @escort_zones[zones.first]
-      unless escort_info
-        message "FAILED TO FIND THE HUNTING ZONE(S) #{zones} IN BASE.YAML"
-        return false
-      end
-      DRCT.walk_to(escort_info['base'])
-      wait_for_script_to_complete('bescort', [escort_info['area'], escort_info['enter']])
-      @exit = [escort_info['area'], 'exit']
-    else
-      @exit = nil
-      return DRCT.find_empty_room(rooms, waiting_room,
-        lambda do |search_attempt|
-          # Skip room if has more people than your max limit
-          return false if DRRoom.pcs.size > @hunting_buddies_max
-          # Skip if one of your nemesis is in the room
-          return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
-          # Continue if one of your friends is in the room
-          return true if (DRRoom.pcs & UserVars.friends).any?
-          # Skip if anyone not in your group is in the room
-          return false if (DRRoom.pcs - DRRoom.group_members).any?
-          # No visible friends in the room and no visible people
+
+    return zones_to_search.any? do |zone_to_search|
+      escort_info = @escort_zones[zone_to_search]
+      if escort_info
+        DRCT.walk_to(escort_info['base'])
+        wait_for_script_to_complete('bescort', [escort_info['area'], escort_info['enter']])
+        @exit = [escort_info['area'], 'exit']
+        return true
+      else
+        @exit = nil
+        rooms_to_search = @hunting_zones.select { |zone_name, zone_rooms| zones_to_search.include?(zone_name) }.values.flatten.compact
+        return DRCT.find_empty_room(rooms_to_search, waiting_room,
+          lambda do |search_attempt|
+            # Skip room if has more people than your max limit
+            return false if DRRoom.pcs.size > @hunting_buddies_max
+            # Skip if one of your nemesis is in the room
+            return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
+            # Continue if one of your friends is in the room
+            return true if (DRRoom.pcs & UserVars.friends).any?
+            # Skip if anyone not in your group is in the room
+            return false if (DRRoom.pcs - DRRoom.group_members).any?
+            # No visible friends in the room and no visible people
             UserVars.friends.each { |friend| Flags.add("hunting-buddy-room-check-#{friend}", friend) }
             Flags.add('hunting-buddy-room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
-          case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
-          when /roundtime/i
-            data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
-            if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
-              pause
-              waitrt?
+            case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
+            when /roundtime/i
+              data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
+              if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
+                pause
+                waitrt?
                 return UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
-            end
-            fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
-            20.times do |_|
-              pause 0.5
+              end
+              fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
+              20.times do |_|
+                pause 0.5
                 return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
                 return false if Flags['hunting-buddy-room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+              end
+              true
+            when /You're not in any condition to be searching around/i
+              DRC.message("***STATUS*** You're too injured to hunt!")
+              @stop_hunting = true
+              @stopped_for_bleeding = bleeding?
+              # Ironically, return true so the search for a suitable hunting room
+              # stops and then the hunting buddy loop will detect that you need help
+              # sooner rather than later.
+              true
             end
-            true
-          when /You're not in any condition to be searching around/i
-            DRC.message("***STATUS*** You're too injured to hunt!")
-            @stop_hunting = true
-            @stopped_for_bleeding = bleeding?
-            # Ironically, return true so the search for a suitable hunting room
-            # stops and then the hunting buddy loop will detect that you need help
-            # sooner rather than later.
-            true
-          end
-        end,
-        @settings.hunting_room_min_mana,
-        @settings.hunting_room_strict_mana,
-        @settings.hunting_room_max_searches
-      )
+          end,
+          @settings.hunting_room_min_mana,
+          @settings.hunting_room_strict_mana,
+          @settings.hunting_room_max_searches
+        )
+      end
     end
-
-    true
   end
 
   # ------------------------------------------------------------
@@ -492,35 +515,6 @@ class HuntingBuddy
     $COMBAT_TRAINER.stop
     pause 1 while $COMBAT_TRAINER.running || Script.running?('combat-trainer')
     DRC.retreat
-  end
-
-  def format_hunting_info(hunting_info_raw)
-    hunting_info = []
-    hunting_info_raw.each do |info|
-      if hunting_info.empty? || hunting_info.last[:zone] != info[:zone]
-        if info['args'].flatten == info['args']
-          info['args'] = [info['args'] || []]
-          info[:duration] = [info[:duration]]
-          info['stop_on'] = [info['stop_on']]
-          info['stop_on_low'] = [info['stop_on_low']] if info['stop_on_low']
-          info['before'] = info['before']
-          info['after'] = info['after']
-          info['during'] = info['during']
-          info['boxes'] = info['boxes']
-        end
-        hunting_info << info
-      else
-        hunting_info.last['args'] << info['args']
-        hunting_info.last[:duration] << info[:duration]
-        hunting_info.last['stop_on'] << info['stop_on']
-        hunting_info.last['stop_on_low'] << info['stop_on_low']
-        hunting_info.last['before'] ||= info['before']
-        hunting_info.last['after'] ||= info['after']
-        hunting_info.last['during'] ||= info['during']
-        hunting_info.last['boxes'] ||= info['boxes']
-      end
-    end
-    hunting_info
   end
 
   def stop_hunting

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -64,11 +64,6 @@ class HuntingBuddy
     @hunting_info = format_hunting_info(hunting_info)
   end
 
-  def need_boxes?
-    return false unless @settings.box_hunt_minimum
-    DRCI.count_all_boxes(@settings) <= @settings.box_hunt_minimum
-  end
-
   def main
     check_bundling_rope
     DRC.wait_for_script_to_complete('restock') unless @settings.sell_loot_skip_bank
@@ -367,6 +362,11 @@ class HuntingBuddy
   end
 
   # ------------------------------------------------------------
+
+  def need_boxes?
+    return false unless @settings.box_hunt_minimum
+    DRCI.count_all_boxes(@settings) <= @settings.box_hunt_minimum
+  end
 
   def over_box_limit?
     $COMBAT_TRAINER.get_process('loot').at_box_limit?

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -26,11 +26,14 @@ class HuntingBuddy
     @stop_on_high_threshold = @settings.stop_on_high_threshold
     echo("  @stop_on_high_threshold: #{@stop_on_high_threshold}") if $debug_mode_hunting
 
-    @magic_exp_threshold = @settings.magic_exp_training_max_threshold
-    @magic_skills = ['Arcane Magic', 'Holy Magic', 'Life Magic', 'Elemental Magic',\
-                     'Lunar Magic', 'Attunement', 'Arcana', 'Targeted Magic', 'Inner Fire',\
-                     'Inner Magic', 'Augmentation', 'Debilitation', 'Utility', 'Warding', 'Sorcery']
-    echo("  @magic_exp_threshold: #{@magic_exp_threshold}") if $debug_mode_hunting
+    @skillset_exp_thresholds = {
+      'Armor' => @settings.armor_exp_training_max_threshold,
+      'Weapon' => @settings.weapon_exp_training_max_threshold,
+      'Magic' => @settings.magic_exp_training_max_threshold,
+      'Survival' => @settings.survival_exp_training_max_threshold,
+      'Lore' => @settings.lore_exp_training_max_threshold
+    }
+    echo("  @skillset_exp_thresholds: #{@skillset_exp_thresholds}") if $debug_mode_hunting
 
     @hunting_buddies_max = @settings.hunting_buddies_max
     echo("  @hunting_buddies_max: #{@hunting_buddies_max}") if $debug_mode_hunting
@@ -131,14 +134,14 @@ class HuntingBuddy
           next
         end
 
-      if all_skills_at_cap?(stop_on_high_skills)
+      if should_stop_for_high_skills?(stop_on_high_skills)
         DRC.message("***STATUS*** Skipping hunt because skills reached learning threshold: #{stop_on_high_skills}")
         stop_actions(during_actions)
         execute_actions(after_actions)
         next
       end
 
-      if stop_on_low_skills_too_low?(stop_on_low_skills)
+      if should_stop_for_low_skills?(stop_on_low_skills)
         DRC.message("***STATUS*** Skipping hunt because skills dropped below learning threshold: #{stop_on_low_skills}")
         stop_actions(during_actions)
         execute_actions(after_actions)
@@ -300,17 +303,76 @@ class HuntingBuddy
     true
   end
 
-  def all_skills_at_cap?(stop_on_high_skills)
-    stop_on_high_skills && !stop_on_high_skills.empty? && stop_on_high_skills.flatten.all? { |skill| DRSkill.getxp(skill) >= (@magic_skills.include?(skill) ? @magic_exp_threshold : @stop_on_high_threshold) }
+  # ------------------------------------------------------------
+
+  # Identify if every skill in the given list has a learning rate
+  # at or above the desired threshold for their skillset.
+  def should_stop_for_high_skills?(stop_on_high_skills = [])
+    stop_on_high_skills && !stop_on_high_skills.empty? && stop_on_high_skills.flatten.all? do |skill|
+      DRSkill.getxp(skill) >= get_skill_exp_high_threshold(skill)
+    end
   end
 
-  def stop_on_low_skills_too_low?(stop_on_low_skills)
-    stop_on_low_skills && stop_on_low_skills.flatten.any? { |skill| DRSkill.getxp(skill) < @stop_on_low_threshold }
+  # Identify if at least one skill in the given list has a learning rate
+  # at or below the desired threshold for their skillset.
+  def should_stop_for_low_skills?(stop_on_low_skills = [])
+    stop_on_low_skills && !stop_on_low_skills.empty? && stop_on_low_skills.flatten.any? do |skill|
+      DRSkill.getxp(skill) <= get_skill_exp_low_threshold(skill)
+    end
   end
+
+  # ------------------------------------------------------------
+
+  # Identify the skills in the given list
+  # that have not yet met their learning rate thresholds
+  # and so we should continue hunting.
+  def get_skills_below_high_threshold(stop_on_high_skills = [])
+    stop_on_high_skills.flatten.select do |skill|
+      DRSkill.getxp(skill) <= get_skill_exp_high_threshold(skill)
+    end
+  end
+
+  # Identify the skills in the given list
+  # that have fallen below their learning rate thresholds
+  # and so we should stop hunting to go work on them.
+  # Usually, these are non-combat skills like locksmithing or crafting.
+  def get_skills_below_low_threshold(stop_on_low_skills = [])
+    stop_on_low_skills.flatten.select do |skill|
+      DRSkill.getxp(skill) <= get_skill_exp_low_threshold(skill)
+    end
+  end
+
+  # ------------------------------------------------------------
+
+  # What is the learning rate high threshold at which point we should stop hunting?
+  def get_skill_exp_high_threshold(skill)
+    get_skillset_exp_high_threshold(DRSkill.getskillset(skill))
+  end
+
+  # What is the learning rate high threshold at which point we should stop hunting?
+  def get_skillset_exp_high_threshold(skillset)
+    @skillset_exp_thresholds[skillset] || @stop_on_high_threshold
+  end
+
+  # ------------------------------------------------------------
+
+  # What is the learning rate low threshold at which point we should stop hunting?
+  def get_skill_exp_low_threshold(skill)
+    get_skillset_exp_low_threshold(DRSkill.getskillset(skill))
+  end
+
+  # What is the learning rate low threshold at which point we should stop hunting?
+  def get_skillset_exp_low_threshold(skillset)
+    @stop_on_low_threshold
+  end
+
+  # ------------------------------------------------------------
 
   def over_box_limit?
     $COMBAT_TRAINER.get_process('loot').at_box_limit?
   end
+
+  # ------------------------------------------------------------
 
   def hunt(args, duration, stop_on_high_skills, stop_on_low_skills, stop_on_boxes, stop_on_no_moons)
     $COMBAT_TRAINER = nil
@@ -349,11 +411,11 @@ class HuntingBuddy
         DRC.message("***STATUS*** Stopping because no moons")
         break
       end
-      if all_skills_at_cap?(stop_on_high_skills)
+      if should_stop_for_high_skills?(stop_on_high_skills)
         DRC.message("***STATUS*** Stopping because skills reached learning threshold: #{stop_on_high_skills}")
         break
       end
-      if stop_on_low_skills_too_low?(stop_on_low_skills)
+      if should_stop_for_low_skills?(stop_on_low_skills)
         DRC.message("***STATUS*** Stopping because skills dropped below learning threshold: #{stop_on_low_skills}")
         break
       end
@@ -381,12 +443,16 @@ class HuntingBuddy
       if (counter % 60).zero?
         if duration
           if stop_on_high_skills
-            DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining or waiting on #{stop_on_high_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
+            DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining or waiting on #{get_skills_below_high_threshold(stop_on_high_skills).join(', ')}")
           else
             DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining")
           end
         else
-          DRC.message("***STATUS*** #{counter / 60} minutes of hunting, still waiting on #{stop_on_high_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
+          if stop_on_high_skills
+            DRC.message("***STATUS*** #{counter / 60} minutes of hunting, still waiting on #{get_skills_below_high_threshold(stop_on_high_skills).join(', ')}")
+          else
+            DRC.message("***STATUS*** #{counter / 60} minutes of hunting")
+          end
         end
       end
       counter += 1

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -79,6 +79,7 @@ class HuntingBuddy
       stop_on_low_skills = info['stop_on_low'] # list of skill names
       stop_on_boxes = info['boxes'] || info['stop_on_boxes'] # boolean
       stop_on_no_moons = info['moons'] || info['stop_on_moons'] # boolean
+      stop_on_encumbrance = info['stop_on_encumbrance'] # numeric threshold
       hunting_zones = [info[:zone]].flatten.compact # string or list of hunting zones
       waiting_room = info['full_waiting_room'] || @settings.safe_room # room id
 
@@ -93,6 +94,7 @@ class HuntingBuddy
         echo("  stop_on_low_skills: #{stop_on_low_skills}")
         echo("  stop_on_boxes: #{stop_on_boxes}")
         echo("  stop_on_no_moons: #{stop_on_no_moons}")
+        echo("  stop_on_encumbrance: #{stop_on_encumbrance}")
         echo("  hunting_zones: #{hunting_zones}")
         echo("  waiting_room: #{waiting_room}")
       end
@@ -126,8 +128,15 @@ class HuntingBuddy
         DRC.message("***STATUS*** Skipping hunt because no moons")
         stop_actions(during_actions)
         execute_actions(after_actions)
-          next
-        end
+        next
+      end
+
+      if encumbered?(stop_on_encumbrance)
+        DRC.message("***STATUS*** Skipping hunt because encumbrance: #{DRStats.encumbrance}, threshold: #{stop_on_encumbrance}")
+        stop_actions(during_actions)
+        execute_actions(after_actions)
+        next
+      end
 
       if should_stop_for_high_skills?(stop_on_high_skills)
         DRC.message("***STATUS*** Skipping hunt because skills reached learning threshold: #{stop_on_high_skills}")
@@ -164,7 +173,8 @@ class HuntingBuddy
           stop_on_high_skills ? stop_on_high_skills[index] : nil,
           stop_on_low_skills ? stop_on_low_skills[index] : nil,
           stop_on_boxes ? stop_on_boxes[index] : nil,
-          stop_on_no_moons ? stop_on_no_moons[index] : nil
+          stop_on_no_moons ? stop_on_no_moons[index] : nil,
+          stop_on_encumbrance ? stop_on_encumbrance[index] : nil
         )
       end
 
@@ -363,18 +373,33 @@ class HuntingBuddy
 
   # ------------------------------------------------------------
 
+  # Is your current encumbrance at or higher than the threshold?
+  # Threshold is a number from 0 (None) to 11 (It's amazing you aren't squashed!)
+  def encumbered?(threshold)
+    return false unless threshold
+    return DRC.check_encumbrance >= threshold
+  end
+
+  # ------------------------------------------------------------
+
+  # Have you reached your lower bound for box count?
+  # Designed to be called before combat-trainer starts
+  # as a way to avoid hunting if you already have enough boxes.
   def need_boxes?
     return false unless @settings.box_hunt_minimum
     DRCI.count_all_boxes(@settings) <= @settings.box_hunt_minimum
   end
 
+  # Have you reached the upper bound for box count?
+  # Designed to be called while combat-trainer is running
+  # as a way to know when to stop once you have enough boxes.
   def over_box_limit?
     $COMBAT_TRAINER.get_process('loot').at_box_limit?
   end
 
   # ------------------------------------------------------------
 
-  def hunt(args, duration, stop_on_high_skills, stop_on_low_skills, stop_on_boxes, stop_on_no_moons)
+  def hunt(args, duration, stop_on_high_skills, stop_on_low_skills, stop_on_boxes, stop_on_no_moons, stop_on_encumbrance)
     $COMBAT_TRAINER = nil
     hunting_room = Room.current.id
     Flags.add('hunting-buddy-familiar-drag', /^Your .+ grabs ahold of you and drags you .+, out of combat.+$/)
@@ -441,6 +466,12 @@ class HuntingBuddy
         Flags.reset('hunting-buddy-familiar-drag')
       end
       if (counter % 60).zero?
+        # To avoid spamming encumbrance checks, this logic is inside
+        # the one minute status update section so it's done only periodically.
+        if encumbered?(stop_on_encumbrance)
+          DRC.message("***STATUS*** Stopping because encumbrance: #{DRStats.encumbrance}, threshold: #{stop_on_encumbrance}")
+          break
+        end
         if duration
           if stop_on_high_skills
             DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining or waiting on #{get_skills_below_high_threshold(stop_on_high_skills).join(', ')}")

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -2,13 +2,9 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#hunting-buddy
 =end
 
-custom_require.call(%w[common common-arcana common-items common-travel drinfomon events spellmonitor equipmanager])
+custom_require.call(%w[common common-arcana common-items common-travel drinfomon equipmanager events spellmonitor])
 
 class HuntingBuddy
-  include DRC
-  include DRCA
-  include DRCI
-  include DRCT
 
   def initialize
     arg_definitions = [[]]
@@ -59,17 +55,21 @@ class HuntingBuddy
 
   def main
     check_bundling_rope
-    wait_for_script_to_complete('restock') unless @settings.sell_loot_skip_bank
+    DRC.wait_for_script_to_complete('restock') unless @settings.sell_loot_skip_bank
 
     @hunting_info.each do |info|
       if @stop_hunting
-        message('***STATUS*** stopping all hunting due to manual intervention')
+        DRC.message("***STATUS*** Stopping all hunting because manual intervention")
+        stop_actions(during_actions)
+        execute_actions(after_actions)
         break
       end
 
       if @stopped_for_bleeding
-        retreat
+        DRC.message("***STATUS*** Stopping all hunting because bleeding")
         stop_script('tendme') if Script.running?('tendme')
+        stop_actions(during_actions)
+        execute_actions(after_actions)
         break
       end
 
@@ -85,7 +85,9 @@ class HuntingBuddy
       waiting_room = info['full_waiting_room'] || @settings.safe_room
 
       if stop_on_boxes && !need_boxes?
-        message('***STATUS*** Skipping hunt because of current boxes is more than the minimum.')
+        DRC.message("***STATUS*** Skipping hunt because have enough boxes")
+        # This purposefully does not perform any actions as an efficiency
+        # to move into the next hunt as quickly as possible.
         next
       end
 
@@ -93,23 +95,22 @@ class HuntingBuddy
       execute_actions(before_actions)
 
       if stop_on_no_moons && !DRCA.moons_visible?
-          message('***STATUS*** Skipping hunt due to no moons')
-          stop_actions(during_actions)
-          # Execute scripts to run after the hunt
-          execute_actions(after_actions)
+        DRC.message("***STATUS*** Skipping hunt because no moons")
+        stop_actions(during_actions)
+        execute_actions(after_actions)
           next
         end
 
       if all_skills_at_cap?(stop_on_skills)
+        DRC.message("***STATUS*** Skipping hunt because skills reached learning threshold")
         stop_actions(during_actions)
-        # Execute scripts to run after the hunt
         execute_actions(after_actions)
         next
       end
 
       if stop_on_low_skills_too_low?(stop_on_low_skills)
+        DRC.message("***STATUS*** Skipping hunt because skills dropped below learning threshold")
         stop_actions(during_actions)
-        # Execute scripts to run after the hunt
         execute_actions(after_actions)
         next
       end
@@ -120,72 +121,91 @@ class HuntingBuddy
 
       args.each_with_index do |arg, index|
         if @stopped_for_bleeding
-          retreat
+          DRC.message("***STATUS*** Stopping all hunting because bleeding")
+          DRC.retreat
           stop_script('tendme') if Script.running?('tendme')
           break
         end
+
+        # Execute background scripts to run during the hunt
         execute_nonblocking_actions(during_actions)
-        hunt(arg, duration ? duration[index] : nil, stop_on_skills ? stop_on_skills[index] : nil, stop_on_low_skills ? stop_on_low_skills[index] : nil, stop_on_boxes ? stop_on_boxes[index] : nil, stop_on_no_moons ? stop_on_no_moons[index] : nil)
+
+        hunt(
+          arg,
+          duration ? duration[index] : nil,
+          stop_on_skills ? stop_on_skills[index] : nil,
+          stop_on_low_skills ? stop_on_low_skills[index] : nil,
+          stop_on_boxes ? stop_on_boxes[index] : nil,
+          stop_on_no_moons ? stop_on_no_moons[index] : nil
+        )
       end
 
+      # Stop background scripts that ran during the hunt
       stop_actions(during_actions)
+
       DRCI.stow_hand('left') unless !DRC.right_hand || !DRC.left_hand
       while DRC.bput('stow feet', /You pick up/, /Stow what/) =~ /You pick up/
       end
-      wait_for_script_to_complete('bescort', @exit) if @exit
-      release_cyclics(@settings.cyclic_no_release)
+
+      DRC.wait_for_script_to_complete('bescort', @exit) if @exit
+      DRCA.release_cyclics(@settings.cyclic_no_release)
 
       # Execute scripts to run after the hunt
       execute_actions(after_actions)
     end
-    walk_to(@settings.safe_room)
-    EquipmentManager.new.wear_equipment_set?('standard')
+
+    DRC.message("***STATUS*** Returning to safe room: #{@settings.safe_room}")
+    DRCT.walk_to(@settings.safe_room)
+    EquipmentManager.new(@settings).wear_equipment_set?('standard')
   end
 
   def execute_actions(actions)
     actions.each do |action|
-      message "***STATUS*** EXECUTE #{action}"
-      action_parts = action.split(' ')
-      script_name = action_parts.shift
-      wait_for_script_to_complete(script_name, action_parts)
+      DRC.message("***STATUS*** EXECUTE #{action}")
+      script_args = action.split(' ')
+      script_name = script_args.shift
+      DRC.wait_for_script_to_complete(script_name, script_args)
     end
   end
 
   def execute_nonblocking_actions(actions)
     actions.each do |action|
-      message "***STATUS*** EXECUTE #{action}"
-      action_parts = action.split(' ')
-      script_name = action_parts.shift
-      start_script(script_name, action_parts)
+      DRC.message("***STATUS*** EXECUTE #{action}")
+      script_args = action.split(' ')
+      script_name = script_args.shift
+      start_script(script_name, script_args)
     end
   end
 
   def stop_actions(actions)
-    actions.each do |script_name|
+    actions.each do |action|
+      DRC.message("***STATUS*** STOP #{action}")
+      script_args = action.split(' ')
+      script_name = script_args.shift
       stop_script(script_name) if Script.running?(script_name)
     end
   end
 
   def check_bundling_rope
     return unless @settings.skinning['skin']
-    return if wearing?('bundle')
-    description = 'bundling rope'
-    return if exists?(description)
+    return if DRCI.wearing?('bundle')
+    return if DRCI.exists?('bundling rope')
 
-    room = get_data('town')[@settings.hometown]['tannery']['id']
-    name = get_data('town')[@settings.hometown]['tannery']['name']
+    tannery_data = get_data('town')[@settings.hometown]['tannery']
+    tanner_room = tannery_data['id']
+    tanner_name = tannery_data['name']
 
-    walk_to(room)
-    bput("ask #{name} for #{description}", 'hands you')
-    bput("stow my #{description}", 'You put')
+    DRCT.walk_to(tanner_room)
+    DRC.bput("ask #{tanner_name} for bundling rope", 'hands you')
+    DRC.stow_item?('bundling rope')
   end
 
   def check_prehunt_buffs
     return unless @settings.waggle_sets['prehunt_buffs']
 
-    walk_to(@buff_room)
+    DRCT.walk_to(@buff_room)
 
-    wait_for_script_to_complete('buff', ['prehunt_buffs'])
+    DRC.wait_for_script_to_complete('buff', ['prehunt_buffs'])
   end
 
   def find_hunting_room?(zone_name, waiting_room)
@@ -199,12 +219,12 @@ class HuntingBuddy
         message "FAILED TO FIND THE HUNTING ZONE(S) #{zones} IN BASE.YAML"
         return false
       end
-      walk_to(escort_info['base'])
+      DRCT.walk_to(escort_info['base'])
       wait_for_script_to_complete('bescort', [escort_info['area'], escort_info['enter']])
       @exit = [escort_info['area'], 'exit']
     else
       @exit = nil
-      return find_empty_room(rooms, waiting_room,
+      return DRCT.find_empty_room(rooms, waiting_room,
         lambda do |search_attempt|
           # Skip room if has more people than your max limit
           return false if DRRoom.pcs.size > @hunting_buddies_max
@@ -233,7 +253,7 @@ class HuntingBuddy
             end
             true
           when /You're not in any condition to be searching around/i
-            DRC.message("You're too injured to hunt!")
+            DRC.message("***STATUS*** You're too injured to hunt!")
             @stop_hunting = true
             @stopped_for_bleeding = bleeding?
             # Ironically, return true so the search for a suitable hunting room
@@ -268,7 +288,7 @@ class HuntingBuddy
     hunting_room = Room.current.id
     Flags.add('familiar_drag', /^Your .+ grabs ahold of you and drags you .+, out of combat.+$/)
 
-    message("***STATUS*** beginning hunt '#{args}' for '#{duration}' minutes")
+    DRC.message("***STATUS*** Beginning hunt '#{args}' for '#{duration}' minutes")
 
     verify_script('combat-trainer')
     start_script('combat-trainer', args)
@@ -283,47 +303,47 @@ class HuntingBuddy
     loop do
       clear
       if health < @settings.health_threshold
-        message('***STATUS*** exiting due to low health')
+        DRC.message("***STATUS*** Exiting because low health: #{health} < #{@settings.health_threshold}")
         fput('avoid all')
         fput('exit')
       end
       if @settings.stop_hunting_if_bleeding && bleeding?
-        message('***STATUS*** stopping due to bleeding')
+        DRC.message("***STATUS*** Stopping because bleeding")
         @stopped_for_bleeding = true
         break
       end
       if stop_on_boxes && over_box_limit?
-        message('***STATUS*** stopping due to boxes')
+        DRC.message("***STATUS*** Stopping hunt because have enough boxes")
         break
       end
       if stop_on_no_moons && !DRCA.moons_visible?
-          message('***STATUS*** stopping due to no moons')
-          break
+        DRC.message("***STATUS*** Stopping because no moons")
+        break
       end
       if all_skills_at_cap?(stop_on_skills)
-        message('***STATUS*** stopping due to capped skills')
+        DRC.message("***STATUS*** Stopping because skills reached learning threshold: #{stop_on_skills}")
         break
       end
       if stop_on_low_skills_too_low?(stop_on_low_skills)
-        message("***STATUS*** stopping due to low skills: #{stop_on_low_skills}")
+        DRC.message("***STATUS*** Stopping because skills dropped below learning threshold: #{stop_on_low_skills}")
         break
       end
       if @stop_hunting || @next_hunt
-        message('***STATUS*** stopping due to manual intervention')
+        DRC.message("***STATUS*** Stopping because manual intervention")
         @next_hunt = false
         break
       end
       if duration && (counter / 60) >= duration
-        message('***STATUS*** stopping due to time')
+        DRC.message("***STATUS*** Stopping because time")
         break
       end
       if Flags['familiar_drag'] && @bail_on_familiar
-        message('***STATUS*** stopping due to familiar dragging from stun')
+        DRC.message("***STATUS*** Stopping because familiar drug while stunned")
         Flags.reset('familiar_drag')
         break
       end
       if Flags['familiar_drag'] && !@bail_on_familiar
-        message('***STATUS*** heading back to room - familiar drug while stunned')
+        DRC.message("***STATUS*** Heading back to room because familiar drug while stunned")
         pause_script('combat-trainer') if Script.running?('combat-trainer')
         DRCT.walk_to(hunting_room)
         unpause_script('combat-trainer') if Script.running?('combat-trainer')
@@ -332,12 +352,12 @@ class HuntingBuddy
       if (counter % 60).zero?
         if duration
           if stop_on_skills
-            message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining or waiting on #{stop_on_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
+            DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining or waiting on #{stop_on_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
           else
-            message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining")
+            DRC.message("***STATUS*** #{duration - (counter / 60)} minutes of hunting remaining")
           end
         else
-          message("***STATUS*** #{counter / 60} minutes of hunting, still waiting on #{stop_on_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
+          DRC.message("***STATUS*** #{counter / 60} minutes of hunting, still waiting on #{stop_on_skills.select { |skill| DRSkill.getxp(skill) < (@magic_skills.include?(skill) ? @magic_exp_threshold : 32) }.join(', ')}")
         end
       end
       counter += 1
@@ -345,7 +365,7 @@ class HuntingBuddy
     end
     $COMBAT_TRAINER.stop
     pause 1 while $COMBAT_TRAINER.running || Script.running?('combat-trainer')
-    retreat
+    DRC.retreat
   end
 
   def format_hunting_info(hunting_info_raw)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -374,8 +374,14 @@ using_light_crossbow: false
 attack_overrides:
 # use attack overrides for aiming trainable skills
 use_overrides_for_aiming_trainables: false
-# threshold in mind-states to train combat_spell_training spells up to.
+# Thresholds in mind-states at which point hunting-buddy considers
+# the 'stop_on' skills to be done training and will end the hunt.
+# You can specify a different threshold per skillset.
+armor_exp_training_max_threshold: 32
+weapon_exp_training_max_threshold: 32
 magic_exp_training_max_threshold: 32
+survival_exp_training_max_threshold: 32
+lore_exp_training_max_threshold: 32
 # only use combat_spell_training spells when there are more than this many mobs in combat.
 combat_spell_training_max_threshold:
 # Timer for casting combat_spell_training.  Edit with extreme caution - too little can cause other casting to be ignored.
@@ -650,7 +656,7 @@ performance_mindstate_goal: 31
 # Define as `forage` to override outdoorsmanship gathering method.
 outdoors_method: collect
 # If you choose forage method, you'll want a room with a trash bin!  Leave blank to not set a default room.
-outdoors_room: 
+outdoors_room:
 # If you choose forage method, you'll want to select a custom item for best learning rate.
 forage_item: rock
 # what item to braid in ;mech-lore


### PR DESCRIPTION
### Dependencies
* https://github.com/rpherbig/dr-scripts/pull/5524

### Background
* Part of a series of updates I'm bringing to `hunting-buddy`
* As dependent PRs are merged then this one's diff will get smaller
* The `format_hunting_info` method manipulates the hunting infos for a multi-hunt config with the goal of preventing the user from needing to leave their current room if the next hunt would be in the same zone. However, the implementation is not intuitive to follow to know how to add more hunting variables like `stop_on_no_moons` or `stop_on_encumbrance`; and it's manipulating many variables when the goal is to simply not search for a new room under certain conditions.

### Changes
* Remove `format_hunting_info` method
* Add new method `current_hunting_zone` to tell us which zone we're currently standing in so that we can use this info in subsequent hunting loop iterations to know if we should search for a new room or not