### PR TITLE
[scripts] [combat-trainer] Make arranging when dissecting optional

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -387,7 +387,6 @@ class LootProcess
     # Setting to determine whether to always arrange, regardless of skinning, or dissecting
     # Depending on the creature level, and the character's skinning skill, simply arranging will teach skinning
     # Defaulting to true to keep existing behaviour.
-    # @always_arrange = skinning['always_arrange'] || true
     @always_arrange = skinning['arrange_for_dissect'].nil? ? true : skinning['arrange_for_dissect']
     echo("  @arrange_for_dissect: #{@arrange_for_dissect}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -804,6 +804,7 @@ class LootProcess
       return
     end
     return if Time.now - @loot_timer < @loot_delay
+    @already_arranged = false
 
     game_state.mob_died = true
     waitrt?
@@ -897,7 +898,7 @@ class LootProcess
 
     arrange_mob(mob_noun, game_state) unless @already_arranged
     @already_arranged = false
-    
+
     pause 0.25
     waitrt?
     if game_state.need_bundle

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -861,8 +861,8 @@ class LootProcess
   #not necromancer related - not to be confused with the necro rituals.  According to GMs this may change but for now they are two separate functions.
   def dissected?(mob_noun, game_state)
     arrange_mob(DRRoom.dead_npcs.first, game_state) if @always_arrange
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
-    when 'You succeed in dissecting the corpse', /You learn something/i
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge')
+    when 'You succeed in dissecting the corpse'
       return true
     when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge','This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
       game_state.undissectable(mob_noun)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -897,7 +897,6 @@ class LootProcess
     return unless game_state.skinnable?(mob_noun)
 
     arrange_mob(mob_noun, game_state) unless @already_arranged
-    @already_arranged = false
 
     pause 0.25
     waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -387,7 +387,7 @@ class LootProcess
     # Setting to determine whether to always arrange, regardless of skinning, or dissecting
     # Depending on the creature level, and the character's skinning skill, simply arranging will teach skinning
     # Defaulting to true to keep existing behaviour.
-    @always_arrange = skinning['arrange_for_dissect'].nil? ? true : skinning['arrange_for_dissect']
+    @arrange_for_dissect = skinning['arrange_for_dissect'].nil? ? true : skinning['arrange_for_dissect']
     echo("  @arrange_for_dissect: #{@arrange_for_dissect}") if $debug_mode_ct
 
     @arrange_all = skinning['arrange_all'] || false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -839,6 +839,7 @@ class LootProcess
     return unless game_state.skinnable?(mob_noun)
     return if game_state.necro_casting?
 
+    @already_arranged = true
     arranges = 0
     type = @arrange_types[mob_noun] || 'skin'
     arrange_message = @arrange_all ? "arrange all for #{type}" : "arrange for #{type}"
@@ -894,8 +895,9 @@ class LootProcess
     return unless @skin
     return unless game_state.skinnable?(mob_noun)
 
-    arrange_mob(DRRoom.dead_npcs.first, game_state)
-
+    arrange_mob(mob_noun, game_state) unless @already_arranged
+    @already_arranged = false
+    
     pause 0.25
     waitrt?
     if game_state.need_bundle

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -387,7 +387,7 @@ class LootProcess
     # Setting to determine whether to always arrange, regardless of skinning, or dissecting
     # Depending on the creature level, and the character's skinning skill, simply arranging will teach skinning
     # Defaulting to true to keep existing behaviour.
-    @always_arrange = skinning['always_arrange'] || true
+    @always_arrange = skinning['always_arrange'].nil? ? true : skinning['always_arrange']
     echo("  @always_arrange: #{@always_arrange}") if $debug_mode_ct
 
     @arrange_all = skinning['arrange_all'] || false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -860,7 +860,7 @@ class LootProcess
 
   def dissected?(mob_noun, game_state)
     arrange_mob(DRRoom.dead_npcs.first, game_state) if @always_arrange
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -384,6 +384,12 @@ class LootProcess
     @dissect_priority = skinning['dissect_priority']
     echo("  @dissect_priority: #{@dissect_priority}") if $debug_mode_ct
 
+    # Setting to determine whether to always arrange, regardless of skinning, or dissecting
+    # Depending on the creature level, and the character's skinning skill, simply arranging will teach skinning
+    # Defaulting to true to keep existing behaviour.
+    @always_arrange = skinning['always_arrange'] || true
+    echo("  @always_arrange: #{@always_arrange}") if $debug_mode_ct
+
     @arrange_all = skinning['arrange_all'] || false
     echo("  @arrange_all: #{@arrange_all}") if $debug_mode_ct
 
@@ -813,7 +819,6 @@ class LootProcess
 
     game_state.sheath_whirlwind_offhand
 
-    arrange_mob(DRRoom.dead_npcs.first, game_state)
     check_skinning(DRRoom.dead_npcs.first, game_state) if check_rituals?(game_state)
 
     game_state.wield_whirlwind_offhand
@@ -855,10 +860,11 @@ class LootProcess
 
   #not necromancer related - not to be confused with the necro rituals.  According to GMs this may change but for now they are two separate functions.
   def dissected?(mob_noun, game_state)
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge')
-    when 'You succeed in dissecting the corpse'
+    arrange_mob(DRRoom.dead_npcs.first, game_state) if @always_arrange
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    when 'You succeed in dissecting the corpse', /You learn something/i
       return true
-    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
+    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge','This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
       game_state.undissectable(mob_noun)
       return false
     when 'would probably object', "should be left alone."
@@ -886,6 +892,8 @@ class LootProcess
 
     return unless @skin
     return unless game_state.skinnable?(mob_noun)
+
+    arrange_mob(DRRoom.dead_npcs.first, game_state)
 
     pause 0.25
     waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -384,6 +384,13 @@ class LootProcess
     @dissect_priority = skinning['dissect_priority']
     echo("  @dissect_priority: #{@dissect_priority}") if $debug_mode_ct
 
+    # Setting to determine whether to always arrange, regardless of skinning, or dissecting
+    # Depending on the creature level, and the character's skinning skill, simply arranging will teach skinning
+    # Defaulting to true to keep existing behaviour.
+    # @always_arrange = skinning['always_arrange'] || true
+    @always_arrange = skinning['arrange_for_dissect'].nil? ? true : skinning['arrange_for_dissect']
+    echo("  @arrange_for_dissect: #{@arrange_for_dissect}") if $debug_mode_ct
+
     @arrange_all = skinning['arrange_all'] || false
     echo("  @arrange_all: #{@arrange_all}") if $debug_mode_ct
 
@@ -874,7 +881,7 @@ class LootProcess
   def check_skinning(mob_noun, game_state)
     already_arranged = false
     if @dissect && game_state.dissectable?(mob_noun)
-      arrange_mob(mob_noun, game_state) if @always_arrange
+      arrange_mob(mob_noun, game_state) if @arrange_for_dissect
       already_arranged = true
       if @dissect_priority == 'First Aid' && DRSkill.getxp('First Aid') <= 32
         return if dissected?(mob_noun, game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -384,12 +384,6 @@ class LootProcess
     @dissect_priority = skinning['dissect_priority']
     echo("  @dissect_priority: #{@dissect_priority}") if $debug_mode_ct
 
-    # Setting to determine whether to always arrange, regardless of skinning, or dissecting
-    # Depending on the creature level, and the character's skinning skill, simply arranging will teach skinning
-    # Defaulting to true to keep existing behaviour.
-    @always_arrange = skinning['always_arrange'].nil? ? true : skinning['always_arrange']
-    echo("  @always_arrange: #{@always_arrange}") if $debug_mode_ct
-
     @arrange_all = skinning['arrange_all'] || false
     echo("  @arrange_all: #{@arrange_all}") if $debug_mode_ct
 
@@ -804,7 +798,6 @@ class LootProcess
       return
     end
     return if Time.now - @loot_timer < @loot_delay
-    @already_arranged = false
 
     game_state.mob_died = true
     waitrt?
@@ -840,7 +833,6 @@ class LootProcess
     return unless game_state.skinnable?(mob_noun)
     return if game_state.necro_casting?
 
-    @already_arranged = true
     arranges = 0
     type = @arrange_types[mob_noun] || 'skin'
     arrange_message = @arrange_all ? "arrange all for #{type}" : "arrange for #{type}"
@@ -861,8 +853,7 @@ class LootProcess
   end
 
   def dissected?(mob_noun, game_state)
-    arrange_mob(DRRoom.dead_npcs.first, game_state) if @always_arrange
-    case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
@@ -881,7 +872,10 @@ class LootProcess
   end
 
   def check_skinning(mob_noun, game_state)
+    already_arranged = false
     if @dissect && game_state.dissectable?(mob_noun)
+      arrange_mob(mob_noun, game_state) if @always_arrange
+      already_arranged = true
       if @dissect_priority == 'First Aid' && DRSkill.getxp('First Aid') <= 32
         return if dissected?(mob_noun, game_state)
       elsif @dissect_priority == 'Skinning' && DRSkill.getxp('Skinning') >= 32
@@ -896,7 +890,7 @@ class LootProcess
     return unless @skin
     return unless game_state.skinnable?(mob_noun)
 
-    arrange_mob(mob_noun, game_state) unless @already_arranged
+    arrange_mob(mob_noun, game_state) unless already_arranged
 
     pause 0.25
     waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -864,7 +864,7 @@ class LootProcess
     case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge')
     when 'You succeed in dissecting the corpse'
       return true
-    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge','This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
+    when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
       game_state.undissectable(mob_noun)
       return false
     when 'would probably object', "should be left alone."

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -880,8 +880,10 @@ class LootProcess
   def check_skinning(mob_noun, game_state)
     already_arranged = false
     if @dissect && game_state.dissectable?(mob_noun)
-      arrange_mob(mob_noun, game_state) if @arrange_for_dissect
-      already_arranged = true
+      if @arrange_for_dissect
+        arrange_mob(mob_noun, game_state)
+        already_arranged = true
+      end
       if @dissect_priority == 'First Aid' && DRSkill.getxp('First Aid') <= 32
         return if dissected?(mob_noun, game_state)
       elsif @dissect_priority == 'Skinning' && DRSkill.getxp('Skinning') >= 32


### PR DESCRIPTION
Reordering the sequence of skinning/dissecting, to make the decision to always arrange optional.

Some creatures teach Skinning when arranged, depending on your skill level, and the range they teach to. When this happens, it's beneficial to always arrange.

When that doesn't happen... arranging to dissect is a waste of time.