### PR TITLE
[script][forge.lic] - remove @ from release symbiosis line

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -401,7 +401,7 @@ class Forge
     else
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
       DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
-      DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this @command')
+      DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
     end
   end
 end


### PR DESCRIPTION
This line should not have the @ in the match text.
`DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this @command')`