### PR TITLE
[script] [bescort] add logic to help swim to cave trolls

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -226,8 +226,12 @@ class Bescort
       ],
       [
         { name: 'galley', regex: /galley/i, description: "Take the M'riss-Mer'Kresh galley." },
-        { name: 'mode', options: %w[mriss merkresh], description: "mriss or merkresh?  Can also be started on the galley."  }
-      ]  
+        { name: 'mode', options: %w[mriss merkresh], description: "mriss or merkresh?  Can also be started on the galley." }
+      ],
+      [
+        { name: 'cave_trolls', regex: /cave_trolls/i, description: "Enter the cave trolls hunting area beyond the stream." },
+        { name: 'mode', options: %w[enter exit], description: "Enter or exit?" }
+      ],
     ]
 
     args = parse_args(arg_definitions)
@@ -305,6 +309,8 @@ class Bescort
       currach(args.mode)
     elsif args.galley
       take_m_m_galley(args.mode)
+    elsif args.cave_trolls
+      cave_trolls(args.mode)
     end
   end
 
@@ -350,6 +356,32 @@ class Bescort
         exit
       end
     end
+  end
+
+  def cave_trolls(mode)
+    flying_mount = @settings.flying_mount
+    @equipment_manager.empty_hands
+    have_changed_gear = flying_mount ? false : @equipment_manager.wear_equipment_set?('swimming')
+    case mode.downcase
+    when /enter/
+      start_room = 19089
+      moveset = %w[southeast southeast southeast]
+    when /exit/
+      start_room = 15759
+      moveset = %w[northwest northwest northwest]
+    end
+    manual_go2(start_room)
+    move('go stream bank')
+    if flying_mount
+      use_flying_mount(flying_mount, 'mount')
+      move(moveset.first)
+    else
+      moveset.each { |dir| swim(dir) }
+    end
+    use_flying_mount(flying_mount, 'dismount') if flying_mount
+    move('go stream bank')
+    @equipment_manager.empty_hands
+    @equipment_manager.wear_equipment_set?('standard') if have_changed_gear
   end
 
   def take_m_m_galley(mode)

--- a/bescort.lic
+++ b/bescort.lic
@@ -359,9 +359,6 @@ class Bescort
   end
 
   def cave_trolls(mode)
-    flying_mount = @settings.flying_mount
-    @equipment_manager.empty_hands
-    have_changed_gear = flying_mount ? false : @equipment_manager.wear_equipment_set?('swimming')
     case mode.downcase
     when /enter/
       start_room = 19089
@@ -372,6 +369,9 @@ class Bescort
     end
     manual_go2(start_room)
     move('go stream bank')
+    flying_mount = @settings.flying_mount
+    @equipment_manager.empty_hands
+    have_changed_gear = flying_mount ? false : @equipment_manager.wear_equipment_set?('swimming')
     if flying_mount
       use_flying_mount(flying_mount, 'mount')
       move(moveset.first) # mount travels all three rooms at once
@@ -379,9 +379,9 @@ class Bescort
       moveset.each { |dir| swim(dir) }
     end
     use_flying_mount(flying_mount, 'dismount') if flying_mount
-    move('go stream bank')
     @equipment_manager.empty_hands
     @equipment_manager.wear_equipment_set?('standard') if have_changed_gear
+    move('go stream bank')
   end
 
   def take_m_m_galley(mode)

--- a/bescort.lic
+++ b/bescort.lic
@@ -374,7 +374,7 @@ class Bescort
     move('go stream bank')
     if flying_mount
       use_flying_mount(flying_mount, 'mount')
-      move(moveset.first)
+      move(moveset.first) # mount travels all three rooms at once
     else
       moveset.each { |dir| swim(dir) }
     end

--- a/bescort.lic
+++ b/bescort.lic
@@ -369,6 +369,7 @@ class Bescort
     end
     manual_go2(start_room)
     move('go stream bank')
+    # Once in the stream then you're in a safe room, get mount or remove gear.
     flying_mount = @settings.flying_mount
     @equipment_manager.empty_hands
     have_changed_gear = flying_mount ? false : @equipment_manager.wear_equipment_set?('swimming')
@@ -379,9 +380,12 @@ class Bescort
       moveset.each { |dir| swim(dir) }
     end
     use_flying_mount(flying_mount, 'dismount') if flying_mount
+    # While in the stream then you're in a safe room, dismount or wear gear.
     @equipment_manager.empty_hands
     @equipment_manager.wear_equipment_set?('standard') if have_changed_gear
     move('go stream bank')
