### PR TITLE
[script][hunting-buddy] Added missing DRC prefix

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -221,7 +221,7 @@ class HuntingBuddy
         return false
       end
       DRCT.walk_to(escort_info['base'])
-      wait_for_script_to_complete('bescort', [escort_info['area'], escort_info['enter']])
+      DRC.wait_for_script_to_complete('bescort', [escort_info['area'], escort_info['enter']])
       @exit = [escort_info['area'], 'exit']
     else
       @exit = nil


### PR DESCRIPTION
The most recent PR against hunting-buddy missed one DRC. prefix, so folks can't go to escort zones, until we add this in.