### PR TITLE
[script][Forge] fixing resume

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -271,6 +271,7 @@ class Forge
   end
 
   def pound(item = @item)
+    get_item(@hammer) unless DRC.right_hand
     DRCA.crafting_magic_routine(@settings)
     case DRC.bput("pound #{item} on anvil with my #{@hammer}",
               /You must be holding .* to do that.$/,
@@ -364,15 +365,14 @@ class Forge
 
   def bellows
     DRCA.crafting_magic_routine(@settings)
-    stow_item(@hammer)
+    stow_item(DRC.right_hand)
     get_item('bellows')
     case DRC.bput('push my bellows', 'Roundtime', 'That tool does not seem')
     when 'That tool does not seem'
       analyze_item
     else
       stow_item('bellows')
-      get_item(@hammer)
-      pound
+      pound if @pound
     end
   end
 
@@ -526,23 +526,24 @@ class Forge
     when 'ready for more pounding', 'ready to be pounded', 'ready for pounding', 'would obstruct pounding'
       get_item(@hammer)
       get_item('tongs')
-      pound = true
+      @pound = true
       pound
-    when 'turned to ensure even heating in the forge'
+    when 'ensure even heating in the forge'
       get_item('tongs') unless DRC.right_hand
-      temper = true
+      @temper = true
       temper_turn
     when 'metal will quickly rust'
-      stow_item(DRC.left_hand)
-      stow_item(DRC.right_hand)
       DRC.bput("get #{@item} from anvil", 'You get')
       add_oil
     when 'The forge fire has died down'
       bellows
+      analyze_item
     when 'metal is in need of some gentle bending', 'to be pulled', 'a mandrel or mold set'
+      get_item(@hammer)
+      get_item('tongs')
+      @pound = true
       turn_item
     when 'with the pliers to stitch them together'
-      stow_item('tongs')
       get_item('plier')
       DRC.bput("pull my #{@item} with my pliers", 'roundtime')
       stow_item('plier')

--- a/forge.lic
+++ b/forge.lic
@@ -216,7 +216,6 @@ class Forge
   def temper_turn(first = false)
     DRCA.crafting_magic_routine(@settings)
     command = first ? "put my #{@item} on the forge" : "turn #{@item} on forge with my tong"
-# NEED to add failure for tongs in wrong configuration
     case DRC.bput(command,
               'needs more fuel', 'need some more fuel',
               'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel',
@@ -481,6 +480,7 @@ class Forge
 
   def find_item
     @location = ''
+    return if DRC.right_hand == @item
     if DRC.bput("look on anvil", 'anvil you see', 'clean and ready') == 'anvil you see'
       @location = ("on anvil")
     elsif DRC.bput("look on forge", 'forge you see', 'There is nothing') == 'forge you see'
@@ -496,8 +496,8 @@ class Forge
     stow_item(DRC.left_hand) # store contents of left hand
     unless DRC.right_hand == @item
       stow_item(DRC.right_hand)
-      find_item
     end
+    find_item
     case DRC.bput("analyze #{@item} #{@location}", 'The metal is nicked and burred from heavy grinding', 'ready for additional grinding at a grinding wheel', #balance/hone
                                       'ensure even heating in the forge', #temper
                                       'The metal is ready to be cooled', #tub

--- a/forge.lic
+++ b/forge.lic
@@ -175,7 +175,9 @@ class Forge
   def do_hone
     spin_grindstone
     DRCA.crafting_magic_routine(@settings)
-    case DRC.bput("push grind with my #{@item}", 'The grinding has left many nicks and burs in the metal that should be cleaned away', 'roundtime')
+    case DRC.bput("push grind with my #{@item}", 'not spinning fast enough', 'The grinding has left many nicks and burs in the metal that should be cleaned away', 'roundtime')
+    when /not spinning fast enough/
+      spin_grindstone
     when /nicks and burs/
       get_item('wire brush')
       DRC.bput("rub my #{@item} with my brush", 'roundtime')
@@ -214,14 +216,18 @@ class Forge
   def temper_turn(first = false)
     DRCA.crafting_magic_routine(@settings)
     command = first ? "put my #{@item} on the forge" : "turn #{@item} on forge with my tong"
-
+# NEED to add failure for tongs in wrong configuration
     case DRC.bput(command,
               'needs more fuel', 'need some more fuel',
               'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel',
               'Roundtime',
               'metal looks to be in need of some oil to preserve', 'to be cleaned')
+    when 'Turn what?'
+      get_item('tongs') unless DRC.right_hand
+      DRC.bput("adjust my tongs", 'alongside the tong', 'You cannot adjust') if @adjustable_tongs
+      find_item
     when 'needs more fuel', 'need some more fuel'
-      get_item('tongs')
+      get_item('tongs') unless DRC.right_hand
       add_fuel
     when 'As you finish working the fire dims and produces less heat', 'As you finish the fire flickers and is unable to consume its fuel'
       get_item('bellows')
@@ -473,20 +479,59 @@ class Forge
     magic_cleanup
   end
 
+  def find_item
+    @location = ''
+    if DRC.bput("look on anvil", 'anvil you see', 'clean and ready') == 'anvil you see'
+      @location = ("on anvil")
+    elsif DRC.bput("look on forge", 'forge you see', 'There is nothing') == 'forge you see'
+      @location = ("on forge")
+    else
+      DRC.message("#{@item} not found")
+      exit
+    end
+  end
+
   def analyze_item
     DRCA.crafting_magic_routine(@settings)
-    stow_item(DRC.left_hand) # store contents of both hands, reacquire hammer and tongs
-    stow_item(DRC.right_hand)
-    get_item(@hammer)
-    get_item('tongs')
-
-    case DRC.bput("analyze #{@item}", 'The metal is ready to be cooled', 'Almost all of the coal has been consumed', 'ready for more pounding', 'metal will quickly rust', 'The forge fire has died down', 'metal is in need of some gentle bending', 'to be pulled', 'ready to be pounded', 'would obstruct pounding', 'ready for pounding', 'with the pliers to stitch them together')
+    stow_item(DRC.left_hand) # store contents of left hand
+    unless DRC.right_hand == @item
+      stow_item(DRC.right_hand)
+      find_item
+    end
+    case DRC.bput("analyze #{@item} #{@location}", 'The metal is nicked and burred from heavy grinding', 'ready for additional grinding at a grinding wheel', #balance/hone
+                                      'ensure even heating in the forge', #temper
+                                      'The metal is ready to be cooled', #tub
+                                      'Almost all of the coal has been consumed', #need fuel
+                                      'metal will quickly rust', #oil
+                                      'The forge fire has died down', #bellows
+                                      'metal is in need of some gentle bending', #turn (pound)
+                                      'to be pulled', 'with the pliers to stitch them together', #add item (armor)
+                                      'ready to be pounded', 'ready for more pounding', 'would obstruct pounding', 'ready for pounding', #pound
+                                      'Roundtime') #done
+    when 'The metal is nicked and burred from heavy grinding'
+      get_item('wire brush')
+      DRC.bput("rub my #{@item} with my brush", 'roundtime')
+      stow_item('brush')
+      do_hone
+    when 'ready for additional grinding at a grinding wheel'
+      do_hone
     when 'The metal is ready to be cooled'
       slack_tub
     when 'Almost all of the coal has been consumed'
+      if @adjustable_tongs
+        get_item('tongs') unless DRC.right_hand
+      end
       add_fuel
+      analyze_item
     when 'ready for more pounding', 'ready to be pounded', 'ready for pounding', 'would obstruct pounding'
+      get_item(@hammer)
+      get_item('tongs')
+      pound = true
       pound
+    when 'turned to ensure even heating in the forge'
+      get_item('tongs') unless DRC.right_hand
+      temper = true
+      temper_turn
     when 'metal will quickly rust'
       stow_item(DRC.left_hand)
       stow_item(DRC.right_hand)
@@ -502,6 +547,9 @@ class Forge
       DRC.bput("pull my #{@item} with my pliers", 'roundtime')
       stow_item('plier')
       analyze_item
+    when 'Roundtime'
+      DRC.message("#{@item} appears to be complete")
+      exit
     end
   end
 


### PR DESCRIPTION
Resume was having trouble. It couldn't resume hone/balance/temper because A: it didn't have the messaging, and B: it couldn't figure out what was being done even if it did. Bellows and Fuel steps are uniform, message-wise, so it needed to do those steps then re analyze.

179/180 ought to have been in the original Forge PR, I don't know how they snuck out the back door.

224-226 fixes failure if you somehow manage to adjust your tongs mid-forge, or if you resume with tongs in the wrong adjustment. 227 checks if the item is even there, as the message for wrongly adjusted tongs and no item to turn are the same. 

274 was added to standardize tool handling for analyze, as this step was previously nested in bellows.

362-375 reflects that change, allowing bellows to do it's job, then either go back to pounding, or return to analyze.

481 is a new method. I found analyze was analyzing anything i had on before anything on an anvil or the forge. This finds the item, unless you're not holding it, and adds location (forge/anvil). If not found, kills the script.

496-500 incorporates this item locating, and starts you empty-handed for analyze(unless you're holding the item), without accidently stowing the very thing you're working on if you're balancing/honing. 

501 is updated to include the locating, and subsequent lines to 510 are some new, some old messaging, organized a little.

511-517 adds the hone/balance messaging. Here it diverts analyze to those routines.

521-525 allows fuel step to occur, then analyzes again (as messaging is the same)

527-529 added due to the change in tool handling for analyze.

531 adds temper to list of analyze outcomes, letting you resume a temper.

491-492 didn't need to be there before, and don't now.

551-553 was added in case you are trying to resume an item that's already complete, where none of the todo messaging would have applied, and it would have hung, instead of just exiting.