### PR TITLE
[script][appraisal] - Fix args

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -5,14 +5,15 @@
 custom_require.call(%w[common drinfomon equipmanager])
 
 class Appraisal
-  
+
   def initialize
     arg_definitions = [
       [
-        { name: 'focus', regex: /focus/i, description: 'Perform appraise focus on an item.' },
-        { name: 'item', regex: /\w+/i, description: 'Item to use appraise focus with.' }
+        { name: 'focus', regex: /focus/i, optional: true,  description: 'Perform appraise focus on an item.' },
+        { name: 'item', regex: /\w+/i, optional: true,  description: 'Item to use appraise focus with.' },
+        { name: 'script_summary', optional: true, description: 'Trains the Appraisal skill by appraising your gear, zills, bundles, gem pouches, and studying the art in the Crossing art gallery.'}
       ],
-      [ 
+      [
         { name: 'nonspecific', regex: /nonspecific/i, optional: true, description: 'Toggle off specific gem_pouch_adjective' },
         { name: 'count', regex: /count/i, optional: true, description: 'Count gem pouches as they are appraised' }
       ]
@@ -100,7 +101,7 @@ class Appraisal
             gem_pouch_container = low_value_gem_pouch_container
           end
           if @count && (low_value_gem_pouch_container.empty? || low_value_gem_pouch_container.nil?)
-            DRC.message("\"count\" passed as an argument, but no low_value_gem_pouch_container defined. Skipping counting.") 
+            DRC.message("\"count\" passed as an argument, but no low_value_gem_pouch_container defined. Skipping counting.")
             @count = false
           end
           if @count


### PR DESCRIPTION
Adds the `optional: true` flag to the args in first set. The script can be called with no args, so they are by definition optional. 

Also adds `script_summary` arg for a script summary help output via #5712 

```
>;appr help
--- Lich: appraisal active.
 SCRIPT SUMMARY: Trains the Appraisal skill by appraising your gear, zills, bundles, gem pouches, and studying the art in the Crossing art gallery. 

 SCRIPT CALL FORMAT AND ARG DESCRIPTIONS (arguments in brackets are optional):
  ;appraisal [focus] [item] 
   focus        Perform appraise focus on an item. 
   item         Item to use appraise focus with. 


 SCRIPT CALL FORMAT AND ARG DESCRIPTIONS (arguments in brackets are optional):
  ;appraisal [nonspecific] [count]
   nonspecific  Toggle off specific gem_pouch_adjective 
   count        Count gem pouches as they are appraised 

--- Lich: appraisal has exited.
>
```