### PR TITLE
[data] [base-hunting] Fix typo backwards compatible

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1434,12 +1434,13 @@ hunting_zones:
   - 16333
   # https://elanthipedia.play.net/Sylph_(1)                              100-175
   # Construct
-  slyphs:
+  sylphs: &sylphs
   - 16909
   - 16910
   - 16911
   - 16912
-  - 16913  
+  - 16913
+  slyphs: *sylphs # Added for backwards compatibility due to a typo
   # https://elanthipedia.play.net/Zombie_red_leucro                      130-180
   # undead
   zombie_red_leucro:


### PR DESCRIPTION
It's typoed to slyphs. I didn't want to leave folks in the lurch though, so adding an anchor for it.