### PR TITLE
[scripts] [common-items] Add entry for remove_item_success_patterns

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -156,7 +156,7 @@ module DRCI
     /^You slip/,
     /^You struggle/,
     /^You take/,
-    /^You tug/,
+    /you tug/i,
     /^You untie/,
     /as you remove/,
     /slide themselves off of your/,


### PR DESCRIPTION
Weird item removal string
```
>;eq echo DRCI.remove_item?('chain balaclava')
Shaking your head briskly, you tug the chain balaclava free of your head and tuck it under one arm.
[exec1: true]
```

We already had a `you tug` but it was anchored and case-sensitive. Small change...