### PR TITLE
[script][shape] - Fix glue application

### DIFF
--- a/shape.lic
+++ b/shape.lic
@@ -53,7 +53,7 @@ class Shape
     @training_spells = @settings.crafting_training_spells
 
     wait_for_script_to_complete('buff', ['shape'])
-    Flags.add('shaping-assembly', 'appears ready to be reinforced with some (backer)', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* (leather (?:strip|cord))', 'You must assemble the (backer)', 'You must assemble the (strips)', 'another arrow (flights)', 'another .* (arrowhead)')
+    Flags.add('shaping-assembly', 'appears ready to be reinforced with some (backer)', 'appears ready to be strengthened with some leather (strips)', 'assembly with the (backing) material can begin', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* (leather (?:strip|cord))', 'You must assemble the (backer)', 'You must assemble the (strips)', 'another arrow (flights)', 'another .* (arrowhead)')
     if args.continue
       shape("analyze my #{@noun}")
     elsif args.laminate
@@ -182,11 +182,11 @@ class Shape
               'Applying the final touches', 'lamination process', 'lightening process', 'cable-backing process', 'These appear to be a type',
               'That tool does not seem suitable for that task.', 'You cannot figure out', 'doesn\'t appear suitable for working',
               'while it is inside of something',
-              'Glue should now be applied', 'glue to fasten it', 'glue applied', 'You brush some glue on your', 'You apply a layer',
               'ready to be clamped', 'with clamps',
+              'Glue should now be applied', 'glue to fasten it', 'glue applied', 'You brush some glue on your', 'You apply a layer',
               'Some wood stain', 'application of stain',
               'You fumble around but',
-              'ASSEMBLE Ingredient1')
+              'ASSEMBLE Ingredient1', 'You need another', 'You must assemble')
     when 'a wood shaper is needed', 'with a wood shaper', 'You whittle away', 'Using abrupt motions you shape', 'You flip some', 'You apply some glue', 'Using slow strokes you scrape', 'You dab the surface', 'You lap the'
       waitrt?
       stow_item(right_hand)
@@ -226,6 +226,8 @@ class Shape
       exit
     when 'That tool does not seem suitable for that task.', 'You cannot figure out', 'doesn\'t appear suitable for working'
       shape("analyze my #{@noun}")
+    when 'ASSEMBLE Ingredient1', 'You need another', 'You must assemble'
+      assemble_part
     end
     crafting_magic_routine(@settings)
     shape(command)

--- a/shape.lic
+++ b/shape.lic
@@ -53,7 +53,7 @@ class Shape
     @training_spells = @settings.crafting_training_spells
 
     wait_for_script_to_complete('buff', ['shape'])
-    Flags.add('shaping-assembly', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* (leather (?:strip|cord))', 'You must assemble the (backer)', 'You must assemble the (strips)', 'another arrow (flights)', 'another .* (arrowhead)')
+    Flags.add('shaping-assembly', 'appears ready to be reinforced with some (backer)', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another .* (leather (?:strip|cord))', 'You must assemble the (backer)', 'You must assemble the (strips)', 'another arrow (flights)', 'another .* (arrowhead)')
     if args.continue
       shape("analyze my #{@noun}")
     elsif args.laminate
@@ -202,7 +202,7 @@ class Shape
       stow_item(right_hand)
       get_item('rasp')
       command = "scrape my #{@noun} with my rasp"
-    when 'ready to be clamped', 'with clamps'
+    when 'ready to be clamped', 'with clamps', 'You brush some glue on your', 'You apply a layer'
       waitrt?
       stow_item(right_hand)
       get_item('clamp')


### PR DESCRIPTION
Small change stemming from issue #5566 

added missing language for the flag

match messaging was present in the case statement, but there was nothing done with it. This, in part, caused the problem we saw in the referenced issue. 

For composite bows, what we needed during initial assembly was a strict ordering of setting up for glue, assembling the backer, applying the glue, then matching that application with the clamps step. 

However, during lamination for any bow, the ordering was applying glue, then setting up for clamps, assembling the backer, then applying clamps.

These two issues were resolved moving the glue success messaging into the clamps section (conditional?), and adding "appears ready to be" messaging to the flag. The last WHEN statement was added as a backstop in case the Flag gets skipped.

[shape log.txt](https://github.com/rpherbig/dr-scripts/files/8934620/shape.log.txt)

[shape log.txt](https://github.com/rpherbig/dr-scripts/files/8934650/shape.log.txt)

[shape log.txt](https://github.com/rpherbig/dr-scripts/files/8934676/shape.log.txt)

I suspect bolts/arrows might need similar love, unless it's been updated since the last time I tried making them.