### PR TITLE
Update base-lumber.yaml - Update to rakash_forest: roomid fix.

### DIFF
--- a/data/base-lumber.yaml
+++ b/data/base-lumber.yaml
@@ -513,7 +513,8 @@ lumber_buddy_rooms:
   - 3378
   - 3379
   - 3380
-  - 3563
+#  - 3563 #movement issues from 3380 to this room
+  - 3381
   - 3382
   - 3383
   - 3384

--- a/data/base-lumber.yaml
+++ b/data/base-lumber.yaml
@@ -513,7 +513,6 @@ lumber_buddy_rooms:
   - 3378
   - 3379
   - 3380
-#  - 3563 #movement issues from 3380 to this room
   - 3381
   - 3382
   - 3383


### PR DESCRIPTION
I had some room movement issues between 3380 and 3563. 

[forestry-buddy: Failed to navigate to room 3563, attempting again]

The room it was attempting to is mapped 3381, this fixed my issue.