### PR TITLE
[script][validate.lic] - Validate hunting_file_list file

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -47,6 +47,11 @@ class DRYamlValidator
       respond("  Validating settings for #{settings.hunting_file_list.size} settings files. Note: yaml errors from #{checkname}-setup.yaml may be duplicated below.")
       respond("")
       settings.hunting_file_list.each do |file|
+        if !File.exist?("./scripts/profiles/#{checkname}-#{file}.yaml")
+          respond("  NO FILE EXISTS: You've identifed #{checkname}-#{file}.yaml in hunting_file_list, but file does not exist.")
+          respond("")
+          next
+        end
         respond("  CHECKING: #{assertions.size} different potential errors in file [#{checkname}-#{file}.yaml]")
         settings_set = file == 'setup' ? get_settings : get_settings([file])
         assertions.each do |symbol|


### PR DESCRIPTION
Validates that the files in hunting_file_list actually exist. Reports to user if not.

While testing my previous PR for `;validate` using a test yaml and setting `hunting_file_list:`, and then subsequently deleting a -test.yaml file, I noticed that `;validate` disguises the fact that a specified file may not exist.

Example here. Note that `Gildaren-test.yaml` has been deleted and does not exist.

```

  You have specified files via yaml setting hunting_file_list.
  Validating settings for 3 settings files. Note: yaml errors from Gildaren-setup.yaml may be duplicated below.

  CHECKING: 102 different potential errors in file [Gildaren-main.yaml]
[validate: WARNING:< You have Sorcery casting whilst crafting, check JUSTICE in your crafting room  >]
[validate: WARNING:< Set crafting_training_spells_enable_sorcery_squelch_warning: true to make this message go away  >]
[validate: ERROR:< stop_on: weapon skill Targeted Magic not in weapon_training: setting  >]
[validate: ERROR:< Item in weapon_training could not be found in gear listings. 'Large Edged: bestard sword'  >]
[validate: ERROR:< Item in weapon_training could not be found in gear listings. 'Twohanded Edged: bestard sword'  >]

  CHECKING: 102 different potential errors in file [Gildaren-back.yaml]
[validate: WARNING:< You have Sorcery casting whilst crafting, check JUSTICE in your crafting room  >]
[validate: WARNING:< Set crafting_training_spells_enable_sorcery_squelch_warning: true to make this message go away  >]
[validate: ERROR:< Item in weapon_training could not be found in gear listings. 'Large Blunt: pine sledgehammer'  >]
[validate: ERROR:< Dance skill 'Small Edged' must be in weapon_training if you're not using dynamic_dance_skill  >]

  CHECKING: 102 different potential errors in file [Gildaren-test.yaml]
[validate: WARNING:< You have no weapons configured in weapon_training: this will likely cause problems.  >]
[validate: WARNING:< You have Sorcery casting whilst crafting, check JUSTICE in your crafting room  >]
[validate: WARNING:< Set crafting_training_spells_enable_sorcery_squelch_warning: true to make this message go away  >]
[validate: ERROR:< Dance skill 'Small Edged' must be in weapon_training if you're not using dynamic_dance_skill  >]
```

Here it is after this change:
```
CHECKING: 102 different potential errors in file [Gildaren-main.yaml]
[validate: WARNING:< You have Sorcery casting whilst crafting, check JUSTICE in your crafting room  >]
[validate: WARNING:< Set crafting_training_spells_enable_sorcery_squelch_warning: true to make this message go away  >]

  NO FILE EXISTS: You've identifed Gildaren-test.yaml in hunting_file_list, but file does not exist.
```