### PR TITLE
[script] [drinfomon] don't squelch on startup, wait til needed

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.13'
+$DRINFOMON_VERSION = '2.0.14'
 
 no_kill_all
 no_pause_all
@@ -647,23 +647,23 @@ end
 
 # For parsing `info` output
 parsing_info_output = false
-squelch_info_output = !UserVars.drinfomon_debug
+squelch_info_output = false
 
 # For parsing `ltb info` output
 parsing_ltb_info_output = false
-squelch_ltb_info_output = !UserVars.drinfomon_debug
+squelch_ltb_info_output = false
 
 # For parsing `played` output
 parsing_played_output = false
-squelch_played_output = !UserVars.drinfomon_debug
+squelch_played_output = false
 
 # For parsing `exp all` output
 parsing_exp_output = false
-squelch_exp_output = !UserVars.drinfomon_debug
+squelch_exp_output = false
 
 # For parsing `exp mods` output
 parsing_exp_mods_output = false
-squelch_exp_mods_output = !UserVars.drinfomon_debug
+squelch_exp_mods_output = false
 
 # How long to wait between info/exp checks.
 drinfomon_passive_delay = get_settings.drinfomon_passive_delay
@@ -737,8 +737,8 @@ balance_values = [
 # Sample XML:
 #
 # Note, depending on your frontend and possibly other settings,
-# the <component> tags may include <preset> tags. The examples
-# below show both variants.
+# the <component> tags may include <preset> tags.
+# The examples below show both variants.
 #
 # FLAG BRIEFEXP ON
 regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[\w\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}


### PR DESCRIPTION
### Background
* Reported by [Xelten in Lich Discord](https://discord.com/channels/745675889622384681/745675890242879671/942934618661871717) that _"if you type exp mods, it doesn't show any response at all, but then if you type it a second time it shows the skills"_
* Upon investigation, the variables that control whether output should be squelched default to `!UserVars.drinfomon_debug` so if you didn't have the debug on then by default the downstreams hooks would squelch the first time info/exp/etc were parsed regardless who initiated the command (player or script)

```
>exp mods

>bounce
You bounce around happily.

>exp mods
The following skills are currently under the influence of a modifier:
  None
```

### Changes
* Don't default the squelch variables to true; instead wait til a script calls the appropriate function that requests for background parsing of info/exp/etc, at which point the squelch variable will be set accordingly

### Tests
* @MahtraDR @asechrest confirmed in Wrayth and Profanity
* I confirmed in Genie