### PR TITLE
[script] [tdps] use DRSkill instead of `exp all`; same data

### DIFF
--- a/tdps.lic
+++ b/tdps.lic
@@ -27,30 +27,14 @@ def cost(current, modifier)
   return cost
 end
 
-circle = nil
-exp = []
-skills = []
-costs = []
-
-#Get current stats, race, and pick the correct modifier array for your race
+# Get current stats, race, and pick the correct modifier array for your race
 stats = [DRStats.strength, DRStats.reflex, DRStats.agility, DRStats.charisma, DRStats.discipline, DRStats.wisdom, DRStats.intelligence, DRStats.stamina]
 race = DRStats.race.downcase.sub(' ', '').sub("'", '')
 mods = races.fetch(race)
 
-put 'exp all'
-waitfor('EXP HELP for more information')
-
-# Capture and extract data
-data = reget(39)
-data.each { |line| exp << line if (/\(.?.\/34\)/ =~ line) }
-exp.each { |line| skills << [line.slice(0,16), line.slice(17,7).strip.to_i, line.slice(25,2).to_i]; skills << [line.slice(50,16), line.slice(67,7).strip.to_i, line.slice(75,2).to_i] }
-skills.delete(["\r", 0, 0])
-ranks = skills.transpose[1]
-
 # Calculate total ranks and total TDPs from that
-total_ranks = ranks.inject(0){ |sum,x| sum + x }
-ranks.map!{ |r| (r*(r+1))/2 }
-rank_tdps = ranks.inject(0){|sum,x| sum + x } / 200
+total_ranks = DRSkill.list.map(&:rank).reduce(:+)
+rank_tdps = DRSkill.list.map { |skill_info| (skill_info.rank * (skill_info.rank + 1)) / 2 }.reduce(:+) / 200
 
 # Calculate TDPs from circling
 circle = DRStats.circle
@@ -67,7 +51,8 @@ else
   echo "Unable to determine circle."
 end
 
-#Calcuate total TDPs spent for each stat
+# Calcuate total TDPs spent for each stat
+costs = []
 for i in 0..7
   costs[i] = cost( stats[i], mods[i] )
 end
@@ -77,11 +62,13 @@ DRC.message("Total Ranks Gained: #{total_ranks}")
 DRC.message("TDPs Gained from Ranks: #{rank_tdps}")
 DRC.message("TDPs Gained from Circling: #{circle_tdps}")
 DRC.message("Total TDPs Gained: #{rank_tdps + circle_tdps}")
-DRC.message("Total TDPs spent: #{costs.inject(0, :+)}")
-DRC.message("TDPs remaining: #{rank_tdps + circle_tdps - costs.inject(0, :+)}")
+DRC.message("Total TDPs spent: #{costs.reduce(0, :+)}")
+DRC.message("TDPs remaining: #{rank_tdps + circle_tdps - costs.reduce(0, :+)}")
 DRC.message("")
 DRC.message("TDPs spent per stat")
+_respond('<output class="mono"/>')
 DRC.message("Strength : ".rjust(16) + "#{costs[0]}" + "Reflex : ".rjust(26-costs[0].to_s.length) + "#{costs[1]}")
 DRC.message("Agility : ".rjust(16) + "#{costs[2]}" + "Charisma : ".rjust(26-costs[2].to_s.length) + "#{costs[3]}")
 DRC.message("Discipline : ".rjust(16) + "#{costs[4]}" + "Wisdom : ".rjust(26-costs[4].to_s.length) + "#{costs[5]}")
 DRC.message("Intelligence : ".rjust(16) + "#{costs[6]}" + "Stamina : ".rjust(26-costs[6].to_s.length) + "#{costs[7]}")
+_respond('<output class="mono"/>')


### PR DESCRIPTION
### Background
* `drinfomon` tracks your character's experience and already has the data stored in `DRSkill`
* Follow up to the intent of https://github.com/rpherbig/dr-scripts/pull/5588

### Changes
* Remove call to `exp all`
* Use `DRSkill` to get sum of your ranks
* Change `inject` to `reduce` since the methods are aliases and the function being performed is a _reduction_ of a list to a single value
* Use `<output class="mono"/>` to format the stat tdps in mono-spaced format so columns line up

