### PR TITLE
update_go2_support_custom_stringprocs

### DIFF
--- a/go2.lic
+++ b/go2.lic
@@ -1,86 +1,72 @@
 =begin
 
-   attempts to find the shortest route between any two rooms in the game
-   requires a map database (;repository download-mapdb)
+	Fork of go2- to fix dragging in DR
+	attempts to find the shortest route between any two rooms in the game
+	requires a map database (;repository download-mapdb)
 
-   ;go2 help
+	;go2 help
 
-            author: Tillmen (tillmen@lichproject.org)
-   original author: Shaelun
-              game: any
-              tags: core, movement
-           version: 1.31
-          required: Lich >= 4.6.14
+	         author: Sarvatt
+	original author: Tillmen (tillmen@lichproject.org)
+	           game: DR
+	           tags: core, movement
+	        version: 1.22f
+	       required: Lich >= 4.6.14
 
-   changelog:
-      1.31 (2022-03-10):
-        Merged in DR changes from v1.22f by Sarvatt
-      1.30 (2022-03-03):
-        Added Util.silver_count to replace check_silvers
-        Added support for uid input by prefixing 'u' on a uid number
-      1.29 (2022-02-27):
-        Added tags for collectibles
-      1.28 (2022-01-23):
-        Added tags for postoffice and mail
-      1.27 (2021-10-29):
-        Fix lag check after COMBATANT verb was updated
-      1.26 (2020-10-08):
-        Fix silver check broken by Commageddon
-      1.25 (2019-05-11):
-        Fix DragonRealms auto drag feature (Sarvatt)
-      1.24 (2019-03-03):
-         Updated formatting for ";go2 list" in GSPlat and GSF
+	changelog:
+		1.22f
+			kill room_numbers if running through a room with peer_tags
+		1.21f (2017-11-29):
+			fix DragonRealms drag feature
+		1.21 (2017-10-07):
+			don't try to stand before swimming movements
+		1.20 (2017-09-17):
+			add confluence-hot and confluence-cold targets
+		1.19 (2016-09-24):
+			fix DragonRealms auto drag feature some more
+
 =end
 =begin
-      1.23 (2019-03-03):
-         add setting for using GSPlat old portal system
-      1.22 (2019-02-10):
-         add settings for using Chronomage day passes
-      1.21 (2017-10-07):
-         don't try to stand before swimming movements
-      1.20 (2017-09-17):
-         add confluence-hot and confluence-cold targets
-      1.19 (2016-09-24):
-         fix DragonRealms auto drag feature some more
-      1.18 (2016-09-24):
-         fix DragonRealms auto drag feature somewhat
-      1.17 (2016-09-12):
-         change portal settings to be saved using UserVars
-      1.16 (2016-08-19):
-         add fwi-trinket setting
-      1.15 (2016-04-01):
-         added experimental setting to auto drag in DragonRealms
-      1.14 (2015-07-09):
-         change ice mode setting to be saved using UserVars
-      1.13 (2015-07-09):
-         don't search for the confluence if you're already there
-      1.12 (2015-07-08):
-         don't do a GS lag check in DR
-      1.11 (2015-04-13):
-         add --instability option
-         fix going to a specific room inside the confluence from outside
-      1.10 (2015-04-13):
-         add confluence and instability targets
-      1.9 (2015-02-08):
-         stop using Map.tags
-      1.8 (2015-01-16):
-         fix ";go2 save" bug
-      1.7 (2014-12-11):
-         added stop-for-dead to the help message
-      1.6 (2014-12-10):
-         added stop-for-dead option
-         add settings to list command
-      1.5 (2014-12-04):
-         remove a debug message
-      1.4 (2014-12-04):
-         added delay setting
-         fixed bug with finding silver cost of a path
-      1.3 (2014-11-09):
-         changed typeahead setting to be different for each character
-      1.2 (2014-10-16):
-         don't use typeaheads for first move: makes it easier to find problems
-      1.1 (2014-10-07):
-         only automatically reduce typeahead setting if there's a typeahead message in the buffer
+
+		1.18 (2016-09-24):
+			fix DragonRealms auto drag feature somewhat
+		1.17 (2016-09-12):
+			change portal settings to be saved using UserVars
+		1.16 (2016-08-19):
+			add fwi-trinket setting
+		1.15 (2016-04-01):
+			added experimental setting to auto drag in DragonRealms
+		1.14 (2015-07-09):
+			change ice mode setting to be saved using UserVars
+		1.13 (2015-07-09):
+			don't search for the confluence if you're already there
+		1.12 (2015-07-08):
+			don't do a GS lag check in DR
+		1.11 (2015-04-13):
+			add --instability option
+			fix going to a specific room inside the confluence from outside
+		1.10 (2015-04-13):
+			add confluence and instability targets
+		1.9 (2015-02-08):
+			stop using Map.tags
+		1.8 (2015-01-16):
+			fix ";go2 save" bug
+		1.7 (2014-12-11):
+			added stop-for-dead to the help message
+		1.6 (2014-12-10):
+			added stop-for-dead option
+			add settings to list command
+		1.5 (2014-12-04):
+			remove a debug message
+		1.4 (2014-12-04):
+			added delay setting
+			fixed bug with finding silver cost of a path
+		1.3 (2014-11-09):
+			changed typeahead setting to be different for each character
+		1.2 (2014-10-16):
+			don't use typeaheads for first move: makes it easier to find problems
+		1.1 (2014-10-07):
+			only automatically reduce typeahead setting if there's a typeahead message in the buffer
 
 =end
 
@@ -96,233 +82,281 @@ CharSettings['delay']            =     0 if CharSettings['delay'].nil?
 CharSettings['stop for dead']    = false if CharSettings['stop for dead'].nil?
 
 show_help = proc {
-   output = "\n"
-   output.concat "   #{$lich_char}#{script.name} <target>                Takes you where you want to go using your saved options.\n"
-   output.concat "   #{$lich_char}#{script.name} <options> <target>      Takes you where you want to go, using the given options\n"
-   output.concat "   #{''.rjust($lich_char.length + script.name.length)}                          instead of your saved options.\n"
-   output.concat "   #{$lich_char}#{script.name} <options>               Saves the given options.\n"
-   output.concat "\n"
-   output.concat "   target:\n"
-   output.concat "\n"
-   output.concat "      <target> may be a room number, a custom target, a built-in target,\n"
-   output.concat "       or part of a room title or room description.\n"
-   output.concat "\n"
-   output.concat "   options:\n"
-   output.concat "\n"
-   output.concat "     --typeahead=<#>                         Sets the number of typeahead lines to use.\n"
-   output.concat "     --delay=<#>                             Sets the delay in seconds between movements\n"
-   output.concat "                                              (disables typeahead).\n"
-   if XMLData.game =~ /^GS/
-      output.concat "     --get-silvers=<on|off>                  Sets if #{script.name} has permission to access your bank\n"
-      output.concat "                                              account.\n"
-      output.concat "     --get-return-trip-silvers=<on|off>      Sets if #{script.name} should withdraw enough silvers to\n"
-      output.concat "                                              return from your destination room to your starting room.\n"
-      output.concat "     --ice-mode=<auto|wait|run>              Sets how #{script.name} should deal with rooms that make\n"
-      output.concat "                                              you slip and fall.\n"
-      output.concat "     --stop-for-dead=<on|off>                Pauses the script if you pass a dead person.\n"
-      output.concat "     --shortcut=<on|off>                     Sets if the shortcut to Ta'Vaalor should be used.\n"
-      output.concat "                                              (climbing and/or simming needed)\n"
-      output.concat "     --use-seeking=<on|off>                  Sets if #{script.name} should use Voln symbol of seeking\n"
-      output.concat "                                              when it will shorten your trip.\n"
-      output.concat "     --use-day-pass=<on|off>                 Use a Chronomage day pass to travel between towns in the\n"
-      output.concat "                                              same zone if you have one.\n"
-      output.concat "     --buy-day-pass=<on|off|locations>       Buy a Chronomage day pass if you don't have an unexpired\n"
-      output.concat "                                              one.  get-silvers will also need to be turned on if you\n"
-      output.concat "                                              want to buy one without gold ring credits.  If you only\n"
-      output.concat "                                              want to buy passes for certain locations, specify the\n"
-      output.concat "                                              locations like so:\n"
-      output.concat "                                              ;go2 --buy-day-pass=wl,imt;imt,wl;imt,sol;ill,val;ill,cys\n"
-      output.concat "     --day-pass-container=<container name>   Sets the container where you keep your day passes\n"
-      output.concat "     --instability=<room number>             Use the instability at the given room number to get into\n"
-      output.concat "                                              the Elementla Confluence instead of finding an attuned one.\n"
-      output.concat "     --fwi-trinket=<trinket name>            Use a FWI trinket to get to/from FWI\n"
-      output.concat "     --fwi-trinket=off                       Stop using a FWI trinket\n"
-   elsif XMLData.game =~ /^DR/
-      output.concat "     --drag=<name>                           Attempt to automatically drag someone to your destination\n"
-      output.concat "                                              (this probably won't work)\n"
-   end
-   if XMLData.game =~ /^GSPlat|^GSF/
-      output.concat "     --portals=<on|off>                      Sets if portals should be used.\n"
-   end
-   if XMLData.game =~ /^GSPlat/
-      output.concat "     --old-portals=<on|off>                  Sets if old (dangerous) portals should be used.\n"
-      output.concat "     --portal-pass=<on|off>                  Turn this on if you have a wearable portal pass and don't\n"
-      output.concat "                                              need a portal ticket.\n"
-   end
-   output.concat "\n"
-   output.concat "   other commands:\n"
-   output.concat "\n"
-   output.concat "      #{$lich_char}#{script.name} save <new name>=<target>      Saves a custom target.  <target> can be the same\n"
-   output.concat "      #{''.rjust($lich_char.length + script.name.length)}                                as before, or \"current\" for your current room\n"
-   output.concat "      #{$lich_char}#{script.name} delete <custom target>        Deletes a saved custom target.\n"
-   output.concat "      #{$lich_char}#{script.name} list                          Shows your settings and custom targets.\n"
-   output.concat "      #{$lich_char}#{script.name} targets                       Shows the built-in targets.\n"
-   output.concat "\n"
-   respond output
+	output = "\n"
+	output.concat "   #{$lich_char}#{script.name} <target>                Takes you where you want to go using your saved options.\n"
+	output.concat "   #{$lich_char}#{script.name} <options> <target>      Takes you where you want to go, using the given options\n"
+	output.concat "   #{''.rjust($lich_char.length + script.name.length)}                          instead of your saved options.\n"
+	output.concat "   #{$lich_char}#{script.name} <options>               Saves the given options.\n"
+	output.concat "\n"
+	output.concat "   target:\n"
+	output.concat "\n"
+	output.concat "      <target> may be a room number, a custom target, a built-in target,\n"
+	output.concat "       or part of a room title or room description.\n"
+	output.concat "\n"
+	output.concat "   options:\n"
+	output.concat "\n"
+	output.concat "     --typeahead=<#>                         Sets the number of typeahead lines to use.\n"
+	output.concat "     --delay=<#>                             Sets the delay in seconds between movements\n"
+	output.concat "                                              (disables typeahead).\n"
+	if XMLData.game =~ /^GS/
+		output.concat "     --get-silvers=<on|off>                  Sets if #{script.name} has permission to access your bank\n"
+		output.concat "                                              account.\n"
+		output.concat "     --get-return-trip-silvers=<on|off>      Sets if #{script.name} should withdraw enough silvers to\n"
+		output.concat "                                              return from your destination room to your starting room.\n"
+		output.concat "     --ice-mode=<auto|wait|run>              Sets how #{script.name} should deal with rooms that make\n"
+		output.concat "                                              you slip and fall.\n"
+		output.concat "     --stop-for-dead=<on|off>                Pauses the script if you pass a dead person.\n"
+		output.concat "     --shortcut=<on|off>                     Sets if the shortcut to Ta'Vaalor should be used.\n"
+		output.concat "                                              (climbing and/or simming needed)\n"
+		output.concat "     --use-seeking=<on|off>                  Sets if #{script.name} should use Voln symbol of seeking\n"
+		output.concat "                                              when it will shorten your trip.\n"
+		output.concat "     --instability=<room number>             Use the instability at the given room number to get into\n"
+		output.concat "                                              the Elementla Confluence instead of finding an attuned one.\n"
+		output.concat "     --fwi-trinket=<trinket name>            Use a FWI trinket to get to/from FWI\n"
+		output.concat "     --fwi-trinket=off                       Stop using a FWI trinket\n"
+	elsif XMLData.game =~ /^DR/
+		output.concat "     --drag=<name>                           Attempt to automatically drag someone to your destination\n"
+		output.concat "                                              (this probably won't work)\n"
+	end
+	if XMLData.game =~ /^GSPlat|^GSF/
+		output.concat "     --portals=<on|off>                      Sets if portals should be used.\n"
+	end
+	if XMLData.game =~ /^GSPlat/
+		output.concat "     --portal-pass=<on|off>                  Turn this on if you have a wearable portal pass and don't\n"
+		output.concat "                                              need a portal ticket.\n"
+	end
+	output.concat "\n"
+	output.concat "   other commands:\n"
+	output.concat "\n"
+	output.concat "      #{$lich_char}#{script.name} save <new name>=<target>      Saves a custom target.  <target> can be the same\n"
+	output.concat "      #{''.rjust($lich_char.length + script.name.length)}                             	  as before, or \"current\" for your current room\n"
+	output.concat "      #{$lich_char}#{script.name} delete <custom target>        Deletes a saved custom target.\n"
+	output.concat "      #{$lich_char}#{script.name} list                          Shows your settings and custom targets.\n"
+	output.concat "      #{$lich_char}#{script.name} targets                       Shows the built-in targets.\n"
+	output.concat "\n"
+	respond output
 }
 
