### PR TITLE
[script][combat-trainer] Fix weather check match hang

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1910,7 +1910,7 @@ class SpellProcess
       unless moon
         echo "No moon available to cast #{data['abbrev']}" if $debug_mode_ct
 
-        @weather ||= bput('weather', 'inside', 'You glance up at the sky.')
+        @weather ||= bput('weather', 'inside', 'You glance up at the sky.', 'You glance outside')
         if @weather =~ /inside/
           message "*** You're inside and there are no available moons. You're going to have a hard time casting #{data['abbrev']}"
         end


### PR DESCRIPTION
Reported by @mwest152 via #5649 

The combat-trainer weather check is missing a possible game output from the `weather` command. Added.