### PR TITLE
[script] [combat-trainer] Barb Research and Berserk Training Abilities

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2351,10 +2351,9 @@ class TrainerProcess
       'App Quick' => 'Appraisal',
       'App' => 'Appraisal',
       'Astro' => 'Astrology',
-      'Barb Research Augmentation' => 'Augmentation',
-      'Barb Research Debilitation' => 'Debilitation',
-      'Barb Research Utility' => 'Utility',
-      'Barb Research Warding' => 'Warding',
+      'Barb Research Augmentation' => 'Augmentation', # Debilitation cannot be learned via meditate research
+      'Barb Research Utility' => 'Utility',           # because it is a combat skill and can only be learned by
+      'Barb Research Warding' => 'Warding',           # contesting your opponent, such as roaring against them.
       'Berserk Landslide' => 'Warding',
       'Berserk Avalanche' => 'Utility',
       'Charged Maneuver' => 'Expertise',
@@ -2556,20 +2555,18 @@ class TrainerProcess
     when /^Recall$/i
       bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
     when /^Barb Research Augmentation$/i
-      bput('meditate research monkey', 'You clear ')
+      DRC.bput('meditate research monkey', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Barb Research Warding$/i
-      bput('meditate research turtle', 'You clear ')
-    when /^Barb Research Debilitation$/i
-      bput('meditate research earthquake', 'You clear ')
+      DRC.bput('meditate research turtle', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Barb Research Utility$/i
-      bput('meditate research prediction', 'You clear ')
+      DRC.bput('meditate research prediction', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Berserk Landslide$/i
       if DRStats.mana >= @barb_buffs_inner_fire_threshold
-        DRCA.activate_barb_buff?('Landslide')
+      DRCA.activate_barb_buff?('Landslide')
       end
     when /^Berserk Avalanche$/i
       if DRStats.mana >= @barb_buffs_inner_fire_threshold
-        DRCA.activate_barb_buff?('Avalanche')
+      DRCA.activate_barb_buff?('Avalanche')
       end
     when /^Collect$/i
       game_state.sheath_whirlwind_offhand

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2561,13 +2561,9 @@ class TrainerProcess
     when /^Barb Research Utility$/i
       DRC.bput('meditate research prediction', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Berserk Landslide$/i
-      if DRStats.mana >= @barb_buffs_inner_fire_threshold
       DRCA.activate_barb_buff?('Landslide')
-      end
     when /^Berserk Avalanche$/i
-      if DRStats.mana >= @barb_buffs_inner_fire_threshold
       DRCA.activate_barb_buff?('Avalanche')
-      end
     when /^Collect$/i
       game_state.sheath_whirlwind_offhand
       retreat
@@ -2927,6 +2923,7 @@ class TrainerProcess
 
   def check_ability(name, ability_info, game_state)
     return false if ['PercMana', 'App Careful'].include?(name) && game_state.casting
+    return false if (name =~ /^Berserk /) && (DRStats.mana < @barb_buffs_inner_fire_threshold)
 
     check = ability_info.is_a?(Hash) ? ability_info[:check] : @skill_map[name]
     check = [check].flatten

--- a/validate.lic
+++ b/validate.lic
@@ -513,7 +513,6 @@ class DRYamlValidator
       'App',
       'Astro',
       'Barb Research Augmentation',
-      'Barb Research Debilitation',
       'Barb Research Utility',
       'Barb Research Warding',
       'Charged Maneuver',


### PR DESCRIPTION
### Background
* Supersedes https://github.com/rpherbig/dr-scripts/pull/5775
* Javac [confirmed](https://discord.com/channels/619301383451181075/619330237418831917/970012705287180328) that Debilitation is not trainable via `meditate research` because it's a combat skill and you must be contested against an opponent.
* The inner fire check to do Berserk Landslide or Berserk Avalanche are _after_ that ability has been chosen as what needs to be trained next. If your inner fire is below your threshold, then you can enter a state that starves out other eligible training abilities while you wait for your inner fire to recuperate.

### Changes
* Remove support for `Barb Research Debilitation` (it doesn't work, see above)
* Move inner fire check when doing berserk training to the `check_ability` method so a different ability will be picked if you don't have enough.