### PR TITLE
[scripts] [appraisal] Adding count argument, and low-value detection

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -13,7 +13,8 @@ class Appraisal
         { name: 'item', regex: /\w+/i, description: 'Item to use appraise focus with.' }
       ],
       [ 
-        { name: 'nonspecific', regex: /nonspecific/i, optional: true, description: 'Toggle off specific gem_pouch_adjective' }
+        { name: 'nonspecific', regex: /nonspecific/i, optional: true, description: 'Toggle off specific gem_pouch_adjective' },
+        { name: 'count', regex: /count/i, optional: true, description: 'Count gem pouches as they are appraised' }
       ]
     ]
 
@@ -29,6 +30,16 @@ class Appraisal
       pouch_adjective = settings.gem_pouch_adjective
     end
 
+    if args.count
+      if settings.low_value_gem_pouch_container.empty? || settings.low_value_gem_pouch_container.nil?
+        DRC.message("\"count\" passed as an argument, but no low_value_gem_pouch_container defined. Exiting") 
+        exit
+      end
+        @count = true
+    end
+
+    pouch_low_value = settings.gem_pouch_low_value.to_i || 1
+
     if args.focus
       if DRSkill.getrank('Appraisal') < 200
         echo 'You need at least 200 Appraisal to use Appraise Focus.'
@@ -43,7 +54,7 @@ class Appraisal
         when 'zills'
           assess_zills
         when 'pouches'
-          train_appraisal_with_pouches(settings.full_pouch_container, settings.spare_gem_pouch_container, pouch_adjective, settings.gem_pouch_noun)
+          train_appraisal_with_pouches(settings.full_pouch_container, settings.spare_gem_pouch_container, settings.low_value_gem_pouch_container, pouch_low_value, pouch_adjective, settings.gem_pouch_noun)
         when 'gear'
           train_appraisal_with_gear
         when 'bundle'
@@ -71,7 +82,7 @@ class Appraisal
     waitrt?
   end
 
-  def train_appraisal_with_pouches(full_pouch_container, spare_gem_pouch_container, gem_pouch_adjective, gem_pouch_noun)
+  def train_appraisal_with_pouches(full_pouch_container, spare_gem_pouch_container, low_value_gem_pouch_container, low_value, gem_pouch_adjective, gem_pouch_noun)
     if gem_pouch_adjective
       case DRC.bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', 'You can.t appraise the', 'Appraise what', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/)
       when /You.ll need to open the .* to examine its contents./
@@ -85,7 +96,21 @@ class Appraisal
     $ORDINALS.each do |ordinal|
       gem_pouch_container = full_pouch_container
       break unless DRCI.get_item?("#{ordinal} #{gem_pouch_adjective} #{gem_pouch_noun}", gem_pouch_container)
-        case DRC.bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/)
+        case DRC.bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime', /You.ll need to open the .* to examine its contents./, /There doesn.t appear to be anything in/, /worth a total of about \d+/)
+        when /worth a total of about (\d+)/
+          pouch_value = Regexp.last_match(1).to_i
+          if pouch_value < low_value
+            DRC.message("Low value pouch found, putting it into low_value_gem_pouch_container")
+            gem_pouch_container = low_value_gem_pouch_container
+          end
+          if @count
+            /(\d+)/ =~ DRC.bput("count my #{gem_pouch_adjective} #{gem_pouch_noun}", /You sort through the contents .* and find \d+ gems in it/)
+            pouch_count = Regexp.last_match(1).to_i
+            if pouch_count < 500
+              DRC.message("Pouch not full, putting it into #{low_value_gem_pouch_container}")
+              gem_pouch_container = low_value_gem_pouch_container
+            end
+          end
         when /You.ll need to open the .* to examine its contents./
           DRC.bput("open my #{gem_pouch_adjective} #{gem_pouch_noun}", /You open your .* ./, /That is already open/)
           DRC.bput("appraise my #{gem_pouch_adjective} #{gem_pouch_noun} quick", 'Roundtime')

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -99,7 +99,7 @@ class Appraisal
             DRC.message("Low value pouch found, putting it into low_value_gem_pouch_container")
             gem_pouch_container = low_value_gem_pouch_container
           end
