### PR TITLE
[script] [combat-trainer] Stop releasing cyclics just to cast them again.

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1644,6 +1644,7 @@ class SpellProcess
                        .select { |_name, data| data['expire'] ? Flags["ct-#{data['abbrev']}"] : true }
                        .select { |name, _data| check_buff_conditions?(name, game_state) }
                        .select { |_name, data| data['starlight_threshold'] ? enough_starlight?(game_state, data) : true }
+                       .reject { |name, data | data['cyclic'] && DRSpells.active_spells.include?(data['name']) }
 
     name, data = recastable_buffs.find do |name, data|
       if data['pet_type']


### PR DESCRIPTION
I pre-cast my debil cyclics, and combat trainer kept releasing them, just to cast them again.

```
 [combat-trainer]>release HYH                                                                                                                                                                                                                 
 The deadening murk around you subsides.                                                                                                                                                                                                      
 [combat-trainer]>prepare HYH 6                                                                                                                                                                                                               
 You begin chanting a mantra to invoke the Hydra Hex spell.  
```

It was driving me mad. This PR stops the above from happening.

If you have a cyclic buff in your prehunt_buff waggle, it will no longer get released by combat trainer when it starts up...

Let's wait a good 24h + to merge this, after it's been reviewed, and deemed ready. 

Note it's tested on a bard, and a cleric here, working perfectly. 