### PR TITLE
Add magic training to attunement walking

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -29,12 +29,14 @@ class Attunement
       ]
     ]
     args = parse_args(arg_definitions, true)
-    settings = get_settings
-    @stationary_skills_only = settings.crossing_training_stationary_skills_only
-    @hometown = settings.hometown
-    @attunement_rooms = settings.attunement_rooms
-    @perceive_health_rooms = settings.perceive_health_rooms
-    @sigil_walk_rooms = settings.sigil_walk_rooms
+    @settings = get_settings
+    @magic_filler = @settings.train_magic_during_attunement_walk
+    @training_spells = @settings.crafting_training_spells
+    @stationary_skills_only = @settings.crossing_training_stationary_skills_only
+    @hometown = @settings.hometown
+    @attunement_rooms = @settings.attunement_rooms
+    @perceive_health_rooms = @settings.perceive_health_rooms
+    @sigil_walk_rooms = @settings.sigil_walk_rooms
     @skill_to_train = if (DRStats.empath? && args.health) 
                         'Empathy' 
                       elsif args.sigil
@@ -42,12 +44,12 @@ class Attunement
                       else
                         'Attunement'
                       end
-    @exp_max_threshold = settings.crossing_training_max_threshold
-    @exp_target_increment = settings.attunement_target_increment
+    @exp_max_threshold = @settings.crossing_training_max_threshold
+    @exp_target_increment = @settings.attunement_target_increment
     @exp_start_mindstate = DRSkill.getxp(@skill_to_train)
     @exp_stop_mindstate = [@exp_start_mindstate + @exp_target_increment, @exp_max_threshold, 34].min
     @lunar_perceive_index = -1
-    train_skill(settings)
+    train_skill
   end
 
   def is_lunar_mage?
@@ -116,16 +118,17 @@ class Attunement
     DRSkill.getxp(@skill_to_train) >= @exp_stop_mindstate
   end
 
-  def train_skill(settings)
+  def train_skill
     room_list = get_rooms
     until done_training?
       # If we keep looping, ensure buffs stay active
-      DRCA.do_buffs(settings, 'attunement')
+      DRCA.do_buffs(@settings, 'attunement')
       room_list.each do |room_id|
         train_skill_in_room(room_id)
         break if done_training?
       end
     end
+    magic_cleanup
   end
 
   def train_skill_in_room(room_id)
@@ -146,13 +149,23 @@ class Attunement
     waitrt?
   end
 
+  def magic_cleanup
+    return if @training_spells.empty?
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    # Do not release symbiosis as it may release the symbiosis research instead of a prepared symbioisis cast.
+  end   
+
   def perceived?
+    
     if is_sigil_walk?
       while /Roundtime/ =~ DRC.bput(get_perceive_command, SECONDARY_SIGILS_PATTERN,'Having recently been searched, this area contains no traces of sigils',"Roundtime",)
         waitrt?
+        DRCA.crafting_magic_routine(@settings) if @magic_filler
       end
       return true
     end
+    DRCA.crafting_magic_routine(@settings) if @magic_filler
     case DRC.bput(get_perceive_command, "You fail to sense", "You're not ready to do that again, yet", "You reach out", "You sense:", "Roundtime")
     when "You reach out", "You sense:"
       true

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -733,6 +733,10 @@ attunement_rooms:
 # train empathy via 'perceive health' command.
 # If not defined then the rooms are taken from base-towns.yaml.
 perceive_health_rooms:
+# Used by 'attunement' script with any option.
+# If set to True then crafting_spell_training will be woven between commands.
+train_magic_during_attunement_walk: false
+
 training_rooms:
 journal_noun: journal
 


### PR DESCRIPTION
Since we can't play worn instruments during perceive walking of any variety, it would be worthwhile to weave magic casting.  Since attunement walking can take a long time, depending on the type of walk, it is quite possible run out of mana with these big no-camb casts.  For empaths (some still health walk) in particular, this could be fatal so I opted to add a toggle here to prevent users being surprised by a sudden lack of mana.