### PR TITLE
[script][workorders] Support for Additional Materials

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -534,7 +534,7 @@ class Craft
                  bput("count my burlap cloth", 'You count out \d+ yards').scan(/\d+/).first.to_i
                end
     stock_needed = ((fabric_volumes - existing) / 10.0).ceil
-    order_fabric(crafting_data['stock-room'], stock_needed, crafting_data['sew-stock-number'], 'burlap cloth')
+    order_fabric(crafting_data['stock-room'], stock_needed, crafting_data['stock']['burlap']['stock-number'], 'burlap cloth')
   end
 
   def check_wood

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -1,4 +1,81 @@
 ---
+stock:
+  bronze:
+    stock-volume: 5
+    stock-number: 11
+    stock-name: bronze
+    stock-value: 562
+  steel:
+    stock-volume: 10
+    stock-number: 9
+    stock-name: steel 
+    stock-value: 1443
+  linen:
+    stock-volume: 10
+    stock-number: 7
+    stock-name: linen
+    stock-value: 750
+  burlap:
+    stock-volume: 10
+    stock-number: 8
+    stock-name: burlap
+    stock-value: 437
+  wool:
+    stock-volume: 10
+    stock-number: 9
+    stock-name: wool
+    stock-value: 656
+  silk:
+    stock-volume: 10
+    stock-number: 10
+    stock-name: silk
+    stock-value: 1125
+  yarn:
+    stock-volume: 100
+    stock-number: 13
+    stock-name: wool
+    stock-value: 625
+  alabaster:
+    stock-volume: 3
+    stock-number: 1
+    stock-name: alabaster
+    stock-value: 218
+  granite:
+    stock-volume: 3
+    stock-number: 3
+    stock-name: granite
+    stock-value: 312
+  marble:
+    stock-volume: 3
+    stock-number: 5
+    stock-name: marble
+    stock-value: 312
+  deer:
+    stock-volume: 10
+    stock-number: 7
+    stock-name: deer
+    stock-value: 125
+  wolf:
+    stock-volume: 10
+    stock-number: 8
+    stock-name: wolf
+    stock-value: 200
+  pine:
+    stock-volume: 5
+    stock-number: 9
+    stock-name: pine
+    stock-value: 625
+  maple:
+    stock-volume: 5
+    stock-number: 10
+    stock-name: maple
+    stock-value: 500
+  balsa:
+    stock-volume: 10
+    stock-number: 11
+    stock-name: balsa
+    stock-value: 562
+  
 blacksmithing:
   Crossing: &zoluren_blacksmithing
     npc: Yalda
@@ -50,8 +127,6 @@ blacksmithing:
     repair-npc: clerk
     stock-volume: 5
     stock-room: 8775
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 8773
     idle-room: 8775
   Leth Deriel:
@@ -99,8 +174,6 @@ blacksmithing:
     repair-npc: clerk
     stock-volume: 5
     stock-room: 19243
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 19264
     idle-room: 19246
   Muspar'i:
@@ -138,8 +211,6 @@ blacksmithing:
     repair-npc: Rokumru
     stock-volume: 5
     stock-room: 11264
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 14350
     idle-room: 11260
     part-room: 11263
@@ -183,8 +254,6 @@ blacksmithing:
     repair-npc: clerk
     stock-volume: 5
     stock-room: 8785
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 8787
     idle-room: 8785
   Langenfirth:
@@ -207,8 +276,6 @@ blacksmithing:
       - 4432
     stock-volume: 5
     stock-room: 4434
-    stock-number: 11
-    stock-name: bronze ingot
     repair-room: 8013
     repair-npc: clerk
     idle-room: 4418
@@ -276,10 +343,7 @@ blacksmithing:
     finisher-number: 6
     repair-room: 16409
     repair-npc: clerk
-    stock-volume: 5
     stock-room: 16405
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 16412
     idle-room: 16405
   Ratha:
@@ -321,10 +385,7 @@ blacksmithing:
     finisher-number: 6
     repair-room: 10755
     repair-npc: clerk