### Tests
_original tdps code_
```
> ,tdp

--- Lich: tdps active.

[tdps]>exp all

Circle: 87
Showing all skills that you have skill in.

          SKILL: Rank/Percent towards next rank/Amount learning/Mindstate Fraction
    Shield Usage:    295 32% clear          (0/34)     Light Armor:    292 36% clear          (0/34)
     Chain Armor:    293 97% clear          (0/34)      Brigandine:    234 92% clear          (0/34)
     Plate Armor:    210 50% clear          (0/34)       Defending:    297 71% clear          (0/34)
   Parry Ability:    314 71% clear          (0/34)     Small Edged:    321 60% clear          (0/34)
     Large Edged:    299 62% clear          (0/34) Twohanded Edged:    303 74% clear          (0/34)
     Small Blunt:    312 85% clear          (0/34)     Large Blunt:    304 70% interested    (12/34)
 Twohanded Blunt:    299 68% clear          (0/34)          Slings:    302 65% clear          (0/34)
             Bow:    302 99% clear          (0/34)        Crossbow:    301 70% clear          (0/34)
          Staves:    294 01% clear          (0/34)        Polearms:    289 56% clear          (0/34)
    Light Thrown:    291 04% clear          (0/34)    Heavy Thrown:    302 00% clear          (0/34)
        Brawling:    292 02% clear          (0/34)  Offhand Weapon:    310 70% clear          (0/34)
   Melee Mastery:    405 23% clear          (0/34) Missile Mastery:    379 58% clear          (0/34)
     Inner Magic:    574 40% captivated    (26/34)          Arcana:    437 62% fascinated    (25/34)
    Augmentation:    570 09% engrossed     (27/34)    Debilitation:    329 64% clear          (0/34)
         Utility:    567 31% riveted       (28/34)         Warding:    442 59% very engaged  (23/34)
         Evasion:    372 43% clear          (0/34)       Athletics:    503 70% clear          (0/34)
      Perception:    428 00% pondering      (7/34)         Stealth:    656 59% clear          (0/34)
    Locksmithing:    551 60% clear          (0/34)        Thievery:    655 29% clear          (0/34)
       First Aid:    427 63% absorbing     (15/34) Outdoorsmanship:    376 45% clear          (0/34)
        Skinning:    431 80% clear          (0/34)        Backstab:    367 79% clear          (0/34)
         Forging:    136 83% clear          (0/34)     Engineering:    136 05% clear          (0/34)
      Outfitting:    136 90% clear          (0/34)         Alchemy:    137 14% clear          (0/34)
      Enchanting:    131 31% clear          (0/34)     Scholarship:    432 88% thoughtful     (4/34)
       Appraisal:    495 93% clear          (0/34)     Performance:    377 46% clear          (0/34)
         Tactics:    327 78% clear          (0/34)

Total Ranks Displayed: 17232
Time Development Points: 74  Favors: 40  Deaths: 8  Departs: 1
Rested EXP Stored: 5:46 hours  Usable This Cycle: 5:46 hours  Cycle Refreshes: 22:51 hours
Overall state of mind: clear
EXP HELP for more information

> 
Total Ranks Gained: 17232

TDPs Gained from Ranks: 17141

TDPs Gained from Circling: 12627

Total TDPs Gained: 29768

Total TDPs spent: 29694

TDPs remaining: 74

TDPs spent per stat

     Strength : 4179             Reflex : 4575

      Agility : 4575           Charisma : 927

   Discipline : 4179             Wisdom : 3540

 Intelligence : 3540            Stamina : 4179

--- Lich: tdps has exited.
```

_proposed tdps code_
```
> ,tdp

--- Lich: tdps active.

Total Ranks Gained: 17232

TDPs Gained from Ranks: 17141

TDPs Gained from Circling: 12627

Total TDPs Gained: 29768

Total TDPs spent: 29694

TDPs remaining: 74

TDPs spent per stat

     Strength : 4179             Reflex : 4575

      Agility : 4575           Charisma : 927

   Discipline : 4179             Wisdom : 3540

 Intelligence : 3540            Stamina : 4179

--- Lich: tdps has exited.
``` 