### PR TITLE
[script][mining-buddy] - Cleanup, add self repair

### DIFF
--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -105,8 +105,13 @@ class MiningBuddy
             @next_repair = Time.now + 7200 #this tech makes repaired tools immune to damage for 2 hours (7200 seconds)
           end
           return
-      when 'not damaged enough', 'cannot figure out how', 'Pour what?', 'You cannot do that while engaged!'
+      when 'not damaged enough', 'You cannot do that while engaged!'
           DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
+          return
+      when 'cannot figure out how', 'Pour what?'
+          @mine_repair_own_tools = false
+          DRC.message("Something went wrong, lets let the professionals handle repairs for today")
+          check_repair
           return
       end
   end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#mining-buddy
 =end
 
-custom_require.call(%w[common common-items common-money common-travel drinfomon])
+custom_require.call(%w[common common-items common-crafting common-money common-travel drinfomon])
 
 class MiningBuddy
 

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -59,6 +59,7 @@ class MiningBuddy
     DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt)
     if @mine_repair_own_tools && DRCI.exists?('wire brush') && DRCI.exists?('of oil')
       self_repair('wire brush')
+      DRCC.stow_crafting_item(@mining_implement, @bag, @forging_belt)
       return
     elsif @mine_repair_own_tools
       DRC.message('Missing brush or oil, reverting to store repair.')

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -5,30 +5,43 @@
 custom_require.call(%w[common common-items common-money common-travel drinfomon])
 
 class MiningBuddy
-  include DRC
-  include DRCI
-  include DRCM
-  include DRCT
 
   def initialize
-    setup
+    @settings = get_settings
+    @area_list = get_data('mining').mining_buddy_rooms
+    @forging_belt = @settings.forging_belt
+    @bag = @settings.crafting_container
+    @bag_items = @settings.crafting_items_in_container
+    @areas = @settings.mines_to_mine
+    @skip_populated = @settings.mining_skip_populated
+    @mine_every_room = @settings.mining_buddy_mine_every_room
+    @vein_list = @settings.mining_buddy_vein_list
+    @mining_implement = @settings.mining_implement
+    @use_packet = @settings.mine_use_packet
+    @hometown = @settings.hometown
+    deeds_data = get_data('crafting').deeds[@hometown]
+    @deeds_room = deeds_data['room']
+    @deeds_number = deeds_data['medium_number']
+    @mine_repair_own_tools = @settings.mine_repair_own_tools
+    echo("#{@areas}:#{@vein_list}") if UserVars.mining_debug
 
-    ensure_copper_on_hand(10_000, @settings)
+    DRCM.ensure_copper_on_hand(10_000, @settings)
 
     if @use_packet
-      buy_deed_packet unless exists?('packet')
-      buy_deed_packet unless exists?('second packet')
+      buy_deed_packet unless DRCI.exists?('packet')
+      buy_deed_packet unless DRCI.exists?('second packet')
 
-      first = bput('look first packet', 'You count \d+').scan(/\d+/).first.to_i
-      second = bput('look second packet', 'You count \d+').scan(/\d+/).first.to_i
+      first = DRC.bput('look first packet', 'You count \d+').scan(/\d+/).first.to_i
+      second = DRC.bput('look second packet', 'You count \d+').scan(/\d+/).first.to_i
 
       if second < first
         fput('get my second packet')
         fput('stow my packet')
       end
     end
-    wait_for_script_to_complete('buff', ['mining'])
-    bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
+    check_repair if @mine_repair_own_tools
+    DRC.wait_for_script_to_complete('buff', ['mining'])
+    DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
 
@@ -42,70 +55,65 @@ class MiningBuddy
     fput('stow my packet')
   end
 