+    # You're now among cave trolls!
+    # The cave is dark; you'll need a light source!
   end
 
   def take_m_m_galley(mode)

--- a/bescort.lic
+++ b/bescort.lic
@@ -232,6 +232,9 @@ class Bescort
 
     args = parse_args(arg_definitions)
 
+    @settings = get_settings
+    @equipment_manager = EquipmentManager.new(@settings)
+
     pause
 
     if args.wilds
@@ -337,7 +340,7 @@ class Bescort
       case type
       when /broom|dirigible/i
         bput('dismount', /Your .* floats down to the ground/, /You climb off/)
-        EquipmentManager.new.empty_hands
+        @equipment_manager.empty_hands
       when /carpet|rug/i
         bput('dismount', /Your .* floats down to the ground/, /You climb off/)
         bput("roll #{type}", /You roll up/, /You can't roll/)
@@ -354,7 +357,7 @@ class Bescort
       echo 'You are not at the galley docks, or on the galley.'
       return
     end
-    
+
     #if you're on the mer'kresh side, check for money (no bank in m'riss.  you're screwed without funds)
     if (Room.current.id == 6555)
       if wealth("Mer'Kresh") < 120  #enough to go over and back 2x
@@ -369,7 +372,7 @@ class Bescort
       if (Room.current.id == 6555 && mode == 'merkresh') || (Room.current.id == 6656 && mode == 'mriss')
         echo "You're there."
         exit
-      
+
       #Not there, but at the transport waiting room
       elsif Room.current.id == 6555 || Room.current.id == 6656
         echo 'waiting for transport'
@@ -384,7 +387,7 @@ class Bescort
         when 'You hand him your lirums and climb aboard'
           pause 1 #allow catch up
         end
-      
+
       #Not there, but on the transport
       elsif ["[[The Galley Cercorim]]","[[The Galley Sanegazat]]"].include?(DRRoom.title)
         echo 'waiting for dock'
@@ -935,7 +938,7 @@ class Bescort
   end
 
   def faldesu(mode)
-    flying_mount = get_settings.flying_mount
+    flying_mount = @settings.flying_mount
     unless mode =~ /haven|crossing/i
       echo 'You must specify haven or crossing for traversing the faldesu river'
       exit
@@ -948,11 +951,11 @@ class Bescort
 
     if UserVars.athletics >= 140
       unless UserVars.athletics >= 300
-        EquipmentManager.new.empty_hands
-        EquipmentManager.new.wear_equipment_set?('swimming')
+        @equipment_manager.empty_hands
+        @equipment_manager.wear_equipment_set?('swimming')
       end
       swim_faldesu(mode =~ /haven/i)
-      EquipmentManager.new.wear_equipment_set?('standard') unless UserVars.athletics >= 300
+      @equipment_manager.wear_equipment_set?('standard') unless UserVars.athletics >= 300
     else
       take_rh_ferry(mode =~ /haven/i)
     end
@@ -966,7 +969,7 @@ class Bescort
 
     path = mode == 'shard' ? $ICE_PATH_SHARD : $ICE_PATH_HIB
 
-    EquipmentManager.new.empty_hands
+    @equipment_manager.empty_hands
     settings = get_settings
     footwear = settings.footwear
     move_fast = false
@@ -1043,7 +1046,7 @@ class Bescort
   end
 
   def swim_faldesu(north)
-    flying_mount = get_settings.flying_mount
+    flying_mount = @settings.flying_mount
     start = north ? 1375 : 473
     manual_go2(start)
     moveset = north ? %w[north northwest northeast] : %w[south southwest southeast]
@@ -1059,7 +1062,7 @@ class Bescort
       end
       move 'go bridge'
       use_flying_mount(flying_mount, 'dismount')
-      EquipmentManager.new.empty_hands
+      @equipment_manager.empty_hands
     else
       swim(moveset[0]) while XMLData.room_exits.include?(moveset[0])
       swim(moveset[1]) while XMLData.room_exits.include?('east')
@@ -1265,7 +1268,7 @@ class Bescort
       elsif XMLData.room_title.include?('The Fangs of Ushnish')
           wander_maze_until('steep cliff', 'climb cliff')
           manual_go2(13_625)
-      else  
+      else
         echo('Must start at Gate of Souls, room number 1784, or within the Fangs of Ushnish Area')
         exit
       end
@@ -1336,9 +1339,9 @@ class Bescort
   end
 
   def segoltha(mode)
-    flying_mount = get_settings.flying_mount
-    EquipmentManager.new.empty_hands
-    have_changed_gear = flying_mount ? false : EquipmentManager.new.wear_equipment_set?('swimming')
+    flying_mount = @settings.flying_mount
+    @equipment_manager.empty_hands
+    have_changed_gear = flying_mount ? false : @equipment_manager.wear_equipment_set?('swimming')
     move_count = 0
     if mode =~ /^n/i
       dir_of_travel = 'north'
@@ -1401,7 +1404,7 @@ class Bescort
       end
       move_count += 1
     end
-    EquipmentManager.new.wear_equipment_set?('standard') if have_changed_gear
+    @equipment_manager.wear_equipment_set?('standard') if have_changed_gear
   end
 
   def croc_swamp(mode)
@@ -1842,7 +1845,7 @@ class Bescort
   end
 
   def enter_thief_guild
-    password = get_settings.shard_thief_password
+    password = @settings.shard_thief_password
     bput('knock', 'You knock on the door')
     bput("say #{password}", 'You lean towards the doorway')
     move 'go door'
@@ -1868,7 +1871,7 @@ class Bescort
   end
 
   def get_fare?(amount, town, room)
-    return false unless get_settings.bescort_fare_handling
+    return false unless @settings.bescort_fare_handling
     settings = get_settings
     town_data = get_data('town')
     echo 'GETTING MONEY, YOU SLOB.'
@@ -1890,7 +1893,7 @@ class Bescort
   end
 
   def hide?
-    return false if get_settings.bescort_hide == false
+    return false if @settings.bescort_hide == false
     DRC.hide?
   end
 end


### PR DESCRIPTION
### Dependencies
* Depending on your athletics and whether you have a flying mount, this change is best supported with https://github.com/dragon-realms/dr-lich/pull/69

### Background
* In Dirge, there is one area of [cave trolls](https://elanthipedia.play.net/Cave_troll) that are only accessible by swimming through a fast current, neck deep, stream.
* This PR adds support for swimming the stream as we do for swimming rivers.
* With 505 athletics, it's difficult to swim against the current and requires a lot of retries.
* With 585 athletics, it's navigable and retries are few and far between.
* Note, this area is pitch black; you need a light source.

### Changes
* Add new option `;bescort cave_trolls [enter|exit]` to swim you into, or out of, the cave troll area
* For performance, load settings and equipment manager once per script run

The red-circled section at bottom are the cave trolls accessible by swimming the stream.
![image](https://user-images.githubusercontent.com/68095633/155091977-52504394-8289-4433-94a5-4ffc1f54f308.png)

### Notes
To take advantage of this update, I need to request @Hiinky to help make two room updates in the map:

```diff
  {
    "id": 15759,
    "title": [
      "[[Wicked Burrow Mine, The Depths]]"
    ],
    "description": [
      "A cacophonous rumbling echos all around from the rapid movement of water somewhere above.  The tunnel narrows deeper into the mine."
    ],
    "paths": [
      "Obvious exits: east."
    ],
    "wayto": {
      "15760": "east",
      "15758": "go bank",
+      "19089": ";e start_script('bescort', ['cave_trolls', 'exit']); wait_while{running?('bescort')};"
    },
    "timeto": {
      "15760": 0.2,
      "15758": 0.2,
+      "19089": ";e if UserVars.athletics > 539 && Script.exists?('bescort') then 0.2 else 20.0 end"
    },
    "image": "Zoluren, Wicked Burrow Mine-1.png",
    "image_coords": [
      509,
      468,
      526,
      487
    ]
  },

  ...

  {
    "id": 19089,
    "title": [
      "[[Wicked Burrow Mine, Stream Bank]]"
    ],
    "description": [
      "Water drips and pours from every inch of stone, all headed down the bank and into the fast-moving stream below.  A small bit of light shines in from the west, barely illuminating the barren walls."
    ],
    "paths": [
      "Obvious exits: west."
    ],
    "wayto": {
      "19088": "west",
      "19198": "go bank",
      "12036": ";e multifput('go passage','go hole')",
      "12156": "northwest",
+      "15759": ";e start_script('bescort', ['cave_trolls', 'enter']); wait_while{running?('bescort')};"
    },
    "timeto": {
      "19088": 0.2,
      "19198": 0.2,
      "12036": 0.2,
      "12156": 0.2,
+      "15759": ";e if UserVars.athletics > 539 && Script.exists?('bescort') then 0.2 else 20.0 end"
    },
    "image": "Zoluren, Wicked Burrow Mine-1.png",
    "image_coords": [
      304,
      392,
      321,
      411
    ]
  },
```