### PR TITLE
[scripts] [log] Add clearstream to filtered patterns

### DIFF
--- a/log.lic
+++ b/log.lic
@@ -61,7 +61,7 @@ loop {
 	begin
 		30000.times {
 			line = get
- 			unless line =~ /^<(?:push|pop)Stream/
+ 			unless line =~ /^<(?:push|pop|clear)Stream/
 			  if stamp_enable
 			    file.puts "#{Time.now.strftime("#{stamp_format}")}: #{line}"
 			  else


### PR DESCRIPTION
Attempting to cut down on this
```
2022-04-15T12:13:00.083460300Z:<clearStream id="moonWindow"/>
```
```
vimes:$ egrep -r clearStream | wc -l
26070
```