### PR TITLE
[script][smith] Update, add prefixes, remove includes, simplified.lic

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -52,7 +52,7 @@ class Smith
     DRCC.find_anvil(@hometown)
     DRC.wait_for_script_to_complete('buff', ['smith'])
     DRC.wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
-    stamp_item(recipe) if stamp
+    stamp_item(recipe['noun']) if stamp
     DRC.wait_for_script_to_complete('forge', ['temper', recipe['noun']])  if temper
     DRC.wait_for_script_to_complete('forge', ['hone', recipe['noun']])    if hone
     DRC.wait_for_script_to_complete('forge', ['balance', recipe['noun']]) if balance
@@ -98,9 +98,9 @@ class Smith
     DRCC.stow_crafting_item('of oil', @bag, @belt)
   end
 
-  def stamp_item(recipe)
+  def stamp_item(noun)
     DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
-    DRC.bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+    DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
     DRCC.stow_crafting_item('stamp', @bag, @belt)
   end
 

--- a/smith.lic
+++ b/smith.lic
@@ -77,12 +77,6 @@ class Smith
     end
   end
 
-  def buy_ingot(discipline)
-    DRCT.order_item(discipline['stock-room'], discipline['stock-number'])
-    DRCC.stow_crafting_item('ingot', @bag, @belt)
-    DRCI.stow_hands
-  end
-
   def check_oil(discipline)
     case DRC.bput('get my of oil', 'You get', 'What were you referring')
     when 'You get'
@@ -98,22 +92,28 @@ class Smith
     DRCC.stow_crafting_item('of oil', @bag, @belt)
   end
 
+  def buy_ingot(discipline)
+    DRCT.order_item(discipline['stock-room'], discipline['stock-number'])
+    DRCC.stow_crafting_item('ingot', @bag, @belt)
+    DRCI.stow_hands
+  end
+
   def stamp_item(noun)
     DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
     DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
     DRCC.stow_crafting_item('stamp', @bag, @belt)
   end
 
-  def dispose_parts(discipline, parts)
-    parts.each do |part|
-      DRCT.dispose(part, discipline['trash-room'])
-    end
-  end
-
   def dispose_scrap(discipline, recipe)
     return unless discipline['stock-volume'] > recipe['volume']
 
     DRCT.dispose(discipline['stock-name'], discipline['trash-room'])
+  end
+
+  def dispose_parts(discipline, parts)
+    parts.each do |part|
+      DRCT.dispose(part, discipline['trash-room'])
+    end
   end
 end
 

--- a/smith.lic
+++ b/smith.lic
@@ -78,18 +78,17 @@ class Smith
   end
 
   def check_oil(discipline)
-    case DRC.bput('get my of oil', 'You get', 'What were you referring')
+    case DRC.bput("get my oil from my #{@bag}", 'You get', 'What were you referring')
     when 'You get'
-      /(\d+)/ =~ DRC.bput('count my of oil', 'The oil has \d+ uses remaining')
+      /(\d+)/ =~ DRC.bput('count my oil', 'The oil has \d+ uses remaining')
       if Regexp.last_match(1).to_i < 3
-        DRCC.stow_crafting_item('of oil', @bag, @belt)
-        DRCT.dispose('of oil', discipline['trash-room'])
+        DRCT.dispose('oil', discipline['trash-room'])
         DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
       end
     else
       DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
     end
-    DRCC.stow_crafting_item('of oil', @bag, @belt)
+    DRCC.stow_crafting_item('oil', @bag, @belt)
   end
 
   def buy_ingot(discipline)

--- a/smith.lic
+++ b/smith.lic
@@ -6,11 +6,6 @@
 custom_require.call(%w[common common-crafting common-items common-money common-travel drinfomon])
 
 class Smith
