### PR TITLE
[data] [base-sorting] Add weapon nouns, add negative lookbehind for "star"

### DIFF
--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,7 +72,7 @@ jewelry:
 - pendant
 - pin
 - ring
-#- (?<!morning\s)star
+- /(?<!morning\s)star/
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,7 +72,7 @@ jewelry:
 - pendant
 - pin
 - ring
-- (?<!morning )star
+- (?<!morning) star
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,7 +72,7 @@ jewelry:
 - pendant
 - pin
 - ring
-#- star
+- (?<!morning )star
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,6 +72,7 @@ jewelry:
 - pendant
 - pin
 - ring
+- (?<!morning) star
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,7 +72,7 @@ jewelry:
 - pendant
 - pin
 - ring
-- star
+#- star
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)
@@ -291,6 +291,10 @@ weapon_nouns:
 - longbow
 - shortbow
 - cutlass
+- morning star
+- pasabas
+- hhr'ata
+- nightstick
 
 ammunition:
 - bolt

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -303,7 +303,7 @@ ammunition:
 - rocks?
 - blowgun darts?
 - blunt(-tipped)?\s(stone|arrow|bolt)s?
-- frost-white shard(s)?
+- frost-white shards?
 
 clothing:
 - alpargatas

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,7 +72,7 @@ jewelry:
 - pendant
 - pin
 - ring
-- (?<!morning) star
+- ^(?!morning\s)star
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)
@@ -291,19 +291,16 @@ weapon_nouns:
 - longbow
 - shortbow
 - cutlass
-- morning star
+- (morning|throwing) star
 - pasabas
 - hhr'ata
 - nightstick
 
 ammunition:
-- bolt
-- bolts
-- arrow
-- arrows
-- rock
-- blowgun dart
-- blowgun darts
+- bolts?
+- arrows?
+- rocks?
+- blowgun darts?
 - blunt(-tipped)?\s(stone|arrow|bolt)s?
 - frost-white shard(s)?
 

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,7 +72,6 @@ jewelry:
 - pendant
 - pin
 - ring
-- (?<!morning) star
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)
@@ -304,6 +303,8 @@ ammunition:
 - rock
 - blowgun dart
 - blowgun darts
+- blunt(-tipped)?\s(stone|arrow|bolt)s?
+- frost-white shard(s)?
 
 clothing:
 - alpargatas

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -72,7 +72,7 @@ jewelry:
 - pendant
 - pin
 - ring
-- ^(?!morning\s)star
+#- (?<!morning\s)star
 
 crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)
@@ -98,7 +98,8 @@ crafting:
 - ingot
 - knitting needles
 - large.*bowl
-- leather bellows
+- bellows
+- pliers
 - logbook
 - loop
 - metal clamp


### PR DESCRIPTION
Adding to weapons list
```
- morning star
- pasabas
- hhr'ata
- nightstick
```
Changed in jewlery list
```
- star
```
to
```
- (?<!morning) star
```

So it won't match a `morning star`

Tested before:
```
In the hip pouch:                                                                                                                                                                                                                            |
jewelry (1):                                                                                                                                                                                                                                 |
    morning star    
```
after
```
In the hip pouch:                                                                                                                                                                                                                            |
weapon (7):                                                                                                                                                                                                                                      
    morning star
 ```