### PR TITLE
[script][first-aid.lic] Fix regression

### DIFF
--- a/first-aid.lic
+++ b/first-aid.lic
@@ -65,7 +65,7 @@ class FirstAid
         when 'You turn'
           case DRC.bput("study my #{@booktype}", 'You attempt to study', 'find it almost impossible to do', 'gradually absorbing', 'difficult time comprehending the advanced text', 'suddenly makes sense to you', '^Why ', 'You need to be holding', 'discerned all you can')
           when 'gradually absorbing'
-            3.times{ DRC.message = DRC.bput("study my #{@booktype}", /Roundtime/, /makes sense/, /discerned all you can/ ); break if DRC.message == 'makes sense' || 'discerned all you can'}
+            3.times{ result = DRC.bput("study my #{@booktype}", /Roundtime/, /makes sense/, /discerned all you can/ ); break if result == 'makes sense' || 'discerned all you can'}
           when 'You need to be holding'
             DRC.bput("get my #{@booktype}", 'You get', 'You are already holding')
           end


### PR DESCRIPTION
DRC was added as a prefix to a variable called 'message' in error, thinking that it was the `message` method in DRC.

Fixed error, renamed variable.