### PR TITLE
[script][combat-trainer] Apparent fix for load/aim loop

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -307,6 +307,7 @@ class SetupProcess
     # as soon as you equip another ranged weapon before you've had
     # a chance to load it because the game_state thinks you're still holding a loaded weapon.
     game_state.loaded = false
+    @firing_check = 0
 
     # Prepare the next weapon
     if next_summoned
@@ -2999,7 +3000,7 @@ class AttackProcess
 
     @firing_delay = settings.firing_delay
     echo(" @firing_delay: #{@firing_delay}") if $debug_mode_ct
-    @firing_timer = Time.now - @firing_delay
+    @firing_timer = Time.now
     echo("@firing_timer: #{@firing_timer}") if $debug_mode_ct
     @firing_check = 0
 
@@ -3045,11 +3046,13 @@ class AttackProcess
 
     if game_state.thrown_skill?
       game_state.loaded = false
+      @firing_check = 0
       attack_thrown(game_state)
     elsif game_state.aimed_skill?
       attack_aimed(charged_maneuver, game_state)
     else
       game_state.loaded = false
+      @firing_check = 0
       attack_melee(charged_maneuver, game_state)
     end
     false
@@ -3163,7 +3166,7 @@ class AttackProcess
   end
 
   def shoot_aimed(command, game_state)
-    echo("Time now: #{Time.now.to_i}") if $debug_mode_ct
+    echo("Time now: #{Time.now}") if $debug_mode_ct
     echo("@firing_timer: #{@firing_timer}") if $debug_mode_ct
     echo("@firing_delay: #{@firing_delay}") if $debug_mode_ct
 
@@ -3208,15 +3211,21 @@ class AttackProcess
   end
 
   def attack_aimed(charged_maneuver, game_state)
-    game_state.loaded = false if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
-    game_state.clear_aim_queue if Flags['ct-ranged-ready']
+    if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
+      game_state.loaded = false
+      @firing_check = 0
+    end
 
     if Flags['ct-aim-failed']
       game_state.loaded = false
+      @firing_check = 0
       Flags.reset('ct-aim-failed')
     end
 
-    if game_state.loaded && (game_state.done_aiming? || (Time.now - @firing_timer).to_i >= @firing_delay)
+    if game_state.loaded && ( (Time.now >= @firing_timer) || Flags['ct-ranged-ready'] )
+      echo("Current Time > @firing_timer: #{Time.now >= @firing_timer}") if $debug_mode_ct
+      echo("Current Time < @firing_timer: #{Time.now <= @firing_timer}") if $debug_mode_ct
+      echo("Flag check: ct-ranged-ready: #{Flags['ct-ranged-ready']}") if $debug_mode_ct
       command = if game_state.use_stealth_ranged? && hide?(@hide_type)
                   @stealth_attack_aimed_action
                 elsif game_state.use_stealth_attack? && hide?(@hide_type)
@@ -3225,7 +3234,10 @@ class AttackProcess
                   'shoot'
                 end
       shoot_aimed(command, game_state)
+      game_state.clear_aim_queue
       game_state.loaded = false
+      @firing_check = 0
+      echo("@firing_check reset normal fire: #{@firing_check}") if debug_mode_ct
       waitrt?
     elsif game_state.loaded && !game_state.aiming_trainables.empty?
       skill = game_state.determine_aiming_skill
@@ -3261,7 +3273,7 @@ class AttackProcess
       end
 
       game_state.sheath_offhand_weapon(skill)
-    elsif game_state.loaded && (Time.now - @firing_timer).to_i < @firing_delay
+    elsif game_state.loaded && (Time.now <= @firing_timer)
       actions = game_state.next_aim_action.split(';')
       actions.each do |action|
         first_word = action.split(' ')[0].downcase
@@ -3316,6 +3328,7 @@ class AttackProcess
         when *load_weapon_failure
           dual_load = false # fallback to single load
           game_state.loaded = false
+          @firing_check = 0
         else
           game_state.loaded = true
         end
@@ -3367,6 +3380,7 @@ class AttackProcess
   def abort_attack_aimed(game_state)
     DRC.message("Unable to load #{game_state.weapon_name}, you may be out of ammunition, dancing until can switch to next weapon")
     game_state.loaded = false
+    @firing_check = 0
     game_state.clear_aim_queue
     dance(game_state)
     # Increment action count so that the script
@@ -3390,7 +3404,8 @@ class AttackProcess
     @firing_check += 1
     echo("@firing_check: #{@firing_check}") if $debug_mode_ct
     echo("@firing_timer: #{@firing_timer}") if $debug_mode_ct
-    @firing_timer = Time.now if @firing_check == 1
+    @firing_timer = Time.now + @firing_delay if @firing_check == 1
+    @firing_timer -= 1
     echo("Check after test - @firing_timer: #{@firing_timer}") if $debug_mode_ct
   end
 
@@ -3422,6 +3437,7 @@ class AttackProcess
       check_firing_time
     when *unloaded_messages
       game_state.loaded = false
+      @firing_check = 0
     when *no_enemy_messages
       game_state.clear_aim_queue
     when *wait_and_retry_messages
@@ -3429,6 +3445,7 @@ class AttackProcess
       aim(game_state)
     else
       game_state.loaded = false
+      @firing_check = 0
     end
   end
 
@@ -3525,6 +3542,8 @@ class AttackProcess
           shoot_aimed('shoot', game_state)
         end
         game_state.loaded = false
+        @firing_check = 0
+        echo("@firing_check reset on maneuver fire: #{@firing_check}") if debug_mode_ct
       end
 
       # Woot! Barbarian reduced their maneuver cooldown so

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4,8 +4,6 @@
 custom_require.call(%w[common common-arcana common-healing common-items common-summoning common-theurgy common-moonmage common-travel drinfomon equipmanager events spellmonitor])
 
 class SetupProcess
-  include DRC
-  include DRCS
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -59,12 +57,12 @@ class SetupProcess
     return true if game_state.done_cleaning_up?
     if game_state.stowing?
       echo('SetupProcess::clean_up') if $debug_mode_ct
-      retreat
+      DRC.retreat
       if game_state.summoned_info(game_state.weapon_skill)
         if DRStats.moon_mage?
           DRCMM.wear_moon_weapon?
         else
-          break_summoned_weapon(game_state.weapon_name)
+          DRCS.break_summoned_weapon(game_state.weapon_name)
         end
       else
         @equipment_manager.stow_weapon(game_state.weapon_name)
@@ -111,17 +109,17 @@ class SetupProcess
 
     game_state.sheath_whirlwind_offhand
 
-    case bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'You take', 'What were you referring to', 'You need a free hand', 'Remove what')
+    case DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'You take', 'What were you referring to', 'You need a free hand', 'Remove what')
     when 'You get', 'You remove', 'You take'
