### PR TITLE
[data] [base.yaml] Set health_threshold default to zero

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1386,7 +1386,7 @@ listen_skills:
 waggle_sets:
 
 # Vitality/spirit level when combat-trainer will log you or afk will start warning about low health/spirit when you get halfway between 100 and this number.
-health_threshold: 50
+health_threshold: 0
 depart_on_death: false
 depart_type: item
 afk_justice_threshold: 4


### PR DESCRIPTION
setting health_threshold: to zero so afk.lic doesn't auto log.  this should be an option people opt into, not a default.