### PR TITLE
[scripts] [combat-trainer] Combat trainer rejigging skinning routine [3 of 3]

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -378,6 +378,15 @@ class LootProcess
     @dissect_priority = skinning['dissect_priority']
     echo("  @dissect_priority: #{@dissect_priority}") if $debug_mode_ct
 
+    @dissect_for_thanatology = skinning['dissect_for_thanatology'] || false
+    echo("  @dissect_for_thanatology: #{@dissect_for_thanatology}") if $debug_mode_ct
+
+    @dissect_cycle_skills = []
+    @dissect_cycle_skills.append("Thanatology") if @dissect_for_thanatology
+    @dissect_cycle_skills.append("First Aid") if @dissect
+    @dissect_cycle_skills.append("Skinning") if @skin
+    echo("  @dissect_cycle_skills: #{@dissect_cycle_skills}") if $debug_mode_ct
+
     # Setting to determine whether to always arrange, regardless of skinning, or dissecting
     # Depending on the creature level, and the character's skinning skill, simply arranging will teach skinning
     # Defaulting to true to keep existing behaviour.
@@ -608,7 +617,7 @@ class LootProcess
       # Occassionally, the thread hasn't updated the left_hand/right_hand variables
       # to know what's currently in your hand and will trash what's in your hand!
       # Do a glance to force the variables to be refreshed before we take action.
-      DRC. DRC.bput('glance', 'You glance .*')
+      DRC.bput('glance', 'You glance .*')
     end
     if DRC.left_hand != pair.first && !@equipment_manager.is_listed_item?(DRC.left_hand)
       DRC.message("Out of room, failed to store: #{DRC.left_hand}")
@@ -813,7 +822,8 @@ class LootProcess
 
     game_state.sheath_whirlwind_offhand
 
-    check_skinning(DRRoom.dead_npcs.first, game_state) if check_rituals?(game_state)
+    echo("DRRoom.dead_npcs.first is: #{DRRoom.dead_npcs.first}") if $debug_mode_ct
+    skin_or_dissect(DRRoom.dead_npcs.first, game_state) if check_rituals?(game_state)
 
     game_state.wield_whirlwind_offhand
 
@@ -848,9 +858,37 @@ class LootProcess
         arranges = 0
         arrange_message = @arrange_all ? 'arrange all' : 'arrange'
       end
-      waitrt?
     end
   end
+
+  def skin_or_dissect(mob_noun, game_state)
+
+    already_arranged = false
+
+    if @dissect && game_state.dissectable?(mob_noun)
+      if @arrange_for_dissect
+        arrange_mob(mob_noun, game_state)
+        already_arranged = true
+      end
+
+      skill_to_train = game_state.sort_by_rate_then_rank(@dissect_cycle_skills, @dissect_priority).first
+
+      if skill_to_train == 'First Aid' || skill_to_train == 'Thanatology'
+        unless dissected?(mob_noun, game_state)
+          arrange_mob(mob_noun, game_state) unless already_arranged
+          check_skinning(mob_noun, game_state) if @skin
+        end
+      elsif skill_to_train == 'Skinning'
+        arrange_mob(mob_noun, game_state) unless already_arranged
+        check_skinning(mob_noun, game_state) if @skin
+      end
+    elsif @skin && game_state.skinnable?(mob_noun)
+      arrange_mob(mob_noun, game_state) unless already_arranged
+      check_skinning(mob_noun, game_state)
+    else
+      return
+    end
+  end  
 
   def dissected?(mob_noun, game_state)
     case  DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
@@ -868,30 +906,6 @@ class LootProcess
   end
 
   def check_skinning(mob_noun, game_state)
