### PR TITLE
Revert "[script] [common] Add missing match for retreating to pole range"

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -544,8 +544,7 @@ module DRC
       /You retreat from combat/,
       /You sneak back out of combat/,
       /Retreat to where/,
-      /There's no place to retreat to/,
-      /You retreat back to pole range/
+      /There's no place to retreat to/
     ]
 
     retreat_messages = [


### PR DESCRIPTION
Reverts rpherbig/dr-scripts#5748. 

Caused a regression. We'll explore further.
