### PR TITLE
[script] [dependency] autostart drinfomon first because most scripts rely on it

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -171,10 +171,12 @@ class ScriptManager
     @lich_url = 'https://api.github.com/repos/dragon-realms/dr-lich/git/trees/master'
     UserVars.autostart_scripts ||= []
     UserVars.autostart_scripts.uniq!
-    UserVars.autostart_scripts = UserVars.autostart_scripts - ['dependency']
+    UserVars.autostart_scripts = UserVars.autostart_scripts - ['dependency', 'drinfomon']
+    UserVars.autostart_scripts = ['drinfomon'] + UserVars.autostart_scripts
     Settings['autostart'] ||= []
     Settings['autostart'].uniq!
-    Settings['autostart'] = Settings['autostart'] - ['dependency']
+    Settings['autostart'] = Settings['autostart'] - ['dependency', 'drinfomon']
+    Settings['autostart'] = ['drinfomon'] + Settings['autostart']
 
     Settings['base_versions'] ||= {}
     CharSettings['next_ruby_version_check_datetime'] = Time.now


### PR DESCRIPTION
### Background
* Chasing performance issues with `drinfomon` defining DRStats, DRSkill, DRRoom, and wiring up its downstream hooks "sooner rather than later"

### Changes
* When autostarting, ensure `drinfomon` is first in the list so that it's incredibly more likely its defined those classes that most all other scripts depend on