### PR TITLE
[script][dependency] Fix spacing

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -79,7 +79,6 @@ class ArgParser
         def_set
           .reject { |x| x[:name].to_s == "script_summary" }
           .each { |x| respond "   #{(x[:display] || x[:name]).ljust(12)} #{x[:description]} #{x[:options] ? '[' + x[:options].join(', ') + ']' : ''}" }
-        respond ''
       end
 
       # Display help output for settings used in the script. Relies on base-help.yaml.
@@ -87,6 +86,7 @@ class ArgParser
       yaml_settings = yaml_data.select { |field, info| info["referenced_by"].include?(Script.current.name)}
 
       unless yaml_settings.empty?
+        respond ''
         respond " YAML SETTINGS USED:"
         yaml_settings.each do |field, info|
           setting_line += "   #{field}: #{info["description"]} #{info["specific_descriptions"][Script.current.name]}"


### PR DESCRIPTION
Where I put the blank `respond ''` caused a double space in some instances. Fixing.

![image](https://user-images.githubusercontent.com/6467969/167237200-db50075a-ed5d-4843-9568-09a61ab1f4e2.png)
