### PR TITLE
[script] [spellmonitor] parse spells when column-formatted

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -18,6 +18,7 @@ class DRSpells
   @@known_feats = {}
   @@refresh_data = {}
   @@slivers = false
+  @@spellbook_format = nil # 'column-formatted' or 'non-column'
 
   @@grabbing_active_spells = false
   @@grabbing_known_spells = false
@@ -72,6 +73,14 @@ class DRSpells
 
   def self.silence_known_spells_hook=(val)
     @@silence_known_spells_hook = val
+  end
+
+  def self.spellbook_format
+    @@spellbook_format
+  end
+
+  def self.spellbook_format=(val)
+    @@spellbook_format = val
   end
 
   # Call this method to cause the script to recheck for known spells and feats.
@@ -205,13 +214,83 @@ end
 
 # This method parses the output from `spells` command for magic users
 # and populates the known spells/feats based on the output.
+#
+# As of June 2022, There are two different output formats: column-formatted and non-column.
+# https://elanthipedia.play.net/Post:Tuesday_Tidings_-_120_-_Spells_-_06/07/2022_-_18:34
+#
+# The XML stream for DragonRealms is whack at best.
+#
+# Examples of non-column output:
+#     You recall the spells you have learned from your training.
+#     In the chapter entitled "Analogous Patterns", you have notes on the Manifest Force [maf] and Gauge Flow [gaf] spells.
+#     You have temporarily memorized the Tailwind [tw] spell.
+#     You recall proficiency with the magic feats of Sorcerous Patterns, Alternate Preparation and Augmentation Mastery.
+#     You are NOT currently set to recognize known spells when prepared by someone else in the area.  (Use SPELL RECOGNIZE ON to change this.)
+#     You are currently set to display full cast messaging.  (Use SPELL BRIEFMSG ON to change this.)
+#     You are currently attempting to hide your spell preparing.  (Use PREPARE /HIDE to change this.)
+#     You can use SPELL STANCE [HELP] to view or modify your spellcasting preferences.
+#
+# Examples of column-formatted output:
+#     You recall the spells you have learned from your training.
+#     <output class="mono"/>
+#     <pushBold/>
+#     Analogous Patterns:
+#     <popBold/>     maf  Manifest Force                  Slot(s): 1   Min Prep: 1     Max Prep: 100
+#          gaf  Gauge Flow                      Slot(s): 2   Min Prep: 5     Max Prep: 100
+#     <pushBold/>
+#     Synthetic Creation:
+#     <popBold/>     acs  Acid Splash                     Slot(s): 1   Min Prep: 1     Max Prep: 50
+#           vs  Viscous Solution                Slot(s): 2   Min Prep: 10    Max Prep: 66
+#     <output class=""/>
+#     <output class="mono"/>
+#     <pushBold/>
+#     Temporarily Memorized:
+#     <popBold/>      tw  Tailwind                        Slot(s): 1   Min Prep: 5     Max Prep: 100
+#     <output class=""/>
+#     You recall proficiency with the magic feats of Sorcerous Patterns, Alternate Preparation and Augmentation Mastery.
+#     You are NOT currently set to recognize known spells when prepared by someone else in the area.  (Use SPELL RECOGNIZE ON to change this.)
+#     You are currently set to display full cast messaging.  (Use SPELL BRIEFMSG ON to change this.)
+#     You are currently attempting to hide your spell preparing.  (Use PREPARE /HIDE to change this.)
+#     You can use SPELL STANCE [HELP] to view or modify your spellcasting preferences.
+#
+# One or more spells may be listed between a <popBold/> <pushBold/> pair,
+# but only one spell and its information are ever listed per line.
+#
 known_mage_spells_hook = proc do |server_string|
   case server_string
+  when /^You will .* (?<format>column-formatted|non-column) output for the SPELLS verb/
+    # Parse `toggle spellbook` command
+    DRSpells.spellbook_format = Regexp.last_match[:format]
+    server_string = nil if DRSpells.silence_known_spells_hook
   when /^You recall the spells you have learned/
     DRSpells.grabbing_known_spells = true
     DRSpells.known_spells.clear()
     DRSpells.known_feats.clear()
+    DRSpells.spellbook_format = 'non-column' # assume original format
     server_string = nil if DRSpells.silence_known_spells_hook
