### PR TITLE
[script][drinfomon] Removing troublesome pauses

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -411,7 +411,6 @@ class DRSkill
   def self.refresh_exp_mods
     @@silence_exp_mods_hook = true
     fput('exp mods')
-    pause 0.25
     @@silence_exp_mods_hook = false
   end
 
@@ -889,11 +888,9 @@ before_dying do
 end
 
 fput('exp all')
-pause 0.25
 unless dead?
   DownstreamHook.add('info_silence', info_silence) unless UserVars.drinfomon_debug
   fput('info')
-  pause 0.25
 end
 
 premiumcheck_silence = proc do |server_string|
@@ -1092,10 +1089,8 @@ while line = script.gets
       UserVars.XPSquelch = true unless UserVars.drinfomon_debug
       DownstreamHook.add('info_silence', info_silence) unless UserVars.drinfomon_debug
       fput('exp all')
-      pause 0.25
       fput('info')
       info_check_time = Time.now
-      pause 0.25
     end
     if Time.now - exp_mods_check_time > exp_mods_check_interval
       DRSkill.refresh_exp_mods


### PR DESCRIPTION
These four pauses (probably not all four, but none are needed, so removing all four) causes drinfomon not to populate info data, in what is the most obnoxious issue we have seen, I think.