-  include DRC
-  include DRCC
-  include DRCI
-  include DRCM
-  include DRCT
 
   def initialize
     arg_definitions = [
@@ -29,11 +24,14 @@ class Smith
     args = parse_args(arg_definitions)
 
     @settings = get_settings
+    @bag = @settings.crafting_container
+    @bag_items = @settings.crafting_items_in_container
+    @belt = @settings.forging_belt
     discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
-    recipe = recipe_lookup(recipes, args.item_name)
+    recipe = DRCC.recipe_lookup(recipes, args.item_name)
     return unless recipe
 
     parts = recipe['part'] || []
@@ -47,25 +45,27 @@ class Smith
       echo '***You will need to do so by hand and then call ;smith again.***'
       exit
     end
-
+    
     buy_parts(parts)
+    check_oil(discipline)
     buy_ingot(discipline) if buy
-    wait_for_script_to_complete('buff', ['smith'])
-    craft_item(recipe, discipline, material)
+    DRCC.find_anvil(@hometown)
+    DRC.wait_for_script_to_complete('buff', ['smith'])
+    DRC.wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
     stamp_item(recipe) if stamp
-    temper_item(discipline, recipe) if temper
-    hone_item(discipline, recipe) if hone
-    balance_item(discipline, recipe) if balance
-    lighten_item(discipline, recipe) if lighten
+    DRC.wait_for_script_to_complete('forge', ['temper', recipe['noun']])  if temper
+    DRC.wait_for_script_to_complete('forge', ['hone', recipe['noun']])    if hone
+    DRC.wait_for_script_to_complete('forge', ['balance', recipe['noun']]) if balance
+    DRC.wait_for_script_to_complete('forge', ['lighten', recipe['noun']]) if lighten
     dispose_scrap(discipline, recipe) if buy
+    dispose_parts(discipline, parts)
   end
 
   def buy_parts(parts)
-    ensure_copper_on_hand(700, @settings)
-    stow_hands
+    DRCM.ensure_copper_on_hand(3000, @settings)
+    DRCI.stow_hands
 
     parts.each do |part|
-      next if exists?(part)
 
       data = get_data('crafting')['recipe_parts'][part][@hometown]
       if data['part-number']
@@ -73,79 +73,47 @@ class Smith
       else
         DRCT.buy_item(data['part-room'], part)
       end
-      bput("put #{part} in my #{@container}", 'You put')
+      DRCC.stow_crafting_item(part, @bag, @belt)
     end
   end
 
   def buy_ingot(discipline)
-    ensure_copper_on_hand(700, @settings)
     DRCT.order_item(discipline['stock-room'], discipline['stock-number'])
-    bput("put ingot in my #{@container}", 'You put')
-    stow_hands
-  end
-
-  def craft_item(recipe, discipline, material)
-    check_oil(discipline)
-    find_anvil(@hometown)
-    wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
+    DRCC.stow_crafting_item('ingot', @bag, @belt)
+    DRCI.stow_hands
   end
 
   def check_oil(discipline)
-    $ORDINALS.each do |ord|
-      case bput("look my #{ord} oil in #{@container}", /thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
-      when /thick and syrupy substance that easily coats and lubricates metal/
-        return if ord == 'first'
-        bput("get my #{ord} oil in #{@container}", /You get/)
-        bput("put oil in my #{@container}", 'You put')
-        return
-      when /I could not find what you were referring to/
-        break
+    case DRC.bput('get my of oil', 'You get', 'What were you referring')
+    when 'You get'
+      /(\d+)/ =~ DRC.bput('count my of oil', 'The oil has \d+ uses remaining')
+      if Regexp.last_match(1).to_i < 3
+        DRCC.stow_crafting_item('of oil', @bag, @belt)
+        DRCT.dispose('of oil', discipline['trash-room'])
+        DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
       end
+    else
+      DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
     end
-
-    ensure_copper_on_hand(1000, @settings)
-    DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
-    bput("put oil in my #{@container}", 'You put')
-    stow_hands
+    DRCC.stow_crafting_item('of oil', @bag, @belt)
   end
 
   def stamp_item(recipe)
-    fput('get my stamp')
-    fput("mark my #{recipe['noun']} with my stamp")
-    pause 1
-    waitrt?
-    fput("put my stamp in my #{@container}")
+    DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
+    DRC.bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+    DRCC.stow_crafting_item('stamp', @bag, @belt)
   end
 
-  def temper_item(discipline, recipe)
-    check_oil(discipline)
-    find_anvil(@hometown)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['temper', recipe['noun']])
-  end
-
-  def hone_item(discipline, recipe)
-    check_oil(discipline)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['hone', recipe['noun']])
-  end
-
-  def balance_item(discipline, recipe)
-    check_oil(discipline)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['balance', recipe['noun']])
-  end
-
-  def lighten_item(discipline, recipe)
-    check_oil(discipline)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['lighten', recipe['noun']])
+  def dispose_parts(discipline, parts)
+    parts.each do |part|
+      DRCT.dispose(part, discipline['trash-room'])
+    end
   end
 
   def dispose_scrap(discipline, recipe)
     return unless discipline['stock-volume'] > recipe['volume']
 
-    dispose(discipline['stock-name'], discipline['trash-room'])
+    DRCT.dispose(discipline['stock-name'], discipline['trash-room'])
   end
 end
 

