### PR TITLE
[script] [combat-trainer] Adding match for swapping weapon

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3277,6 +3277,7 @@ class AttackProcess
         /but are unable to draw upon its majesty/, # unable to dual load without ability
         /without steadier hands/, # unable to dual load without ability
         /You can not load .* in your left hand/,
+        /You need to hold the.*in your right hand to load it/,
         /You attempt to ready your/,
         /Push what?/,
         /It's best to hold/,

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3277,7 +3277,7 @@ class AttackProcess
         /but are unable to draw upon its majesty/, # unable to dual load without ability
         /without steadier hands/, # unable to dual load without ability
         /You can not load .* in your left hand/,
-        /You need to hold the.*in your right hand to load it/,
+        /You need to hold the .* in your right hand to load it/,
         /You attempt to ready your/,
         /Push what?/,
         /It's best to hold/,

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3159,7 +3159,7 @@ class AttackProcess
     case result
     when /How can you (poach|snipe)/i
       shoot_aimed('shoot', game_state)
-    when /That weapon must be in your right hand to fire|But you don't have a ranged weapon in your hand to fire with/i
+    when /That weapon must be in your right hand to fire|But you don't have a ranged weapon in your hand to fire with|You need to hold the.*in your right hand to load it/i
       # Explicitly say 'swap right' because if you're holding a swappable weapon (e.g. riste)
       # then just 'swap' will try to switch the weapon mode, not move it to other hand.
       if fput('swap right') =~ /You (swap|move)/i

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3159,7 +3159,7 @@ class AttackProcess
     case result
     when /How can you (poach|snipe)/i
       shoot_aimed('shoot', game_state)
-    when /That weapon must be in your right hand to fire|But you don't have a ranged weapon in your hand to fire with|You need to hold the.*in your right hand to load it/i
+    when /That weapon must be in your right hand to fire|But you don't have a ranged weapon in your hand to fire with/i
       # Explicitly say 'swap right' because if you're holding a swappable weapon (e.g. riste)
       # then just 'swap' will try to switch the weapon mode, not move it to other hand.
       if fput('swap right') =~ /You (swap|move)/i


### PR DESCRIPTION
This is a fun one... The bow started on the right hand. We swapped it to the left, and then couldn't load it because it was in the left hand.

```
[combat-trainer]>shoot
The cloud rat is already quite dead.
You turn to face a silver-grey cloud rat.
That weapon must be in your right hand to fire!
[combat-trainer]>swap right
A silver-grey cloud rat rears back on its hind legs, chittering loudly. 
[combat-trainer]>load my nisha shortbow
You move a mistwood Nisha shortbow to your left hand.
A blunt tip arrow falls from your Nisha shortbow.
You need to hold the Nisha shortbow in your right hand to load it.
[combat-trainer]>load my nisha shortbow
You need to hold the Nisha shortbow in your right hand to load it.
```

This is just part of the fix. The `fput('swap right')` in line 3165 is causing problems, and needs to be made a nice case bput. I'll look into that tomorrow.