### PR TITLE
[scripts] [crossing-repair] Adding force_repair_town override

### DIFF
--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -62,7 +62,7 @@ class CrossingRepair
     amount, denom = settings.sell_loot_money_on_hand.split(' ')
     @keep_copper = DRCM.convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
-    @hometown_data = get_data('town')[settings.hometown]
+    @hometown_data = get_data('town')[settings.force_repair_town] || get_data('town')[settings.hometown]
 
     # Start performance script for some sweet TDPs.
     start_script('performance', ['noclean']) unless settings.instrument

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -17,8 +17,8 @@ class CrossingRepair
 
     args = parse_args(arg_definitions)
     $debug_mode_crossing_repair = args.debug || UserVars.crossing_repair_debug
-    town = DRC.get_town_name(args.town || settings.force_repair_town)
     settings = get_settings
+    town = DRC.get_town_name(args.town || settings.force_repair_town)
 
     # If town argument is not recognized, choosing to exit the script with error
     # instead of continue with the character's hometown because if the player

--- a/crossing-repair.lic
+++ b/crossing-repair.lic
@@ -17,7 +17,7 @@ class CrossingRepair
 
     args = parse_args(arg_definitions)
     $debug_mode_crossing_repair = args.debug || UserVars.crossing_repair_debug
-    town = DRC.get_town_name(args.town)
+    town = DRC.get_town_name(args.town || settings.force_repair_town)
     settings = get_settings
 
     # If town argument is not recognized, choosing to exit the script with error
@@ -62,7 +62,7 @@ class CrossingRepair
     amount, denom = settings.sell_loot_money_on_hand.split(' ')
     @keep_copper = DRCM.convert_to_copper(amount, denom)
     @repair_withdrawal_amount = settings.repair_withdrawal_amount
-    @hometown_data = get_data('town')[settings.force_repair_town] || get_data('town')[settings.hometown]
+    @hometown_data = get_data('town')[settings.hometown]
 
     # Start performance script for some sweet TDPs.
     start_script('performance', ['noclean']) unless settings.instrument

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -544,6 +544,8 @@ safe_room_withdraw_amount: 4_000
 # Amount to deposit back in back after healing (only used if force_healer_town is set)
 safe_room_keep_bank_amount:
 
+# override the repair location to use instead of hometown
+force_repair_town:
 
 # Spellcasting (and Khri) settings
 use_harness_when_arcana_locked: false


### PR DESCRIPTION
Now that all repairers repair everything... I'd like to spread the load on Ylono a bit, and try a quieter place to repair.

Tested with
```yaml
hometown: Shard
force_repair_town: Steelclaw Clan
```
Works for me. Does not accept the short aliases the args accepts, however, but it's in line with the other force_*_town overrides in that respect.