### PR TITLE
[script] [drinfomon] fix: handle when log in with 100% concentration

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -31,7 +31,7 @@ class DRStats
   # pulse with vitals updates and the correct values will be set.
   # If you're already at 100% then the game may not send the vitals until
   # you take an action to consume or restore a vital. Because of this, you
-  # can get stuff by common-arcana waiting for your concentration or mana
+  # can get stuck by common-arcana waiting for your concentration or mana
   # to increase to at least 80% even though you logged in with 100%.
   @@concentration ||= 100
   @@health ||= 100

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.10'
+$DRINFOMON_VERSION = '2.0.11'
 
 no_kill_all
 no_pause_all
@@ -23,11 +23,17 @@ class DRStats
   @@wisdom ||= 0
   @@discipline ||= 0
   @@charisma ||= 0
-  @@concentration ||= 0
   @@favors ||= 0
   @@tdps ||= 0
   @@encumbrance = nil
   @@balance ||= 8
+  # Assume vitals are 100%. If they aren't then the game will rather quickly
+  # pulse with vitals updates and the correct values will be set.
+  # If you're already at 100% then the game may not send the vitals until
+  # you take an action to consume or restore a vital. Because of this, you
+  # can get stuff by common-arcana waiting for your concentration or mana
+  # to increase to at least 80% even though you logged in with 100%.
+  @@concentration ||= 100
   @@health ||= 100
   @@mana ||= 100
   @@fatigue ||= 100


### PR DESCRIPTION
### Background
* If vitals aren't 100% at logon then the game will rather quickly pulse with vitals updates and the correct values will be set on DRStats.
* If you're already at 100% then the game may not send the vitals until you take an action to consume or restore a vital.
* Because of this, you can get stuff by common-arcana waiting for your concentration or mana to increase to at least 80% even though you logged in with 100%.
* DRStats already defaulted health/mana/fatigue/spirit to 100%, but concentration defaulted to 0%

### Changes
* Default DRStats.concentration to 100% also, bringing it in line with the other vitals

_Note, this was a pre-existing bug with drinfomon prior to version 2.0 but someone just now reported it to us_