### PR TITLE
[script][common-healing] - Better handling of dropping dislodged

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -326,7 +326,7 @@ module DRCH
     # You dislodged ammo or a parasite, discard it. Note, some parasites go away and don't
     # end up in your hand. Fine, it'll just fail to dispose.
     tend_dislodge = [
-      /^You \w+ remove (a|the) (.*) from/
+      /^You \w+ remove (a|the|some) (.*) from/
     ]
 
     result = DRC.bput("tend #{person} #{body_part}", *tend_success, *tend_failure, *tend_dislodge)

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -320,19 +320,20 @@ module DRCH
     tend_failure = [
       /You fumble/,
       /too injured for you to do that/,
-      /TEND allows for the tending of wounds/
+      /TEND allows for the tending of wounds/,
+      /^You must have a hand free/
     ]
-    # You dislodged ammo or a parasite, discard it.
+    # You dislodged ammo or a parasite, discard it. Note, some parasites go away and don't
+    # end up in your hand. Fine, it'll just fail to dispose.
     tend_dislodge = [
-      /You \w+ remove/
+      /^You \w+ remove (a|the) (.*) from/
     ]
-    snap = [DRC.left_hand, DRC.right_hand]
+
     result = DRC.bput("tend #{person} #{body_part}", *tend_success, *tend_failure, *tend_dislodge)
     waitrt?
     case result
     when *tend_dislodge
-      DRCI.dispose_trash(DRC.left_hand, get_settings.worn_trashcan, get_settings.worn_trashcan_verb) if DRC.left_hand != snap.first
-      DRCI.dispose_trash(DRC.right_hand, get_settings.worn_trashcan, get_settings.worn_trashcan_verb) if DRC.right_hand != snap.last
+      DRCI.dispose_trash(Regexp.last_match(2), get_settings.worn_trashcan, get_settings.worn_trashcan_verb)
       bind_wound(body_part, person)
     when *tend_failure
       false


### PR DESCRIPTION
Addresses #5811 

Tries to do a better job of dropping _only_ the thing we've just dislodged by capturing it via regex and not something else that might have gotten into our hands. As far as I know there is only a single tend dislodge message with just a couple of word variations. But we'll need to monitor to make sure that's the case.

Also fixes a `bput` match hang when your hands are full (still returns False that tending was unsuccessful; this script does not do item handling).