### PR TITLE
[script] [dependency] - Foundation for robust help output

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -85,7 +85,7 @@ class ArgParser
 
       # Display help output for settings used in the script. Relies on base-help.yaml.
       yaml_data = get_data('help').to_h
-      if !yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}.empty?
+      unless yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}.empty?
         respond " YAML SETTINGS USED:"
         yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}
                   .each do | field, info |

--- a/dependency.lic
+++ b/dependency.lic
@@ -50,7 +50,7 @@ class ArgParser
 
   def display_args(data)
     # Display help output for script arguments
-    unless Script.current.name == "bootstrap"
+    if Script.current.name != "bootstrap"
       data.each do |def_set|
         respond ''
         def_set.each { |x| respond " SCRIPT SUMMARY: #{x[:description]} " if x[:name].to_s == "script_summary"; }

--- a/dependency.lic
+++ b/dependency.lic
@@ -53,7 +53,9 @@ class ArgParser
     if Script.current.name != "bootstrap"
       data.each do |def_set|
         respond ''
-        def_set.each { |x| respond " SCRIPT SUMMARY: #{x[:description]} " if x[:name].to_s == "script_summary"; }
+        def_set
+          .select { |x| x[:name].to_s == "script_summary" }
+          .each { |x| respond " SCRIPT SUMMARY: #{x[:description]} " }
         respond ''
         respond " SCRIPT CALL FORMAT AND ARG DESCRIPTIONS:"
         respond "  ;#{Script.current.name} " + def_set.map { |x| format_item(x) }.join(' ')

--- a/dependency.lic
+++ b/dependency.lic
@@ -49,7 +49,26 @@ class ArgParser
   end
 
   def display_args(data)
-    # Display help output for script arguments
+    # This section displays help output for a script. It recognizes when a script call has been given
+    # with the wrong number or incorrect arguments, or when a script has been called via
+    # ;script-name help. It outputs an example script call, including arguments, with optional
+    # arguments enclosed in brackets. If an optional script_summary argument has been specified within
+    # the script, it also outputs a summary of the script. Further, if yaml settings have been
+    # outlined in base-help.yaml, it will output help information for the yaml settings used.
+    # Example output when all help settings have been specified:
+    #
+    # >;circlecheck help
+    #   SCRIPT SUMMARY: Checks your circle and skills to next circle. Optionally checks skills for a target circle.
+
+    #   SCRIPT CALL FORMAT AND ARG DESCRIPTIONS (arguments in brackets are optional):
+    #    ;circlecheck [debug] [mode] [target] [script_summary]
+    #     debug        Runs the script with debug messages.
+    #     mode         Only display requirements you don't meet [brief, short, next]
+    #     target       See requirements for a specific circle
+
+    #   YAML SETTINGS USED:
+    #     circlecheck_prettyprint: Tells circlecheck to use the pretty print formatting for output.
+
     if Script.current.name != "bootstrap"
       data.each do |def_set|
         respond ''
@@ -57,7 +76,7 @@ class ArgParser
           .select { |x| x[:name].to_s == "script_summary" }
           .each { |x| respond " SCRIPT SUMMARY: #{x[:description]} " }
         respond ''
-        respond " SCRIPT CALL FORMAT AND ARG DESCRIPTIONS:"
+        respond " SCRIPT CALL FORMAT AND ARG DESCRIPTIONS (arguments in brackets are optional):"
         respond "  ;#{Script.current.name} " + def_set.map { |x| format_item(x) }.join(' ')
         def_set
           .reject { |x| x[:name].to_s == "script_summary" }

--- a/dependency.lic
+++ b/dependency.lic
@@ -59,15 +59,15 @@ class ArgParser
     #
     # >;circlecheck help
     #   SCRIPT SUMMARY: Checks your circle and skills to next circle. Optionally checks skills for a target circle.
-
+    #
     #   SCRIPT CALL FORMAT AND ARG DESCRIPTIONS (arguments in brackets are optional):
     #    ;circlecheck [debug] [mode] [target] [script_summary]
     #     debug        Runs the script with debug messages.
     #     mode         Only display requirements you don't meet [brief, short, next]
     #     target       See requirements for a specific circle
-
+    #
     #   YAML SETTINGS USED:
-    #     circlecheck_prettyprint: Tells circlecheck to use the pretty print formatting for output.
+    #     circlecheck_prettyprint: Tells circlecheck to use the pretty print formatting for output. [Ex: true/false]
     if Script.current.name != "bootstrap"
       data.each do |def_set|
         def_set
@@ -84,14 +84,15 @@ class ArgParser
 
       # Display help output for settings used in the script. Relies on base-help.yaml.
       yaml_data = get_data('help').to_h
