### PR TITLE
Revert "[data] [base-items] Changing to matching scrolls based on regex patterns instead of listing all nouns"

### DIFF
--- a/data/base-items.yaml
+++ b/data/base-items.yaml
@@ -129,9 +129,44 @@ gem_nouns:
 - ivory tooth
 
 scroll_nouns:
-- \b([\w\'\"\-]+) (scroll|vellum|bark|tablet|parchment|roll|papyrus)\b
-- seishaka leaf
+- amber-hued scroll
+- antelope vellum
+- blood-red scroll
+- clay tablet
+- crumpled scroll
+- dark scroll
+- dingy vellum
+- faded scroll
+- faded vellum
+- fine scroll
+- green scroll
+- hhr'lav'geluhh bark
+- illuminated scroll
+- inky-black scroll
+- moldering scroll
+- moldy papyrus
+- mottled scroll
+- musty scroll
 - ostracon
+- papyrus roll
+- parchment scroll
+- pristine scroll
+- red scroll
+- seishaka leaf
+- shadowy scroll
+- silvered scroll
+- slender scroll
+- smudged parchment
+- sturdy scroll
+- tattered papyrus
+- tattered scroll
+- textured scroll
+- thick scroll
+- wax tablet
+- white scroll
+- white vellum
+- whorled scroll
+- yellowed scroll
 
 metal_types:
 # Common Metals


### PR DESCRIPTION
Reverts rpherbig/dr-scripts#5747

Discovered additional spots in code where it expects a list of nouns, not regex. Reverting for now.