-  def setup
-    @settings = get_settings
-    @area_list = get_data('mining').mining_buddy_rooms
-    @forging_belt = @settings.forging_belt
-    @areas = @settings.mines_to_mine
-    @skip_populated = @settings.mining_skip_populated
-    @mine_every_room = @settings.mining_buddy_mine_every_room
-    @vein_list = @settings.mining_buddy_vein_list
-    @mining_implement = @settings.mining_implement
-    @use_packet = @settings.mine_use_packet
-    @hometown = @settings.hometown
-    deeds_data = get_data('crafting').deeds[@hometown]
-    @deeds_room = deeds_data['room']
-    @deeds_number = deeds_data['medium_number']
-    echo("#{@areas}:#{@vein_list}") if UserVars.mining_debug
-  end
-
-  def get_mining_tool
-    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
-      bput("untie my #{@mining_implement}", 'You remove', 'You untie')
-    else
-      bput("get my #{@mining_implement}", 'You get', 'You are already')
-    end
-  end
-
-  def store_mining_tool
-    waitrt?
-    if @forging_belt['items'].grep(/#{@mining_implement}/i).any?
-      fput("tie my #{@mining_implement} to #{@forging_belt['name']}")
-    else
-      fput("stow my #{@mining_implement}")
-    end
-  end
-
   def check_repair
-    get_mining_tool
-    result = bput("anal my #{@mining_implement}", 'practically in mint', 'pristine condition', 'in good condition', 'crafting tool and it is rather scuffed up', 'Roundtime')
+    DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt)
+    if @mine_repair_own_tools && DRCI.exists?('wire brush') && DRCI.exists?('of oil')
+      self_repair('wire brush')
+      return
+    elsif @mine_repair_own_tools
+      DRC.message('Missing brush or oil, reverting to store repair.')
+      @mine_repair_own_tools = false
+    end
+
+    result = DRC.bput("analyze my #{@mining_implement}", 'practically in mint', 'pristine condition', 'in good condition', 'crafting tool and it is rather scuffed up', 'Roundtime')
     waitrt?
 
-    store_mining_tool
+    DRCC.stow_crafting_item(@mining_implement, @bag, @forging_belt)
     return unless /roundtime/i =~ result
     repair = get_data('town')[@hometown]['metal_repair']
-    walk_to(repair['id'])
-    get_mining_tool
+    DRCT.walk_to(repair['id'])
+    DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt)
     fput("give #{repair['name']}")
     fput("give #{repair['name']}")
-    pause 10 until bput('look at my ticket', 'should be ready by now', 'Looking at the') == 'should be ready by now'
+    pause 10 until DRC.bput('look at my ticket', 'should be ready by now', 'Looking at the') == 'should be ready by now'
     fput("give #{repair['name']}")
-    store_mining_tool
+    DRCC.stow_crafting_item(@mining_implement, @bag, @forging_belt)
+  end
+
+  def self_repair(repair_tool)
+    DRCC.get_crafting_item(repair_tool, @bag, @bag_items, @forging_belt)
+    command = repair_tool == 'wire brush' ? "rub #{@mining_implement} with my wire brush" : "pour my oil on my #{@mining_implement}"
+    
+      case DRC.bput(command, 'Roundtime', 'not damaged enough',                            
+                               'You cannot do that while engaged!', 'cannot figure out how', 'Pour what?')
+      when 'Roundtime'
+          DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
+          return if repair_tool == "of oil"
+          self_repair('of oil')
+          return
+      when 'not damaged enough', 'cannot figure out how', 'Pour what?'
+          DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
+          return
+      when 'You cannot do that while engaged!'
+          DRC.retreat
+          self_repair(repair_tool)
+          return
+      end
   end
 
   def mine_rooms(rooms)
     rooms.each do |room|
-      wait_for_script_to_complete('safe-room') if bleeding?
+      DRC.wait_for_script_to_complete('safe-room') if bleeding?
       next unless mine?(room)
       check_repair
       DRCA.do_buffs(@settings, 'mining')
-      bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
+      DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     end
   end
 
   def mine?(room)
     waitrt?
-    walk_to(room)
+    DRCT.walk_to(room)
     unless DRRoom.pcs.empty?
       return false if @skip_populated
 
@@ -113,7 +121,7 @@ class MiningBuddy
     end
 
     unless @mine_every_room
-      bput('prospect', 'Roundtime')
+      DRC.bput('prospect', 'Roundtime')
       results = reget(20, 'can be mined here')
 
       waitrt?
@@ -130,7 +138,7 @@ class MiningBuddy
 
     waitrt?
 
-    wait_for_script_to_complete('mine')
+    DRC.wait_for_script_to_complete('mine')
     true
   end
 end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -91,12 +91,8 @@ class MiningBuddy
           return if repair_tool == "of oil"
           self_repair('of oil')
           return
-      when 'not damaged enough', 'cannot figure out how', 'Pour what?'
+      when 'not damaged enough', 'cannot figure out how', 'Pour what?', 'You cannot do that while engaged!'
           DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
