### PR TITLE
[script] [smith] Update material acquisition logic

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -58,6 +58,7 @@ class Smith
     balance_item(discipline, recipe) if balance
     lighten_item(discipline, recipe) if lighten
     dispose_scrap(discipline, recipe) if buy
+    dispose_parts(discipline, parts)
   end
 
   def buy_parts(parts)
@@ -65,7 +66,6 @@ class Smith
     stow_hands
 
     parts.each do |part|
-      next if exists?(part)
 
       data = get_data('crafting')['recipe_parts'][part][@hometown]
       if data['part-number']
@@ -140,6 +140,12 @@ class Smith
     check_oil(discipline)
     fput("get my #{recipe['noun']}")
     wait_for_script_to_complete('forge', ['lighten', recipe['noun']])
+  end
+
+  def dispose_parts(discipline, parts)
+    parts.each do |part|
+      dispose(part, discipline['trash-room'])
+    end
   end
 
   def dispose_scrap(discipline, recipe)


### PR DESCRIPTION
Adjusted smith to allow it to purchase multiples of parts for certain recipes, eg hauberks. The parts are listed correctly in base-recipes, but it was only purchasing one of each(on account of only buying if !exists?[some part]) resulting in premature termination of forge script on assembly of duplicate part.

Current behavior
```
>;smith covellite "metal ring hauberk"

[smith]>wealth dokoras

  2 platinum, 12 gold, 2 silver, 16 bronze, and 22 copper Dokoras (32,382 copper Dokoras).

[smith]>stow right

You put your book in your haversack.

[smith]>tap my large padding 

You tap some large cloth padding inside your haversack.

[smith]>tap my small padding 

You tap some small cloth padding inside your haversack.

[smith]>tap my small padding 

You tap some small cloth padding inside your haversack.
```

As you can see, the check for small padding passes even if theres only one, despite tapping twice (each do). 

This version doesn't tap, just buys. 

```
[smith]>buy large padding

You decide to purchase the padding, and pay the sales clerk 108 Dokoras.
The sales clerk hands you your large cloth padding.

[smith]>put large padding in my haversack

You put your padding in your haversack.

[smith]>buy small padding

You decide to purchase the padding, and pay the sales clerk 45 Dokoras.
The sales clerk hands you your small cloth padding.

[smith]>put small padding in my haversack

You put your padding in your haversack.

[smith]>buy small padding

You decide to purchase the padding, and pay the sales clerk 45 Dokoras.
The sales clerk hands you your small cloth padding.

[smith]>put small padding in my haversack

You put your padding in your haversack.
```

That solves that problem, but if something goes haywire on some other aspect of forging, you could end up with stacks of paddings and such that you don't end up using, which could spiral into a trip to the junkyard. Hence the additional method to dispose of anything smith purchases after work is done.
```
[go2: travel time: 0:00:00]
--- Lich: go2 has exited.
[smith]>get my short cord
What were you referring to?
>
[workorders]>get my forging logbook
You get a forging work order logbook from inside your haversack.
>
[workorders]>bundle my claws with my logbook
You notate the claws in the logbook then bundle it up for delivery.
```

attempt is made after every completed craft to dispose of the parts purchased. if they wern't used, they're cleaned out of the bags.