-      if /The red light within the egg is dim and moves about sluggishly|Your lungs are tired from having sounded a/ =~ bput(@warhon_activation_command,'light envelops the area briefly', 'The red light within the egg is dim and moves about sluggishly', 'Something about the area inhibits','You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
+      if /The red light within the egg is dim and moves about sluggishly|Your lungs are tired from having sounded a/ =~ DRC.bput(@warhon_activation_command,'light envelops the area briefly', 'The red light within the egg is dim and moves about sluggishly', 'Something about the area inhibits','You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
         @next_warhorn = Time.now + 60
       else
         @next_warhorn = Time.now + 300
       end
       waitrt?
-      bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+      DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when 'What were you referring to'
-      message "#{@warhorn} NOT FOUND! Removing from hunt."
+      DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
       @warhorn = nil
     end
 
@@ -241,7 +239,7 @@ class SetupProcess
       game_state.reset_stance = false
       pause
       waitrt?
-      bput("stance set #{@stance_override}", 'Setting your')
+      DRC.bput("stance set #{@stance_override}", 'Setting your')
       @override_done = true
       return
     end
@@ -279,7 +277,7 @@ class SetupProcess
     end
 
     return if vals == previous
-    return unless /maximum number of points \((\d+)/ =~ bput(build_stance_string(vals), 'Setting your Evasion stance to', 'is above your maximum number of points \(\d+')
+    return unless /maximum number of points \((\d+)/ =~ DRC.bput(build_stance_string(vals), 'Setting your Evasion stance to', 'is above your maximum number of points \(\d+')
     check_stance(game_state, Regexp.last_match(1).to_i)
   end
 
@@ -297,7 +295,7 @@ class SetupProcess
       @equipment_manager.stow_weapon(game_state.last_weapon_name)
       game_state.sheath_whirlwind_offhand
     elsif !next_summoned && !DRStats.moon_mage?
-      break_summoned_weapon(game_state.last_weapon_name)
+      DRCS.break_summoned_weapon(game_state.last_weapon_name)
     elsif !next_summoned && DRStats.moon_mage?
       DRCMM.wear_moon_weapon?
     end
@@ -313,7 +311,7 @@ class SetupProcess
     if next_summoned
       game_state.prepare_summoned_weapon(last_summoned)
     else
-      bput('aim stop', "But you're not aiming", 'You stop concentrating', 'You are already') if game_state.aimed_skill?
+      DRC.bput('aim stop', "But you're not aiming", 'You stop concentrating', 'You are already') if game_state.aimed_skill?
       game_state.wield_weapon
       if game_state.whirlwind_trainable?
         game_state.currently_whirlwinding = true
@@ -326,7 +324,7 @@ class SetupProcess
 
     # Invoke Focus
     return unless game_state.weapon_skill == 'Targeted Magic' && game_state.weapon_name
-    bput("invoke #{game_state.weapon_name}", 'You')
+    DRC.bput("invoke #{game_state.weapon_name}", 'You')
     waitrt?
   end
 
@@ -340,12 +338,12 @@ class SetupProcess
   def validate_regalia(settings)
     return unless @cycle_regalia
     if @cycle_armors
-      message 'ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!'
+      DRC.message 'ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!'
       @cycle_regalia = nil
     end
 
     if settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?
-      message "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
+      DRC.message "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
       @cycle_regalia = nil
     end
     # reset swap clock if you start CT already wearing a regalia.
@@ -365,11 +363,6 @@ class SetupProcess
 end
 
 class LootProcess
-  include DRC
-  include DRCI
-  include DRCS
-  include DRCH
-  include DRCMM
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -535,53 +528,53 @@ class LootProcess
 
     special = @loot_specials.find { |x| x['name'] == item }
     if special
-      if bput("get #{item}", 'You pick up', 'There isn\'t any more room', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory') == 'already in your inventory'
-        bput("get other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+      if DRC.bput("get #{item}", 'You pick up', 'There isn\'t any more room', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory') == 'already in your inventory'
+        DRC.bput("get other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       end
       pause 0.25
-      bput("put #{item} in my #{special['bag']}", 'you put')
+      DRC.bput("put #{item} in my #{special['bag']}", 'you put')
       return
     end
 
-    case bput("stow #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
+    case DRC.bput("stow #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
     when 'already in your inventory'
       if @gem_nouns.include?(item)
-        bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+        DRC.bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       elsif @box_nouns.include?(item)
         item_reg = item.split.join('.*')
         return stow_loot(DRRoom.room_objs.grep(/\b#{item_reg}$/).first.split.last(2).join(' '), game_state)
       else
-        bput("stow other #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
+        DRC.bput("stow other #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
       end
     when 'You pick up', 'You get'
       @current_box_count += 1 if @box_loot_limit && @box_nouns.include?(item)
     end
     pause 0.25
     if Flags['container-full']
-      bput("drop #{item}", 'You drop')
+      DRC.bput("drop #{item}", 'You drop')
       game_state.unlootable(item)
     end
 
     return unless Flags['pouch-full']
-    bput("drop my #{item}", 'You drop', 'What were')
+    DRC.bput("drop my #{item}", 'You drop', 'What were')
     unless @spare_gem_pouch_container
       game_state.unlootable(item)
       return
     end
-    bput("remove my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You remove')
+    DRC.bput("remove my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You remove')
     if @full_pouch_container
-      case bput("put my #{@gem_pouch_adjective} #{@gem_pouch_noun} in my #{@full_pouch_container}", 'You put','too heavy to go in there')
+      case DRC.bput("put my #{@gem_pouch_adjective} #{@gem_pouch_noun} in my #{@full_pouch_container}", 'You put','too heavy to go in there')
       when 'too heavy to go in there'
-        bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
+        DRC.bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
       end
     else
-      bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
+      DRC.bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
     end
-    bput("get #{@gem_pouch_adjective} #{@gem_pouch_noun} from my #{@spare_gem_pouch_container}", 'You get a')
-    bput("wear my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You attach')
-    bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+    DRC.bput("get #{@gem_pouch_adjective} #{@gem_pouch_noun} from my #{@spare_gem_pouch_container}", 'You get a')
+    DRC.bput("wear my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You attach')
+    DRC.bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
     if @tie_pouch
-      bput("tie my #{@gem_pouch_noun}", 'You tie')
+      DRC.bput("tie my #{@gem_pouch_noun}", 'You tie')
     else
       fput("close my #{@gem_pouch_noun}")
     end
@@ -612,7 +605,7 @@ class LootProcess
     if DRC.left_hand != pair.first || DRC.right_hand != pair.last
       # Mitigating a race condition when wand-watcher or another script pauses
       # combat-trainer while it's looting, then resumes in the middle of this function.
-      # Occassionally, the thread hasn't updated the left_hand/right_hand variables
+      # Occassionally, the thread hasn't updated the DRC.left_hand/right_hand variables
       # to know what's currently in your hand and will trash what's in your hand!
       # Do a glance to force the variables to be refreshed before we take action.
       DRC.bput('glance', 'You glance .*')
@@ -724,7 +717,7 @@ class LootProcess
 
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w[consume harvest arise].include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
-    result = bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
+    result = DRC.bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
     echo result if $debug_mode_ct
     case result
     when @rituals['arise']
@@ -760,9 +753,9 @@ class LootProcess
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     loop do
-      result = bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], @rituals['failures'])
+      result = DRC.bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], @rituals['failures'])
       break if result.empty? || @rituals['failures'].any? { |msg| result.include?(msg) }
-      bput("drop my #{right_hand}", 'You drop', 'You discard', 'Please rephrase')
+      DRC.bput("drop my #{DRC.right_hand}", 'You drop', 'You discard', 'Please rephrase')
       break if @dissect_and_butcher && !@ritual_type.eql?('butcher')
     end
 
@@ -773,27 +766,27 @@ class LootProcess
   def necro_harvest_check
     unless @necro_store
       echo 'Store material: false, dropping harvested material' if $debug_mode_ct
-      bput('drop material', 'you discard it')
+      DRC.bput('drop material', 'you discard it')
       return
     end
 
-    quality = bput('glance','You glance down.*')
+    quality = DRC.bput('glance','You glance down.*')
     if quality['great'] || quality['excellent'] || quality['perfect'] || quality['flawless']
       echo 'Harvested high quality material.' if $debug_mode_ct
     else
-      bput('drop material', 'you discard it')
+      DRC.bput('drop material', 'you discard it')
       echo 'Dropped low quality material.' if $debug_mode_ct
       return
     end
 
     echo 'Store material: true, checking count of stored material' if $debug_mode_ct
     if @current_harvest_count >= @necro_count
-      bput('drop material', 'you discard it')
+      DRC.bput('drop material', 'you discard it')
       echo 'Already full on stored material, dropping harvested material.' if $debug_mode_ct
       return
     end
 
-    result = bput("put material in my #{@necro_container}", 'You put')
+    result = DRC.bput("put material in my #{@necro_container}", 'You put')
     @current_harvest_count += 1 if result =~ /^You put/
   end
 
@@ -810,7 +803,7 @@ class LootProcess
     waitrt?
     return if Flags['using-corpse']
     if (Time.now - @last_rites_timer > 600) && @last_rites && game_state.blessed_room
-      bput("pray #{DRRoom.dead_npcs.first}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for')
+      DRC.bput("pray #{DRRoom.dead_npcs.first}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for')
       waitrt?
       fput "recite Meraud, power the holy fires that unleash my righteous vengeance;Chadatru, guide my sword to swing in justice;Everild, give me the power to conquer my enemies;Truffenyi, let me not lose sight of compassion and mercy;Else, I will become like those I despise;Urrem'tier, receive into your fetid grasp these wicked souls;May the Tamsine's realms never know their evil ways again;May all the Immortals guide your faithful soldier #{checkname}."
       waitrt?
@@ -825,7 +818,7 @@ class LootProcess
     game_state.wield_whirlwind_offhand
 
     unless game_state.necro_casting?
-      while bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
+      while DRC.bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
         pause
         waitrt?
       end
@@ -845,7 +838,7 @@ class LootProcess
     arrange_message = @arrange_all ? "arrange all for #{type}" : "arrange for #{type}"
     while arranges < @arrange_count
       arranges += 1
-      case bput(arrange_message, 'You begin to arrange', 'You continue arranging', 'You make a mistake', 'You complete arranging', 'That creature cannot', 'That has already been arranged', 'Arrange what', 'cannot be skinned', 'You make a serious mistake in the arranging process', 'The .* is currently being arranged to produce')
+      case DRC.bput(arrange_message, 'You begin to arrange', 'You continue arranging', 'You make a mistake', 'You complete arranging', 'That creature cannot', 'That has already been arranged', 'Arrange what', 'cannot be skinned', 'You make a serious mistake in the arranging process', 'The .* is currently being arranged to produce')
       when 'You complete arranging', 'That has already been arranged', 'You make a serious mistake in the arranging process', 'Arrange what'
         break
       when 'cannot be skinned'
@@ -860,7 +853,7 @@ class LootProcess
   end
 
   def dissected?(mob_noun, game_state)
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
@@ -904,12 +897,12 @@ class LootProcess
     pause 0.25
     waitrt?
     if game_state.need_bundle
-      case bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
+      case DRC.bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
       when /lumpy/
         if @tie_bundle
-          bput('tie my bundle', 'TIE the bundle again')
-          bput('tie my bundle', 'you tie the bundle')
-          bput('adjust my bundle', 'You adjust')
+          DRC.bput('tie my bundle', 'TIE the bundle again')
+          DRC.bput('tie my bundle', 'you tie the bundle')
+          DRC.bput('adjust my bundle', 'You adjust')
         end
         game_state.need_bundle = false
       when /tight/
@@ -917,8 +910,8 @@ class LootProcess
       end
     end
 
-    snap = [left_hand, right_hand]
-    case bput('skin', 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
+    snap = [DRC.left_hand, DRC.right_hand]
+    case DRC.bput('skin', 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
     when 'You must have one hand free to skin'
       temp_item = DRC.left_hand
       if DRCI.lower_item?(temp_item)
@@ -931,7 +924,7 @@ class LootProcess
       fput 'drop skin'
       fput 'skin'
     when 'need a more appropriate weapon', 'need to have a bladed instrument to skin'
-      message('BUY A SKINNING KNIFE')
+      DRC.message('BUY A SKINNING KNIFE')
       @skin = false
       return
     when 'cannot be skinned'
@@ -940,26 +933,26 @@ class LootProcess
     end
     pause 1
     waitrt?
-    if game_state.need_bundle && snap != [left_hand, right_hand]
+    if game_state.need_bundle && snap != [DRC.left_hand, DRC.right_hand]
       stored_moon = false
       if DRStats.moon_mage? && DRCMM.wear_moon_weapon?
         stored_moon = true
       elsif summoned = game_state.summoned_info(game_state.weapon_skill)
-        break_summoned_weapon(game_state.weapon_name)
+        DRCS.break_summoned_weapon(game_state.weapon_name)
       else
         @equipment_manager.stow_weapon(game_state.weapon_name)
       end
-      if bput('get bundling rope', 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
+      if DRC.bput('get bundling rope', 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
         fput('bundle')
         fput('wear my bundle')
         if @tie_bundle
-          bput('tie my bundle', 'TIE the bundle again')
-          bput('tie my bundle', 'you tie the bundle')
-          bput('adjust my bundle', 'You adjust')
+          DRC.bput('tie my bundle', 'TIE the bundle again')
+          DRC.bput('tie my bundle', 'you tie the bundle')
+          DRC.bput('adjust my bundle', 'You adjust')
         end
       else
-        dispose_trash(left_hand) if snap.first != left_hand && !@equipment_manager.is_listed_item?(left_hand)
-        dispose_trash(right_hand) if snap.last != right_hand && !@equipment_manager.is_listed_item?(right_hand)
+        DRCI.dispose_trash(DRC.left_hand) if snap.first != DRC.left_hand && !@equipment_manager.is_listed_item?(DRC.left_hand)
+        DRCI.dispose_trash(DRC.right_hand) if snap.last != DRC.right_hand && !@equipment_manager.is_listed_item?(DRC.right_hand)
       end
       game_state.need_bundle = false
       unless stored_moon && DRCMM.hold_moon_weapon?
@@ -970,15 +963,12 @@ class LootProcess
         end
       end
     end
-    dispose_trash(left_hand) if snap.first != left_hand && !@equipment_manager.is_listed_item?(left_hand)
-    dispose_trash(right_hand) if snap.last != right_hand && !@equipment_manager.is_listed_item?(right_hand)
+    DRCI.dispose_trash(DRC.left_hand) if snap.first != DRC.left_hand && !@equipment_manager.is_listed_item?(DRC.left_hand)
+    DRCI.dispose_trash(DRC.right_hand) if snap.last != DRC.right_hand && !@equipment_manager.is_listed_item?(DRC.right_hand)
   end
 end
 
 class SafetyProcess
-  include DRC
-  include DRCH
-  include DRCT
 
   def initialize(settings, equipment_manager)
     echo('New SafetyProcess') if $debug_mode_ct
@@ -1010,7 +1000,7 @@ class SafetyProcess
     end
 
     fput 'exit' if DRStats.health < @health_threshold
-    fix_standing
+    DRC.fix_standing
     check_item_recovery(game_state)
     tend_lodged
     active_mitigation
@@ -1069,24 +1059,24 @@ class SafetyProcess
   end
 
   def warn_failed_item_recovery(item)
-    5.times{ DRC.message "UNABLE TO RECOVER FROM #{item} LOSS!"; beep }
+    5.times{ DRC.message "UNABLE TO RECOVER FROM #{item} LOSS!"; DRC.beep }
   end
 
   def tend_lodged
     return unless Flags['ct-lodged']
-    bind_wound(Flags['ct-lodged'][:body_part])
+    DRCH.bind_wound(Flags['ct-lodged'][:body_part])
     Flags.reset('ct-lodged')
   end
 
   def keep_away
     return unless Flags['ct-engaged']
     Flags.reset('ct-engaged')
-    retreat
+    DRC.retreat
   end
 
   def active_mitigation
     return unless Flags['active-mitigation']
-    bput("#{Flags['active-mitigation'][:action]} #{Flags['active-mitigation'][:obstacle]}", 'You manage to', "You've got to", 'Please rephrase', 'You jump back', "You can't do")
+    DRC.bput("#{Flags['active-mitigation'][:action]} #{Flags['active-mitigation'][:obstacle]}", 'You manage to', "You've got to", 'Please rephrase', 'You jump back', "You can't do")
     Flags.reset('active-mitigation')
   end
 
@@ -1095,7 +1085,7 @@ class SafetyProcess
 
     unless danger
       Flags.reset('ct-engaged')
-      retreat
+      DRC.retreat
     end
 
     keep_away
@@ -1104,12 +1094,6 @@ class SafetyProcess
 end
 
 class SpellProcess
-  include DRC
-  include DRCA
-  include DRCS
-  include DRCH
-  include DRCT
-  include DRCMM
 
   $weapon_buffs = ['Ignite', 'Rutilor\'s Edge', 'Resonance']
 
@@ -1263,7 +1247,7 @@ class SpellProcess
 
     return unless DRStats.trader? && @regalia_array
     @regalia_spell = get_data('spells').spell_data['Regalia'] if @regalia_array && @regalia_spell.nil? # get data from the regalia waggle or base-spells
-    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None' # prepare to check for bespoke regalia
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None' # prepare to check for bespoke regalia
     @know_bespoke = DRC.bput('pre bspk', 'Bespoke Regalia', 'You have no idea', 'fully prepared', 'already preparing') == 'Bespoke Regalia' # check for bespoke regalia
   end
 
@@ -1287,10 +1271,10 @@ class SpellProcess
     if game_state.finish_spell_casting?
       echo('SpellProcess::clean_up') if $debug_mode_ct
       game_state.next_clean_up_step
-      release_cyclics(@settings.cyclic_no_release)
+      DRCA.release_cyclics(@settings.cyclic_no_release)
       if checkprep != 'None'
-        bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-        bput('release mana', 'You release all', "You aren't harnessing any mana")
+        DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+        DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
       end
       if @tk_ammo
         waitrt?
@@ -1371,7 +1355,7 @@ class SpellProcess
         end
       end
       DRCA.cast_spell(moonblade_spell, @settings)
-      created_slivers = bput("break moonblade", "The slivers drift about", "dissipate without any benefit", "Break what?") == "The slivers drift about"
+      created_slivers = DRC.bput("break moonblade", "The slivers drift about", "dissipate without any benefit", "Break what?") == "The slivers drift about"
       retry_count = retry_count + 1
     end
     DRC.message("Failed to create slivers for telekinetic ammo after #{retry_count} attempts") unless created_slivers
@@ -1382,7 +1366,7 @@ class SpellProcess
     return unless @osrel_amount && DRSpells.active_spells['Osrel Meraud']
     return unless Time.now - @osrel_timer > 300
     @osrel_timer = Time.now
-    infuse_om(!@osrel_no_harness, @osrel_amount)
+    DRCA.infuse_om(!@osrel_no_harness, @osrel_amount)
   end
 
   def check_timer(game_state)
@@ -1390,8 +1374,8 @@ class SpellProcess
 
     game_state.cast_timer = nil
     if game_state.casting
-      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      bput('release mana', 'You release all', "You aren't harnessing any mana")
+      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     end
     game_state.casting = false
   end
@@ -1434,8 +1418,8 @@ class SpellProcess
     return unless Flags['ct-need-bless']
     Flags.reset('ct-need-bless')
 
-    prepare?('Bless', 1)
-    cast?("cast #{right_hand || left_hand}")
+    DRCA.prepare?('Bless', 1)
+    DRCA.cast?("cast #{DRC.right_hand || DRC.left_hand}")
   end
 
   def check_ignite(game_state)
@@ -1445,7 +1429,7 @@ class SpellProcess
     return unless DRSpells.active_spells['Ignite']
 
     # Release the spell on the character
-    bput('release ignite', 'The warm feeling in your hand goes away', 'Release what')
+    DRC.bput('release ignite', 'The warm feeling in your hand goes away', 'Release what')
     # Wait for the spell on the weapon to be released (it can take a second or two to pulse)
     pause 1
   end
@@ -1457,7 +1441,7 @@ class SpellProcess
     return unless DRSpells.active_spells['Rutilor\'s Edge']
 
     # Release the spell on the character
-    bput('release rue', 'You sense the Rutilor\'s Edge spell fade away', 'Release what')
+    DRC.bput('release rue', 'You sense the Rutilor\'s Edge spell fade away', 'Release what')
     # Wait for the spell on the weapon to be released (it can take a second or two to pulse)
     pause 1
   end
@@ -1477,18 +1461,18 @@ class SpellProcess
     return unless ready_to_cast?(game_state)
 
     game_state.check_harness if @should_harness
-    cast_spell(game_state)
+    DRCA.cast_spell(game_state)
   end
 
   def check_invoke(game_state)
     return unless @should_invoke
     return if @cambrinth_invoke_exact_amount && game_state.charges_total.zero?
-    find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    DRCA.find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
     @should_invoke = nil
     invoke_amount = @cambrinth_invoke_exact_amount ? game_state.charges_total : nil
     game_state.charges_total = nil
-    invoke(@cambrinth, @dedicated_camb_use, invoke_amount)
-    stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    DRCA.invoke(@cambrinth, @dedicated_camb_use, invoke_amount)
+    DRCA.stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
   end
 
   def cast_spell(game_state)
@@ -1504,7 +1488,7 @@ class SpellProcess
       end
     end
 
-    hide?(@hide_type) if game_state.hide_on_cast && game_state.use_stealth?
+    DRC.hide?(@hide_type) if game_state.hide_on_cast && game_state.use_stealth?
 
     if game_state.casting_sorcery
       @equipment_manager.stow_weapon(game_state.weapon_name)
@@ -1512,7 +1496,7 @@ class SpellProcess
 
     if game_state.casting_regalia
       result = DRCA.parse_regalia
-      if result.empty? # if not wearing a regalia, retreat, swap to regalia gearset, then cast
+      if result.empty? # if not wearing a regalia, DRC.retreat, swap to regalia gearset, then cast
         DRC.retreat
         @equipment_manager.wear_equipment_set?('regalia')
         @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill) if @settings.gear_sets['regalia'].include?(game_state.weapon_name)
@@ -1565,7 +1549,7 @@ class SpellProcess
     end
 
     if game_state.casting_moonblade
-      if left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?
+      if DRC.left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?
         # The moonblade was summoned or refreshed while training something else
         DRCMM.wear_moon_weapon?
       end
@@ -1600,7 +1584,7 @@ class SpellProcess
     return if game_state.casting
     return unless @training_spells
     return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
-    release_cyclics if @release_cyclic_on_low_mana && DRStats.mana < @release_cyclic_threshold
+    DRCA.release_cyclics if @release_cyclic_on_low_mana && DRStats.mana < @release_cyclic_threshold
     return if DRStats.mana < @training_spell_mana_threshold
 
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
@@ -1642,7 +1626,7 @@ class SpellProcess
   end
 
   def cast_runestone(data, game_state)
-    prepare_to_cast_runestone?(data, @settings)
+    DRCA.prepare_to_cast_runestone?(data, @settings)
     return unless DRCI.in_hands?(data['runestone_name'])
     prepare_spell(data, game_state, @buff_force_cambrinth)
     return unless DRCI.in_hands?(data['runestone_name'])
@@ -1754,7 +1738,7 @@ class SpellProcess
   def check_trader_magic(game_state) # handles starlight-depletion and regalia
     return unless DRStats.trader?
     if Flags['ct-starlight-depleted']
-      message '----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----'
+      DRC.message '----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----'
       @buff_spells.reject! { |spell| @buff_spells[spell]['starlight_threshold'] > -1 } # delete all buffs and offensive spells. Potential to add stellar collector support later
       @offensive_spells.reject! { |spell| spell['starlight_threshold'] > -1 }
       @aura_frequency = 0
@@ -1865,7 +1849,7 @@ class SpellProcess
 
   def cast_ritual(data, game_state)
     if summoned = game_state.summoned_info(game_state.weapon_skill)
-      break_summoned_weapon(game_state.weapon_name)
+      DRCS.break_summoned_weapon(game_state.weapon_name)
     else
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
@@ -1887,7 +1871,7 @@ class SpellProcess
   def prepare_spell(data, game_state, force_cambrinth = false)
     return unless data
 
-    data = check_discern(data, @settings) if data['use_auto_mana']
+    data = DRCA.check_discern(data, @settings) if data['use_auto_mana']
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
     echo("prepare spell: #{data}") if $debug_mode_ct
@@ -1901,12 +1885,12 @@ class SpellProcess
     command = data['prep_type'] if data['prep_type']
 
     if command == 'segue'
-      return if segue?(data['abbrev'], data['mana'])
+      return if DRCA.segue?(data['abbrev'], data['mana'])
       command = 'prep'
     end
 
     if data['cyclic']
-      release_cyclics
+      DRCA.release_cyclics
       game_state.casting_cyclic = true
     end
 
@@ -1992,7 +1976,6 @@ class SpellProcess
 end
 
 class PetProcess
-  include DRC
 
   def initialize(settings)
     echo('New Pet Process') if $debug_mode_ct
@@ -2058,7 +2041,7 @@ class PetProcess
   def command_zombie(command, game_state)
     return unless game_state.cfb_active?
 
-    case bput("command zombie #{command}", 'willing it to come back to you', 'You have already shifted', 'That is not a valid stance', 'is already right beside you', 'zombie shambles off with a groan', 'You sense a flicker of acknowledgement through the link', 'you sense your .+ shift into (a|an) \w+ stance', 'you sense your .+ behavior shift')
+    case DRC.bput("command zombie #{command}", 'willing it to come back to you', 'You have already shifted', 'That is not a valid stance', 'is already right beside you', 'zombie shambles off with a groan', 'You sense a flicker of acknowledgement through the link', 'you sense your .+ shift into (a|an) \w+ stance', 'you sense your .+ behavior shift')
     when 'is already right beside you'
       echo('  Zombie is present') if $debug_mode_ct
       @is_present = true
@@ -2076,9 +2059,6 @@ class PetProcess
 end
 
 class AbilityProcess
-  include DRC
-  include DRCA
-  include DRCT
 
   def initialize(settings)
     echo('New AbilityProcess') if $debug_mode_ct
@@ -2162,15 +2142,15 @@ class AbilityProcess
     return unless @paladin_use_badge
     return unless Time.now - UserVars.paladin_last_badge_use > @badge_reuse_cooldown
 
-    case bput("#{@paladin_badge_get_verb} my pilgrim badge", 'You take off', 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
+    case DRC.bput("#{@paladin_badge_get_verb} my pilgrim badge", 'You take off', 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
     when 'You get', 'You remove', 'You take off'
-      retreat
-      bput('pray my pilgrim badge', 'You think upon the immortals')
+      DRC.retreat
+      DRC.bput('pray my pilgrim badge', 'You think upon the immortals')
       UserVars.paladin_last_badge_use = Time.now
       waitrt?
-      bput("#{@paladin_badge_store_verb} my pilgrim badge", 'You put', 'You attach')
+      DRC.bput("#{@paladin_badge_store_verb} my pilgrim badge", 'You put', 'You attach')
     when 'What were you referring to'
-      message '***PILGRIM BADGE NOT FOUND! REMOVING FROM HUNT.***'
+      DRC.message '***PILGRIM BADGE NOT FOUND! REMOVING FROM HUNT.***'
       @paladin_use_badge = false
       return
     end
@@ -2180,7 +2160,7 @@ class AbilityProcess
     return unless @use_mana_glyph
     return unless Flags['glyph-mana-expired']
 
-    bput('glyph mana', 'You trace a glyph', 'You begin to trace')
+    DRC.bput('glyph mana', 'You trace a glyph', 'You begin to trace')
     Flags.reset('glyph-mana-expired')
     echo 'Used Glyph of Mana!' if $debug_mode_ct
   end
@@ -2299,8 +2279,6 @@ class AbilityProcess
 end
 
 class ManipulateProcess
-  include DRC
-  include DRCT
 
   def initialize(settings)
     echo('New ManipulateProcess') if $debug_mode_ct
@@ -2329,7 +2307,7 @@ class ManipulateProcess
   end
 
   def manipulate(game_state)
-    bput('manip stop all', 'You relax your will', 'But you aren')
+    DRC.bput('manip stop all', 'You relax your will', 'But you aren')
 
     manipulate_count = 0
     npc_occurrences = Hash.new(0)
@@ -2341,7 +2319,7 @@ class ManipulateProcess
       index = npc_occurrences[npc]
       ordinal_string = $ORDINALS[index]
 
-      case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence', 'Manipulate what')
+      case DRC.bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence', 'Manipulate what')
       when 'does not seem to have a life essence' then
         game_state.construct(npc)
       else
@@ -2355,11 +2333,6 @@ class ManipulateProcess
 end
 
 class TrainerProcess
-  include DRC
-  include DRCT
-  include DRCI
-  include DRCMM
-  include DRCA
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -2406,7 +2379,7 @@ class TrainerProcess
 
     @skill_map['Hunt'] = %w[Perception Scouting] if DRStats.ranger?
     @favor_god = settings.favor_god
-    if settings.favor_goal && @favor_god && /delicate/ =~ bput("tap #{@favor_god} orb", 'The orb is delicate', 'I could not find')
+    if settings.favor_goal && @favor_god && /delicate/ =~ DRC.bput("tap #{@favor_god} orb", 'The orb is delicate', 'I could not find')
       @training_abilities['Favor Orb'] = settings.favor_orb_rub_frequency
     end
 
@@ -2509,13 +2482,13 @@ class TrainerProcess
     when /^PercMana$/i
       moon_mage_perc(game_state)
     when /^Perc$/i
-      bput('perc', 'You reach out', 'Strangely, you can sense absolutely nothing.') unless game_state.retreating?
+      DRC.bput('perc', 'You reach out', 'Strangely, you can sense absolutely nothing.') unless game_state.retreating?
     when /^Perc Health$/i
-      bput('perc heal', 'You close your eyes')
+      DRC.bput('perc heal', 'You close your eyes')
     when /^Astro$/i
       astrology(game_state)
     when /^Flee$/i
-      waitfor('Obvious') unless bput('flee bluff', 'You begin', 'see anything engaged with you', 'You suddenly realize') == 'see anything engaged with you'
+      waitfor('Obvious') unless DRC.bput('flee bluff', 'You begin', 'see anything engaged with you', 'You suddenly realize') == 'see anything engaged with you'
     when /^App$/i
       appraise(game_state, '')
     when /^App Quick$/i
@@ -2523,46 +2496,46 @@ class TrainerProcess
     when /^App Careful$/i
       appraise(game_state, 'careful')
     when /^App Pouch$/i
-      retreat
-      bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
+      DRC.retreat
+      DRC.bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
     when /^App Bundle$/i
-      retreat
-      bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
+      DRC.retreat
+      DRC.bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
     when /^Summon (?<element>.*?) Domain$/i
-      retreat
-      bput("summon #{Regexp.last_match[:element]} domain", "turn your attention inward", "It isn't possible to perform", "Summon allows Warrior Mages", "Roundtime")
+      DRC.retreat
+      DRC.bput("summon #{Regexp.last_match[:element]} domain", "turn your attention inward", "It isn't possible to perform", "Summon allows Warrior Mages", "Roundtime")
       waitrt?
-      fix_standing
+      DRC.fix_standing
     when /^Tactics$/i
-      bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
+      DRC.bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
     when /^Analyze$/i
       analyze(game_state, 0)
     when /^Hunt$/i
-      bput('hunt', 'You take note of ', 'You find yourself unable to hunt in this area') unless game_state.retreating?
+      DRC.bput('hunt', 'You take note of ', 'You find yourself unable to hunt in this area') unless game_state.retreating?
     when /^Teach$/i
       UserVars.friends.select { |c| DRRoom.pcs.include?(c) }.each do |character|
-        bput("teach #{@combat_teaching_skill} to #{character}", 'You begin to', 'is already listening to you', 'is listening to someone else', 'I could not find who you were referring to', 'You have already offered', 'That person is too busy teaching', 'You are already teaching', 'You cannot teach two different classes at the same time', 'is not paying attention to you', 'You cannot listen to a teacher and teach', 'already trying to teach you something', 'trying to teach someone else')
+        DRC.bput("teach #{@combat_teaching_skill} to #{character}", 'You begin to', 'is already listening to you', 'is listening to someone else', 'I could not find who you were referring to', 'You have already offered', 'That person is too busy teaching', 'You are already teaching', 'You cannot teach two different classes at the same time', 'is not paying attention to you', 'You cannot listen to a teacher and teach', 'already trying to teach you something', 'trying to teach someone else')
       end
     when /^Pray$/i
-      bput("pray #{@favor_god}", 'You offer a quiet prayer', 'Clasping your hands humbly', 'You hum under your breath', 'You murmur under your breath', 'You proclaim cheerfully', 'You raise your voice', 'You glance heavenward', 'You quietly go over the mantra', 'Immersing yourself in your faith', 'You bow your head', 'You murmur softly to yourself', 'You pray in susurration', 'You raise your fist', 'You lift your chin proudly', 'Feeling your blood boiling', 'You sigh and say softly', 'You open your arms', 'You glance at your surroundings', 'You mutter a prayer', 'Aligning your thoughts', 'You grumble ominously', 'You offer a prayer', 'You pray quietly', 'You throw your head back', 'With a mirthful laugh', 'Smiling joyously', 'You chant solemnly', 'You roll your eyes heavenward', 'You intone serenely', 'You narrow your eyes', 'You take a deep breath', 'You recite fervently', 'With an exultant grin', 'With renewed purpose', 'Drawing your fist to your heart', 'Glancing furtively at the comforting', 'You close your eyes and slow', 'You still your thoughts and whisper', 'You prepare to take lives', 'You raise your hands lightly', 'Bristling up against a sudden', 'You slowly square your shoulders', 'You tap the center of your forehead', 'You whisper your prayer', 'With a pat you double-check', 'Quietly touching your lips')
+      DRC.bput("pray #{@favor_god}", 'You offer a quiet prayer', 'Clasping your hands humbly', 'You hum under your breath', 'You murmur under your breath', 'You proclaim cheerfully', 'You raise your voice', 'You glance heavenward', 'You quietly go over the mantra', 'Immersing yourself in your faith', 'You bow your head', 'You murmur softly to yourself', 'You pray in susurration', 'You raise your fist', 'You lift your chin proudly', 'Feeling your blood boiling', 'You sigh and say softly', 'You open your arms', 'You glance at your surroundings', 'You mutter a prayer', 'Aligning your thoughts', 'You grumble ominously', 'You offer a prayer', 'You pray quietly', 'You throw your head back', 'With a mirthful laugh', 'Smiling joyously', 'You chant solemnly', 'You roll your eyes heavenward', 'You intone serenely', 'You narrow your eyes', 'You take a deep breath', 'You recite fervently', 'With an exultant grin', 'With renewed purpose', 'Drawing your fist to your heart', 'Glancing furtively at the comforting', 'You close your eyes and slow', 'You still your thoughts and whisper', 'You prepare to take lives', 'You raise your hands lightly', 'Bristling up against a sudden', 'You slowly square your shoulders', 'You tap the center of your forehead', 'You whisper your prayer', 'With a pat you double-check', 'Quietly touching your lips')
     when /^Scream$/i
       DRC.bput('Scream conc', 'Inhaling deeply', 'There is nothing', 'You open your mouth, then close it suddenly, looking somewhat like a fish', 'Scream at what?') unless game_state.npcs.empty?
     when /^Khri Prowess$/i
       unless game_state.npcs.empty?
-        if kneel_for_khri?(@kneel_khri, 'khri prowess')
-          retreat
+        if DRCA.kneel_for_khri?(@kneel_khri, 'khri prowess')
+          DRC.retreat
           fput('kneel')
         end
-        bput('khri prowess', 'Remembering the mantra of mind over matter', 'You\'re already using the Prowess meditation.', 'previous use of the Prowess', 'Your body is willing', 'Your mind and body are willing')
-        if kneel_for_khri?(@kneel_khri, 'khri prowess')
+        DRC.bput('khri prowess', 'Remembering the mantra of mind over matter', 'You\'re already using the Prowess meditation.', 'previous use of the Prowess', 'Your body is willing', 'Your mind and body are willing')
+        if DRCA.kneel_for_khri?(@kneel_khri, 'khri prowess')
           waitrt?
-          fix_standing
+          DRC.fix_standing
         end
       end
      when /^Stealth$/i
       hide_action(game_state)
     when /^(Ret|Retreat) Stealth$/i
-      retreat
+      DRC.retreat
       hide_action(game_state)
     when /^Ambush Stun$/i
       return ambush_stun(game_state)
@@ -2580,7 +2553,7 @@ class TrainerProcess
     when /^PrayerMat$/i
       pray_mat(game_state)
     when /^Recall$/i
-      bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
+      DRC.bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
     when /^Barb Research Augmentation$/i
       DRC.bput('meditate research monkey', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Barb Research Warding$/i
@@ -2593,12 +2566,12 @@ class TrainerProcess
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
       game_state.sheath_whirlwind_offhand
-      retreat
+      DRC.retreat
       put('engage') unless game_state.npcs.empty? || game_state.retreating?
-      collect(@forage_item)
+      DRC.collect(@forage_item)
       waitrt?
       game_state.wield_whirlwind_offhand
-      kick_pile?
+      DRC.kick_pile?
     when /^Almanac$/i
       UserVars.almanac_last_use ||= Time.now - 600
       use_almanac(game_state)
@@ -2607,10 +2580,10 @@ class TrainerProcess
     when /^Herbs$/i
       if game_state.npcs.empty? || @combat_trainer_herbs_allowhands
         game_state.sheath_whirlwind_offhand
-        wait_for_script_to_complete('heal-remedy', ['quick'])
+        DRC.wait_for_script_to_complete('heal-remedy', ['quick'])
         game_state.wield_whirlwind_offhand
       else
-        wait_for_script_to_complete('heal-remedy', %w[quick nohands])
+        DRC.wait_for_script_to_complete('heal-remedy', %w[quick nohands])
       end
     when /^Tessera$/i
       invest_in_tessera(game_state)
@@ -2622,20 +2595,20 @@ class TrainerProcess
   private
 
   def hide_action(game_state)
-    if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
-      stalked = bput('stalk', 'Stalk what',
+    if DRC.hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
+      stalked = DRC.bput('stalk', 'Stalk what',
                      'Try being out of sight',
                      'You move into position',
                      'already stalking',
                      'discovers you, ruining your hiding place') == ('You move into position' || 'already stalking')
-      bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
+      DRC.bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
     end
-    bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden
+    DRC.bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden
   end
 
   def use_almanac(game_state)
     return unless Time.now - UserVars.almanac_last_use >= 600
-    return if left_hand && !game_state.currently_whirlwinding
+    return if DRC.left_hand && !game_state.currently_whirlwinding
     unless @almanac_skills.empty?
       training_skills = @almanac_skills.select { |skill| DRSkill.getxp(skill) < 18 }
       training_skill = game_state.sort_by_rate_then_rank(training_skills).first
@@ -2643,15 +2616,15 @@ class TrainerProcess
     end
 
     game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
-    retreat
-    fput('engage') unless game_state.npcs.empty? || game_state.retreating?
-    bput("get my #{@almanac}", 'You get', 'What were')
+    DRC.retreat
+    DRC.bput('engage', 'You are already', 'You begin to', 'What do you') unless game_state.npcs.empty? || game_state.retreating?
+    DRC.bput("get my #{@almanac}", 'You get', 'What were')
     if training_skill
-      bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
+      DRC.bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
     end
-    bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what')
+    DRC.bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what')
     waitrt?
-    bput("stow my #{@almanac}", 'You put', 'Stow what','You hold out')
+    DRC.bput("stow my #{@almanac}", 'You put', 'Stow what','You hold out')
     UserVars.almanac_last_use = Time.now
     game_state.wield_whirlwind_offhand if game_state.currently_whirlwinding
   end
@@ -2659,9 +2632,9 @@ class TrainerProcess
   def smite(game_state)
     return if game_state.npcs.empty?
     return if game_state.brawling? || game_state.offhand? || game_state.aimed_skill?
-    return if right_hand.nil?
+    return if DRC.right_hand.nil?
 
-    bput("smite", "Drawing strength from your conviction", "Drawing upon holy wrath", "You aren't close enough", "What are you trying to attack")
+    DRC.bput("smite", "Drawing strength from your conviction", "Drawing upon holy wrath", "You aren't close enough", "What are you trying to attack")
   end
 
   def meraud_commune(game_state)
@@ -2740,8 +2713,8 @@ class TrainerProcess
       game_state.wield_specific_weapon(@stun_weapon, @stun_weapon_skill)
     end
 
-    if hide?
-      bput('ambush stun', 'Wouldn\'t it be better if you used a melee weapon?', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime', 'is already out cold')
+    if DRC.hide?
+      DRC.bput('ambush stun', 'Wouldn\'t it be better if you used a melee weapon?', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime', 'is already out cold')
       pause
       waitrt?
     end
@@ -2758,15 +2731,15 @@ class TrainerProcess
     return unless @dirt_stacker
     return if @dirt_empty
 
-    unless bput("push my #{@dirt_stacker}",
+    unless DRC.bput("push my #{@dirt_stacker}",
                 'You push', 'have any dirt', "I don't think pushing") == 'You push'
       @dirt_empty = true
       return
     end
 
     dirt_in_hand = true
-    if hide?
-      dirt_in_hand = bput(
+    if DRC.hide?
+      dirt_in_hand = DRC.bput(
         'ambush choke',
         'Wouldn\'t it be better if you used a melee weapon?',
         'You must be hidden or invisible to ambush',
@@ -2781,7 +2754,7 @@ class TrainerProcess
     end
 
     return unless dirt_in_hand
-    bput("put my dirt in my #{@dirt_stacker}",
+    DRC.bput("put my dirt in my #{@dirt_stacker}",
          'dumping some dirt', 'What were you referring')
   end
 
@@ -2789,16 +2762,16 @@ class TrainerProcess
     return if game_state.npcs.empty?
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
-    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
+    case DRC.bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
     when 'Analyze what'
-      case bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
+      case DRC.bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
       when 'There is nothing else', 'What are you trying'
-        fput('engage')
+        DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
         pause 2
       end
       analyze(game_state, fail_count)
     when 'You must be closer'
-      fput('engage')
+      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
     when 'Your analysis reveals a massive opening'
       return
     when 'You fail to find any holes'
@@ -2815,7 +2788,7 @@ class TrainerProcess
     target = (game_state.npcs - @no_app).first
     return unless target
     return if DRSkill.getrank('Appraisal') < 76
-    return if bput("app #{target} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what') != 'Perhaps that'
+    return if DRC.bput("app #{target} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what') != 'Perhaps that'
 
     @no_app << target
   end
@@ -2823,20 +2796,20 @@ class TrainerProcess
   def moon_mage_perc(game_state)
     return if game_state.retreating?
 
-    retreat unless DRSkill.getrank('Attunement') > 500 || DRStats.trader?
-    bput('perc mana', 'You reach out')
+    DRC.retreat unless DRSkill.getrank('Attunement') > 500 || DRStats.trader?
+    DRC.bput('perc mana', 'You reach out')
   end
 
   def astrology(game_state)
     return if game_state.retreating?
 
-    retreat
+    DRC.retreat
     if DRSkill.getrank('Astrology') <= 120
       DRCMM.predict('weather')
       waitrt?
-      fput('engage')
+      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
     else
-      retreat
+      DRC.retreat
       check_heavens(game_state)
       Flags.reset('bad-search')
     end
@@ -2910,14 +2883,14 @@ class TrainerProcess
   end
 
   def execute_predict
-    retreat
+    DRC.retreat
     case DRCMM.predict('future')
     when 'You are far too occupied by present matters to immerse yourself in matters of the future'
-      retreat
+      DRC.retreat
       waitrt?
       execute_predict
     when 'You look inside yourself'
-      stow_hands
+      DRCI.stow_hands
       return
     end
   end
@@ -2929,8 +2902,8 @@ class TrainerProcess
     DRC.retreat
     return unless /inside your (.*)\./ =~ DRC.bput("get my tessera", 'You get a .+ tessera from inside your (.*).', 'What were you')
     container = DRC.get_noun(Regexp.last_match(1))
-    game_state.starlight_values['level'] = 0 if bput('ask my tessera about invest', 'You send your') == 'You send your'
-    bput("put my tessera in my #{container}", 'You put', 'What were you')
+    game_state.starlight_values['level'] = 0 if DRC.bput('ask my tessera about invest', 'You send your') == 'You send your'
+    DRC.bput("put my tessera in my #{container}", 'You put', 'What were you')
     DRCI.stow_hand('left') if DRC.left_hand.include?('tessera')
     DRCI.stow_hand('right') if DRC.right_hand.include?('tessera')
   end
@@ -2966,7 +2939,6 @@ class TrainerProcess
 end
 
 class AttackProcess
-  include DRC
 
   def initialize(settings)
     echo('New AttackProcess') if $debug_mode_ct
@@ -3091,7 +3063,7 @@ class AttackProcess
     # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
     unless maneuver_success
       if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush? || game_state.ambush_stun_training?
-        hide?(@hide_type)
+        DRC.hide?(@hide_type)
       end
 
       verb = game_state.melee_attack_verb
@@ -3108,14 +3080,14 @@ class AttackProcess
         end
       end
 
-      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
+      DRC.bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
     pause
     waitrt?
 
     if reget(5, 'flying too high for you to attack')
-      case bput('face next', 'There is nothing', 'You turn to face', 'Face what')
+      case DRC.bput('face next', 'There is nothing', 'You turn to face', 'Face what')
       when 'There is nothing'
         pause 5
       end
@@ -3130,36 +3102,36 @@ class AttackProcess
     end
 
     if reget(5, 'You aren\'t close enough to attack', 'It would help if you were closer')
-      fput('engage')
+      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
       pause 6
     else
       game_state.action_taken
     end
     return unless reget(5, 'You need two hands')
 
-    fput('stow left') if left_hand && left_hand !~ /\b#{game_state.weapon_name}/i
-    fput('stow right') if right_hand && right_hand !~ /\b#{game_state.weapon_name}/i
+    fput('stow left') if DRC.left_hand && DRC.left_hand !~ /\b#{game_state.weapon_name}/i
+    fput('stow right') if DRC.right_hand && DRC.right_hand !~ /\b#{game_state.weapon_name}/i
   end
 
   def attack_thrown(game_state)
     attack_action = game_state.thrown_attack_verb
     attack_action += ' left' if game_state.offhand?
-    bput(attack_action, 'roundtime', 'What are you trying to')
+    DRC.bput(attack_action, 'roundtime', 'What are you trying to')
     waitrt?
 
     if game_state.weapon_name == 'blades'
-      until /(Stow what|You put your)/ =~ bput('stow blade', 'Stow what', 'You pick up .*blade', 'You put your')
+      until /(Stow what|You put your)/ =~ DRC.bput('stow blade', 'Stow what', 'You pick up .*blade', 'You put your')
       end
     end
 
     retrieve_action = game_state.thrown_retrieve_verb
-    case bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke")
+    case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke")
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work
-      bput("get #{game_state.weapon_name}", 'You pick up', 'You get')
+      DRC.bput("get #{game_state.weapon_name}", 'You pick up', 'You get')
     when 'You catch'
-      bput('swap', 'You move', 'You have nothing') if game_state.offhand?
+      DRC.bput('swap', 'You move', 'You have nothing') if game_state.offhand?
     end
 
     game_state.action_taken
@@ -3173,10 +3145,10 @@ class AttackProcess
     # Occasionally the game borks and the phrases like "Face what?"
     # appear before the text that you fired your weapon.
     # So, we use a flag to see if the message ever appears
-    # rather than relying on the first message returned from bput.
+    # rather than relying on the first message returned from DRC.bput.
     Flags.reset('ct-ranged-ammo')
 
-    result = bput(command, /you (fire|poach|snipe)/i, /isn't loaded/i, /There is nothing/i, /But your/i, /I could not find/i, /with no effect and falls (to the ground|to your feet)/i, /Face what/i, /How can you (poach|snipe)/i, /you don't feel like fighting right now/i, /That weapon must be in your right hand to fire/i, /But you don't have a ranged weapon in your hand to fire with/i)
+    result = DRC.bput(command, /you (fire|poach|snipe)/i, /isn't loaded/i, /There is nothing/i, /But your/i, /I could not find/i, /with no effect and falls (to the ground|to your feet)/i, /Face what/i, /How can you (poach|snipe)/i, /you don't feel like fighting right now/i, /That weapon must be in your right hand to fire/i, /But you don't have a ranged weapon in your hand to fire with/i)
     waitrt?
 
     case result
@@ -3226,9 +3198,9 @@ class AttackProcess
       echo("Current Time > @firing_timer: #{Time.now >= @firing_timer}") if $debug_mode_ct
       echo("Current Time < @firing_timer: #{Time.now <= @firing_timer}") if $debug_mode_ct
       echo("Flag check: ct-ranged-ready: #{Flags['ct-ranged-ready']}") if $debug_mode_ct
-      command = if game_state.use_stealth_ranged? && hide?(@hide_type)
+      command = if game_state.use_stealth_ranged? && DRC.hide?(@hide_type)
                   @stealth_attack_aimed_action
-                elsif game_state.use_stealth_attack? && hide?(@hide_type)
+                elsif game_state.use_stealth_attack? && DRC.hide?(@hide_type)
                   @stealth_attack_aimed_action
                 else
                   'shoot'
@@ -3263,12 +3235,12 @@ class AttackProcess
         next unless skill.include?('Thrown')
         retrieve_action = "get my #{weapon_name}"
         retrieve_action = 'invoke' if action.include?('hurl')
-        case bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch',\
+        case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch',\
                             'What were you', "You don't have any bonds to invoke")
         when 'What were you'
           # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
           # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work
-          bput("get #{weapon_name}", 'You pick up', 'You get', 'What were')
+          DRC.bput("get #{weapon_name}", 'You pick up', 'You get', 'What were')
         end
       end
 
@@ -3281,7 +3253,7 @@ class AttackProcess
         matches = ['You get', 'You draw out', 'You draw your', 'You pick up', "You're already holding that", 'You are already holding that'] if @get_actions.include?(first_word)
         matches = ['Roundtime', "You aren't close enough to attack", 'What are you', 'There is nothing'] if @rt_actions.include?(first_word)
         matches = ['You put', 'You sheathe', 'Sheathing a', 'Sheathing some'] if @stow_actions.include?(first_word)
-        bput(action.strip, matches)
+        DRC.bput(action.strip, matches)
         pause 0.25
         waitrt?
       end
@@ -3322,8 +3294,8 @@ class AttackProcess
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
         Flags.reset('ct-ranged-loaded')
-        load_weapon_result = bput('load arrows', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
-        load_weapon_result = bput('load arrows', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        load_weapon_result = DRC.bput('load arrows', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
+        load_weapon_result = DRC.bput('load arrows', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
         case load_weapon_result
         when *load_weapon_failure
           dual_load = false # fallback to single load
@@ -3340,8 +3312,8 @@ class AttackProcess
         Flags.reset('ct-ranged-loaded')
         Flags.reset('ct-using-repeating-crossbow')
 
-        load_weapon_result = bput("load my #{game_state.weapon_name}", { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
-        load_weapon_result = bput("load my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        load_weapon_result = DRC.bput("load my #{game_state.weapon_name}", { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
+        load_weapon_result = DRC.bput("load my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
         waitrt?
 
         case load_weapon_result
@@ -3351,7 +3323,7 @@ class AttackProcess
         when *load_weapon_success
           # Check if loading a repeating crossbow because we need to then push ammo into the chamber
           if Flags['ct-using-repeating-crossbow']
-            case bput("push my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure)
+            case DRC.bput("push my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure)
             when *load_weapon_failure
               abort_attack_aimed(game_state)
               return
@@ -3389,10 +3361,10 @@ class AttackProcess
   end
 
   def execute_aiming_action?(action, game_state)
-    case bput(action, 'Roundtime', 'close enough', 'What are you', 'There is nothing', 'must be closer', 'Bumbling, you slip')
+    case DRC.bput(action, 'Roundtime', 'close enough', 'What are you', 'There is nothing', 'must be closer', 'Bumbling, you slip')
     when 'close enough', 'must be closer'
       return false if game_state.retreating?
-      fput('engage')
+      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
       pause 2.5
     when 'What are you', 'There is nothing'
       return false
@@ -3431,7 +3403,7 @@ class AttackProcess
       /Strangely, you don't feel like fighting right now/
     ]
 
-    case bput("aim", *aim_success_messages, *unloaded_messages, *no_enemy_messages, *wait_and_retry_messages)
+    case DRC.bput("aim", *aim_success_messages, *unloaded_messages, *no_enemy_messages, *wait_and_retry_messages)
     when *aim_success_messages
       game_state.loaded = true
       check_firing_time
@@ -3454,9 +3426,9 @@ class AttackProcess
       pause 1
     else
       game_state.set_dance_queue
-      case bput(game_state.next_dance_action, 'You must be closer', 'There is nothing else', 'What are you trying', /.*/)
+      case DRC.bput(game_state.next_dance_action, 'You must be closer', 'There is nothing else', 'What are you trying', /.*/)
       when 'You must be closer', 'There is nothing else', 'What are you trying'
-        fput('engage')
+        DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
         pause 2
       end
       pause 0.5
@@ -3510,7 +3482,7 @@ class AttackProcess
       /^You are unable to focus on performing a maneuver while aiming at an enemy/
     ]
 
-    attempt = bput("maneuver #{action}", *maneuver_success_messages, *maneuver_failure_messages)
+    attempt = DRC.bput("maneuver #{action}", *maneuver_success_messages, *maneuver_failure_messages)
 
     waitrt?
 
@@ -3576,7 +3548,7 @@ class AttackProcess
     # The majority of the time, if not always, the words to reference the item are the first and last (e.g. matte sphere).
     ammo_parts = ammo.strip.split(' ')
     ammo = [ammo_parts.first, ammo_parts.last].compact.uniq.join(' ')
-    case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
+    case DRC.bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
     when 'You pick up', 'You put your'
       stow_ammo(ammo, quantity - 1)
     when 'Stow what'
@@ -3590,7 +3562,6 @@ class AttackProcess
 end
 
 class CombatTrainer
-  include DRC
 
   attr_reader :running
 
@@ -3650,7 +3621,7 @@ class CombatTrainer
 
     Flags.add('last-stance', 'Setting your Evasion stance to \d+%, your Parry stance to \d+%, and your Shield stance to \d+%.  You have \d+ stance points left')
 
-    bput("stance set #{settings.default_stance}", 'Setting your')
+    DRC.bput("stance set #{settings.default_stance}", 'Setting your')
 
     @stop = false
     @running = true
@@ -3709,9 +3680,6 @@ class CombatTrainer
 end
 
 class GameState
-  include DRCA
-  include DRCS
-  include DRC
 
   $martial_skills = ['Brawling']
   $edged_skills = ['Small Edged', 'Large Edged', 'Twohanded Edged']
@@ -3844,12 +3812,12 @@ class GameState
     @stances.keys do |key|
       settings = @stances[key]
       unless (settings & %w[evasion parry shield]).empty?
-        message 'Please update to the latest version of stance: settings!'
+        DRC.message 'Please update to the latest version of stance: settings!'
         settings.map! { |x| { 'parry' => 'Parry Ability', 'shield' => 'Shield Usage', 'evasion' => 'Evasion' }[x] }
       end
       (['Evasion', 'Shield Usage', 'Parry Ability'] - settings).each { |x| settings << x }
       unless settings.size == 3
-        message "Error: stance settings #{settings} include invalid stance."
+        DRC.message "Error: stance settings #{settings} include invalid stance."
         exit
       end
     end
@@ -4088,7 +4056,7 @@ class GameState
   end
 
   def sheath_whirlwind_offhand
-    return unless currently_whirlwinding && left_hand
+    return unless currently_whirlwinding && DRC.left_hand
     @equipment_manager.stow_weapon(whirlwind_offhand_name)
   end
 
@@ -4280,7 +4248,7 @@ class GameState
     @retreating = @retreat_threshold && npcs.length >= @retreat_threshold
   end
 
-  def retreat_weapons
+  def DRC.retreat_weapons
     weapon_training.select { |skill, _| $ranged_skills.include?(skill) }
   end
 
@@ -4383,7 +4351,7 @@ class GameState
     @dancing
   end
 
-  def retreating?
+  def DRC.retreating?
     @retreating
   end
 
@@ -4506,10 +4474,10 @@ class GameState
     echo("check_charging?: #{next_charge}") if $debug_mode_ct
 
     return true if next_charge.zero?
-    find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
-    @charges = [] unless charge?(@cambrinth, next_charge)
+    DRCA.find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    @charges = [] unless DRCA.charge?(@cambrinth, next_charge)
 
-    stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    DRCA.stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
 
     true
   end
@@ -4569,7 +4537,7 @@ class GameState
       return
     end
 
-    harness_mana(@charges.flatten)
+    DRCA.harness_mana(@charges.flatten)
 
     @charges = []
   end
@@ -4587,11 +4555,11 @@ class GameState
   def prepare_summoned_weapon(weapon_already_summoned)
     info = summoned_info(weapon_skill)
 
-    summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
-    shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot) if weapon_already_summoned || DRStats.moon_mage?
-    turn_summoned_weapon if info['turn']
-    push_summoned_weapon if info['push']
-    pull_summoned_weapon if info['pull']
+    DRCS.summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
+    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot) if weapon_already_summoned || DRStats.moon_mage?
+    DRCS.turn_summoned_weapon if info['turn']
+    DRCS.push_summoned_weapon if info['push']
+    DRCS.pull_summoned_weapon if info['pull']
   end
 
   def can_ambush_stun?
@@ -4823,7 +4791,7 @@ class GameState
     return false if combo_type != 'flame' && !Flags["ct-#{combo_type}-ready"] && DRStats.barbarian?
     return false if DRSkill.getrank('Expertise') < expertise_requirement
 
-    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?')
+    result = DRC.bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?')
     waitrt?
 
     case result
@@ -4831,11 +4799,11 @@ class GameState
       Flags.reset("ct-#{combo_type}-ready")
       return false
     when 'You must be closer'
-      fput('engage')
+      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
     when 'You fail to find any'
       perform_analyze?(combo_type, expertise_requirement)
     when 'Analyze what?'
-      case bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
+      case DRC.bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
       when 'You turn'
         return perform_analyze?(combo_type, expertise_requirement)
       end
@@ -4845,7 +4813,7 @@ class GameState
     end
 
     text = result.match(/by landing an? (.*)\.$/).to_a[1]
-    @analyze_combo_array = list_to_nouns(text)
+    @analyze_combo_array = DRC.list_to_nouns(text)
 
     true
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4,6 +4,8 @@
 custom_require.call(%w[common common-arcana common-healing common-items common-summoning common-theurgy common-moonmage common-travel drinfomon equipmanager events spellmonitor])
 
 class SetupProcess
+  include DRC
+  include DRCS
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -57,12 +59,12 @@ class SetupProcess
     return true if game_state.done_cleaning_up?
     if game_state.stowing?
       echo('SetupProcess::clean_up') if $debug_mode_ct
-      DRC.retreat
+      retreat
       if game_state.summoned_info(game_state.weapon_skill)
         if DRStats.moon_mage?
           DRCMM.wear_moon_weapon?
         else
-          DRCS.break_summoned_weapon(game_state.weapon_name)
+          break_summoned_weapon(game_state.weapon_name)
         end
       else
         @equipment_manager.stow_weapon(game_state.weapon_name)
@@ -109,17 +111,17 @@ class SetupProcess
 
     game_state.sheath_whirlwind_offhand
 
-    case DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'You take', 'What were you referring to', 'You need a free hand', 'Remove what')
+    case bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'You take', 'What were you referring to', 'You need a free hand', 'Remove what')
     when 'You get', 'You remove', 'You take'
-      if /The red light within the egg is dim and moves about sluggishly|Your lungs are tired from having sounded a/ =~ DRC.bput(@warhon_activation_command,'light envelops the area briefly', 'The red light within the egg is dim and moves about sluggishly', 'Something about the area inhibits','You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
+      if /The red light within the egg is dim and moves about sluggishly|Your lungs are tired from having sounded a/ =~ bput(@warhon_activation_command,'light envelops the area briefly', 'The red light within the egg is dim and moves about sluggishly', 'Something about the area inhibits','You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
         @next_warhorn = Time.now + 60
       else
         @next_warhorn = Time.now + 300
       end
       waitrt?
-      DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+      bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when 'What were you referring to'
-      DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
+      message "#{@warhorn} NOT FOUND! Removing from hunt."
       @warhorn = nil
     end
 
@@ -239,7 +241,7 @@ class SetupProcess
       game_state.reset_stance = false
       pause
       waitrt?
-      DRC.bput("stance set #{@stance_override}", 'Setting your')
+      bput("stance set #{@stance_override}", 'Setting your')
       @override_done = true
       return
     end
@@ -277,7 +279,7 @@ class SetupProcess
     end
 
     return if vals == previous
-    return unless /maximum number of points \((\d+)/ =~ DRC.bput(build_stance_string(vals), 'Setting your Evasion stance to', 'is above your maximum number of points \(\d+')
+    return unless /maximum number of points \((\d+)/ =~ bput(build_stance_string(vals), 'Setting your Evasion stance to', 'is above your maximum number of points \(\d+')
     check_stance(game_state, Regexp.last_match(1).to_i)
   end
 
@@ -295,7 +297,7 @@ class SetupProcess
       @equipment_manager.stow_weapon(game_state.last_weapon_name)
       game_state.sheath_whirlwind_offhand
     elsif !next_summoned && !DRStats.moon_mage?
-      DRCS.break_summoned_weapon(game_state.last_weapon_name)
+      break_summoned_weapon(game_state.last_weapon_name)
     elsif !next_summoned && DRStats.moon_mage?
       DRCMM.wear_moon_weapon?
     end
@@ -311,7 +313,7 @@ class SetupProcess
     if next_summoned
       game_state.prepare_summoned_weapon(last_summoned)
     else
-      DRC.bput('aim stop', "But you're not aiming", 'You stop concentrating', 'You are already') if game_state.aimed_skill?
+      bput('aim stop', "But you're not aiming", 'You stop concentrating', 'You are already') if game_state.aimed_skill?
       game_state.wield_weapon
       if game_state.whirlwind_trainable?
         game_state.currently_whirlwinding = true
@@ -324,7 +326,7 @@ class SetupProcess
 
     # Invoke Focus
     return unless game_state.weapon_skill == 'Targeted Magic' && game_state.weapon_name
-    DRC.bput("invoke #{game_state.weapon_name}", 'You')
+    bput("invoke #{game_state.weapon_name}", 'You')
     waitrt?
   end
 
@@ -338,12 +340,12 @@ class SetupProcess
   def validate_regalia(settings)
     return unless @cycle_regalia
     if @cycle_armors
-      DRC.message 'ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!'
+      message 'ERROR - Regalia cycling and armorswap cycling at the same time not currently supported!  Removing Regalia from combat-training!'
       @cycle_regalia = nil
     end
 
     if settings.gear_sets['regalia'].empty? || settings.gear_sets['regalia'].nil?
-      DRC.message "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
+      message "ERROR - Regalia cycling requires a gear_set named 'regalia' that will be worn immediately before casting. Removing Regalia from combat-training!"
       @cycle_regalia = nil
     end
     # reset swap clock if you start CT already wearing a regalia.
@@ -363,6 +365,11 @@ class SetupProcess
 end
 
 class LootProcess
+  include DRC
+  include DRCI
+  include DRCS
+  include DRCH
+  include DRCMM
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -528,53 +535,53 @@ class LootProcess
 
     special = @loot_specials.find { |x| x['name'] == item }
     if special
-      if DRC.bput("get #{item}", 'You pick up', 'There isn\'t any more room', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory') == 'already in your inventory'
-        DRC.bput("get other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+      if bput("get #{item}", 'You pick up', 'There isn\'t any more room', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory') == 'already in your inventory'
+        bput("get other #{item}", 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       end
       pause 0.25
-      DRC.bput("put #{item} in my #{special['bag']}", 'you put')
+      bput("put #{item} in my #{special['bag']}", 'you put')
       return
     end
 
-    case DRC.bput("stow #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
+    case bput("stow #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
     when 'already in your inventory'
       if @gem_nouns.include?(item)
-        DRC.bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+        bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
       elsif @box_nouns.include?(item)
         item_reg = item.split.join('.*')
         return stow_loot(DRRoom.room_objs.grep(/\b#{item_reg}$/).first.split.last(2).join(' '), game_state)
       else
-        DRC.bput("stow other #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
+        bput("stow other #{item}", 'You pick up', 'You put', 'You get', 'You need a free hand', 'needs to be tended to be removed', 'There isn\'t any more room', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory', 'The .* is not designed to carry anything', 'rapidly decays away', 'cracks and rots away')
       end
     when 'You pick up', 'You get'
       @current_box_count += 1 if @box_loot_limit && @box_nouns.include?(item)
     end
     pause 0.25
     if Flags['container-full']
-      DRC.bput("drop #{item}", 'You drop')
+      bput("drop #{item}", 'You drop')
       game_state.unlootable(item)
     end
 
     return unless Flags['pouch-full']
-    DRC.bput("drop my #{item}", 'You drop', 'What were')
+    bput("drop my #{item}", 'You drop', 'What were')
     unless @spare_gem_pouch_container
       game_state.unlootable(item)
       return
     end
-    DRC.bput("remove my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You remove')
+    bput("remove my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You remove')
     if @full_pouch_container
-      case DRC.bput("put my #{@gem_pouch_adjective} #{@gem_pouch_noun} in my #{@full_pouch_container}", 'You put','too heavy to go in there')
+      case bput("put my #{@gem_pouch_adjective} #{@gem_pouch_noun} in my #{@full_pouch_container}", 'You put','too heavy to go in there')
       when 'too heavy to go in there'
-        DRC.bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
+        bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
       end
     else
-      DRC.bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
+      bput("stow my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You put')
     end
-    DRC.bput("get #{@gem_pouch_adjective} #{@gem_pouch_noun} from my #{@spare_gem_pouch_container}", 'You get a')
-    DRC.bput("wear my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You attach')
-    DRC.bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
+    bput("get #{@gem_pouch_adjective} #{@gem_pouch_noun} from my #{@spare_gem_pouch_container}", 'You get a')
+    bput("wear my #{@gem_pouch_adjective} #{@gem_pouch_noun}", 'You attach')
+    bput('stow gem', 'You pick up', 'You get', 'You need a free hand', 'You just can\'t', 'push you over the item limit', 'You stop as you realize the .* is not yours', 'Stow what', 'already in your inventory')
     if @tie_pouch
-      DRC.bput("tie my #{@gem_pouch_noun}", 'You tie')
+      bput("tie my #{@gem_pouch_noun}", 'You tie')
     else
       fput("close my #{@gem_pouch_noun}")
     end
@@ -605,7 +612,7 @@ class LootProcess
     if DRC.left_hand != pair.first || DRC.right_hand != pair.last
       # Mitigating a race condition when wand-watcher or another script pauses
       # combat-trainer while it's looting, then resumes in the middle of this function.
-      # Occassionally, the thread hasn't updated the DRC.left_hand/right_hand variables
+      # Occassionally, the thread hasn't updated the left_hand/right_hand variables
       # to know what's currently in your hand and will trash what's in your hand!
       # Do a glance to force the variables to be refreshed before we take action.
       DRC.bput('glance', 'You glance .*')
@@ -717,7 +724,7 @@ class LootProcess
 
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w[consume harvest arise].include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
-    result = DRC.bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
+    result = bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
     echo result if $debug_mode_ct
     case result
     when @rituals['arise']
@@ -753,9 +760,9 @@ class LootProcess
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     loop do
-      result = DRC.bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], @rituals['failures'])
+      result = bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], @rituals['failures'])
       break if result.empty? || @rituals['failures'].any? { |msg| result.include?(msg) }
-      DRC.bput("drop my #{DRC.right_hand}", 'You drop', 'You discard', 'Please rephrase')
+      bput("drop my #{right_hand}", 'You drop', 'You discard', 'Please rephrase')
       break if @dissect_and_butcher && !@ritual_type.eql?('butcher')
     end
 
@@ -766,27 +773,27 @@ class LootProcess
   def necro_harvest_check
     unless @necro_store
       echo 'Store material: false, dropping harvested material' if $debug_mode_ct
-      DRC.bput('drop material', 'you discard it')
+      bput('drop material', 'you discard it')
       return
     end
 
-    quality = DRC.bput('glance','You glance down.*')
+    quality = bput('glance','You glance down.*')
     if quality['great'] || quality['excellent'] || quality['perfect'] || quality['flawless']
       echo 'Harvested high quality material.' if $debug_mode_ct
     else
-      DRC.bput('drop material', 'you discard it')
+      bput('drop material', 'you discard it')
       echo 'Dropped low quality material.' if $debug_mode_ct
       return
     end
 
     echo 'Store material: true, checking count of stored material' if $debug_mode_ct
     if @current_harvest_count >= @necro_count
-      DRC.bput('drop material', 'you discard it')
+      bput('drop material', 'you discard it')
       echo 'Already full on stored material, dropping harvested material.' if $debug_mode_ct
       return
     end
 
-    result = DRC.bput("put material in my #{@necro_container}", 'You put')
+    result = bput("put material in my #{@necro_container}", 'You put')
     @current_harvest_count += 1 if result =~ /^You put/
   end
 
@@ -803,7 +810,7 @@ class LootProcess
     waitrt?
     return if Flags['using-corpse']
     if (Time.now - @last_rites_timer > 600) && @last_rites && game_state.blessed_room
-      DRC.bput("pray #{DRRoom.dead_npcs.first}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for')
+      bput("pray #{DRRoom.dead_npcs.first}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for')
       waitrt?
       fput "recite Meraud, power the holy fires that unleash my righteous vengeance;Chadatru, guide my sword to swing in justice;Everild, give me the power to conquer my enemies;Truffenyi, let me not lose sight of compassion and mercy;Else, I will become like those I despise;Urrem'tier, receive into your fetid grasp these wicked souls;May the Tamsine's realms never know their evil ways again;May all the Immortals guide your faithful soldier #{checkname}."
       waitrt?
@@ -818,7 +825,7 @@ class LootProcess
     game_state.wield_whirlwind_offhand
 
     unless game_state.necro_casting?
-      while DRC.bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
+      while bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
         pause
         waitrt?
       end
@@ -838,7 +845,7 @@ class LootProcess
     arrange_message = @arrange_all ? "arrange all for #{type}" : "arrange for #{type}"
     while arranges < @arrange_count
       arranges += 1
-      case DRC.bput(arrange_message, 'You begin to arrange', 'You continue arranging', 'You make a mistake', 'You complete arranging', 'That creature cannot', 'That has already been arranged', 'Arrange what', 'cannot be skinned', 'You make a serious mistake in the arranging process', 'The .* is currently being arranged to produce')
+      case bput(arrange_message, 'You begin to arrange', 'You continue arranging', 'You make a mistake', 'You complete arranging', 'That creature cannot', 'That has already been arranged', 'Arrange what', 'cannot be skinned', 'You make a serious mistake in the arranging process', 'The .* is currently being arranged to produce')
       when 'You complete arranging', 'That has already been arranged', 'You make a serious mistake in the arranging process', 'Arrange what'
         break
       when 'cannot be skinned'
@@ -853,7 +860,7 @@ class LootProcess
   end
 
   def dissected?(mob_noun, game_state)
-    case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'
@@ -897,12 +904,12 @@ class LootProcess
     pause 0.25
     waitrt?
     if game_state.need_bundle
-      case DRC.bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
+      case bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
       when /lumpy/
         if @tie_bundle
-          DRC.bput('tie my bundle', 'TIE the bundle again')
-          DRC.bput('tie my bundle', 'you tie the bundle')
-          DRC.bput('adjust my bundle', 'You adjust')
+          bput('tie my bundle', 'TIE the bundle again')
+          bput('tie my bundle', 'you tie the bundle')
+          bput('adjust my bundle', 'You adjust')
         end
         game_state.need_bundle = false
       when /tight/
@@ -910,8 +917,8 @@ class LootProcess
       end
     end
 
-    snap = [DRC.left_hand, DRC.right_hand]
-    case DRC.bput('skin', 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
+    snap = [left_hand, right_hand]
+    case bput('skin', 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
     when 'You must have one hand free to skin'
       temp_item = DRC.left_hand
       if DRCI.lower_item?(temp_item)
@@ -924,7 +931,7 @@ class LootProcess
       fput 'drop skin'
       fput 'skin'
     when 'need a more appropriate weapon', 'need to have a bladed instrument to skin'
-      DRC.message('BUY A SKINNING KNIFE')
+      message('BUY A SKINNING KNIFE')
       @skin = false
       return
     when 'cannot be skinned'
@@ -933,26 +940,26 @@ class LootProcess
     end
     pause 1
     waitrt?
-    if game_state.need_bundle && snap != [DRC.left_hand, DRC.right_hand]
+    if game_state.need_bundle && snap != [left_hand, right_hand]
       stored_moon = false
       if DRStats.moon_mage? && DRCMM.wear_moon_weapon?
         stored_moon = true
       elsif summoned = game_state.summoned_info(game_state.weapon_skill)
-        DRCS.break_summoned_weapon(game_state.weapon_name)
+        break_summoned_weapon(game_state.weapon_name)
       else
         @equipment_manager.stow_weapon(game_state.weapon_name)
       end
-      if DRC.bput('get bundling rope', 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
+      if bput('get bundling rope', 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
         fput('bundle')
         fput('wear my bundle')
         if @tie_bundle
-          DRC.bput('tie my bundle', 'TIE the bundle again')
-          DRC.bput('tie my bundle', 'you tie the bundle')
-          DRC.bput('adjust my bundle', 'You adjust')
+          bput('tie my bundle', 'TIE the bundle again')
+          bput('tie my bundle', 'you tie the bundle')
+          bput('adjust my bundle', 'You adjust')
         end
       else
-        DRCI.dispose_trash(DRC.left_hand) if snap.first != DRC.left_hand && !@equipment_manager.is_listed_item?(DRC.left_hand)
-        DRCI.dispose_trash(DRC.right_hand) if snap.last != DRC.right_hand && !@equipment_manager.is_listed_item?(DRC.right_hand)
+        dispose_trash(left_hand) if snap.first != left_hand && !@equipment_manager.is_listed_item?(left_hand)
+        dispose_trash(right_hand) if snap.last != right_hand && !@equipment_manager.is_listed_item?(right_hand)
       end
       game_state.need_bundle = false
       unless stored_moon && DRCMM.hold_moon_weapon?
@@ -963,12 +970,15 @@ class LootProcess
         end
       end
     end
-    DRCI.dispose_trash(DRC.left_hand) if snap.first != DRC.left_hand && !@equipment_manager.is_listed_item?(DRC.left_hand)
-    DRCI.dispose_trash(DRC.right_hand) if snap.last != DRC.right_hand && !@equipment_manager.is_listed_item?(DRC.right_hand)
+    dispose_trash(left_hand) if snap.first != left_hand && !@equipment_manager.is_listed_item?(left_hand)
+    dispose_trash(right_hand) if snap.last != right_hand && !@equipment_manager.is_listed_item?(right_hand)
   end
 end
 
 class SafetyProcess
+  include DRC
+  include DRCH
+  include DRCT
 
   def initialize(settings, equipment_manager)
     echo('New SafetyProcess') if $debug_mode_ct
@@ -1000,7 +1010,7 @@ class SafetyProcess
     end
 
     fput 'exit' if DRStats.health < @health_threshold
-    DRC.fix_standing
+    fix_standing
     check_item_recovery(game_state)
     tend_lodged
     active_mitigation
@@ -1059,24 +1069,24 @@ class SafetyProcess
   end
 
   def warn_failed_item_recovery(item)
-    5.times{ DRC.message "UNABLE TO RECOVER FROM #{item} LOSS!"; DRC.beep }
+    5.times{ DRC.message "UNABLE TO RECOVER FROM #{item} LOSS!"; beep }
   end
 
   def tend_lodged
     return unless Flags['ct-lodged']
-    DRCH.bind_wound(Flags['ct-lodged'][:body_part])
+    bind_wound(Flags['ct-lodged'][:body_part])
     Flags.reset('ct-lodged')
   end
 
   def keep_away
     return unless Flags['ct-engaged']
     Flags.reset('ct-engaged')
-    DRC.retreat
+    retreat
   end
 
   def active_mitigation
     return unless Flags['active-mitigation']
-    DRC.bput("#{Flags['active-mitigation'][:action]} #{Flags['active-mitigation'][:obstacle]}", 'You manage to', "You've got to", 'Please rephrase', 'You jump back', "You can't do")
+    bput("#{Flags['active-mitigation'][:action]} #{Flags['active-mitigation'][:obstacle]}", 'You manage to', "You've got to", 'Please rephrase', 'You jump back', "You can't do")
     Flags.reset('active-mitigation')
   end
 
@@ -1085,7 +1095,7 @@ class SafetyProcess
 
     unless danger
       Flags.reset('ct-engaged')
-      DRC.retreat
+      retreat
     end
 
     keep_away
@@ -1094,6 +1104,12 @@ class SafetyProcess
 end
 
 class SpellProcess
+  include DRC
+  include DRCA
+  include DRCS
+  include DRCH
+  include DRCT
+  include DRCMM
 
   $weapon_buffs = ['Ignite', 'Rutilor\'s Edge', 'Resonance']
 
@@ -1247,7 +1263,7 @@ class SpellProcess
 
     return unless DRStats.trader? && @regalia_array
     @regalia_spell = get_data('spells').spell_data['Regalia'] if @regalia_array && @regalia_spell.nil? # get data from the regalia waggle or base-spells
-    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None' # prepare to check for bespoke regalia
+    bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None' # prepare to check for bespoke regalia
     @know_bespoke = DRC.bput('pre bspk', 'Bespoke Regalia', 'You have no idea', 'fully prepared', 'already preparing') == 'Bespoke Regalia' # check for bespoke regalia
   end
 
@@ -1271,10 +1287,10 @@ class SpellProcess
     if game_state.finish_spell_casting?
       echo('SpellProcess::clean_up') if $debug_mode_ct
       game_state.next_clean_up_step
-      DRCA.release_cyclics(@settings.cyclic_no_release)
+      release_cyclics(@settings.cyclic_no_release)
       if checkprep != 'None'
-        DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-        DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+        bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+        bput('release mana', 'You release all', "You aren't harnessing any mana")
       end
       if @tk_ammo
         waitrt?
@@ -1355,7 +1371,7 @@ class SpellProcess
         end
       end
       DRCA.cast_spell(moonblade_spell, @settings)
-      created_slivers = DRC.bput("break moonblade", "The slivers drift about", "dissipate without any benefit", "Break what?") == "The slivers drift about"
+      created_slivers = bput("break moonblade", "The slivers drift about", "dissipate without any benefit", "Break what?") == "The slivers drift about"
       retry_count = retry_count + 1
     end
     DRC.message("Failed to create slivers for telekinetic ammo after #{retry_count} attempts") unless created_slivers
@@ -1366,7 +1382,7 @@ class SpellProcess
     return unless @osrel_amount && DRSpells.active_spells['Osrel Meraud']
     return unless Time.now - @osrel_timer > 300
     @osrel_timer = Time.now
-    DRCA.infuse_om(!@osrel_no_harness, @osrel_amount)
+    infuse_om(!@osrel_no_harness, @osrel_amount)
   end
 
   def check_timer(game_state)
@@ -1374,8 +1390,8 @@ class SpellProcess
 
     game_state.cast_timer = nil
     if game_state.casting
-      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+      bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      bput('release mana', 'You release all', "You aren't harnessing any mana")
     end
     game_state.casting = false
   end
@@ -1418,8 +1434,8 @@ class SpellProcess
     return unless Flags['ct-need-bless']
     Flags.reset('ct-need-bless')
 
-    DRCA.prepare?('Bless', 1)
-    DRCA.cast?("cast #{DRC.right_hand || DRC.left_hand}")
+    prepare?('Bless', 1)
+    cast?("cast #{right_hand || left_hand}")
   end
 
   def check_ignite(game_state)
@@ -1429,7 +1445,7 @@ class SpellProcess
     return unless DRSpells.active_spells['Ignite']
 
     # Release the spell on the character
-    DRC.bput('release ignite', 'The warm feeling in your hand goes away', 'Release what')
+    bput('release ignite', 'The warm feeling in your hand goes away', 'Release what')
     # Wait for the spell on the weapon to be released (it can take a second or two to pulse)
     pause 1
   end
@@ -1441,7 +1457,7 @@ class SpellProcess
     return unless DRSpells.active_spells['Rutilor\'s Edge']
 
     # Release the spell on the character
-    DRC.bput('release rue', 'You sense the Rutilor\'s Edge spell fade away', 'Release what')
+    bput('release rue', 'You sense the Rutilor\'s Edge spell fade away', 'Release what')
     # Wait for the spell on the weapon to be released (it can take a second or two to pulse)
     pause 1
   end
@@ -1461,18 +1477,18 @@ class SpellProcess
     return unless ready_to_cast?(game_state)
 
     game_state.check_harness if @should_harness
-    DRCA.cast_spell(game_state)
+    cast_spell(game_state)
   end
 
   def check_invoke(game_state)
     return unless @should_invoke
     return if @cambrinth_invoke_exact_amount && game_state.charges_total.zero?
-    DRCA.find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
     @should_invoke = nil
     invoke_amount = @cambrinth_invoke_exact_amount ? game_state.charges_total : nil
     game_state.charges_total = nil
-    DRCA.invoke(@cambrinth, @dedicated_camb_use, invoke_amount)
-    DRCA.stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    invoke(@cambrinth, @dedicated_camb_use, invoke_amount)
+    stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
   end
 
   def cast_spell(game_state)
@@ -1488,7 +1504,7 @@ class SpellProcess
       end
     end
 
-    DRC.hide?(@hide_type) if game_state.hide_on_cast && game_state.use_stealth?
+    hide?(@hide_type) if game_state.hide_on_cast && game_state.use_stealth?
 
     if game_state.casting_sorcery
       @equipment_manager.stow_weapon(game_state.weapon_name)
@@ -1496,7 +1512,7 @@ class SpellProcess
 
     if game_state.casting_regalia
       result = DRCA.parse_regalia
-      if result.empty? # if not wearing a regalia, DRC.retreat, swap to regalia gearset, then cast
+      if result.empty? # if not wearing a regalia, retreat, swap to regalia gearset, then cast
         DRC.retreat
         @equipment_manager.wear_equipment_set?('regalia')
         @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill) if @settings.gear_sets['regalia'].include?(game_state.weapon_name)
@@ -1549,7 +1565,7 @@ class SpellProcess
     end
 
     if game_state.casting_moonblade
-      if DRC.left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?
+      if left_hand =~ /moon/ || game_state.brawling? || game_state.offhand?
         # The moonblade was summoned or refreshed while training something else
         DRCMM.wear_moon_weapon?
       end
@@ -1584,7 +1600,7 @@ class SpellProcess
     return if game_state.casting
     return unless @training_spells
     return if @training_spells_max_threshold && game_state.npcs.length > @training_spells_max_threshold
-    DRCA.release_cyclics if @release_cyclic_on_low_mana && DRStats.mana < @release_cyclic_threshold
+    release_cyclics if @release_cyclic_on_low_mana && DRStats.mana < @release_cyclic_threshold
     return if DRStats.mana < @training_spell_mana_threshold
 
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
@@ -1626,7 +1642,7 @@ class SpellProcess
   end
 
   def cast_runestone(data, game_state)
-    DRCA.prepare_to_cast_runestone?(data, @settings)
+    prepare_to_cast_runestone?(data, @settings)
     return unless DRCI.in_hands?(data['runestone_name'])
     prepare_spell(data, game_state, @buff_force_cambrinth)
     return unless DRCI.in_hands?(data['runestone_name'])
@@ -1738,7 +1754,7 @@ class SpellProcess
   def check_trader_magic(game_state) # handles starlight-depletion and regalia
     return unless DRStats.trader?
     if Flags['ct-starlight-depleted']
-      DRC.message '----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----'
+      message '----OUT OF STARLIGHT - DELETING STARLIGHT MAGIC----'
       @buff_spells.reject! { |spell| @buff_spells[spell]['starlight_threshold'] > -1 } # delete all buffs and offensive spells. Potential to add stellar collector support later
       @offensive_spells.reject! { |spell| spell['starlight_threshold'] > -1 }
       @aura_frequency = 0
@@ -1849,7 +1865,7 @@ class SpellProcess
 
   def cast_ritual(data, game_state)
     if summoned = game_state.summoned_info(game_state.weapon_skill)
-      DRCS.break_summoned_weapon(game_state.weapon_name)
+      break_summoned_weapon(game_state.weapon_name)
     else
       @equipment_manager.stow_weapon(game_state.weapon_name)
     end
@@ -1871,7 +1887,7 @@ class SpellProcess
   def prepare_spell(data, game_state, force_cambrinth = false)
     return unless data
 
-    data = DRCA.check_discern(data, @settings) if data['use_auto_mana']
+    data = check_discern(data, @settings) if data['use_auto_mana']
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
     echo("prepare spell: #{data}") if $debug_mode_ct
@@ -1885,12 +1901,12 @@ class SpellProcess
     command = data['prep_type'] if data['prep_type']
 
     if command == 'segue'
-      return if DRCA.segue?(data['abbrev'], data['mana'])
+      return if segue?(data['abbrev'], data['mana'])
       command = 'prep'
     end
 
     if data['cyclic']
-      DRCA.release_cyclics
+      release_cyclics
       game_state.casting_cyclic = true
     end
 
@@ -1976,6 +1992,7 @@ class SpellProcess
 end
 
 class PetProcess
+  include DRC
 
   def initialize(settings)
     echo('New Pet Process') if $debug_mode_ct
@@ -2041,7 +2058,7 @@ class PetProcess
   def command_zombie(command, game_state)
     return unless game_state.cfb_active?
 
-    case DRC.bput("command zombie #{command}", 'willing it to come back to you', 'You have already shifted', 'That is not a valid stance', 'is already right beside you', 'zombie shambles off with a groan', 'You sense a flicker of acknowledgement through the link', 'you sense your .+ shift into (a|an) \w+ stance', 'you sense your .+ behavior shift')
+    case bput("command zombie #{command}", 'willing it to come back to you', 'You have already shifted', 'That is not a valid stance', 'is already right beside you', 'zombie shambles off with a groan', 'You sense a flicker of acknowledgement through the link', 'you sense your .+ shift into (a|an) \w+ stance', 'you sense your .+ behavior shift')
     when 'is already right beside you'
       echo('  Zombie is present') if $debug_mode_ct
       @is_present = true
@@ -2059,6 +2076,9 @@ class PetProcess
 end
 
 class AbilityProcess
+  include DRC
+  include DRCA
+  include DRCT
 
   def initialize(settings)
     echo('New AbilityProcess') if $debug_mode_ct
@@ -2142,15 +2162,15 @@ class AbilityProcess
     return unless @paladin_use_badge
     return unless Time.now - UserVars.paladin_last_badge_use > @badge_reuse_cooldown
 
-    case DRC.bput("#{@paladin_badge_get_verb} my pilgrim badge", 'You take off', 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
+    case bput("#{@paladin_badge_get_verb} my pilgrim badge", 'You take off', 'You get', 'You remove', 'What were you referring to', 'You need a free hand', 'Remove what')
     when 'You get', 'You remove', 'You take off'
-      DRC.retreat
-      DRC.bput('pray my pilgrim badge', 'You think upon the immortals')
+      retreat
+      bput('pray my pilgrim badge', 'You think upon the immortals')
       UserVars.paladin_last_badge_use = Time.now
       waitrt?
-      DRC.bput("#{@paladin_badge_store_verb} my pilgrim badge", 'You put', 'You attach')
+      bput("#{@paladin_badge_store_verb} my pilgrim badge", 'You put', 'You attach')
     when 'What were you referring to'
-      DRC.message '***PILGRIM BADGE NOT FOUND! REMOVING FROM HUNT.***'
+      message '***PILGRIM BADGE NOT FOUND! REMOVING FROM HUNT.***'
       @paladin_use_badge = false
       return
     end
@@ -2160,7 +2180,7 @@ class AbilityProcess
     return unless @use_mana_glyph
     return unless Flags['glyph-mana-expired']
 
-    DRC.bput('glyph mana', 'You trace a glyph', 'You begin to trace')
+    bput('glyph mana', 'You trace a glyph', 'You begin to trace')
     Flags.reset('glyph-mana-expired')
     echo 'Used Glyph of Mana!' if $debug_mode_ct
   end
@@ -2279,6 +2299,8 @@ class AbilityProcess
 end
 
 class ManipulateProcess
+  include DRC
+  include DRCT
 
   def initialize(settings)
     echo('New ManipulateProcess') if $debug_mode_ct
@@ -2307,7 +2329,7 @@ class ManipulateProcess
   end
 
   def manipulate(game_state)
-    DRC.bput('manip stop all', 'You relax your will', 'But you aren')
+    bput('manip stop all', 'You relax your will', 'But you aren')
 
     manipulate_count = 0
     npc_occurrences = Hash.new(0)
@@ -2319,7 +2341,7 @@ class ManipulateProcess
       index = npc_occurrences[npc]
       ordinal_string = $ORDINALS[index]
 
-      case DRC.bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence', 'Manipulate what')
+      case bput("manipulate friendship #{ordinal_string} #{npc}", 'You\'re already manipulating', 'beyond your ken', 'You attempt to empathically manipulate', 'You strain', 'does not seem to have a life essence', 'Manipulate what')
       when 'does not seem to have a life essence' then
         game_state.construct(npc)
       else
@@ -2333,6 +2355,11 @@ class ManipulateProcess
 end
 
 class TrainerProcess
+  include DRC
+  include DRCT
+  include DRCI
+  include DRCMM
+  include DRCA
 
   def initialize(settings, equipment_manager)
     @equipment_manager = equipment_manager
@@ -2379,7 +2406,7 @@ class TrainerProcess
 
     @skill_map['Hunt'] = %w[Perception Scouting] if DRStats.ranger?
     @favor_god = settings.favor_god
-    if settings.favor_goal && @favor_god && /delicate/ =~ DRC.bput("tap #{@favor_god} orb", 'The orb is delicate', 'I could not find')
+    if settings.favor_goal && @favor_god && /delicate/ =~ bput("tap #{@favor_god} orb", 'The orb is delicate', 'I could not find')
       @training_abilities['Favor Orb'] = settings.favor_orb_rub_frequency
     end
 
@@ -2482,13 +2509,13 @@ class TrainerProcess
     when /^PercMana$/i
       moon_mage_perc(game_state)
     when /^Perc$/i
-      DRC.bput('perc', 'You reach out', 'Strangely, you can sense absolutely nothing.') unless game_state.retreating?
+      bput('perc', 'You reach out', 'Strangely, you can sense absolutely nothing.') unless game_state.retreating?
     when /^Perc Health$/i
-      DRC.bput('perc heal', 'You close your eyes')
+      bput('perc heal', 'You close your eyes')
     when /^Astro$/i
       astrology(game_state)
     when /^Flee$/i
-      waitfor('Obvious') unless DRC.bput('flee bluff', 'You begin', 'see anything engaged with you', 'You suddenly realize') == 'see anything engaged with you'
+      waitfor('Obvious') unless bput('flee bluff', 'You begin', 'see anything engaged with you', 'You suddenly realize') == 'see anything engaged with you'
     when /^App$/i
       appraise(game_state, '')
     when /^App Quick$/i
@@ -2496,46 +2523,46 @@ class TrainerProcess
     when /^App Careful$/i
       appraise(game_state, 'careful')
     when /^App Pouch$/i
-      DRC.retreat
-      DRC.bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
+      retreat
+      bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
     when /^App Bundle$/i
-      DRC.retreat
-      DRC.bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
+      retreat
+      bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
     when /^Summon (?<element>.*?) Domain$/i
-      DRC.retreat
-      DRC.bput("summon #{Regexp.last_match[:element]} domain", "turn your attention inward", "It isn't possible to perform", "Summon allows Warrior Mages", "Roundtime")
+      retreat
+      bput("summon #{Regexp.last_match[:element]} domain", "turn your attention inward", "It isn't possible to perform", "Summon allows Warrior Mages", "Roundtime")
       waitrt?
-      DRC.fix_standing
+      fix_standing
     when /^Tactics$/i
-      DRC.bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
+      bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty?
     when /^Analyze$/i
       analyze(game_state, 0)
     when /^Hunt$/i
-      DRC.bput('hunt', 'You take note of ', 'You find yourself unable to hunt in this area') unless game_state.retreating?
+      bput('hunt', 'You take note of ', 'You find yourself unable to hunt in this area') unless game_state.retreating?
     when /^Teach$/i
       UserVars.friends.select { |c| DRRoom.pcs.include?(c) }.each do |character|
-        DRC.bput("teach #{@combat_teaching_skill} to #{character}", 'You begin to', 'is already listening to you', 'is listening to someone else', 'I could not find who you were referring to', 'You have already offered', 'That person is too busy teaching', 'You are already teaching', 'You cannot teach two different classes at the same time', 'is not paying attention to you', 'You cannot listen to a teacher and teach', 'already trying to teach you something', 'trying to teach someone else')
+        bput("teach #{@combat_teaching_skill} to #{character}", 'You begin to', 'is already listening to you', 'is listening to someone else', 'I could not find who you were referring to', 'You have already offered', 'That person is too busy teaching', 'You are already teaching', 'You cannot teach two different classes at the same time', 'is not paying attention to you', 'You cannot listen to a teacher and teach', 'already trying to teach you something', 'trying to teach someone else')
       end
     when /^Pray$/i
-      DRC.bput("pray #{@favor_god}", 'You offer a quiet prayer', 'Clasping your hands humbly', 'You hum under your breath', 'You murmur under your breath', 'You proclaim cheerfully', 'You raise your voice', 'You glance heavenward', 'You quietly go over the mantra', 'Immersing yourself in your faith', 'You bow your head', 'You murmur softly to yourself', 'You pray in susurration', 'You raise your fist', 'You lift your chin proudly', 'Feeling your blood boiling', 'You sigh and say softly', 'You open your arms', 'You glance at your surroundings', 'You mutter a prayer', 'Aligning your thoughts', 'You grumble ominously', 'You offer a prayer', 'You pray quietly', 'You throw your head back', 'With a mirthful laugh', 'Smiling joyously', 'You chant solemnly', 'You roll your eyes heavenward', 'You intone serenely', 'You narrow your eyes', 'You take a deep breath', 'You recite fervently', 'With an exultant grin', 'With renewed purpose', 'Drawing your fist to your heart', 'Glancing furtively at the comforting', 'You close your eyes and slow', 'You still your thoughts and whisper', 'You prepare to take lives', 'You raise your hands lightly', 'Bristling up against a sudden', 'You slowly square your shoulders', 'You tap the center of your forehead', 'You whisper your prayer', 'With a pat you double-check', 'Quietly touching your lips')
+      bput("pray #{@favor_god}", 'You offer a quiet prayer', 'Clasping your hands humbly', 'You hum under your breath', 'You murmur under your breath', 'You proclaim cheerfully', 'You raise your voice', 'You glance heavenward', 'You quietly go over the mantra', 'Immersing yourself in your faith', 'You bow your head', 'You murmur softly to yourself', 'You pray in susurration', 'You raise your fist', 'You lift your chin proudly', 'Feeling your blood boiling', 'You sigh and say softly', 'You open your arms', 'You glance at your surroundings', 'You mutter a prayer', 'Aligning your thoughts', 'You grumble ominously', 'You offer a prayer', 'You pray quietly', 'You throw your head back', 'With a mirthful laugh', 'Smiling joyously', 'You chant solemnly', 'You roll your eyes heavenward', 'You intone serenely', 'You narrow your eyes', 'You take a deep breath', 'You recite fervently', 'With an exultant grin', 'With renewed purpose', 'Drawing your fist to your heart', 'Glancing furtively at the comforting', 'You close your eyes and slow', 'You still your thoughts and whisper', 'You prepare to take lives', 'You raise your hands lightly', 'Bristling up against a sudden', 'You slowly square your shoulders', 'You tap the center of your forehead', 'You whisper your prayer', 'With a pat you double-check', 'Quietly touching your lips')
     when /^Scream$/i
       DRC.bput('Scream conc', 'Inhaling deeply', 'There is nothing', 'You open your mouth, then close it suddenly, looking somewhat like a fish', 'Scream at what?') unless game_state.npcs.empty?
     when /^Khri Prowess$/i
       unless game_state.npcs.empty?
-        if DRCA.kneel_for_khri?(@kneel_khri, 'khri prowess')
-          DRC.retreat
+        if kneel_for_khri?(@kneel_khri, 'khri prowess')
+          retreat
           fput('kneel')
         end
-        DRC.bput('khri prowess', 'Remembering the mantra of mind over matter', 'You\'re already using the Prowess meditation.', 'previous use of the Prowess', 'Your body is willing', 'Your mind and body are willing')
-        if DRCA.kneel_for_khri?(@kneel_khri, 'khri prowess')
+        bput('khri prowess', 'Remembering the mantra of mind over matter', 'You\'re already using the Prowess meditation.', 'previous use of the Prowess', 'Your body is willing', 'Your mind and body are willing')
+        if kneel_for_khri?(@kneel_khri, 'khri prowess')
           waitrt?
-          DRC.fix_standing
+          fix_standing
         end
       end
      when /^Stealth$/i
       hide_action(game_state)
     when /^(Ret|Retreat) Stealth$/i
-      DRC.retreat
+      retreat
       hide_action(game_state)
     when /^Ambush Stun$/i
       return ambush_stun(game_state)
@@ -2553,7 +2580,7 @@ class TrainerProcess
     when /^PrayerMat$/i
       pray_mat(game_state)
     when /^Recall$/i
-      DRC.bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
+      bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
     when /^Barb Research Augmentation$/i
       DRC.bput('meditate research monkey', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Barb Research Warding$/i
@@ -2566,12 +2593,12 @@ class TrainerProcess
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
       game_state.sheath_whirlwind_offhand
-      DRC.retreat
+      retreat
       put('engage') unless game_state.npcs.empty? || game_state.retreating?
-      DRC.collect(@forage_item)
+      collect(@forage_item)
       waitrt?
       game_state.wield_whirlwind_offhand
-      DRC.kick_pile?
+      kick_pile?
     when /^Almanac$/i
       UserVars.almanac_last_use ||= Time.now - 600
       use_almanac(game_state)
@@ -2580,10 +2607,10 @@ class TrainerProcess
     when /^Herbs$/i
       if game_state.npcs.empty? || @combat_trainer_herbs_allowhands
         game_state.sheath_whirlwind_offhand
-        DRC.wait_for_script_to_complete('heal-remedy', ['quick'])
+        wait_for_script_to_complete('heal-remedy', ['quick'])
         game_state.wield_whirlwind_offhand
       else
-        DRC.wait_for_script_to_complete('heal-remedy', %w[quick nohands])
+        wait_for_script_to_complete('heal-remedy', %w[quick nohands])
       end
     when /^Tessera$/i
       invest_in_tessera(game_state)
@@ -2595,20 +2622,20 @@ class TrainerProcess
   private
 
   def hide_action(game_state)
-    if DRC.hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
-      stalked = DRC.bput('stalk', 'Stalk what',
+    if hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
+      stalked = bput('stalk', 'Stalk what',
                      'Try being out of sight',
                      'You move into position',
                      'already stalking',
                      'discovers you, ruining your hiding place') == ('You move into position' || 'already stalking')
-      DRC.bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
+      bput('stop stalk', "You're not stalking anything though", 'You stop stalking') if stalked
     end
-    DRC.bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden
+    bput('unhide', 'You come out of hiding', 'You slip out of hiding', 'But you are not', 'You try to creep out of hiding but your injuries cause you to stumble and crash to the ground!') if (game_state.npcs.empty? || @force_unhide) && hidden
   end
 
   def use_almanac(game_state)
     return unless Time.now - UserVars.almanac_last_use >= 600
-    return if DRC.left_hand && !game_state.currently_whirlwinding
+    return if left_hand && !game_state.currently_whirlwinding
     unless @almanac_skills.empty?
       training_skills = @almanac_skills.select { |skill| DRSkill.getxp(skill) < 18 }
       training_skill = game_state.sort_by_rate_then_rank(training_skills).first
@@ -2616,15 +2643,15 @@ class TrainerProcess
     end
 
     game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
-    DRC.retreat
-    DRC.bput('engage', 'You are already', 'You begin to', 'What do you') unless game_state.npcs.empty? || game_state.retreating?
-    DRC.bput("get my #{@almanac}", 'You get', 'What were')
+    retreat
+    fput('engage') unless game_state.npcs.empty? || game_state.retreating?
+    bput("get my #{@almanac}", 'You get', 'What were')
     if training_skill
-      DRC.bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
+      bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
     end
-    DRC.bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what')
+    bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what')
     waitrt?
-    DRC.bput("stow my #{@almanac}", 'You put', 'Stow what','You hold out')
+    bput("stow my #{@almanac}", 'You put', 'Stow what','You hold out')
     UserVars.almanac_last_use = Time.now
     game_state.wield_whirlwind_offhand if game_state.currently_whirlwinding
   end
@@ -2632,9 +2659,9 @@ class TrainerProcess
   def smite(game_state)
     return if game_state.npcs.empty?
     return if game_state.brawling? || game_state.offhand? || game_state.aimed_skill?
-    return if DRC.right_hand.nil?
+    return if right_hand.nil?
 
-    DRC.bput("smite", "Drawing strength from your conviction", "Drawing upon holy wrath", "You aren't close enough", "What are you trying to attack")
+    bput("smite", "Drawing strength from your conviction", "Drawing upon holy wrath", "You aren't close enough", "What are you trying to attack")
   end
 
   def meraud_commune(game_state)
@@ -2713,8 +2740,8 @@ class TrainerProcess
       game_state.wield_specific_weapon(@stun_weapon, @stun_weapon_skill)
     end
 
-    if DRC.hide?
-      DRC.bput('ambush stun', 'Wouldn\'t it be better if you used a melee weapon?', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime', 'is already out cold')
+    if hide?
+      bput('ambush stun', 'Wouldn\'t it be better if you used a melee weapon?', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime', 'is already out cold')
       pause
       waitrt?
     end
@@ -2731,15 +2758,15 @@ class TrainerProcess
     return unless @dirt_stacker
     return if @dirt_empty
 
-    unless DRC.bput("push my #{@dirt_stacker}",
+    unless bput("push my #{@dirt_stacker}",
                 'You push', 'have any dirt', "I don't think pushing") == 'You push'
       @dirt_empty = true
       return
     end
 
     dirt_in_hand = true
-    if DRC.hide?
-      dirt_in_hand = DRC.bput(
+    if hide?
+      dirt_in_hand = bput(
         'ambush choke',
         'Wouldn\'t it be better if you used a melee weapon?',
         'You must be hidden or invisible to ambush',
@@ -2754,7 +2781,7 @@ class TrainerProcess
     end
 
     return unless dirt_in_hand
-    DRC.bput("put my dirt in my #{@dirt_stacker}",
+    bput("put my dirt in my #{@dirt_stacker}",
          'dumping some dirt', 'What were you referring')
   end
 
@@ -2762,16 +2789,16 @@ class TrainerProcess
     return if game_state.npcs.empty?
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
-    case DRC.bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
+    case bput('analyze', 'roundtime', 'Analyze what', 'Your analysis reveals a massive opening', /You reveal an? .* (?:weakness|opening)/, /Your analysis reveals an? .* (?:weakness|opening)/, 'You fail to find any holes', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack', 'Bumbling, you slip') # unless
     when 'Analyze what'
-      case DRC.bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
+      case bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
       when 'There is nothing else', 'What are you trying'
-        DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
+        fput('engage')
         pause 2
       end
       analyze(game_state, fail_count)
     when 'You must be closer'
-      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
+      fput('engage')
     when 'Your analysis reveals a massive opening'
       return
     when 'You fail to find any holes'
@@ -2788,7 +2815,7 @@ class TrainerProcess
     target = (game_state.npcs - @no_app).first
     return unless target
     return if DRSkill.getrank('Appraisal') < 76
-    return if DRC.bput("app #{target} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what') != 'Perhaps that'
+    return if bput("app #{target} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what') != 'Perhaps that'
 
     @no_app << target
   end
@@ -2796,20 +2823,20 @@ class TrainerProcess
   def moon_mage_perc(game_state)
     return if game_state.retreating?
 
-    DRC.retreat unless DRSkill.getrank('Attunement') > 500 || DRStats.trader?
-    DRC.bput('perc mana', 'You reach out')
+    retreat unless DRSkill.getrank('Attunement') > 500 || DRStats.trader?
+    bput('perc mana', 'You reach out')
   end
 
   def astrology(game_state)
     return if game_state.retreating?
 
-    DRC.retreat
+    retreat
     if DRSkill.getrank('Astrology') <= 120
       DRCMM.predict('weather')
       waitrt?
-      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
+      fput('engage')
     else
-      DRC.retreat
+      retreat
       check_heavens(game_state)
       Flags.reset('bad-search')
     end
@@ -2883,14 +2910,14 @@ class TrainerProcess
   end
 
   def execute_predict
-    DRC.retreat
+    retreat
     case DRCMM.predict('future')
     when 'You are far too occupied by present matters to immerse yourself in matters of the future'
-      DRC.retreat
+      retreat
       waitrt?
       execute_predict
     when 'You look inside yourself'
-      DRCI.stow_hands
+      stow_hands
       return
     end
   end
@@ -2902,8 +2929,8 @@ class TrainerProcess
     DRC.retreat
     return unless /inside your (.*)\./ =~ DRC.bput("get my tessera", 'You get a .+ tessera from inside your (.*).', 'What were you')
     container = DRC.get_noun(Regexp.last_match(1))
-    game_state.starlight_values['level'] = 0 if DRC.bput('ask my tessera about invest', 'You send your') == 'You send your'
-    DRC.bput("put my tessera in my #{container}", 'You put', 'What were you')
+    game_state.starlight_values['level'] = 0 if bput('ask my tessera about invest', 'You send your') == 'You send your'
+    bput("put my tessera in my #{container}", 'You put', 'What were you')
     DRCI.stow_hand('left') if DRC.left_hand.include?('tessera')
     DRCI.stow_hand('right') if DRC.right_hand.include?('tessera')
   end
@@ -2939,6 +2966,7 @@ class TrainerProcess
 end
 
 class AttackProcess
+  include DRC
 
   def initialize(settings)
     echo('New AttackProcess') if $debug_mode_ct
@@ -3063,7 +3091,7 @@ class AttackProcess
     # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
     unless maneuver_success
       if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush? || game_state.ambush_stun_training?
-        DRC.hide?(@hide_type)
+        hide?(@hide_type)
       end
 
       verb = game_state.melee_attack_verb
@@ -3080,14 +3108,14 @@ class AttackProcess
         end
       end
 
-      DRC.bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
+      bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
     pause
     waitrt?
 
     if reget(5, 'flying too high for you to attack')
-      case DRC.bput('face next', 'There is nothing', 'You turn to face', 'Face what')
+      case bput('face next', 'There is nothing', 'You turn to face', 'Face what')
       when 'There is nothing'
         pause 5
       end
@@ -3102,36 +3130,36 @@ class AttackProcess
     end
 
     if reget(5, 'You aren\'t close enough to attack', 'It would help if you were closer')
-      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
+      fput('engage')
       pause 6
     else
       game_state.action_taken
     end
     return unless reget(5, 'You need two hands')
 
-    fput('stow left') if DRC.left_hand && DRC.left_hand !~ /\b#{game_state.weapon_name}/i
-    fput('stow right') if DRC.right_hand && DRC.right_hand !~ /\b#{game_state.weapon_name}/i
+    fput('stow left') if left_hand && left_hand !~ /\b#{game_state.weapon_name}/i
+    fput('stow right') if right_hand && right_hand !~ /\b#{game_state.weapon_name}/i
   end
 
   def attack_thrown(game_state)
     attack_action = game_state.thrown_attack_verb
     attack_action += ' left' if game_state.offhand?
-    DRC.bput(attack_action, 'roundtime', 'What are you trying to')
+    bput(attack_action, 'roundtime', 'What are you trying to')
     waitrt?
 
     if game_state.weapon_name == 'blades'
-      until /(Stow what|You put your)/ =~ DRC.bput('stow blade', 'Stow what', 'You pick up .*blade', 'You put your')
+      until /(Stow what|You put your)/ =~ bput('stow blade', 'Stow what', 'You pick up .*blade', 'You put your')
       end
     end
 
     retrieve_action = game_state.thrown_retrieve_verb
-    case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke")
+    case bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke")
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work
-      DRC.bput("get #{game_state.weapon_name}", 'You pick up', 'You get')
+      bput("get #{game_state.weapon_name}", 'You pick up', 'You get')
     when 'You catch'
-      DRC.bput('swap', 'You move', 'You have nothing') if game_state.offhand?
+      bput('swap', 'You move', 'You have nothing') if game_state.offhand?
     end
 
     game_state.action_taken
@@ -3145,10 +3173,10 @@ class AttackProcess
     # Occasionally the game borks and the phrases like "Face what?"
     # appear before the text that you fired your weapon.
     # So, we use a flag to see if the message ever appears
-    # rather than relying on the first message returned from DRC.bput.
+    # rather than relying on the first message returned from bput.
     Flags.reset('ct-ranged-ammo')
 
-    result = DRC.bput(command, /you (fire|poach|snipe)/i, /isn't loaded/i, /There is nothing/i, /But your/i, /I could not find/i, /with no effect and falls (to the ground|to your feet)/i, /Face what/i, /How can you (poach|snipe)/i, /you don't feel like fighting right now/i, /That weapon must be in your right hand to fire/i, /But you don't have a ranged weapon in your hand to fire with/i)
+    result = bput(command, /you (fire|poach|snipe)/i, /isn't loaded/i, /There is nothing/i, /But your/i, /I could not find/i, /with no effect and falls (to the ground|to your feet)/i, /Face what/i, /How can you (poach|snipe)/i, /you don't feel like fighting right now/i, /That weapon must be in your right hand to fire/i, /But you don't have a ranged weapon in your hand to fire with/i)
     waitrt?
 
     case result
@@ -3198,9 +3226,9 @@ class AttackProcess
       echo("Current Time > @firing_timer: #{Time.now >= @firing_timer}") if $debug_mode_ct
       echo("Current Time < @firing_timer: #{Time.now <= @firing_timer}") if $debug_mode_ct
       echo("Flag check: ct-ranged-ready: #{Flags['ct-ranged-ready']}") if $debug_mode_ct
-      command = if game_state.use_stealth_ranged? && DRC.hide?(@hide_type)
+      command = if game_state.use_stealth_ranged? && hide?(@hide_type)
                   @stealth_attack_aimed_action
-                elsif game_state.use_stealth_attack? && DRC.hide?(@hide_type)
+                elsif game_state.use_stealth_attack? && hide?(@hide_type)
                   @stealth_attack_aimed_action
                 else
                   'shoot'
@@ -3235,12 +3263,12 @@ class AttackProcess
         next unless skill.include?('Thrown')
         retrieve_action = "get my #{weapon_name}"
         retrieve_action = 'invoke' if action.include?('hurl')
-        case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch',\
+        case bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch',\
                             'What were you', "You don't have any bonds to invoke")
         when 'What were you'
           # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
           # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work
-          DRC.bput("get #{weapon_name}", 'You pick up', 'You get', 'What were')
+          bput("get #{weapon_name}", 'You pick up', 'You get', 'What were')
         end
       end
 
@@ -3253,7 +3281,7 @@ class AttackProcess
         matches = ['You get', 'You draw out', 'You draw your', 'You pick up', "You're already holding that", 'You are already holding that'] if @get_actions.include?(first_word)
         matches = ['Roundtime', "You aren't close enough to attack", 'What are you', 'There is nothing'] if @rt_actions.include?(first_word)
         matches = ['You put', 'You sheathe', 'Sheathing a', 'Sheathing some'] if @stow_actions.include?(first_word)
-        DRC.bput(action.strip, matches)
+        bput(action.strip, matches)
         pause 0.25
         waitrt?
       end
@@ -3294,8 +3322,8 @@ class AttackProcess
         # Occasionally, there may be no game output after loading.
         # To be on the safe side, we do two attempts to get output.
         Flags.reset('ct-ranged-loaded')
-        load_weapon_result = DRC.bput('load arrows', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
-        load_weapon_result = DRC.bput('load arrows', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        load_weapon_result = bput('load arrows', { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
+        load_weapon_result = bput('load arrows', *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
         case load_weapon_result
         when *load_weapon_failure
           dual_load = false # fallback to single load
@@ -3312,8 +3340,8 @@ class AttackProcess
         Flags.reset('ct-ranged-loaded')
         Flags.reset('ct-using-repeating-crossbow')
 
-        load_weapon_result = DRC.bput("load my #{game_state.weapon_name}", { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
-        load_weapon_result = DRC.bput("load my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
+        load_weapon_result = bput("load my #{game_state.weapon_name}", { 'timeout' => 1, 'suppress_no_match' => true }, *load_weapon_success, *load_weapon_failure)
+        load_weapon_result = bput("load my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure) unless Flags['ct-ranged-loaded']
         waitrt?
 
         case load_weapon_result
@@ -3323,7 +3351,7 @@ class AttackProcess
         when *load_weapon_success
           # Check if loading a repeating crossbow because we need to then push ammo into the chamber
           if Flags['ct-using-repeating-crossbow']
-            case DRC.bput("push my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure)
+            case bput("push my #{game_state.weapon_name}", *load_weapon_success, *load_weapon_failure)
             when *load_weapon_failure
               abort_attack_aimed(game_state)
               return
@@ -3361,10 +3389,10 @@ class AttackProcess
   end
 
   def execute_aiming_action?(action, game_state)
-    case DRC.bput(action, 'Roundtime', 'close enough', 'What are you', 'There is nothing', 'must be closer', 'Bumbling, you slip')
+    case bput(action, 'Roundtime', 'close enough', 'What are you', 'There is nothing', 'must be closer', 'Bumbling, you slip')
     when 'close enough', 'must be closer'
       return false if game_state.retreating?
-      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
+      fput('engage')
       pause 2.5
     when 'What are you', 'There is nothing'
       return false
@@ -3403,7 +3431,7 @@ class AttackProcess
       /Strangely, you don't feel like fighting right now/
     ]
 
-    case DRC.bput("aim", *aim_success_messages, *unloaded_messages, *no_enemy_messages, *wait_and_retry_messages)
+    case bput("aim", *aim_success_messages, *unloaded_messages, *no_enemy_messages, *wait_and_retry_messages)
     when *aim_success_messages
       game_state.loaded = true
       check_firing_time
@@ -3426,9 +3454,9 @@ class AttackProcess
       pause 1
     else
       game_state.set_dance_queue
-      case DRC.bput(game_state.next_dance_action, 'You must be closer', 'There is nothing else', 'What are you trying', /.*/)
+      case bput(game_state.next_dance_action, 'You must be closer', 'There is nothing else', 'What are you trying', /.*/)
       when 'You must be closer', 'There is nothing else', 'What are you trying'
-        DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
+        fput('engage')
         pause 2
       end
       pause 0.5
@@ -3482,7 +3510,7 @@ class AttackProcess
       /^You are unable to focus on performing a maneuver while aiming at an enemy/
     ]
 
-    attempt = DRC.bput("maneuver #{action}", *maneuver_success_messages, *maneuver_failure_messages)
+    attempt = bput("maneuver #{action}", *maneuver_success_messages, *maneuver_failure_messages)
 
     waitrt?
 
@@ -3548,7 +3576,7 @@ class AttackProcess
     # The majority of the time, if not always, the words to reference the item are the first and last (e.g. matte sphere).
     ammo_parts = ammo.strip.split(' ')
     ammo = [ammo_parts.first, ammo_parts.last].compact.uniq.join(' ')
-    case DRC.bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
+    case bput("stow my #{ammo}", 'You pick up', 'You put your', 'Stow what', 'needs to be tended to be removed')
     when 'You pick up', 'You put your'
       stow_ammo(ammo, quantity - 1)
     when 'Stow what'
@@ -3562,6 +3590,7 @@ class AttackProcess
 end
 
 class CombatTrainer
+  include DRC
 
   attr_reader :running
 
@@ -3621,7 +3650,7 @@ class CombatTrainer
 
     Flags.add('last-stance', 'Setting your Evasion stance to \d+%, your Parry stance to \d+%, and your Shield stance to \d+%.  You have \d+ stance points left')
 
-    DRC.bput("stance set #{settings.default_stance}", 'Setting your')
+    bput("stance set #{settings.default_stance}", 'Setting your')
 
     @stop = false
     @running = true
@@ -3680,6 +3709,9 @@ class CombatTrainer
 end
 
 class GameState
+  include DRCA
+  include DRCS
+  include DRC
 
   $martial_skills = ['Brawling']
   $edged_skills = ['Small Edged', 'Large Edged', 'Twohanded Edged']
@@ -3812,12 +3844,12 @@ class GameState
     @stances.keys do |key|
       settings = @stances[key]
       unless (settings & %w[evasion parry shield]).empty?
-        DRC.message 'Please update to the latest version of stance: settings!'
+        message 'Please update to the latest version of stance: settings!'
         settings.map! { |x| { 'parry' => 'Parry Ability', 'shield' => 'Shield Usage', 'evasion' => 'Evasion' }[x] }
       end
       (['Evasion', 'Shield Usage', 'Parry Ability'] - settings).each { |x| settings << x }
       unless settings.size == 3
-        DRC.message "Error: stance settings #{settings} include invalid stance."
+        message "Error: stance settings #{settings} include invalid stance."
         exit
       end
     end
@@ -4056,7 +4088,7 @@ class GameState
   end
 
   def sheath_whirlwind_offhand
-    return unless currently_whirlwinding && DRC.left_hand
+    return unless currently_whirlwinding && left_hand
     @equipment_manager.stow_weapon(whirlwind_offhand_name)
   end
 
@@ -4248,7 +4280,7 @@ class GameState
     @retreating = @retreat_threshold && npcs.length >= @retreat_threshold
   end
 
-  def DRC.retreat_weapons
+  def retreat_weapons
     weapon_training.select { |skill, _| $ranged_skills.include?(skill) }
   end
 
@@ -4351,7 +4383,7 @@ class GameState
     @dancing
   end
 
-  def DRC.retreating?
+  def retreating?
     @retreating
   end
 
@@ -4474,10 +4506,10 @@ class GameState
     echo("check_charging?: #{next_charge}") if $debug_mode_ct
 
     return true if next_charge.zero?
-    DRCA.find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
-    @charges = [] unless DRCA.charge?(@cambrinth, next_charge)
+    find_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    @charges = [] unless charge?(@cambrinth, next_charge)
 
-    DRCA.stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
+    stow_cambrinth(@cambrinth, @stored_cambrinth, @cambrinth_cap)
 
     true
   end
@@ -4537,7 +4569,7 @@ class GameState
       return
     end
 
-    DRCA.harness_mana(@charges.flatten)
+    harness_mana(@charges.flatten)
 
     @charges = []
   end
@@ -4555,11 +4587,11 @@ class GameState
   def prepare_summoned_weapon(weapon_already_summoned)
     info = summoned_info(weapon_skill)
 
-    DRCS.summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
-    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot) if weapon_already_summoned || DRStats.moon_mage?
-    DRCS.turn_summoned_weapon if info['turn']
-    DRCS.push_summoned_weapon if info['push']
-    DRCS.pull_summoned_weapon if info['pull']
+    summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
+    shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot) if weapon_already_summoned || DRStats.moon_mage?
+    turn_summoned_weapon if info['turn']
+    push_summoned_weapon if info['push']
+    pull_summoned_weapon if info['pull']
   end
 
   def can_ambush_stun?
@@ -4791,7 +4823,7 @@ class GameState
     return false if combo_type != 'flame' && !Flags["ct-#{combo_type}-ready"] && DRStats.barbarian?
     return false if DRSkill.getrank('Expertise') < expertise_requirement
 
-    result = DRC.bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?')
+    result = bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any','What are you trying to attack\?')
     waitrt?
 
     case result
@@ -4799,11 +4831,11 @@ class GameState
       Flags.reset("ct-#{combo_type}-ready")
       return false
     when 'You must be closer'
-      DRC.bput('engage', 'You are already', 'You begin to', 'What do you')
+      fput('engage')
     when 'You fail to find any'
       perform_analyze?(combo_type, expertise_requirement)
     when 'Analyze what?'
-      case DRC.bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
+      case bput('face next', 'There is nothing else', 'You turn', 'What are you trying', 'Face what')
       when 'You turn'
         return perform_analyze?(combo_type, expertise_requirement)
       end
@@ -4813,7 +4845,7 @@ class GameState
     end
 
     text = result.match(/by landing an? (.*)\.$/).to_a[1]
-    @analyze_combo_array = DRC.list_to_nouns(text)
+    @analyze_combo_array = list_to_nouns(text)
 
     true
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3237,7 +3237,7 @@ class AttackProcess
       game_state.clear_aim_queue
       game_state.loaded = false
       @firing_check = 0
-      echo("@firing_check reset normal fire: #{@firing_check}") if debug_mode_ct
+      echo("@firing_check reset normal fire: #{@firing_check}") if $debug_mode_ct
       waitrt?
     elsif game_state.loaded && !game_state.aiming_trainables.empty?
       skill = game_state.determine_aiming_skill

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3543,7 +3543,7 @@ class AttackProcess
         end
         game_state.loaded = false
         @firing_check = 0
-        echo("@firing_check reset on maneuver fire: #{@firing_check}") if debug_mode_ct
+        echo("@firing_check reset on maneuver fire: #{@firing_check}") if $debug_mode_ct
       end
 
       # Woot! Barbarian reduced their maneuver cooldown so


### PR DESCRIPTION
Inverted timer function, added incremental reduction in time-to-fire to break check_firing_time loops.

added @firing_check resets after each instance of game_state.loaded becoming false, in order that we not skip the initial condition on the first time check (which sets the disparity between now and next fire) when we start aiming after a fresh load.

added some debug lines to help with testing.

```
game_state.clear_aim_queue if Flags['ct-ranged-ready']
```
This line was leaving ct with nothing to do when full-aim message arrived, but the conditionals weren't passing the firing command(still not sure why) so i moved the flag opposite our timer. As long as EITHER the full aim message has arrived, OR the time has expired, we get a fire command, but until then, we keep cycling fillers.

Best way I've found to recreate the bug was commenting out aim_fillers entirely (4425 in the current version), do ranged weapons only, no offhand attacks, and only training abilities was combat-maneuvers. 