### PR TITLE
[script][workorders] Handle clamps like any other tool

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -338,12 +338,6 @@ class WorkOrders
         end
         stow_tool('wood stain')
 
-        case DRC.bput('get my clamps', 'What were you', 'You get some')
-        when 'What were you'
-          DRCT.order_item(info['tool-room'], info['clamps-number'])
-        end
-        stow_tool('clamps')
-
         buy_parts(recipe['part'], info['part-room'])
         DRCC.find_shaping_room(@hometown, @engineering_room)
       end


### PR DESCRIPTION
Clamps is not a consumable, so there's no reason to handle them like a consumable. Now, there's a cognizable reason not to:

```
Longshot82 — Today at 6:53 PM
anyone else all of a sudden having a problem with their toolbelts not working?
Mahtra — Today at 6:55 PM
no 😄
that sounds like a yaml issue
Longshot82 — Today at 6:57 PM
hmmmm no, because its been running fine until now
its calling to get clamps right out the gate instead of untie them,
I see what its doing, its trying to check the clamps like theyre backer or glue
```
He's right, of course. Removing this little block won't affect any script in any way different than missing any tool would. However, keeping it means they're not handled via common-crafting. 