### PR TITLE
[script] [exp-monitor] fix memory leak

### DIFF
--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -7,6 +7,13 @@ UserVars.echo_exp = true
 UserVars.echo_exp_time ||= 1
 DRSkill.gained_skills.shift(DRSkill.gained_skills.size).uniq
 
+before_dying do
+  # Turn off setting when script stops otherwise drinfomon script will
+  # continue to append data to DRSkill.gained_skills array as a memory leak.
+  UserVars.echo_exp = false
+  DRSkill.gained_skills.clear
+end
+
 loop do
   new_skills = DRSkill.gained_skills.shift(DRSkill.gained_skills.size).uniq
   respond("  Gained: #{new_skills.join(', ')}") unless new_skills.empty?


### PR DESCRIPTION
### Background
* The `exp-monitor` script sets `UserVars.echo_exp = true` on script start; but never sets it to `false`
* The `drinfomon` script appends gained skills to `DRSkill.gained_skills` array when `UserVars.echo_exp == true`
* If `exp-monitor` is stopped but `UserVars.echo_exp ` is still `true` then nothing ever truncates the array and it grows forever (aka, memory leak)

```
,e echo UserVars.echo_exp
--- Lich: exec1 active.

[exec1: true]

--- Lich: exec1 has exited.
```
```
> ,e echo DRSkill.gained_skills

--- Lich: exec1 active.

[exec1: ["Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Utility", "Warding", "Augmentation", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Utility", "Warding", "Engineering", "Augmentation", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Utility", "Warding", "Augmentation", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Augmentation", "Utility", "Inner Magic", "Perception", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Utility", "Warding", "Augmentation", "Inner Magic", "Chain Armor", "Arcana", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Utility", "Warding", "Augmentation", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Utility", "Warding", "Augmentation", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Engineering", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Utility", "Warding", "Inner Magic", "Augmentation", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Utility", "Arcana", "Utility", "Inner Magic", "Augmentation", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Tactics", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Inner Magic", "Arcana", "Appraisal", "Appraisal", "Appraisal", "Appraisal", "Appraisal", "Appraisal", "Thievery", "Stealth", "Augmentation", "Utility", "Inner Magic", "Thievery", "Stealth", "Augmentation", "Utility", "Inner Magic", "Thievery", "Stealth", "Athletics", "Performance", "Athletics", "Athletics", "Athletics", "Athletics", "Augmentation", "Utility", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Tactics", "Tactics", "Tactics", "Augmentation", "Utility", "Warding", "Inner Magic", "Tactics", "Tactics", "Tactics", "Debilitation", "Backstab", "Inner Magic", "Small Edged", "Melee Mastery", "Small Edged", "Melee Mastery", "Backstab", "Augmentation", "Utility", "Warding", "Inner Magic", "Debilitation", "Backstab", "Inner Magic", "Appraisal", "Augmentation", "Utility", "Warding", "Inner Magic", "Debilitation", "Backstab", "Inner Magic", "Athletics", "Athletics", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding", "Inner Magic", "Athletics", "Athletics", "Augmentation", "Utility", "Warding", "Augmentation", "Warding", "Inner Magic", "Athletics", "Athletics", "Augmentation", "Utility", "Warding", "Inner Magic", "Augmentation", "Utility", "Warding"]]

--- Lich: exec1 has exited.
```

### Changes
* Add `before_dying` block to `exp-monitor` to set `UserVars.echo_exp = false` and clear `DRSkill.gained_skills` to prevent memory leak
