### PR TITLE
combat-trainer - add prefix to bput on line 856

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -853,7 +853,7 @@ class LootProcess
   end
 
   def dissected?(mob_noun, game_state)
-    case bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
+    case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That's going to be hard","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered'


### PR DESCRIPTION
Added missing DRC. prefix for the bput on line 856