### PR TITLE
[script][smith] Updates, add descriptions, simplify.

### DIFF
--- a/smith.lic
+++ b/smith.lic
@@ -6,64 +6,65 @@
 custom_require.call(%w[common common-crafting common-items common-money common-travel drinfomon])
 
 class Smith
-  include DRC
-  include DRCC
-  include DRCI
-  include DRCM
-  include DRCT
 
   def initialize
     arg_definitions = [
       [
         { name: 'material', regex: /\w+/, description: 'Metal type of the ingot' },
         { name: 'item_name', display: 'recipe name', regex: /^[A-z\s\-\']+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
-        { name: 'stamp', regex: /^stamp/i, optional: true },
-        { name: 'temper', regex: /^temper/i, optional: true },
-        { name: 'hone', regex: /^hone/i, optional: true },
-        { name: 'balance', regex: /^balance/i, optional: true },
-        { name: 'lighten', regex: /^lighten/i, optional: true },
-        { name: 'buy', regex: /^buy/i, optional: true }
+        { name: 'stamp', regex: /^stamp/i, optional: true, description: 'To stamp completed items'},
+        { name: 'here', regex: /^here/i, optional: true, description: 'Force it to forge in the room you are currently in, useful for private forge rentals or forge wands' },
+        { name: 'temper', regex: /^temper/i, optional: true, description: 'Tempers crafted item, boost durability' },
+        { name: 'hone', regex: /^hone/i, optional: true, description: 'Hones crafted item(weapon only), reducing weight and impact' },
+        { name: 'balance', regex: /^balance/i, optional: true, description: 'Balance crafted item (weapon only), increasing balance at the cost of suitability'},
+        { name: 'lighten', regex: /^lighten/i, optional: true, description: 'Lightens crafted armor or shield, reducing weight only'},
+        { name: 'buy', regex: /^buy/i, optional: true, description: 'Used to purchase the ingot' }
       ]
     ]
 
     args = parse_args(arg_definitions)
 
     @settings = get_settings
+    @bag = @settings.crafting_container
+    @bag_items = @settings.crafting_items_in_container
+    @belt = @settings.forging_belt
     discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
-    recipe = recipe_lookup(recipes, args.item_name)
+    recipe = DRCC.recipe_lookup(recipes, args.item_name)
     return unless recipe
+    
+    DRCM.ensure_copper_on_hand(3000, @settings) unless args.here
 
     parts = recipe['part'] || []
-    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten)
+    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.here)
   end
 
-  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten)
+  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten, stay)
     if discipline['stock-volume'] < recipe['volume'] && buy
       echo '***You cannot buy an ingot large enough to craft this item.***'
       echo '***Automatically combining ingots via smelting is not yet supported.***'
       echo '***You will need to do so by hand and then call ;smith again.***'
       exit
     end
-
-    buy_parts(parts)
+    
+    buy_parts(parts) unless stay
     buy_ingot(discipline) if buy
-    wait_for_script_to_complete('buff', ['smith'])
-    craft_item(recipe, discipline, material)
-    stamp_item(recipe) if stamp
-    temper_item(discipline, recipe) if temper
-    hone_item(discipline, recipe) if hone
-    balance_item(discipline, recipe) if balance
-    lighten_item(discipline, recipe) if lighten
+    DRCC.find_anvil(@hometown) unless stay
+    DRC.wait_for_script_to_complete('buff', ['smith'])
+    DRC.wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
+    stamp_item(recipe['noun']) if stamp
+    DRC.wait_for_script_to_complete('forge', ['temper', recipe['noun']])  if temper
+    DRC.wait_for_script_to_complete('forge', ['hone', recipe['noun']])    if hone
+    DRC.wait_for_script_to_complete('forge', ['balance', recipe['noun']]) if balance
+    DRC.wait_for_script_to_complete('forge', ['lighten', recipe['noun']]) if lighten
     dispose_scrap(discipline, recipe) if buy
-    dispose_parts(discipline, parts)
+    dispose_parts(discipline, parts) unless stay
   end
 
   def buy_parts(parts)
-    ensure_copper_on_hand(700, @settings)
-    stow_hands
+    DRCI.stow_hands
 
     parts.each do |part|
 
@@ -73,85 +74,32 @@ class Smith
       else
         DRCT.buy_item(data['part-room'], part)
       end
-      bput("put #{part} in my #{@container}", 'You put')
+      DRCC.stow_crafting_item(part, @bag, @belt)
     end
   end
 
   def buy_ingot(discipline)
