### PR TITLE
[script][remedy] - Fix TrueClass error for Lich5 users

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -140,13 +140,13 @@ class Remedy
     # there are still issues when herbs are in a different container (not @bag or @herb_container), script will still run fine
 
     if (name == @herb1 || name == @herb2) && @settings.herb_container && bput("tap #{name} in #{@herb_container}", 'You tap', 'I could not find what you were referring to.', 'You lightly tap') == 'You tap'
-      get_crafting_item(name, @herb_container, [name], @belt) # bag_items is TRUE to look for herbs in herb_container
+      get_crafting_item(name, @herb_container, [name], @belt) # Look for herbs in herb_container
     elsif (name == @herb1 || name == @herb2) && bput("tap #{name} in #{@bag}", 'You tap', 'I could not find what you were referring to.', 'You lightly tap') == 'You tap'
-      get_crafting_item(name, @bag, [name], @belt) # bag_items is TRUE to look for herbs in bag
+      get_crafting_item(name, @bag, [name], @belt) # Look for herbs in bag
     elsif at_feet
       get_crafting_item(name, @bag, nil, @belt) # This elsif used primarily to get bowl/mortar etc. from at our feet after lowering it.
     else
-      get_crafting_item(name, @bag, @bag_items, @belt) # bag_items is FALSE to GET HERB without specifying a bag
+      get_crafting_item(name, @bag, @bag_items, @belt) # Primarily to get herb without specifying a bag
       'none' # return specified to handle herbs differently for this option (to prevent a bug)
     end
   end

--- a/remedy.lic
+++ b/remedy.lic
@@ -140,11 +140,11 @@ class Remedy
     # there are still issues when herbs are in a different container (not @bag or @herb_container), script will still run fine
 
     if (name == @herb1 || name == @herb2) && @settings.herb_container && bput("tap #{name} in #{@herb_container}", 'You tap', 'I could not find what you were referring to.', 'You lightly tap') == 'You tap'
-      get_crafting_item(name, @herb_container, true, @belt) # bag_items is TRUE to look for herbs in herb_container
+      get_crafting_item(name, @herb_container, [name], @belt) # bag_items is TRUE to look for herbs in herb_container
     elsif (name == @herb1 || name == @herb2) && bput("tap #{name} in #{@bag}", 'You tap', 'I could not find what you were referring to.', 'You lightly tap') == 'You tap'
-      get_crafting_item(name, @bag, true, @belt) # bag_items is TRUE to look for herbs in bag
+      get_crafting_item(name, @bag, [name], @belt) # bag_items is TRUE to look for herbs in bag
     elsif at_feet
-      get_crafting_item(name, @bag, false, @belt) # This elsif used primarily to get bowl/mortar etc. from at our feet after lowering it.
+      get_crafting_item(name, @bag, nil, @belt) # This elsif used primarily to get bowl/mortar etc. from at our feet after lowering it.
     else
       get_crafting_item(name, @bag, @bag_items, @belt) # bag_items is FALSE to GET HERB without specifying a bag
       'none' # return specified to handle herbs differently for this option (to prevent a bug)


### PR DESCRIPTION
Fixes TrueClass error resulting from Lich4 -> Lich5 since True and False class are no longer overloaded.

Error log:

```
[remedy]>tap jadice in backpack
You tap some dried jadice inside your canvas backpack.
>
--- Lich: error: undefined method `include?' for true:TrueClass
    common-crafting:161:in `get_crafting_item'
    remedy:145:in `get_item'
--- Lich: remedy has exited.
```

Thank you @rcuhljr for the assist on how to fix this.