### PR TITLE
combat-trainer - Warhorn/egg bput fix

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -110,8 +110,8 @@ class SetupProcess
 
     game_state.sheath_whirlwind_offhand
 
-    case DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", 'You get', 'You remove', 'You take', 'What were you referring to', 'You need a free hand', 'Remove what')
-    when 'You get', 'You remove', 'You take'
+    case DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn|egg).*\.$/, /^You remove.*(?:warhorn|egg).*\.$/, /^You take.*(?:warhorn|egg).*\.$/, /^What were you referring to/, /^You need a free hand/, /^Remove what/)
+    when /^You get.*(?:warhorn|egg).*\.$/, /^You remove.*(?:warhorn|egg).*\.$/, /^You take.*(?:warhorn|egg).*\.$/
       if /The red light within the egg is dim and moves about sluggishly|Your lungs are tired from having sounded a/ =~ DRC.bput(@warhon_activation_command,'light envelops the area briefly', 'The red light within the egg is dim and moves about sluggishly', 'Something about the area inhibits','You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
         @next_warhorn = Time.now + 60
       else
@@ -119,7 +119,7 @@ class SetupProcess
       end
       waitrt?
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
-    when 'What were you referring to'
+    when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
       @warhorn = nil
     end


### PR DESCRIPTION
Changing the bput matches to regexes instead of strings because we found out that the string matches get converted into case insensitive in the bput code.

Also added anchors to the matches to make it as specific as possible.