-    ensure_copper_on_hand(700, @settings)
     DRCT.order_item(discipline['stock-room'], discipline['stock-number'])
-    bput("put ingot in my #{@container}", 'You put')
-    stow_hands
+    DRCC.stow_crafting_item('ingot', @bag, @belt)
+    DRCI.stow_hands
   end
 
-  def craft_item(recipe, discipline, material)
-    check_oil(discipline)
-    find_anvil(@hometown)
-    wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
-  end
-
-  def check_oil(discipline)
-    $ORDINALS.each do |ord|
-      case bput("look my #{ord} oil in #{@container}", /thick and syrupy substance that easily coats and lubricates metal/, /You see nothing unusual/, /I could not find what you were referring to/, /There appears to be something written/, /(coal|lamp|fish) oil/, /The oil bottle is full/)
-      when /thick and syrupy substance that easily coats and lubricates metal/
-        return if ord == 'first'
-        bput("get my #{ord} oil in #{@container}", /You get/)
-        bput("put oil in my #{@container}", 'You put')
-        return
-      when /I could not find what you were referring to/
-        break
-      end
-    end
-
-    ensure_copper_on_hand(1000, @settings)
-    DRCT.order_item(discipline['finisher-room'], discipline['finisher-number'])
-    bput("put oil in my #{@container}", 'You put')
-    stow_hands
-  end
-
-  def stamp_item(recipe)
-    fput('get my stamp')
-    fput("mark my #{recipe['noun']} with my stamp")
-    pause 1
-    waitrt?
-    fput("put my stamp in my #{@container}")
-  end
-
-  def temper_item(discipline, recipe)
-    check_oil(discipline)
-    find_anvil(@hometown)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['temper', recipe['noun']])
-  end
-
-  def hone_item(discipline, recipe)
-    check_oil(discipline)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['hone', recipe['noun']])
-  end
-
-  def balance_item(discipline, recipe)
-    check_oil(discipline)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['balance', recipe['noun']])
-  end
-
-  def lighten_item(discipline, recipe)
-    check_oil(discipline)
-    fput("get my #{recipe['noun']}")
-    wait_for_script_to_complete('forge', ['lighten', recipe['noun']])
-  end
-
-  def dispose_parts(discipline, parts)
-    parts.each do |part|
-      dispose(part, discipline['trash-room'])
-    end
+  def stamp_item(noun)
+    DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
+    DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+    DRCC.stow_crafting_item('stamp', @bag, @belt)
   end
 
   def dispose_scrap(discipline, recipe)
     return unless discipline['stock-volume'] > recipe['volume']
 
-    dispose(discipline['stock-name'], discipline['trash-room'])
+    DRCT.dispose(discipline['stock-name'], discipline['trash-room'])
+  end
+
+  def dispose_parts(discipline, parts)
+    parts.each do |part|
+      DRCT.dispose(part, discipline['trash-room'])
+    end
   end
 end
 

--- a/smith.lic
+++ b/smith.lic
@@ -29,6 +29,8 @@ class Smith
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.forging_belt
     discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
+    workorders_materials = @settings.workorders_materials
+    @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
@@ -79,7 +81,7 @@ class Smith
   end
 
   def buy_ingot(discipline)
-    DRCT.order_item(discipline['stock-room'], discipline['stock-number'])
+    DRCT.order_item(discipline['stock-room'], @materials_info['stock-number'])
     DRCC.stow_crafting_item('ingot', @bag, @belt)
     DRCI.stow_hands
   end
@@ -91,9 +93,9 @@ class Smith
   end
 
   def dispose_scrap(discipline, recipe)
-    return unless discipline['stock-volume'] > recipe['volume']
+    return unless @materials_info['stock-volume'] > recipe['volume']
 
-    DRCT.dispose(discipline['stock-name'], discipline['trash-room'])
+    DRCT.dispose(@materials_info['stock-name'], discipline['trash-room'])
   end
 
   def dispose_parts(discipline, parts)


### PR DESCRIPTION
Removes includes, add prefixes.
Some tidying up of the methods, condensing.
Added:
1. variable HERE, which skips buying, dumping parts, and looking for anvils. This assumes you're already at one. For use with forge rentals and forge wands.
2. Added descriptions for some of the variables.
3. Parts handling was changed from tapping to check if you already have them to just buying them. This was because some templates required multiples of the same part, and this wasn't purchasing more than one, which resulted in a hang on some items.
4. Made stamp a little more robust.

Oil handling is done by grunt scripts like forge, both a pre-craft check and a catch if you run out midway through, so no reason to keep it here.