### PR TITLE
[scripts] [dependency] kill drinfomon before starting dependency on self update

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.8'
+$DEPENDENCY_VERSION = '1.4.9'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all
@@ -1693,6 +1693,7 @@ def update_d
     sleep 2
     force_start_script('dependency')
   end
+  stop_script('drinfomon') if Script.running?('drinfomon')
   stop_script('dependency')
 end
 


### PR DESCRIPTION
With this change, in lich5, we end up with a working install after first launch. No need to restart lich/the game at all. 