### PR TITLE
shape.lic - syntax error when using master book

### DIFF
--- a/shape.lic
+++ b/shape.lic
@@ -126,7 +126,7 @@ class Shape
       end
     else
       if @settings.master_crafting_book
-        DRC.bput("turn my #{@settings.master_crafting_book} to discipline shaping}", 'You turn the')
+        DRC.bput("turn my #{@settings.master_crafting_book} to discipline shaping", 'You turn the')
         DRC.bput("turn my #{@settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, @settings.master_crafting_book)}", 'You turn your', 'The .* is already')
         DRC.bput("study my #{@settings.master_crafting_book}", 'Roundtime')
       else


### PR DESCRIPTION
There's a `}` after the discipline name when trying to turn the book.