-    stock-volume: 5
     stock-room: 10758
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 10767
     idle-room: 10765
   Aesry:
@@ -357,10 +418,7 @@ blacksmithing:
     finisher-number: 6
     repair-room: 17692
     repair-npc: clerk
-    stock-volume: 5
     stock-room: 17694
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 17690
     idle-room: 17689      
   Hibarnhvidar: &forfedhar_blacksmithing
@@ -401,10 +459,7 @@ blacksmithing:
     finisher-number: 6
     repair-room: 8887
     repair-npc: clerk
-    stock-volume: 5
     stock-room: 8894
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 8895
     idle-room: 8893
   Fang Cove:
@@ -440,10 +495,7 @@ blacksmithing:
     finisher-number: 6
     repair-room: 9143
     repair-npc: clerk
-    stock-volume: 5
     stock-room: 9132
-    stock-number: 11
-    stock-name: bronze ingot
     trash-room: 14881
     idle-room: 9136
   Mer'Kresh:
@@ -481,10 +533,7 @@ blacksmithing:
     finisher-number: 6
     repair-room: 11807
     repair-npc: Diwitt
-    stock-volume: 5
     stock-room: 8811
-    stock-name: bronze ingot
-    stock-number: 11
     trash-room: 8813
     idle-room: 8808
   Boar Clan:
@@ -522,10 +571,6 @@ tailoring:
     repair-npc: clerk
     stock-room: 16667
     tool-room: 16668
-    sew-stock-number: 8
-    sew-stock-name: burlap
-    knit-stock-number: 13
-    knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 16661
   Leth Deriel:
@@ -558,10 +603,6 @@ tailoring:
     repair-npc: clerk
     stock-room: 9716
     tool-room: 9717
-    sew-stock-number: 8
-    sew-stock-name: burlap
-    knit-stock-number: 13
-    knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 9720
   Langenfirth:
@@ -596,10 +637,6 @@ tailoring:
     repair-npc: clerk
     stock-room: 10939
     tool-room: 10938
-    sew-stock-number: 8
-    sew-stock-name: burlap
-    knit-stock-number: 13
-    knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 19333
   Ratha:
@@ -625,10 +662,6 @@ tailoring:
     repair-npc: clerk
     stock-room: 10746
     tool-room: 10749
-    sew-stock-number: 8
-    sew-stock-name: burlap
-    knit-stock-number: 13
-    knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 10744
   Fang Cove:
@@ -656,10 +689,6 @@ tailoring:
     repair-npc: clerk
     stock-room: 9125
     tool-room: 9124
-    sew-stock-number: 8
-    sew-stock-name: burlap
-    knit-stock-number: 13
-    knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 9127
   Muspar'i:
@@ -687,10 +716,6 @@ tailoring:
     repair-npc: Mhhrval
     stock-room: 11252
     tool-room: 11253
-    sew-stock-number: 8
-    sew-stock-name: burlap
-    knit-stock-number: 13
-    knit-stock-name: wool
     pattern-book: tailoring
     idle-room: 11251
   Hibarnhvidar:
@@ -715,9 +740,6 @@ shaping:
     repair-room: 19209
     repair-npc: Rangu
     stock-room: 8864
-    stock-number: 10
-    stock-name: maple
-    stock-volume: 5
     pattern-book: shaping
     part-room: 8864
     tool-room: 8865
@@ -741,9 +763,6 @@ shaping:
     repair-room: 9143
     repair-npc: clerk
     stock-room: 9118
-    stock-number: 10
-    stock-name: maple
-    stock-volume: 5
     pattern-book: shaping
     part-room: 9118
     tool-room: 9119
@@ -767,9 +786,6 @@ shaping:
     repair-room: 8856
     repair-npc: Valomenica
     stock-room: 8858
-    stock-number: 10
-    stock-name: maple
-    stock-volume: 5
     pattern-book: shaping
     part-room: 8857
     tool-room: 8857
@@ -796,9 +812,6 @@ shaping:
     repair-room: 10734
     repair-npc: Glarstan
     stock-room: 10738
