### PR TITLE
[script] [common] restore bold for Genie frontend; extract logic to own bold method

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -757,6 +757,8 @@ module DRC
     DRC.bput("stance set #{stance}", /Setting your/)
   end
 
+  # Sends a message to the atmospherics window.
+  # By default the message is bold.
   def atmo(text, make_bold = true)
     _respond(
       "<pushStream id=\"atmospherics\"/>" + (make_bold ? bold(text) : text),
@@ -764,6 +766,10 @@ module DRC
     )
   end
 
+  # Helper function to wrap text in the necessary markup
+  # to make it render as bold in a frontend client.
+  # This method has little use to other scripts and is designed for
+  # `atmo` and `message` methods in common.lic.
   def bold(text)
     string = ''
 
@@ -778,6 +784,8 @@ module DRC
     string
   end
 
+  # Sends a message to the game window.
+  # By default the message is bold.
   def message(text, make_bold = true)
     string = ''
     if text.index('\n')

--- a/common.lic
+++ b/common.lic
@@ -757,28 +757,34 @@ module DRC
     DRC.bput("stance set #{stance}", /Setting your/)
   end
 
-  def atmo(text)
+  def atmo(text, make_bold = true)
     _respond(
-      "<pushStream id=\"atmospherics\"/>" + text,
+      "<pushStream id=\"atmospherics\"/>" + (make_bold ? bold(text) : text),
       "<popStream id=\"atmospherics\" /><prompt time=\"#{Time.now.to_i}\">&gt;</prompt>"
     )
   end
 
   def bold(text)
-    "<pushBold/>#{text}<popBold/>"
-  end
-
-  def message(text)
     string = ''
+
     $fake_stormfront ? string.concat("\034GSL\r\n ") : string.concat("<pushBold\/>")
     string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
+
+    string.concat(text)
+
+    string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
+    $fake_stormfront ? string.concat("\034GSM\r\n ") : string.concat("<popBold\/>")
+
+    string
+  end
+
+  def message(text, make_bold = true)
+    string = ''
     if text.index('\n')
       text.split('\n').each { |line| string.concat("#{line}") }
     else
       string.concat(text)
     end
-#   string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
-    $fake_stormfront ? string.concat("\034GSM\r\n ") : string.concat("<popBold\/>")
-    _respond string
+    _respond (make_bold ? bold(string) : string)
   end
 end


### PR DESCRIPTION
### Background
* A previous commit commented out `string.concat("\r") if $frontend == 'genie' #fix genie monsterbold` which Genie needs in order to know to make text bold.

### Changes
* Refactor bold logic into its own method that now also has the logic for frontends
* Add second argument to `atmo` and `message` methods that let you control whether you want the text bold or not, and in this way the two methods just put text in a window and the caller decides if it should be bold or not.
* Supercedes https://github.com/rpherbig/dr-scripts/pull/5565

### Tests
Myself, @MahtraDR, @asechrest confirmed in Genie, Profanity, and Wrayth (rebranded StormFront)

We ran these commands:
```
;e DRC.message('text') # bold message
;e DRC.message('text', true) # bold message
;e DRC.message('text', false) # not bold

;e DRC.atmo('text') # bold message to atmo window
;e DRC.atmo('text', true) # bold message to atmo window
;e DRC.atmo('text', false) # not bold message to atmo window
```

![image](https://user-images.githubusercontent.com/68095633/153737502-c4e15c7d-6dfe-4db2-9c62-ea908e7ce8d8.png)


![image](https://user-images.githubusercontent.com/68095633/153737458-fb058a34-f9de-4e18-8cfe-79ba6e7c83c5.png)

