### PR TITLE
[script] [drinfomon] hotfix for parsing exp pulses

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.11'
+$DRINFOMON_VERSION = '2.0.12'
 
 no_kill_all
 no_pause_all
@@ -731,17 +731,19 @@ balance_values = [
 #
 # Sample XML:
 #
+# Note, depending on your frontend and possibly other settings,
+# the <component> tags may include <preset> tags. The examples
+# below show both variants.
+#
 # FLAG BRIEFEXP ON
-regex_flag_briefexp_on = %r{<component id='exp [^<>]+'><preset id='whisper'><d cmd='skill (?<skill>[\w\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\]<\/preset><\/component>}
+regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[\w\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
 # <component id='exp Augmentation'><preset id='whisper'><d cmd='skill Augmentation'>     Aug</d>:  565 39%  [ 2/34]</preset></component>
-# <component id='exp Utility'><preset id='whisper'><d cmd='skill Utility'>    Util</d>:  562 56%  [ 3/34]</preset></component>
-# <component id='exp Inner Magic'><preset id='whisper'><d cmd='skill Inner Magic'>      IM</d>:  569 68%  [ 2/34]</preset></component>
+# <component id='exp Utility'><d cmd='skill Utility'>    Util</d>:  562 56%  [ 3/34]</component>
 # ---
 # FLAG BRIEFEXP OFF
-regex_flag_briefexp_off = %r{<component id='exp [^<>]+'><preset id='whisper'>\s+\b(?<skill>.*)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s\b(?<rate>[\w\s]+)\b\s+<\/preset><\/component>}
+regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[\w\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[\w\s]+)\b.*?<\/component>}
 # <component id='exp Augmentation'><preset id='whisper'>    Augmentation:  565 39% learning     </preset></component>
-# <component id='exp Utility'><preset id='whisper'>         Utility:  562 57% learning     </preset></component>
-# <component id='exp Inner Magic'><preset id='whisper'>     Inner Magic:  569 68% learning     </preset></component>
+# <component id='exp Utility'>         Utility:  562 57% learning     </component>
 # ---
 # Empty mindstate
 regex_exp_clear_mindstate = %r{<component id='exp (?<skill>.*)'><\/component>}


### PR DESCRIPTION
### Background
* SIMU or frontends are being funky with exp pulses and you might receive different XML tags
* Despite testing with Wrayth, Profanity, and Genie, we still missed some edge cases for folks

### Changes
* Loosen the regex patterns to not care about `<preset id='whisper'>`

### Tests
* regex for briefexp OFF https://regex101.com/r/BgmtDZ/1
* regex for briefexp ON https://regex101.com/r/alDcpE/1

Fix confirmed by myself, @MahtraDR @asechrest and Xelten in Genie, Profanity, and Wrayth frontends