### PR TITLE
[script][restock.lic] - Add support for Shard bribes

### DIFF
--- a/restock.lic
+++ b/restock.lic
@@ -3,12 +3,12 @@
 custom_require.call(%w[common common-items common-money common-travel])
 
 class Restock
-  include DRC
 
   def initialize
     arg_definitions = [
       [
-        { name: 'debug', regex: /debug/, optional: true, description: ''}
+        { name: 'debug', regex: /debug/, optional: true, description: ''},
+        { name: 'script_summary', optional: true, description: 'A script for restocking your supply of stackable and nonstackable items. Will parse your YAML for a restock set and make the appropriate purchases to maintain your desired quantity. This is called at the start of hunting-buddy as the preferred mechanism to maintain ammunition counts.'}
       ]
     ]
 
@@ -27,13 +27,16 @@ class Restock
   end
 
   def start_restock
+    # Parse data from user's yaml and base-consumables
     items = parse_restockable_items
-
+    # If user has specified a custom location to restock a specific item, grab that here
     custom_loc_items = items.select { |k| k['hometown'] }
-
+    # Remove those custom location items from the primary restock items list
     items -= custom_loc_items
+    # Call the restock_items method on restock items that don't have custom location set
     restock_items(items, @settings.hometown)
 
+    # Restock items that have a custom location set
     custom_loc_items.map { |k| k['hometown'] }.uniq
                     .each do |_hometown|
       custom_loc_items.group_by { |v| v['hometown'] }
@@ -65,8 +68,12 @@ class Restock
     DRCI.stow_hands
 
     if coin_needed > 0
-      ### The following line is for the bribe to the night attendant to let you in.
-      coin_needed += 2502 if UserVars.sun['night'] && town =~ /\bShard\b/
+      # The following line is for the bribe to the night attendant to let you in to shops in Shard.
+      # Since the total bribe amounts are paltry in comparison to a modern character's average
+      # wealth, we'll avoid complexity and just grab the highest bribe amount times the number
+      # of restock items, even if its daytime. We deposit excess coins at the end, anyway.
+      coin_needed += 2502 * item_list.length.to_i
+      echo "Coin needed is #{coin_needed}" if @debug
       DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
     end
 
@@ -90,21 +97,38 @@ class Restock
   end
 
   def parse_restockable_items
+    # Get the yaml restock hash
     item_list = @restock
+    # Get the hometown consumables from base-consumables
     hometown_data = get_data('consumables')[@hometown]
     items = []
+
+    # Iterate through the yaml restock hash
     item_list.each do |key, value|
       echo "Restock Item: #{key} - #{value}" if @debug
+
+      # If any restock key exists as a key in hometown consumables
+      # AND a custom town specification doesn't exist in this restock item,
+      # then we'll restock this item using the data in base-consumables for our hometown.
       if hometown_data.key?(key) && !value.key?('hometown')
+        # Get hash from base-consumables for the specific restock item (e.g. 'arrow')
         ht_data = hometown_data[key]
+
+        # Iterate through the base-consumables hash. Use consumable data from base-consumables
+        # _unless_ specific data is specified in user's yaml.
         ht_data.each_key { |k| value[k] = ht_data[k] unless value.key?(k) }
         items.push(value)
+      # Otherwise, the user has specified a custom restock. This custom set needs to specify
+      # ALL data for restocking, since we're not doing a base-consumables lookup.
       elsif valid_item_data?(value)
         items.push(value)
       else
         echo "No hometown of explicit data for '#{key}'"
       end
     end
+    # Return the full set of populated restock data, either full custom user-provided or from
+    # base-consumables or a combination thereof.
+    echo "Items are: #{items}" if @debug
     items
   end
 
@@ -113,9 +137,9 @@ class Restock
 
     count = 0
     $ORDINALS.each do |ordinal|
-      count_msg = bput("count my #{ordinal} #{item['name']}", 
-          'I could not find what you were referring to.', 
-          'tell you much of anything.', 
+      count_msg = DRC.bput("count my #{ordinal} #{item['name']}",
+          'I could not find what you were referring to.',
+          'tell you much of anything.',
           'and see there \w+ .+ left.',
           'The \S+ has about \d+ uses of .* remaining\.  It is labeled',
           'The \S+ has about one use of .* remaining\.  It is labeled',
@@ -137,7 +161,7 @@ class Restock
         redo
       else
         count_txt = count_msg.match(/and see there \w+ (.+) left./).captures.first.tr('-', ' ')
-        count += text2num(count_txt)
+        count += DRC.text2num(count_txt)
       end
       waitrt?
     end
@@ -149,7 +173,7 @@ class Restock
 
     container = item['container']
     unless container
-      /inside your (.*).|I could not find/ =~ bput("tap my #{item['name']}", 'inside your (.*).', 'I could not find')
+      /inside your (.*).|I could not find/ =~ DRC.bput("tap my #{item['name']}", 'inside your (.*).', 'I could not find')
       tap_result = Regexp.last_match(1)
       return 0 if tap_result.nil?
       container = tap_result

--- a/restock.lic
+++ b/restock.lic
@@ -7,8 +7,7 @@ class Restock
   def initialize
     arg_definitions = [
       [
-        { name: 'debug', regex: /debug/, optional: true, description: ''},
-        { name: 'script_summary', optional: true, description: 'A script for restocking your supply of stackable and nonstackable items. Will parse your YAML for a restock set and make the appropriate purchases to maintain your desired quantity. This is called at the start of hunting-buddy as the preferred mechanism to maintain ammunition counts.'}
+        { name: 'debug', regex: /debug/, optional: true, description: 'Use this arg to run the script in debug mode.'}
       ]
     ]
 


### PR DESCRIPTION
Updates to restock.lic:

1. Now supports Shard nighttime bribes by calculating the cost of items to restock to include the highest known bribe amount in shard - 2500 copper times the number of shops we need to visit. The previous version of this script attempted to gauge nightime by using a UserVar that was exclusive to moonmages and also may not have accurately represented the time when Shard shops close. Because the total amount of the bribes is relatively small, we avoid complexity and just grab the highest known bribe times the number of shops we'll visit in Shard to ensure we have enough money to bribe. After playing around with custom stringprocs and a bescort method to handle bribing and entering Shard shops at night, I realized that `;restock` uses the `DRCT.walk_to` method, which does an automatic retry of shop entry if we fail to enter. Thus, as long as we have enough money to 1) bribe the shop and 2) still buy all the stuff we need, then shop entry should succeed and restock should successfully complete.
2. Remove the include line, add proper method prefixes.
3. Added some code comments that helped me decipher code flow and I think will help future contributors who are new to this script.
4. Added some additional debug echoes
5. Added a description to the debug arg so that it has proper output for `;restock help`