### PR TITLE
[script][drinfomon] Fix regex bug when room pc is using pyre

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -544,7 +544,7 @@ end
 def find_pcs(room_players)
   room_players.sub(/ and (.*)$/) { ", #{Regexp.last_match(1)}" }
               .split(', ')
-              .map { |obj| obj.sub(/ (who|whose body) (has|is|appears|glows) .+/, '').sub(/ \(.+\)/, '') }
+              .map { |obj| obj.sub(/ (who|whose body)? ?(has|is|appears|glows) .+/, '').sub(/ \(.+\)/, '') }
               .map { |obj| obj.strip.scan(/\w+$/).first }
 end
 


### PR DESCRIPTION
I happened to notice one day that `hunting-buddy` was not honoring my friend list and kept passing up a hunting room that clearly had a PC in it that was a member of my friend list.

```
Also here: Floofer is surrounded by swirling flames and Fluffy.
Obvious paths: north, south.
```

Some testing with `;e echo DRRoom.pcs` showed that it was not properly parsing this post flavor text. The existing regex expects `WHO is surrounded by swirling flames`. This may be the only buff that doesn't use "who".

Fixed the regex:

Existing regex:
```
>;drroom-test
--- Lich: drroom-test active.
[drroom-test: Parsing: Floofer is surrounded by swirling flames and Fluffy]
[drroom-test: ["flames", "Fluffy"]]
--- Lich: drroom-test has exited.
```

Fixed regex:
```
>;drroom-test
--- Lich: drroom-test active.
[drroom-test: Parsing: Floofer is surrounded by swirling flames and Fluffy]
[drroom-test: ["Floofer", "Fluffy"]]
--- Lich: drroom-test has exited.
```