### PR TITLE
[data] [base-hunting] Adding notes explaining why these rooms are commented out

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1054,7 +1054,7 @@ hunting_zones:
   - 19195
   - 19196
   - 19204
-# - 19193
+# - 19193 # commented out due to extremely low spawn rates in the room
   # https://elanthipedia.play.net/Giant_bear                             210-290
   # Super high spawn
   giant_bears:
@@ -1534,8 +1534,8 @@ hunting_zones:
   - 16541
   - 16542
   - 16543
-  # - 16538
   - 16539
+# - 16538 # commented out due to extremely low spawn rates in the room
   # https://elanthipedia.play.net/Cloud_rat                              325-425
   # same rats - Estate Holder Only
   cloud_rats_hollow:


### PR DESCRIPTION
Adding notes explaining why these were commented out. 

@BinuDR has also mentioned we can get GMs to look at these rooms' spawn rates, and how we might go about that. Will follow that up.