### PR TITLE
[scripts] [common-arcana] Changing the fput in release_cyclics to a bput

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -58,7 +58,7 @@ module DRCA
     /^The web of shadows twitches one last time and then goes inert/,  # Shadow Web (SHW)
     /^You release your mental hold on the lunar energy that sustains your moongate/,  # Moongate (MG)
     /^The refractive field surrounding you fades away/,  # Steps of Vuan (SOV)
-    /^A glimmering brilliant red sphere suddenly flares with a cold light and vaporizes! /,  # Starlight Sphere (SLS)
+    /^A glimmering brilliant .* sphere suddenly flares with a cold light and vaporizes! /,  # Starlight Sphere (SLS)
     # Trader spells
     /^Your calligraphy of light assailing a black marble gargoyle dulls into nothingness/,  # Arbiter's Stylus (ARS)
     /^The faint .* moonsmoke blows away from your face/,  # Mask of the Moons (MOM)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -15,6 +15,61 @@ $MANA_MAP = {
 module DRCA
   module_function
 
+  @@cyclic_release_success_patterns = [
+    # Ranger spells
+    /^The world seems to accelerate around you as the spirit of the cheetah escapes you/,  # Cheetah Swiftness
+    /^You feel distinctly frail and vulnerable as the spirit of the bear leaves you/,  # Bear Strength
+    /^The forces of nature that you roused are no longer with you/,  # Awaken Forest
+    # Empath spells
+    /^Aesandry Darlaeth loses cohesion, returning your reaction time to normal/,  # Aesandry Darlaeth
+    /^You sense your hold on your Guardian Spirit weaken, then evaporate entirely/,  # Guardian Spirit
+    /^The signs of empathic atrocity escape to the deepest pits of your personality, your touch no longer deadly/,  # Icutu Zaharenela
+    /^The tingling across your body diminishes as you feel the motes of energy fade away/,  # Regenerate
+    # Bard spells
+    /^You sing, purposely warbling some of the held notes for effec/,  # Abandoned Heart (ABAN)
+    /^The final tones of your enchante end with an abrupt flourish that leaves stark silence in its wake/,  # Aether Wolves (AEWO)
+    /^With a rising crescendo in your voice, you reprise the strong lines of the chorus of Albreda's Balm before bringing it to an abrupt conclusion/,  # Albreda's Balm (ALB)
+    /^The final, quiet notes of Blessing of the Fae stir the air gently, and die away/,  # Blessing of the Fae (BOTF)
+    /^The warm air swirling around you stills and begins to cool/,  # Caress of the Sun (CARE)
+    /^A few fleeting, soporific notes tarry in the air before your lullaby slowly dies down like the night receding at Anduwen/,  # Damaris' Lullaby (DALU)
+    /^You no longer feel the clarity of vision you had, as shadows creep across the area/,  # Eye of Kertigen (EYE)
+    /^You let your voice fade even as the pace of Faenella's Grace slows, winding down to a quiet conclusion/,  # Faenella's Grace (FAE)
+    /^The aethereal static subsides, returning your spellcasting abilities to normal/,  # Glythtide's Joy (GJ)
+    /^As your rendition of Hodierna's Lilt winds down to a close, you let each note linger on the air a moment, drawing out the final moment with a reluctance to let the soothing melody fade/,  # Hodierna's Lilt (HODI)
+    /^You build the final notes of Phoenix's Pyre with an upward scale that rises into a steep crescendo, and end with an abrupt silence/,  # Phoenix's Pyre (PYRE)
+    /^The dome of light extinguishes as the final notes of music die away/,  # Sanctuary
+    # Warrior Mage spels
+    /^The dark mantle of aether surrounding you fades away/,  # Aether Cloak (AC)
+    /^You release your connection to the Elemental Plane of Electricity, allowing the static electricity to dissipate/,  # Electrostatic Eddy (EE)
+    /^Your link to the Fire Rain matrix has been severed/,  # Fire Rain (FR)
+    /^The chilling vapor surrounding you dissipates slowly/,  # Rimefang (spell) (RIM)
+    /^The frost-covered blade circling around you shatters into a fine icy mist/,  # Rimefang (spell) (RIM)
+    /^The jagged stone spears surrounding you at .* range tremble slightly, then crumble into a grey dust that is quickly reclaimed by the earth/,  # Ring of Spears (ROS)
+    # Cleric spells
+    /^The deadening murk around you subsides/,  # Hydra Hex (HYH)
+    /^You sense the dark presence depart/,  # Soul Attrition (SA)
+    # Resurrection (REZZ) does not have messaging that makes it usable here.
+    /^The heightened sense of spiritual awareness leaves you/,  # Revelation (REV)
+    /^The swirling fog dissipates from around you/,  # Ghost Shroud (GHS)
+    # Paladin spells
+    /^The holy golden radiance of your soul subsides, retreating into your body/,  # Holy Warrior (HOW)
+    /^Truffenyi's Rally ends, leaving behind a momentary sensation of something stuck in your throat/,  # Truffenyi's Rally (TR)
+    # Moon Mage spells
+    /^The web of shadows twitches one last time and then goes inert/,  # Shadow Web (SHW)
+    /^You release your mental hold on the lunar energy that sustains your moongate/,  # Moongate (MG)
+    /^The refractive field surrounding you fades away/,  # Steps of Vuan (SOV)
+    /^A glimmering brilliant red sphere suddenly flares with a cold light and vaporizes! /,  # Starlight Sphere (SLS)
+    # Trader spells
+    /^Your calligraphy of light assailing a black marble gargoyle dulls into nothingness/,  # Arbiter's Stylus (ARS)
+    /^The faint .* moonsmoke blows away from your face/,  # Mask of the Moons (MOM)
+    # Necromancer spells
+    /^The Rite of Contrition matrix loses cohesion, leaving your aura naked/,  # Rite of Contrition (ROC)
+    /^The Rite of Forbearance matrix loses cohesion, leaving you to wallow in temptation/,  # Rite of Forbearance (ROF)
+    /^The Rite of Grace matrix loses cohesion, leaving your body exposed/,  # Rite of Grace (ROG)
+    /^The greenish hues about you vanish as the Universal Solvent matrix loses its cohesion/  # Universal Solvent (USOL)
+  ]
+ 
+
   def infuse_om(harness, amount)
     return unless DRSpells.active_spells['Osrel Meraud'] && DRSpells.active_spells['Osrel Meraud'] < 90
     return unless amount
