### PR TITLE
[script] [combat-trainer] Add setting to ignore weapon mindstates [2 of 2]

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -28,7 +28,8 @@ class SetupProcess
     echo("  @cycle_regalia: #{@cycle_regalia}") if $debug_mode_ct
     @default_armor = settings.default_armor_type
     echo("  @default_armor: #{@default_armor}") if $debug_mode_ct
-
+    @ignore_weapon_mindstate = settings.combat_trainer_ignore_weapon_mindstate
+    echo("  @ignore_weapon_mindstate: #{@ignore_weapon_mindstate}") if $debug_mode_ct
     @gearsets = settings.gear_sets
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
@@ -197,6 +198,7 @@ class SetupProcess
 
   def determine_next_to_train(game_state, weapon_training, ending_ranged)
     return unless game_state.skill_done? || !weapon_training[game_state.weapon_skill] || ending_ranged
+    return if @ignore_weapon_mindstate
     #check if all weapons are maxed exp to prevent rapid cycling
     if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
       echo 'all weapons locked, not switching' if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -6,7 +6,6 @@ custom_require.call(%w[common common-arcana common-healing common-items common-s
 class SetupProcess
 
   def initialize(settings, equipment_manager)
-    $debug_mode_ct = true
     @equipment_manager = equipment_manager
     echo('New SetupProcess') if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -6,6 +6,7 @@ custom_require.call(%w[common common-arcana common-healing common-items common-s
 class SetupProcess
 
   def initialize(settings, equipment_manager)
+    $debug_mode_ct = true
     @equipment_manager = equipment_manager
     echo('New SetupProcess') if $debug_mode_ct
 
@@ -198,12 +199,15 @@ class SetupProcess
 
   def determine_next_to_train(game_state, weapon_training, ending_ranged)
     return unless game_state.skill_done? || !weapon_training[game_state.weapon_skill] || ending_ranged
-    return if @ignore_weapon_mindstate
-    #check if all weapons are maxed exp to prevent rapid cycling
-    if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
-      echo 'all weapons locked, not switching' if $debug_mode_ct
-      return
+    
+    unless @ignore_weapon_mindstate
+      #check if all weapons are maxed exp to prevent rapid cycling
+      if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
+        echo 'all weapons locked, not switching' if $debug_mode_ct
+        return
+      end
     end
+
 
     echo('new skill needed for training') if $debug_mode_ct
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -307,6 +307,8 @@ zombie:
   behavior: defensive
 # a hash of weapon skills and the weapons used to train them. They must be defined in gear
 weapon_training:
+# Tells Ct to ignore mindstates, allowing one to farm whilst mindlocked, or with capped weapons
+combat_trainer_ignore_weapon_mindstate:
 # how many mindstates to use a weapon for
 combat_trainer_target_increment: 3
 # how many actions to do if you dont hit the mindstate goal before swapping weapons

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -308,7 +308,7 @@ zombie:
 # a hash of weapon skills and the weapons used to train them. They must be defined in gear
 weapon_training:
 # Tells Ct to ignore mindstates, allowing one to farm whilst mindlocked, or with capped weapons
-combat_trainer_ignore_weapon_mindstate:
+combat_trainer_ignore_weapon_mindstate: false
 # how many mindstates to use a weapon for
 combat_trainer_target_increment: 3
 # how many actions to do if you dont hit the mindstate goal before swapping weapons


### PR DESCRIPTION
~~Depends on https://github.com/rpherbig/dr-scripts/pull/5892~~

Adds setting `combat_trainer_ignore_weapon_mindstate` which when set, tells CT to ignore mindstates, and just work on action counts. Allows farming with capped weapons.