-      unless yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}.empty?
+      yaml_settings = yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}
+
+      unless yaml_settings.empty?
         respond " YAML SETTINGS USED:"
-        yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}
-                  .each do | field, info |
-                    setting_line += "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}"
-                    setting_line += " [Ex: #{info["example"]}]" unless info["example"].to_s.nil? || info["example"].to_s.empty?
-                    respond setting_line
-                  end
+        yaml_settings.each do |field, info|
+          setting_line += "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}"
+          setting_line += " [Ex: #{info["example"]}]" unless info["example"].to_s.nil? || info["example"].to_s.empty?
+          respond setting_line
+        end
         respond ""
       end
     end

--- a/dependency.lic
+++ b/dependency.lic
@@ -59,7 +59,9 @@ class ArgParser
         respond ''
         respond " SCRIPT CALL FORMAT AND ARG DESCRIPTIONS:"
         respond "  ;#{Script.current.name} " + def_set.map { |x| format_item(x) }.join(' ')
-        def_set.each { |x| respond "   #{(x[:display] || x[:name]).ljust(12)} #{x[:description]} #{x[:options] ? '[' + x[:options].join(', ') + ']' : ''}" unless x[:name].to_s == "script_summary"; }
+        def_set
+          .reject { |x| x[:name].to_s == "script_summary" }
+          .each { |x| respond "   #{(x[:display] || x[:name]).ljust(12)} #{x[:description]} #{x[:options] ? '[' + x[:options].join(', ') + ']' : ''}" }
         respond ''
       end
 

--- a/dependency.lic
+++ b/dependency.lic
@@ -83,12 +83,17 @@ class ArgParser
         respond ''
       end
 
-      # Display help output for settings used in the script. Relies on base-yaml.yaml.
-      yaml_data = get_data('yaml').to_h
-      unless yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}.empty?
+      # Display help output for settings used in the script. Relies on base-help.yaml.
+      yaml_data = get_data('help').to_h
+      if !yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}.empty?
         respond " YAML SETTINGS USED:"
         yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}
-                  .each {|field, info| respond "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}" }
+                  .each do | field, info |
+                    setting_line += "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}"
+                    setting_line += "[Ex: #{info["example"]}]" unless info["example"].to_s.nil? || info["example"].to_s.empty?
+                    respond setting_line
+                  end
+                  # .each {|field, info| respond "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}" + "[Ex: #{info["example"]}]"}
         respond ""
       end
     end

--- a/dependency.lic
+++ b/dependency.lic
@@ -76,7 +76,7 @@ class ArgParser
           .each { |x| respond " SCRIPT SUMMARY: #{x[:description]} " }
         respond ''
         respond " SCRIPT CALL FORMAT AND ARG DESCRIPTIONS (arguments in brackets are optional):"
-        respond "  ;#{Script.current.name} " + def_set.map { |x| format_item(x) }.join(' ')
+        respond "  ;#{Script.current.name} " + def_set.map { |x| format_item(x) unless x[:name].to_s == "script_summary"}.join(' ')
         def_set
           .reject { |x| x[:name].to_s == "script_summary" }
           .each { |x| respond "   #{(x[:display] || x[:name]).ljust(12)} #{x[:description]} #{x[:options] ? '[' + x[:options].join(', ') + ']' : ''}" }

--- a/dependency.lic
+++ b/dependency.lic
@@ -93,7 +93,6 @@ class ArgParser
                     setting_line += "[Ex: #{info["example"]}]" unless info["example"].to_s.nil? || info["example"].to_s.empty?
                     respond setting_line
                   end
-                  # .each {|field, info| respond "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}" + "[Ex: #{info["example"]}]"}
         respond ""
       end
     end

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.10'
+$DEPENDENCY_VERSION = '1.4.11'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all

--- a/dependency.lic
+++ b/dependency.lic
@@ -68,7 +68,6 @@ class ArgParser
 
     #   YAML SETTINGS USED:
     #     circlecheck_prettyprint: Tells circlecheck to use the pretty print formatting for output.
-
     if Script.current.name != "bootstrap"
       data.each do |def_set|
         respond ''

--- a/dependency.lic
+++ b/dependency.lic
@@ -70,7 +70,6 @@ class ArgParser
     #     circlecheck_prettyprint: Tells circlecheck to use the pretty print formatting for output.
     if Script.current.name != "bootstrap"
       data.each do |def_set|
-        respond ''
         def_set
           .select { |x| x[:name].to_s == "script_summary" }
           .each { |x| respond " SCRIPT SUMMARY: #{x[:description]} " }
@@ -90,7 +89,7 @@ class ArgParser
         yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}
                   .each do | field, info |
                     setting_line += "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}"
