### PR TITLE
[scripts] [hunting-buddy] Extra YAMLs and configurable prehunt_buff waggle

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -10,7 +10,7 @@ class HuntingBuddy
     arg_definitions = [[]]
     args = parse_args(arg_definitions, true)
 
-    @settings = get_settings
+    @settings = get_settings(args.flex)
 
     @town_data = get_data('town')[@settings.hometown]
     @hunting_data = get_data('hunting')
@@ -40,6 +40,9 @@ class HuntingBuddy
 
     @prehunt_buffing_room = @settings.prehunt_buffing_room || @settings.prehunt_buffs
     echo("  @prehunt_buffing_room: #{@prehunt_buffing_room}") if $debug_mode_hunting
+
+    @prehunt_buff_waggle = @settings.prehunt_buff_waggle || 'prehunt_buffs'
+    echo("  @prehunt_buff_waggle: #{@prehunt_buff_waggle}") if $debug_mode_hunting
 
     # After checking all hunting files to use, this array
     # will be the combined set of hunting infos to execute.
@@ -250,11 +253,11 @@ class HuntingBuddy
   end
 
   def check_prehunt_buffs
-    return unless @settings.waggle_sets['prehunt_buffs']
+    return unless @settings.waggle_sets[@prehunt_buff_waggle]
 
     DRCT.walk_to(@prehunt_buffing_room)
 
-    DRC.wait_for_script_to_complete('buff', ['prehunt_buffs'])
+    DRC.wait_for_script_to_complete('buff', [@prehunt_buff_waggle])
   end
 
   # ------------------------------------------------------------


### PR DESCRIPTION
Allows additional YAMLs to be specified as flex args and honored. Also introduces a new `prehunt_buff_waggle` setting that defaults to `prehunt_buffs` so different hunts can use different waggle sets.