### PR TITLE
[script][validate.lic] - Fix hunting_file_list block

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -17,10 +17,23 @@ class DRYamlValidator
 
     setup_data
 
-    if settings.hunting_file_list
-      respond("  Validating settings for #{settings.hunting_file_list.size} settings files")
+    respond("")
+    respond("  CHECKING: #{assertions.size} different potential errors in [#{checkname}-setup.yaml]")
+    assertions.each do |symbol|
+      if args.verbose
+        respond("  #{symbol}")
+        @test_symbol = symbol
+      end
+      send(symbol, settings)
+    end
+
+    if !settings.hunting_file_list.empty?
+      respond("")
+      respond("  You have specified files via yaml setting hunting_file_list.")
+      respond("  Validating settings for #{settings.hunting_file_list.size} settings files. Note: yaml errors from #{checkname}-setup.yaml may be duplicated below.")
+      respond("")
       settings.hunting_file_list.each do |file|
-        respond("  Checking #{assertions.size} different potential errors in file #{checkname}-#{file}.yaml")
+        respond("  CHECKING: #{assertions.size} different potential errors in file [#{checkname}-#{file}.yaml]")
         settings_set = file == 'setup' ? get_settings : get_settings([file])
         assertions.each do |symbol|
           if args.verbose
@@ -29,20 +42,13 @@ class DRYamlValidator
           end
           send(symbol, settings_set)
         end
-      end
-    else
-      respond("  Checking #{assertions.size} different potential errors")
-      assertions.each do |symbol|
-        if args.verbose
-          respond("  #{symbol}")
-          @test_symbol = symbol
-        end
-        send(symbol, settings)
+        respond("")
       end
     end
 
     respond("  WARNINGS:#{@warning_count} ERRORS:#{@error_count}")
     respond('  All done!')
+    respond("")
   end
 
   def assert_that_root_keys_exist(settings)
@@ -59,13 +65,13 @@ class DRYamlValidator
 
   def assert_that_cyclic_no_release_spell_is_invalid_unless_listed_in_base_spells(settings)
     return if !settings.cyclic_no_release
-    
+
     spell_data = get_data('spells').spell_data
 
     settings.cyclic_no_release
       .reject { |spell_name| spell_data.include?(spell_name) }
       .each { |spell_name| error("#{spell_name} in cyclic_no_release is not a valid spell name.") }
-  end 
+  end
 
   def assert_that_holy_weapon_charging_has_valid_hometown_unless_using_icon(settings)
     return unless DRStats.paladin?
@@ -187,7 +193,7 @@ class DRYamlValidator
   def assert_that_crafting_training_spells_are_skills(settings)
     return unless settings.crafting_training_spells
 
-    valid_crafting_training_spells_skills = %w[Augmentation Utility Warding] 
+    valid_crafting_training_spells_skills = %w[Augmentation Utility Warding]
     valid_crafting_training_spells_skills.append("Sorcery") if settings.crafting_training_spells_enable_sorcery
 
     settings.crafting_training_spells


### PR DESCRIPTION
Via discussion in Discord, it was discovered that `;validate` was not functioning properly as a result of the dependency thread-safety rewrite. After diagnosis with @MahtraDR and @rcuhljr, we determined that the check in `;validate` to determine if a user has specified a `hunting_file_list` was checking against a nil value. The dependency rewrite now favors any specification in `base-empty.yaml`, and within that file `hunting_file_list` is specified as empty.

Because `;validate` was checking against a nil value, and the absence of a user specifying `hunting_file_list` is never nil, validate was never getting to the `else` block wherein a user's primary `<Username>-setup.yaml` would be validate.

This fix reorders the process a bit. It will now always validate the user's primary yaml file, and also validate a user-specified list of yaml files after that.