-          return
-      when 'You cannot do that while engaged!'
-          DRC.retreat
-          self_repair(repair_tool)
           return
       end
   end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -7,25 +7,25 @@ custom_require.call(%w[common common-items common-crafting common-money common-t
 class MiningBuddy
 
   def initialize
-    @settings = get_settings
+    settings = get_settings
     @area_list = get_data('mining').mining_buddy_rooms
-    @forging_belt = @settings.forging_belt
-    @bag = @settings.crafting_container
-    @bag_items = @settings.crafting_items_in_container
-    @areas = @settings.mines_to_mine
-    @skip_populated = @settings.mining_skip_populated
-    @mine_every_room = @settings.mining_buddy_mine_every_room
-    @vein_list = @settings.mining_buddy_vein_list
-    @mining_implement = @settings.mining_implement
-    @use_packet = @settings.mine_use_packet
-    @hometown = @settings.hometown
+    @forging_belt = settings.forging_belt
+    @bag = settings.crafting_container
+    @bag_items = settings.crafting_items_in_container
+    @areas = settings.mines_to_mine
+    @skip_populated = settings.mining_skip_populated
+    @mine_every_room = settings.mining_buddy_mine_every_room
+    @vein_list = settings.mining_buddy_vein_list
+    @mining_implement = settings.mining_implement
+    @use_packet = settings.mine_use_packet
+    @hometown = settings.hometown
     deeds_data = get_data('crafting').deeds[@hometown]
     @deeds_room = deeds_data['room']
     @deeds_number = deeds_data['medium_number']
-    @mine_repair_own_tools = @settings.mine_repair_own_tools
+    @mine_repair_own_tools = settings.mine_repair_own_tools
     echo("#{@areas}:#{@vein_list}") if UserVars.mining_debug
 
-    DRCM.ensure_copper_on_hand(10_000, @settings)
+    DRCM.ensure_copper_on_hand(10_000, settings)
 
     if @use_packet
       buy_deed_packet unless DRCI.exists?('packet')
@@ -103,7 +103,7 @@ class MiningBuddy
       DRC.wait_for_script_to_complete('safe-room') if bleeding?
       next unless mine?(room)
       check_repair
-      DRCA.do_buffs(@settings, 'mining')
+      DRC.wait_for_script_to_complete('buff', ['mining'])
       DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     end
   end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -23,7 +23,7 @@ class MiningBuddy
     @deeds_room = deeds_data['room']
     @deeds_number = deeds_data['medium_number']
     @mine_repair_own_tools = settings.mine_repair_own_tools
-    echo("#{@areas}:#{@vein_list}") if UserVars.mining_debug
+    DRC.message("#{@areas}:#{@vein_list}") if UserVars.mining_debug
 
     DRCM.ensure_copper_on_hand(10_000, settings)
 
@@ -35,8 +35,8 @@ class MiningBuddy
       second = DRC.bput('look second packet', 'You count \d+').scan(/\d+/).first.to_i
 
       if second < first
-        fput('get my second packet')
-        fput('stow my packet')
+        DRCC.get_crafting_item('second packet', @bag, @bag_items, @forging_belt)
+        DRCC.stow_crafting_item('packet', @bag, @forging_belt)
       end
     end
     check_repair if @mine_repair_own_tools
@@ -57,7 +57,8 @@ class MiningBuddy
 
   def check_repair
     DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt)
-    if @mine_repair_own_tools && DRCI.exists?('wire brush') && DRCI.exists?('of oil')
+
+    if @mine_repair_own_tools && DRCI.exists?('wire brush') && DRCI.exists?('of oil') #can you repair your own tools(yaml setting), and do you have the required materials to do so?
       self_repair('wire brush')
       DRCC.stow_crafting_item(@mining_implement, @bag, @forging_belt)
       return

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -74,10 +74,10 @@ class MiningBuddy
     repair = get_data('town')[@hometown]['metal_repair']
     DRCT.walk_to(repair['id'])
     DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt)
-    fput("give #{repair['name']}")
-    fput("give #{repair['name']}")
+    DRC.bput("give #{repair['name']}", 'Just give it to me again', "If you agree, give it to me again", "You don't need to specify the object", "Please don't lose this ticket!", "You hand.*")
+    DRC.bput("give #{repair['name']}", 'Just give it to me again', "If you agree, give it to me again", "You don't need to specify the object", "Please don't lose this ticket!", "You hand.*")
     pause 10 until DRC.bput('look at my ticket', 'should be ready by now', 'Looking at the') == 'should be ready by now'
