### PR TITLE
[script][common-money] Add message for too many transactions

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -203,7 +203,7 @@ module DRCM
       )
       when 'The clerk counts', 'You count out'
         break true
-      when 'The clerk glares at you.', 'Hey!  Slow down!'
+      when 'The clerk glares at you.', 'Hey!  Slow down!', "I don't know what you think you're doing"
         pause 15
       when 'The clerk tells', 'If you value your hands', 'find a new deposit jar',
         "You must be at a bank teller's window to withdraw money", "You don't have that much money",


### PR DESCRIPTION
Adds the most common message when you have too many transactions in too little time. Existing logic catches this and pauses 15 before trying again. We were just missing the proper messaging for most of the realm's banks.