-    stock-number: 10
-    stock-name: maple
-    stock-volume: 5
     pattern-book: shaping
     part-room: 10737
     tool-room: 10737
@@ -821,9 +834,6 @@ shaping:
     repair-room: 9575
     repair-npc: clerk
     stock-room: 19306
-    stock-number: 10
-    stock-name: maple
-    stock-volume: 5
     pattern-book: shaping
     part-room: 19306
     tool-room: 9574
@@ -858,9 +868,6 @@ shaping:
     repair-room: 11269
     repair-npc: Sizlldan
     stock-room: 11272
-    stock-number: 10
-    stock-name: maple
-    stock-volume: 5
     pattern-book: shaping
     part-room: 11272
     tool-room: 11276
@@ -889,14 +896,7 @@ carving:
     repair-room: 19209
     repair-npc: Rangu
     stock-room: 8864
-    stock-number: 1
-    stock-name: alabaster
-    stock-volume: 3
-    stock-bone-number: 8
-    stock-bone-name: wolf
-    stock-bone-volume: 10
     pattern-book: carving
-    part-room: 8864
   Leth Deriel:
     << : *zoluren_carving
   Riverhaven: &theren_carving
@@ -912,11 +912,7 @@ carving:
     repair-room: 8856
     repair-npc: Valomenica
     stock-room: 9110
-    stock-number: 1
-    stock-name: alabaster
-    stock-volume: 3
     pattern-book: carving
-    part-room: 8857
   Langenfirth:
     << : *theren_carving
   Therenborough:
@@ -939,12 +935,6 @@ carving:
     repair-room: 9575
     repair-npc: clerk
     stock-room: 19306
-    stock-number: 1
-    stock-name: alabaster
-    stock-volume: 3
-    stock-bone-number: 8
-    stock-bone-name: wolf
-    stock-bone-volume: 10
     pattern-book: carving
     part-room: 19306
     idle-room:
@@ -974,12 +964,6 @@ carving:
     polish-room: 11276
     polish-number: 4
     stock-room: 11272
-    stock-number: 1
-    stock-name: alabaster
-    stock-volume: 3
-    stock-bone-number: 8
-    stock-bone-name: wolf
-    stock-bone-volume: 10
     pattern-book: carving
     part-room: 11272
   Hibarnhvidar:
@@ -1002,12 +986,6 @@ carving:
     repair-room: 9143
     repair-npc: clerk
     stock-room: 9118
-    stock-number: 1
-    stock-name: alabaster
-    stock-volume: 3
-    stock-bone-number: 8
-    stock-bone-name: wolf
-    stock-bone-volume: 10
     pattern-book: carving
     part-room: 9118
     idle-room: 9118

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -851,6 +851,16 @@ water_container:
 herb_container:
 # override craft.lic training items
 craft_overrides:
+# Settings to change the stock materials purchased by Workorders to fulfill orders.
+# Lower workability materials, eg pine/linen are more difficult to use, and therefore teach better with fewer items crafted.
+# Use at own risk. This is an advanced feature, techs and some skill in the craft discipline highly recommended.
+workorders_materials:
+  fabric_type: burlap
+  wood_type: maple
+  stone_type: alabaster
+  bone_type: wolf
+  metal_type: bronze
+  knit_type: yarn
 # Following settings, including herb_container:, are required to override workorders for remedies
 # container used for raw herbs foraged - used by alchemy.lic script
 alchemy_herb_storage:

--- a/trade.lic
+++ b/trade.lic
@@ -1693,7 +1693,7 @@ class Trade
                 end
       stock_needed = ((@outfitting_quantity - existing) / 10.0).ceil
 
-      order_fabric(crafting_data['stock-room'], stock_needed, crafting_data['sew-stock-number'], "#{crafting_data['sew-stock-name']} cloth")
+      order_fabric(crafting_data['stock-room'], stock_needed, crafting_data['stock']['burlap']['stock-number'], "burlap cloth")
       count_materials('burlap cloth') if stock_needed > 0
     end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -40,6 +40,7 @@ class WorkOrders
     @retain_crafting_materials = @settings.retain_crafting_materials
     @workorders_repair = @settings.workorders_repair
     @workorders_override_store = @settings.workorders_override_store
