### PR TITLE
[script][combat-trainer] - Handle message when mob already dissected

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -859,7 +859,7 @@ class LootProcess
   end
 
   def dissected?(mob_noun, game_state)
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing further",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'


### PR DESCRIPTION
Reported by Xelten in Discord: https://discord.com/channels/745675889622384681/912127186419482664/991337067265130526

```
When you try to dissect something while hunting with someone else, you can occasionally get this message that combat-trainer doesn't recognize as a "you should just move on" thing:  The corpse has been defiled already.  You'll learn nothing from the remains.
```

Adjusted an existing bput failure message to also catch this failure message. The method return false automatically if we fall through all the case/when statements.