### PR TITLE
[script] [wand-watcher] Added additional `activation_blocked_messages` item when too injured

### DIFF
--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -46,7 +46,8 @@ class WandWatcher
                                     /^You shouldn't disrupt the area/,
                                     /^You really shouldn't be loitering in here/,
                                     /^As you begin to do that an assistant scowls at you and motions for you to stop/,
-                                    /^You cannot .* while maintaining the effort to stay hidden/]
+                                    /^You cannot .* while maintaining the effort to stay hidden/,
+                                    /^You are in no condition to do that/]
     UserVars.wand_watcher_timers = {} if !(UserVars.wand_watcher_timers) || args.reset
 
     # Don't allow users to make foolish mistakes, always prevent use during go2/burgle

--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -46,8 +46,7 @@ class WandWatcher
                                     /^You shouldn't disrupt the area/,
                                     /^You really shouldn't be loitering in here/,
                                     /^As you begin to do that an assistant scowls at you and motions for you to stop/,
-                                    /^You cannot .* while maintaining the effort to stay hidden/,
-                                    /^You are in no condition to do that/]
+                                    /^You cannot .* while maintaining the effort to stay hidden/]
     UserVars.wand_watcher_timers = {} if !(UserVars.wand_watcher_timers) || args.reset
 
     # Don't allow users to make foolish mistakes, always prevent use during go2/burgle

--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -171,6 +171,11 @@ class WandWatcher
         redo unless redo_count > count
         # If you run out of wands to try, set next attempt to be 1/2 the cooldown time
         UserVars.wand_watcher_timers[wand] = Time.now + (cooldown / 2)
+      when /^You are in no condition to do that/
+        # Activation failed due to being too injured.
+        # Message the user and push out the retry time a little bit.
+        message "Failed to activate due to being too injured."
+        UserVars.wand_watcher_timers[wand] = Time.now + 60
       when /^You cannot .* while maintaining the effort to stay hidden/
         # Activation failed due to being invisible or hidden.
         # Message the user and push out the retry time a little bit.


### PR DESCRIPTION
/^You are in no condition to do that/
This was reported to not have a match when the user invoking the wand had too high of a wound level (head wound mostly).