### PR TITLE
[script][pick] Update match to prevent autolooters causing pick to hang

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -708,7 +708,7 @@ class Pick
 
   def loot(box_noun)
     echo "Looting #{box_noun}..." if @debug
-    if DRC.bput("open my #{box_noun}", /You open/, /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
+    if DRC.bput("open my #{box_noun}", /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
       echo 'Bug: Tried to loot locked box...'
       return
     end


### PR DESCRIPTION
Looks like Lich being awesome is causing a problem with how quickly it moves through these methods. When using an autolooter for coins, sometimes it matches the "You open the wooden strongbox" for the open step, then loads the match table for DRCI.get_item_list(box_noun, 'look') {line 722 in this version}, gets the contents before the bput(and before autolooter snags the coins), thus enters the looting phase with a faulty list, which, as you see below, hangs pick as it continues trying to get the coins.

```
[pick]>open my wooden strongbox
Gained: Locksmithing(+2)
...wait 1 seconds.
sR>
[pick]>open my wooden strongbox
You open the wooden strongbox...

In the wooden strongbox you see a small mint green pearl, a large faceted green-yellow peridot, some copper coins, some bronze coins, some silver coins, and some gold coins.
You quickly pocket the coins.
s>
[pick]>look in my wooden strongbox
[pick]>get pearl from my wooden strongbox
s>
In the wooden strongbox you see a small mint green pearl and a large faceted green-yellow peridot.
s>
You get a small mint green pearl from inside your wooden strongbox.
s>
[pick]>stow my pearl
You open your pouch and put the mint green pearl inside, closing it once more.
s>
[pick]>get peridot from my wooden strongbox
You get a large faceted green-yellow peridot from inside your wooden strongbox.
s>
[pick]>stow my peridot
You open your pouch and put the green-yellow peridot inside, closing it once more.
s>
[pick]>get coins from my wooden strongbox
What were you referring to?
s>
Gained: Augmentation(+1), Utility(+1), Inner Magic(+1)
[pick: *** No match was found after 15 seconds, dumping info]
[pick: messages seen length: 7]
[pick: message: Khri Sight  (38 roisaen)]
[pick: message: Khri Safe  (38 roisaen)]
[pick: message: Khri Focus  (38 roisaen)]
[pick: message: Khri Hasten  (38 roisaen)]
[pick: message: Khri Dampen  (38 roisaen)]
[pick: message: [DRPrime]-DR:Comfrin: "I lurve you Kaelie. We may have differing views on things but you're a doll"]
[pick: message: What were you referring to?]
[pick: checked against [/You get (.*) from inside/i, /You pick up \d* \w* (?:lirum|dokora|kronar)s?/i]]
[pick: for command get coins from my wooden strongbox]
***Unrecognized Item:  - trashing it.***
[pick]>drop my coins
What were you referring to?
s>
[pick]>get coins from my wooden strongbox
What were you referring to?
```

Removing "You open" from the match table, and forcing it to match either locked, or "In the .* you see" means it can't double dip on a single event, and the items list should populate from the second look, after autolooter has done it's thing.