### PR TITLE
[scripts] [common-theurgy] Making `def wave_incense?` a bit more robust.

### DIFF
--- a/common-theurgy.lic
+++ b/common-theurgy.lic
@@ -201,12 +201,23 @@ module DRCTH
   def wave_incense?(theurgy_supply_container, flint_lighter, target)
     empty_cleric_hands(theurgy_supply_container)
 
-    if !DRCI.get_item?(flint_lighter)
-      DRC.message("Can't find #{flint_lighter} to light incense")
+    unless has_flint?
+      DRC.message("Can't find flint to light")
+      return false
+    end 
+
+    unless has_incense?
+      DRC.message("Can't find incense to light")
+      return false
+    end 
+      
+    unless DRCI.get_item?(flint_lighter)
+      DRC.message("Can't get #{flint_lighter} to light incense")
       return false
     end
-    if !DRCI.get_item?('incense', theurgy_supply_container)
-      DRC.message("Can't find incense to light")
+
+    unless DRCI.get_item?('incense', theurgy_supply_container)
+      DRC.message("Can't get incense to light")
       empty_cleric_hands(theurgy_supply_container)
       return false
     end

--- a/common-theurgy.lic
+++ b/common-theurgy.lic
@@ -223,7 +223,7 @@ module DRCTH
     end
 
     lighting_attempts = 0
-    while DRC.bput('light my incense with my flint', 'nothing happens', 'bursts into flames', 'much too dark in here to do that') == 'nothing happens'
+    while DRC.bput('light my incense with my flint', 'nothing happens', 'bursts into flames', 'much too dark in here to do that', 'What were you referring to?') == 'nothing happens'
       waitrt?
 
       lighting_attempts += 1


### PR DESCRIPTION
We now look for flint, and incense before starting, and exit with meaningful messages if either isn't available.