@@ -432,7 +487,7 @@ module DRCA
       .select { |name, _properties| DRSpells.active_spells.keys.include?(name) }
       .reject { |name| cyclic_no_release.include?(name) }
       .map { |_name, properties| properties['abbrev'] }
-      .each { |abbrev| fput("release #{abbrev}") }
+      .each { |abbrev| DRC.bput("release #{abbrev}", @@cyclic_release_success_patterns, 'Release what?' ) }
   end
 
   def parse_regalia # generates an array of currently-worn regalia armor nouns

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -60,7 +60,7 @@ module DRCA
     /^The refractive field surrounding you fades away/,  # Steps of Vuan (SOV)
     /^A glimmering brilliant .* sphere suddenly flares with a cold light and vaporizes! /,  # Starlight Sphere (SLS)
     # Trader spells
-    /^Your calligraphy of light assailing a black marble gargoyle dulls into nothingness/,  # Arbiter's Stylus (ARS)
+    /^Your calligraphy of light assailing/,  # Arbiter's Stylus (ARS)
     /^The faint .* moonsmoke blows away from your face/,  # Mask of the Moons (MOM)
     # Necromancer spells
     /^The Rite of Contrition matrix loses cohesion, leaving your aura naked/,  # Rite of Contrition (ROC)


### PR DESCRIPTION
The fput is fine and well, but even with it in combat-trainer, hunting buddy, and t2... sometimes spells don't get released because of RT. 

I considered just adding a `waitrt?`, but I feel this is more reliable.

If anyone can conceive of a different release_failure message message than `Release what?` I'd be happy to add an array of patterns, but if that's the only one, I'd rather keep it this way. Happy to take feedback on this point.