+# For Dragonrealms only
+# A change in behavior from Lich4 to Lich5 caused certain ;go2 map wayto movements to fail.
+# This is because of the way the map stringprocs are structured, and the method used to evaluate
+# certain map moves, which involved an arguably dubious overloading of FalseClass on Lich4.
+# The transition to Lich5 makes it necessary to fix some stringprocs as an interim solution, at
+# least until the map can be divested from current owner control and handled appropriately. This code
+# also allows the flexibility to pull custom map wayto overrides from the standard yaml hierarchy.
+if XMLData.game =~ /^DR/
+  # Get yaml settings
+  settings = get_settings
+
+  # Get base wayto overrides. These base map wayto overrides were created to fix some travel hiccups
+  # from converting from Lich4 to Lich5. They are not needed for Lich4 users, so we'll check Lich
+  # version shortly.
+  base_wayto_overrides = settings.base_wayto_overrides
+  personal_wayto_overrides = settings.personal_wayto_overrides
+
+  # Notify user we've detected and are using personal map stringproc overrides
+
+  # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
+  # The reason for favoring personal overrides is that any user who has the ability to create
+  # custom map stringprocs can be trusted to have their customization favored vs. the base overrides.
+  # If they break the functionality, that's on them.
+  if LICH_VERSION[0].to_i >= 5
+    wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
+    echo "Using base.yaml's Lich5+ map wayto stringproc overrides."
+    unless personal_wayto_overrides.empty?
+      echo "Using your personal map wayto stringproc overrides, which take precendence over base."
+    end
+  else
+    wayto_overrides = personal_wayto_overrides
+  end
+
+  # Iterate through the aggregated map wayto overrides from above and set new stringprocs
+  wayto_overrides.each do | key, values |
+    Map.list[values['start_room'].to_i].wayto["#{values['end_room']}"] = StringProc.new("#{values['str_proc']}")
+    echo values['str_proc']
+  end
+end
+
 change_map_vaalor_shortcut = proc { |use_shortcut|
-   unless Map.list.any? { |room| room.timeto.any? { |adj_id,time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }
-      if use_shortcut
-         Room[16745].timeto['16746'] = 15
-         Room[16746].timeto['16745'] = 15
-      else
-         Room[16745].timeto['16746'] = 15000
-         Room[16746].timeto['16745'] = 15000
-      end
-   end
+	unless Map.list.any? { |room| room.timeto.any? { |adj_id,time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }
+		if use_shortcut
+			Room[16745].timeto['16746'] = 15
+			Room[16746].timeto['16745'] = 15
+		else
+			Room[16745].timeto['16746'] = 15000
+			Room[16746].timeto['16745'] = 15000
+		end
+	end
+}
+
+check_silvers = proc {
+	hook_proc = proc { |server_string|
+		if server_string =~ /^\s*Name\:|^\s*Gender\:|^\s*Normal \(Bonus\)|^\s*Strength \(STR\)\:|^\s*Constitution \(CON\)\:|^\s*Dexterity \(DEX\)\:|^\s*Agility \(AGI\)\:|^\s*Discipline \(DIS\)\:|^\s*Aura \(AUR\)\:|^\s*Logic \(LOG\)\:|^\s*Intuition \(INT\)\:|^\s*Wisdom \(WIS\)\:|^\s*Influence \(INF\)\:/
+			nil
+		elsif server_string =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9]+)/
+			DownstreamHook.remove('go2_check_silvers')
+			nil
+		else
+			server_string
+		end
+	}
+	clear
+	DownstreamHook.add('go2_check_silvers', hook_proc)
+	silence_me unless undo_silence = silence_me
+	put 'info'
+	silence_me if undo_silence
+	while (line = get)
+		if line =~ /^\s*Mana\:\s+\-?[0-9]+\s+Silver\:\s+([0-9]+)/
+			silvers = $1.to_i
+			break
+		end
+	end
+	silvers
 }
 
 get_silver_cost = proc { |path|
-   cost = 0
-   path.each_index { |index|
-      Room[path[index]].tags.each { |tag|
-         if tag =~ /^silver-cost:#{path[index+1]}:(.*)$/
-            cost_string = $1
-            if cost_string =~ /^[0-9]+$/
-               cost += cost_string.to_i
-            else
-               cost += StringProc.new(cost_string).call.to_i
-            end
-         end
-      }
-   }
-   cost
+	cost = 0
+	path.each_index { |index|
+		Room[path[index]].tags.each { |tag|
+			if tag =~ /^silver-cost:#{path[index+1]}:(.*)$/
+				cost_string = $1
+				if cost_string =~ /^[0-9]+$/
+					cost += cost_string.to_i
+				else
+					cost += StringProc.new(cost_string).call.to_i
+				end
+			end
+		}
+	}
+	cost
 }
 
 #
 # check for general commands
 #
 if script.vars.empty? or script.vars[0].strip =~ /^help$/i
-   show_help.call
-   exit
+	show_help.call
+	exit
 elsif script.vars[0] =~ /^targets$/i
