### PR TITLE
[script] [common-items] Exclude 'into' from @@tap_success_patterns

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -260,7 +260,7 @@ module DRCI
   ]
 
   @@tap_success_patterns = [
-    /^You tap .*/, # The `.*` is needed to capture entire phrase. Methods parse it to know if an item is worn, stowed, etc.
+    /^You tap\s(?!into).*/, # The `.*` is needed to capture entire phrase. Methods parse it to know if an item is worn, stowed, etc.
     /^You (thump|drum) your finger/, # You tapped an item with fancy verbiage, ohh la la!
     /^The orb is delicate/, # You tapped a favor orb
     /^You .* on the shoulder/ # You tapped someone


### PR DESCRIPTION
Accounting for

```
119646 2022-04-14T02:06:59.648107200Z:[om-watcher]>harness 15
119647 2022-04-14T02:06:59.648502200Z:[craft]>tap my congruence sigil-scroll
119648 2022-04-14T02:06:59.799068200Z:You tap into the mana from fifteen of the surrounding streams and attempt to keep it channeling in a stream around you.
119649 2022-04-14T02:06:59.799381900Z:Roundtime: 1 sec.
119650 2022-04-14T02:06:59.799475200Z:...wait 1 seconds.
119651 2022-04-14T02:07:00.602128400Z:[craft]>tap my abolition sigil-scroll
119652 2022-04-14T02:07:00.602261600Z:[om-watcher]>infuse om 15
```

Which leads to a false positive on success. (and is a very common line)

Tested here https://rubular.com/r/QtjnmXWXzoMchq