### PR TITLE
[script] [dependency] inject spell `name` property into the data

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1108,7 +1108,6 @@ class SetupFiles
 
     battle_cries_data = base_data_spells.battle_cries
     spells_data = base_data_spells.spell_data
-    spells_data_values = spells_data.values
     empty_data = base_data_empty.empty_values
 
     # Populate nil settings with default empty arrays/hashes

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.11'
+$DEPENDENCY_VERSION = '1.4.12'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all
@@ -1129,11 +1129,33 @@ class SetupFiles
       # Maps are treated as two-element arrays, first is the key, last is the value.
       # So we grab the last element which leaves us with map of spell properties.
       spell_data = spell_match.last
+      # Inject spell name into the spell properties.
+      # Some scripts check for either `abbrev` or `name`
+      # but our base spells data doesn't have name as a property, so we set it.
+      spell_data['name'] ||= spell_match.first
+
+      spell_data
     end
 
     # Find spell data by its abbreviation, case insensitive.
     get_spell_data_by_abbrev = lambda do |abbrev_to_find|
-      spells_data_values.find { |data| data['abbrev'].casecmp?(abbrev_to_find) }
+      # This creates a new map filtered to only the entries that match the spell abbreviation.
+      spell_matches = spells_data.select { |name, data| data['abbrev'].casecmp?(abbrev_to_find) }
+      # It's theoretically possible, though unlikely, that multiple
+      # entries were returned if base data had the same spell listed
+      # with different capitalization. Let's take the first entry we found.
+      spell_match = spell_matches.first
+      # We now have a map of spell name to map of spell properties.
+      # What we want to return is just the map of spell properties.
+      # Maps are treated as two-element arrays, first is the key, last is the value.
+      # So we grab the last element which leaves us with map of spell properties.
+      spell_data = spell_match.last
+      # Inject spell name into the spell properties.
+      # Some scripts check for either `abbrev` or `name`
+      # but our base spells data doesn't have name as a property, so we set it.
+      spell_data['name'] ||= spell_match.first
+
+      spell_data
     end
 
     # Given a hash for a single spell definition,


### PR DESCRIPTION
### Background
* In `data/base-spells.yaml`, the name of spells are only listed as keys in the `spell_data` map. It is not also part of the spell settings like the `abbrev` property.
* In `combat-trainer`, the `offensive_spell_cycle` setting takes a list of spell **names** and [grabs the spell data](https://github.com/rpherbig/dr-scripts/blob/624f953dd09528dc2eb94b29b2a898ced6a3443b/combat-trainer.lic#L1828) from your `offensive_spells` setting. Unless you've added the `name` spell property yourself in your yaml, then the script will pick the wrong spell from your cycle because it'll be comparing a desired spell name to cast to `nil`.
* A solution is to ensure the `name` property is hydrated on all spell data in your character's settings, and we can automate that as part of `dependency` that was already hydrating other spell properties (e.g. mana type, recast, etc).

```yaml
waggle_sets:
  soul_sickness:
    Soul Sickness: &soul_sickness
      abbrev: SICK # unless player's specify `name` and `abbrev` then some scripts won't find the data
      symbiosis: false
      mana: 4
  ...

offensive_spells:
  - << : *soul_sickness
  - << : *divine_radiance
  - << : *aesrela_everild
  - << : *fists_of_faenella

offensive_spell_cycle:
  - Soul Sickness
  - Divine Radiance
  - Aesrela Everild
  - Fists of Faenella
```

### Changes
* When dependency is hydrating your spell settings from `data/base-spells.yaml`, ensure the `name` property is set.

### Test
_Note that the `name` property is now part of the spell data in your settings_
```
,e echo get_settings.offensive_spells.first
--- Lich: exec1 active.

[exec1: {"skill"=>"Debilitation", "harmless"=>true, "abbrev"=>"SICK", "mana"=>4, "expire"=>"The spiritual weight lifts off", "mana_type"=>"holy", "prep"=>"prepare", "recast"=>1, "name"=>"Soul Sickness", "symbiosis"=>false}]

--- Lich: exec1 has exited.
```