### PR TITLE
[scripts] [common] Removing no-longer-needed special handling for genie

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -783,11 +783,9 @@ module DRC
     string = ''
 
     $fake_stormfront ? string.concat("\034GSL\r\n ") : string.concat("<pushBold\/>")
-    string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
 
     string.concat(text)
 
-    string.concat("\r") if $frontend == 'genie'   #fix genie monsterbold
     $fake_stormfront ? string.concat("\034GSM\r\n ") : string.concat("<popBold\/>")
 
     string


### PR DESCRIPTION
@jingounchained have been coordinating on this for awhile now, and with the release of https://github.com/GenieClient/Genie4/releases/tag/4.0.2.4 the extra carriage returns are no longer needed for genie. 

Should remove the weird-looking double spacing issues in genie+lich.