-   echo 'generating list...'
-   dr_interesting_tags = ["alchemist", "armorshop", "bakery", "bank", "barbarian", "bard", "boutique", "cleric", "clericshop", "empath", "exchange", "fletcher", "forge", "furrier", "gemshop", "general store", "herbalist", "inn", "locksmith", "moonmage", "movers ", "necromancer", "npchealer", "paladin", "pawnshop", "ranger", "smokeshop", "stable", "thief", "town", "trader", "warmage", "weaponshop"] 
-   gs_interesting_tags = [ "advguard", "advguard2", "advguild", "advpickup", "alchemist", "armorshop", "bakery", "bank", "bardguild", "boutique", "chronomage", "clericguild", "clericshop", "collectibles", "consignment", "empathguild", "exchange", "fletcher", "forge", "furrier", "gemshop", "general store", "herbalist", "inn", "locksmith pool", "locksmith", "mail", "movers", "npccleric", "npchealer", "pawnshop", "postoffice", "rangerguild", "smokeshop", "sorcererguild", "sunfist", "town", "voln", "warriorguild", "weaponshop", "wizardguild"  ]
-   town_list = Map.list.find_all { |room| room.tags.include?('town') }
-   town_ids = town_list.collect { |room| room.id }
-   town_hash = Hash.new
-   town_ids.each { |id| town_hash[id] = Array.new }
-   interesting_tags = if XMLData.game =~ /^DR/
-                        dr_interesting_tags
-                      else
-                        gs_interesting_tags
-                      end
-   for tag in interesting_tags
-      for room in Map.list.find_all { |room| room.tags.include?(tag) }
-         if nearest = Room[room.id].find_nearest(town_ids)
-            unless town_hash[nearest].any? { |line| line =~ /^ \- #{tag.ljust(17)} / }
-               town_hash[nearest].push " - #{tag.ljust(17)} #{room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(34)} - #{room.id.to_s.rjust(5)}"
-            end
-         end
-      end
-   end
-   output = "\n"
-   town_list.each { |town_room|
-      output.concat "---------------------------------------------------------------\n"
-      output.concat " - town              #{town_room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(34)} - #{town_room.id.to_s.rjust(5)}\n"
-      output.concat "---------------------------------------------------------------\n"
-      town_hash[town_room.id].sort.each { |thingie|
-         output.concat thingie
-         output.concat "\n"
-      }
-      output.concat "\n"
-   }
-   if XMLData.game =~ /^DR/
-     output.concat "---------------------------------------------------------------\n"
-     output.concat " - Known Nexus Rooms\n"
-     output.concat "---------------------------------------------------------------\n"
-     Map.list.find_all{ |room| room.tags.include?('nexus') }
-                      .each{ |room| output.concat "#{room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(45)} - #{room.id.to_s.rjust(5)}\n" }
-   end
-   respond output
-   exit
+	echo 'generating list...'
+  gs_interesting_tags = ['alchemist', 'consignment', 'bank', 'furrier', 'gemshop', 'herbalist', 'locksmith', 'pawnshop', 'town', 'advguard', 'advguild', 'advpickup', 'armorshop', 'bakery', 'bardguild', 'boutique', 'chronomage', 'clericguild', 'empathguild', 'forge', 'general store', 'npccleric', 'npchealer', 'movers', 'smokeshop', 'sorcererguild', 'warriorguild', 'weaponshop', 'wizardguild', 'advguard2', 'clericshop', 'fletcher', 'rangerguild', 'sunfist', 'voln', 'exchange', 'inn', 'exchange']
+  dr_interesting_tags = ['alchemist', 'bank', 'furrier', 'gemshop', 'herbalist', 'locksmith', 'pawnshop', 'town', 'armorshop', 'bakery', 'bard', 'boutique', 'forge', 'general store', 'npchealer', 'movers', 'smokeshop', 'weaponshop', 'clericshop', 'fletcher', 'exchange', 'inn', 'cleric', 'empath', 'necromancer', 'thief', 'moonmage', 'warmage', 'ranger', 'bard', 'trader', 'barbarian', 'paladin', 'stable' ]
+
+  town_list = Map.list.find_all { |room| room.tags.include?('town') }
+  town_ids = town_list.collect(&:id)
+  town_hash = {}
+  town_ids.each { |id| town_hash[id] = [] }
+  interesting_tags = if XMLData.game == 'DR'
+                       dr_interesting_tags
+                     else
+                       gs_interesting_tags
+                     end
+  for tag in interesting_tags
+		for room in Map.list.find_all { |room| room.tags.include?(tag) }
+			if nearest = Room[room.id].find_nearest(town_ids)
+				unless town_hash[nearest].any? { |line| line =~ /^ \- #{tag.ljust(17)} / }
+					town_hash[nearest].push " - #{tag.ljust(17)} #{room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(34)} - #{room.id.to_s.rjust(5)}"
+				end
+			end
+		end
+	end
+	output = "\n"
+	town_list.each { |town_room|
+		output.concat "---------------------------------------------------------------\n"
+		output.concat " - town              #{town_room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(34)} - #{town_room.id.to_s.rjust(5)}\n"
+		output.concat "---------------------------------------------------------------\n"
+		town_hash[town_room.id].sort.each { |thingie|
+			output.concat thingie
+			output.concat "\n"
+		}
+		output.concat "\n"
+	}
+  if XMLData.game =~ /^DR/
+    output.concat "---------------------------------------------------------------\n"
+    output.concat " - Known Nexus Rooms\n"
+    output.concat "---------------------------------------------------------------\n"
+    Map.list.find_all{ |room| room.tags.include?('nexus') }
+            .each{ |room| output.concat "#{room.title.first.sub(/^\[/, '').sub(/\]$/, '').ljust(45)} - #{room.id.to_s.rjust(5)}\n" }
+  end
+	respond output
+	exit
 elsif script.vars[0] =~ /^list$/i
-   output = "\n"
-   output.concat "settings:\n"
-   output.concat "\n"
-   output.concat "            typeahead: #{CharSettings['typeahead']}"
-   if (CharSettings['typeahead'] > 0) and (CharSettings['delay'] > 0)
-      output.concat " (not used because delay > 0)"
-   end
-   output.concat "\n"
-   output.concat "                delay: #{CharSettings['delay']}\n"
-   output.concat "          get silvers: #{CharSettings['get silvers'] ? 'on' : 'off'}\n"
-   output.concat "   get return silvers: #{CharSettings['get return trip silvers'] ? 'on' : 'off'}\n"
-   output.concat "             ice mode: #{UserVars.mapdb_ice_mode.nil? ? 'auto' : UserVars.mapdb_ice_mode}\n"
-   output.concat "          use seeking: #{CharSettings['use seeking'] ? 'on' : 'off'}\n"
-   output.concat "         use day pass: #{UserVars.mapdb_use_day_pass == 'yes' ? 'on' : 'off'}\n"
-   output.concat "         buy day pass: #{UserVars.mapdb_buy_day_pass.nil? ? 'off' : UserVars.mapdb_buy_day_pass}\n"
-   output.concat "   day pass container: #{UserVars.day_pass_sack.nil? ? '(not set)' : UserVars.day_pass_sack}\n"
-   if XMLData.game =~ /^GS/
-      output.concat "        stop for dead: #{CharSettings['stop for dead'] ? 'on' : 'off'}\n"
-      output.concat "      vaalor shortcut: #{CharSettings['vaalor shortcut'] ? 'on' : 'off'}\n"
-      output.concat "          FWI trinket: #{UserVars.mapdb_fwi_trinket ? UserVars.mapdb_fwi_trinket : '(not set)'}\n"
-   end
-   if XMLData.game =~ /^GSPlat|^GSF/
-      output.concat "          use portals: #{(UserVars.mapdb_use_portals == 'yes') ? 'yes' : 'no'}\n"
-   end
-   if XMLData.game =~ /^GSPlat/
-      output.concat "      use old portals: #{(UserVars.mapdb_use_old_portals == 'yes') ? 'yes' : 'no'}\n"
-   end
-   if XMLData.game =~ /^GSPlat|^GSF/
-      output.concat "     have portal pass: #{(UserVars.mapdb_have_portal_pass == 'yes') ? 'yes' : 'no'}\n"
-   end
-   output.concat "\n"
-   output.concat "custom targets:\n"
-   output.concat "\n"
-   for target_name,target_num in GameSettings['custom targets'].sort
-      output.concat "   #{target_name.ljust(20)} = #{target_num.to_s.rjust(5)}   #{Map[target_num].title.first}\n"
-   end
-   output.concat "\n"
-   respond output
-   exit
+	output = "\n"
+	output.concat "settings:\n"
+	output.concat "\n"
+	output.concat "            typeahead: #{CharSettings['typeahead']}"
+	if (CharSettings['typeahead'] > 0) and (CharSettings['delay'] > 0)
+		output.concat " (not used because delay > 0)"
+	end
+	output.concat "\n"
+	output.concat "                delay: #{CharSettings['delay']}\n"
+	output.concat "          get silvers: #{CharSettings['get silvers'] ? 'on' : 'off'}\n"
+	output.concat "   get return silvers: #{CharSettings['get return trip silvers'] ? 'on' : 'off'}\n"
+	output.concat "             ice mode: #{UserVars.mapdb_ice_mode.nil? ? 'auto' : UserVars.mapdb_ice_mode}\n"
+	output.concat "          use seeking: #{CharSettings['use seeking'] ? 'on' : 'off'}\n"
+	if XMLData.game =~ /^GS/
+		output.concat "        stop for dead: #{CharSettings['stop for dead'] ? 'on' : 'off'}\n"
+		output.concat "      vaalor shortcut: #{CharSettings['vaalor shortcut'] ? 'on' : 'off'}\n"
+		output.concat "          FWI trinket: #{UserVars.mapdb_fwi_trinket ? UserVars.mapdb_fwi_trinket : '(not set)'}\n"
+	end
+	if XMLData.game =~ /^GSPlat|^GSF/
+		output.concat "          use portals: #{(UserVars.mapdb_use_portals == 'yes') ? 'yes' : 'no'}"
+		output.concat "     have portal pass: #{(UserVars.mapdb_have_portal_pass == 'yes') ? 'yes' : 'no'}"
+	end
+	output.concat "\n"
+	output.concat "custom targets:\n"
+	output.concat "\n"
+	for target_name,target_num in GameSettings['custom targets'].sort
+		output.concat "   #{target_name.ljust(20)} = #{target_num.to_s.rjust(5)}   #{Map[target_num].title.first}\n"
+	end
+	output.concat "\n"
+	respond output
+	exit
 elsif script.vars[1] =~ /^save/i
-   unless script.vars[0] =~ /^save (.+?)=(.+)$/
-      echo "error: You're doing it wrong."
-      exit
-   end
-   target_name = $1.strip
-   target = $2.strip
-   if target_name =~ /^\d+$/
-      echo "error: target name can't be just a number."
-      exit
-   end
-   if target =~ /^current$/i
-      unless target_room = Map.current
-         echo 'error: your current room was not found in the map database.'
-         exit
-      end
-   else
-      unless target =~ /^\d+$/ and (target_room = Map[target.to_i])
-         unless target_room = Map[target]
-            echo "error: could not identify the target room"
-            exit
-         end
-      end
-   end
-   custom_targets = (GameSettings['custom targets'] || Hash.new)
-   custom_targets[target_name] = target_room.id
-   GameSettings['custom targets'] = custom_targets
-   echo "custom target saved (#{target_name}->#{target_room.id})"
-   exit
+	unless script.vars[0] =~ /^save (.+?)=(.+)$/
+		echo "error: You're doing it wrong."
+		exit
+	end
+	target_name = $1.strip
+	target = $2.strip
+	if target_name =~ /^\d+$/
+		echo "error: target name can't be just a number."
+		exit
+	end
+	if target =~ /^current$/i
+		unless target_room = Map.current
+			echo 'error: your current room was not found in the map database.'
+			exit
+		end
+	else
+		unless target =~ /^\d+$/ and (target_room = Map[target.to_i])
+			unless target_room = Map[target]
+				echo "error: could not identify the target room"
+				exit
+			end
+		end
+	end
+	custom_targets = (GameSettings['custom targets'] || Hash.new)
+	custom_targets[target_name] = target_room.id
+	GameSettings['custom targets'] = custom_targets
+	echo "custom target saved (#{target_name}->#{target_room.id})"
+	exit
 elsif script.vars[1] =~ /^delete$/i
-   delkey = script.vars[0].sub(/\s*delete\s*/i, '')
-   custom_targets = (GameSettings['custom targets'] || Hash.new)
-   if kilkey = custom_targets.keys.find { |key| key =~ /^#{delkey}$/i } or kilkey = custom_targets.keys.find { |key| key =~ /^#{delkey}/i }
-      custom_targets.delete(kilkey)
-      GameSettings['custom targets'] = custom_targets
-      echo "custom target deleted (#{kilkey})"
-      exit
-   else
-      echo "#{delkey} does not appear to be a custom target"
-      exit
-   end
+	delkey = script.vars[0].sub(/\s*delete\s*/i, '')
+	custom_targets = (GameSettings['custom targets'] || Hash.new)
+	if kilkey = custom_targets.keys.find { |key| key =~ /^#{delkey}$/i } or kilkey = custom_targets.keys.find { |key| key =~ /^#{delkey}/i }
+		custom_targets.delete(kilkey)
+		GameSettings['custom targets'] = custom_targets
+		echo "custom target deleted (#{kilkey})"
+		exit
+	else
+		echo "#{delkey} does not appear to be a custom target"
+		exit
+	end
 elsif script.vars[1] =~ /^reload$/i
-   Map.reload
-   echo  'map data has been reloaded'
-   exit
+	Map.reload
+	echo  'map data has been reloaded'
+	exit
 end
 
 #
@@ -338,68 +372,47 @@ setting_ice_mode                = nil
 setting_fwi_trinket             = nil
 setting_get_silvers             = nil
 setting_use_seeking             = nil
-setting_use_day_pass            = nil
-setting_buy_day_pass            = nil
-setting_day_pass_container      = nil
 setting_stop_for_dead           = nil
 setting_get_return_trip_silvers = nil
 setting_have_portal_pass        = nil
 setting_use_portals             = nil
-setting_use_old_portals         = nil
 setting_instability             = nil
 setting_drag                    = nil
 
 for var in script.vars[1..-1]
-   if var =~ /^(?:\-\-)?typeahead=([0-9]+)$/i
-      setting_typeahead = $1.to_i
-   elsif var =~ /^(?:\-\-)?delay=([0-9\.]+)$/i
-      setting_delay = $1.to_f
-   elsif var =~ /^\-\-instability=([0-9]+)$/i
-      setting_instability = $1.to_i
-   elsif var =~ /^_disable_confirm_$|^--disable-confirm$/i
-      setting_disable_confirm = true
-   elsif var =~ /^--stop-for-dead$/i
-      setting_stop_for_dead = true
-   elsif var =~ /^--stop-for-dead=(on|true|yes|off|false|no)/i
-      setting_stop_for_dead = setting_value[$1]
-   elsif (XMLData.game =~ /^GS/) and var =~ /^(?:\-\-)?shortcut=(on|true|yes|off|false|no)$/i
-      setting_use_vaalor_shortcut = setting_value[$1]
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?ice\-?mode=(auto|wait|run)$/i)
-      setting_ice_mode = $1.downcase
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?get[_\-]?(?:silver|coin)s?=(on|true|yes|off|false|no)$/i)
-      setting_get_silvers = setting_value[$1]
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?use[_\-]?seeking=(on|true|yes|off|false|no)$/i)
-      setting_use_seeking = setting_value[$1]
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^\-\-use[_\-]?day[_\-]?pass=(on|true|yes|off|false|no)$/i)
-      setting_use_day_pass = setting_value[$1]
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^\-\-buy[_\-]?day[_\-]?pass=(.+)$/i)
-      if setting_value[$1]
-         setting_buy_day_pass = setting_value[$1]
-      else
-         setting_buy_day_pass = $1
-         setting_buy_day_pass.split(';').each { |location|
-            if location !~ /^\s*(?:wl,imt|imt,wl|wl,sol|sol,wl|imt,sol|ill,val|val,ill|ill,cys|cys,ill|val,cys|cys,val)\s*$/i
-               echo "warning: Location #{location} is invalid.  Using it anyway."
-            end
-         }
-      end
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^\-\-day[_\-]?pass[_\-]?(?:container|sack)=(.+)$/i)
-      setting_day_pass_container = $1
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?get\-return\-trip\-silvers=(on|true|yes|off|false|no)$/i)
-      setting_get_return_trip_silvers = setting_value[$1]
-   elsif (XMLData.game =~ /^DR/) and (var =~ /^(?:\-\-)?drag=(.+)$/i)
-      setting_drag = $1
-   elsif (XMLData.game =~ /^GSF|^GSPlat/) and (var =~ /^(?:\-\-)?portals?=(on|true|yes|off|false|no)$/i)
-      setting_use_portals = setting_value[$1]
-   elsif (XMLData.game =~ /^GSPlat/) and (var =~ /^(?:\-\-)?old\-portals?=(on|true|yes|off|false|no)$/i)
-      setting_use_old_portals = setting_value[$1]
-   elsif (XMLData.game =~ /^GSPlat/) and (var =~ /^(?:\-\-)?portal\-pass=(on|true|yes|off|false|no)$/i)
-      setting_have_portal_pass = setting_value[$1]
-   elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?fwi\-?trinket=(.+)$/i)
-      setting_fwi_trinket = $1.downcase
-   else
-      target_search_array.push(var)
-   end
+	if var =~ /^(?:\-\-)?typeahead=([0-9]+)$/i
+		setting_typeahead = $1.to_i
+	elsif var =~ /^(?:\-\-)?delay=([0-9\.]+)$/i
+		setting_delay = $1.to_f
+	elsif var =~ /^\-\-instability=([0-9]+)$/i
+		setting_instability = $1.to_i
+	elsif var =~ /^_disable_confirm_$|^--disable-confirm$/i
+		setting_disable_confirm = true
+	elsif var =~ /^--stop-for-dead$/i
+		setting_stop_for_dead = true
+	elsif var =~ /^--stop-for-dead=(on|true|yes|off|false|no)/i
+		setting_stop_for_dead = setting_value[$1]
+	elsif (XMLData.game =~ /^GS/) and var =~ /^(?:\-\-)?shortcut=(on|true|yes|off|false|no)$/i
+		setting_use_vaalor_shortcut = setting_value[$1]
+	elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?ice\-?mode=(auto|wait|run)$/i)
+		setting_ice_mode = $1.downcase
+	elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?get[_\-]?(?:silver|coin)s?=(on|true|yes|off|false|no)$/i)
+		setting_get_silvers = setting_value[$1]
+	elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?use[_\-]?seeking=(on|true|yes|off|false|no)$/i)
+		setting_use_seeking = setting_value[$1]
+	elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?get\-return\-trip\-silvers=(on|true|yes|off|false|no)$/i)
+		setting_get_return_trip_silvers = setting_value[$1]
+	elsif (XMLData.game =~ /^DR/) and (var =~ /^(?:\-\-)?drag=(.+)$/i)
+		setting_drag = $1
+	elsif (XMLData.game =~ /^GSF|^GSPlat/) and (var =~ /^(?:\-\-)?portals?=(on|true|yes|off|false|no)$/i)
+		setting_use_portals = setting_value[$1]
+	elsif (XMLData.game =~ /^GSPlat/) and (var =~ /^(?:\-\-)?portal\-pass=(on|true|yes|off|false|no)$/i)
+		setting_have_portal_pass = setting_value[$1]
+	elsif (XMLData.game =~ /^GS/) and (var =~ /^(?:\-\-)?fwi\-?trinket=(.+)$/i)
+		setting_fwi_trinket = $1.downcase
+	else
+		target_search_array.push(var)
+	end
 end
 target_search_string = target_search_array.join(' ')
 
