### PR TITLE
[script][common]Removing the pipe from def message

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -769,11 +769,11 @@ module DRC
     $fake_stormfront ? string.concat("\034GSL\r\n ") : string.concat("<pushBold\/>")
     string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
     if text.index('\n')
-      text.split('\n').each { |line| string.concat("| #{line}") }
+      text.split('\n').each { |line| string.concat("#{line}") }
     else
-      string.concat('| ' + text)
+      string.concat(text)
     end
-    string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
+#   string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
     $fake_stormfront ? string.concat("\034GSM\r\n ") : string.concat("<popBold\/>")
     _respond string
   end


### PR DESCRIPTION
Looking at the history, seems the pipe was a tad contentions even then https://github.com/rpherbig/dr-scripts/pull/3599

However, for the then-intended use case of debug messages, it made sense in a way.

Today we use DRC.message for all kinds of messages, and the pipe comes up as a topic quite a bit.

@rpherbig How would you feel about removing the pipe?