### PR TITLE
[script] [drinfomon] tighten up regex patterns; fix logic bug in IF condition

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.18'
+$DRINFOMON_VERSION = '2.0.19'
 
 no_kill_all
 no_pause_all
@@ -765,21 +765,21 @@ balance_values = [
 # The examples below show both variants.
 #
 # FLAG BRIEFEXP ON
-regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[\w\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
+regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[a-zA-Z\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
 # <component id='exp Augmentation'><preset id='whisper'><d cmd='skill Augmentation'>     Aug</d>:  565 39%  [ 2/34]</preset></component>
 # <component id='exp Utility'><d cmd='skill Utility'>    Util</d>:  562 56%  [ 3/34]</component>
 # ---
 # FLAG BRIEFEXP OFF
-regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[\w\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[\w\s]+)\b.*?<\/component>}
+regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
 # <component id='exp Augmentation'><preset id='whisper'>    Augmentation:  565 39% learning     </preset></component>
 # <component id='exp Utility'>         Utility:  562 57% learning     </component>
 # ---
 # Empty mindstate
-regex_exp_clear_mindstate = %r{<component id='exp (?<skill>.*)'><\/component>}
+regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
 # <component id='exp Augmentation'></component>
 # ---
 # EXP ALL
-regex_exp_columns = /(\s*(?<skill>[\w\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\s+(?<rate>[\w\s]+)\b)/
+regex_exp_columns = /(\s*(?<skill>[a-zA-Z\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\s+(?<rate>[a-zA-Z\s]+)\b)/
 # <output class="mono"/>
 # Circle: 80
 # Showing all skills that you have skill in.
@@ -870,7 +870,7 @@ exp_hook = proc do |server_string|
   when /^(Circle: (\d+)|Showing all skills that you have skill in)/
     parsing_exp_output = true
   when regex_exp_columns
-    if parsing_exp_output = true
+    if parsing_exp_output
       server_string.scan(regex_exp_columns) do |skill, rank, percent, rate|
         rate = learning_rates.index(rate) # convert word to number
         DRSkill.update(skill, rank, rate, percent)


### PR DESCRIPTION
### Background
* When `UserVars.track_exp = true` then the script appends the amount of ranks gained per skill this session to the `server_string`.
* This modified string, due to a logic bug with the IF condition, is evaluated and parsed as if it was output from `exp all` (which it wasn't) and calls `DRSkill.update(...)` with an incorrect mindstate value.
* This incorrect mindstate  value causes `exp-monitor` to think that your prior mindstate was 0 and whatever your current mindstate is is the delta and so each pulse prints "Skill Name(+34)" or some erroneously high number.

```
 Gained: Arcana(+34), Performance(+34)
```

### Changes
* First, tighten up the regex patterns to match skill names as letters and spaces, don't mistakenly pick up numbers (which would come from the injected rank gain when `UserVars.track_exp = true`
* Second, fix the flawed IF condition to check if `parsing_exp_output` is the value true, not assign it to true then check

### Tests
@MahtraDR and I collaborated in Discord and tested together.