### PR TITLE
Update makesteel.lic

### DIFF
--- a/makesteel.lic
+++ b/makesteel.lic
@@ -5,16 +5,11 @@
 custom_require.call(%w[common common-crafting common-items common-money common-travel drinfomon])
 
 class MakeSteel
-  include DRC
-  include DRCC
-  include DRCI
-  include DRCM
-  include DRCT
 
   def initialize
     arg_definitions = [
       [
-        { name: 'count', regex: /\d/i, description: 'Number of iron ingots to smelt' },
+        { name: 'count', regex: /^(0?[1-9]|1[0-9]|2[0-1])$/, description: 'Number of iron ingots to smelt. (e.g. 1-21)' },
         { name: 'type', options: %w[l m h], optional: true, description: 'Carbon content, defaults to high' },
         { name: 'refine', regex: /refine/i, optional: true, description: 'If provided, refine the resulting ingot' }
       ]
@@ -26,35 +21,20 @@ class MakeSteel
     @settings = get_settings
     @stock_room = get_data('crafting')['blacksmithing'][@settings.hometown]['stock-room']
 
-    ensure_copper_on_hand(2000 * total_count, @settings)
+    DRCM.ensure_copper_on_hand(2000 * total_count, @settings)
 
-    combine = total_count > 6
-    remaining_count = total_count
-    while remaining_count > 0
-      step = [6, remaining_count].min
-      smelt_ingot(step, type)
-      remaining_count -= step
-    end
-
-    if combine
-      until bput('get my steel ingot', 'You get', 'What were') == 'What were'
-        fput('put ingot in cruc')
-      end
-      wait_for_script_to_complete('smelt')
-      fput('stow ingot')
-    end
+    smelt_ingot(total_count, type)
 
     refine if args.refine
   end
 
   def refine
     DRCT.order_item(get_data('crafting')['blacksmithing'][@settings.hometown]['finisher-room'], 9) unless exists?('flux')
-    find_empty_crucible(@settings.hometown)
-    until bput('get my steel ingot', 'You get', 'What were') == 'What were'
-      bput('put ingot in cruc', 'You put')
-    end
-    wait_for_script_to_complete('smelt', ['refine'])
-    fput('stow ingot')
+    DRCC.find_empty_crucible(@settings.hometown)
+    DRCI.get_item('steel ingot')
+    DRC.bput('put my steel ingot in crucible', /You put your.*in the.*crucible\./)
+    DRC.wait_for_script_to_complete('smelt', ['refine'])
+    DRCI.stow_item?('ingot')
   end
 
   def smelt_ingot(count, type)
@@ -65,30 +45,42 @@ class MakeSteel
       order_stow(2) if type == 'h'
     end
 
-    find_empty_crucible(@settings.hometown)
+    DRCC.find_empty_crucible(@settings.hometown)
 
     multiplier = case type
                  when 'l'
-                   2
+                   1
                  when 'm'
-                   3
+                   2
                  when 'h'
-                   4
+                   3
                  end
 
     (count * multiplier).times do
-      fput('get my nugget')
-      fput('put my nugget in cruc')
-      pause 0.5
+      DRCI.get_item('coal nugget')
+      case DRC.bput('put my nugget in crucible', /You put your.*in the.*crucible\./, /You decide that smelting such a volume of metal at once would be dangerous/)
+      when /You decide that smelting such a volume of metal at once would be dangerous/
+        DRC.message("*** An error has occurred, too much metal in crucible. ***")
+        exit
+      end
     end
 
-    wait_for_script_to_complete('smelt')
-    fput('stow ingot')
+    count.times do
+      DRCI.get_item('iron nugget')
+      case DRC.bput('put my nugget in cruc', /You put your.*in the.*crucible\./, /You decide that smelting such a volume of metal at once would be dangerous/)
+      when /You decide that smelting such a volume of metal at once would be dangerous/
+        DRC.message("*** An error has occurred, too much metal in crucible. ***")
+        exit
+      end
+    end
+
+    DRC.wait_for_script_to_complete('smelt')
+    DRCI.stow_item?('ingot')
   end
 
   def order_stow(num)
     DRCT.order_item(@stock_room, num)
-    fput('stow nugget')
+    DRCI.stow_item?('nugget')
   end
 end
 


### PR DESCRIPTION
Currently takes the total volume request and breaks it down into 60 volume chunks, makes each of those, and then combines all of those ingots together.
This takes way too much time and also there is no protection against a user asking for more than the maximum volume a crucible will hold.

```
~~~snipped out the smelting of multiple 60 volume ingots ~~~
[makesteel]>get my steel ingot
You get a steel ingot from inside your traveler's pack.
[makesteel]>put ingot in cruc
You put your ingot in the granite crucible.
[makesteel]>get my steel ingot
You get a steel ingot from inside your traveler's pack.
[makesteel]>put ingot in cruc
You put your ingot in the granite crucible.
[makesteel]>get my steel ingot
Finesse  (10 roisaen)
You get a steel ingot from inside your traveler's pack.
[makesteel]>put ingot in cruc
You put your ingot in the granite crucible.
[makesteel]>get my steel ingot
You get a steel ingot from inside your traveler's pack.
[makesteel]>put ingot in cruc
You decide that smelting such a volume of metal at once would be dangerous, and stop.
Roundtime: 2 sec.
[makesteel]>get my steel ingot
You are already holding that.
[makesteel: *** No match was found after 15 seconds, dumping info]
[makesteel: messages seen length: 3]
[makesteel: message:  * Timekeeper Aspirant Selesthiel shrugs off grasping tentacles as he arrives from a yawning abyss.]
[makesteel: message: Finesse  (10 roisaen)]
[makesteel: message: You are already holding that.]
[makesteel: checked against [/You get/i, /What were/i]]
[makesteel: for command get my steel ingot]
[makesteel]>put ingot in cruc
```

While I was editing the script I changed some fputs to bputs, and others to use the common-items methods for getting and stowing stuff.
I also added the module prefixes to all commands and removed the includes.