### PR TITLE
[script] [exp-monitor] consolidate pulses for the same skill

### DIFF
--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -16,7 +16,16 @@ end
 
 loop do
   new_skills = DRSkill.gained_skills.shift(DRSkill.gained_skills.size)
-  new_skills = new_skills.map { |gain| "#{gain[:skill]}(+#{gain[:change]})" }
+  # Some actions may pulse the same skill multiple times.
+  # When this happens then we aggregate the individual pulses
+  # so that we can report on "Skill(+3)" instead of "Skill(+1), Skill(+1), ..."
+  new_skills = new_skills.reduce(Hash.new) do |result, gain|
+    skill = gain[:skill]
+    value = gain[:change]
+    result[skill] += value
+    result
+  end
+  new_skills = new_skills.keys.map { |skill| "#{skill}(+#{new_skills[skill]})" }
   respond("Gained: #{new_skills.join(', ')}") unless new_skills.empty?
   pause UserVars.echo_exp_time
 end


### PR DESCRIPTION
### Background
* `exp-monitor` script runs periodically to output how many mindstates you increased in which skills, if any.
* When doing multiple actions that earn very quickly (e.g. running through a place that trains athletics) then you might pulse the same skill multiple times in that interval.
* It is ambiguous to players if seeing `Gained: Athletics(+1), Athletics(+1), Athletics(+1)` is legit or a bug.

### Changes
* Consolidate skill pulses to report on the aggregate mindstates that have increased since the last time the script reported information. For example, instead of three +1's for Athletics you'd see one `Athletics(+3)`