--- a/smith.lic
+++ b/smith.lic
@@ -12,12 +12,13 @@ class Smith
       [
         { name: 'material', regex: /\w+/, description: 'Metal type of the ingot' },
         { name: 'item_name', display: 'recipe name', regex: /^[A-z\s\-\']+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
-        { name: 'stamp', regex: /^stamp/i, optional: true },
-        { name: 'temper', regex: /^temper/i, optional: true },
-        { name: 'hone', regex: /^hone/i, optional: true },
-        { name: 'balance', regex: /^balance/i, optional: true },
-        { name: 'lighten', regex: /^lighten/i, optional: true },
-        { name: 'buy', regex: /^buy/i, optional: true }
+        { name: 'stamp', regex: /^stamp/i, optional: true, description: 'To stamp completed items'},
+        { name: 'here', regex: /^here/i, optional: true, description: 'Force it to forge in the room you are currently in, useful for private forge rentals or forge wands' },
+        { name: 'temper', regex: /^temper/i, optional: true, description: 'Tempers crafted item, boost durability' },
+        { name: 'hone', regex: /^hone/i, optional: true, description: 'Hones crafted item(weapon only), reducing weight and impact' },
+        { name: 'balance', regex: /^balance/i, optional: true, description: 'Balance crafted item (weapon only), increasing balance at the cost of suitability'},
+        { name: 'lighten', regex: /^lighten/i, optional: true, description: 'Lightens crafted armor or shield, reducing weight only'},
+        { name: 'buy', regex: /^buy/i, optional: true, description: 'Used to purchase the ingot' }
       ]
     ]
 
@@ -33,12 +34,14 @@ class Smith
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = DRCC.recipe_lookup(recipes, args.item_name)
     return unless recipe
+    
+    DRCM.ensure_copper_on_hand(3000, @settings) unless args.here
 
     parts = recipe['part'] || []
-    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten)
+    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.here)
   end
 
-  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten)
+  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten, stay)
     if discipline['stock-volume'] < recipe['volume'] && buy
       echo '***You cannot buy an ingot large enough to craft this item.***'
       echo '***Automatically combining ingots via smelting is not yet supported.***'
@@ -46,10 +49,9 @@ class Smith
       exit
     end
     
-    buy_parts(parts)
-    check_oil(discipline)
+    buy_parts(parts) unless stay
     buy_ingot(discipline) if buy
-    DRCC.find_anvil(@hometown)
+    DRCC.find_anvil(@hometown) unless stay
     DRC.wait_for_script_to_complete('buff', ['smith'])
     DRC.wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
     stamp_item(recipe['noun']) if stamp
@@ -58,11 +60,10 @@ class Smith
     DRC.wait_for_script_to_complete('forge', ['balance', recipe['noun']]) if balance
     DRC.wait_for_script_to_complete('forge', ['lighten', recipe['noun']]) if lighten
     dispose_scrap(discipline, recipe) if buy
-    dispose_parts(discipline, parts)
+    dispose_parts(discipline, parts) unless stay
   end
 
   def buy_parts(parts)
-    DRCM.ensure_copper_on_hand(3000, @settings)
     DRCI.stow_hands
 
     parts.each do |part|
@@ -75,20 +76,6 @@ class Smith
       end
       DRCC.stow_crafting_item(part, @bag, @belt)
     end
-  end
-
-  def check_oil(discipline)
-    case DRC.bput("get my oil from my #{@bag}", 'You get', 'What were you referring')
-    when 'You get'
-      /(\d+)/ =~ DRC.bput('count my oil', 'The oil has \d+ uses remaining')
-      if Regexp.last_match(1).to_i < 3
-        DRCT.dispose('oil', discipline['trash-room'])
-        DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
-      end
-    else
-      DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
-    end
-    DRCC.stow_crafting_item('oil', @bag, @belt)
   end
 
   def buy_ingot(discipline)


### PR DESCRIPTION
Removed includes.
Added prefixes.

Changed handling of oil since "of oil" only ever gets the crafting oil. Each smith cycle will consume a maximum of 3 parts of oil (one for initial craft, one for temper, one for enhancement) meaning if we have 3 when smith starts, we always have enough. Redundant oil checks removed.

The four enhancement methods all included a "get my noun" line, but forge doesn't stow, so this isn't necessary either.

As a result, five of the methods (craft_item, hone, balance, temper, lighten) were just running a script, so i just put the script calls in the smith method with the same conditional as before and removed those other methods.

I never used smith to stamp(forge w/ yaml setting), but I'm pretty sure it was broken as written. This version should work. 

Bumped coin_on_hand to 3 gold, figuring 1000 for oil, leaving 2000 for ingot/parts. Removed repeated coin checks, so one trip to the bank per cycle.