### PR TITLE
[scripts] [drinfomon] Cleaning up when exiting the game

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.21'
+$DRINFOMON_VERSION = '2.0.22'
 
 no_kill_all
 no_pause_all
@@ -1243,7 +1243,7 @@ before_dying do
   DownstreamHook.remove('ltb_info_hook')
   DownstreamHook.remove('played_hook')
   DownstreamHook.remove('status_hook')
-  Object.send(:remove_const, :DRINFOMON)
+  Object.send(:remove_const, :DRINFOMON) if Object.const_defined?(:DRINFOMON)
 end
 
 UpstreamHook.add('drinfomon', drinfomon_upstream_hook)


### PR DESCRIPTION
As a result of having dependency custom_require drinfomon, we now need to clean up when we exit the game.

Prior to this change, on exit:
```
>exit

--- Lich: error: constant Object::DRINFOMON not defined
    drinfomon:1246:in `remove_const'
    drinfomon:1246:in `block in _script'
--- Lich: dependency has exited.
--- Lich: drinfomon has exited.
--- Lich: lnet has exited.
```

Post this change:
```
>exit

--- Lich: 'drinfomon' has been stopped by dependency.
--- Lich: dependency has exited.
--- Lich: drinfomon has exited.
--- Lich: lnet has exited.
```