### PR TITLE
[script] [common-moonmage] check if telescope is in hands before get/stow

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -25,6 +25,7 @@ module DRCMM
   end
 
   def get_telescope?(telescope_name = 'telescope', storage)
+    return true if DRCI.in_hands?(telescope_name);
     if storage['tied']
       DRCI.untie_item?(telescope_name, storage['tied'])
     elsif storage['container']
@@ -35,6 +36,7 @@ module DRCMM
   end
 
   def store_telescope?(telescope_name = "telescope", storage)
+    return true unless DRCI.in_hands?(telescope_name);
     if storage['tied']
       DRCI.tie_item?(telescope_name, storage['tied'])
     elsif storage['container']
@@ -267,7 +269,7 @@ module DRCMM
     return nil
   end
 
-## Migrating predition/planet/moon defs from common-arcana to here.
+## Migrating prediction/planet/moon defs from common-arcana to here.
 #Delete this line, and the defs from common-arcana after they've been
 #merged here and things look good.
 
@@ -317,6 +319,5 @@ module DRCMM
     end
     DRC.message("Could not set planet data. Cannot cast #{data['abbrev']}")
   end
-
 
 end


### PR DESCRIPTION
### Background
* If the telescope is already in your hands then `DRCMM.get_telescope?(...)` will try to get it _again_ and your hands may become full holding two telescopes and then unable to use them.

### Changes
* If already holding telescope, don't try to get it again
* If not holding telescope, don't try to stow it

### Test
_started with holding a telescope_
```
> ,e echo DRCMM.store_telescope?('telescope', get_settings.telescope_storage)

[exec1]>put my telescope in my icy satchel

You put your telescope in your icy blue satchel. 

[exec1: true]
```
```
> ,e echo DRCMM.store_telescope?('telescope', get_settings.telescope_storage)

[exec1: true]
```
```
,e echo DRCMM.get_telescope?('telescope', get_settings.telescope_storage)

[exec1]>get my telescope from my icy satchel

You get a cherry telescope from inside your icy blue satchel. 

[exec1: true]
```
```
,e echo DRCMM.get_telescope?('telescope', get_settings.telescope_storage)

[exec1: true]
```