### PR TITLE
[script] [dependency] don't duplicate autostarts

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -200,7 +200,7 @@ class ScriptManager
   end
 
   def update_autostarts
-    @autostarts = UserVars.autostart_scripts + Settings['autostart']
+    @autostarts = (UserVars.autostart_scripts + Settings['autostart']).uniq
   end
 
   def update_status_url


### PR DESCRIPTION
### Background
* The `update_autostarts` method concatenates `UserVars.autostart_scripts` and `Settings['autostart']` without regard to if a script has been added in both locations.
* This lead to multiple script instances showing in `;listall` but it's confusing when people show their `;e echo list_autostarts` and a script is listed multiple times

### Changes
* Call `uniq` on the concatenated lists