### PR TITLE
[script][mining-buddy] Add waitrt?

### DIFF
--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -116,6 +116,8 @@ class MiningBuddy
       bput('prospect', 'Roundtime')
       results = reget(20, 'can be mined here')
 
+      waitrt?
+
       echo(results) if UserVars.mining_debug
 
       return false if results.nil?


### PR DESCRIPTION
Diagnosed by @vtcifer -

`mining-buddy` dumps the script during RT. Log below. Added a `waitrt?` into the unless block after the bput.

```
[mining-buddy]>prospect
You feel fully rested.
You see evidence of mineral deposits and are certain a good quantity remains to be found.
This area is composed of igneous rock layers.
Studying the geology, you are certain that continued mining will be quite safe.
You are certain that obsidian can be mined here.
You are certain that covellite can be mined here.
No miners appear to be nearby, and you will be unable to deed resources mined in this area.
Roundtime: 10 sec.
--- Lich: mining-buddy has exited.
--- Lich: crossing-training active.
[crossing-training]>open my hunting pack
...wait 9 seconds.
```