-          unless !(settings.low_value_gem_pouch_container.empty? || settings.low_value_gem_pouch_container.nil?)
+          unless !(low_value_gem_pouch_container.empty? || low_value_gem_pouch_container.nil?)
             DRC.message("\"count\" passed as an argument, but no low_value_gem_pouch_container defined. Skipping counting.") 
             @count = false
           end

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -31,14 +31,10 @@ class Appraisal
     end
 
     if args.count
-      if settings.low_value_gem_pouch_container.empty? || settings.low_value_gem_pouch_container.nil?
-        DRC.message("\"count\" passed as an argument, but no low_value_gem_pouch_container defined. Exiting") 
-        exit
-      end
-        @count = true
+      @count = true
     end
 
-    pouch_low_value = settings.gem_pouch_low_value.to_i || 0
+    pouch_low_value = settings.gem_pouch_low_value.to_i || 1
 
     if args.focus
       if DRSkill.getrank('Appraisal') < 200
@@ -102,6 +98,10 @@ class Appraisal
           if pouch_value < low_value
             DRC.message("Low value pouch found, putting it into low_value_gem_pouch_container")
             gem_pouch_container = low_value_gem_pouch_container
+          end
+          unless !(settings.low_value_gem_pouch_container.empty? || settings.low_value_gem_pouch_container.nil?)
+            DRC.message("\"count\" passed as an argument, but no low_value_gem_pouch_container defined. Skipping counting.") 
+            @count = false
           end
           if @count
             /(\d+)/ =~ DRC.bput("count my #{gem_pouch_adjective} #{gem_pouch_noun}", /You sort through the contents .* and find \d+ gems in it/)

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -38,7 +38,7 @@ class Appraisal
         @count = true
     end
 
-    pouch_low_value = settings.gem_pouch_low_value.to_i || 1
+    pouch_low_value = settings.gem_pouch_low_value.to_i || 0
 
     if args.focus
       if DRSkill.getrank('Appraisal') < 200

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2244,5 +2244,3 @@ base_wayto_overrides:
     start_room: 27558
     end_room: 27556
     str_proc: start_script('bescort', ['asketis_mount', 'down']);wait_while{running?('bescort')};
-
-

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -709,6 +709,13 @@ mine_for_outdoorsmanship: false
 appraisal_training:
 - art
 full_pouch_container:
+# gem_pouch_low_value value in coppers below which pouches will be put
+# into low_value_gem_pouch_container 
+gem_pouch_low_value:
+# This setting is used by gem_pouch_low_value above, as well as the
+# "count" argument to appraisal.lic
+low_value_gem_pouch_container:
+
 classes_to_teach:
 avoid_athletics_in_justice: false
 athletics_outdoorsmanship_rooms:
@@ -2237,3 +2244,5 @@ base_wayto_overrides:
     start_room: 27558
     end_room: 27556
     str_proc: start_script('bescort', ['asketis_mount', 'down']);wait_while{running?('bescort')};
+
+

--- a/validate.lic
+++ b/validate.lic
@@ -92,6 +92,11 @@ class DRYamlValidator
     warn("You have the following invalid appraisal_training settings: #{bad_settings}\nValid appraisal_training settings are: #{valid_settings}")
   end
 
+  def assert_that_low_value_gem_pouch_settings_are_valid(settings)
+    return unless settings.gem_pouch_low_value && (settings.low_value_gem_pouch_container.nil? || settings.low_value_gem_pouch_container.empty?)
+    error("gem_pouch_low_value defined, but no low_value_gem_pouch_container for low value pouches to go into")
+  end
+
   def assert_that_sorcery_is_dangerous(settings)
     return unless settings.crafting_training_spells_enable_sorcery
     return if settings.crafting_training_spells_enable_sorcery_squelch_warning


### PR DESCRIPTION
Allows for pouches to be checked against count, so pouches with 1-499 gems in the full pouch container can be put into a separate container for sorting.

Also allows for custom values set in yaml, below which, pouches can sorted out of the full pouch container.

I have hundreds of pouches, and only want to keep ones above a certain value, is my use case.