-    fput("give #{repair['name']}")
+    DRC.bput("give #{repair['name']}", 'You hand', 'takes your ticket')
     DRCC.stow_crafting_item(@mining_implement, @bag, @forging_belt)
   end
 

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -86,7 +86,7 @@ class MiningBuddy
     command = repair_tool == 'wire brush' ? "rub #{@mining_implement} with my wire brush" : "pour my oil on my #{@mining_implement}"
     
       case DRC.bput(command, 'Roundtime', 'not damaged enough',                            
-                               'You cannot do that while engaged!', 'cannot figure out how', 'Pour what?')
+                             'You cannot do that while engaged!', 'cannot figure out how', 'Pour what?')
       when 'Roundtime'
           DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
           return if repair_tool == "of oil"

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -48,7 +48,7 @@ class MiningBuddy
       end
     end
     check_repair
-    DRC.wait_for_script_to_complete('buff', ['mining'])
+    DRC.wait_for_script_to_complete('buff', ['mining-buddy'])
     DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
@@ -116,8 +116,6 @@ class MiningBuddy
       DRC.wait_for_script_to_complete('safe-room') if bleeding?
       next unless mine?(room)
       check_repair
-      DRC.wait_for_script_to_complete('buff', ['mining'])
-      DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     end
   end
 
@@ -149,6 +147,7 @@ class MiningBuddy
     waitrt?
 
     DRC.wait_for_script_to_complete('mine')
+    DRC.wait_for_script_to_complete('buff', ['mining-buddy'])
     true
   end
 end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -23,8 +23,16 @@ class MiningBuddy
     @deeds_room = deeds_data['room']
     @deeds_number = deeds_data['medium_number']
     @mine_repair_own_tools = settings.mine_repair_own_tools
+    @next_repair = Time.now #sets time check for tools repair, useful if you have Proper Forging Tool Repair.
     DRC.message("#{@areas}:#{@vein_list}") if UserVars.mining_debug
-
+    
+    #checks yaml settings against tools
+    #corrects settings when tongs are wrongly set as adjustable, and/or when implement is tongs.
+    unless settings.adjustable_tongs && DRCC.get_adjust_tongs?('reset shovel', @bag, @bag_items, @forging_belt)
+      @mining_implement.sub!(/.* tongs/, "shovel") 
+    end
+    DRCC.stow_crafting_item(@mining_implement, @bag, @forging_belt) if DRCI.in_hands?(@mining_implement)
+    
     DRCM.ensure_copper_on_hand(10_000, settings)
 
     if @use_packet
@@ -39,7 +47,7 @@ class MiningBuddy
         DRCC.stow_crafting_item('packet', @bag, @forging_belt)
       end
     end
-    check_repair if @mine_repair_own_tools
+    check_repair
     DRC.wait_for_script_to_complete('buff', ['mining'])
     DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
@@ -56,7 +64,8 @@ class MiningBuddy
   end
 
   def check_repair
-    DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt)
+    return if @next_repair > Time.now #kicks back if you've repaired the tools yourself in the last 2 hours, and have the Proper Forging Tool Care tech, which makes them immune to damage for 2 hours.
+    DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt) unless DRCI.in_hands?(@mining_implement)
 
     if @mine_repair_own_tools && DRCI.exists?('wire brush') && DRCI.exists?('of oil') #can you repair your own tools(yaml setting), and do you have the required materials to do so?
       self_repair('wire brush')
@@ -92,6 +101,9 @@ class MiningBuddy
           DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
           return if repair_tool == "of oil"
           self_repair('of oil')
+          if /You recall/i =~ DRC.bput('craft blacksmithing Proper Forging Tool Care', 'You recall that you know this technique', 'You know nothing about that technique')
+            @next_repair = Time.now + 7200 #this tech makes repaired tools immune to damage for 2 hours (7200 seconds)
+          end
           return
       when 'not damaged enough', 'cannot figure out how', 'Pour what?', 'You cannot do that while engaged!'
           DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1046,6 +1046,9 @@ mining_implement: shovel
 mine_use_packet: true
 mine_while_training: false
 mining_attempt_timer: 0