+    @workorders_materials = @settings.workorders_materials
 
     DRC.wait_for_script_to_complete('safe-room', ['force']) if @settings.workorders_force_heal
 
@@ -76,6 +77,7 @@ class WorkOrders
 
     case discipline
     when 'blacksmithing', 'weaponsmithing', 'armorsmithing'
+      materials_info = crafting_data['stock'][@workorders_materials['metal_type']]
       skill = 'Forging'
       tools = @settings.forging_tools
       @belt = @settings.forging_belt
@@ -85,6 +87,7 @@ class WorkOrders
                        :forge_items
                      end
     when 'tailoring'
+      materials_info = crafting_data['stock'][@workorders_materials['fabric_type']]
       skill = 'Outfitting'
       @outfitting_room = @settings.outfitting_room
       tools = @settings.outfitting_tools
@@ -93,6 +96,7 @@ class WorkOrders
       when 4, 2, 3
         craft_method = :sew_items
       when 5
+        materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
         craft_method = :knit_items
       else
         if item['chapter']
@@ -101,12 +105,18 @@ class WorkOrders
         end
       end
     when 'shaping'
+      materials_info = crafting_data['stock'][@workorders_materials['wood_type']]
       skill = 'Engineering'
       @engineering_room = @settings.engineering_room
       tools = @settings.shaping_tools
       @belt = @settings.engineering_belt
       craft_method = :shape_items
     when 'carving'
+      if @carving_type = 'bone'
+        materials_info = crafting_data['stock'][@workorders_materials['bone_type']]
+      else
+        materials_info = crafting_data['stock'][@workorders_materials['stone_type']]
+      end
       skill = 'Engineering'
       @engineering_room = @settings.engineering_room
       tools = @settings.carving_tools
@@ -136,7 +146,7 @@ class WorkOrders
       exit
     end
 
-    send(craft_method, info, item, quantity)
+    send(craft_method, info, materials_info, item, quantity)
 
     complete_work_order(info)
 
@@ -186,10 +196,10 @@ class WorkOrders
     end
   end
 
-  def find_recipe(info, recipe, quantity)
-    volume_label = recipe['material'] == 'bone' ? 'stock-bone-volume' : 'stock-volume'
-    items_per_stock = info[volume_label] / recipe['volume']
-    spare_stock = (info[volume_label] % recipe['volume']).nonzero?
+  def find_recipe(materials_info, recipe, quantity)
+    echo(materials_info)
+    items_per_stock = materials_info['stock-volume'] / recipe['volume']
+    spare_stock = (materials_info['stock-volume'] % recipe['volume']).nonzero?
 
     scrap = spare_stock || (quantity % items_per_stock).nonzero?
 
@@ -202,24 +212,16 @@ class WorkOrders
     fput('go door')
   end
 
-  def carve_items(info, item, quantity)
+  def carve_items(info, materials_info, item, quantity)
     DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
-    recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
+    recipe, items_per_stock, spare_stock, scrap = find_recipe(materials_info, item, quantity)
     material_noun = %w[deed pebble stone rock rock boulder]
     material_volume = 0
     bone_carving = recipe['material'] == 'bone'
 
-    if bone_carving
-      stock_name = 'stock-bone-name'
-      stock_number = 'stock-bone-number'
-    else
-      stock_name = 'stock-name'
-      stock_number = 'stock-number'
-    end
-
     case DRC.bput('get my surface polish', 'You get', 'What were')
     when 'You get'
-      /(\d+)/ =~ DRC.bput('count my polish', 'The surface polish has \d+ uses remaining')
+      /(\d+)/ =~ bput('count my polish', 'The surface polish has \d+ uses remaining')
       if Regexp.last_match(1).to_i < 3
         stow_tool('polish')
         DRCT.dispose('polish')
