### PR TITLE
[script] [hunting-buddy] mitigate thinking room is taken when someone walks by

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -314,7 +314,17 @@ class HuntingBuddy
             return false if (DRRoom.pcs - DRRoom.group_members).any?
             # No visible friends in the room and no visible people
             UserVars.friends.each { |friend| Flags.add("hunting-buddy-room-check-#{friend}", friend) }
-            Flags.add('hunting-buddy-room-check', 'says, ', 'say, ', 'You hear', 'Someone snipes a')
+            Flags.add('hunting-buddy-room-check',
+              # someone speaks
+              /says?, /,
+              /You hear/,
+              # someone attacks from the shadows
+              /Someone snipes a/,
+              /leaps from hiding and ambushes/,
+              # someone is already hunting here
+              /[A-Z][a-z]+ begins to advance/,
+              /[A-Z][a-z]+ (jabs|slices|draws|chops|sweeps|lunges|thrusts|claws|gouges|elbows|kicks|punches|knees|shoves|lobs|throws|hurls|fires|shoots|feints) (a|an|some|his|her|their)/
+            )
             case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
             when /roundtime/i
               data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
@@ -324,12 +334,14 @@ class HuntingBuddy
                 return UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
               end
               fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
+              room_is_empty = true
               20.times do |_|
                 pause 0.5
                 return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
-                return false if Flags['hunting-buddy-room-check'] || !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+                return false if Flags['hunting-buddy-room-check']
+                room_is_empty = !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
               end
-              true
+              room_is_empty
             when /You're not in any condition to be searching around/i
               DRC.message("***STATUS*** You're too injured to hunt!")
               @stop_hunting = true

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -339,7 +339,7 @@ class HuntingBuddy
                 pause 0.5
                 return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
                 return false if Flags['hunting-buddy-room-check']
-                room_is_empty = !(DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+                room_is_empty = (DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
               end
               room_is_empty
             when /You're not in any condition to be searching around/i


### PR DESCRIPTION
### Background
* Fixes https://github.com/rpherbig/dr-scripts/issues/2444

### Changes
* When `hunting-buddy` has found a room and is waiting ~10 seconds to see if the room is available, don't immediately leave just because someone else walked into or through the room. Instead, look for more telling signs like the person engages a critter or attacks.

### Tests
* Recruiting testers in [Discord](https://discord.com/channels/745675889622384681/745675890242879671/947707157850247218)
* I've tested that the logic will move on if someone shows up and attacks in the room; but will claim the room if someone walks through or stands in the room but doesn't attack