@@ -407,544 +420,494 @@ target_search_string = target_search_array.join(' ')
 # if only settings were given, save the settings and exit
 #
 if target_search_string.empty?
-   unless setting_delay.nil?
-      CharSettings['delay'] = setting_delay
-      echo "delay setting changed to #{setting_delay} seconds"
-   end
-   unless setting_typeahead.nil?
-      CharSettings['typeahead'] = setting_typeahead
-      echo "typeahead setting changed to #{setting_typeahead}"
-      if CharSettings['delay'].to_f > 0
-         echo "typeahead setting will not be used, because the delay setting is greater than zero"
-      end
-   end
-   if XMLData.game =~ /^GSPlat|^GSF/
-      unless setting_use_portals.nil?
-         UserVars.mapdb_use_portals = (setting_use_portals ? 'yes' : 'no')
-         echo "portals will #{'not ' unless setting_use_portals}be used"
-      end
-   end
-   if XMLData.game =~ /^GSPlat/
-      unless setting_use_old_portals.nil?
-         UserVars.mapdb_use_old_portals = (setting_use_old_portals ? 'yes' : 'no')
-         echo "old portals will #{'not ' unless setting_use_old_portals}be used"
-      end
-      unless setting_have_portal_pass.nil?
-         UserVars.mapdb_have_portal_pass = (setting_have_portal_pass ? 'yes' : 'no')
-         echo "the script will #{'not ' if setting_have_portal_pass}try to pull out a portal ticket to use portals"
-      end
-   end
-   if XMLData.game =~ /^GS/
-      unless setting_use_vaalor_shortcut.nil?
-         CharSettings['vaalor shortcut'] = setting_use_vaalor_shortcut
-         $go2_use_vaalor_shortcut = setting_use_vaalor_shortcut
-         change_map_vaalor_shortcut.call(setting_use_vaalor_shortcut)
-         echo "shortcut between Ta'Vaalor and Ta'Illistim will #{'not ' unless setting_use_vaalor_shortcut}be used"
-      end
-      unless setting_get_silvers.nil?
-         CharSettings['get silvers'] = setting_get_silvers
-         echo "go2 #{ if setting_get_silvers then 'may' else 'will not' end } withdraw money from your bank account for travel expenses"
-      end
-      unless setting_use_seeking.nil?
-         CharSettings['use seeking'] = setting_use_seeking
-         $go2_use_seeking = setting_use_seeking
-         echo "go2 #{ if setting_use_seeking then 'may' else 'will not' end } use symbol of seeking for faster travel"
-      end
-      unless setting_use_day_pass.nil?
-         UserVars.mapdb_use_day_pass = setting_use_day_pass
-         echo "go2 #{ if setting_use_day_pass then 'will' else 'will not' end } use Chronomage day passes for faster travel"
-      end
-      unless setting_buy_day_pass.nil?
-         UserVars.mapdb_buy_day_pass = setting_buy_day_pass
-         echo 'setting saved' # fixme: be more descriptive
-      end
-      unless setting_day_pass_container.nil?
-         UserVars.day_pass_sack = setting_day_pass_container
-         echo 'setting saved' # fixme: be more descriptive
-      end
-      unless setting_stop_for_dead.nil?
-         CharSettings['stop for dead'] = setting_stop_for_dead
-         echo "go2 #{ if setting_stop_for_dead then 'will (probably)' else 'will not' end } stop when it sees dead people"
-      end
-      unless setting_ice_mode.nil?
-         UserVars.mapdb_ice_mode = setting_ice_mode
-         echo 'setting saved' # fixme: be more descriptive
-      end
-      unless setting_fwi_trinket.nil?
-         if setting_fwi_trinket == 'off'
-            UserVars.mapdb_fwi_trinket = nil
-         else
-            UserVars.mapdb_fwi_trinket = setting_fwi_trinket
-         end
-         echo 'setting saved' # fixme: be more descriptive
-      end
-      unless setting_get_return_trip_silvers.nil?
-         CharSettings['get return trip silvers'] = setting_get_return_trip_silvers
-         echo "silvers will #{'not ' unless setting_get_return_trip_silvers}be withdrawn in advance for return trips"
-      end
-   end
-   exit
+	unless setting_delay.nil?
+		CharSettings['delay'] = setting_delay
+		echo "delay setting changed to #{setting_delay} seconds"
+	end
+	unless setting_typeahead.nil?
+		CharSettings['typeahead'] = setting_typeahead
+		echo "typeahead setting changed to #{setting_typeahead}"
+		if CharSettings['delay'].to_f > 0
+			echo "typeahead setting will not be used, because the delay setting is greater than zero"
+		end
+	end
+	if XMLData.game =~ /^GSPlat|^GSF/
+		unless setting_use_portals.nil?
+			UserVars.mapdb_use_portals = (setting_use_portals ? 'yes' : 'no')
+			echo "portals will #{'not ' unless setting_use_portals}be used"
+		end
+	end
+	if XMLData.game =~ /^GSPlat/
+		unless setting_have_portal_pass.nil?
+			UserVars.mapdb_have_portal_pass = (setting_have_portal_pass ? 'yes' : 'no')
+			echo "the script will #{'not ' if setting_have_portal_pass}try to pull out a portal ticket to use portals"
+		end
+	end
+	if XMLData.game =~ /^GS/
+		unless setting_use_vaalor_shortcut.nil?
+			CharSettings['vaalor shortcut'] = setting_use_vaalor_shortcut
+			$go2_use_vaalor_shortcut = setting_use_vaalor_shortcut
+			change_map_vaalor_shortcut.call(setting_use_vaalor_shortcut)
+			echo "shortcut between Ta'Vaalor and Ta'Illistim will #{'not ' unless setting_use_vaalor_shortcut}be used"
+		end
+		unless setting_get_silvers.nil?
+			CharSettings['get silvers'] = setting_get_silvers
+			echo "go2 #{ if setting_get_silvers then 'may' else 'will not' end } withdraw money from your bank account for travel expenses"
+		end
+		unless setting_use_seeking.nil?
+			CharSettings['use seeking'] = setting_use_seeking
+			$go2_use_seeking = setting_use_seeking
+			echo "go2 #{ if setting_use_seeking then 'may' else 'will not' end } use symbol of seeking for faster travel"
+		end
+		unless setting_stop_for_dead.nil?
+			CharSettings['stop for dead'] = setting_stop_for_dead
+			echo "go2 #{ if setting_stop_for_dead then 'will (probably)' else 'will not' end } stop when it sees dead people"
+		end
+		unless setting_ice_mode.nil?
+			UserVars.mapdb_ice_mode = setting_ice_mode
+			echo 'setting saved' # fixme: be more descriptive
+		end
+		unless setting_fwi_trinket.nil?
+			if setting_fwi_trinket == 'off'
+				UserVars.mapdb_fwi_trinket = nil
+			else
+				UserVars.mapdb_fwi_trinket = setting_fwi_trinket
+			end
+			echo 'setting saved' # fixme: be more descriptive
+		end
+		unless setting_get_return_trip_silvers.nil?
+			CharSettings['get return trip silvers'] = setting_get_return_trip_silvers
+			echo "silvers will #{'not ' unless setting_get_return_trip_silvers}be withdrawn in advance for return trips"
+		end
+	end
+	exit
 end
 
 unless start_room = Room.current
-   echo 'error: your current room was not found in the map database'
-   exit
+	echo 'error: your current room was not found in the map database'
+	exit
 end
 
 #
 # target was given; use saved settings, override them with command line settings, but don't save them
 #
 if setting_drag
-   setting_typeahead = 0
+	setting_typeahead = 0
 elsif setting_typeahead.nil?
-   setting_typeahead = CharSettings['typeahead']
+	setting_typeahead = CharSettings['typeahead']
 end
 
 if setting_delay.nil?
-   setting_delay = CharSettings['delay']
+	setting_delay = CharSettings['delay']
 end
 
 if setting_get_silvers.nil?
-   $go2_get_silvers = CharSettings['get silvers']
+	$go2_get_silvers = CharSettings['get silvers']
 else
-   before_dying { $go2_get_silvers = CharSettings['get silvers'] }
-   $go2_get_silvers = setting_get_silvers
+	before_dying { $go2_get_silvers = CharSettings['get silvers'] }
+	$go2_get_silvers = setting_get_silvers
 end
 
 if setting_use_seeking.nil?
-   $go2_use_seeking = CharSettings['use seeking']
+	$go2_use_seeking = CharSettings['use seeking']
 else
-   before_dying { $go2_use_seeking = CharSettings['use seeking'] }
-   $go2_use_seeking = setting_use_seeking
-end
-
-if setting_use_day_pass
-   previous_use_day_pass = UserVars.mapdb_use_day_pass
-   before_dying { UserVars.mapdb_use_day_pass = previous_use_day_pass }
-   UserVars.mapdb_use_day_pass = setting_use_day_pass
-end
-
-if setting_buy_day_pass
-   previous_buy_day_pass = UserVars.mapdb_buy_day_pass
-   before_dying { UserVars.mapdb_buy_day_pass = previous_buy_day_pass }
-   UserVars.mapdb_buy_day_pass = setting_buy_day_pass
-end
-
-if setting_day_pass_container
-   previous_day_pass_container = UserVars.day_pass_sack
-   before_dying { UserVars.day_pass_sack = previous_day_pass_container }
-   UserVars.day_pass_sack = setting_day_pass_container
+	before_dying { $go2_use_seeking = CharSettings['use seeking'] }
+	$go2_use_seeking = setting_use_seeking
 end
 
 if setting_stop_for_dead.nil?
-   setting_stop_for_dead = CharSettings['stop for dead']
+	setting_stop_for_dead = CharSettings['stop for dead']
 end
 
 if setting_ice_mode
-   previous_ice_mode = UserVars.mapdb_ice_mode
-   before_dying { UserVars.mapdb_ice_mode = previous_ice_mode }
-   UserVars.mapdb_ice_mode = setting_ice_mode
+	previous_ice_mode = UserVars.mapdb_ice_mode
+	before_dying { UserVars.mapdb_ice_mode = previous_ice_mode }
+	UserVars.mapdb_ice_mode = setting_ice_mode
 end
 
 if setting_fwi_trinket
-   previous_fwi_trinket = UserVars.mapdb_fwi_trinket
-   before_dying { UserVars.mapdb_fwi_trinket = previous_fwi_trinket }
-   if setting_fwi_trinket == 'off'
-      UserVars.mapdb_fwi_trinket = nil
-   else
-      UserVars.mapdb_fwi_trinket = setting_fwi_trinket
-   end
+	previous_fwi_trinket = UserVars.mapdb_fwi_trinket
+	before_dying { UserVars.mapdb_fwi_trinket = previous_fwi_trinket }
+	if setting_fwi_trinket == 'off'
+		UserVars.mapdb_fwi_trinket = nil
+	else
+		UserVars.mapdb_fwi_trinket = setting_fwi_trinket
+	end
 end
 
 unless setting_use_portals.nil?
-   previous_use_portals = UserVars.mapdb_use_portals
-   before_dying { UserVars.mapdb_use_portals = previous_use_portals }
-   UserVars.mapdb_use_portals = (setting_use_portals ? 'yes' : 'no')
-end
-
-unless setting_use_old_portals.nil?
-   previous_use_old_portals = UserVars.mapdb_use_old_portals
-   before_dying { UserVars.mapdb_use_old_portals = previous_use_old_portals }
-   UserVars.mapdb_use_old_portals = (setting_use_old_portals ? 'yes' : 'no')
+	previous_use_portals = UserVars.mapdb_use_portals
+	before_dying { UserVars.mapdb_use_portals = previous_use_portals }
+	UserVars.mapdb_use_portals = (setting_use_portals ? 'yes' : 'no')
 end
 
 unless setting_have_portal_pass.nil?
-   previous_have_portal_pass = UserVars.mapdb_have_portal_pass
-   before_dying { UserVars.mapdb_have_portal_pass = previous_have_portal_pass }
-   UserVars.mapdb_have_portal_pass = (setting_have_portal_pass ? 'yes' : 'no')
+	previous_have_portal_pass = UserVars.mapdb_have_portal_pass
+	before_dying { UserVars.mapdb_have_portal_pass = previous_have_portal_pass }
+	UserVars.mapdb_have_portal_pass = (setting_have_portal_pass ? 'yes' : 'no')
 end
 
 if setting_use_vaalor_shortcut.nil?
