### PR TITLE
[data] [base-hunting] Updating note for cave trolls, and cloud rats

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1054,7 +1054,7 @@ hunting_zones:
   - 19195
   - 19196
   - 19204
-# - 19193 # commented out due to extremely low spawn rates in the room
+# - 19193 # First room, not a spawn room. Confirmed by GMs.
   # https://elanthipedia.play.net/Giant_bear                             210-290
   # Super high spawn
   giant_bears:
@@ -1530,12 +1530,12 @@ hunting_zones:
   # https://elanthipedia.play.net/Cloud_rat                              325-425
   # Ranks estimate based on Creature Level 63-67
   cloud_rats:
+  - 16538
   - 16540
   - 16541
   - 16542
   - 16543
   - 16539
-# - 16538 # commented out due to extremely low spawn rates in the room
   # https://elanthipedia.play.net/Cloud_rat                              325-425
   # same rats - Estate Holder Only
   cloud_rats_hollow:


### PR DESCRIPTION
Spoke with a GM about these rooms.

Confirmed Cave Troll room is not meant to be a spawn room. Keep the comment, updated the note.

Cloud Rats had the room reinstated. That room was erroneously set as a non-spawn room.

Convo link here https://discordapp.com/channels/619301383451181075/831336521620652032/950521974369681419