### PR TITLE
[script] [common-items] add failure pattern when unable to move

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -30,6 +30,7 @@ module DRCI
     /^No littering/,
     /^Where do you want to put that/,
     /^You really shouldn't be loitering/,
+    /^You don't seem to be able to move/,
     # You may get the next message if you've been cursed and unable to let go of items.
     # Find a Cleric to uncurse you.
     /^Oddly, when you attempt to stash it away safely/,
@@ -72,6 +73,7 @@ module DRCI
     /^You just can't/,
     /^You stop as you realize the .* is not yours/,
     /^You can't reach that from here/, # on a mount like a flying carpet
+    /^You don't seem to be able to move/,
     /^Get what/,
     /^I could not/,
     /^What were you/,
@@ -122,6 +124,7 @@ module DRCI
   ]
 
   @@tie_item_failure_patterns = [
+    /^You don't seem to be able to move/,
     /^There's no more free ties/,
     /^You must be holding/,
     /^Tie what/
@@ -132,6 +135,7 @@ module DRCI
   ]
 
   @@untie_item_failure_patterns = [
+    /^You don't seem to be able to move/,
     /^You fumble with the ties/,
     /^Untie what/
   ]
@@ -198,6 +202,7 @@ module DRCI
     /^You just can't get/,
     /^You can't put items/,
     /^You can only take items out/,
+    /^You don't seem to be able to move/,
     /^Perhaps you should be holding that first/,
     /^Containers can't be placed in/,
     /^The .* is not designed to carry anything/,
@@ -246,6 +251,7 @@ module DRCI
   ]
 
   @@rummage_failure_patterns = [
+    /^You don't seem to be able to move/,
     /^I could not find/,
     /^I don't know what you are referring to/,
     /^What were you referring to/
@@ -259,6 +265,7 @@ module DRCI
   ]
 
   @@tap_failure_patterns = [
+    /^You don't seem to be able to move/,
     /^I could not find/,
     /^I don't know what you are referring to/,
     /^What were you referring to/
@@ -280,6 +287,7 @@ module DRCI
     /^You don't want to ruin your spell just for that do you/,
     /^It would be a shame to disturb the silence of this place for that/,
     /^This is probably not the time nor place for that/,
+    /^You don't seem to be able to move/,
     /^There is no way to do that/,
     /^You can't do that/,
     /^Open what/
@@ -299,6 +307,7 @@ module DRCI
     /^You don't want to ruin your spell just for that do you/,
     /^It would be a shame to disturb the silence of this place for that/,
     /^This is probably not the time nor place for that/,
+    /^You don't seem to be able to move/,
     /^There is no way to do that/,
     /^You can't do that/
   ]
@@ -316,6 +325,7 @@ module DRCI
   ]
 
   @@lower_failure_patterns = [
+    /^You don't seem to be able to move/,
     /^But you aren't holding anything/,
     /^Please rephrase that command/,
     /^What were you referring to/,


### PR DESCRIPTION
### Background
* When feeding a [living vines cloak](https://elanthipedia.play.net/Category:Living_vine_cloaks), you are rooted in the ground and unable to move
* If a background script happens to run like `almanac` then it'll fail to "get" your item and complain about unmatched string

### Changes
* Add failure match for `You don't seem to be able to move`

### Example
```
The vivid blooms upon your dendritic cloak flutter as the vines probe about aimlessly.

> feed cloak
You relax your body, allowing the vines to roam downward to test the ground for nutrients.

The vines sink deeply into the mud and begin to feed, binding you in place.
 
The feeding vines undulate in a pleased manner as they gorge themselves on the rich nutrients in the mud.

[almanac]>get my almanac 

You don't seem to be able to move to do that.

[almanac: *** No match was found after 15 seconds, dumping info]

...

[almanac: message: You don't seem to be able to move to do that.]

[almanac: checked against [/^You get/, /^You pick/, /^You pluck/, /^You slip/, /^You deftly remove/, /^You are already holding/, /^You fade in for a moment as you/, /^You need a free hand/, /^You can't pick that up with your hand that damaged/, /^Your (left|right) hand is too injured/, /^You just can't/, /^You stop as you realize the .* is not yours/, /^You can't reach that from here/, /^Get what/, /^I could not/, /^What were you/, /already in your inventory/, /needs to be tended to be removed/, /push you over the item limit/, /rapidly decays away/, /cracks and rots away/]]

[almanac: for command get my almanac ]

| Almanac not found, exiting
```