### PR TITLE
[data][base.yaml] - Add roar helm noun

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -191,6 +191,8 @@ battle_cries:
 battle_cry_cycle:
 # The number of seconds to wait between battle cries.
 battle_cry_cooldown: 90
+# Set the noun of your roar helm to use scream helm before roars.
+roar_helm_noun:
 
 # Defines the number of monsters you will keep in combat with you by performing 'dance actions' or attacking with only 'harmless: true' spells. 0 means kill everything.
 dance_threshold: 0


### PR DESCRIPTION
#5819  relies on this.

Add `roar_helm_noun` to support scream helm functionality being added to combat-trainer for barbs.