### PR TITLE
[script][ranger-companion.lic] Fix failure to unpause scripts

### DIFF
--- a/ranger-companion.lic
+++ b/ranger-companion.lic
@@ -21,11 +21,13 @@ class Companion
 
     while line = get
       waitrt?
+
       # Dismiss wolf if it grows past the baby stage
       if line =~ /^.*(young|full-grown) wolf (begins|howls|paws|looks|perks|sits|pants|stands|carefully)/
         echo('*** Your companion is too old for this script to work ***')
         exit
       end
+
       # A baby wolf stands up then paces back and forth nervously.
       # A baby wolf paces back and forth.
       if line =~ /^.*wolf( stands up then|) paces back and forth*/
@@ -35,12 +37,14 @@ class Companion
           DRC.bput('pet second wolf', 'You pet your baby wolf', 'Touch what', 'wolf shies away from you')
         end
       end
+
       # A baby raccoon stands up then paces back and forth nervously.
       # A baby raccoon paces back and forth.
       # TODO: Find messaging when there's multiple raccoons in one room.
       if line =~ /^.*raccoon( stands up then|) paces back and forth*/
         DRC.bput('pet raccoon', 'You pet', 'Touch what')
       end
+
       if line =~ /^A .* wolf begins to whimper./
         pause 1 until DRC.pause_all
         waitrt?
@@ -58,16 +62,21 @@ class Companion
           exit
         end
         DRC.bput('stow my milk', 'You put your', 'Stow what')
+        DRC.unpause_all
       end
+
+      # Move to next loop iteration unless we see racoon whimpering
       next unless line =~ /^A .* raccoon begins to whimper./
       pause 1 until DRC.pause_all
       waitrt?
+
       DRC.bput('stow left', 'Stow what', 'You put')
       case DRC.bput('get my corn', 'You get', 'You are already holding', 'What were you referring to')
       when 'What were you referring to'
         DRC.bput('signal companion to sleep', 'raccoon wanders off to find a quiet place to sleep.')
         exit
       end
+
       DRC.bput('feed my corn to raccoon', 'raccoon greedily eats')
       DRC.bput('stow my corn', 'You put your', 'Stow what')
       DRC.unpause_all


### PR DESCRIPTION
Fix failure to unpause after feeding a wolf milk. Also provide some visual separation between code blocks. Tested with a wolf and `;sanowret-crystal` running. This script properly paused, and unpaused.

```yaml
>
A baby wolf begins to whimper.
>
--- Lich: sanowret-crystal paused.
[ranger-companion]>stow left
Stow what?  Type 'STOW HELP' for details.
>
[ranger-companion]>get my milk
You get a bottle of fresh milk from inside your canvas backpack.
>
[ranger-companion]>feed my milk to wolf
The baby wolf greedily drinks a bottle of fresh milk.
>
[ranger-companion]>stow my milk
You put your milk in your canvas backpack.
>
--- Lich: sanowret-crystal unpaused.
```