### PR TITLE
[script][forge] Add Master Crafting books

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -132,15 +132,15 @@ module DRCC
     end
   end
 
-  def find_recipe(chapter, match_string)
-    case DRC.bput("turn my book to chapter #{chapter}", 'You turn', 'You are too distracted to be doing that right now', 'The book is already turned')
+  def find_recipe(chapter, match_string, book = 'book')
+    case DRC.bput("turn my #{book} to chapter #{chapter}", 'You turn', 'You are too distracted to be doing that right now', 'The .* is already turned')
     when 'You are too distracted to be doing that right now'
       echo '***CANNOT TURN BOOK, ASSUMING I AM ENGAGED IN COMBAT***'
       fput('look')
       fput('exit')
     end
 
-    recipe = DRC.bput('read my book', "Page \\d+:\\s(?:some|a|an)?\\s*#{match_string}").split('Page').find { |x| x =~ /#{match_string}/i }
+    recipe = DRC.bput("read my #{book}", "Page \\d+:\\s(?:some|a|an)?\\s*#{match_string}").split('Page').find { |x| x =~ /#{match_string}/i }
     recipe =~ /(\d+):/
     Regexp.last_match(1)
   end

--- a/forge.lic
+++ b/forge.lic
@@ -140,12 +140,12 @@ class Forge
       @command = "pound ingot on anvil with my #{@hammer}"
     else
       return if @recipe_name.include?('temper')
-      DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
-      echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
       if settings.master_crafting_book
         DRC.bput("turn my #{@master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The .* is already')
         DRC.bput("study my #{@master_crafting_book}", 'Roundtime')
       else
+        DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
+        echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
         DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
         DRC.bput('study my book', 'Roundtime')
       end

--- a/forge.lic
+++ b/forge.lic
@@ -10,7 +10,7 @@ class Forge
 
     arg_definitions = [
       [
-        { name: 'book_type', display: 'book type', options: %w[black armor weapon], description: 'What smithing type is this item.' },
+        { name: 'book_type', display: 'book type', options: %w[blacksmithing armorsmithing weaponsmithing], description: 'What smithing type is this item.' },
         { name: 'chapter', regex: /\d+/i, variable: true, description: 'Chapter containing the item.' },
         { name: 'recipe_name', display: 'recipe name', regex: /^[A-z\s\-\']+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
         { name: 'metal', regex: /\w+/i, variable: true, description: 'Type of metal ingot to use.' },
@@ -18,7 +18,7 @@ class Forge
         { name: 'debug', regex: /debug/i, optional: true, description: 'displays debug information' }
       ],
       [
-        { name: 'book_type', display: 'book type', options: %w[black armor weapon], description: 'What smithing type is this item.' },
+        { name: 'book_type', display: 'book type', options: %w[blacksmithing armorsmithing weaponsmithing], description: 'What smithing type is this item.' },
         { name: 'instruction', regex: /\w+/i, variable: true, description: 'instruction noun' },
         { name: 'metal', regex: /\w+/i, variable: true, description: 'Type of metal ingot to use.' },
         { name: 'noun', regex: /\w+/i, variable: true, description: 'name of item being crafted' },
@@ -31,7 +31,7 @@ class Forge
       ],
       [
         { name: 'resume', regex: /resume/i },
-        { name: 'book_type', display: 'book type', options: %w[black armor weapon], description: 'What smithing type is this item.' },
+        { name: 'book_type', display: 'book type', options: %w[blacksmithing armorsmithing weaponsmithing], description: 'What smithing type is this item.' },
         { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item to resume.' },
         { name: 'debug', regex: /debug/i, optional: true, description: 'displays debug information' }
       ]
@@ -63,6 +63,7 @@ class Forge
     @debug = args.debug || settings.debug_mode
 
     DRC.wait_for_script_to_complete('buff', ['forge'])
+    DRC.bput("turn my book to discipline #{@book_type}", 'You turn the book') if settings.master_crafting_book
     if settings.adjustable_tongs
       @adjustable_tongs = DRCC.get_adjust_tongs?('reset tongs', @bag, @bag_items, @forging_belt)
       echo("Tongs adjustable?                            :: #{@adjustable_tongs}") if @debug
@@ -79,14 +80,6 @@ class Forge
     work(settings) if args.resume
     prep(settings)
     work(settings)
-  end
-
-  def turn_to
-    DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt)
-    echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
-    DRC.bput("turn my book to #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
-    DRC.bput('study my book', 'Roundtime')
-    DRCC.stow_crafting_item('book', @bag, @forging_belt)
   end
 
   def check_hand(x)
@@ -115,7 +108,7 @@ class Forge
       check_hand(@item) unless DRCI.in_left_hand?(@item)
       spin_grindstone unless @resume
       @chapter = 10
-      @book_type = 'weapon'
+      @book_type = 'weaponsmithing'
       @stamp = false
     when 'metal armor lightening', 'metal armor reinforcing'
       @home_tool = 'pliers'
@@ -123,7 +116,7 @@ class Forge
       @command = "pull my #{@item} with my pliers"
       check_hand(@item) unless DRCI.in_left_hand?(@item)
       @chapter = 5
-      @book_type = 'armor'
+      @book_type = 'armorsmithing'
       @stamp = false
     else
       @location = "on anvil"
@@ -139,19 +132,19 @@ class Forge
   def prep(settings)
     DRCA.crafting_magic_routine(settings)
     if @instruction
-      DRCC.get_crafting_item("#{@instruction} instructions", @bag, @bag_items, @forging_belt)
+      DRCC.get_crafting_item("#{@instruction} instructions", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
       if /again/ =~ DRC.bput('study my instructions', 'Roundtime', 'Study them again')
         DRC.bput('study my instructions', 'Roundtime', 'Study them again')
       end
-      DRCC.stow_crafting_item('instructions', @bag, @forging_belt)
+      DRCC.stow_crafting_item('instructions', @bag, @forging_belt) unless settings.master_crafting_book
       @command = "pound ingot on anvil with my #{@hammer}"
     else
       return if @recipe_name.include?('temper')
-      DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt)
+      DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
       echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
       DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
       DRC.bput('study my book', 'Roundtime')
-      DRCC.stow_crafting_item('book', @bag, @forging_belt)
+      DRCC.stow_crafting_item('book', @bag, @forging_belt) unless settings.master_crafting_book
     end
     swap_tool(@home_tool)
     if @metal

--- a/forge.lic
+++ b/forge.lic
@@ -143,7 +143,7 @@ class Forge
         DRC.bput("turn my #{settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The .* is already')
         DRC.bput("study my #{settings.master_crafting_book}", 'Roundtime')
       else
-        DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
+        DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt)
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
         DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
         DRC.bput('study my book', 'Roundtime')

--- a/forge.lic
+++ b/forge.lic
@@ -142,9 +142,13 @@ class Forge
       return if @recipe_name.include?('temper')
       DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
       echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
-      DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
-      DRC.bput('study my book', 'Roundtime')
-      DRCC.stow_crafting_item('book', @bag, @forging_belt) unless settings.master_crafting_book
+      if settings.master_crafting_book
+        DRC.bput("turn my #{@master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The .* is already')
+        DRC.bput("study my #{@master_crafting_book}", 'Roundtime')
+      else
+        DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
+        DRC.bput('study my book', 'Roundtime')
+      end
     end
     swap_tool(@home_tool)
     if @metal

--- a/forge.lic
+++ b/forge.lic
@@ -63,7 +63,7 @@ class Forge
     @debug = args.debug || settings.debug_mode
 
     DRC.wait_for_script_to_complete('buff', ['forge'])
-    DRC.bput("turn my #{@master_crafting_book} to discipline #{@book_type}", 'You turn the') if settings.master_crafting_book
+    DRC.bput("turn my #{settings.master_crafting_book} to discipline #{@book_type}", 'You turn the') if settings.master_crafting_book
     if settings.adjustable_tongs
       @adjustable_tongs = DRCC.get_adjust_tongs?('reset tongs', @bag, @bag_items, @forging_belt)
       echo("Tongs adjustable?                            :: #{@adjustable_tongs}") if @debug
@@ -140,8 +140,8 @@ class Forge
     else
       return if @recipe_name.include?('temper')
       if settings.master_crafting_book
-        DRC.bput("turn my #{@master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The .* is already')
-        DRC.bput("study my #{@master_crafting_book}", 'Roundtime')
+        DRC.bput("turn my #{settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The .* is already')
+        DRC.bput("study my #{settings.master_crafting_book}", 'Roundtime')
       else
         DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175

--- a/forge.lic
+++ b/forge.lic
@@ -56,6 +56,7 @@ class Forge
     args.recipe_name.sub!("hone", "metal weapon honing")
     args.recipe_name.sub!("balance", "metal weapon balancing")
     args.recipe_name.sub!("lighten", "metal armor lightening")
+    args.recipe_name.sub!("reinforce", "metal armor reinforcing")
     @recipe_name = args.recipe_name
     echo("Recipe                                       :: #{ @recipe_name }") if @debug
     @metal = args.metal
@@ -63,7 +64,6 @@ class Forge
     @debug = args.debug || settings.debug_mode
 
     DRC.wait_for_script_to_complete('buff', ['forge'])
-    DRC.bput("turn my #{settings.master_crafting_book} to discipline #{@book_type}", 'You turn the') if settings.master_crafting_book
     if settings.adjustable_tongs
       @adjustable_tongs = DRCC.get_adjust_tongs?('reset tongs', @bag, @bag_items, @forging_belt)
       echo("Tongs adjustable?                            :: #{@adjustable_tongs}") if @debug
@@ -140,6 +140,7 @@ class Forge
     else
       return if @recipe_name.include?('temper')
       if settings.master_crafting_book
+        DRC.bput("turn my #{settings.master_crafting_book} to discipline #{@book_type}", 'You turn the') if settings.master_crafting_book
         DRC.bput("turn my #{settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, settings.master_crafting_book)}", 'You turn your', 'The .* is already')
         DRC.bput("study my #{settings.master_crafting_book}", 'Roundtime')
       else

--- a/forge.lic
+++ b/forge.lic
@@ -63,7 +63,7 @@ class Forge
     @debug = args.debug || settings.debug_mode
 
     DRC.wait_for_script_to_complete('buff', ['forge'])
-    DRC.bput("turn my book to discipline #{@book_type}", 'You turn the book') if settings.master_crafting_book
+    DRC.bput("turn my #{@master_crafting_book} to discipline #{@book_type}", 'You turn the') if settings.master_crafting_book
     if settings.adjustable_tongs
       @adjustable_tongs = DRCC.get_adjust_tongs?('reset tongs', @bag, @bag_items, @forging_belt)
       echo("Tongs adjustable?                            :: #{@adjustable_tongs}") if @debug

--- a/forge.lic
+++ b/forge.lic
@@ -132,11 +132,10 @@ class Forge
   def prep(settings)
     DRCA.crafting_magic_routine(settings)
     if @instruction
-      DRCC.get_crafting_item("#{@instruction} instructions", @bag, @bag_items, @forging_belt) unless settings.master_crafting_book
+      DRCC.get_crafting_item("#{@instruction} instructions", @bag, @bag_items, @forging_belt)
       if /again/ =~ DRC.bput('study my instructions', 'Roundtime', 'Study them again')
         DRC.bput('study my instructions', 'Roundtime', 'Study them again')
       end
-      DRCC.stow_crafting_item('instructions', @bag, @forging_belt) unless settings.master_crafting_book
       @command = "pound ingot on anvil with my #{@hammer}"
     else
       return if @recipe_name.include?('temper')

--- a/forge.lic
+++ b/forge.lic
@@ -140,7 +140,7 @@ class Forge
     else
       return if @recipe_name.include?('temper')
       if settings.master_crafting_book
-        DRC.bput("turn my #{settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The .* is already')
+        DRC.bput("turn my #{settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, settings.master_crafting_book)}", 'You turn your', 'The .* is already')
         DRC.bput("study my #{settings.master_crafting_book}", 'Roundtime')
       else
         DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -782,6 +782,7 @@ crafting_container: backpack
 # list of items to only grab from crafting_container, aka - oil for forging
 crafting_items_in_container:
 adjustable_tongs: false
+master_crafting_book: false
 forging_tools:
 - diagonal-peen hammer
 - tong


### PR DESCRIPTION
Works for the worn master crafting book, requires yaml setting:
```
master_crafting_book: true
```
Tested by Chyral:
```
[forge]>turn my book to discipline armorsmithing

You turn the book to the section on armorsmithing.

[forge]>turn my book to chapter 4

You turn your book to chapter 4, entitled "Shield Design".

[forge]>read my book
```
Couple additional changes:
1. First, turn_to method wasn't being used anymore, so went ahead and deprecated.
2. book_type is ONLY used by the end user to start forge. Otherwise, smith was submitting the full name (armorsmithing) when running, which forge picked up anyways. This allowed me to dump book_type right into the master crafting book portion in a way that would work when forge was run alone, and when run by smith.
3. Only gets or stows the book when it's NOT a master crafting book.

If anyone has a master crafting book that isn't worn, they may run into trouble.