### PR TITLE
[script][combat-trainer] - Better stop process

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3553,10 +3553,14 @@ class CombatTrainer
 
   def stop
     echo 'Received stop signal' if $debug_mode_ct
+
+    # If we receive a stop signal early in the combat-trainer setup process, the @stop boolean may overwrite.
+    # Wait until combat-trainer is @running before setting the stop boolean.
     until @running
-      echo 'Waiting for combat trainer to finish starting, before telling it to stop.'
+      echo 'Waiting for combat trainer to finish starting, before telling it to stop.' if $debug_mode_ct
       pause 5
     end
+
     @stop = true
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3553,6 +3553,10 @@ class CombatTrainer
 
   def stop
     echo 'Received stop signal' if $debug_mode_ct
+    until @running
+      echo 'Waiting for combat trainer to finish starting, before telling it to stop.'
+      pause 5
+    end
     @stop = true
   end
 


### PR DESCRIPTION
Addresses #5814 via @Tirost , wherein `combat-trainer` will sometimes fail to stop when `hunting-buddy` sends a remote stop request extremely early in the process.

This attempts to wait for combat-trainer to init and setup before setting the stop boolean, since the setup process sets the boolean to false and may overwrite.

Credit to @vtcifer , this is an exact copy/paste of his proposed solution.

Settings as draft for the moment and I'll grab a couple testers if I can.