### PR TITLE
fixing a couple DRC.right_hand_noun with a typo

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -138,7 +138,7 @@ class Sew
     check_pins
     study_tailoring(1, 'tailored armor lightening')
     DRCC.get_crafting_item('scissors', @bag, @bag_items, @belt)
-    @noun = DRC.right_hand.noun
+    @noun = DRC.right_hand_noun
     do_sew("cut my #{@noun} with my scissors", 'scissors', true)
   end
 
@@ -147,7 +147,7 @@ class Sew
     check_pins
     study_tailoring(1, 'tailored armor reinforcing')
     DRCC.get_crafting_item('scissors', @bag, @bag_items, @belt)
-    @noun = DRC.right_hand.noun
+    @noun = DRC.right_hand_noun
     do_sew("cut my #{@noun} with my scissors", 'scissors')
   end
 


### PR DESCRIPTION
per title