### PR TITLE
[scripts] [dependency] Dependency allow alternate profiles directory

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.9'
+$DEPENDENCY_VERSION = '1.4.10'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all

--- a/dependency.lic
+++ b/dependency.lic
@@ -939,7 +939,15 @@ class SetupFiles
   private
 
   SCRIPTS_DATA_PATH = File.join('.', 'scripts', 'data')
-  SCRIPTS_PROFILES_PATH = File.join('.', 'scripts', 'profiles')
+
+  # use alternate location for settings to allow folks to use lich with
+  # alternate configurations in Test/Platinum/Fallen
+  if File.exist?("#{DATA_DIR}/#{XMLData.game}/base.yaml") && File.exist?("#{DATA_DIR}/#{XMLData.game}/base-empty.yaml") && File.exist?("#{DATA_DIR}/#{XMLData.game}/#{checkname}-setup.yaml")
+    echo("Detected game instance-specific files. Looking settings in #{File.join(DATA_DIR, XMLData.game)}")
+    SCRIPTS_PROFILES_PATH = File.join(DATA_DIR, XMLData.game)
+  else
+    SCRIPTS_PROFILES_PATH = File.join('.', 'scripts', 'profiles')
+  end
 
   # Reloads the base profiles plus any that match the filenames given.
   def reload_profiles(filenames = [])

--- a/dependency.lic
+++ b/dependency.lic
@@ -943,7 +943,7 @@ class SetupFiles
   # use alternate location for settings to allow folks to use lich with
   # alternate configurations in Test/Platinum/Fallen
   if File.exist?("#{DATA_DIR}/#{XMLData.game}/base.yaml") && File.exist?("#{DATA_DIR}/#{XMLData.game}/base-empty.yaml") && File.exist?("#{DATA_DIR}/#{XMLData.game}/#{checkname}-setup.yaml")
-    echo("Detected game instance-specific files. Looking settings in #{File.join(DATA_DIR, XMLData.game)}")
+    echo("Detected game instance-specific files. Loading settings from #{File.join(DATA_DIR, XMLData.game)}")
     SCRIPTS_PROFILES_PATH = File.join(DATA_DIR, XMLData.game)
   else
     SCRIPTS_PROFILES_PATH = File.join('.', 'scripts', 'profiles')


### PR DESCRIPTION
If we find `base.yaml`, `base-empty.yaml`, and `Name-setup.yaml` in `lich/data/Game (DR|DRT|DRX|DRF)` then use that directory for settings.

Allows per-game instance yamls basically, if you play on Fallen/Platinum, or even Test.