### PR TITLE
[script] [drinfomon] add back tracking exp (was inadvertently removed)

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.12'
+$DRINFOMON_VERSION = '2.0.13'
 
 no_kill_all
 no_pause_all
@@ -711,6 +711,11 @@ learning_rates = [
   'mind lock'
 ]
 
+# We use this to right pad learning rate names when formatting
+# the output to show gained ranks in the experience window in Wrayth/StormFront.
+# This variable tells us how wide to make the column.
+longest_learning_rate_length = learning_rates.sort_by(&:length).last.length
+
 # Balance levels in order from 0/11 to 11/11
 balance_values = [
   'completely',
@@ -815,17 +820,18 @@ exp_hook = proc do |server_string|
       # change the IF condition to only run if `UserVars.track_exp` is true
       # as well as remove this comment block and the initialization assignment.
       UserVars.track_exp ||= true
-      server_string.sub!(/<\/preset>/, " #{sprintf("%0.2f", DRSkill.gained_exp(skill))}</preset>")
+      server_string.sub!(/(\/34\])/, "\\1 #{sprintf('%0.2f', DRSkill.gained_exp(skill))}")
     end
   when regex_flag_briefexp_off
     skill = Regexp.last_match[:skill]
     rank = Regexp.last_match[:rank]
-    rate = learning_rates.index(Regexp.last_match[:rate]) # convert word to number
+    rate_word = Regexp.last_match[:rate]
+    rate = learning_rates.index(rate_word) # convert word to number
     percent = Regexp.last_match[:percent]
     DRSkill.update(skill, rank, rate, percent)
     # Show to the right of the experience learning rate the gained ranks this session.
     if UserVars.track_exp
-      server_string.sub!(/<\/preset>/, " #{sprintf("%0.2f", DRSkill.gained_exp(skill))}</preset>")
+      server_string.sub!(/(%\s+)(#{rate_word})/, "\\1 #{rate_word.ljust(longest_learning_rate_length)} #{sprintf('%0.2f', DRSkill.gained_exp(skill))}")
     end
   when regex_exp_clear_mindstate
     skill = Regexp.last_match[:skill]

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.11'
+$DRINFOMON_VERSION = '2.0.12'
 
 no_kill_all
 no_pause_all
@@ -804,12 +804,29 @@ exp_hook = proc do |server_string|
     rate = Regexp.last_match[:rate] # already a number
     percent = Regexp.last_match[:percent]
     DRSkill.update(skill, rank, rate, percent)
+    # Show to the right of the experience learning rate the gained ranks this session.
+    if UserVars.track_exp || UserVars.track_exp.nil?
+      # Historically, this feature to show gained exp was on by default
+      # and could be turned off by setting `UserVars.track_exp = false`.
+      # As of February 2022, we want features to be opt-in to minimize
+      # impact to players who don't want Lich to change out from under them.
+      # To get to that point with this feature, we need to correct the data
+      # and set to true if it was already nil. In a subsequent update we'll
+      # change the IF condition to only run if `UserVars.track_exp` is true
+      # as well as remove this comment block and the initialization assignment.
+      UserVars.track_exp ||= true
+      server_string.sub!(/<\/preset>/, " #{sprintf("%0.2f", DRSkill.gained_exp(skill))}</preset>")
+    end
   when regex_flag_briefexp_off
     skill = Regexp.last_match[:skill]
     rank = Regexp.last_match[:rank]
     rate = learning_rates.index(Regexp.last_match[:rate]) # convert word to number
     percent = Regexp.last_match[:percent]
     DRSkill.update(skill, rank, rate, percent)
+    # Show to the right of the experience learning rate the gained ranks this session.
+    if UserVars.track_exp
+      server_string.sub!(/<\/preset>/, " #{sprintf("%0.2f", DRSkill.gained_exp(skill))}</preset>")
+    end
   when regex_exp_clear_mindstate
     skill = Regexp.last_match[:skill]
     DRSkill.clear_mind(skill)


### PR DESCRIPTION
### Dependencies
* https://github.com/rpherbig/dr-scripts/pull/5587

### Background
* Reported by [Xelten in Lich Discord](https://discord.com/channels/745675889622384681/745675890242879671/942573238305845289)
* This feature [previously existed](https://github.com/rpherbig/dr-scripts/blob/959e4f1b1fe5f612b23c89a04a4f6dcaf8501a0e/drinfomon.lic#L646) in drinfomon pre v2.0 but was inadvertently removed (sorry!)
* Players who use Wrayth frontend (rebraned StormFront) use this feature to show cumulative ranks gained in their current session.

> Users of Genie, and possibly other non-Wrayth frontends, should NOT set `UserVars.track_exp = true` because the EXPTracker plugin won't recognize the modified server string.

### Changes
* Previously, this featue was only enabled when `toggle briefexp on`; it now is supported whether that's on or off
* The feature was enabled when `UserVars.track_exp` was true or nil; to begin adopting a philosophy of "players opt-in to new features unless it's critical issue" then we're doing two things:
  1. The original code path will begin setting `UserVars.track_exp ||= true` to standardize old data to explicitly opt in to the feature.
  2. To show the cumulative ranks gained when `toggle briefexp off` then players must opt-in (since this is net new functionality) by setting `UserVars.track_exp = true`

The code comments go in to more details.

In a subsequent pull request we may look at moving some of these UserVars to YAML settings for ease of management.

### Tests
This has been tested in Wrayth frontend (rebranded StormFront). I can't figure out how to show the Field Experience window in Genie; but most Genie users use the "EXPTracker" plugin which has this feature and lots more bells and whistles.

@MahtraDR @asechrest FYI in case you all can/want to test this in another frontend like Profanity, thanks!

_when briefexp on_
![brief_exp_on](https://user-images.githubusercontent.com/68095633/153817470-359b2aac-b15b-43db-a4bd-ec0e04d4aca7.png)

_when briefexp off_
![brief_exp_off](https://user-images.githubusercontent.com/68095633/153817483-8e68601f-143f-4349-a61c-4ce4809a99dd.png)

And if `UserVars.track_exp = false` then the numbers don't show at all in either scenario.