+#If you have basic and/or advanced tool repair blacksmithing techniques, this allows you to repair mining tool in place, rather than returning
+#to town whenever a repair is necessary. Not recommended for use without those techs, requires wire brush and flask of oil.
+mine_repair_own_tools: false
 
 ## Locksmithing Settings ##
 #https://elanthipedia.play.net/Lich_script_repository#locksmithing


### PR DESCRIPTION
Removed includes, add prefixes.

Added self repair linked to yaml setting mine_repair_own_tools. Does one round of repair (brush then oil) at the startup, then one round whenever check_repair is called (after finishing a node). If this setting is false, as it is by default in base, repair behavior remains unchanged.

small test script for repair:

> custom_require.call(%w[common common-crafting])
> 
> class Test
> 
>     def initialize
>         @settings = get_settings
>         crafting_data = get_data('crafting')
>         @hometown = @settings.hometown
>         @mine_repair_own_tools = @settings.mine_repair_own_tools
>         @mining_implement = @settings.mining_implement
>         @forging_belt = @settings.forging_belt
>         @bag = @settings.crafting_container
>         @bag_items = @settings.crafting_items_in_container
>         check_repair
>         exit
>     end
> 
>     def check_repair
>         DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @forging_belt)
>         if @mine_repair_own_tools && DRCI.exists?('wire brush') && DRCI.exists?('of oil')
>           self_repair('wire brush')
>           return
>         elsif @mine_repair_own_tools
>           DRC.message('Missing brush or oil, reverting to store repair.')
>           @mine_repair_own_tools = false
>         end
>         echo(@mine_repair_own_tools)
>     end
>       
> 
>     def self_repair(repair_tool)
>         DRCC.get_crafting_item(repair_tool, @bag, @bag_items, @forging_belt)
>         command = repair_tool == 'wire brush' ? "rub #{DRC.right_hand} with my wire brush" : "pour my oil on my #{@mining_implement}"
>         
>         case DRC.bput(command, 'Roundtime', 'not damaged enough',                            
>                                'You cannot do that while engaged!', 'cannot figure out how', 'Pour what?')
>         when 'Roundtime'
>           DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
>           return if repair_tool == "of oil"
>           self_repair('of oil')
>           return
>         when 'not damaged enough', 'cannot figure out how', 'Pour what?'
>           DRCC.stow_crafting_item(repair_tool, @bag, @forging_belt)
>           return
>         when 'You cannot do that while engaged!'
>           DRC.retreat
>           self_repair(repair_tool)
>           return
>         end
>       end

Tool NOT damaged (repair called, no damage on tool):

```
--- Lich: test active.

[test]>untie my tongs from my agonite toolstrap

You untie some articulated covellite tongs from the straps of your agonite toolstrap.

[test]>tap my wire brush 

You tap an iron wire brush inside your haversack.

[test]>tap my of oil 

You tap a flask of oil inside your haversack.

[test]>get my wire brush

You get an iron wire brush from inside your haversack.

[test]>rub articulated tongs with my wire brush

The articulated tongs is not damaged enough to warrant repair.

[test]>put my wire brush in my haversack

You put your brush in your haversack.

--- Lich: test has exited.
```

Tool damaged:

```

--- Lich: test active.

[test]>get my wire brush

You get an iron wire brush from inside your haversack.

[test]>rub articulated tongs with my wire brush

Gently you begin rubbing the wire brush along the surface of the articulated tongs.
Swipe after swipe removes substantial amounts of grime and debris from the tongs.  Using steady strokes you bring the material's surface to a smooth finish.
Roundtime: 13 sec.

[test]>put my wire brush in my haversack

You put your brush in your haversack.

[test]>get my of oil

You get a flask of oil from inside your haversack.

[test]>pour my oil on my tongs

You pour a small amount of the oil onto the articulated tongs and work it in using a cloth.  Wiping away the excess, you have completed the repair work.
Roundtime: 13 sec.

[test]>put my of oil in my haversack

You put your oil in your haversack.

--- Lich: test has exited.
```

Repair initiated, brush/oil unaccessable/missing:

```
[test]>get my tongs

You are already holding that.

[test]>tap my wire brush 

I could not find what you were referring to.
Missing brush or oil, reverting to store repair.

[test: false]

--- Lich: test has exited.
```

