### PR TITLE
[script][go2.lic] - Add support for custom map wayto stringproc overrides (Change 3 of 3)

### DIFF
--- a/go2.lic
+++ b/go2.lic
@@ -161,6 +161,46 @@ show_help = proc {
    respond output
 }
 
+# For Dragonrealms only
+# A change in behavior from Lich4 to Lich5 caused certain ;go2 map wayto movements to fail.
+# This is because of the way the map stringprocs are structured, and the method used to evaluate
+# certain map moves, which involved an arguably dubious overloading of FalseClass on Lich4.
+# The transition to Lich5 makes it necessary to fix some stringprocs as an interim solution, at
+# least until the map can be divested from current owner control and handled appropriately. This code
+# also allows the flexibility to pull custom map wayto overrides from the standard yaml hierarchy.
+if XMLData.game =~ /^DR/
+  # Get yaml settings
+  settings = get_settings
+
+  # Get base wayto overrides. These base map wayto overrides were created to fix some travel hiccups
+  # from converting from Lich4 to Lich5. They are not needed for Lich4 users, so we'll check Lich
+  # version shortly.
+  base_wayto_overrides = settings.base_wayto_overrides
+  personal_wayto_overrides = settings.personal_wayto_overrides
+
+  # Notify user we've detected and are using personal map stringproc overrides
+
+  # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
+  # The reason for favoring personal overrides is that any user who has the ability to create
+  # custom map stringprocs can be trusted to have their customization favored vs. the base overrides.
+  # If they break the functionality, that's on them.
+  if LICH_VERSION[0].to_i >= 5
+    wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
+    echo "Using base.yaml's Lich5+ map wayto stringproc overrides."
+    unless personal_wayto_overrides.empty?
+      echo "Using your personal map wayto stringproc overrides, which take precendence over base."
+    end
+  else
+    wayto_overrides = personal_wayto_overrides
+  end
+
+  # Iterate through the aggregated map wayto overrides from above and set new stringprocs
+  wayto_overrides.each do | key, values |
+    Map.list[values['start_room'].to_i].wayto["#{values['end_room']}"] = StringProc.new("#{values['str_proc']}")
+    echo values['str_proc']
+  end
+end
+
 change_map_vaalor_shortcut = proc { |use_shortcut|
    unless Map.list.any? { |room| room.timeto.any? { |adj_id,time| time.class == Proc and time._dump =~ /$go2_use_vaalor_shortcut/ } }
       if use_shortcut
@@ -198,7 +238,7 @@ if script.vars.empty? or script.vars[0].strip =~ /^help$/i
    exit
 elsif script.vars[0] =~ /^targets$/i
    echo 'generating list...'
-   dr_interesting_tags = ["alchemist", "armorshop", "bakery", "bank", "barbarian", "bard", "boutique", "cleric", "clericshop", "empath", "exchange", "fletcher", "forge", "furrier", "gemshop", "general store", "herbalist", "inn", "locksmith", "moonmage", "movers ", "necromancer", "npchealer", "paladin", "pawnshop", "ranger", "smokeshop", "stable", "thief", "town", "trader", "warmage", "weaponshop"] 
+   dr_interesting_tags = ["alchemist", "armorshop", "bakery", "bank", "barbarian", "bard", "boutique", "cleric", "clericshop", "empath", "exchange", "fletcher", "forge", "furrier", "gemshop", "general store", "herbalist", "inn", "locksmith", "moonmage", "movers ", "necromancer", "npchealer", "paladin", "pawnshop", "ranger", "smokeshop", "stable", "thief", "town", "trader", "warmage", "weaponshop"]
    gs_interesting_tags = [ "advguard", "advguard2", "advguild", "advpickup", "alchemist", "armorshop", "bakery", "bank", "bardguild", "boutique", "chronomage", "clericguild", "clericshop", "collectibles", "consignment", "empathguild", "exchange", "fletcher", "forge", "furrier", "gemshop", "general store", "herbalist", "inn", "locksmith pool", "locksmith", "mail", "movers", "npccleric", "npchealer", "pawnshop", "postoffice", "rangerguild", "smokeshop", "sorcererguild", "sunfist", "town", "voln", "warriorguild", "weaponshop", "wizardguild"  ]
    town_list = Map.list.find_all { |room| room.tags.include?('town') }
    town_ids = town_list.collect { |room| room.id }

--- a/go2.lic
+++ b/go2.lic
@@ -197,7 +197,6 @@ if XMLData.game =~ /^DR/
   # Iterate through the aggregated map wayto overrides from above and set new stringprocs
   wayto_overrides.each do | key, values |
     Map.list[values['start_room'].to_i].wayto["#{values['end_room']}"] = StringProc.new("#{values['str_proc']}")
-    echo values['str_proc']
   end
 end
 

--- a/go2.lic
+++ b/go2.lic
@@ -9,10 +9,12 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.31
+           version: 1.32
           required: Lich >= 4.6.14
 
    changelog:
+      1.32 (2022-03-22):
+        For DR: add support for yaml-based map stringproc overrides
       1.31 (2022-03-10):
         Merged in DR changes from v1.22f by Sarvatt
       1.30 (2022-03-03):

--- a/go2.lic
+++ b/go2.lic
@@ -178,8 +178,6 @@ if XMLData.game =~ /^DR/
   base_wayto_overrides = settings.base_wayto_overrides
   personal_wayto_overrides = settings.personal_wayto_overrides
 
-  # Notify user we've detected and are using personal map stringproc overrides
-
   # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
   # The reason for favoring personal overrides is that any user who has the ability to create
   # custom map stringprocs can be trusted to have their customization favored vs. the base overrides.
@@ -187,6 +185,7 @@ if XMLData.game =~ /^DR/
   if LICH_VERSION[0].to_i >= 5
     wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
     echo "Using base.yaml's Lich5+ map wayto stringproc overrides."
+    # Notify user we've detected and are using personal map stringproc overrides
     unless personal_wayto_overrides.empty?
       echo "Using your personal map wayto stringproc overrides, which take precendence over base."
     end

--- a/go2.lic
+++ b/go2.lic
@@ -172,26 +172,12 @@ if XMLData.game =~ /^DR/
   # Get yaml settings
   settings = get_settings
 
-  # Get base wayto overrides. These base map wayto overrides were created to fix some travel hiccups
-  # from converting from Lich4 to Lich5. They are not needed for Lich4 users, so we'll check Lich
-  # version shortly.
+  # Get base and personal wayto overrides
   base_wayto_overrides = settings.base_wayto_overrides
   personal_wayto_overrides = settings.personal_wayto_overrides
 
   # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
-  # The reason for favoring personal overrides is that any user who has the ability to create
-  # custom map stringprocs can be trusted to have their customization favored vs. the base overrides.
-  # If they break the functionality, that's on them.
-  if LICH_VERSION[0].to_i >= 5
-    wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
-    echo "Using base.yaml's Lich5+ map wayto stringproc overrides."
-    # Notify user we've detected and are using personal map stringproc overrides
-    unless personal_wayto_overrides.empty?
-      echo "Using your personal map wayto stringproc overrides, which take precendence over base."
-    end
-  else
-    wayto_overrides = personal_wayto_overrides
-  end
+  wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
 
   # Iterate through the aggregated map wayto overrides from above and set new stringprocs
   wayto_overrides.each do | key, values |


### PR DESCRIPTION
This is a part of a series of changes that do the following:

1. Fix some travel failures resulting from the move from Lich4 to Lich5 which arise due to Lich4's overloading of the FalseClass method and Lich5's refusal to do so. These travel failures are best fixed in the map stringprocs but, in the meantime, we'll build in a fix. These fixes will live in base.yaml and their implementation will be handled in ;go2 and pass through a DR game and Lich 5+ version check before being deployed, since those still on Lich4 don't need the fix.
2. Allow appropriately skilled users to set custom map wayto stringproc overrides by implementing them in their yaml hierarchy. Said personal wayto overrides will be favored over the base overrides for like-named hash keys. Users who can handle stringproc overrides will be trusted not to break their implementation.

This PR sets the following:

1. Adds support for processing of custom map wayto stringproc overrides
2. Does the following checks: is game DR? If so, and base.yaml stringproc overrides exist, is user's Lich version 5+?
3. Merges the base overrides and personal overrides into a single hash, favoring the user's personal overrides in the case of identical hash keys.