### PR TITLE
[script] [dependency] hydrate crossing_training_sorcery with base spell data

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1128,6 +1128,14 @@ class SetupFiles
       spells_list.map!(&enrich_spells_with_data_block)
     end
 
+    # Spell settings that are configured as a map of a single spell's properties.
+    # Enrich each's spell definition by merging base spell data with spell settings.
+    [
+      'crossing_training_sorcery',
+    ].each do |key|
+      settings[key] = enrich_spells_with_data_block.call(settings[key])
+    end
+
     # For TM spells, default their 'prep' command to 'target'
     # unless a custom 'prep' command is already specified.
     settings.offensive_spells.each do |spell_setting|


### PR DESCRIPTION
### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/1357

### Changes
* Add section to hydrate spells where the setting is a single spelll's definition (non-waggle style)

### Test
```yaml
crossing_training_sorcery:
  abbrev: CV
  mana: 20
```
```
> ,e echo get_settings.crossing_training_sorcery

--- Lich: exec1 active.

[exec1: {"skill"=>"Augmentation", "abbrev"=>"CV", "mana"=>20, 
         "mana_type"=>"lunar", "prep"=>"prepare", "recast"=>1}]

--- Lich: exec1 has exited.
```

Also ran `sorcery` script to confirm it read and cast the spell correctly.