### PR TITLE
[script] [vanity-pet] add yaml support for pet name/container

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -711,7 +711,7 @@ appraisal_training:
 - art
 full_pouch_container:
 # gem_pouch_low_value value in coppers below which pouches will be put
-# into low_value_gem_pouch_container 
+# into low_value_gem_pouch_container
 gem_pouch_low_value:
 # This setting is used by gem_pouch_low_value above, as well as the
 # "count" argument to appraisal.lic
@@ -2116,6 +2116,28 @@ tarantula_startup_delay: 15
 tarantula_skip_alternate: false
 tarantula_no_use_scripts:
 tarantula_debug: false
+
+####################
+# Vanity Pet
+####################
+
+# Default action to do with pet.
+# STOW will pick up pet and put it in your pet container.
+# DROP will take pet from container and drop it on the ground to follow you.
+# If not specified then you must provide it when running the script.
+vanity_pet_action:
+
+# Name of your pet.
+# If not specified then you must provide it when running the script.
+vanity_pet_name:
+
+# Where to stow your pet.
+# If not specified then you must provide it when running the script.
+vanity_pet_container:
+
+####################
+# Faux Atmo
+####################
 
 # Number of minutes to wait between performing a verb on an item.
 faux_atmo_interval: 15

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2125,7 +2125,7 @@ tarantula_debug: false
 # STOW will pick up pet and put it in your pet container.
 # DROP will take pet from container and drop it on the ground to follow you.
 # If not specified then you must provide it when running the script.
-vanity_pet_action:
+vanity_pet_action: stow
 
 # Name of your pet.
 # If not specified then you must provide it when running the script.

--- a/vanity-pet.lic
+++ b/vanity-pet.lic
@@ -11,23 +11,36 @@ class VanityPet
   def initialize
     arg_definitions = [
       [
-        { name: 'pet_action', regex: /(stow|drop)/, optional: false, description: 'STOW or DROP to either stow your pet in their container or drop them to the ground.' },
-        { name: 'pet_name', regex: /(\w+)/, optional: false, description: 'Name of your pet.' },
-        { name: 'pet_container', regex: /(\w+)/, optional: false, description: 'Container for your pet.' },
-        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug output' },
+        { name: 'pet_action', regex: /(stow|drop)/, optional: true, description: 'STOW or DROP to either stow your pet in their container or drop them to the ground.' },
+        { name: 'pet_name', regex: /^(?!debug)\w+$/, optional: true, description: 'Name of your pet.' },
+        { name: 'pet_container', regex: /^(?!debug)\w+$/, optional: true, description: 'Container for your pet.' },
+        { name: 'debug', regex: /^debug$/i, optional: true, description: 'Enable debug output' },
       ]
     ]
 
     args = parse_args(arg_definitions, true)
+    settings = get_settings
+
     $debug_mode_pet = UserVars.pet_debug || args.debug
 
-    echo args if $debug_mode_pet
+    pet_action = args.pet_action || settings.vanity_pet_action
+    pet_name = args.pet_name || settings.vanity_pet_name
+    pet_container = args.pet_container || settings.vanity_pet_container
 
-    case args.pet_action
+    if $debug_mode_pet
+      echo "pet_action: #{pet_action}"
+      echo "pet_name: #{pet_name}"
+      echo "pet_container: #{pet_container}"
+    end
+
+    case pet_action
     when 'stow'
-      stow_pet(args.pet_name, args.pet_container)
+      stow_pet(pet_name, pet_container)
     when 'drop'
-      drop_pet(args.pet_name, args.pet_container)
+      drop_pet(pet_name, pet_container)
+    else
+      DRC.message("Unkown pet action: #{pet_action}")
+      DRC.message("For usage run '#{$clean_lich_char}vanity-pet help'")
     end
   end
 


### PR DESCRIPTION
### Background
* I created the `vanity-pet` script to simplify the stow/drop mechanics of using my pet.
* Most of the time I run the script from T2 and so passing in the arguments is no big deal: `vanity-pet stow snaggletoothed.boar woven.sack`
* Occasionally I want to run the script manually and I either forget the argument order or don't want to type everything.

### Changes
* Support yaml settings for the default pet action/name/container the script will use.

### Configuration
```yaml
# Default action to do with pet.
# STOW will pick up pet and put it in your pet container.
# DROP will take pet from container and drop it on the ground to follow you.
vanity_pet_action: stow

# Name of your pet.
vanity_pet_name: snaggletoothed boar

# Where to stow your pet.
vanity_pet_container: woven sack
```

### Usage
**Drop**
```
,vanity-pet drop
--- Lich: vanity-pet active.

[vanity-pet]>tap my snaggletoothed boar in my woven sack

You tap a foul-smelling snaggletoothed boar inside a soft woven sack.

> 
[vanity-pet]>get my snaggletoothed boar from my woven sack

You pluck a foul-smelling snaggletoothed boar from a soft woven sack with a golden piglet charm, the creature snorting as you wake it up.

> 
[vanity-pet]>drop my snaggletoothed boar

You set the snaggletoothed boar on the ground.  It trots around you in a circle, happily oinking.

--- Lich: vanity-pet has exited.
```

**Stow**
```
,vanity-pet stow
--- Lich: vanity-pet active.

[vanity-pet]>get snaggletoothed boar

You scoop the snaggletoothed boar up.

[vanity-pet]>put my snaggletoothed boar in my woven sack

You tuck your snaggletoothed boar into its snug woven sack and it curls up to go to sleep, snorting softly.

> 
--- Lich: vanity-pet has exited.
```

