### PR TITLE
[script][appraisal] - Return to behavior

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -9,9 +9,11 @@ class Appraisal
   def initialize
     arg_definitions = [
       [
-        { name: 'focus', regex: /focus/i, optional: true,  description: 'Perform appraise focus on an item.' },
-        { name: 'item', regex: /\w+/i, optional: true,  description: 'Item to use appraise focus with.' },
-        { name: 'script_summary', optional: true, description: 'Trains the Appraisal skill by appraising your gear, zills, bundles, gem pouches, and studying the art in the Crossing art gallery.'},
+        { name: 'focus', regex: /focus/i, description: 'Perform appraise focus on an item.' },
+        { name: 'item', regex: /\w+/i, description: 'Item to use appraise focus with.' },
+        { name: 'script_summary', optional: true, description: 'Trains the Appraisal skill by appraising your gear, zills, bundles, gem pouches, and studying the art in the Crossing art gallery.'}
+      ],
+      [
         { name: 'nonspecific', regex: /nonspecific/i, optional: true, description: 'Toggle off specific gem_pouch_adjective' },
         { name: 'count', regex: /count/i, optional: true, description: 'Count gem pouches as they are appraised' }
       ]


### PR DESCRIPTION
Last night I introduced a breaking change by misunderstanding the argument sets and which were truly optional vs. required. @MahtraDR rolled a quick fix for me while I was sleeping since the failure was reported in Discord.

This cleans up my mess by returning to identical previous functionality and also retaining my `script_summary` argument for the help output I'm building.

Sorry about that.