### PR TITLE
[script] [clerk-tools] Removed includes/unnused commons, added prefixes, fixed a tiny = literal.

### DIFF
--- a/clerk-tools.lic
+++ b/clerk-tools.lic
@@ -1,11 +1,7 @@
 
-custom_require.call(%w[drinfomon equipmanager common common-crafting common-items common-travel])
+custom_require.call(%w[common common-crafting common-travel])
 
 class Clerk
-  include DRC
-  include DRCC
-  include DRCI
-  include DRCT
 
   def initialize
     arg_definitions = [
@@ -58,7 +54,7 @@ class Clerk
 
     if action == 'store'
       store_tools(tools, roomnumber)
-    elsif action = 'get'
+    elsif action == 'get'
       get_tools(tools, roomnumber, repairnpc)
     else
       echo 'Unknown action'
@@ -68,9 +64,9 @@ class Clerk
   def get_tools(tools, roomnumber, repairnpc)
     DRCT.walk_to(roomnumber)
     tools.each do |tool|
-      case bput("ask #{repairnpc} for #{tool}", 'Ah, yes, we have one of your tools like that', 'Ah, yes, we have several of your tools like that', "It doesn't look like we have anything like that")
+      case DRC.bput("ask #{repairnpc} for #{tool}", 'Ah, yes, we have one of your tools like that', 'Ah, yes, we have several of your tools like that', "It doesn't look like we have anything like that")
       when 'Ah, yes, we have one of your tools like that'
-        stow_crafting_item(tool, @bag, @belt)
+        DRCC.stow_crafting_item(tool, @bag, @belt)
       when 'Ah, yes, we have several of your tools like that'
         # #Sack
       end
@@ -81,10 +77,10 @@ class Clerk
     echo roomnumber
     DRCT.walk_to(roomnumber)
     tools.each do |tool|
-      get_crafting_item(tool, @bag, @belt, @belt)
-      case bput("put #{tool} on counter", 'Feel free to come back for your item any time', "You don't have enough space in your storage")
+      DRCC.get_crafting_item(tool, @bag, @belt, @belt)
+      case DRC.bput("put #{tool} on counter", 'Feel free to come back for your item any time', "You don't have enough space in your storage")
       when "You don't have enough space in your storage"
-        stow_crafting_item(tool, @bag, @belt)
+        DRCC.stow_crafting_item(tool, @bag, @belt)
       end
     end
   end


### PR DESCRIPTION
Fixed line 61 for `clerk-tools:61: warning: found `= literal' in conditional, should be ==`

Removed includes/unnused commons, added prefixes.