### PR TITLE
[script][tarantula] Add pause all

### DIFF
--- a/tarantula.lic
+++ b/tarantula.lic
@@ -73,7 +73,7 @@ class Tarantula
     return skill.sample
   end
 
-  def turn_tarantula?(skill)
+  def turn_tarantula?(skill, scripts_to_unpause)
     name = skill
     if skill =~ /(Lunar|Holy|Elemental|Life|Arcane|Inner) (Magic|Fire)/i
       skill = 'Magic'
@@ -86,8 +86,10 @@ class Tarantula
       DRC.message("*** Error, wrong skillset chosen. ***") if @debug
       check_last
       use_tarantula
+      DRC.unpause_all_list(scripts_to_unpause)
       return false
     when /You should stop practicing your Athletics/
+      DRC.unpause_all_list(scripts_to_unpause)
       return false
     end
   end
@@ -95,10 +97,12 @@ class Tarantula
   def use_tarantula
     return if Time.now - UserVars.tarantula_last_use < 600
     return if @no_use_scripts.any? { |name| Script.running?(name) }
+    scripts_to_unpause = []
+    scripts_to_unpause = DRC.smart_pause_all
 
     skill = choose_skill
     if skill
-      return unless turn_tarantula?(skill)
+      return unless turn_tarantula?(skill, scripts_to_unpause)
     else
       DRC.message("*** Skipping alternate skills due to user setting. ***") if @skip_alternate && @debug
       return if @skip_alternate
@@ -133,6 +137,7 @@ class Tarantula
     when /You should stop practicing your Athletics/
       DRC.message("*** Tarantula can't be used while using climb practice. ***") if @debug
     end
+    DRC.unpause_all_list(scripts_to_unpause)
   end
 
   def passive_loop

--- a/tarantula.lic
+++ b/tarantula.lic
@@ -138,7 +138,6 @@ class Tarantula
     when /You should stop practicing your Athletics/
       DRC.message("*** Tarantula can't be used while using climb practice. ***") if @debug
     end
-    DRC.unpause_all_list(scripts_to_unpause)
   end
 
   def passive_loop

--- a/tarantula.lic
+++ b/tarantula.lic
@@ -74,8 +74,8 @@ class Tarantula
   end
 
   def turn_tarantula?(skill)
-    scripts_to_unpause = []
-    scripts_to_unpause = DRC.smart_pause_all
+    @scripts_to_unpause = []
+    @scripts_to_unpause = DRC.smart_pause_all
 
     name = skill
     if skill =~ /(Lunar|Holy|Elemental|Life|Arcane|Inner) (Magic|Fire)/i
@@ -89,10 +89,9 @@ class Tarantula
       DRC.message("*** Error, wrong skillset chosen. ***") if @debug
       check_last
       use_tarantula
-      DRC.unpause_all_list(scripts_to_unpause)
       return false
     when /You should stop practicing your Athletics/
-      DRC.unpause_all_list(scripts_to_unpause)
+      DRC.unpause_all_list(@scripts_to_unpause)
       return false
     end
   end
@@ -138,6 +137,7 @@ class Tarantula
     when /You should stop practicing your Athletics/
       DRC.message("*** Tarantula can't be used while using climb practice. ***") if @debug
     end
+    DRC.unpause_all_list(@scripts_to_unpause)
   end
 
   def passive_loop

--- a/tarantula.lic
+++ b/tarantula.lic
@@ -5,6 +5,7 @@
 custom_require.call(%w(common common-items drinfomon))
 
 no_kill_all
+no_pause_all
 
 class Tarantula
 
@@ -73,7 +74,10 @@ class Tarantula
     return skill.sample
   end
 
-  def turn_tarantula?(skill, scripts_to_unpause)
+  def turn_tarantula?(skill)
+    scripts_to_unpause = []
+    scripts_to_unpause = DRC.smart_pause_all
+
     name = skill
     if skill =~ /(Lunar|Holy|Elemental|Life|Arcane|Inner) (Magic|Fire)/i
       skill = 'Magic'
@@ -97,12 +101,10 @@ class Tarantula
   def use_tarantula
     return if Time.now - UserVars.tarantula_last_use < 600
     return if @no_use_scripts.any? { |name| Script.running?(name) }
-    scripts_to_unpause = []
-    scripts_to_unpause = DRC.smart_pause_all
 
     skill = choose_skill
     if skill
-      return unless turn_tarantula?(skill, scripts_to_unpause)
+      return unless turn_tarantula?(skill)
     else
       DRC.message("*** Skipping alternate skills due to user setting. ***") if @skip_alternate && @debug
       return if @skip_alternate
@@ -110,7 +112,7 @@ class Tarantula
       alt = choose_alternate
       if alt
         skill = alt
-        return unless turn_tarantula?(alt, scripts_to_unpause)
+        return unless turn_tarantula?(alt)
       else
         DRC.message("*** No alternative skill available.  ***") if @debug
         return

