### PR TITLE
[script][hunting-buddy] Fix room number re-ordering

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -288,6 +288,9 @@ class HuntingBuddy
 
         # After grabbing the list of hunting zones specified in the user's yaml, we'll iterate
         # through each and aggregate the room numbers from base-hunting.yaml.
+        # NOTE: Be sure to preserve the order we aggregate the room numbers to match the order
+        # of the :zone: list in the yaml. Users expect the :zone: list to be a priority order.
+        # If they list prereni first, they want to try there first.
         zones_to_search.each do |zone|
           rooms_to_search += @hunting_zones["#{zone}"] unless @hunting_zones["#{zone}"] == nil
         end

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -284,7 +284,21 @@ class HuntingBuddy
         return true
       else
         @exit = nil
-        rooms_to_search = @hunting_zones.select { |zone_name, zone_rooms| zones_to_search.include?(zone_name) }.values.flatten.compact
+        rooms_to_search = []
+
+        # After grabbing the list of hunting zones specified in the user's yaml, we'll iterate
+        # through each and aggregate the room numbers from base-hunting.yaml.
+        zones_to_search.each do |zone|
+          rooms_to_search += @hunting_zones["#{zone}"] unless @hunting_zones["#{zone}"] == nil
+        end
+
+        # Make sure our aggregated room list isn't empty. If it is, warn and don't go hunting.
+        if rooms_to_search.empty?
+          DRC.message("Unable to look up hunting rooms for your yaml-specified hunting :zone: list.")
+          DRC.message("Check your yaml syntax and ensure your :zone:'s match base-hunting.yaml.")
+          exit
+        end
+
         return DRCT.find_empty_room(rooms_to_search, waiting_room,
           lambda do |search_attempt|
             # Skip room if has more people than your max limit


### PR DESCRIPTION
An issue was reported in Discord that `hunting-buddy` was choosing "from the bottom" of the yaml `:zone:` list in `hunting_info`.

With some strategic echoes I was able to discover that, while we pull the `:zone:` list from the yaml in proper order, the process of "looking up" the zones in `base-hunting.yaml` is essentially a top-to-bottom lookup, which allows the possibility that the _second_ specified `:zone:` might come _first_ in base-hunting, which then aggregates the roomnumbers for that zone first, sending us hunting to those roomnumbers first.

I was able to recreate the issue by having the following yaml zone list:

```yaml
- :zone:
  - cloud_rats
  - elder_blue_dappled_prereni
```

Because prereni come before cloud rats in base-hunting, those roomnumbers are aggregated first in our final roomnumber array that we use to go search for a hunting room.

Unfortunately, I had a little trouble figuring out how to tweak the existing logic using hash `.select` and `.include?` and still get it to work. So I went a slightly different direction on the solution. I also added a section to warn if our hunting room list is empty.

@KatoakDR @MahtraDR @BinuDR 

If there is a cleaner way to do this and just tweak the existing one-line logic, happy to have that suggested.