### PR TITLE
[script] [dependency] skip drinfomon autostart, and remove from autostart if found

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -330,7 +330,7 @@ class ScriptManager
     repo_scripts.each { |(name, _)| get_script(name, force) }
     autostarts.each do |script|
       if script == 'drinfomon'
-        respond "\n---\ndrinfomon found in autostarts. Attempting to remove it now. If unsuccessful, it can be safely removed with `;e stop_autostart('drinfomon')`\n---\n"
+        respond "\n---\ndrinfomon found in autostarts. Attempting to remove it now. If unsuccessful, it can be safely removed with `#{$clean_lich_char}e stop_autostart('drinfomon')`\n---\n"
         stop_autostart('drinfomon')
         next
       end

--- a/dependency.lic
+++ b/dependency.lic
@@ -330,7 +330,7 @@ class ScriptManager
     repo_scripts.each { |(name, _)| get_script(name, force) }
     autostarts.each do |script|
       if script == 'drinfomon'
-        respond "\n---\ndrinfomon found in autostarts. Attempting to remove it now. If unsuccessful, it can be safely removed with `#{$clean_lich_char}e stop_autostart('drinfomon')`\n---\n"
+        respond "\n---\ndrinfomon found in autostarts. This method is no longer used. Attempting to remove it now. If unsuccessful, it can be safely removed with `#{$clean_lich_char}e stop_autostart('drinfomon')`\n---\n"
         stop_autostart('drinfomon')
         next
       end

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.7'
+$DEPENDENCY_VERSION = '1.4.8'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all
@@ -329,6 +329,11 @@ class ScriptManager
     @versions = nil
     repo_scripts.each { |(name, _)| get_script(name, force) }
     autostarts.each do |script|
+      if script == 'drinfomon'
+        respond "\n---\ndrinfomon found in autostarts. Attempting to remove it now. If unsuccessful, it can be safely removed with `;e stop_autostart('drinfomon')`\n---\n"
+        stop_autostart('drinfomon')
+        next
+      end
       custom_require.call(script)
       begin
         pause 0.2


### PR DESCRIPTION
Since we now start drinfomon as script zero directly from dependency, we no longer need it autostarted.

Some folks still have that autostart, which causes weird "drinfomon is already running" messages.

With this change, we make a note, and remove drinfomon from autostarts

```
drinfomon found in autostarts. Attempting to remove it now. If unsuccessful, it can be safely removed with `;e stop_autostart('drinfomon')`
```
This was successful.
```
>;e echo list_autostarts
--- Lich: exec1 active.
[exec1: ["sanowret-crystal", "almanac", "esp", "smartlisten", "play", "log", "tarantula", "afk", "sorter", "exp-monitor", "textsubs", "roomnumbers", "tdps"]]
--- Lich: exec1 has exited.    
```

This is similar logic to what we did with lich5's autostart for dependency in https://github.com/elanthia-online/lich-5/pull/179