### PR TITLE
[scripts] [dependency] Dependency kill drinfomon before dying

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.5'
+$DEPENDENCY_VERSION = '1.4.6'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all

--- a/dependency.lic
+++ b/dependency.lic
@@ -1743,6 +1743,7 @@ end
 
 before_dying do
   $moon_watch = nil
+  stop_script('drinfomon') if Script.running?('drinfomon')
 end
 
 $setupfiles.reload


### PR DESCRIPTION
if we don't kill drinfomon, we can start it again when scripts need it. This resolves the obnoxious bootstrap hanging issues. 