-    already_arranged = false
-    if @dissect && game_state.dissectable?(mob_noun)
-      if @arrange_for_dissect
-        arrange_mob(mob_noun, game_state)
-        already_arranged = true
-      end
-      if @dissect_priority == 'First Aid' && DRSkill.getxp('First Aid') <= 32
-        return if dissected?(mob_noun, game_state)
-      elsif @dissect_priority == 'Skinning' && DRSkill.getxp('Skinning') >= 32
-        return if dissected?(mob_noun, game_state)
-      elsif DRSkill.getxp('First Aid') < DRSkill.getxp('Skinning')
-        return if dissected?(mob_noun, game_state)
-      elsif !game_state.skinnable?(mob_noun) && DRSkill.getxp('First Aid') <= 32
-        return if dissected?(mob_noun, game_state)
-      end
-    end
-
-    return unless @skin
-    return unless game_state.skinnable?(mob_noun)
-
-    arrange_mob(mob_noun, game_state) unless already_arranged
-
-    pause 0.25
-    waitrt?
     if game_state.need_bundle
       case  DRC.bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
       when /lumpy/

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -948,7 +948,7 @@ class LootProcess
         @equipment_manager.stow_weapon(game_state.weapon_name)
       end
       if  DRC.bput('get bundling rope', 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
-        DRC.bput('bundle', You bundle)
+        DRC.bput('bundle', 'You bundle')
         DRCI.wear_item?('bundle')
         if @tie_bundle
            DRC.bput('tie my bundle', 'TIE the bundle again')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -891,7 +891,7 @@ class LootProcess
   end  
 
   def dissected?(mob_noun, game_state)
-    case  DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered', 'You realize after a few seconds')
+    case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered', 'You realize after a few seconds')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered', 'You realize after a few seconds'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -891,10 +891,10 @@ class LootProcess
   end  
 
   def dissected?(mob_noun, game_state)
-    case  DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    case  DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered', 'You realize after a few seconds')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
-    when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
+    when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered', 'You realize after a few seconds'
       return false
     when 'While likely a fascinating study',"That'd be a waste of time.",'You do not yet possess the knowledge'
       game_state.undissectable(mob_noun)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -85,15 +85,15 @@ cycle_armors_hysteresis: true
 default_armor_type:
 # Skinning/dissect settings
 skinning:
-  skin: true # by default try to skin
+  skin: true         # by default try to skin
   arrange_all: false # To use arrange_all, make sure to set arrange_count to 1
-  arrange_count: 0 # by default do not arrange
+  arrange_count: 0   # by default do not arrange
   arrange_for_dissect: true      # defaults to true to keep previous behaviour
   dissect_for_thanatology: false # Redeemed necros can turn off rituals entirely and use this instead
-  tie_bundle: false # Don't tie bundles by default
-  dissect: false    # Don't dissect by default
-  dissect_priority:   # Skinning | First Aid | Or leave blank to cycle between.
-  arrange_types:      # Hash of creature noun to the type of arranging to do. Defaults to skin.
+  tie_bundle: false  # Don't tie bundles by default
+  dissect: false     # Don't dissect by default
+  dissect_priority:  # Skinning | First Aid | Or leave blank to cycle between.
+  arrange_types:     # Hash of creature noun to the type of arranging to do. Defaults to skin.
     adder: part
     ape: skin
     arbelog: part

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -83,15 +83,17 @@ cycle_armors_time: 125
 cycle_armors_hysteresis: true
 # works with cycle_armors, regalia, and hysteresis.  Which armor type to use when all others on your list are trained.
 default_armor_type:
-# To use arrange_all, make sure to set arrange_count to 1
+# Skinning/dissect settings
 skinning:
-  skin: true
-  arrange_all: false
-  arrange_count: 0
-  tie_bundle: false
-  dissect: false
+  skin: true # by default try to skin
+  arrange_all: false # To use arrange_all, make sure to set arrange_count to 1
+  arrange_count: 0 # by default do not arrange
+  arrange_for_dissect: true      # defaults to true to keep previous behaviour
+  dissect_for_thanatology: false # Redeemed necros can turn off rituals entirely and use this instead
+  tie_bundle: false # Don't tie bundles by default
+  dissect: false    # Don't dissect by default
   dissect_priority:   # Skinning | First Aid | Or leave blank to cycle between.
-  arrange_types: # Hash of creature noun to the type of arranging to do. Defaults to skin.
+  arrange_types:      # Hash of creature noun to the type of arranging to do. Defaults to skin.
     adder: part
     ape: skin
     arbelog: part


### PR DESCRIPTION
Depends on 
~~https://github.com/rpherbig/dr-scripts/pull/5867~~
and
~~https://github.com/rpherbig/dr-scripts/pull/5866~~

Rejigs the skinning routine to use the same priority function as weapon/defenses training. 

Adds the option to train Thanatology in this section for redeemed necros. 

Cleaned up the check_skinning routine a bit, removed some dicier fputs that drop items without checking what they're dropping, opting to stop skinning instead when over item limits.