### PR TITLE
[scripts] [buff] Add option for custom targets

### DIFF
--- a/buff.lic
+++ b/buff.lic
@@ -11,7 +11,7 @@ class Waggle
       [
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
         { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' },
-        { name: 'target', regex: /(?:target=(\w+))/i, optional: true, description: 'Recast spells even if currently active' }
+        { name: 'target', regex: /target=\w+/i, optional: true, description: 'Recast spells even if currently active' }
       ]
     ]
 

--- a/buff.lic
+++ b/buff.lic
@@ -11,7 +11,7 @@ class Waggle
       [
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
         { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' },
-        { name: 'target', regex: /target=\w+/i, optional: true, description: 'Recast spells even if currently active' }
+        { name: 'target', regex: /target=\w+/i, optional: true, description: 'Force target for spells' }
       ]
     ]
 

--- a/buff.lic
+++ b/buff.lic
@@ -30,8 +30,6 @@ class Waggle
         spell_data['recast'] = 99 # force spell to be recast
       end
     elsif args.target
-      target = args.target
-      echo "#{target}"
       target = args.target.split('=')[1]
       settings.waggle_sets[setname].values.each do |spell_data|
         spell_data['cast'] = "cast #{target}" # Cast on our target
@@ -39,7 +37,7 @@ class Waggle
       end
     end
 
-    # DRCA.do_buffs(settings, setname)
+    DRCA.do_buffs(settings, setname)
     
   end
 end

--- a/buff.lic
+++ b/buff.lic
@@ -38,7 +38,6 @@ class Waggle
     end
 
     DRCA.do_buffs(settings, setname)
-    
   end
 end
 

--- a/buff.lic
+++ b/buff.lic
@@ -10,7 +10,8 @@ class Waggle
     arg_definitions = [
       [
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
-        { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' }
+        { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' },
+        { name: 'target', regex: /(target=(\w+))/i, optional: true, description: 'Recast spells even if currently active' }
       ]
     ]
 
@@ -26,6 +27,12 @@ class Waggle
 
     if args.force
       settings.waggle_sets[setname].values.each do |spell_data|
+        spell_data['recast'] = 99 # force spell to be recast
+      end
+    elsif args.target
+      target = args.target.split('=')[1]
+      settings.waggle_sets[setname].values.each do |spell_data|
+        spell_data['cast'] = "cast #{target}" # Cast on our target
         spell_data['recast'] = 99 # force spell to be recast
       end
     end

--- a/buff.lic
+++ b/buff.lic
@@ -11,7 +11,7 @@ class Waggle
       [
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
         { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' },
-        { name: 'target', regex: /(target=(\w+))/i, optional: true, description: 'Recast spells even if currently active' }
+        { name: 'target', regex: /(?:target=(\w+))/i, optional: true, description: 'Recast spells even if currently active' }
       ]
     ]
 
@@ -30,14 +30,17 @@ class Waggle
         spell_data['recast'] = 99 # force spell to be recast
       end
     elsif args.target
+      target = args.target
+      echo "#{target}"
       target = args.target.split('=')[1]
       settings.waggle_sets[setname].values.each do |spell_data|
         spell_data['cast'] = "cast #{target}" # Cast on our target
-        spell_data['recast'] = 99 # force spell to be recast
+        spell_data['recast'] = 99 # force spell to be cast
       end
     end
 
-    DRCA.do_buffs(settings, setname)
+    # DRCA.do_buffs(settings, setname)
+    
   end
 end
 


### PR DESCRIPTION
Allows me to buff others using existing waggle sets. So my empath can for example
```
;buff mef target=mahtra
```

And it'll force-cast MEF, using my ranger as the overwrite target.