### PR TITLE
[data] [base-sorting] Adding instruments category, and 'book'

### DIFF
--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -78,7 +78,7 @@ crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)
 - (?:Aldamdin|curved|damite|Glaes-edged|Kertig|square|tapered|Tomiek|triple-fluted|Tyrium|wide).*shovel
 - (?:apprentice .*|journeyman .*|master .*) (?:book|instructions)
-- book
+- ^book$
 - borax flux
 - brazier
 - burin

--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -78,6 +78,7 @@ crafting:
 - (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)
 - (?:Aldamdin|curved|damite|Glaes-edged|Kertig|square|tapered|Tomiek|triple-fluted|Tyrium|wide).*shovel
 - (?:apprentice .*|journeyman .*|master .*) (?:book|instructions)
+- book
 - borax flux
 - brazier
 - burin
@@ -150,6 +151,10 @@ brawling:
 - knuckles
 - knuckleguards
 - stomping boots
+
+instruments:
+- zills
+- cowbell
 
 armor_nouns:
 - aegis


### PR DESCRIPTION
The `book` is because of a quirk between `look` and `rummage` changing the description of crafting books. 

look yields
```
master remedy book
```
where rummage yields
```
book of master remedy instructions
```

Since `DRC.remove_flavor_text` removes all the post-noun flavor text, all we have left is `book` to match against when rummaging.

It was driving me nuts trying to figure out why my books showed up under `other` when I rummaged, but under `crafting` when I looked. 

Currently all `book` items go under other anyway, so if suddenly some other books are going under crafting, we can tackle that when it happens...