### PR TITLE
[script][events] - Create concept of event history

### DIFF
--- a/events.lic
+++ b/events.lic
@@ -26,12 +26,6 @@ class Flags
     @@history[key] = []
   end
 
-  def self.add_with_history(key, *matchers)
-    @@flags[key] = false
-    @@matchers[key] = matchers.map { |item| item.is_a?(Regexp) ? item : /#{item}/i }
-    @@history[key] = []
-  end
-
   def self.reset(key)
     @@flags[key] = false
   end

--- a/events.lic
+++ b/events.lic
@@ -23,6 +23,11 @@ class Flags
   def self.add(key, *matchers)
     @@flags[key] = false
     @@matchers[key] = matchers.map { |item| item.is_a?(Regexp) ? item : /#{item}/i }
+  end
+
+  def self.add_with_history(key, *matchers)
+    @@flags[key] = false
+    @@matchers[key] = matchers.map { |item| item.is_a?(Regexp) ? item : /#{item}/i }
     @@history[key] = []
   end
 
@@ -58,7 +63,7 @@ events_action = proc do |server_string|
     regexes.each do |regex|
       if matches = server_string.match(regex)
         Flags.flags[key] = matches
-        Flags.history[key].push(matches)
+        Flags.history[key].push(matches) unless Flags.history[key].nil?
         break
       end
     end

--- a/events.lic
+++ b/events.lic
@@ -23,6 +23,7 @@ class Flags
   def self.add(key, *matchers)
     @@flags[key] = false
     @@matchers[key] = matchers.map { |item| item.is_a?(Regexp) ? item : /#{item}/i }
+    @@history[key] = []
   end
 
   def self.add_with_history(key, *matchers)

--- a/events.lic
+++ b/events.lic
@@ -10,6 +10,7 @@ setpriority(0)
 class Flags
   @@flags = {}
   @@matchers = {}
+  @@history = {}
 
   def self.[](key)
     @@flags[key]
@@ -22,6 +23,7 @@ class Flags
   def self.add(key, *matchers)
     @@flags[key] = false
     @@matchers[key] = matchers.map { |item| item.is_a?(Regexp) ? item : /#{item}/i }
+    @@history[key] = []
   end
 
   def self.reset(key)
@@ -31,6 +33,7 @@ class Flags
   def self.delete(key)
     @@matchers.delete key
     @@flags.delete key
+    @@history.delete key
   end
 
   def self.flags
@@ -40,6 +43,14 @@ class Flags
   def self.matchers
     @@matchers
   end
+
+  def self.history
+    @@history
+  end
+
+  def self.read_matches(key)
+    @@history[key].shift(@@history[key].count)
+  end
 end
 
 events_action = proc do |server_string|
@@ -47,6 +58,7 @@ events_action = proc do |server_string|
     regexes.each do |regex|
       if matches = server_string.match(regex)
         Flags.flags[key] = matches
+        Flags.history[key].push(matches)
         break
       end
     end


### PR DESCRIPTION
(Releasing as draft while we discuss)

Currently, Flags have no concept of a history of the events they've seen, and no concept of how many times they've seen the event and been "tripped". This is not a problem and having a history of the events they've seen was not originally contemplated. It was simply "have we seen it one or a dozen times? Ok, flag on".

This PR adds a concept of an event history to the `events` script and class Flags. Tracking history is opt-in and history is held in a separate array of MatchData, with an entry for each time `events` has seen a match since the user last retrieved the data. A user can retrieve the history and act on it as they wish.

To create a flag with history tracking, a user would call `Flags.add_with_history('name', 'matches')`. The history can then be retrieved with `Flags.read_matches('name')`. Reading the matches clears the history array.

**_Why Have This Concept?_**

The way `events` is structured now, it is not truly tracking all specified events. It's just watching for a match, and setting the flag to on. If the flag sees three matches in succession, it's simply reassigning the flag array with the last MatchData seen. Allowing the script to have a history of all events triggered opens up an ability to act on them each and every time on a 1-to-1 level if a user so desires and to know exactly what matches were seen.

**_Possible Future Uses_**

- Better `;log` scripts
- True Lich-based triggers (I'm working on this, though unsure if I'll release)

