### PR TITLE
[script][validate.lic] - Suppress validating -setup in hunting_file_list

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -46,23 +46,25 @@ class DRYamlValidator
       respond("  You have specified files via yaml setting hunting_file_list.")
       respond("  Validating settings for #{settings.hunting_file_list.size} settings files. Note: yaml errors from #{checkname}-setup.yaml may be duplicated below.")
       respond("")
-      settings.hunting_file_list.each do |file|
-        if !File.exist?("./scripts/profiles/#{checkname}-#{file}.yaml")
-          respond("  NO FILE EXISTS: You've identifed #{checkname}-#{file}.yaml in hunting_file_list, but file does not exist.")
-          respond("")
-          next
-        end
-        respond("  CHECKING: #{assertions.size} different potential errors in file [#{checkname}-#{file}.yaml]")
-        settings_set = file == 'setup' ? get_settings : get_settings([file])
-        assertions.each do |symbol|
-          if args.verbose
-            respond("  #{symbol}")
-            @test_symbol = symbol
+      settings.hunting_file_list
+        .reject { |file| file.to_s == "setup" } # We already check this file by default. Don't duplicate.
+        .each do |file|
+          if !File.exist?("./scripts/profiles/#{checkname}-#{file}.yaml")
+            respond("  NO FILE EXISTS: You've identifed #{checkname}-#{file}.yaml in hunting_file_list, but file does not exist.")
+            respond("")
+            next
           end
-          send(symbol, settings_set)
+          respond("  CHECKING: #{assertions.size} different potential errors in file [#{checkname}-#{file}.yaml]")
+          settings_set = file == 'setup' ? get_settings : get_settings([file])
+          assertions.each do |symbol|
+            if args.verbose
+              respond("  #{symbol}")
+              @test_symbol = symbol
+            end
+            send(symbol, settings_set)
+          end
+          respond("")
         end
-        respond("")
-      end
     end
 
     respond("  WARNINGS:#{@warning_count} ERRORS:#{@error_count}")


### PR DESCRIPTION
Suppresses validating -setup a second time if listed in `hunting_file_list` since we already validate that file by default. I noticed this with a copy/paste of someone's validate output in Discord.