### PR TITLE
[script] [dependency] Changing def add_self_to_autostart

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1621,8 +1621,8 @@ def remove_from_autostart(scripts)
 end
 
 def add_self_to_autostart
-  start_script('autostart', ['add', '--global', File.basename('dependency', '.*')])
-  pause 0.1 while Script.running?('autostart')
+  start_script('autostart', ['add', '--global', 'dependency'])
+  pause while Script.running?('autostart')
 end
 
 def update_d


### PR DESCRIPTION
When we got our lich merged into lich-5, we broke some of their things, and our autostart function as is, depends on some broken functionality. This simplifies the function, makes it explicit, and makes it conform to lich-5 code. 

Reference for our code breaking lich-5 here https://github.com/elanthia-online/lich-5/pull/152