### PR TITLE
Remove forcing wyvern mountain from undergondola arg

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -337,7 +337,7 @@ class Athletics
     if UserVars.athletics < 540
       override_location_and_practice('undergondola_branch')
     else
-      DRC.message("Warning: ;athletics undergondola with more than 850 athletics is not best useand you may consider ;athletics wyverns instead.") if UserVars.athletics > 850
+      DRC.message("Warning: ;athletics undergondola with more than 850 athletics is not best use and you may consider ;athletics wyverns instead.") if UserVars.athletics > 850
       walk_to(9607)
       walk_to(9515)
       until done_training?

--- a/athletics.lic
+++ b/athletics.lic
@@ -336,7 +336,8 @@ class Athletics
   def climb_branch
     if UserVars.athletics < 540
       override_location_and_practice('undergondola_branch')
-    elsif UserVars.athletics < 850
+    else
+      DRC.message("Warning: ;athletics undergondola with more than 850 athletics is not best useand you may consider ;athletics wyverns instead.") if UserVars.athletics > 850
       walk_to(9607)
       walk_to(9515)
       until done_training?
@@ -347,8 +348,6 @@ class Athletics
         break if done_training?
         outdoorsmanship_waiting(4)
       end
-    else
-      climb_wyvern
     end
   end
 


### PR DESCRIPTION
There is a known DC/freeze bug that randomly effects folks trying to train athletics on wyvern mountain that often results in character death.  Removing the default behavior to force anyone over 850 athletics (even though its best training) allows the user to avoid unnecessary deaths while a visible warning alerts the user that their current method is less effective.