### PR TITLE
[script] [common] Add missing match for retreating to pole range

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -544,7 +544,8 @@ module DRC
       /You retreat from combat/,
       /You sneak back out of combat/,
       /Retreat to where/,
-      /There's no place to retreat to/
+      /There's no place to retreat to/,
+      /You retreat back to pole range/
     ]
 
     retreat_messages = [


### PR DESCRIPTION
As reported by `Alternative#6032` on Discord.

```
[safe-room: *** No match was found after 15 seconds, dumping info]
[safe-room: messages seen length: 0]
[safe-room: checked against [/You are already as far away as you can get/, /You retreat from combat/, /You sneak back out of combat/, /Retreat to where/, /There's no place to retreat to/, /retreat/, /sneak/, /grip on you/, /grip remains solid/, /You try to back/, /You must stand first/, /You stop advancing/, /You are already/]]
[safe-room: for command retreat]
[safe-room]>retreat
You retreat back to pole range.
```