### PR TITLE
[script] [hunting-buddy] Catching race condition for stop_on_skills

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -480,7 +480,7 @@ class HuntingBuddy
     # it before it can get the 'stop' comand.
     # Wait 10 seconds or until combat trainer is all ready to roll
     start = Time.now
-    pause until Time.now - start > 10 || $COMBAT_TRAINER.running
+    pause until Time.now - start > 30 || $COMBAT_TRAINER.running
 
     counter = 0
     loop do

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -478,9 +478,9 @@ class HuntingBuddy
 
     # This pause "fixes" a race condition with combat starting and the monitors below trying to kill
     # it before it can get the 'stop' comand.
-    # A better solution would be a smarter utility "wait_for_script_to_start" or some call into
-    # combat i.e. `pause 0.5 until $COMBAT_TRAINER.is_ready` or something.
-    pause 2
+    # Wait 10 seconds or until combat trainer is all ready to roll
+    start = Time.now
+    pause until Time.now - start > 10 || $COMBAT_TRAINER.running
 
     counter = 0
     loop do

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -478,7 +478,7 @@ class HuntingBuddy
 
     # This pause "fixes" a race condition with combat starting and the monitors below trying to kill
     # it before it can get the 'stop' comand.
-    # Wait 10 seconds or until combat trainer is all ready to roll
+    # Wait 30 seconds or until combat trainer is all ready to roll
     start = Time.now
     pause until Time.now - start > 30 || $COMBAT_TRAINER.running
 


### PR DESCRIPTION
Addresses a regression technically introduced when https://github.com/rpherbig/dr-scripts/pull/4849 was merged.

The current check just waits 2 seconds, which isn't enough time, and leads to issues like those described in https://github.com/rpherbig/dr-scripts/issues/5814

Resolves https://github.com/rpherbig/dr-scripts/issues/5814
Closes https://github.com/rpherbig/dr-scripts/pull/5816