### PR TITLE
Fix perc when backlashed

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2483,7 +2483,7 @@ class TrainerProcess
     when /^PercMana$/i
       moon_mage_perc(game_state)
     when /^Perc$/i
-      bput('perc', 'You reach out') unless game_state.retreating?
+      bput('perc', 'You reach out', 'Strangely, you can sense absolutely nothing.') unless game_state.retreating?
     when /^Perc Health$/i
       bput('perc heal', 'You close your eyes')
     when /^Astro$/i


### PR DESCRIPTION
I found that if you backlash sorcery and get the attunement one that it doesn't match anything and times out. I added the perc message for when this occurs to the list of matches.

The message you get is:
[combat-trainer]>perc
Strangely, you can sense absolutely nothing.

Before:
Tries to perc, no match, times out

After:
It has a match now and proceeds