--- a/tarantula.lic
+++ b/tarantula.lic
@@ -110,7 +110,7 @@ class Tarantula
       alt = choose_alternate
       if alt
         skill = alt
-        return unless turn_tarantula?(alt)
+        return unless turn_tarantula?(alt, scripts_to_unpause)
       else
         DRC.message("*** No alternative skill available.  ***") if @debug
         return

--- a/tarantula.lic
+++ b/tarantula.lic
@@ -74,7 +74,6 @@ class Tarantula
   end
 
   def turn_tarantula?(skill)
-    @scripts_to_unpause = []
     @scripts_to_unpause = DRC.smart_pause_all
 
     name = skill

--- a/tarantula.lic
+++ b/tarantula.lic
@@ -5,7 +5,6 @@
 custom_require.call(%w(common common-items drinfomon))
 
 no_kill_all
-no_pause_all
 
 class Tarantula
 


### PR DESCRIPTION
Gives Tarantula script the same function as Almanac and Tessera to minimize disruptive interactions while running concurrently with other scripts.

Resolves https://github.com/rpherbig/dr-scripts/issues/5903

Issue from discord:
```
[forge]>get my tongs

You get some clockwork-enhanced tongs with an attached shovel head from inside your trapper's duffel.
> 
[forge]>pound ingot on anvil with my silversteel mallet

You realize the hide scraper will not require as much metal as you have, and so you split the ingot and leave the portion you won't be using in your pack.

Sparks fly into the air as you transfer the scraper back and forth between the forge fires and the anvil, alternating heating with vigorous hammering of the metal.  Blow after blow rings out without any problems at all.
Roundtime: 11 sec.

Learned: Forging(0)
[forge]>pound scraper on anvil with my silversteel mallet

After using the tongs to warm the scraper over the forge fire, you place it down upon the anvil and make some adjustments to its shape with carefully timed hammer taps.  Blow after blow rings out without any problems at all.

As you complete working the fire dies down and needs more fuel.
Roundtime: 14 sec.
R> Learned: Forging(+1)

A small tongue of fire licks out along the edges of a fiery fissure.
R> 
[forge]>adjust my tongs

...wait 2 seconds.
R> 
[tarantula]>turn my harvester spider to Defending

...wait 1 seconds.
R> 
[tarantula]>turn my harvester spider to Defending

[forge]>adjust my tongs

[forge]>adjust my tongs

You fiddle with the tiny levers and dials of the spider's mechanical abdomen.  The process is complex, but you feel an intuitive grasp of the mechanism from the moment you touch it.
With a *click*, your changes snap into place.  The harvester spider will now consume Defending knowledge.
> 
[tarantula]>rub my harvester spider

You lock the tongs into a fully extended position.  Then you reach alongside the tong's body, and pull free the head of a shovel.
> 
With a yank you fold the shovel head back alongside the tong's body.  Then you unlock the arms, readying them for use as tongs once more.
> 
[forge]>push fuel with my tongs

The spider comes alive in your hand!  It skitters to the top of your spine, moving with far more agility than its metallic heaviness should allow.  A sharp stab of pain erupts at the base of your neck as it injects venom into your nervous system!
It is mere moments afterward that you feel an itching, tingling, and crawling sensation all across the inside of your skull.  In a mind-wracking flurry of sensation, you find yourself forgetting your recent progress on defending, but somehow unbidden knowledge into other Armors tasks are mapped into your psyche.
> 
I don't think pushing that would have any effect.
```
As you can see from both, Tarantula is firing commands and getting feedback, which the currently running script (first pick, then forge) is receiving and interpreting, causing errors. 

I do not have a Tarantula, therefore I cannot test this script specifically, but the logic is pulled directly from Tessera:
```ruby
  def use_tessera
    #Smart pause of scripts first prior to run cycle.
    scripts_to_unpause = []
    scripts_to_unpause = DRC.smart_pause_all
    waitrt?
    pause 1
    clear

    #Safe actions to use tessera, retreats first, then asks tessera about invest.
    DRC.retreat
    waitrt?
    
    #If it cannot find the tessera (bags may be closed, not in inventory), then the script exits.
    unless DRCI.get_item_if_not_held?(@tessera) && DRCI.in_hands?(@tessera)
      if DRCI.exists?(@tessera)
        DRC.message('Hands full, will try again later')
        DRC.unpause_all_list(scripts_to_unpause)
        return
      else
        DRC.message('Tessera not found, exiting')
        DRC.unpause_all_list(scripts_to_unpause)
        exit
      end
    end

    #command to use the tessera, then stow it away and set the time once it was last attempted. Unpauses scripts at end.
    DRC.bput("ask my #{@tessera} about invest", 'You send your', 'You cannot do that while focusing on combat')
    waitrt?
    DRCI.put_away_item?(@tessera)
    UserVars.tessera_last_use = Time.now
    DRC.unpause_all_list(scripts_to_unpause)
  end
  ```
