### PR TITLE
[script][ranger-companion] Fix failure to unpause_all

### DIFF
--- a/ranger-companion.lic
+++ b/ranger-companion.lic
@@ -7,7 +7,6 @@ custom_require.call(%w[common drinfomon])
 no_pause_all
 
 class Companion
-  include DRC
 
   def initialize
     unless DRStats.ranger?
@@ -15,7 +14,7 @@ class Companion
       exit
     end
 
-    case bput('whistle for companion', 'Your lips are too dry', 'wolf scrambles in', 'raccoon scrambles in', 'You whistle a merry tune', 'wolf perks', 'You whistle loudly for your companion', 'purse your lips to call')
+    case DRC.bput('whistle for companion', 'Your lips are too dry', 'wolf scrambles in', 'raccoon scrambles in', 'You whistle a merry tune', 'wolf perks', 'You whistle loudly for your companion', 'purse your lips to call')
     when 'purse your lips to call'
       exit
     end
@@ -30,49 +29,47 @@ class Companion
       # A baby wolf stands up then paces back and forth nervously.
       # A baby wolf paces back and forth.
       if line =~ /^.*wolf( stands up then|) paces back and forth*/
-        case bput('pet wolf', 'You pet your baby wolf', 'Touch what', 'wolf shies away from you')
+        case DRC.bput('pet wolf', 'You pet your baby wolf', 'Touch what', 'wolf shies away from you')
         # Matches when there are 2 wolves in the room
         when 'wolf shies away from you'
-          bput('pet second wolf', 'You pet your baby wolf', 'Touch what', 'wolf shies away from you')
+          DRC.bput('pet second wolf', 'You pet your baby wolf', 'Touch what', 'wolf shies away from you')
         end
       end
       # A baby raccoon stands up then paces back and forth nervously.
       # A baby raccoon paces back and forth.
       # TODO: Find messaging when there's multiple raccoons in one room.
       if line =~ /^.*raccoon( stands up then|) paces back and forth*/
-        bput('pet raccoon', 'You pet', 'Touch what')
+        DRC.bput('pet raccoon', 'You pet', 'Touch what')
       end
       if line =~ /^A .* wolf begins to whimper./
-        pause 1 until pause_all
+        pause 1 until DRC.pause_all
         waitrt?
-        bput('stow left', 'Stow what', 'You put')
-        case bput('get my milk', 'You get', 'You are already holding', 'What were you referring to')
+        DRC.bput('stow left', 'Stow what', 'You put')
+        case DRC.bput('get my milk', 'You get', 'You are already holding', 'What were you referring to')
         when 'What were you referring to'
-          bput('signal companion to sleep', 'wolf wanders off to find', 'Your companion is not', 'You have no companion', 'snapping your fingers')
+          DRC.bput('signal companion to sleep', 'wolf wanders off to find', 'Your companion is not', 'You have no companion', 'snapping your fingers')
           exit
         end
-        case bput('feed my milk to wolf', 'The baby wolf greedily drinks', "It doesn't seem hungry", "You can't feed with", 'wolf shies away from you')
+        case DRC.bput('feed my milk to wolf', 'The baby wolf greedily drinks', "It doesn't seem hungry", "You can't feed with", 'wolf shies away from you')
         when 'wolf shies away from you'
-          bput('feed my milk to second wolf', 'The baby wolf greedily drinks', "It doesn't seem hungry", "You can't feed with", 'wolf shies away from you')
+          DRC.bput('feed my milk to second wolf', 'The baby wolf greedily drinks', "It doesn't seem hungry", "You can't feed with", 'wolf shies away from you')
         when "You can't feed with"
-          bput('signal companion to sleep', 'wolf wanders off to find', 'Your companion is not', 'You have no companion', 'snapping your fingers')
+          DRC.bput('signal companion to sleep', 'wolf wanders off to find', 'Your companion is not', 'You have no companion', 'snapping your fingers')
           exit
         end
-        bput('stow my milk', 'You put your', 'Stow what')
-        unpause_all
+        DRC.bput('stow my milk', 'You put your', 'Stow what')
       end
       next unless line =~ /^A .* raccoon begins to whimper./
-      pause 1 until pause_all
+      pause 1 until DRC.pause_all
       waitrt?
-      bput('stow left', 'Stow what', 'You put')
-      case bput('get my corn', 'You get', 'You are already holding', 'What were you referring to')
+      DRC.bput('stow left', 'Stow what', 'You put')
+      case DRC.bput('get my corn', 'You get', 'You are already holding', 'What were you referring to')
       when 'What were you referring to'
-        bput('signal companion to sleep', 'raccoon wanders off to find a quiet place to sleep.')
+        DRC.bput('signal companion to sleep', 'raccoon wanders off to find a quiet place to sleep.')
         exit
       end
-      bput('feed my corn to raccoon', 'raccoon greedily eats')
-      bput('stow my corn', 'You put your', 'Stow what')
-      unpause_all
+      DRC.bput('feed my corn to raccoon', 'raccoon greedily eats')
+      DRC.bput('stow my corn', 'You put your', 'Stow what')
     end
   end
 end
@@ -80,6 +77,7 @@ end
 before_dying do
   DRC.bput('signal companion to sleep', 'wolf wanders off to find', 'Your companion is not', 'You have no companion', 'snapping your fingers', 'quiet place to sleep')
   DRC.bput('signal companion to hunt', 'suddenly catches a scent', 'is too young to hunt', 'Your companion is not', 'You have no companion', 'snapping your fingers')
+  DRC.unpause_all
 end
 
 Companion.new

--- a/ranger-companion.lic
+++ b/ranger-companion.lic
@@ -70,6 +70,7 @@ class Companion
       end
       DRC.bput('feed my corn to raccoon', 'raccoon greedily eats')
       DRC.bput('stow my corn', 'You put your', 'Stow what')
+      DRC.unpause_all
     end
   end
 end


### PR DESCRIPTION
Resolves #5563

The script uses `pause_all` in various spots while handling the ranger companion, but fails to `unpause_all` after certain `if` blocks wherein the script exits.

Migrated multiple instances of `unpause_all` to a single call in `before_dying`. Also removed the DRC include in favor of properly prefixed DRC methods.

Tested locally but not exhaustively. The companion system sucks so it's not especially inspiring to dig into, sorry to say.