### PR TITLE
[scripts] [dependency] Returning if trying to run autostart from within autostart

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1666,7 +1666,7 @@ def validate_supported_ruby_version
 end
 
 def remove_from_autostart(scripts)
-  return while Script.running?('autostart')
+  return if Script.running?('autostart')
   scripts.each do |script|
     start_script('autostart', ['remove', '--global', File.basename(script, '.*')])
     pause 0.1 while Script.running?('autostart')
@@ -1676,7 +1676,7 @@ def remove_from_autostart(scripts)
 end
 
 def add_self_to_autostart
-  return while Script.running?('autostart')
+  return if Script.running?('autostart')
   start_script('autostart', ['add', '--global', 'dependency'])
   pause while Script.running?('autostart')
 end

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.5'
+$DEPENDENCY_VERSION = '1.4.6'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all

--- a/dependency.lic
+++ b/dependency.lic
@@ -1666,6 +1666,7 @@ def validate_supported_ruby_version
 end
 
 def remove_from_autostart(scripts)
+  return while Script.running?('autostart')
   scripts.each do |script|
     start_script('autostart', ['remove', '--global', File.basename(script, '.*')])
     pause 0.1 while Script.running?('autostart')

--- a/dependency.lic
+++ b/dependency.lic
@@ -1675,7 +1675,7 @@ def remove_from_autostart(scripts)
 end
 
 def add_self_to_autostart
-  pause while Script.running?('autostart')
+  return while Script.running?('autostart')
   start_script('autostart', ['add', '--global', 'dependency'])
   pause while Script.running?('autostart')
 end

--- a/dependency.lic
+++ b/dependency.lic
@@ -1675,6 +1675,7 @@ def remove_from_autostart(scripts)
 end
 
 def add_self_to_autostart
+  pause while Script.running?('autostart')
   start_script('autostart', ['add', '--global', 'dependency'])
   pause while Script.running?('autostart')
 end


### PR DESCRIPTION
As part of the lich5 migration, we're autostarting dependency to install when we detect game as DR. These two lines just cause us to not mess up the process if we're being started from within an autostart.

Note, I am happy to make this a bit more involved and add messaging around and whatnot. My goal with this change is purely to make it "just work" with Lich5 now, and once our user base moves over, I'd like to deprecate this function (and a bunch of others we won't use anymore...) anyway. As is, this PR doesn't change existing behaviour, hence I felt ok to make it a silent return. 

The motivator for this change is https://github.com/elanthia-online/lich-5/pull/162/files