### PR TITLE
[script] [athletics] Update Shard athletics options

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -240,8 +240,10 @@ class Athletics
         override_location_and_practice('shard_embrasure')
       elsif UserVars.athletics < 540
         climb_cliffs
-      elsif UserVars.athletics
+      elsif UserVars.athletics < 850
         climb_branch
+      elsif UserVars.athletics
+        climb_wyvern
       end
     end
   end
@@ -337,7 +339,7 @@ class Athletics
     if UserVars.athletics < 540
       override_location_and_practice('undergondola_branch')
     else
-      DRC.message("Warning: ;athletics undergondola with more than 850 athletics is not best use and you may consider ;athletics wyverns instead.") if UserVars.athletics > 850
+      DRC.message("Warning: Using the undergondola arg with more than 850 athletics is not best use and you may consider the wyvern option instead.") if UserVars.athletics > 850
       walk_to(9607)
       walk_to(9515)
       until done_training?


### PR DESCRIPTION
Updating the notes for clear reading with Genie or other front end.  Also re-adding the logic for correctly selecting wyvern mountain when running `;athletics` without an arg.  The way it was previously forced during `undergondola` was the only way to automatically select the correct option.  Relocating that logic to shard_athletics reverts default behavior while still allowing users to block the DC mountain.