-   setting_use_vaalor_shortcut = CharSettings['vaalor shortcut']
+	setting_use_vaalor_shortcut = CharSettings['vaalor shortcut']
 else
-   before_dying { $go2_use_vaalor_shortcut = CharSettings['vaalor shortcut'] }
+	before_dying { $go2_use_vaalor_shortcut = CharSettings['vaalor shortcut'] }
 end
 $go2_use_vaalor_shortcut = setting_use_vaalor_shortcut
 
 if setting_get_return_trip_silvers.nil?
-   setting_get_return_trip_silvers = CharSettings['get return trip silvers']
+	setting_get_return_trip_silvers = CharSettings['get return trip silvers']
 end
 
 if XMLData.game =~ /^GS/
-   change_map_vaalor_shortcut.call(setting_use_vaalor_shortcut)
+	change_map_vaalor_shortcut.call(setting_use_vaalor_shortcut)
 end
 
 #
 # find target
 #
-if defined?(Map.ids_from_uid)
-  uid_pattern = /u(?<uid>\d+)/
-  if m = uid_pattern.match(target_search_string)
-    uid = m[:uid].to_i
-    lookup_id = Map.ids_from_uid(uid)
-    if lookup_id.size > 0
-       target_search_string = "#{lookup_id[0]}"
-     end
-  end
-end
 if (target_search_string =~ /^[0-9]+$/) or (XMLData.game =~ /^GS/ and target_search_string =~ /^confluence(?:\-hot|\-cold)?$|^instability$/i)
-   if target_search_string =~ /^[0-9]+$/
-      unless destination = Map[target_search_string.to_i]
-         echo "error: room number (#{target_search_string}) was not found in the map database"
-         exit
-      end
-      confirm = false
-   end
-   if (target_search_string =~ /^confluence(?:\-hot|\-cold)?$|^instability$/i) or (XMLData.game =~ /^GS/ and destination.title.first == '[Elemental Confluence]' and XMLData.room_title != '[Elemental Confluence]')
-      if target_search_string =~ /^confluence$/ and XMLData.room_title == '[Elemental Confluence]'
-         echo "you're already here..."
-         exit
-      end
-      town_ids          = [ 228, 2300, 1438, 1005, 188, 1932, 3519, 10855, 3668 ]
-      found_instability = false
-      if setting_instability
-         Script.run('go2', setting_instability.to_s, :force => true)
-         if GameObj.loot.any? { |o| o.noun == 'instability' }
-            $mapdb_last_instability = Room.current.id
-            $mapdb_instability_timeto = Hash.new
-            for id in town_ids
-               path = Room[$mapdb_last_instability].path_to(id)
-               if path.nil?
-                  $mapdb_instability_timeto[id] = nil
-               else
-                  $mapdb_instability_timeto[id] = Map.estimate_time(path)
-               end
-            end
-            found_instability = true
-         end
-      else
-         if CharSettings['element'].nil?
-            r = dothistimeout 'attune', 5, /^\s*You are attuned to the Element of|^\s*ATTUNE SET/
-            if r =~ /You are attuned to the Element of (.+)\./
-               CharSettings['element'] = $1.downcase
-            elsif r =~ /ATTUNE SET/
-               echo "You're not attuned to an element, so I don't know how to find an instability."
-               exit
-            else
-               echo "error: can't get right"
-               exit
-            end
-         end
+	if target_search_string =~ /^[0-9]+$/
+		unless destination = Map[target_search_string.to_i]
+			echo "error: room number (#{target_search_string}) was not found in the map database"
+			exit
+		end
+		confirm = false
+	end
+	if (target_search_string =~ /^confluence(?:\-hot|\-cold)?$|^instability$/i) or (XMLData.game =~ /^GS/ and destination.title.first == '[Elemental Confluence]' and XMLData.room_title != '[Elemental Confluence]')
+		if target_search_string =~ /^confluence$/ and XMLData.room_title == '[Elemental Confluence]'
+			echo "you're already here..."
+			exit
+		end
+		town_ids          = [ 228, 2300, 1438, 1005, 188, 1932, 3519, 10855, 3668 ]
+		found_instability = false
+		if setting_instability
+			Script.run('go2', setting_instability.to_s, :force => true)
+			if GameObj.loot.any? { |o| o.noun == 'instability' }
+				$mapdb_last_instability = Room.current.id
+				$mapdb_instability_timeto = Hash.new
+				for id in town_ids
+					path = Room[$mapdb_last_instability].path_to(id)
+					if path.nil?
+						$mapdb_instability_timeto[id] = nil
+					else
+						$mapdb_instability_timeto[id] = Map.estimate_time(path)
+					end
+				end
+				found_instability = true
+			end
+		else
+			if CharSettings['element'].nil?
+				r = dothistimeout 'attune', 5, /^\s*You are attuned to the Element of|^\s*ATTUNE SET/
+				if r =~ /You are attuned to the Element of (.+)\./
+					CharSettings['element'] = $1.downcase
+				elsif r =~ /ATTUNE SET/
+					echo "You're not attuned to an element, so I don't know how to find an instability."
+					exit
+				else
+					echo "error: can't get right"
+					exit
+				end
+			end
 
-         GameSettings['recent-instabilities'] ||= Array.new
+			GameSettings['recent-instabilities'] ||= Array.new
 
-         good_room_ids     = Array.new
-         bad_room_ids      = Array.new
-         got_room_text     = false
-         to_element        = { 'gust of wind' => 'air', 'burst of sparks' => 'lightning', 'waft of heat' => 'fire', 'puff of rock dust' => 'earth', 'puff of mist' => 'water', }
+			good_room_ids     = Array.new
+			bad_room_ids      = Array.new
+			got_room_text     = false
+			to_element        = { 'gust of wind' => 'air', 'burst of sparks' => 'lightning', 'waft of heat' => 'fire', 'puff of rock dust' => 'earth', 'puff of mist' => 'water', }
 
-         check_instability = proc {
-            if GameObj.loot.any? { |o| o.noun == 'instability' }
-               r = dothistimeout 'look instability', 10, /^The air is oddly warped and distorted here, almost as if something unseen was trying to push through from the other side of an invisible barrier\.  Every so often a (?:gust of wind|burst of sparks|waft of heat|puff of rock dust|puff of mist) (?:is|are) emitted from the anomaly, which quickly reseals itself\./
-               if r =~ /(gust of wind|burst of sparks|waft of heat|puff of rock dust|puff of mist)/
-                  element = to_element[$1]
-                  unless GameSettings['recent-instabilities'].any? { |i| (i[:room_id] == Room.current.id) and i[:element] == element }
-                     GameSettings['recent-instabilities'].push(:room_id => Room.current.id, :element => element, :first_seen => Time.now.to_i)
-                  end
-                  if (element == CharSettings['element'])
-                     $mapdb_last_instability = Room.current.id
-                     $mapdb_instability_timeto = Hash.new
-                     for id in town_ids
-                        path = Room[$mapdb_last_instability].path_to(id)
-                        if path.nil?
-                           $mapdb_instability_timeto[id] = nil
-                        else
-                           $mapdb_instability_timeto[id] = Map.estimate_time(path)
-                        end
-                     end
-                     found_instability = true
-                  end
-               else
-                  echo "error: can't get right"
-                  exit
-               end
-            else
-               GameSettings['recent-instabilities'].delete_if { |i| i[:room_id] == Room.current.id }
-               false
-            end
-         }
+			check_instability = proc {
+				if GameObj.loot.any? { |o| o.noun == 'instability' }
+					r = dothistimeout 'look instability', 10, /^The air is oddly warped and distorted here, almost as if something unseen was trying to push through from the other side of an invisible barrier\.  Every so often a (?:gust of wind|burst of sparks|waft of heat|puff of rock dust|puff of mist) (?:is|are) emitted from the anomaly, which quickly reseals itself\./
+					if r =~ /(gust of wind|burst of sparks|waft of heat|puff of rock dust|puff of mist)/
+						element = to_element[$1]
+						unless GameSettings['recent-instabilities'].any? { |i| (i[:room_id] == Room.current.id) and i[:element] == element }
+							GameSettings['recent-instabilities'].push(:room_id => Room.current.id, :element => element, :first_seen => Time.now.to_i)
+						end
+						if (element == CharSettings['element'])
+							$mapdb_last_instability = Room.current.id
+							$mapdb_instability_timeto = Hash.new
+							for id in town_ids
+								path = Room[$mapdb_last_instability].path_to(id)
+								if path.nil?
+									$mapdb_instability_timeto[id] = nil
+								else
+									$mapdb_instability_timeto[id] = Map.estimate_time(path)
+								end
+							end
+							found_instability = true
+						end
+					else
+						echo "error: can't get right"
+						exit
+					end
+				else
+					GameSettings['recent-instabilities'].delete_if { |i| i[:room_id] == Room.current.id }
+					false
+				end
+			}
 
-         #
-         # go directly to nearby recently seen attuned instabilities
-         #
-         GameSettings['recent-instabilities'].delete_if { |i| i[:first_seen] < (Time.now.to_i - 21600) }
-         GameSettings['recent-instabilities'].find_all { |i| i[:element] == CharSettings['element'] }.each { |i|
-            # fixme: would one full dijkstra be faster?
-            if (path = Room.current.path_to(i[:room_id])) and (Map.estimate_time(path) <= 10.0)
-               Script.run('go2', i[:room_id].to_s, :force => true)
-               break if check_instability.call
-            end
-         }
+			#
+			# go directly to nearby recently seen attuned instabilities
+			#
+			GameSettings['recent-instabilities'].delete_if { |i| i[:first_seen] < (Time.now.to_i - 21600) }
+			GameSettings['recent-instabilities'].find_all { |i| i[:element] == CharSettings['element'] }.each { |i|
+				# fixme: would one full dijkstra be faster?
+				if (path = Room.current.path_to(i[:room_id])) and (Map.estimate_time(path) <= 10.0)
+					Script.run('go2', i[:room_id].to_s, :force => true)
+					break if check_instability.call
+				end
+			}
 
-         #
-         # get room numbers from attune sense
-         #
-         unless found_instability
-            if (last_roomdesc = $_SERVERBUFFER_.reverse.find { |line| line =~ /<style id="roomDesc"\/>/ }) and (last_roomdesc =~ /<style id="roomDesc"\/></)
-               set_desc = true
-            else
-               set_desc = false
-            end
+			#
+			# get room numbers from attune sense
+			#
+			unless found_instability
+				if (last_roomdesc = $_SERVERBUFFER_.reverse.find { |line| line =~ /<style id="roomDesc"\/>/ }) and (last_roomdesc =~ /<style id="roomDesc"\/></)
+					set_desc = true
+				else
+					set_desc = false
+				end
 
-            2.times {
-               put 'set description on' if set_desc
-               sense_result = dothistimeout 'attune sense', 5, /^You sense nothing unusual\.|^You sense an unusual fluctuation emanating from .+\.|^You feel your senses being pulled towards a strong fluctuation\.\.\.|^You feel a strong sense of instability surround you!/
-               put 'set description off' if set_desc
-               if sense_result =~ /^You sense an unusual fluctuation emanating from (.+)\./
-                  location = $1
-                  bad_room_ids = Room.list.find_all { |r| r.location == location }.collect { |r| r.id }
-               elsif sense_result =~ /^You feel your senses being pulled towards a strong fluctuation\.\.\./
-                  location = Room.current.location
-                  room_text = Array.new
-                  3.times { room_text.push(get) }
-                  good_room_ids = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.desc.include?(room_text[1]) and r.paths.include?(room_text[2]) and r.location == location }.collect { |r| r.id }
-                  if good_room_ids.empty?
-                     desc_regex = /#{Regexp.escape(room_text[1]).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
-                     good_room_ids = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.paths.include?(room_text[2]) and r.location == location and r.desc.any? { |d| d =~ desc_regex } }.collect { |r| r.id }
-                  end
-                  got_room_text = true
-                  Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless good_room_ids.include?(r.id) }
-               elsif sense_result =~ /^You feel a strong sense of instability surround you!/
-                  location = Room.current.location
-                  good_room_ids = [ Room.current.id ]
-                  Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless good_room_ids.include?(r.id) }
-               elsif sense_result =~ /^You sense nothing unusual\./
-                  echo "error: can't get right"
-                  exit
-               else
-                  echo "error: unrecognized result from \"attune sense\""
-                  exit
-               end
+				2.times {
+					put 'set description on' if set_desc
+					sense_result = dothistimeout 'attune sense', 5, /^You sense nothing unusual\.|^You sense an unusual fluctuation emanating from .+\.|^You feel your senses being pulled towards a strong fluctuation\.\.\.|^You feel a strong sense of instability surround you!/
+					put 'set description off' if set_desc
+					if sense_result =~ /^You sense an unusual fluctuation emanating from (.+)\./
+						location = $1
+						bad_room_ids = Room.list.find_all { |r| r.location == location }.collect { |r| r.id }
+					elsif sense_result =~ /^You feel your senses being pulled towards a strong fluctuation\.\.\./
+						location = Room.current.location
+						room_text = Array.new
+						3.times { room_text.push(get) }
+						good_room_ids = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.desc.include?(room_text[1]) and r.paths.include?(room_text[2]) and r.location == location }.collect { |r| r.id }
+						if good_room_ids.empty?
+							desc_regex = /#{Regexp.escape(room_text[1]).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
+							good_room_ids = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.paths.include?(room_text[2]) and r.location == location and r.desc.any? { |d| d =~ desc_regex } }.collect { |r| r.id }
+						end
+						got_room_text = true
+						Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless good_room_ids.include?(r.id) }
+					elsif sense_result =~ /^You feel a strong sense of instability surround you!/
+						location = Room.current.location
+						good_room_ids = [ Room.current.id ]
+						Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless good_room_ids.include?(r.id) }
+					elsif sense_result =~ /^You sense nothing unusual\./
+						echo "error: can't get right"
+						exit
+					else
+						echo "error: unrecognized result from \"attune sense\""
+						exit
+					end
 
