### PR TITLE
[script] [combat-trainer] Add match for redeemed necro dissecting

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -858,7 +858,7 @@ class LootProcess
     case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
-    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
+    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge','This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
       game_state.undissectable(mob_noun)
       return false
     when 'would probably object', "should be left alone."

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -853,12 +853,14 @@ class LootProcess
     end
   end
 
-  #not necromancer related - not to be confused with the necro rituals.  According to GMs this may change but for now they are two separate functions.
   def dissected?(mob_noun, game_state)
+    arrange_mob(mob_noun, game_state) if @always_arrange
     case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
-    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge','This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
+    when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
+      return false
+    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
       game_state.undissectable(mob_noun)
       return false
     when 'would probably object', "should be left alone."

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -855,8 +855,8 @@ class LootProcess
 
   #not necromancer related - not to be confused with the necro rituals.  According to GMs this may change but for now they are two separate functions.
   def dissected?(mob_noun, game_state)
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge')
-    when 'You succeed in dissecting the corpse'
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
       game_state.undissectable(mob_noun)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -854,7 +854,6 @@ class LootProcess
   end
 
   def dissected?(mob_noun, game_state)
-    arrange_mob(mob_noun, game_state) if @always_arrange
     case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true


### PR DESCRIPTION
A redeemed necro is kinda sorta not a necro in some ways.

This allows a redeemed necro to keep a safe, and blank rituals section, and just dissect like everybody else...