@@ -233,23 +235,23 @@ class WorkOrders
     order_parts(recipe['part'], quantity) if recipe['part']
 
     quantity.times do |count|
-      DRCT.dispose("#{info['stock-name']} #{material_noun[material_volume]}") if count > 0 && spare_stock
+      DRCT.dispose("#{materials_info['stock-name']} #{material_noun[material_volume]}") if count > 0 && spare_stock
       if items_per_stock.zero? || (count % items_per_stock).zero?
         if count > 0
-          go_door
+          go_door if XMLData.room_title.include?('Workshop')
           pause 0.5 until Room.current.id
         end
         if bone_carving
-          DRC.bput("get my #{info[stock_name]} stack", 'What were', 'You get', 'You pick')
-          while DRC.bput("count my #{info[stock_name]} stack", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
-            DRCT.order_item(info['stock-room'], info[stock_number])
+          DRC.bput("get my #{materials_info['stock_name']} stack", 'What were', 'You get', 'You pick')
+          while DRC.bput("count my #{materials_info['stock_name']} stack", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
+            DRCT.order_item(info['stock-room'], materials_info['stock_number'])
             DRC.bput('combine', 'combine')
           end
         else
-          DRCT.order_item(info['stock-room'], info[stock_number])
+          DRCT.order_item(info['stock-room'], materials_info['stock_number'])
           if @engineering_room
             fput('tap my deed')
-            material_volume = info['stock-volume']
+            material_volume = materials_info['stock-volume']
           else
             material_volume = 0
           end
@@ -258,7 +260,7 @@ class WorkOrders
       end
 
       if !bone_carving
-        rock_result = DRC.bput("get #{info['stock-name']} #{material_noun[material_volume]}", 'You get', 'What were', 'You are not strong', 'You pick up', 'but can\'t quite lift it')
+        rock_result = DRC.bput("get #{materials_info['stock-name']} #{material_noun[material_volume]}", 'You get', 'What were', 'You are not strong', 'You pick up', 'but can\'t quite lift it')
         DRCC.find_shaping_room(@hometown, @engineering_room) unless rock_result =~ /You are not strong|but can\'t quite lift it/i
       else
         DRCC.find_shaping_room(@hometown, @engineering_room)
@@ -267,47 +269,47 @@ class WorkOrders
 
       DRC.wait_for_script_to_complete('carve', [recipe['chapter'], recipe['name'], info[stock_name], bone_carving ? 'stack' : material_noun[material_volume], recipe['noun']])
 
-      material_volume = info['stock-volume'] if material_volume == 0
+      material_volume = materials_info['stock-volume'] if material_volume == 0
       material_volume -= recipe['volume']
 
       bundle_item(recipe['noun'], info['logbook'])
     end
     if bone_carving
-      fput("get my #{info[stock_name]} stack")
+      fput("get my #{materials_info['stock-name']} stack")
       if checkleft || checkright
         DRCI.stow_hands
-        DRCT.dispose("#{info[stock_name]} stack") unless @retain_crafting_materials
+        DRCT.dispose("#{materials_info['stock-name']} stack") unless @retain_crafting_materials
       end
     elsif scrap
-      DRCT.dispose("#{info['stock-name']} #{material_noun[material_volume]}")
+      DRCT.dispose("#{materials_info['stock-name']} #{material_noun[material_volume]}")
     end
     go_door if XMLData.room_title.include?('Workshop')
   end
 
-  def shape_items(info, item, quantity)
+  def shape_items(info, materials_info, item, quantity)
     DRCM.ensure_copper_on_hand(@cash_on_hand || 10_000, @settings)
-    recipe, items_per_stock, spare_stock, scrap = find_recipe(info, item, quantity)
+    recipe, items_per_stock, spare_stock, scrap = find_recipe(materials_info, item, quantity)
 
     quantity.times do |count|
       if items_per_stock.zero? || (count % items_per_stock).zero?
         if count > 0 && spare_stock && !@retain_crafting_materials
-          DRCT.dispose("#{info['stock-name']} lumber")
+          DRCT.dispose("#{materials_info['stock-name']} lumber")
         elsif count > 0 && spare_stock && @retain_crafting_materials
           DRC.bput('stow feet', 'You put', 'What', 'Stow what?')
-          DRC.bput("get my #{info['stock-name']} lumber", 'What were', 'You get')
-          DRC.bput("get my other #{info['stock-name']} lumber", 'What were', 'You get')
+          DRC.bput("get my #{materials_info['stock-name']} lumber", 'What were', 'You get')
+          DRC.bput("get my other #{materials_info['stock-name']} lumber", 'What were', 'You get')
           DRC.bput('combine', 'combine')
           stow_tool(DRC.left_hand)
           stow_tool(DRC.right_hand)
         end
 
         if count > 0
-          go_door
+          go_door if XMLData.room_title.include?('Workshop')
           pause 0.5 until Room.current.id
         end
-        DRC.bput("get my #{info['stock-name']} lumber", 'What were', 'You get')
-        while DRC.bput("count my #{info['stock-name']} lumber", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
-          DRCT.order_item(info['stock-room'], info['stock-number'])
+        DRC.bput("get my #{materials_info['stock-name']} lumber", 'What were', 'You get')
+        while DRC.bput("count my #{materials_info['stock-name']} lumber", 'You count.*\d+', 'I could not').scan(/\d+/).first.to_i < recipe['volume']
+          DRCT.order_item(info['stock-room'], materials_info['stock-number'])
           DRC.bput('combine', 'combine')
         end
         stow_tool('lumber')
@@ -338,11 +340,17 @@ class WorkOrders
         end
         stow_tool('wood stain')
 
+        case DRC.bput('get my clamps', 'What were you', 'You get some')
+        when 'What were you'
+          DRCT.order_item(info['tool-room'], info['clamps-number'])
+        end
+        stow_tool('clamps')
+
         buy_parts(recipe['part'], info['part-room'])
         DRCC.find_shaping_room(@hometown, @engineering_room)
       end
 
-      DRC.wait_for_script_to_complete('shape', ['log', recipe['chapter'], recipe['name'], info['stock-name'], recipe['noun']])
+      DRC.wait_for_script_to_complete('shape', ['log', recipe['chapter'], recipe['name'], materials_info['stock-name'], recipe['noun']])
       case DRC.bput('read my engineering logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
@@ -350,14 +358,14 @@ class WorkOrders
       end
     end
 
-    DRCT.dispose("#{info['stock-name']} lumber") if scrap && !@retain_crafting_materials
+    DRCT.dispose("#{materials_info['stock-name']} lumber") if scrap && !@retain_crafting_materials
     if @retain_crafting_materials
       stow_tool(DRC.left_hand)
       stow_tool(DRC.right_hand)
       if scrap
         DRC.bput('stow feet', 'You put', 'What', 'Stow what?')
-        DRC.bput("get my #{info['stock-name']} lumber", 'What were', 'You get')
-        DRC.bput("get my other #{info['stock-name']} lumber", 'What were', 'You get')
+        DRC.bput("get my #{materials_info['stock-name']} lumber", 'What were', 'You get')
+        DRC.bput("get my other #{materials_info['stock-name']} lumber", 'What were', 'You get')
         DRC.bput('combine', 'combine')
         stow_tool(DRC.left_hand)
         stow_tool(DRC.right_hand)
@@ -397,19 +405,19 @@ class WorkOrders
     stow_tool(type)
   end
 
-  def sew_items(info, recipe, quantity)
+  def sew_items(info, materials_info, recipe, quantity)
     DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
 
-    existing = if DRC.bput("get #{info['sew-stock-name']} cloth from my #{@bag}", 'What were', 'You get') == 'What were'
+    existing = if DRC.bput("get #{materials_info['stock-name']} cloth from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
                else
-                 while DRC.bput("get #{info['sew-stock-name']} cloth from my #{@bag}", 'What were', 'You get') == 'You get'
-                   DRC.bput("combine #{info['sew-stock-name']} cloth with #{info['sew-stock-name']} cloth", 'You combine')
+                 while DRC.bput("get #{materials_info['stock-name']} cloth from my #{@bag}", 'What were', 'You get') == 'You get'
+                   DRC.bput("combine #{materials_info['stock-name']} cloth with #{materials_info['stock-name']} cloth", 'You combine')
                  end
-                 DRC.bput("count my #{info['sew-stock-name']} cloth", 'You count out \d+ yards').scan(/\d+/).first.to_i
+                 DRC.bput("count my #{materials_info['stock-name']} cloth", 'You count out \d+ yards').scan(/\d+/).first.to_i
                end
     stock_needed = ((quantity * recipe['volume'] - existing) / 10.0).ceil
-    order_fabric(info['stock-room'], stock_needed, info['sew-stock-number'], "#{info['sew-stock-name']} cloth")
+    order_fabric(info['stock-room'], stock_needed, materials_info['stock-number'], "#{materials_info['stock-name']} cloth")
     order_parts(recipe['part'], quantity) if recipe['part']
 
     case DRC.bput('get my pins', 'You get', 'What were')
@@ -428,7 +436,7 @@ class WorkOrders
     DRCC.find_sewing_room(@hometown, @outfitting_room)
 
     quantity.times do |count|
-      DRC.wait_for_script_to_complete('sew', ['log', 'sewing', recipe['chapter'], recipe['name'], recipe['noun'], info['sew-stock-name']])
+      DRC.wait_for_script_to_complete('sew', ['log', 'sewing', recipe['chapter'], recipe['name'], recipe['noun'], materials_info['stock-name']])
       case DRC.bput('read my outfitting logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
@@ -436,7 +444,7 @@ class WorkOrders
       end
     end
     leftover = (quantity * recipe['volume']) % 10 != 0
-    DRCT.dispose("#{info['sew-stock-name']} cloth") if leftover && !@retain_crafting_materials
+    DRCT.dispose("#{materials_info['stock-name']} cloth") if leftover && !@retain_crafting_materials
     stow_tool(DRC.left_hand) if @retain_crafting_materials
     stow_tool(DRC.right_hand) if @retain_crafting_materials
   end
@@ -448,17 +456,17 @@ class WorkOrders
                  0
                else
                  while DRC.bput("get yarn from my #{@bag}", 'What were', 'You get') == 'You get'
-                   DRC.bput("combine #{info['sew-stock-name']} yarn with #{info['sew-stock-name']} yarn", 'You combine')
+                   DRC.bput("combine #{materials_info['stock-name']} yarn with #{materials_info['stock-name']} yarn", 'You combine')
                  end
                  DRC.bput('count my yarn', 'You count out \d+ yards').scan(/\d+/).first.to_i
                end
     stock_needed = ((quantity * recipe['volume'] - existing) / 100.0).ceil
-    order_fabric(info['stock-room'], stock_needed, info['knit-stock-number'], 'yarn')
+    order_fabric(info['stock-room'], stock_needed, materials_info['stock-number'], 'yarn')
 
     DRCC.find_sewing_room(@hometown, @outfitting_room)
 
     quantity.times do |count|
-      DRC.wait_for_script_to_complete('sew', ['log', 'knitting', recipe['chapter'], recipe['name'], recipe['noun'], info['knit-stock-name']])
+      DRC.wait_for_script_to_complete('sew', ['log', 'knitting', recipe['chapter'], recipe['name'], recipe['noun'], materials_info['stock-name']])
       case DRC.bput('read my outfitting logbook', 'This work order appears to be complete.', 'You must bundle and deliver \d+ more')
       when /You must bundle and deliver \d+ more /
         log_num = Regexp.last_match(1).to_i
@@ -621,26 +629,26 @@ class WorkOrders
     DRCT.dispose(recipe['herb2']) while recipe['herb2'] && DRCI.exists?(recipe['herb2']) unless @retain_crafting_materials
   end
 
-  def forge_items(info, item, quantity)
-    recipe, = find_recipe(info, item, quantity)
+  def forge_items(info, materials_info, item, quantity)
+    recipe, items_per_stock, spare_stock, scrap = find_recipe(materials_info, item, quantity)
     remaining_volume = 0
 
     DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
 
     quantity.times do
       if remaining_volume < recipe['volume']
-        DRCT.dispose(info['stock-name'], info['trash-room']) if remaining_volume > 0
-        DRCT.order_item(info['stock-room'], info['stock-number'])
+        DRCT.dispose("#{materials_info['stock-name']} ingot", info['trash-room']) if remaining_volume > 0
+        DRCT.order_item(info['stock-room'], materials_info['stock-number'])
         DRCI.stow_hands
-        remaining_volume = info['stock-volume']
+        remaining_volume = materials_info['stock-volume']
       end
 
-      DRC.wait_for_script_to_complete('smith', ['bronze', item['name']])
+      DRC.wait_for_script_to_complete('smith', [materials_info['stock-name'], item['name']])
       bundle_item(recipe['noun'], info['logbook'])
 
       remaining_volume -= recipe['volume']
     end
-    DRCT.dispose(info['stock-name'], info['trash-room']) if remaining_volume > 0
+    DRCT.dispose("#{materials_info['stock-name']} ingot", info['trash-room']) if remaining_volume > 0
   end
 
   def ingot_volume
@@ -653,8 +661,8 @@ class WorkOrders
     res.scan(/\d+/).first.to_i
   end
 
-  def forge_items_with_own_ingot(info, item, quantity)
-    recipe, = find_recipe(info, item, quantity)
+  def forge_items_with_own_ingot(info, materials_info, item, quantity)
+    recipe, items_per_stock, spare_stock, scrap = find_recipe(materials_info, item, quantity)
 
     if DRC.bput("get my #{@use_own_ingot_type} ingot", 'You get', 'What were') == 'What were'
       if DRC.bput("get my #{@use_own_ingot_type} deed", 'You get', 'What were') == 'What were'

--- a/workorders.lic
+++ b/workorders.lic
@@ -221,7 +221,7 @@ class WorkOrders
 
     case DRC.bput('get my surface polish', 'You get', 'What were')
     when 'You get'
-      /(\d+)/ =~ bput('count my polish', 'The surface polish has \d+ uses remaining')
+      /(\d+)/ =~ DRC.bput('count my polish', 'The surface polish has \d+ uses remaining')
       if Regexp.last_match(1).to_i < 3
         stow_tool('polish')
         DRCT.dispose('polish')
@@ -339,12 +339,6 @@ class WorkOrders
           DRCT.order_item(info['tool-room'], info['stain-number'])
         end
         stow_tool('wood stain')
-
-        case DRC.bput('get my clamps', 'What were you', 'You get some')
-        when 'What were you'
-          DRCT.order_item(info['tool-room'], info['clamps-number'])
-        end
-        stow_tool('clamps')
 
         buy_parts(recipe['part'], info['part-room'])
         DRCC.find_shaping_room(@hometown, @engineering_room)


### PR DESCRIPTION
Resubmit of [#5784](https://github.com/rpherbig/dr-scripts/pull/5784)

Adds support for additional materials for workorders_materials yaml setting. You can modify one, some, or all of the stock materials used by workorders, in order that you maximize learning and minimize items required. This becomes far more important as you get into guru levels of crafting, but it's useful starting from about 200 ranks.

The changes to base-crafting were to standardize the stock references, since there was no meaningful reason(that i can see) to have separate names or tied to towns. The numbers, values(currency notwithstanding), names were all the same everywhere.

The changes to both Trade and Craft were for a single line that used hometown>sew-stock-number, rather than the new stock>burlap>stock-number. Per a previous question, I didn't add this function to craft or trade because I don't use those scripts, and I don't know that that's something the folks who do use it would want. There certainly haven't been any requests for it that I've seen.

Added default materials to base.yaml, same materials that workorders has been using all along, so no change in the function of workorders for anyone who's uninterested in making these adjustments.

I have been using this exclusively for a couple weeks now, and welcome additional testing.