### PR TITLE
[scripts] [drinfomon] Add magma cobra fix for DRRoom.find_npcs

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.24'
+$DRINFOMON_VERSION = '2.0.25'
 
 no_kill_all
 no_pause_all
@@ -593,7 +593,7 @@ def find_npcs(room_objs)
            .scan(%r{<pushBold/>[^<>]*<popBold/> which appears dead|<pushBold/>[^<>]*<popBold/> \(dead\)|<pushBold/>[^<>]*<popBold/>})
            .reject { |obj| obj =~ /which appears dead|\(dead\)/ }
            .map { |obj| obj.sub('<pushBold/>', '').sub(%r{<popBold/>.*}, '') }
-           .map { |obj| obj.split(/\sand\s/).last.sub(/\swith\s.*/, '') }
+           .map { |obj| obj.split(/\sand\s/).last.sub(/(?:\sglowing)?\swith\s.*/, '') }
            .map { |obj| obj.strip.scan(/[A-z'-]+$/).first }
 end
 
@@ -602,7 +602,7 @@ def find_dead_npcs(room_objs)
            .strip.scan(%r{<pushBold/>[^<>]*<popBold/> which appears dead|<pushBold/>[^<>]*<popBold/> \(dead\)|<pushBold/>[^<>]*<popBold/>})
            .select { |obj| obj =~ /which appears dead|\(dead\)/ }
            .map { |obj| obj.sub('<pushBold/>', '').sub(%r{<popBold/>.*}, '') }
-           .map { |obj| obj.split(/\sand\s/).last.sub(/\swith\s.*/, '') }
+           .map { |obj| obj.split(/\sand\s/).last.sub(/(?:\sglowing)?\swith\s.*/, '') }
            .map { |obj| obj.strip.scan(/[A-z'-]+$/).first }
 end
 


### PR DESCRIPTION
New NPC introduced today.

Starts as `magma cobra glowing with internal heat` and turns into `magma cobra with a congealing shell of rocky scales` (has another transformation as well, but that one doesn't break npc detection.

Prior to this change, the npc name is detected as `glowing` which we would now exclude.

I am not 100% confident (although I'd like to think...) that this will not break a potential NPC named `glowing` I don't know of any though...
