### PR TITLE
[script] [drinfomon] [exp-monitor] Track learning rate increases only

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.15'
+$DRINFOMON_VERSION = '2.0.16'
 
 no_kill_all
 no_pause_all

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -795,12 +795,6 @@ regex_exp_columns = /(\s*(?<skill>[\w\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\
 # <output class=""/>
 # ---
 exp_hook = proc do |server_string|
-  # This conditional is for the `exp-monitor` script.
-  if UserVars.echo_exp && (server_string =~ regex_flag_briefexp_on || server_string =~ regex_flag_briefexp_off)
-    skill = Regexp.last_match[:skill]
-    DRSkill.gained_skills << skill
-  end
-
   # These sections are parsing xml tags sent to experience window.
   # The game sends these tags automatically and we don't need
   # to conditionally parse them based on value of `parsing_exp_output`.
@@ -810,6 +804,12 @@ exp_hook = proc do |server_string|
     rank = Regexp.last_match[:rank]
     rate = Regexp.last_match[:rate] # already a number
     percent = Regexp.last_match[:percent]
+    # This conditional is for the `exp-monitor` script.
+    old_rate = DRSkill.getxp(skill)
+    rate_change = rate - old_rate
+    if UserVars.echo_exp && rate_change > 0
+      DRSkill.gained_skills << { skill: skill, change: rate_change }
+    end
     DRSkill.update(skill, rank, rate, percent)
     # Show to the right of the experience learning rate the gained ranks this session.
     if UserVars.track_exp || UserVars.track_exp.nil?
@@ -830,6 +830,12 @@ exp_hook = proc do |server_string|
     rate_word = Regexp.last_match[:rate]
     rate = learning_rates.index(rate_word) # convert word to number
     percent = Regexp.last_match[:percent]
+    # This conditional is for the `exp-monitor` script.
+    old_rate = DRSkill.getxp(skill)
+    rate_change = rate - old_rate
+    if UserVars.echo_exp && rate_change > 0
+      DRSkill.gained_skills << { skill: skill, change: rate_change }
+    end
     DRSkill.update(skill, rank, rate, percent)
     # Show to the right of the experience learning rate the gained ranks this session.
     if UserVars.track_exp

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -301,10 +301,10 @@ class DRSkill
   attr_writer :rank, :exp, :percent, :current, :baseline
 
   def initialize(name, rank, exp, percent)
-    @name = name
-    @rank = rank.to_i
-    @exp = exp.to_i
-    @percent = percent.to_i
+    @name = name # skill name like 'Evasion'
+    @rank = rank.to_i # earned ranks in the skill
+    @exp = exp.to_i # learning rate in the skill from 0 to 34
+    @percent = percent.to_i # percent to next rank from 0 to 100
     @baseline = rank.to_i + (percent.to_i / 100.0)
     @current = rank.to_i + (percent.to_i / 100.0)
     @skillset = lookup_skillset(@name)
@@ -317,18 +317,41 @@ class DRSkill
     @@list.each { |skill| skill.baseline = skill.current }
   end
 
+  # Primarily used by `learned` script to track how long it's
+  # been tracking your experience gains this session.
   def self.start_time
     @@start_time
   end
 
+  # List of skills that have increased their learning rates.
+  # Primarily used by `exp-monitor` script to echo which skills
+  # gained experience after you performed an action.
   def self.gained_skills
     @@gained_skills
   end
 
+  # Returns the amount of ranks that have been gained since
+  # the baseline was last reset. This allows you to track
+  # rank gain for a given play session.
+  #
+  # Note, don't confuse the 'exp' in this method name with DRSkill.getxp(..)
+  # which returns the current learning rate of the skill.
   def self.gained_exp(val)
     skill = self.find_skill(val)
     if skill
       return skill.current ? (skill.current - skill.baseline).round(2) : 0.00
+    end
+  end
+
+  # Updates DRStats.gained_skills if the learning rate increased.
+  # The original consumer of this data is the `exp-monitor` script.
+  def self.handle_exp_change(name, new_exp)
+    return unless UserVars.echo_exp
+
+    old_exp = DRSkill.getxp(name)
+    change = new_exp.to_i - old_exp.to_i
+    if change > 0
+      DRSkill.gained_skills << { skill: name, change: change }
     end
   end
 
@@ -337,6 +360,7 @@ class DRSkill
   end
 
   def self.update(name, rank, exp, percent)
+    self.handle_exp_change(name, exp)
     skill = self.find_skill(name)
     if skill
       skill.rank = rank.to_i
@@ -804,12 +828,6 @@ exp_hook = proc do |server_string|
     rank = Regexp.last_match[:rank]
     rate = Regexp.last_match[:rate] # already a number
     percent = Regexp.last_match[:percent]
-    # This conditional is for the `exp-monitor` script.
-    old_rate = DRSkill.getxp(skill)
-    rate_change = rate - old_rate
-    if UserVars.echo_exp && rate_change > 0
-      DRSkill.gained_skills << { skill: skill, change: rate_change }
-    end
     DRSkill.update(skill, rank, rate, percent)
     # Show to the right of the experience learning rate the gained ranks this session.
     if UserVars.track_exp || UserVars.track_exp.nil?
@@ -830,12 +848,6 @@ exp_hook = proc do |server_string|
     rate_word = Regexp.last_match[:rate]
     rate = learning_rates.index(rate_word) # convert word to number
     percent = Regexp.last_match[:percent]
-    # This conditional is for the `exp-monitor` script.
-    old_rate = DRSkill.getxp(skill)
-    rate_change = rate - old_rate
-    if UserVars.echo_exp && rate_change > 0
-      DRSkill.gained_skills << { skill: skill, change: rate_change }
-    end
     DRSkill.update(skill, rank, rate, percent)
     # Show to the right of the experience learning rate the gained ranks this session.
     if UserVars.track_exp

--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -5,7 +5,7 @@ custom_require.call(['drinfomon'])
 
 UserVars.echo_exp = true
 UserVars.echo_exp_time ||= 1
-DRSkill.gained_skills.shift(DRSkill.gained_skills.size).uniq
+DRSkill.gained_skills.clear
 
 before_dying do
   # Turn off setting when script stops otherwise drinfomon script will
@@ -15,7 +15,8 @@ before_dying do
 end
 
 loop do
-  new_skills = DRSkill.gained_skills.shift(DRSkill.gained_skills.size).uniq
-  respond("  Gained: #{new_skills.join(', ')}") unless new_skills.empty?
+  new_skills = DRSkill.gained_skills.shift(DRSkill.gained_skills.size)
+  new_skills = new_skills.map { |gain| "#{gain[:skill]}(+#{gain[:change]})" }
+  respond("Gained: #{new_skills.join(', ')}") unless new_skills.empty?
   pause UserVars.echo_exp_time
 end


### PR DESCRIPTION
### Background
* The `exp-monitor` script is for echoing when you increased your learning rate in a skill so you can easily correlate an action to ROI
* The `drinfomon` script, which monitors for exp pulses, pushes data to `DRSkill.gained_skills` that `exp-monitor` relies on.
* However, the `drinfomon` script was not distinguishing between an exp pulse for new experience vs drained experience, which made it difficult to understand what the output even meant.

### Changes
* Update `drinfomon` to only push data to `DRSkill.gained_skills` if the learning rate indeed increased, and also pass along what that delta change was.
* Update `exp-monitor` to show the experience learning rate change along with the skill (which also mirrors how Genie's EXPTracker plugin does it too)

### Test
```
> collect rock
You manage to collect a pile of rocks.
Roundtime: 15 sec.

Gained: Outdoorsmanship(+2), Perception(+1)
```

I'm a Genie user, so I'm testing the change by ensuring the output from EXPTracker plugin (though I may be on a customized variant of the plugin) matches `exp-monitor` script. So far, it's spot on.

![image](https://user-images.githubusercontent.com/68095633/154832430-e8bcd044-d0a3-40d9-9b1c-dbcb2ff415fa.png)

![image](https://user-images.githubusercontent.com/68095633/154832455-fd1a0ae0-2535-493d-b04c-581f82e0c560.png)
