### PR TITLE
[data] [base.yaml] [base-empty.yaml] base_stringproc_overrides (Change 2 of 3)

### DIFF
--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -113,3 +113,6 @@ empty_values:
   battle_cries: []
   battle_cry_cycle: []
   cyclic_no_release: []
+  base_wayto_overrides: {}
+  personal_wayto_overrides: {}
+

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2219,3 +2219,21 @@ skill_recorder_check_exp_mods: false
 # The polling interval reduces spamming commands while we wait
 # for your dead body to be resurrected so that we can run `info` again.
 drinfomon_passive_delay: 30
+
+# For Dragonrealms on Lich5 only
+# A change in behavior from Lich4 to Lich5 caused certain ;go2 map wayto movements to fail.
+# This is because of the way the map stringprocs are structured, and the method used to evaluate
+# certain map moves, which involved an arguably dubious overloading of FalseClass on Lich4.
+# The transition to Lich5 makes it necessary to fix some stringprocs as an interim solution, at
+# least until the map can be divested from current control and handled appropriately. This section
+# FIXES via stringproc known map movement failures as a result of the transition to Lich5. A user
+# with the appropriate skill can overload these in their own yaml(s).
+base_wayto_overrides:
+  aksetis_mount_up:
+    start_room: 27558
+    end_room: 31491
+    str_proc: start_script('bescort', ['asketis_mount', 'up']);wait_while{running?('bescort')};
+  aksetis_mount_down:
+    start_room: 27558
+    end_room: 27556
+    str_proc: start_script('bescort', ['asketis_mount', 'down']);wait_while{running?('bescort')};


### PR DESCRIPTION
This is a part of a series of changes that do the following:

1. Fix some travel failures resulting from the move from Lich4 to Lich5 which arise due to Lich4's overloading of the FalseClass method and Lich5's refusal to do so. These travel failures are best fixed in the map stringprocs but, in the meantime, we'll build in a fix. These fixes will live in base.yaml and their implementation will be handled in ;go2 and pass through a DR game and Lich 5+ version check before being deployed, since those still on Lich4 don't need the fix.
2. Allow appropriately skilled users to set custom map wayto stringproc overrides by implementing them in their yaml hierarchy. Said personal wayto overrides will be favored over the base overrides for like-named hash keys. Users who can handle stringproc overrides will be trusted not to break their implementation.

This PR sets the following:

1. Adds empty hashes for new yaml settings `base_wayto_overrides` and `personal_wayto_overrides`.
2. Add base overrides to traverse asketi's mount near Black Margle Gargoyles as a fix for the Lich5 travel hiccup mentioned above. Implementation of this travel fix will be handled within `;go2` and will have a DR game and Lich5+ version check.