### PR TITLE
[script] [clean-leather] scrape normal speed regex fix

### DIFF
--- a/clean-leather.lic
+++ b/clean-leather.lic
@@ -99,8 +99,8 @@ class CleanLeather
 
     # Scrapes a skin until it's fully-scraped
     loop do
-      case DRC.bput("scrape #{hide} with my scraper #{speed}", /^You (quickly|carefully)? scrape your/i, /looks as clean as you/i)
-      when /^You (quickly|carefully)? scrape your/i
+      case DRC.bput("scrape #{hide} with my scraper #{speed}", /^You (quickly|carefully)? scrape your/i, /looks as clean as you/i, /^You scrape your/i)
+      when /^You (quickly|carefully)? scrape your/i, /^You scrape your/i
         waitrt?
         next
       when /looks as clean as you/


### PR DESCRIPTION
Scraping normal speed does not have the quick|carefully regex conditions. Therefor it would pause and abort. This just simply adds  /^You scrape your/i into lines 102 and 103 fixing the hang issue.