### PR TITLE
Fix common healing to work when diseased but no wounds

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -24,7 +24,7 @@ module DRCH
     diseased = false
     poisoned = false
 
-    DRC.bput('health', 'You have', 'You feel somewhat tired and seem to be having trouble breathing')
+    DRC.bput('health', 'You have', 'You feel somewhat tired and seem to be having trouble breathing', 'Your wounds')
     pause 0.5
     health_lines = reget(50).map(&:strip).reverse
 


### PR DESCRIPTION
I found that common healing does not handle the case when you are diseased but have no wounds and the infection is not dormant.

It looks like this in game:
`Your body feels at full strength.
Your spirit feels full of life.
 
Your wounds are infected.`
