### PR TITLE
common-crafting - Logic fix in find_empty_crucible

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -13,7 +13,7 @@ module DRCC
   end
 
   def find_empty_crucible(hometown)
-    return unless DRC.bput('tap crucible', 'I could not', 'You tap.*crucible') == 'I could not'
+    return if DRC.bput('tap crucible', 'I could not', /You tap.*crucible/) =~ /You tap.*crucible/ && empty_crucible?
     crucibles = get_data('crafting')['blacksmithing'][hometown]['crucibles']
     idle_room = get_data('crafting')['blacksmithing'][hometown]['idle-room']
     DRCT.find_sorted_empty_room(crucibles, idle_room, proc { (DRRoom.pcs - DRRoom.group_members).empty? && empty_crucible? })


### PR DESCRIPTION
Current behavior:

If you're already in a room with a crucible when this method is called, it only tries to tap a crucible to verify that one is there.  It does not also check to make sure it's empty.