-               while (line = get?)
-                  if line =~ /^You sense an unusual fluctuation emanating from (.+)\./
-                     location = $1
-                     Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
-                  elsif sense_result =~ /^You feel your senses being pulled towards a strong fluctuation\.\.\./
-                     location = Room.current.location
-                     room_text = Array.new
-                     3.times { room_text.push(get) }
-                     gri = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.desc.include?(room_text[1]) and r.paths.include?(room_text[2]) and r.location == location }.collect { |r| r.id }
-                     if gri.empty?
-                        desc_regex = /#{Regexp.escape(room_text[1]).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
-                        gri = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.paths.include?(room_text[2]) and r.location == location and r.desc.any? { |d| d =~ desc_regex } }.collect { |r| r.id }
-                     end
-                     gri.each { |i| good_room_ids.push(i) unless good_room_ids.include?(i) }
-                     got_room_text = true
-                     Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
-                  elsif sense_result =~ /^You feel a strong sense of instability surround you!/
-                     location = Room.current.location
-                     good_room_ids.push(Room.current.id) unless good_room_ids.include?(Room.current.id)
-                     Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
-                  else
-                     break
-                  end
-               end
-               waitrt?
-               break if got_room_text or (good_room_ids.count > 0)
-               Script.run('go2', Room.current.find_nearest(bad_room_ids).to_s, :force => true)
-            }
+					while (line = get?)
+						if line =~ /^You sense an unusual fluctuation emanating from (.+)\./
+							location = $1
+							Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
+						elsif sense_result =~ /^You feel your senses being pulled towards a strong fluctuation\.\.\./
+							location = Room.current.location
+							room_text = Array.new
+							3.times { room_text.push(get) }
+							gri = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.desc.include?(room_text[1]) and r.paths.include?(room_text[2]) and r.location == location }.collect { |r| r.id }
+							if gri.empty?
+								desc_regex = /#{Regexp.escape(room_text[1]).gsub(/\\\.(?:\\\.\\\.)?/, '|')}/
+								gri = Room.list.find_all { |r| r.title.include?(room_text[0]) and r.paths.include?(room_text[2]) and r.location == location and r.desc.any? { |d| d =~ desc_regex } }.collect { |r| r.id }
+							end
+							gri.each { |i| good_room_ids.push(i) unless good_room_ids.include?(i) }
+							got_room_text = true
+							Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
+						elsif sense_result =~ /^You feel a strong sense of instability surround you!/
+							location = Room.current.location
+							good_room_ids.push(Room.current.id) unless good_room_ids.include?(Room.current.id)
+							Room.list.find_all { |r| r.location == location }.each { |r| bad_room_ids.push(r.id) unless bad_room_ids.include?(r.id) or good_room_ids.include?(r.id) }
+						else
+							break
+						end
+					end
+					waitrt?
+					break if got_room_text or (good_room_ids.count > 0)
+					Script.run('go2', Room.current.find_nearest(bad_room_ids).to_s, :force => true)
+				}
 
