### PR TITLE
[script][hunting-buddy] - Allow custom hunting zones

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -290,15 +290,26 @@ class HuntingBuddy
         # through each and aggregate the room numbers from base-hunting.yaml.
         # NOTE: Be sure to preserve the order we aggregate the room numbers to match the order
         # of the :zone: list in the yaml. Users expect the :zone: list to be a priority order.
-        # If they list prereni first, they want to try there first.
+        # We also allow custom hunting zones specified in Charname-setup.yaml.
         zones_to_search.each do |zone|
-          rooms_to_search += @hunting_zones["#{zone}"] unless @hunting_zones["#{zone}"] == nil
+          if @settings.custom_hunting_zones["#{zone}"]
+            echo "Overriding base.yaml's #{zone}" if @hunting_zones["#{zone}"]
+            rooms_to_search += @settings.custom_hunting_zones["#{zone}"]
+          else
+            if @hunting_zones["#{zone}"]
+              rooms_to_search += @hunting_zones["#{zone}"]
+            else
+              echo "Unable to find hunting zone: #{zone}"
+            end
+          end
         end
+
+        echo "Aggregated hunting room list: #{rooms_to_search}" if $debug_mode_hunting
 
         # Make sure our aggregated room list isn't empty. If it is, warn and don't go hunting.
         if rooms_to_search.empty?
-          DRC.message("Unable to look up hunting rooms for your yaml-specified hunting :zone: list.")
-          DRC.message("Check your yaml syntax and ensure your :zone:'s match base-hunting.yaml.")
+          DRC.message("Unable to look up any hunting rooms for your yaml-specified hunting :zone: list.")
+          DRC.message("Check your yaml syntax and ensure your :zone:'s base-hunting.yaml or your custom zone name.")
           exit
         end
 

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -293,7 +293,7 @@ class HuntingBuddy
         # We also allow custom hunting zones specified in Charname-setup.yaml.
         zones_to_search.each do |zone|
           if @settings.custom_hunting_zones["#{zone}"]
-            echo "Overriding base.yaml's #{zone}" if @hunting_zones["#{zone}"]
+            echo "Overriding base-hunting.yaml's #{zone}" if @hunting_zones["#{zone}"]
             rooms_to_search += @settings.custom_hunting_zones["#{zone}"]
           else
             if @hunting_zones["#{zone}"]

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -309,7 +309,7 @@ class HuntingBuddy
         # Make sure our aggregated room list isn't empty. If it is, warn and don't go hunting.
         if rooms_to_search.empty?
           DRC.message("Unable to look up any hunting rooms for your yaml-specified hunting :zone: list.")
-          DRC.message("Check your yaml syntax and ensure your :zone:'s base-hunting.yaml or your custom zone name.")
+          DRC.message("Check your yaml syntax and ensure your :zone:'s name matches base-hunting.yaml or your custom zone name.")
           exit
         end
 


### PR DESCRIPTION
Allows custom hunting zones specified in `Charname-setup.yaml`.

Hunting-buddy now looks to your yaml first for the hunting zone, then to `base-hunting`. Thus, you can specify custom-named hunting zones or override `base-hunting` zones with a same-named key, allowing you to reorder the rooms or remove bad-mana rooms, etc., without editing base-hunting.

Example of specifying custom hunting zones (roomnumbers are made up):
```yaml
custom_hunting_zones:
  custom_zone1:
    - 2357
    - 2358
  custom_zone2:
    - 9534
    - 9535
  black_marble_gargoyles:
    - 9519
   ```

Then in your hunting info section:
```yaml
hunting_info:
- :zone:
  - custom_zone1
  - custom_zone2
  - cloud_rats
 ```