### PR TITLE
[script][common-items] - Be explicit with new trash bin

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -369,6 +369,7 @@ module DRCI
         trashcan = 'waste basket' if DRRoom.room_objs.include?('waste basket')
       elsif trashcan == 'bin'
         trashcan = 'waste bin' if DRRoom.room_objs.include?('waste bin')
+        trashcan = 'small bin' if DRRoom.room_objs.include?('small bin concealed with some nearby brush')
       elsif trashcan == 'arms'
         trashcan = 'statue'
       elsif trashcan == 'birdbath'


### PR DESCRIPTION
In concert with #5827 to handle the new trash bin in Steelclaw Clan called: `small bin concealed with some nearby brush`

The primary issue was that `DRCI.dispose_trash`'s process was identifying the trash bin's noun wrong. @KatoakDR fixed that.

While it _does_ now work to dispose of trash in this bin, it does not explicitly identify this specific bin. Rather, it relies on the fact that our `do` loop iterator variable happens to be set to `bin` after we're done paring down the room_objs to try to find our bin noun, which winds up working (because our `bput` happens to be within the do loop, so the iterator variable is still within scope). It never actually follows convention of this method by identifying the bin in the if/elsif block and setting the `trashcan` variable purposefully.

This does so. TLDR: be explicit about identifying this new trash bin and setting our variable appropriately.