-                    setting_line += "[Ex: #{info["example"]}]" unless info["example"].to_s.nil? || info["example"].to_s.empty?
+                    setting_line += " [Ex: #{info["example"]}]" unless info["example"].to_s.nil? || info["example"].to_s.empty?
                     respond setting_line
                   end
         respond ""

--- a/dependency.lic
+++ b/dependency.lic
@@ -49,10 +49,26 @@ class ArgParser
   end
 
   def display_args(data)
-    data.each do |def_set|
-      respond ''
-      respond "  ;#{Script.current.name} " + def_set.map { |x| format_item(x) }.join(' ')
-      def_set.each { |x| respond "   #{(x[:display] || x[:name]).ljust(12)} #{x[:description]} #{x[:options] ? '[' + x[:options].join(', ') + ']' : ''}"; }
+    # Display help output for script arguments
+    unless Script.current.name == "bootstrap"
+      data.each do |def_set|
+        respond ''
+        def_set.each { |x| respond " SCRIPT SUMMARY: #{x[:description]} " if x[:name].to_s == "script_summary"; }
+        respond ''
+        respond " SCRIPT CALL FORMAT AND ARG DESCRIPTIONS:"
+        respond "  ;#{Script.current.name} " + def_set.map { |x| format_item(x) }.join(' ')
+        def_set.each { |x| respond "   #{(x[:display] || x[:name]).ljust(12)} #{x[:description]} #{x[:options] ? '[' + x[:options].join(', ') + ']' : ''}" unless x[:name].to_s == "script_summary"; }
+        respond ''
+      end
+
+      # Display help output for settings used in the script. Relies on base-yaml.yaml.
+      yaml_data = get_data('yaml').to_h
+      unless yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}.empty?
+        respond " YAML SETTINGS USED:"
+        yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}
+                  .each {|field, info| respond "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}" }
+        respond ""
+      end
     end
   end
 
@@ -1748,8 +1764,8 @@ full_install if install
 
 force_start_script('bootstrap', ['wipe_constants'])
 
-# Proactively starting DRinfomon as script zero to prevent 
-# race conditions involving this script which so many other 
+# Proactively starting DRinfomon as script zero to prevent
+# race conditions involving this script which so many other
 # scripts depend on, and which is slow to start on its own
 echo("Starting DRinfomon, this will take a few seconds.")
 custom_require.call('drinfomon')


### PR DESCRIPTION
These changes to dependency provide part of a foundation for robust in-game help output for all curated scripts. Up-front thanks to @rcuhljr who gave me a huge assist with the core code.

Help output will consist of 3 elements and be provided via a `;<script-name> help` command:

1. A script summary (new)
2. An example of how to call the script and the arguments, and a list of the arguments with descriptions (existing)
3. A list of the yaml settings used in the script, including a general description of the setting as well as a specific description of how the settings is used in the script. (new)

Example of help output: 
![image](https://user-images.githubusercontent.com/6467969/161397786-0a86e233-0815-4c66-8235-0cc4533defea.png)

Display of this help output is fully driven by ArgParser. The structure for help output was already there so I felt like it was a good fit to broaden within it.

The new script summary will pull via ArgParser from a script argument called `script_summary`. Example from my locally edited circlecheck script:

```yaml
def main
  arg_definitions = [
    [
      { name: 'debug', regex: /debug/i, optional: true, description: 'Runs the script with debug messages.' },
      { name: 'mode', options: %w[brief short next], optional: true, description: 'Only display requirements you don\'t meet' },
      { name: 'target', regex: /^\d+$/, optional: true, description: 'See requirements for a specific circle' },
      { name: 'script_summary', optional: true, description: 'Checks your circle and skills to next circle. Optionally checks skills for a target circle.'}
    ]
  ]
```

The new section listing yaml settings used in the script will pull from a "yaml of yamls" called `base-help.yaml` via a `get_data` call. The information here needs to be built manually. We discussed trying to automate the pulling of yaml settings help information by building some parser like ArgParser but for yaml settings, but this "yaml of yaml" approach was determined to be the least intensive for existing script changes while also allowing full backward compatibility, _as well as_ doing little harm if I fall off the face of the Earth and no one cares to update the help information in the future.

Note: all of these changes will be fully backward compatible. If no `script_summary` argument exists, no problem, script functions as-is. If no yaml settings data is built out in base-help.yaml for a script, no sweat, the information just won't be available in the help output.

One final thing of note: because the help output is driven by ArgParser, scripts that don't take an argument and thus don't call `parse_args` will have no help output available unless we implement a `script_summary` argument and a call to ArgParser. I'd like to do that within those scripts, though I recognize it could be considered a superfluous call just for the sake of help output, so I'll take ideas here if you have another idea.

