### PR TITLE
[scripts] [combat-trainer] Gentle tweak to necro_healing routine

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1777,10 +1777,11 @@ class SpellProcess
 
   def check_consume(game_state)
     return unless DRStats.necromancer?
+    return unless @siphon_vit_threshold
     return unless @necromancer_healing
     return if game_state.casting
 
-    if DRStats.health <= @siphon_vit_threshold && @necromancer_healing['Siphon Vitality'] && !game_state.npcs.empty?
+    if DRStats.health <= @siphon_vit_threshold.to_i && @necromancer_healing['Siphon Vitality'] && !game_state.npcs.empty?
       @necromancer_healing['Siphon Vitality']['prep'] = 'target'
       prepare_spell(@necromancer_healing['Siphon Vitality'], game_state, true)
       return

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1777,7 +1777,6 @@ class SpellProcess
 
   def check_consume(game_state)
     return unless DRStats.necromancer?
-    return unless @siphon_vit_threshold
     return unless @necromancer_healing
     return if game_state.casting
 


### PR DESCRIPTION
Reddemed necros have a metaspell that changes how Siphon Vitality works, and changes the spell into a vitality barrier, instead of  a vitality heal. Hence, I set that threshold to nil, which led to...
```
--- Lich: error: comparison of Integer with nil failed
        combat-trainer:1798:in `<='
        combat-trainer:1798:in `check_consume'
--- Lich: combat-trainer has exited.
```
`to_i` makes the nil into a zero, and it isn't a problem anymore.