### PR TITLE
[script] [drinfomon] match punctuation in encumbrance value

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -1000,7 +1000,7 @@ regex_info_gender_age_circle = /^Gender:\s+\b(?<gender>.+)\b\s+Age:\s+\b(?<age>.
 # Note, in the following regex do not capture 'Concentration' because you'll get your literal amount available, like 419,
 # but what our scripts operate on is the percentage which comes through as an xml tag parsed by the `status_hook`.
 regex_info_stat_value = /(?<stat>Strength|Agility|Discipline|Intelligence|Reflex|Charisma|Wisdom|Stamina|Favors|TDPs)\s+:\s+(?<value>\d+)/
-regex_info_encumbrance = /^\s*Encumbrance\s+:\s+(?<encumbrance>[\w\s'?!]+)/
+regex_info_encumbrance = /^\s*Encumbrance\s+:\s+(?<encumbrance>[\w\s'?!]+)$/
 regex_info_balance = /^(?:You are|\[You're) (?<balance>#{Regexp.union(balance_values)}) balanced?/
 # ---
 info_hook = proc do |server_string|

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.19'
+$DRINFOMON_VERSION = '2.0.20'
 
 no_kill_all
 no_pause_all
@@ -1000,7 +1000,7 @@ regex_info_gender_age_circle = /^Gender:\s+\b(?<gender>.+)\b\s+Age:\s+\b(?<age>.
 # Note, in the following regex do not capture 'Concentration' because you'll get your literal amount available, like 419,
 # but what our scripts operate on is the percentage which comes through as an xml tag parsed by the `status_hook`.
 regex_info_stat_value = /(?<stat>Strength|Agility|Discipline|Intelligence|Reflex|Charisma|Wisdom|Stamina|Favors|TDPs)\s+:\s+(?<value>\d+)/
-regex_info_encumbrance = /^\s*Encumbrance\s+:\s+(?<encumbrance>[\w\s]+)/
+regex_info_encumbrance = /^\s*Encumbrance\s+:\s+(?<encumbrance>[\w\s'?!]+)/
 regex_info_balance = /^(?:You are|\[You're) (?<balance>#{Regexp.union(balance_values)}) balanced?/
 # ---
 info_hook = proc do |server_string|


### PR DESCRIPTION
### Background
* The regex pattern for matching encumbrance values does not match punctuation marks but there's two values that have them "Are you even able to move?" and "It's amazing you aren't squashed!"

### Changes
* Update encumbrance regex to allow punctuation

### Test
https://regex101.com/r/6LstJn/1