### PR TITLE
[script][equipmanager.lic] - Fix wield weapon match failure with hand injury

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -243,7 +243,12 @@ class EquipmentManager
   def get_item?(item)
     return true if DRCI.in_hands?(item)
     if item.wield
-      bput("wield my #{item.short_name}", 'You draw', 'You deftly remove', 'You slip', 'Wield what', 'With a flick of your wrist you stealthily unsheathe') != 'Wield what'
+      case bput("wield my #{item.short_name}", 'You draw', 'You deftly remove', 'You slip', 'With a flick of your wrist you stealthily unsheathe', 'Wield what', 'Your left hand is too injured', 'Your right hand is too injured')
+      when 'Your left hand is too injured', 'Your right hand is too injured', 'Wield what'
+        return false
+      else
+        return true
+      end
     elsif item.transforms_to
       item = item_by_desc(item.transforms_to)
       item.worn ? get_item_helper(item, :worn) : get_item_helper(item, :stowed)

--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -243,8 +243,8 @@ class EquipmentManager
   def get_item?(item)
     return true if DRCI.in_hands?(item)
     if item.wield
-      case bput("wield my #{item.short_name}", 'You draw', 'You deftly remove', 'You slip', 'With a flick of your wrist you stealthily unsheathe', 'Wield what', 'Your left hand is too injured', 'Your right hand is too injured')
-      when 'Your left hand is too injured', 'Your right hand is too injured', 'Wield what'
+      case bput("wield my #{item.short_name}", 'You draw', 'You deftly remove', 'You slip', 'With a flick of your wrist you stealthily unsheathe', 'Wield what', 'Your right hand is too injured', 'Your left hand is too injured')
+      when 'Your right hand is too injured', 'Your left hand is too injured', 'Wield what'
         return false
       else
         return true


### PR DESCRIPTION
Reported via #5637 

This fixes the match hang. I do wonder, though, whether the `wield` verbs balks if you have a bad hand injury, but the `get` verb would still work to get a weapon in your hand?