### PR TITLE
[script][common-arcana] Made prep_time explicit, and added it as an option for ritual spells

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -612,13 +612,8 @@ module DRCA
     cast_lifecycle_lambda.call('post-prep', data, settings) if cast_lifecycle_lambda != nil
 
     if data['prep_time']
-      echo("data['prep_time'] is #{data['prep_time']}")
-      echo("Time.now is #{Time.now}")
-      echo("prepare_time is #{prepare_time}")
-      echo("Time.now - prepare_time is #{Time.now - prepare_time}")
       pause until Time.now - prepare_time >= data['prep_time']
     else
-      echo("echo data[prep_time] is #{data['prep_time']}")
       waitcastrt?
     end
 

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -184,25 +184,31 @@ module DRCA
     name
   end
 
-  def ritual(spell, settings)
-    DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
+  def ritual(data, settings)
+    DRC.retreat(settings.ignored_npcs) unless data['skip_retreat']
     DRC.release_invisibility
     DRC.set_stance('shield')
 
     command = 'prepare'
-    command = spell['prep'] if spell['prep']
-    command = spell['prep_type'] if spell['prep_type']
+    command = data['prep'] if data['prep']
+    command = data['prep_type'] if data['prep_type']
 
-    return unless prepare?(spell['abbrev'], spell['mana'], spell['symbiosis'], command, spell['tattoo_tm'], spell['runestone_name'], spell['runestone_tm'])
-    find_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'], spell['sheathed_focus'])
+    return unless prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
+    prepare_time = Time.now
+    find_focus(data['focus'], data['worn_focus'], data['tied_focus'], data['sheathed_focus'])
 
-    invoke(spell['focus'], nil, nil)
-    stow_focus(spell['focus'], spell['worn_focus'], spell['tied_focus'], spell['sheathed_focus'])
-    DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
+    invoke(data['focus'], nil, nil)
+    stow_focus(data['focus'], data['worn_focus'], data['tied_focus'], data['sheathed_focus'])
+    DRC.retreat(settings.ignored_npcs) unless data['skip_retreat']
 
-    waitcastrt?
-    return unless cast?(spell['cast'], spell['symbiosis'], spell['before'], spell['after'])
-    DRC.retreat(settings.ignored_npcs) unless spell['skip_retreat']
+    if data['prep_time']
+      pause until Time.now - prepare_time >= data['prep_time']
+    else
+      waitcastrt?
+    end
+
+    return unless cast?(data['cast'], data['symbiosis'], data['before'], data['after'])
+    DRC.retreat(settings.ignored_npcs) unless data['skip_retreat']
   end
 
   def prepare_to_cast_runestone?(spell, settings)
@@ -606,8 +612,13 @@ module DRCA
     cast_lifecycle_lambda.call('post-prep', data, settings) if cast_lifecycle_lambda != nil
 
     if data['prep_time']
-      pause 0.1 until checkcastrt.zero? || Time.now - prepare_time >= data['prep_time']
+      echo("data['prep_time'] is #{data['prep_time']}")
+      echo("Time.now is #{Time.now}")
+      echo("prepare_time is #{prepare_time}")
+      echo("Time.now - prepare_time is #{Time.now - prepare_time}")
+      pause until Time.now - prepare_time >= data['prep_time']
     else
+      echo("echo data[prep_time] is #{data['prep_time']}")
       waitcastrt?
     end
 


### PR DESCRIPTION
Prior to this, two things:

1. ritual spells didn't honor `prep_time`
2. `prep_time` was only respected if it was shorter than `waitcastrt?`

With this PR, ritual spells can have `prep_time`, and it is always explicitly honored.

I also normalized the variable call names between the two methods.

I tested this locally using
```
  bloodthorns: &bloodthorns
    Bloodthorns:
      prep_time: 40
      mana: 500
      recast: 5
      focus: emerald.charm
      worn_focus: true
      before:
      - message: spell stance 130 100 70
      after:
      - message: spell stance 130 100 70
```
for rituals, and
```
  rits: &rits
    River in the Sky:
      mana: 23
      prep_time: 40
      cambrinth: [23]
      recast: 2
      cast: cast low
      before:
      - message: spell stance 100 130 70
      after:
      - message: spell stance 100 100 100
``` 
for non-rituals
and setting the `prep_time` tunable to various values. 