### PR TITLE
[script][bescort] Add support for asketi's mount traversing (Change 1 of 3)

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -365,10 +365,10 @@ class Bescort
   end
 
   def asketis_mount(mode)
-    if mode.include?('up')
+    if mode == "up"
       while bput("climb up", /^You work your way/i, /^You climb over/, /^You can't do that/i) =~ /^You work your way/i
       end
-    elsif mode.include?('down')
+    elsif mode == "down"
       while bput("climb down", /^You work your way/i, /^You climb down/, /^You can't do that/i) =~ /^You work your way/i
       end
     end

--- a/bescort.lic
+++ b/bescort.lic
@@ -232,6 +232,10 @@ class Bescort
         { name: 'cave_trolls', regex: /cave_trolls/i, description: "Enter the cave trolls hunting area beyond the stream." },
         { name: 'mode', options: %w[enter exit], description: "Enter or exit?" }
       ],
+      [
+        { name: 'asketis_mount', regex: /asketis_mount/i, description: "Climb up or down Asketi's Mount to Black Marble Gargoyles." },
+        { name: 'mode', options: %w[up down], description: "Climb up or climb down?" }
+      ],
     ]
 
     args = parse_args(arg_definitions)
@@ -311,6 +315,8 @@ class Bescort
       take_m_m_galley(args.mode)
     elsif args.cave_trolls
       cave_trolls(args.mode)
+    elsif args.asketis_mount
+      asketis_mount(args.mode)
     end
   end
 
@@ -354,6 +360,16 @@ class Bescort
       else
         message("#{type} is not a valid type of flying mount.")
         exit
+      end
+    end
+  end
+
+  def asketis_mount(mode)
+    if mode.include?('up')
+      while bput("climb up", /^You work your way/i, /^You climb over/, /^You can't do that/i) =~ /^You work your way/i
+      end
+    elsif mode.include?('down')
+      while bput("climb down", /^You work your way/i, /^You climb down/, /^You can't do that/i) =~ /^You work your way/i
       end
     end
   end


### PR DESCRIPTION
Adds support for traversing asketi's mount up and down in the Black Marble Gargoyles area via `bescort`.

This is a part of a series of changes that do the following:

1. Fix some travel failures resulting from the move from Lich4 to Lich5 which arise due to Lich4's overloading of the FalseClass method and Lich5's refusal to do so. These travel failures are best fixed in the map stringprocs but, in the meantime, we'll build in a fix. These fixes will live in `base.yaml` and their implementation will be handled in `;go2` and pass through a DR game and Lich 5+ version check before being deployed, since those still on Lich4 don't need the fix.
2. Allow appropriately skilled users to set custom map wayto stringproc overrides by implementing them in their yaml hierarchy. Said personal wayto overrides will be favored over the base overrides for like-named hash keys. Users who can handle stringproc overrides will be trusted not to break their implementation.

This PR sets the following:

1. Add args and methods to `bescort.lic` to traverse asketi's mount. Subsequent PRs will utilize this method.