### PR TITLE
[scripts] [common-arcana] Adding missing reference to DRCMM

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -822,7 +822,7 @@ module DRCA
     return unless settings
 
     # Skip preparing lunar spell if no moons available
-    return unless set_moon_data(data)
+    return unless DRCMM.set_moon_data(data)
 
     release_cyclics if data['cyclic']
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'


### PR DESCRIPTION
Found whilst testing removing them all that this one I'd missed.

without
```
 --- Lich: go2 has exited.                                                                                                                                                                                                                    
 --- Lich: outdoorsmanship active.                                                                                                                                                                                                            
 --- Lich: error: undefined method `set_moon_data' for #<Outdoorsmanship:0x0000560c4236d4c8>                                                                                                                                                  
 Did you mean?  setup_data                                                                                                                                                                                                                    
         common-arcana:743:in `crafting_prepare_spell'                                                                                                                                                                                        
         common-arcana:781:in `crafting_magic_routine'                                                                                                                                                                                        
 --- Lich: outdoorsmanship has exited.                                                                                                                                                                                                        
 You feel fully attuned to the mana streams again.     
```

With, no errors.