-            #
-            # go to rooms and junk
-            #
-            loop {
-               next_id = nil
-               next_id = Room.current.find_nearest(good_room_ids) unless good_room_ids.empty?
-               if next_id.nil?
-                  next_id_list = bad_room_ids.find_all { |r| GameSettings['recent-instabilities'].any? { |i| (i[:room_id] == r) and (i[:element] == CharSettings['element']) } }
-                  next_id = Room.current.find_nearest(next_id_list) unless next_id_list.empty?
-               end
-               if next_id.nil?
-                  next_id = (Room.current.wayto.keys.find { |k| bad_room_ids.include?(k) } || Room.current.find_nearest(bad_room_ids))
-               end
-               if next_id.nil?
-                  echo 'fail'
-                  exit
-               end
-               if Room.current.wayto.keys.include?(next_id.to_s)
-                  way = Room.current.wayto[next_id.to_s]
-                  if way.class == Proc
-                     way.call
-                  elsif way.class == String
-                     move way
-                  else
-                     echo "error: map database movement is neither a Proc or a String"
-                     exit
-                  end
-               else
-                  Script.run('go2', next_id.to_s, :force => true)
-               end
-               good_room_ids.delete(next_id)
-               bad_room_ids.delete(next_id)
-               break if check_instability.call
-            }
-         end
-      end
-      if found_instability
-         if target_search_string == 'instability'
-            exit
-         elsif target_search_string == 'confluence'
-            put 'unhide' if invisible?
-            move 'push instability with my soulstone'
-            exit
-         elsif target_search_string == 'confluence-hot'
-            put 'unhide' if invisible?
-            move 'push instability with my soulstone'
-            exit if Room.current.tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ }
-            if hot_id = Room.current.wayto.keys.find { |r| Room[r].tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ } }
-               begin
-                  go_thread = Thread.new { Room.current.wayto[hot_id].call }
-                  sleep 0.1 until Room.current.tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ }
-               ensure
-                  go_thread.kill rescue nil
-               end
-            end
-            exit
-         elsif target_search_string == 'confluence-cold'
-            put 'unhide' if invisible?
-            move 'push instability with my soulstone'
-            exit if Room.current.tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ }
-            if cold_id = Room.current.wayto.keys.find { |r| Room[r].tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ } }
-               begin
-                  go_thread = Thread.new { Room.current.wayto[cold_id].call }
-                  sleep 0.1 until Room.current.tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ }
-               ensure
-                  go_thread.kill rescue nil
-               end
-            end
-            exit
-         else
-            put 'unhide' if invisible?
-            move 'push instability with my soulstone'
-            sleep 0.3
-            unless start_room = Room.current
-               echo 'error: your current room was not found in the map database'
-               exit
-            end
-         end
-      else
-         echo 'error: all hope is lost'
-         exit
-      end
-   end
+				#
+				# go to rooms and junk
+				#
+				loop {
+					next_id = nil
+					next_id = Room.current.find_nearest(good_room_ids) unless good_room_ids.empty?
+					if next_id.nil?
+						next_id_list = bad_room_ids.find_all { |r| GameSettings['recent-instabilities'].any? { |i| (i[:room_id] == r) and (i[:element] == CharSettings['element']) } }
+						next_id = Room.current.find_nearest(next_id_list) unless next_id_list.empty?
+					end
+					if next_id.nil?
+						next_id = (Room.current.wayto.keys.find { |k| bad_room_ids.include?(k) } || Room.current.find_nearest(bad_room_ids))
+					end
+					if next_id.nil?
+						echo 'fail'
+						exit
+					end
+					if Room.current.wayto.keys.include?(next_id.to_s)
+						way = Room.current.wayto[next_id.to_s]
+						if way.class == Proc
+							way.call
+						elsif way.class == String
+							move way
+						else
+							echo "error: map database movement is neither a Proc or a String"
+							exit
+						end
+					else
+						Script.run('go2', next_id.to_s, :force => true)
+					end
+					good_room_ids.delete(next_id)
+					bad_room_ids.delete(next_id)
+					break if check_instability.call
+				}
+			end
+		end
+		if found_instability
+			if target_search_string == 'instability'
+				exit
+			elsif target_search_string == 'confluence'
+				put 'unhide' if invisible?
+				move 'push instability with my soulstone'
+				exit
+			elsif target_search_string == 'confluence-hot'
+				put 'unhide' if invisible?
+				move 'push instability with my soulstone'
+				exit if Room.current.tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ }
+				if hot_id = Room.current.wayto.keys.find { |r| Room[r].tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ } }
+					begin
+						go_thread = Thread.new { Room.current.wayto[hot_id].call }
+						sleep 0.1 until Room.current.tags.any? { |t| t =~ /^huge (?:fire|lava|steam|lightning) elemental$/ }
+					ensure
+						go_thread.kill rescue nil
+					end
+				end
+				exit
+			elsif target_search_string == 'confluence-cold'
+				put 'unhide' if invisible?
+				move 'push instability with my soulstone'
+				exit if Room.current.tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ }
+				if cold_id = Room.current.wayto.keys.find { |r| Room[r].tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ } }
+					begin
+						go_thread = Thread.new { Room.current.wayto[cold_id].call }
+						sleep 0.1 until Room.current.tags.any? { |t| t =~ /^huge (?:air|earth|ice|water) elemental$/ }
+					ensure
+						go_thread.kill rescue nil
+					end
+				end
+				exit
+			else
+				put 'unhide' if invisible?
+				move 'push instability with my soulstone'
+				sleep 0.3
+				unless start_room = Room.current
+					echo 'error: your current room was not found in the map database'
+					exit
+				end
+			end
+		else
+			echo 'error: all hope is lost'
+			exit
+		end
+	end
 elsif (custom_targets = GameSettings['custom targets']) and (target = custom_targets.keys.find { |key| key =~ /^#{target_search_string}$/i }) or (target = custom_targets.keys.find { |key| key =~ /^#{target_search_string}/i })
-   destination_id = custom_targets[target]
-   unless destination = Map[destination_id]
-      echo "error: custom target (#{destination_id}) was not found in the map database"
-      exit
-   end
-   confirm = false
+	destination_id = custom_targets[target]
+	unless destination = Map[destination_id]
+		echo "error: custom target (#{destination_id}) was not found in the map database"
+		exit
+	end
+	confirm = false
 elsif Map.list.any? { |r| r.tags.include?(target_search_string) }
-   target_list = Map.list.find_all { |room| room.tags.include?(target_search_string) }.collect { |room| room.id }
-   if target_list.empty?
-      echo 'fixme (1)'
-      exit
-   end
-   if target_list.include?(start_room.id)
-      echo "you're already here..."
-      exit
-   end
-   previous, shortest_distances = start_room.dijkstra(target_list)
-   target_list.delete_if { |room_id| shortest_distances[room_id].nil? }
-   if target_list.empty?
-      echo 'fixme (2)'
-      exit
-   end
-   target_id = target_list.sort { |a,b| shortest_distances[a] <=> shortest_distances[b] }.first
-   unless target_id and (destination = Map[target_id])
-      echo 'fixme (3)'
-      exit
-   end
-   if shortest_distances[destination.id] < 20
-      confirm = false
-   else
-      confirm = true
-   end
+	target_list = Map.list.find_all { |room| room.tags.include?(target_search_string) }.collect { |room| room.id }
+	if target_list.empty?
+		echo 'fixme (1)'
+		exit
+	end
+	if target_list.include?(start_room.id)
+		echo "you're already here..."
+		exit
+	end
+	previous, shortest_distances = start_room.dijkstra(target_list)
+	target_list.delete_if { |room_id| shortest_distances[room_id].nil? }
+	if target_list.empty?
+		echo 'fixme (2)'
+		exit
+	end
+	target_id = target_list.sort { |a,b| shortest_distances[a] <=> shortest_distances[b] }.first
+	unless target_id and (destination = Map[target_id])
+		echo 'fixme (3)'
+		exit
+	end
+	if shortest_distances[destination.id] < 20
+		confirm = false
+	else
+		confirm = true
+	end
 else
-   chkre = /#{target_search_string.sub(/\.$/, '').gsub(/\.(?:\.\.)?/, '|')}/i
-   chk = /#{Regexp.escape(target_search_string.strip)}/i
-   room_list = Map.list.find_all { |room| room.title.find { |title| title =~ chk } or room.description.find { |desc| desc =~ chk } or room.description.find { |desc| desc =~ chkre } }
-   if room_list.nil? or room_list.empty?
-      echo 'no matching rooms found'
-      exit
-   end
-   if room_list.length == 1
-      destination = room_list.first
-      confirm = true
-   else
-      destination = nil
-      first = 1
-      show_size = 20
-      respond "#{room_list.length} matching rooms found:"
-      while first < room_list.length
-         respond
-         for which in (first)..([(first+show_size-1),room_list.length].min)
-            respond "#{(which).to_s.rjust(5)}: #{room_list[which-1].title.first.ljust(37)} (#{room_list[which-1].id})"
-         end
-         respond
-         respond "select a room (;send <#{first}-#{[first+show_size-1,room_list.length].min}>)#{ " or ';send next' for more" if (first+show_size-1) < room_list.length}"
-         respond
-         clear
-         line = nil
-         line = get until line.strip =~ /^[0-9]+$|^next$/i
-         if line =~ /^next$/
-            first += show_size
-         else
-            destination = room_list[line.to_i-1]
-            break
-         end
-      end
-      unless destination
-         echo 'no more rooms match'
-         exit
-      end
-      confirm = false
-   end
+	chkre = /#{target_search_string.sub(/\.$/, '').gsub(/\.(?:\.\.)?/, '|')}/i
+	chk = /#{Regexp.escape(target_search_string.strip)}/i
+	room_list = Map.list.find_all { |room| room.title.find { |title| title =~ chk } or room.description.find { |desc| desc =~ chk } or room.description.find { |desc| desc =~ chkre } }
+	if room_list.nil? or room_list.empty?
+		echo 'no matching rooms found'
+		exit
+	end
+	if room_list.length == 1
+		destination = room_list.first
+		confirm = true
+	else
+		destination = nil
+		first = 1
+		show_size = 20
+		respond "#{room_list.length} matching rooms found:"
+		while first < room_list.length
+			respond
+			for which in (first)..([(first+show_size-1),room_list.length].min)
+				respond "#{(which).to_s.rjust(5)}: #{room_list[which-1].title.first.ljust(37)} (#{room_list[which-1].id})"
+			end
+			respond
+			respond "select a room (;send <#{first}-#{[first+show_size-1,room_list.length].min}>)#{ " or ';send next' for more" if (first+show_size-1) < room_list.length}"
+			respond
+			clear
+			line = nil
+			line = get until line.strip =~ /^[0-9]+$|^next$/i
+			if line =~ /^next$/
+				first += show_size
+			else
+				destination = room_list[line.to_i-1]
+				break
+			end
+		end
+		unless destination
+			echo 'no more rooms match'
+			exit
+		end
+		confirm = false
+	end
 end
 
 if setting_stop_for_dead and (setting_typeahead > 0) and (setting_delay <= 0)
-   $go2_see_dead_people = false
-   exec_string = "
-      hide_me
-      status_tags
-      parent_id = #{Script.self.object_id}
-      Thread.new { loop { sleep 3; Script.self.kill unless Script.running.any? { |s| s.object_id == parent_id } or Script.hidden.any? { |s| s.object_id == parent_id } } }
-      while (line = get)
-         if line =~ /<compDef id='room players'>Also here:.*? the body of </
-            $go2_see_dead_people = true
-         end
-      end
-   "
-   start_exec_script(exec_string, flags={ :quiet => true })
+	$go2_see_dead_people = false
+	exec_string = "
+		hide_me
+		status_tags
+		parent_id = #{Script.self.object_id}
+		Thread.new { loop { sleep 3; Script.self.kill unless Script.running.any? { |s| s.object_id == parent_id } or Script.hidden.any? { |s| s.object_id == parent_id } } }
+		while (line = get)
+			if line =~ /<compDef id='room players'>Also here:.*? the body of </
+				$go2_see_dead_people = true
+			end
+		end
+	"
+	start_exec_script(exec_string, flags={ :quiet => true })
 end
 
 #
 # move
 #
 if start_room.id == destination.id
-   echo "you're already here..."
-   exit
+	echo "you're already here..."
+	exit
 end
 
 start_time   = nil
@@ -954,301 +917,303 @@ first_move   = true
 
 loop {
 
-   moves_sent = $room_count
+	moves_sent = $room_count
 
-   if $go2_restart
-      first_move = true
-      break if Room.current.id == destination.id
-      echo 'restarting script...'
-      if error_count > 1
-         if XMLData.game =~ /^GS/
-            dothistimeout 'help lag-check', 5, /^No help files matching that entry were found\./
-         else
-            sleep 5
-         end
-      end
-      unless start_room = Map.current
-         echo 'error: your current room was not found in the map database'
-         exit
-      end
-      previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
-   end
+	if $go2_restart
+		first_move = true
+		break if Room.current.id == destination.id
+		echo 'restarting script...'
+		if error_count > 1
+			# dothis 'help lag-check', /^No help files matching that entry were found\.|^MERCHANT HELP/
+			if XMLData.game =~ /^GS/
+				dothis 'combatant', /^That only works in the Gladiator Arenas\./
+			else
+				sleep 5
+			end
+		end
+		unless start_room = Map.current
+			echo 'error: your current room was not found in the map database'
+			exit
+		end
+		previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
+	end
 
-   unless previous and shortest_distances
-      previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
-   end
-   unless previous[destination.id]
-      echo "error: failed to find a path between your current room (#{start_room.id}) and destination room (#{destination.id})"
-      exit
-   end
-   path = [ destination.id ]
-   path.push(previous[path[-1]]) until previous[path[-1]].nil?
-   path.reverse!
-   est_time = shortest_distances[destination.id]
-   previous = shortest_distances = nil
-   if Script.running?('roomnumbers')
-     rooms = [Room.current.id] + path
-     if rooms.any? { |room| Room[room].tags.first.include?('peer') }
-       stop_script('roomnumbers')
-       before_dying { start_script('roomnumbers') } unless Room[rooms.last].tags.first.include?('peer')
-     end
-   end
+	unless previous and shortest_distances
+		previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
+	end
+	unless previous[destination.id]
+		echo "error: failed to find a path between your current room (#{start_room.id}) and destination room (#{destination.id})"
+		exit
+	end
+	path = [ destination.id ]
+	path.push(previous[path[-1]]) until previous[path[-1]].nil?
+	path.reverse!
+	est_time = shortest_distances[destination.id]
+	previous = shortest_distances = nil
 
-   if Script.running?('textsubs') && est_time > 5
-     stop_script('textsubs')
-     before_dying { start_script('textsubs') }
-   end
+	if Script.running?('roomnumbers')
+		rooms = [Room.current.id] + path
+		if rooms.any? { |room| Room[room].tags.first.include?('peer') }
+			stop_script('roomnumbers')
+			before_dying { start_script('roomnumbers') } unless Room[rooms.last].tags.first.include?('peer')
+		end
+	end
 
-   if XMLData.game =~ /^GS/
-      needed_silvers = get_silver_cost.call(path)
-      if setting_get_return_trip_silvers
-         return_previous, return_shortest_distances = Map.dijkstra(destination.id, start_room.id)
-         return_path = [ start_room.id ]
-         return_path.push(return_previous[return_path[-1]]) until return_previous[return_path[-1]].nil?
-         return_path.reverse!
-         return_previous = return_shortest_distances = nil
-         needed_silvers += get_silver_cost.call(return_path)
-         return_path = nil
-      end
-      if needed_silvers > 0
-         current_silvers = Lich::Util.silver_count
-         if needed_silvers > current_silvers
-            if $go2_get_silvers
-               unless bank_id = Room.current.find_all_nearest_by_tag('bank').find { |room_id| current_silvers >= get_silver_cost.call(Room.current.path_to(room_id)) }
-                  echo "error: You're too poor to go to the bank."
-                  exit
-               end
-               pr, s = Map.dijkstra(Room.current.id, bank_id)
-               est_time = s[bank_id]
-               pr = s = nil
-               pr, s = Map.dijkstra(bank_id, destination.id)
-               est_time += s[destination.id]
-               pr = s = nil
-               unless setting_disable_confirm or not confirm
-                  confirm = false
-                  respond "ETA: #{(est_time/60.0).as_time}.  #{path.length-1} (wrong) rooms between this room (#{start_room.id}), the bank (#{bank_id}), and:"
-                  respond destination.to_s + "\n\nTo go here, unpause the script.  To abort, kill the script."
-                  pause_script
-               end
-               if $go2_started_go2_bank
-                  echo "You're too poor to go to the bank."
-                  exit
-               end
-               begin
-                  $go2_started_go2_bank = true
-                  go2_count = Script.running.find_all { |s| s.name == script.name }.length
-                  force_start_script script.name, [ bank_id.to_s ]
-                  wait_until { Script.running.find_all { |s| s.name == script.name }.length <= go2_count }
-               ensure
-                  $go2_started_go2_bank = false
-               end
-               unless start_room = Room.current
-                  echo 'error: your current room was not found in the map database'
-                  exit
-               end
-               moves_sent = $room_count
-               previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
-               unless previous[destination.id]
-                  echo "error: failed to find a path between your current room (#{start_room.id}) and destination room (#{destination.id})"
-                  exit
-               end
-               path = [ destination.id ]
-               path.push(previous[path[-1]]) until previous[path[-1]].nil?
-               path.reverse!
-               est_time = shortest_distances[destination.id]
-               previous = shortest_distances = nil
-               needed_silvers = get_silver_cost.call(path)
-               if setting_get_return_trip_silvers
-                  return_previous, return_shortest_distances = Map.dijkstra(destination.id, start_room.id)
-                  return_path = [ start_room.id ]
-                  return_path.push(return_previous[return_path[-1]]) until return_previous[return_path[-1]].nil?
-                  return_path.reverse!
-                  return_previous = return_shortest_distances = nil
-                  needed_silvers += get_silver_cost.call(return_path)
-                  return_path = nil
-               end
-               fput 'unhide' if hidden? or invisible?
-               if XMLData.room_title == '[Pinefar, Depository]'
-                  fput "ask banker for #{[(needed_silvers - Lich::Util.silver_count), 20].max} silvers"
-               else
-                  fput "withdraw #{needed_silvers - Lich::Util.silver_count} silvers"
-               end
-            else
-               echo 'You are too poor to make this trip.'
-               echo 'To give go2 permission to take your monies, type ;go2 getsilvers=on'
-               echo 'Continuing anyway in 10 seconds...'
-               sleep 10
-            end
-         end
-      end
-   end
+	if Script.running?('textsubs') && est_time > 5
+		stop_script('textsubs')
+		before_dying { start_script('textsubs') }
+	end
 
-   if setting_disable_confirm or $go2_restart or not confirm
-      echo "ETA: #{(est_time/60.0).as_time} (#{path.length-1} rooms to move through)"
-   else
-      respond "ETA: #{(est_time/60.0).as_time}.  #{path.length-1} rooms between this room (#{start_room.id}) and:"
-      respond destination.to_s + "\n\nTo go here, unpause the script.  To abort, kill the script."
-      pause_script
-   end
+	if XMLData.game =~ /^GS/
+		needed_silvers = get_silver_cost.call(path)
+		if setting_get_return_trip_silvers
+			return_previous, return_shortest_distances = Map.dijkstra(destination.id, start_room.id)
+			return_path = [ start_room.id ]
+			return_path.push(return_previous[return_path[-1]]) until return_previous[return_path[-1]].nil?
+			return_path.reverse!
+			return_previous = return_shortest_distances = nil
+			needed_silvers += get_silver_cost.call(return_path)
+			return_path = nil
+		end
+		if needed_silvers > 0
+			current_silvers = check_silvers.call
+			if needed_silvers > current_silvers
+				if $go2_get_silvers
+					unless bank_id = Room.current.find_all_nearest_by_tag('bank').find { |room_id| current_silvers >= get_silver_cost.call(Room.current.path_to(room_id)) }
+						echo "error: You're too poor to go to the bank."
+						exit
+					end
+					pr, s = Map.dijkstra(Room.current.id, bank_id)
+					est_time = s[bank_id]
+					pr = s = nil
+					pr, s = Map.dijkstra(bank_id, destination.id)
+					est_time += s[destination.id]
+					pr = s = nil
+					unless setting_disable_confirm or not confirm
+						confirm = false
+						respond "ETA: #{(est_time/60.0).as_time}.  #{path.length-1} (wrong) rooms between this room (#{start_room.id}), the bank (#{bank_id}), and:"
+						respond destination.to_s + "\n\nTo go here, unpause the script.  To abort, kill the script."
+						pause_script
+					end
+					if $go2_started_go2_bank
+						echo "You're too poor to go to the bank."
+						exit
+					end
+					begin
+						$go2_started_go2_bank = true
+						go2_count = Script.running.find_all { |s| s.name == script.name }.length
+						force_start_script script.name, [ bank_id.to_s ]
+						wait_until { Script.running.find_all { |s| s.name == script.name }.length <= go2_count }
+					ensure
+						$go2_started_go2_bank = false
+					end
+					unless start_room = Room.current
+						echo 'error: your current room was not found in the map database'
+						exit
+					end
+					moves_sent = $room_count
+					previous, shortest_distances = Map.dijkstra(start_room.id, destination.id)
+					unless previous[destination.id]
+						echo "error: failed to find a path between your current room (#{start_room.id}) and destination room (#{destination.id})"
+						exit
+					end
+					path = [ destination.id ]
+					path.push(previous[path[-1]]) until previous[path[-1]].nil?
+					path.reverse!
+					est_time = shortest_distances[destination.id]
+					previous = shortest_distances = nil
+					needed_silvers = get_silver_cost.call(path)
+					if setting_get_return_trip_silvers
+						return_previous, return_shortest_distances = Map.dijkstra(destination.id, start_room.id)
+						return_path = [ start_room.id ]
+						return_path.push(return_previous[return_path[-1]]) until return_previous[return_path[-1]].nil?
+						return_path.reverse!
+						return_previous = return_shortest_distances = nil
+						needed_silvers += get_silver_cost.call(return_path)
+						return_path = nil
+					end
+					fput 'unhide' if hidden? or invisible?
+					if XMLData.room_title == '[Pinefar, Depository]'
+						fput "ask banker for #{[(needed_silvers - check_silvers.call), 20].max} silvers"
+					else
+						fput "withdraw #{needed_silvers - check_silvers.call} silvers"
+					end
+				else
+					echo 'You are too poor to make this trip.'
+					echo 'To give go2 permission to take your monies, type ;go2 getsilvers=on'
+					echo 'Continuing anyway in 10 seconds...'
+					sleep 10
+				end
+			end
+		end
+	end
 
-   start_time = Time.now.to_f unless $go2_restart
+	if setting_disable_confirm or $go2_restart or not confirm
+		echo "ETA: #{(est_time/60.0).as_time} (#{path.length-1} rooms to move through)"
+	else
+		respond "ETA: #{(est_time/60.0).as_time}.  #{path.length-1} rooms between this room (#{start_room.id}) and:"
+		respond destination.to_s + "\n\nTo go here, unpause the script.  To abort, kill the script."
+		pause_script
+	end
 
-   $go2_restart = false
+	start_time = Time.now.to_f unless $go2_restart
 
-   path.each_index { |idx|
-      room = Map[path[idx]]
-      next_id = (path[idx + 1] || break).to_s
+	$go2_restart = false
 
-      exit if dead?
-      wait_while { muckled? }
-      unless standing? or (room.wayto[next_id].inspect =~ /swim/i)
-         waitrt?
-         fput 'stand'
-      end
-      waitrt?
+	path.each_index { |idx|
+		room = Map[path[idx]]
+		next_id = (path[idx + 1] || break).to_s
 
-      if room.wayto[next_id].class == Proc
-         if setting_drag
-            echo "error: drag feature can't deal with StringProc movements yet"
-            exit
-         end
-         # echo 'proc: ' + room.id.to_s + ' -> ' + next_id.to_s
-         if (setting_typeahead > 0) and (setting_delay <= 0)
-            50.times {
-               break if ($room_count >= moves_sent)
-               sleep 0.05
-            }
-            if setting_stop_for_dead and $go2_see_dead_people
-               $go2_restart = true
-               10.times {
-                  break if GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
-                  idx -= 1
-                  break unless (way = Room.current.wayto[path[idx].to_s])
-                  if way.class == Proc
-                     way.call
-                  else
-                     move way
-                  end
-               }
-               pause_script
-               $go2_see_dead_people = false
-               break
-            end
-            unless ($room_count >= moves_sent)
-               if $_SERVERBUFFER_.any? { |line| line =~ /Sorry, you may only type ahead/ }
-                  echo 'reducing typeahead setting...'
-                  setting_typeahead -= 1
-               end
-               $go2_restart = true
-               break
-            end
-         end
-         begin
-            room_id_before_proc = Room.current.id
-            room.wayto[next_id].call
-            sleep setting_delay
-            pause_script if setting_stop_for_dead and GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
-            # $go2_restart = true if Room.current.id == room_id_before_proc
-            break if $go2_restart
-         rescue
-            respond "--- error running mini-script: #{room.id} -> #{next_id}"
-            respond $!
-            exit
-         end
-         moves_sent = $room_count
-      else
-         if (setting_typeahead > 0) and (setting_delay <= 0) and not first_move
-            time = Time.now + 3
-            moves = moves_sent - setting_typeahead
-            loop {
-               break if ($room_count >= moves) or (Time.now > time)
-               sleep 0.02
-            }
-            if setting_stop_for_dead and $go2_see_dead_people
-               $go2_restart = true
-               50.times {
-                  break if ($room_count >= moves_sent)
-                  sleep 0.05
-               }
-               10.times {
-                  break if GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
-                  idx -= 1
-                  break unless (way = Room.current.wayto[path[idx].to_s])
-                  if way.class == Proc
-                     way.call
-                  else
-                     move way
-                  end
-               }
-               pause_script
-               $go2_see_dead_people = false
-               break
-            end
-            unless ($room_count + setting_typeahead) >= moves_sent
-               if $_SERVERBUFFER_.any? { |line| line =~ /Sorry, you may only type ahead/ }
-                  echo 'reducing typeahead setting...'
-                  setting_typeahead -= 1
-               end
-               $go2_restart = true
-               break
-            end
-            put room.wayto[next_id]
-            moves_sent += 1
-         else
-            first_move = false
-            moves_sent += 1
-            if setting_drag
-               way = room.wayto[next_id]
-               if way =~ /^(north|northeast|east|southeast|south|southwest|west|northwest|n|ne|e|se|s|sw|w|nw|up|u|down|d|out)$/i
-                  way = "drag #{setting_drag} #{way}"
-                  result = move way
-               elsif way =~ /^(?:go|climb) /i
-                  way = way.sub(/^(?:go|climb) /i, "drag #{setting_drag} ")
-                  result = move way
-               else
-                  echo "error: drag feature doesn't know how to deal with this movement: #{way}"
-                  exit
-               end
-            else
-               result = move room.wayto[next_id]
-            end
-            sleep setting_delay
-            pause_script if setting_stop_for_dead and GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
-            unless result
-               error_count += 1
-               if (idx == 0) and (error_count > 2) and (Room.current.id == room.id)
-                  echo "changing Room[#{room.id}].timeto['#{next_id}'] to nil"
-                  old_room = room
-                  old_next_id = next_id
-                  old_timeto = room.timeto[next_id]
-                  before_dying {
-                     echo "reverting Room[#{old_room.id}].timeto['#{old_next_id}'] back to #{old_timeto.inspect}"
-                     old_room.timeto[old_next_id] = old_timeto
-                  }
-                  room.timeto[next_id] = nil
-               end
-               $go2_restart = true
-               break
-            end
-         end
-      end
-      waitrt?
-      if $go2_cast and Spell[515].active? and (checkprep == Spell[402].name) and Spell[402].affordable?
-         Spell[402].cast
-      end
-   }
+		exit if dead?
+		wait_while { muckled? }
+		unless standing? or (room.wayto[next_id].inspect =~ /swim/i)
+			waitrt?
+			fput 'stand'
+		end
+		waitrt?
 
-   if (setting_typeahead > 0) and (setting_delay <= 0)
-      50.times {
-         break if ($room_count >= moves_sent)
-         sleep 0.05
-      }
-      unless $room_count >= moves_sent
-         $go2_restart = true
-      end
-   end
+		if room.wayto[next_id].class == Proc
+			if setting_drag
+				echo "error: drag feature can't deal with StringProc movements yet"
+				exit
+			end
+			# echo 'proc: ' + room.id.to_s + ' -> ' + next_id.to_s
+			if (setting_typeahead > 0) and (setting_delay <= 0)
+				50.times {
+					break if ($room_count >= moves_sent)
+					sleep 0.05
+				}
+				if setting_stop_for_dead and $go2_see_dead_people
+					$go2_restart = true
+					10.times {
+						break if GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+						idx -= 1
+						break unless (way = Room.current.wayto[path[idx].to_s])
+						if way.class == Proc
+							way.call
+						else
+							move way
+						end
+					}
+					pause_script
+					$go2_see_dead_people = false
+					break
+				end
+				unless ($room_count >= moves_sent)
+					if $_SERVERBUFFER_.any? { |line| line =~ /Sorry, you may only type ahead/ }
+						echo 'reducing typeahead setting...'
+						setting_typeahead -= 1
+					end
+					$go2_restart = true
+					break
+				end
+			end
+			begin
+				room_id_before_proc = Room.current.id
+				room.wayto[next_id].call
+				sleep setting_delay
+				pause_script if setting_stop_for_dead and GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+				# $go2_restart = true if Room.current.id == room_id_before_proc
+				break if $go2_restart
+			rescue
+				respond "--- error running mini-script: #{room.id} -> #{next_id}"
+				respond $!
+				exit
+			end
+			moves_sent = $room_count
+		else
+			if (setting_typeahead > 0) and (setting_delay <= 0) and not first_move
+				time = Time.now + 3
+				moves = moves_sent - setting_typeahead
+				loop {
+					break if ($room_count >= moves) or (Time.now > time)
+					sleep 0.02
+				}
+				if setting_stop_for_dead and $go2_see_dead_people
+					$go2_restart = true
+					50.times {
+						break if ($room_count >= moves_sent)
+						sleep 0.05
+					}
+					10.times {
+						break if GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+						idx -= 1
+						break unless (way = Room.current.wayto[path[idx].to_s])
+						if way.class == Proc
+							way.call
+						else
+							move way
+						end
+					}
+					pause_script
+					$go2_see_dead_people = false
+					break
+				end
+				unless ($room_count + setting_typeahead) >= moves_sent
+					if $_SERVERBUFFER_.any? { |line| line =~ /Sorry, you may only type ahead/ }
+						echo 'reducing typeahead setting...'
+						setting_typeahead -= 1
+					end
+					$go2_restart = true
+					break
+				end
+				put room.wayto[next_id]
+				moves_sent += 1
+			else
+				first_move = false
+				moves_sent += 1
+				if setting_drag
+					way = room.wayto[next_id]
+					if way =~ /^(north|northeast|east|southeast|south|southwest|west|northwest|n|ne|e|se|s|sw|w|nw|up|u|down|d|out)$/i
+						way = "drag #{setting_drag} #{way}"
+						result = move way
+					elsif way =~ /^(?:go|climb) /i
+						way = way.sub(/^(?:go|climb) /i, "drag #{setting_drag} ")
+						result = move way
+					else
+						echo "error: drag feature doesn't know how to deal with this movement: #{way}"
+						exit
+					end
+				else
+					result = move room.wayto[next_id]
+				end
+				sleep setting_delay
+				pause_script if setting_stop_for_dead and GameObj.pcs.any? { |pc| pc.status =~ /dead/ }
+				unless result
+					error_count += 1
+					if (idx == 0) and (error_count > 2) and (Room.current.id == room.id)
+						echo "changing Room[#{room.id}].timeto['#{next_id}'] to nil"
+						old_room = room
+						old_next_id = next_id
+						old_timeto = room.timeto[next_id]
+						before_dying {
+							echo "reverting Room[#{old_room.id}].timeto['#{old_next_id}'] back to #{old_timeto.inspect}"
+							old_room.timeto[old_next_id] = old_timeto
+						}
+						room.timeto[next_id] = nil
+					end
+					$go2_restart = true
+					break
+				end
+			end
+		end
+		waitrt?
+		if $go2_cast and Spell[515].active? and (checkprep == Spell[402].name) and Spell[402].affordable?
+			Spell[402].cast
+		end
+	}
 
-   break unless $go2_restart
+	if (setting_typeahead > 0) and (setting_delay <= 0)
+		50.times {
+			break if ($room_count >= moves_sent)
+			sleep 0.05
+		}
+		unless $room_count >= moves_sent
+			$go2_restart = true
+		end
+	end
+
+	break unless $go2_restart
 }
 
 sleep 0.1


### PR DESCRIPTION
This is a part of a series of changes that do the following:

1. Fix some travel failures resulting from the move from Lich4 to Lich5 which arise due to Lich4's overloading of the FalseClass method and Lich5's refusal to do so. These travel failures are best fixed in the map stringprocs but, in the meantime, we'll build in a fix. These fixes will live in base.yaml and their implementation will be handled in ;go2 and pass through a DR game and Lich 5+ version check before being deployed, since those still on Lich4 don't need the fix.
2. Allow appropriately skilled users to set custom map wayto stringproc overrides by implementing them in their yaml hierarchy. Said personal wayto overrides will be favored over the base overrides for like-named hash keys. Users who can handle stringproc overrides will be trusted not to break their implementation.

This PR sets the following:

1. Adds to `;go2` a structure to check that game is Dragonrealms, grab yaml settings that specify map wayto stringproc overrides, allow default overrides to fix some Lich5 travel hiccups in the interim, allow power users to specify their own travel stringprocs, aggregate all overrides, and set them for travel.