### PR TITLE
[script] [common-arcana] abort cast if invisibility/hiding blocks you

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -151,7 +151,7 @@ module DRCA
     when 'Your desire to prepare this offensive spell suddenly slips away'
       pause 1
       return prepare?(abbrev, mana, symbiosis, command, tattoo_tm, runestone_name, runestone_tm)
-    when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now', 'You have no idea how to cast that spell', 'You have yet to receive any training in the magical arts', 'Please don\'t do that here'
+    when 'Something in the area interferes with your spell preparations', 'You shouldn\'t disrupt the area right now', 'You have no idea how to cast that spell', 'You have yet to receive any training in the magical arts', 'Please don\'t do that here', 'You cannot use the tattoo while maintaining the effort to stay hidden'
       DRC.bput('release symbiosis', 'You release the', 'But you haven\'t') if symbiosis
       return false
     when 'Well, that was fun'
@@ -863,7 +863,7 @@ module DRCA
     result = DRC.bput("pathway sense", *charge_levels)
     charge_levels.find_index { |pattern| pattern =~ result }
   end
-  
+
   # check which symbiotic research is active
   def perc_symbiotic_research
     case DRC.bput('perceive', /combine the weaves of the (\w+) symbiosis/, /Roundtime/)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -137,6 +137,7 @@ prep_messages:
 - You bring your hands together and slowly spread them apart
 - Focusing intently, you trace a
 - Please don't do that here
+- You cannot use the tattoo while maintaining the effort to stay hidden
 
 cast_messages:
 - You clench your fists


### PR DESCRIPTION
### Background
* While invisible, I am unable to invoke my magical tattoo to prepare a spell.
* There is no match string for the error message and got the "no match found after 15 seconds" error.

```
[buff]>invoke my tattoo 3
You cannot use the tattoo while maintaining the effort to stay hidden.
I> 
[buff: *** No match was found after 15 seconds, dumping info]
... snip ...
[buff: message: You cannot use the tattoo while maintaining the effort to stay hidden.]
```

### Changes
* Add match string for `You cannot use the tattoo while maintaining the effort to stay hidden`

### Test
```
,buff dmrs
--- Lich: buff active.
[buff]>release mana
You aren't harnessing any mana.
I> 
[buff]>invoke my tattoo 3
You cannot use the tattoo while maintaining the effort to stay hidden.
I> 
--- Lich: buff has exited.
```