### PR TITLE
[script] [hunting-buddy] Add option to pick a room to go to after hunting-buddy ends instead of default safe-room

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -156,8 +156,8 @@ class HuntingBuddy
       execute_actions(after_actions)
     end
 
-    DRC.message("***STATUS*** Returning to safe room: #{@settings.after_hunt_room}")
-    DRCT.walk_to(@settings.after_hunt_room)
+    DRC.message("***STATUS*** Returning to safe room: #{@after_hunt_room}")
+    DRCT.walk_to(@after_hunt_room)
     EquipmentManager.new(@settings).wear_equipment_set?('standard')
   end
 

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -25,6 +25,7 @@ class HuntingBuddy
 
     # Will deprecate prehunt_buffs tag as a room
     @buff_room = @settings.prehunt_buffing_room || @settings.prehunt_buffs
+    @after_hunt_room = @settings.force_after_hunt_room || @settings.safe_room
 
     hunting_info = []
     if @settings.hunting_file_list || args.flex.any?
@@ -155,8 +156,8 @@ class HuntingBuddy
       execute_actions(after_actions)
     end
 
-    DRC.message("***STATUS*** Returning to safe room: #{@settings.safe_room}")
-    DRCT.walk_to(@settings.safe_room)
+    DRC.message("***STATUS*** Returning to safe room: #{@settings.after_hunt_room}")
+    DRCT.walk_to(@settings.after_hunt_room)
     EquipmentManager.new(@settings).wear_equipment_set?('standard')
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -531,6 +531,9 @@ safe_room_tip_amount:
 safe_room_empath:
 safe_room_empaths:
 
+# override the room you go to when hunting-buddy ends
+force_after_hunt_room:
+
 # override the npc healer to use from hometown
 force_healer_town:
 # Amount to withdraw from bank for healing


### PR DESCRIPTION
Does just what the title says, adds a new field force_after_hunt_room to overwrite where hunting-buddy goes when it ends.

Q: Do I need to add something to validator for this to check it's a number?