### PR TITLE
[scripts] [drinfomon] [bootstrap] [dependency] Wait for `drinfomon` to initialize before start other scripts

### DIFF
--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -3,6 +3,8 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#bootstrap
 =end
 
+$BOOTSTRAP_VERSION = '1.0.1'
+
 class_defs = {
   'drinfomon' => :DRINFOMON,
   'equipmanager' => :EquipmentManager,

--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -58,7 +58,7 @@ if args.wipe_constants
   exit
 end
 
-scripts_to_run = args.flex
+scripts_to_run = args.flex || []
 echo scripts_to_run.to_s if UserVars.bootstrap_debug
 until scripts_to_run.empty?
   script_to_run = scripts_to_run.shift

--- a/bootstrap.lic
+++ b/bootstrap.lic
@@ -3,9 +3,27 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#bootstrap
 =end
 
-class_defs = { 'equipmanager' => :EquipmentManager, 'common' => :DRC, 'common-travel' => :DRCT, 'common-crafting' => :DRCC, 'common-summoning' => :DRCS, 'common-money' => :DRCM, 'common-arcana' => :DRCA, 'common-items' => :DRCI, 'common-healing' => :DRCH, 'common-validation' => :CharacterValidator, 'common-moonmage' => :DRCMM, 'common-theurgy' => :DRCTH }
+class_defs = {
+  'drinfomon' => :DRINFOMON,
+  'equipmanager' => :EquipmentManager,
+  'common' => :DRC,
+  'common-travel' => :DRCT,
+  'common-crafting' => :DRCC,
+  'common-summoning' => :DRCS,
+  'common-money' => :DRCM,
+  'common-arcana' => :DRCA,
+  'common-items' => :DRCI,
+  'common-healing' => :DRCH,
+  'common-validation' => :CharacterValidator,
+  'common-moonmage' => :DRCMM,
+  'common-theurgy' => :DRCTH
+}
 
-arg_definitions = [[{ name: 'wipe_constants', regex: /wipe_constants/i, optional: true }]]
+arg_definitions = [
+  [
+    { name: 'wipe_constants', regex: /wipe_constants/i, optional: true }
+  ]
+]
 
 args = parse_args(arg_definitions, true)
 
@@ -44,13 +62,23 @@ until scripts_to_run.empty?
   script_to_run = scripts_to_run.shift
   respond("BS:#{script_to_run}:#{scripts_to_run}") if UserVars.bootstrap_debug
   next if (!class_defs[script_to_run] && Script.running?(script_to_run)) || (class_defs[script_to_run] && constant_defined?(class_defs[script_to_run]))
-  respond("BS:Running #{script_to_run}") if UserVars.bootstrap_debug
+  respond("BS:starting:#{script_to_run}") if UserVars.bootstrap_debug
   exit unless verify_script(scripts_to_run)
   start_script(script_to_run)
   pause 0.05
   snapshot = Time.now
   if class_defs[script_to_run]
-    pause 0.05 until constant_defined?(class_defs[script_to_run]) && !Script.running?(script_to_run)
+    # Most of the scripts we wait on are common utility scripts.
+    # They run and define a bunch of methods then end. Awesome.
+    # `drinfomon` is different and has a continuous background loop,
+    # so it's an "always on" script. But we also need to wait for it
+    # to have run long enough to parse and define some core data.
+    # Therefore, our condition on how long to wait for `drinfomon`
+    # is just until the constant has been defined, otherwise we'd wait forever.
+    # Alternatively, `drinfomon` could be refactored where the background loop
+    # is in a script separate from what initially parses exp/info so it behaves
+    # like the common scripts, but that seemed more stressful/risky than this change.
+    pause 0.05 until constant_defined?(class_defs[script_to_run]) && (!Script.running?(script_to_run) || script_to_run == 'drinfomon')
     pause 0.05
   else
     until !Script.running?(script_to_run) || Time.now - snapshot > 0.25

--- a/dependency.lic
+++ b/dependency.lic
@@ -176,7 +176,6 @@ class ScriptManager
     Settings['autostart'] ||= []
     Settings['autostart'].uniq!
     Settings['autostart'] = Settings['autostart'] - ['dependency', 'drinfomon']
-    Settings['autostart'] = ['drinfomon'] + Settings['autostart']
 
     Settings['base_versions'] ||= {}
     CharSettings['next_ruby_version_check_datetime'] = Time.now
@@ -1390,7 +1389,7 @@ end
 def custom_require
   lambda do |script_names|
     script_names = [script_names] unless script_names.is_a?(Array)
-    respond("CR - starting:#{script_names}") if UserVars.bootstrap_debug
+    respond("CR:starting:#{script_names}") if UserVars.bootstrap_debug
     bootstrapper = force_start_script('bootstrap', script_names)
     pause 0.05
     while Script.running.include?(bootstrapper)

--- a/dependency.lic
+++ b/dependency.lic
@@ -171,11 +171,10 @@ class ScriptManager
     @lich_url = 'https://api.github.com/repos/dragon-realms/dr-lich/git/trees/master'
     UserVars.autostart_scripts ||= []
     UserVars.autostart_scripts.uniq!
-    UserVars.autostart_scripts = UserVars.autostart_scripts - ['dependency', 'drinfomon']
-    UserVars.autostart_scripts = ['drinfomon'] + UserVars.autostart_scripts
+    UserVars.autostart_scripts = UserVars.autostart_scripts - ['dependency']
     Settings['autostart'] ||= []
     Settings['autostart'].uniq!
-    Settings['autostart'] = Settings['autostart'] - ['dependency', 'drinfomon']
+    Settings['autostart'] = Settings['autostart'] - ['dependency']
 
     Settings['base_versions'] ||= {}
     CharSettings['next_ruby_version_check_datetime'] = Time.now

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.2'
+$DEPENDENCY_VERSION = '1.4.3'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -1307,6 +1307,17 @@ check_ltb_info.call
 check_played.call
 check_exp_all.call
 
+# Wait for exp/info to have been parsed before we continue
+# otherwise scripts that rely on this data will error.
+pause 0.05 while DRSkill.list.empty?
+# Note, while dead we cannot check your info, so we skip in that scenario.
+# If you're alive, we wait til a reasonable sample of info has been populated.
+# Race and Guild represent the start of info lines, Favors and TDPs represent the end.
+pause 0.05 while !dead? && (DRStats.race.nil? || DRStats.guild.nil? || DRStats.favors.nil? || DRStats.tdps.nil?)
+# Formally signal that we've loaded so that other scripts can start.
+# See `bootstrap` script for more details about the constants logic.
+Object.const_set(:DRINFOMON, true) unless constant_defined?(:DRINFOMON)
+
 # Start loop to process incoming data.
 while line = script.gets
   begin
@@ -1428,8 +1439,8 @@ while line = script.gets
       end
     end
     # If we don't know the character's guild yet, keep checking.
-    # The polling interval reduces spamming commands while new characters
-    # work on joining a guild or while commoners thrive guildless.
+    # The polling interval reduces spamming commands while we wait
+    # for your dead body to be resurrected so that we can run `info` again.
     if DRStats.guild.nil? && !dead? && (Time.now - info_check_time > info_check_interval)
       check_exp_all.call
       check_info.call

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.14'
+$DRINFOMON_VERSION = '2.0.15'
 
 no_kill_all
 no_pause_all

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2171,6 +2171,7 @@ skill_recorder_check_exp_mods: false
 
 # The number of seconds the `drinfomon` script waits
 # between checking your info and experience until it detects your guild.
-# The script usually picks it up near instantly upon login, but for
-# new characters or long-term commoners then this throttles the periodic check.
+# The script usually picks it up near instantly upon login unless you're dead.
+# The polling interval reduces spamming commands while we wait
+# for your dead body to be resurrected so that we can run `info` again.
 drinfomon_passive_delay: 30


### PR DESCRIPTION
### Background
* Because Lich scripts are run in a multi-threaded environment, we encounter race conditions.
* One of the highest chances to encounter the race conditions is at login when scripts are autostarting.
* Occasionally, a script that depends on `drinfomon` may end up starting while `drinfomon` is in the middle of parsing experience/info/played/etc and that script errors because DRSkill or DRStats is not yet initialized.
  - @BinuDR and @MahtraDR can reproduce this race condition when autostarting `tdps` script
* `bootstrap` already has a mechanism to wait for a script to initialize before it starts the next script, we can use that for `drinfomon`.

### Changes
* Add new constant `:DRINFOMON` to `bootstrap` to hook into its "initialization wait" logic
* Add checks to `drinfomon` to wait until we reasonably think DRSkill and DRStats are initialized then define the `:DRINFOMON` constant
* Remove `drinfomon` from Lich autostarts so that it only exists in `dependency`'s custom autostarts (this is an attempt to further mitigate race conditions by funneling the logic through dependency and bootstrap)