### PR TITLE
[scripts] [dependency] Autostarting DRinfomon as script zero

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.6'
+$DEPENDENCY_VERSION = '1.4.7'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all
@@ -1733,6 +1733,13 @@ end
 full_install if install
 
 force_start_script('bootstrap', ['wipe_constants'])
+
+# Proactively starting DRinfomon as script zero to prevent 
+# race conditions involving this script which so many other 
+# scripts depend on, and which is slow to start on its own
+echo("Starting DRinfomon, this will take a few seconds.")
+custom_require.call('drinfomon')
+echo("DRinfomon ready.")
 
 $manager.check_base_files
 $manager.check_data_files


### PR DESCRIPTION
In discussions with @rcuhljr , @asechrest  and myselffound that DRinfomon is slow to start, and with other scripts depending on it as a dependency, we were hitting the script timeout limit waiting on dependencies. This splits the difference between DRinfomon being a script, and being part of lich, and makes it reliable insofar as other scripts go.