### PR TITLE
[data][base.yaml] - Fix cosmetic typos

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2229,11 +2229,11 @@ drinfomon_passive_delay: 30
 # FIXES via stringproc known map movement failures as a result of the transition to Lich5. A user
 # with the appropriate skill can overload these in their own yaml(s).
 base_wayto_overrides:
-  aksetis_mount_up:
+  asketis_mount_up:
     start_room: 27558
     end_room: 31491
     str_proc: start_script('bescort', ['asketis_mount', 'up']);wait_while{running?('bescort')};
-  aksetis_mount_down:
+  asketis_mount_down:
     start_room: 27558
     end_room: 27556
     str_proc: start_script('bescort', ['asketis_mount', 'down']);wait_while{running?('bescort')};


### PR DESCRIPTION
Typos were non-breaking since the stringprocs were spelled correctly. These typos are in the labeling only.

Asketis vs. Aksetis. Thanks @KatoakDR for the keen eye.