### PR TITLE
[script][validate.lic] Add yaml file extension validator

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -18,6 +18,20 @@ class DRYamlValidator
     setup_data
 
     respond("")
+    respond("  CHECKING: That yaml file extensions are .yaml and not .yml")
+    if Dir['./scripts/profiles/*.*'].join(',') =~ /yml/
+      profiles = Dir['./scripts/profiles/*.*']
+
+      echo "**WARNING**: You have yaml files with a .yml file extension. Lich requires the extension to be .yaml."
+      echo "Please change the extension to .yaml for the following profiles:"
+      profiles.each do | profile |
+        respond("   #{profile}") if profile =~ /yml/
+      end
+    else
+      respond("   PASSED")
+    end
+
+    respond("")
     respond("  CHECKING: #{assertions.size} different potential errors in [#{checkname}-setup.yaml]")
     assertions.each do |symbol|
       if args.verbose

--- a/validate.lic
+++ b/validate.lic
@@ -19,9 +19,9 @@ class DRYamlValidator
 
     respond("")
     respond("  CHECKING: That yaml file extensions are .yaml and not .yml")
-    if Dir['./scripts/profiles/*.*'].join(',') =~ /yml/
-      profiles = Dir['./scripts/profiles/*.*']
+    profiles = Dir['./scripts/profiles/*.*']
 
+    if !profiles.grep(/yml/).empty?
       echo "**WARNING**: You have yaml files with a .yml file extension. Lich requires the extension to be .yaml."
       echo "Please change the extension to .yaml for the following profiles:"
       profiles.each do | profile |


### PR DESCRIPTION
Adds a file extension validator to identify when a user has profiles with a `.yml` extension instead of a `.yaml` extension. If it finds .yml extensions, it lists the files.

Example of passing check:
```
>;validate
--- Lich: validate active.

  CHECKING: That yaml file extensions are .yaml and not .yml
   PASSED
```

Example of finding wrong extension:
```
>;validate
--- Lich: validate active.

  CHECKING: That yaml file extensions are .yaml and not .yml
[validate: **WARNING**: You have yaml files with a .yml file extension. Lich requires the extension to be .yaml.]
[validate: Please change the extension to .yaml for the following profiles:]
   ./scripts/profiles/Gildaren-back.yml
   ./scripts/profiles/Gildaren-setup.yml
```