### PR TITLE
[script][common-theurgy] Fixing holy water predicates, adding one commune error.

### DIFF
--- a/common-theurgy.lic
+++ b/common-theurgy.lic
@@ -148,11 +148,11 @@ module DRCTH
       return false
     end
     unless sprinkle?(water_holder, target)
-      empty_cleric_hands(theurgy_supply_container)
+      DRCI.put_away_item?(water_holder, theurgy_supply_container)
       DRC.message("Couldn't sprinkle holy water.")
       return false
     end
-    empty_cleric_hands(theurgy_supply_container)
+    DRCI.put_away_item?(water_holder, theurgy_supply_container)
     return true
   end
 

--- a/common-theurgy.lic
+++ b/common-theurgy.lic
@@ -13,6 +13,7 @@ module DRCTH
   ] unless defined?(CLERIC_ITEMS)
 
   COMMUNE_ERRORS = [
+    'As you commune you sense that the ground is already consecrated.',
     'You stop as you realize that you have attempted a commune',
     'completed this commune too recently'
   ] unless defined?(COMMUNE_ERRORS)


### PR DESCRIPTION
DRCTH.empty_cleric_hands only works for items in CLERIC_ITEMS, and we're not going to add all possible water sources to that. Makes more sense to just put water holder into theurgy container like this.

Also added a Meraud commune error message for then the ground is already consecrated.