### PR TITLE
[script] [go2] fix: `timeto` must be specified else ignored in pathfinding algorithm

### DIFF
--- a/go2.lic
+++ b/go2.lic
@@ -183,7 +183,14 @@ if XMLData.game =~ /^DR/
 
   # Iterate through the aggregated map wayto overrides from above and set new stringprocs
   wayto_overrides.each do | key, values |
-    Map.list[values['start_room'].to_i].wayto["#{values['end_room']}"] = StringProc.new("#{values['str_proc']}")
+    start_room_id = values['start_room'].to_i
+    end_room_id = values['end_room'].to_i
+    travel_command = StringProc.new("#{values['str_proc']}")
+    travel_time = 0.2
+
+    start_room = Map.list[start_room_id]
+    start_room.wayto["#{end_room_id}"] = travel_command
+    start_room.timeto["#{end_room_id}"] = travel_time
   end
 end
 

--- a/go2.lic
+++ b/go2.lic
@@ -185,12 +185,28 @@ if XMLData.game =~ /^DR/
   wayto_overrides.each do | key, values |
     start_room_id = values['start_room'].to_i
     end_room_id = values['end_room'].to_i
-    travel_command = StringProc.new("#{values['str_proc']}")
-    travel_time = values['travel_time'].to_f || 0.2
 
     start_room = Map.list[start_room_id]
-    start_room.wayto["#{end_room_id}"] = travel_command
-    start_room.timeto["#{end_room_id}"] = travel_time
+
+    old_wayto = start_room.wayto["#{end_room_id}"]
+    old_timeto = start_room.timeto["#{end_room_id}"]
+
+    new_wayto = old_wayto
+    new_timeto = old_timeto
+
+    if values['str_proc']
+      new_wayto = StringProc.new("#{values['str_proc']}")
+    end
+
+    if values['travel_time']
+      new_timeto = values['travel_time'].to_f
+    end
+
+    start_room.wayto["#{end_room_id}"] = new_wayto
+    start_room.timeto["#{end_room_id}"] = new_timeto
+
+    echo "old_wayto=#{old_wayto}, new_wayto=#{new_wayto}"
+    echo "old_timeto=#{old_timeto}, new_timeto=#{new_timeto}"
   end
 end
 

--- a/go2.lic
+++ b/go2.lic
@@ -204,9 +204,6 @@ if XMLData.game =~ /^DR/
 
     start_room.wayto["#{end_room_id}"] = new_wayto
     start_room.timeto["#{end_room_id}"] = new_timeto
-
-    echo "old_wayto=#{old_wayto}, new_wayto=#{new_wayto}"
-    echo "old_timeto=#{old_timeto}, new_timeto=#{new_timeto}"
   end
 end
 

--- a/go2.lic
+++ b/go2.lic
@@ -186,7 +186,7 @@ if XMLData.game =~ /^DR/
     start_room_id = values['start_room'].to_i
     end_room_id = values['end_room'].to_i
     travel_command = StringProc.new("#{values['str_proc']}")
-    travel_time = 0.2
+    travel_time = values['travel_time'].to_f || 0.2
 
     start_room = Map.list[start_room_id]
     start_room.wayto["#{end_room_id}"] = travel_command

--- a/go2.lic
+++ b/go2.lic
@@ -9,10 +9,13 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.32
+           version: 1.33
           required: Lich >= 4.6.14
 
    changelog:
+      1.33 (2022-04-20):
+        Support overriding `timeto` for yaml-based map stringproc overrides
+        Only overrides `wayto` and/or `timeto` if that option specified in yaml
       1.32 (2022-03-22):
         For DR: add support for yaml-based map stringproc overrides
       1.31 (2022-03-10):


### PR DESCRIPTION
### Background
* I'm trying to provide a custom route through some caves, but every time I tried to go to the destination room I received error that there was no path from where I was (Crossing) to where I wanted to go (some distant caves).
* I stumbled upon this issue because my overrides are creating a new pathway between two rooms that didn't previously exist so there was no preexisting `timeto` property.

```
[go2: error: failed to find a path between your current room (1900) and destination room (15760)]
```

```yaml
personal_wayto_overrides:
  cave_trolls_stream_enter:
    start_room: 19089
    end_room: 15759
    str_proc: start_script('bescort', ['cave_trolls', 'enter']); wait_while{running?('bescort')};
  cave_trolls_stream_exit:
    start_room: 15759
    end_room: 19089
    str_proc: start_script('bescort', ['cave_trolls', 'exit']); wait_while{running?('bescort')};
```

### Changes
* When applying custom pathing overrides, ensure `timeto` is populated so that the pathing is considered in routing algorithm
