### PR TITLE
[scripts] [validate] Add check for badly formatted backstab setting

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -978,6 +978,19 @@ class DRYamlValidator
     end
   end
 
+  def assert_that_backstab_is_not_an_array(settings)
+    return unless settings.backstab && settings.backstab.is_a?(Array)
+
+    list = <<~END
+      backstab:
+        - Small Edged
+        - Small Blunt
+    END
+
+    error('setting backstab is defined as #{settings.backstab} which is not correct. A correct setting is a list of weapons to use when backstabbing like this:')
+    echo("#{list}")
+  end
+
   def assert_that_prehunt_buffs_is_deprecated(settings)
     return unless settings.prehunt_buffs
 

--- a/validate.lic
+++ b/validate.lic
@@ -979,16 +979,9 @@ class DRYamlValidator
   end
 
   def assert_that_backstab_is_not_an_array(settings)
-    return unless !settings.backstab || settings.backstab.is_a?(Array)
+    return unless !settings.backstab || !settings.backstab.is_a?(Array)
 
-    list = <<~END
-      backstab:
-                - Small Edged
-                - Small Blunt
-    END
-
-    error('setting backstab is defined as #{settings.backstab} which is not correct. A correct setting is a list of weapons to use when backstabbing like this:')
-    echo("#{list}")
+    error("setting backstab is defined as \"#{settings.backstab}\" which is not correct. A correct setting is a list of weapons to use when backstabbing, see base.yaml for an example.")
   end
 
   def assert_that_prehunt_buffs_is_deprecated(settings)

--- a/validate.lic
+++ b/validate.lic
@@ -979,12 +979,12 @@ class DRYamlValidator
   end
 
   def assert_that_backstab_is_not_an_array(settings)
-    return unless settings.backstab && settings.backstab.is_a?(Array)
+    return unless !settings.backstab || settings.backstab.is_a?(Array)
 
     list = <<~END
       backstab:
-        - Small Edged
-        - Small Blunt
+                - Small Edged
+                - Small Blunt
     END
 
     error('setting backstab is defined as #{settings.backstab} which is not correct. A correct setting is a list of weapons to use when backstabbing like this:')

--- a/validate.lic
+++ b/validate.lic
@@ -979,7 +979,7 @@ class DRYamlValidator
   end
 
   def assert_that_backstab_is_not_an_array(settings)
-    return unless !settings.backstab || !settings.backstab.is_a?(Array)
+    return unless settings.backstab && !settings.backstab.is_a?(Array)
 
     error("setting backstab is defined as \"#{settings.backstab}\" which is not correct. A correct setting is a list of weapons to use when backstabbing, see base.yaml for an example.")
   end


### PR DESCRIPTION
I was helping a user today who had this in their yaml
```yaml
backstab: false
```

Which on lich4 has no error because of FalseClass, and we even have some examples in [Samples ](https://github.com/rpherbig/dr-scripts/blob/fc24b296f8ff5e4851305ac7b90d4bfe37d8afa2/profiles/Samples/Thief/Shagium-farm.yaml#L28) suggesting it could be a Bool.

On lich5, this user received 
```
--- Lich: error: undefined method `include?' for false:FalseClass
        combat-trainer:4329:in `backstab?'
        combat-trainer:3064:in `attack_melee'
--- Lich: combat-trainer has exited.
```

instead. This PR will alert the user that they need to fix their yaml to make `backstab` a list of weapons instead.
