### PR TITLE
[scripts] [combat trainer] Streamlining the mat training routine

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2673,12 +2673,7 @@ class TrainerProcess
   end
 
   def pray_mat(game_state)
-    ready_to_mat = (
-      DRCI.exists?(@prayer_mat, @prayer_mat_container) &&
-      DRCI.exists?("wine", @theurgy_supply_container)
-      )
-
-    unless ready_to_mat
+    unless DRCI.exists?(@prayer_mat, @prayer_mat_container)
       DRC.message("*** Cannot run PrayerMat; need prayer mat in prayer_mat_container or in theurgy_supply_container, and wine in theurgy_supply_container")
       @training_abilities.delete('PrayerMat')
       return
@@ -2699,7 +2694,7 @@ class TrainerProcess
     DRC.bput("kiss #{@prayer_mat}", 'You bend forward to kiss')
 
     if DRCI.get_item?("wine", @theurgy_supply_container)
-      DRC.bput("pour wine on #{@prayer_mat}", 'You quietly pour', 'Pour what', 'You set aside')
+      DRC.bput("pour wine on #{@prayer_mat}", { 'timeout' => 2, 'suppress_no_match' => true }, 'You quietly pour', 'Pour what', 'You set aside')
       DRCTH.empty_cleric_hands(@theurgy_supply_container)
     else
       DRC.message("*** Finishing PrayerMat early; Cannot get wine from theurgy_supply_container")

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2674,7 +2674,7 @@ class TrainerProcess
 
   def pray_mat(game_state)
     unless DRCI.exists?(@prayer_mat, @prayer_mat_container)
-      DRC.message("*** Cannot run PrayerMat; need prayer mat in prayer_mat_container or in theurgy_supply_container, and wine in theurgy_supply_container")
+      DRC.message("*** Cannot run PrayerMat; need prayer mat in prayer_mat_container or in theurgy_supply_container")
       @training_abilities.delete('PrayerMat')
       return
     end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2694,6 +2694,11 @@ class TrainerProcess
     DRC.bput("kiss #{@prayer_mat}", 'You bend forward to kiss')
 
     if DRCI.get_item?("wine", @theurgy_supply_container)
+      # We suppress_no_match here, and reduce the timeout because some
+      # wine needs to be blessed to work. If the wine isn't blessed
+      # (when it should be) there is simply no messaging of any kind on
+      # pour. In those instances, it always causes a 15 second hang.
+      # These settings prevent that hand.
       DRC.bput("pour wine on #{@prayer_mat}", { 'timeout' => 2, 'suppress_no_match' => true }, 'You quietly pour', 'Pour what', 'You set aside')
       DRCTH.empty_cleric_hands(@theurgy_supply_container)
     else


### PR DESCRIPTION
Moving the wine check to the spot that needs the wine. Even without wine, we can kiss, and dance.

Making the wine pour not match, and timeout faster because if the wine isn't blessed, there is no messaging of any kind, and always causes a 15 second hang. 