### PR TITLE
[script][drinfomon] - Fix alfar warrior

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -592,6 +592,7 @@ def find_npcs(room_objs)
   room_objs.sub(/You also see/, '').sub(/ with a [\w\s]+ sitting astride its back/, '').strip
            .scan(%r{<pushBold/>[^<>]*<popBold/> which appears dead|<pushBold/>[^<>]*<popBold/> \(dead\)|<pushBold/>[^<>]*<popBold/>})
            .reject { |obj| obj =~ /which appears dead|\(dead\)/ }
+           .map { |obj| obj.sub(/.*alfar warrior.*/, 'alfar warrior') }
            .map { |obj| obj.sub('<pushBold/>', '').sub(%r{<popBold/>.*}, '') }
            .map { |obj| obj.split(/\sand\s/).last.sub(/(?:\sglowing)?\swith\s.*/, '') }
            .map { |obj| obj.strip.scan(/[A-z'-]+$/).first }


### PR DESCRIPTION
First reported by Itharl on Discord: https://discordapp.com/channels/745675889622384681/745678251250417674/980926744926248960

Special thanks to DantiaDR who worked through the diagnosis with Itharl and pintpointed the exact spot in combat-trainer that was the issue.

Fixes an issue where altered alfar warriors were being parsed incorrectly in DRRoom's `find_npcs` method. This affects `combat-trainer` because there is a section that allows an empath to bring out an Alfar Warrior. Said section pauses 0.5 until we see `warrior` in the list of room npcs. The incorrect parsing caused an indefinite hang.

I'll likely submit a separate PR to eliminate the possibility of an indefinite hang in combat-trainer.

Log of the issue:
```
[combat-trainer]>prepare gs 5



R> 
[combat-trainer]>circle

...wait 1 seconds.

R> 
You hear a muffled whirring sound.
[combat-trainer]>circle
You fake a granite gargoyle, first moving one way and then another, leaving it off balance.
[You're nimbly balanced and have slight advantage.]
Roundtime: 3 sec.
* A granite gargoyle maneuvers at you.  You dodge.
[You're nimbly balanced and in better position.]
* A granite gargoyle maneuvers at you.  You evade.
[You're nimbly balanced and in good position.]
[combat-trainer]>cast custom
Your heart skips a beat as your spell sends a subtle jingling call outward from you in all directions.
You feel fully rested.
* A granite gargoyle slams down at you.  You dodge.
[You're nimbly balanced and in very strong position.]
* A granite gargoyle bites at you.  You block with an ebon-hued buckler.
[You're nimbly balanced and overwhelming your opponent.]
* A granite gargoyle pounds at you.  You dodge.
[You're nimbly balanced and in strong position.]
An imperious alfar warrior swathed in a wrap of kirmiko calmly strides in and surveys the area.
<hangs forever>
```