+  when /^<output class="mono"\/>/
+    # Matched an xml tag while parsing spells, must be column-formatted output
+    if DRSpells.grabbing_known_spells
+      DRSpells.spellbook_format = 'column-formatted'
+    end
+    server_string = nil if DRSpells.silence_known_spells_hook
+  when /^[\w\s]+:/
+    # Matched the spellbook name in column-formatted output, ignore
+    server_string = nil if DRSpells.silence_known_spells_hook
+  when /Slot\(s\): \d+ \s+ Min Prep: \d+ \s+ Max Prep: \d+/
+    # Matched the spell info in column-formatted output, parse
+    if DRSpells.grabbing_known_spells && DRSpells.spellbook_format == 'column-formatted'
+      spell = server_string
+        .sub('<popBold/>', '') # remove xml tag at start of some lines
+        .slice(10, 32) # grab the spell name, after the alias and before Slots
+        .strip
+      if !spell.empty?
+        DRSpells.known_spells[spell] = true
+      end
+    end
+    # Preserve the pop bold command we removed from start of spell line
+    # otherwise lots of game text suddenly are highlighted yellow
+    server_string = '<popBold/>' if DRSpells.silence_known_spells_hook
   when /^In the chapter entitled|^You have temporarily memorized|^From your apprenticeship you remember practicing/
     if DRSpells.grabbing_known_spells
       server_string


### PR DESCRIPTION
### Background
* [Tuesday Tidings 120](https://elanthipedia.play.net/Post:Tuesday_Tidings_-_120_-_Spells_-_06/07/2022_-_18:34) introduced a new column-formatted output for `SPELL` command. Players can choose to set this format as their default so we need to be able to parse that output.
* Thankfully, this only impacts the logic for identifying known spells so the blast radius is fairly small.
* With or without `toggle spellbook` enabled, the output of Thief khri and Barbarian abilities did not change.

### Changes
* Update the `known_mage_spells_hook` method to infer the spell output format and parse accordingly.

## Tests

### non-column output
```
> toggle spellbook
You will see the default, non-column output for the SPELLS verb.

> ,e DRSpells.refresh_known_spells

--- Lich: exec1 active.

[exec1]>spells 

--- Lich: exec1 has exited.

> ,e echo DRSpells.known_spells ; echo DRSpells.known_feats ; echo DRSpells.spellbook_format

--- Lich: exec1 active.

[exec1: {"Minor Physical Protection"=>true, "Shield of Light"=>true, "Benediction"=>true, "Major Physical Protection"=>true, "Auspice"=>true, "Centering"=>true, "Soul Sickness"=>true, "Bless"=>true, "Divine Radiance"=>true, "Fists of Faenella"=>true, "Aesrela Everild"=>true, "Heavenly Fires"=>true, "Sanctify Pattern"=>true, "Persistence of Mana"=>true, "Manifest Force"=>true}]

[exec1: {"Augmentation Mastery"=>true, "Utility Mastery"=>true, "Warding Mastery"=>true, "Improvised Rituals"=>true, "Cautious Casting"=>true, "Injured Casting"=>true, "Deep Attunement"=>true, "Efficient Channeling"=>true, "Efficient Harnessing"=>true}]

[exec1: non-column]

--- Lich: exec1 has exited.
```

### column-formatted output
```
> toggle spellbook
You will now see a column-formatted output for the SPELLS verb.

> ,e DRSpells.refresh_known_spells

--- Lich: exec1 active.

[exec1]>spells 

--- Lich: exec1 has exited.

> ,e echo DRSpells.known_spells ; echo DRSpells.known_feats ; echo DRSpells.spellbook_format

--- Lich: exec1 active.

[exec1: {"Minor Physical Protection"=>true, "Shield of Light"=>true, "Benediction"=>true, "Major Physical Protection"=>true, "Auspice"=>true, "Centering"=>true, "Soul Sickness"=>true, "Bless"=>true, "Divine Radiance"=>true, "Fists of Faenella"=>true, "Aesrela Everild"=>true, "Heavenly Fires"=>true, "Sanctify Pattern"=>true, "Persistence of Mana"=>true, "Manifest Force"=>true}]

[exec1: {"Augmentation Mastery"=>true, "Utility Mastery"=>true, "Warding Mastery"=>true, "Improvised Rituals"=>true, "Cautious Casting"=>true, "Injured Casting"=>true, "Deep Attunement"=>true, "Efficient Channeling"=>true, "Efficient Harnessing"=>true}]

[exec1: column-formatted]

--- Lich: exec1 has exited.
```