### PR TITLE
[script][combat-trainer] - Refactor egg and warhorn use

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2185,13 +2185,14 @@ class AbilityProcess
     if noun =~ /egg/i
       return unless Time.now > UserVars.warhorn["last_egg"] + 900
       if use_egg?
+        DRC.message("SUCCESSFUL egg use") if $debug_mode_ct
         UserVars.warhorn["last_egg"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end
     else
       return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
       if use_warhorn?
-        DRC.message("SUCCESSFUL horn use")
+        DRC.message("SUCCESSFUL horn use") if $debug_mode_ct
         UserVars.warhorn["last_warhorn"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -37,7 +37,7 @@ class SetupProcess
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
 
     # Allows user to set the warhorn cooldown
-    @warhorn_cooldown = settings.warhorn_cooldown || 1200
+    @warhorn_cooldown = settings.warhorn_cooldown
     echo("  @warhorn_cooldown: #{@warhorn_cooldown}") if $debug_mode_ct
 
     @last_warhorn = Time.now - @warhorn_cooldown
@@ -187,7 +187,7 @@ class SetupProcess
       return true
     when /^What were you referring to/, /Invoke what?/
       DRC.message("Can't find egg, removing from hunt.")
-      @warhorn_or_egg.delete(@egg)
+      # @warhorn_or_egg.delete('egg')
       return true
     end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -104,7 +104,6 @@ class SetupProcess
     was_retreating = game_state.retreating?
     game_state.update_room_npcs
     if game_state.dancing?
-      DRC.message("USING warhorn in dance section")
       use_warhorn_or_egg(game_state) unless @warhorn_or_egg.empty?
       game_state.dance
     elsif game_state.retreating?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2235,21 +2235,21 @@ class AbilityProcess
       warhorn_activation = DRC.bput(@warhorn_activation_command, 'Something about the area inhibits',
         'You sound a series of bursts from the', 'Your lungs are tired from having sounded a', 'not accomplishing much and looking rather silly')
       if /Your lungs are tired from having sounded a/ =~ warhorn_activation
-        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+        stow_warhorn
         return false
       elsif /Something about the area inhibits/ =~ warhorn_activation
         DRC.message "Can't use #{@warhorn} in this area. Removing from hunt."
-        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+        stow_warhorn
         @warhorn_or_egg.delete(@warhorn)
         return false
       elsif /not accomplishing much and looking rather silly/ =~ warhorn_activation
         DRC.message "You can't use a warhorn. Removing from hunt."
-        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+        stow_warhorn
         @warhorn_or_egg.delete(@warhorn)
         return false
       end
       waitrt?
-      DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+      stow_warhorn
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
       @warhorn_or_egg.delete(@warhorn)
@@ -2257,6 +2257,10 @@ class AbilityProcess
     end
 
     return true
+  end
+
+  def stow_warhorn
+    DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
   end
 
   def check_paladin_skills

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -37,7 +37,7 @@ class SetupProcess
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
 
     # Allows user to set the warhorn cooldown
-    @warhorn_cooldown = settings.warhorn_cooldown.to_i
+    @warhorn_cooldown = settings.warhorn_cooldown.to_i || 1200
     echo("  @warhorn_cooldown: #{@warhorn_cooldown}") if $debug_mode_ct
 
     @last_warhorn = Time.now - @warhorn_cooldown

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -31,24 +31,52 @@ class SetupProcess
     @ignore_weapon_mindstate = settings.combat_trainer_ignore_weapon_mindstate
     echo("  @ignore_weapon_mindstate: #{@ignore_weapon_mindstate}") if $debug_mode_ct
     @gearsets = settings.gear_sets
+
+    # Warhorn setting, could be legacy egg or warhorn
     @warhorn = settings.warhorn
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
-    @next_warhorn = Time.now
+
+    # Allows user to set the warhorn cooldown
+    @warhorn_cooldown = settings.warhorn_cooldown || 1200
+    echo("  @warhorn_cooldown: #{@warhorn_cooldown}") if $debug_mode_ct
+
+    @last_warhorn = Time.now - @warhorn_cooldown
+    echo("  @last_warhorn: #{@last_warhorn}") if $debug_mode_ct
+
+    # Egg settings, for egg only
+    @egg = settings.egg
+    echo("  @egg: #{@egg}") if $debug_mode_ct
+
+    @last_egg = Time.now - 900
+    echo("  @last_egg: #{@last_egg}") if $debug_mode_ct
+
+    @last_warhorn_or_egg = Time.now - 600
+    echo("  @last_warhorn_or_egg: #{@last_warhorn_or_egg}") if $debug_mode_ct
+
+    # Array representing warhorn and/or egg settings. We'll use this to rotate if both are set.
+    @warhorn_or_egg = [@warhorn, @egg].compact
 
     validate_regalia(settings)
+    set_warhorn if @warhorn
 
-    return unless @warhorn
+  end
 
-    if @warhorn.casecmp('egg').zero?
-      @warhon_activation_command = "invoke my #{@warhorn}"
+  # Handle some legacy use of warhorn: egg, as well as figure out if it's a wearable warhorn.
+  def set_warhorn
+    if @warhorn =~ /egg/
+      echo "Legacy use of warhorn: egg. Handling."
+      @warhorn_activation_command = "invoke my #{@warhorn}"
     else
-      @warhon_activation_command = "exhale #{@warhorn} lure"
+      echo "Warhorn is actually a warhorn, not legacy use of : egg."
+      @warhorn_activation_command = "exhale #{@warhorn} lure"
     end
 
     if DRCI.wearing?(@warhorn)
+      echo "We're wearing the warhorn, remove/wear"
       @warhorn_get_verb = 'remove'
       @warhorn_store_verb = 'wear'
     else
+      echo "Not wearing warhorn, get/stow"
       @warhorn_get_verb = 'get'
       @warhorn_store_verb = 'stow'
     end
@@ -76,7 +104,8 @@ class SetupProcess
     was_retreating = game_state.retreating?
     game_state.update_room_npcs
     if game_state.dancing?
-      blow_warhorn(game_state)
+      DRC.message("USING warhorn in dance section")
+      use_warhorn_or_egg(game_state)
       game_state.dance
     elsif game_state.retreating?
       determine_next_to_train(game_state, game_state.retreat_weapons, false)
@@ -104,27 +133,88 @@ class SetupProcess
 
   private
 
-  def blow_warhorn(game_state)
-    return unless @warhorn
-    return if Time.now < @next_warhorn
+  # Controller method for warhorn and/or egg use
+  def use_warhorn_or_egg(game_state)
+    DRC.message(" ")
+    DRC.message("Warhorn/egg array is: #{@warhorn_or_egg}")
+    DRC.message("Time since last warhorn effect: #{(Time.now - @last_warhorn_or_egg)/60}")
+    DRC.message("Time since last warhorn use: #{(Time.now - @last_warhorn)/60}")
+    DRC.message("Time since last egg use: #{(Time.now - @last_egg)/60}")
+
+    # Return unless either warhorn or egg are set
+    return unless @warhorn || @egg
+
+    # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
+    DRC.message("NOT 10 minutes since last worhorn") unless Time.now > (@last_warhorn_or_egg + 600)
+    return unless Time.now > (@last_warhorn_or_egg + 600)
 
     game_state.sheath_whirlwind_offhand
 
-    case DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn|egg).*\.$/, /^You remove.*(?:warhorn|egg).*\.$/, /^You take.*(?:warhorn|egg).*\.$/, /^What were you referring to/, /^You need a free hand/, /^Remove what/)
-    when /^You get.*(?:warhorn|egg).*\.$/, /^You remove.*(?:warhorn|egg).*\.$/, /^You take.*(?:warhorn|egg).*\.$/
-      if /The red light within the egg is dim and moves about sluggishly|Your lungs are tired from having sounded a/ =~ DRC.bput(@warhon_activation_command,'light envelops the area briefly', 'The red light within the egg is dim and moves about sluggishly', 'Something about the area inhibits','You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
-        @next_warhorn = Time.now + 60
-      else
-        @next_warhorn = Time.now + 300
+    # We created an array and we'll use the first element as the noun. If we define a warhorn or
+    # an egg, we'll later rotate the elements.
+    noun = @warhorn_or_egg[0]
+
+    if noun =~ /egg/i
+      return unless Time.now > @last_egg + 900
+      if use_egg?
+        DRC.message("SUCCESSFUL egg use")
+        @last_egg = Time.now
+        @last_warhorn_or_egg = Time.now
+      end
+    else
+      return unless Time.now > @last_warhorn + @warhorn_cooldown
+      if use_warhorn?
+        DRC.message("SUCCESSFUL horn use")
+        @last_warhorn = Time.now
+        @last_warhorn_or_egg = Time.now
+      end
+    end
+
+    game_state.wield_whirlwind_offhand
+    DRC.message("Rotating warhorn/egg.")
+    @warhorn_or_egg.rotate!
+  end
+
+  def use_egg?
+    use_egg = DRC.bput('invoke my egg', 'light envelops the area briefly',
+      'The red light within the egg is dim and moves about sluggishly',
+      'Something about the area inhibits', 'Invoke what?')
+
+    case use_egg
+    when /The red light within the egg is dim and moves about sluggishly/
+      return false
+    when /Something about the area inhibits/, /^What were you referring to/, /Invoke what?/
+      DRC.message "Egg not found or can't be used in this area."
+      return true
+    end
+
+    return true
+  end
+
+  # Method to handle using the warhorn
+  def use_warhorn?
+
+    use_warhorn = DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn).*\.$/,
+     /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/, /^What were you referring to/,
+     /^You need a free hand/, /^Remove what/)
+
+    case use_warhorn
+    when /^You get.*(?:warhorn).*\.$/, /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/
+      warhorn_activation = DRC.bput(@warhorn_activation_command, 'Something about the area inhibits',
+        'You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
+      if /Your lungs are tired from having sounded a/ =~ warhorn_activation
+        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+        return false
       end
       waitrt?
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      @warhorn = nil
+      # @warhorn = nil
+      return true
     end
 
-    game_state.wield_whirlwind_offhand
+    return true
   end
 
   def armor_hysteresis?
@@ -198,7 +288,7 @@ class SetupProcess
 
   def determine_next_to_train(game_state, weapon_training, ending_ranged)
     return unless game_state.skill_done? || !weapon_training[game_state.weapon_skill] || ending_ranged
-    
+
     unless @ignore_weapon_mindstate
       #check if all weapons are maxed exp to prevent rapid cycling
       if weapon_training.reject { | skill,_ |  DRSkill.getxp(skill) == 34 }.empty?
@@ -892,7 +982,7 @@ class LootProcess
     else
       return
     end
-  end  
+  end
 
   def dissected?(mob_noun, game_state)
     case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered', 'You realize after a few seconds')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -189,8 +189,8 @@ class SetupProcess
       return false
     when /^What were you referring to/, /Invoke what?/
       DRC.message("Can't find egg, removing from hunt.")
-      # @warhorn_or_egg.delete('egg')
-      return true
+      @warhorn_or_egg.delete('egg')
+      return false
     end
 
     return true
@@ -213,8 +213,8 @@ class SetupProcess
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      # @warhorn_or_egg.delete(@warhorn)
-      return true
+      @warhorn_or_egg.delete(@warhorn)
+      return false
     end
 
     return true

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2120,17 +2120,15 @@ class AbilityProcess
     check_paladin_skills
     check_nonspell_buffs(game_state)
     check_battle_cries(game_state)
-
-    DRC.message(" ")
-    DRC.message("Will now attempt use of warhorn or egg")
-    DRC.message("Warhorn and egg array empty! All usage will be skipped.") if @warhorn_or_egg.empty?
+    DRC.message("warhorn_or_egg array is: #{@warhorn_or_egg}")  if $debug_mode_ct
     use_warhorn_or_egg(game_state) unless @warhorn_or_egg.nil? || @warhorn_or_egg.empty?
-
     false
   end
 
   private
 
+  # Sets up our warhorn and/or egg use. Sets timers. Allows legacy use of warhorn: egg. Checks to
+  # see if we're using a wearable warhorn or have it in a bag.
   def set_warhorn_or_egg
     # Helps us rotate horn/egg use
     @warhorn_or_egg = [@warhorn, @egg].compact
@@ -2141,27 +2139,30 @@ class AbilityProcess
     UserVars.warhorn["last_egg"] = (Time.now - 900) unless UserVars.warhorn["last_egg"]
     UserVars.warhorn["last_warhorn_or_egg"] = (Time.now - 600) unless UserVars.warhorn["last_warhorn_or_egg"]
 
+    # If user has defined both a warhorn and egg, we'll rotate, and since cooldowns are persistent in UserVars,
+    # do a one-time check to see which has lower time left, and put that first.
     if @warhorn_or_egg.count > 1
       if (Time.now - UserVars.warhorn["last_egg"]) > (Time.now - UserVars.warhorn["last_warhorn"])
-        DRC.message("Rotating egg/warhorn array to put lowest cooldown first")
         @warhorn_or_egg.rotate!
       end
     end
 
+    # This is how an egg was specified prior to this warhorn/egg rotation code. We'll still support.
     if @warhorn =~ /egg/
-      echo "Legacy use of warhorn: egg. Handling."
+      echo "Legacy use of warhorn: egg. Handling." if $debug_mode_ct
       @warhorn_activation_command = "invoke my #{@warhorn}"
     else
-      echo "Warhorn is actually a warhorn, not legacy use of : egg."
+      echo "Warhorn is actually a warhorn, not legacy use of : egg." if $debug_mode_ct
       @warhorn_activation_command = "exhale #{@warhorn} lure"
     end
 
+    # Set our warhorn verbs depending on whether a worn or stowed warhorn.
     if DRCI.wearing?(@warhorn)
-      echo "We're wearing the warhorn, remove/wear"
+      echo "We're wearing the warhorn, remove/wear are the verbs." if $debug_mode_ct
       @warhorn_get_verb = 'remove'
       @warhorn_store_verb = 'wear'
     else
-      echo "Not wearing warhorn, get/stow"
+      echo "Not wearing warhorn, get/stow are the verbs." if $debug_mode_ct
       @warhorn_get_verb = 'get'
       @warhorn_store_verb = 'stow'
     end
@@ -2169,29 +2170,25 @@ class AbilityProcess
 
   # Controller method for warhorn and/or egg use
   def use_warhorn_or_egg(game_state)
-    DRC.message("Warhorn/egg array is: #{@warhorn_or_egg}")
-    DRC.message("Time since last warhorn effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"])/60}")
-    DRC.message("Time since last warhorn use: #{(Time.now - UserVars.warhorn["last_warhorn"])/60}")
-    DRC.message("Time since last egg use: #{(Time.now - UserVars.warhorn["last_egg"])/60}")
+    DRC.message("Time since last warhorn room effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"])/60}") if $debug_mode_ct
+    DRC.message("Time since last warhorn use: #{(Time.now - UserVars.warhorn["last_warhorn"])/60}") if $debug_mode_ct
+    DRC.message("Time since last egg use: #{(Time.now - UserVars.warhorn["last_egg"])/60}") if $debug_mode_ct
 
     # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
-    DRC.message("NOT 10 minutes since last worhorn or egg room effect") unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
     return unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
 
     game_state.sheath_whirlwind_offhand
 
     noun = @warhorn_or_egg[0]
 
+    # Check timers. Egg is always 15 minutes. Warhorn is 20 minutes, or configurable.
     if noun =~ /egg/i
-      DRC.message("Timer not up for egg.") unless Time.now > UserVars.warhorn["last_egg"] + 900
       return unless Time.now > UserVars.warhorn["last_egg"] + 900
       if use_egg?
-        DRC.message("SUCCESSFUL egg use")
         UserVars.warhorn["last_egg"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end
     else
-      DRC.message("Not #{@warhorn_cooldown/60} minutes since last warhorn.") unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
       return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
       if use_warhorn?
         DRC.message("SUCCESSFUL horn use")
@@ -2201,7 +2198,8 @@ class AbilityProcess
     end
 
     game_state.wield_whirlwind_offhand
-    DRC.message("Rotating warhorn/egg.")
+
+    # Rotate array to rotate warhorn/egg use. If we only have one, this still works fine.
     @warhorn_or_egg.rotate!
   end
 
@@ -2214,7 +2212,8 @@ class AbilityProcess
     when /The red light within the egg is dim and moves about sluggishly/
       return false
     when /Something about the area inhibits/
-      DRC.message("Egg can't be used in this area.")
+      DRC.message("Egg can't be used in this area. Removing from hunt.")
+      @warhorn_or_egg.delete('egg')
       return false
     when /^What were you referring to/, /Invoke what?/
       DRC.message("Can't find egg, removing from hunt.")
@@ -2237,12 +2236,23 @@ class AbilityProcess
       if /Your lungs are tired from having sounded a/ =~ warhorn_activation
         DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
         return false
+      elsif /Something about the area inhibits/ =~ warhorn_activation
+        DRC.message "Can't use #{@warhorn} in this area. Removing from hunt."
+        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+        @warhorn_or_egg.delete(@warhorn)
+        return false
+      elsif /not accomplishing much and looking rather silly/ =~ warhorn_activation
+        DRC.message "You can't use a warhorn. Removing from hunt."
+        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+        DRC.message("@warhorn_or_egg before delete is: #{@warhorn_or_egg}")
+        @warhorn_or_egg.delete(@warhorn)
+        DRC.message("@warhorn_or_egg after delete is: #{@warhorn_or_egg}")
+        return false
       end
       waitrt?
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      @warhorn = nil
       @warhorn_or_egg.delete(@warhorn)
       return false
     end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -37,7 +37,7 @@ class SetupProcess
     echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
 
     # Allows user to set the warhorn cooldown
-    @warhorn_cooldown = settings.warhorn_cooldown
+    @warhorn_cooldown = settings.warhorn_cooldown.to_i
     echo("  @warhorn_cooldown: #{@warhorn_cooldown}") if $debug_mode_ct
 
     @last_warhorn = Time.now - @warhorn_cooldown
@@ -144,7 +144,7 @@ class SetupProcess
     return unless @warhorn || @egg
 
     # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
-    DRC.message("NOT 10 minutes since last worhorn") unless Time.now > (@last_warhorn_or_egg + 600)
+    DRC.message("NOT 10 minutes since last worhorn effect") unless Time.now > (@last_warhorn_or_egg + 600)
     return unless Time.now > (@last_warhorn_or_egg + 600)
 
     game_state.sheath_whirlwind_offhand
@@ -161,7 +161,8 @@ class SetupProcess
         @last_warhorn_or_egg = Time.now
       end
     else
-      return unless Time.now > @last_warhorn + @warhorn_cooldown
+      DRC.message("Not #{@warhorn_cooldown/60} minutes since last warhorn.") unless Time.now > (@last_warhorn + @warhorn_cooldown)
+      return unless Time.now > (@last_warhorn + @warhorn_cooldown)
       if use_warhorn?
         DRC.message("SUCCESSFUL horn use")
         @last_warhorn = Time.now
@@ -213,7 +214,7 @@ class SetupProcess
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      @warhorn_or_egg.delete(@warhorn)
+      # @warhorn_or_egg.delete(@warhorn)
       return true
     end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -40,29 +40,32 @@ class SetupProcess
     @warhorn_cooldown = settings.warhorn_cooldown.to_i || 1200
     echo("  @warhorn_cooldown: #{@warhorn_cooldown}") if $debug_mode_ct
 
-    @last_warhorn = Time.now - @warhorn_cooldown
-    echo("  @last_warhorn: #{@last_warhorn}") if $debug_mode_ct
-
     # Egg settings, for egg only
     @egg = settings.egg
     echo("  @egg: #{@egg}") if $debug_mode_ct
 
-    @last_egg = Time.now - 900
-    echo("  @last_egg: #{@last_egg}") if $debug_mode_ct
-
-    @last_warhorn_or_egg = Time.now - 600
-    echo("  @last_warhorn_or_egg: #{@last_warhorn_or_egg}") if $debug_mode_ct
-
-    # Array representing warhorn and/or egg settings. We'll use this to rotate if both are set.
-    @warhorn_or_egg = [@warhorn, @egg].compact
-
     validate_regalia(settings)
-    set_warhorn if @warhorn
+    set_warhorn_or_egg if @warhorn || @egg
 
   end
 
-  # Handle some legacy use of warhorn: egg, as well as figure out if it's a wearable warhorn.
-  def set_warhorn
+  def set_warhorn_or_egg
+    # Helps us rotate horn/egg use
+    @warhorn_or_egg = [@warhorn, @egg].compact
+
+    # Store timestamps in UserVars
+    UserVars.warhorn = {} unless UserVars.warhorn
+    UserVars.warhorn["last_warhorn"] = (Time.now - @warhorn_cooldown) unless UserVars.warhorn["last_warhorn"]
+    UserVars.warhorn["last_egg"] = (Time.now - 900) unless UserVars.warhorn["last_egg"]
+    UserVars.warhorn["last_warhorn_or_egg"] = (Time.now - 600) unless UserVars.warhorn["last_warhorn_or_egg"]
+
+    if @warhorn_or_egg.count > 1
+      if (Time.now - UserVars.warhorn["last_egg"]) > (Time.now - UserVars.warhorn["last_warhorn"])
+        DRC.message("Rotating egg/warhorn array to put lowest cooldown first")
+        @warhorn_or_egg.rotate!
+      end
+    end
+
     if @warhorn =~ /egg/
       echo "Legacy use of warhorn: egg. Handling."
       @warhorn_activation_command = "invoke my #{@warhorn}"
@@ -104,6 +107,9 @@ class SetupProcess
     was_retreating = game_state.retreating?
     game_state.update_room_npcs
     if game_state.dancing?
+      DRC.message(" ")
+      DRC.message("Game state is dancing, will now attempt use of warhorn or egg")
+      DRC.message("Warhorn and egg array empty! All usage will be skipped.") if @warhorn_or_egg.empty?
       use_warhorn_or_egg(game_state) unless @warhorn_or_egg.empty?
       game_state.dance
     elsif game_state.retreating?
@@ -134,39 +140,34 @@ class SetupProcess
 
   # Controller method for warhorn and/or egg use
   def use_warhorn_or_egg(game_state)
-    DRC.message(" ")
     DRC.message("Warhorn/egg array is: #{@warhorn_or_egg}")
-    DRC.message("Time since last warhorn effect: #{(Time.now - @last_warhorn_or_egg)/60}")
-    DRC.message("Time since last warhorn use: #{(Time.now - @last_warhorn)/60}")
-    DRC.message("Time since last egg use: #{(Time.now - @last_egg)/60}")
-
-    # Return unless either warhorn or egg are set
-    return unless @warhorn || @egg
+    DRC.message("Time since last warhorn effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"])/60}")
+    DRC.message("Time since last warhorn use: #{(Time.now - UserVars.warhorn["last_warhorn"])/60}")
+    DRC.message("Time since last egg use: #{(Time.now - UserVars.warhorn["last_egg"])/60}")
 
     # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
-    DRC.message("NOT 10 minutes since last worhorn effect") unless Time.now > (@last_warhorn_or_egg + 600)
-    return unless Time.now > (@last_warhorn_or_egg + 600)
+    DRC.message("NOT 10 minutes since last worhorn or egg room effect") unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
+    return unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
 
     game_state.sheath_whirlwind_offhand
 
-    # We created an array and we'll use the first element as the noun. If we define a warhorn or
-    # an egg, we'll later rotate the elements.
     noun = @warhorn_or_egg[0]
 
     if noun =~ /egg/i
-      return unless Time.now > @last_egg + 900
+      DRC.message("Timer not up for egg.") unless Time.now > UserVars.warhorn["last_egg"] + 900
+      return unless Time.now > UserVars.warhorn["last_egg"] + 900
       if use_egg?
         DRC.message("SUCCESSFUL egg use")
-        @last_egg = Time.now
-        @last_warhorn_or_egg = Time.now
+        UserVars.warhorn["last_egg"] = Time.now
+        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end
     else
-      DRC.message("Not #{@warhorn_cooldown/60} minutes since last warhorn.") unless Time.now > (@last_warhorn + @warhorn_cooldown)
-      return unless Time.now > (@last_warhorn + @warhorn_cooldown)
+      DRC.message("Not #{@warhorn_cooldown/60} minutes since last warhorn.") unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
+      return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
       if use_warhorn?
         DRC.message("SUCCESSFUL horn use")
-        @last_warhorn = Time.now
-        @last_warhorn_or_egg = Time.now
+        UserVars.warhorn["last_warhorn"] = Time.now
+        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end
     end
 
@@ -188,16 +189,14 @@ class SetupProcess
       return false
     when /^What were you referring to/, /Invoke what?/
       DRC.message("Can't find egg, removing from hunt.")
-      @warhorn_or_egg.delete('egg')
-      return false
+      # @warhorn_or_egg.delete('egg')
+      return true
     end
 
     return true
   end
 
-  # Method to handle using the warhorn
   def use_warhorn?
-
     use_warhorn = DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn).*\.$/,
      /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/, /^What were you referring to/,
      /^You need a free hand/, /^Remove what/)
@@ -214,8 +213,8 @@ class SetupProcess
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      @warhorn_or_egg.delete(@warhorn)
-      return false
+      # @warhorn_or_egg.delete(@warhorn)
+      return true
     end
 
     return true

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2245,9 +2245,7 @@ class AbilityProcess
       elsif /not accomplishing much and looking rather silly/ =~ warhorn_activation
         DRC.message "You can't use a warhorn. Removing from hunt."
         DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
-        DRC.message("@warhorn_or_egg before delete is: #{@warhorn_or_egg}")
         @warhorn_or_egg.delete(@warhorn)
-        DRC.message("@warhorn_or_egg after delete is: #{@warhorn_or_egg}")
         return false
       end
       waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -185,11 +185,11 @@ class SetupProcess
       return false
     when /Something about the area inhibits/
       DRC.message("Egg can't be used in this area.")
-      return true
+      return false
     when /^What were you referring to/, /Invoke what?/
       DRC.message("Can't find egg, removing from hunt.")
-      # @warhorn_or_egg.delete('egg')
-      return true
+      @warhorn_or_egg.delete('egg')
+      return false
     end
 
     return true
@@ -214,8 +214,8 @@ class SetupProcess
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      # @warhorn_or_egg.delete(@warhorn)
-      return true
+      @warhorn_or_egg.delete(@warhorn)
+      return false
     end
 
     return true

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -32,57 +32,7 @@ class SetupProcess
     echo("  @ignore_weapon_mindstate: #{@ignore_weapon_mindstate}") if $debug_mode_ct
     @gearsets = settings.gear_sets
 
-    # Warhorn setting, could be legacy egg or warhorn
-    @warhorn = settings.warhorn
-    echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
-
-    # Allows user to set the warhorn cooldown
-    @warhorn_cooldown = settings.warhorn_cooldown.to_i || 1200
-    echo("  @warhorn_cooldown: #{@warhorn_cooldown}") if $debug_mode_ct
-
-    # Egg settings, for egg only
-    @egg = settings.egg
-    echo("  @egg: #{@egg}") if $debug_mode_ct
-
     validate_regalia(settings)
-    set_warhorn_or_egg if @warhorn || @egg
-
-  end
-
-  def set_warhorn_or_egg
-    # Helps us rotate horn/egg use
-    @warhorn_or_egg = [@warhorn, @egg].compact
-
-    # Store timestamps in UserVars
-    UserVars.warhorn = {} unless UserVars.warhorn
-    UserVars.warhorn["last_warhorn"] = (Time.now - @warhorn_cooldown) unless UserVars.warhorn["last_warhorn"]
-    UserVars.warhorn["last_egg"] = (Time.now - 900) unless UserVars.warhorn["last_egg"]
-    UserVars.warhorn["last_warhorn_or_egg"] = (Time.now - 600) unless UserVars.warhorn["last_warhorn_or_egg"]
-
-    if @warhorn_or_egg.count > 1
-      if (Time.now - UserVars.warhorn["last_egg"]) > (Time.now - UserVars.warhorn["last_warhorn"])
-        DRC.message("Rotating egg/warhorn array to put lowest cooldown first")
-        @warhorn_or_egg.rotate!
-      end
-    end
-
-    if @warhorn =~ /egg/
-      echo "Legacy use of warhorn: egg. Handling."
-      @warhorn_activation_command = "invoke my #{@warhorn}"
-    else
-      echo "Warhorn is actually a warhorn, not legacy use of : egg."
-      @warhorn_activation_command = "exhale #{@warhorn} lure"
-    end
-
-    if DRCI.wearing?(@warhorn)
-      echo "We're wearing the warhorn, remove/wear"
-      @warhorn_get_verb = 'remove'
-      @warhorn_store_verb = 'wear'
-    else
-      echo "Not wearing warhorn, get/stow"
-      @warhorn_get_verb = 'get'
-      @warhorn_store_verb = 'stow'
-    end
   end
 
   def execute(game_state)
@@ -107,10 +57,6 @@ class SetupProcess
     was_retreating = game_state.retreating?
     game_state.update_room_npcs
     if game_state.dancing?
-      DRC.message(" ")
-      DRC.message("Game state is dancing, will now attempt use of warhorn or egg")
-      DRC.message("Warhorn and egg array empty! All usage will be skipped.") if @warhorn_or_egg.empty?
-      use_warhorn_or_egg(game_state) unless @warhorn_or_egg.empty?
       game_state.dance
     elsif game_state.retreating?
       determine_next_to_train(game_state, game_state.retreat_weapons, false)
@@ -137,88 +83,6 @@ class SetupProcess
   end
 
   private
-
-  # Controller method for warhorn and/or egg use
-  def use_warhorn_or_egg(game_state)
-    DRC.message("Warhorn/egg array is: #{@warhorn_or_egg}")
-    DRC.message("Time since last warhorn effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"])/60}")
-    DRC.message("Time since last warhorn use: #{(Time.now - UserVars.warhorn["last_warhorn"])/60}")
-    DRC.message("Time since last egg use: #{(Time.now - UserVars.warhorn["last_egg"])/60}")
-
-    # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
-    DRC.message("NOT 10 minutes since last worhorn or egg room effect") unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
-    return unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
-
-    game_state.sheath_whirlwind_offhand
-
-    noun = @warhorn_or_egg[0]
-
-    if noun =~ /egg/i
-      DRC.message("Timer not up for egg.") unless Time.now > UserVars.warhorn["last_egg"] + 900
-      return unless Time.now > UserVars.warhorn["last_egg"] + 900
-      if use_egg?
-        DRC.message("SUCCESSFUL egg use")
-        UserVars.warhorn["last_egg"] = Time.now
-        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
-      end
-    else
-      DRC.message("Not #{@warhorn_cooldown/60} minutes since last warhorn.") unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
-      return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
-      if use_warhorn?
-        DRC.message("SUCCESSFUL horn use")
-        UserVars.warhorn["last_warhorn"] = Time.now
-        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
-      end
-    end
-
-    game_state.wield_whirlwind_offhand
-    DRC.message("Rotating warhorn/egg.")
-    @warhorn_or_egg.rotate!
-  end
-
-  def use_egg?
-    use_egg = DRC.bput('invoke my egg', 'light envelops the area briefly',
-      'The red light within the egg is dim and moves about sluggishly',
-      'Something about the area inhibits', 'Invoke what?')
-
-    case use_egg
-    when /The red light within the egg is dim and moves about sluggishly/
-      return false
-    when /Something about the area inhibits/
-      DRC.message("Egg can't be used in this area.")
-      return false
-    when /^What were you referring to/, /Invoke what?/
-      DRC.message("Can't find egg, removing from hunt.")
-      @warhorn_or_egg.delete('egg')
-      return false
-    end
-
-    return true
-  end
-
-  def use_warhorn?
-    use_warhorn = DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn).*\.$/,
-     /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/, /^What were you referring to/,
-     /^You need a free hand/, /^Remove what/)
-
-    case use_warhorn
-    when /^You get.*(?:warhorn).*\.$/, /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/
-      warhorn_activation = DRC.bput(@warhorn_activation_command, 'Something about the area inhibits',
-        'You sound a series of bursts from the', 'Your lungs are tired from having sounded a')
-      if /Your lungs are tired from having sounded a/ =~ warhorn_activation
-        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
-        return false
-      end
-      waitrt?
-      DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
-    when /^What were you referring to/
-      DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      @warhorn_or_egg.delete(@warhorn)
-      return false
-    end
-
-    return true
-  end
 
   def armor_hysteresis?
     return false unless @armor_hysteresis
@@ -2224,6 +2088,20 @@ class AbilityProcess
       echo 'Added glyph of mana expiration flag.' if $debug_mode_ct
     end
 
+    # Warhorn setting, could be legacy egg or warhorn
+    @warhorn = settings.warhorn
+    echo("  @warhorn: #{@warhorn}") if $debug_mode_ct
+
+    # Allows user to set the warhorn cooldown
+    @warhorn_cooldown = settings.warhorn_cooldown.to_i || 1200
+    echo("  @warhorn_cooldown: #{@warhorn_cooldown}") if $debug_mode_ct
+
+    # Egg settings, for egg only
+    @egg = settings.egg
+    echo("  @egg: #{@egg}") if $debug_mode_ct
+
+    set_warhorn_or_egg if @warhorn || @egg
+
     return unless @paladin_use_badge
 
     if DRCI.wearing?('pilgrim badge')
@@ -2242,10 +2120,135 @@ class AbilityProcess
     check_paladin_skills
     check_nonspell_buffs(game_state)
     check_battle_cries(game_state)
+
+    DRC.message(" ")
+    DRC.message("Will now attempt use of warhorn or egg")
+    DRC.message("Warhorn and egg array empty! All usage will be skipped.") if @warhorn_or_egg.empty?
+    use_warhorn_or_egg(game_state) unless @warhorn_or_egg.nil? || @warhorn_or_egg.empty?
+
     false
   end
 
   private
+
+  def set_warhorn_or_egg
+    # Helps us rotate horn/egg use
+    @warhorn_or_egg = [@warhorn, @egg].compact
+
+    # Store timestamps in UserVars
+    UserVars.warhorn = {} unless UserVars.warhorn
+    UserVars.warhorn["last_warhorn"] = (Time.now - @warhorn_cooldown) unless UserVars.warhorn["last_warhorn"]
+    UserVars.warhorn["last_egg"] = (Time.now - 900) unless UserVars.warhorn["last_egg"]
+    UserVars.warhorn["last_warhorn_or_egg"] = (Time.now - 600) unless UserVars.warhorn["last_warhorn_or_egg"]
+
+    if @warhorn_or_egg.count > 1
+      if (Time.now - UserVars.warhorn["last_egg"]) > (Time.now - UserVars.warhorn["last_warhorn"])
+        DRC.message("Rotating egg/warhorn array to put lowest cooldown first")
+        @warhorn_or_egg.rotate!
+      end
+    end
+
+    if @warhorn =~ /egg/
+      echo "Legacy use of warhorn: egg. Handling."
+      @warhorn_activation_command = "invoke my #{@warhorn}"
+    else
+      echo "Warhorn is actually a warhorn, not legacy use of : egg."
+      @warhorn_activation_command = "exhale #{@warhorn} lure"
+    end
+
+    if DRCI.wearing?(@warhorn)
+      echo "We're wearing the warhorn, remove/wear"
+      @warhorn_get_verb = 'remove'
+      @warhorn_store_verb = 'wear'
+    else
+      echo "Not wearing warhorn, get/stow"
+      @warhorn_get_verb = 'get'
+      @warhorn_store_verb = 'stow'
+    end
+  end
+
+  # Controller method for warhorn and/or egg use
+  def use_warhorn_or_egg(game_state)
+    DRC.message("Warhorn/egg array is: #{@warhorn_or_egg}")
+    DRC.message("Time since last warhorn effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"])/60}")
+    DRC.message("Time since last warhorn use: #{(Time.now - UserVars.warhorn["last_warhorn"])/60}")
+    DRC.message("Time since last egg use: #{(Time.now - UserVars.warhorn["last_egg"])/60}")
+
+    # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
+    DRC.message("NOT 10 minutes since last worhorn or egg room effect") unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
+    return unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
+
+    game_state.sheath_whirlwind_offhand
+
+    noun = @warhorn_or_egg[0]
+
+    if noun =~ /egg/i
+      DRC.message("Timer not up for egg.") unless Time.now > UserVars.warhorn["last_egg"] + 900
+      return unless Time.now > UserVars.warhorn["last_egg"] + 900
+      if use_egg?
+        DRC.message("SUCCESSFUL egg use")
+        UserVars.warhorn["last_egg"] = Time.now
+        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
+      end
+    else
+      DRC.message("Not #{@warhorn_cooldown/60} minutes since last warhorn.") unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
+      return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
+      if use_warhorn?
+        DRC.message("SUCCESSFUL horn use")
+        UserVars.warhorn["last_warhorn"] = Time.now
+        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
+      end
+    end
+
+    game_state.wield_whirlwind_offhand
+    DRC.message("Rotating warhorn/egg.")
+    @warhorn_or_egg.rotate!
+  end
+
+  def use_egg?
+    use_egg = DRC.bput('invoke my egg', 'light envelops the area briefly',
+      'The red light within the egg is dim and moves about sluggishly',
+      'Something about the area inhibits', 'Invoke what?')
+
+    case use_egg
+    when /The red light within the egg is dim and moves about sluggishly/
+      return false
+    when /Something about the area inhibits/
+      DRC.message("Egg can't be used in this area.")
+      return false
+    when /^What were you referring to/, /Invoke what?/
+      DRC.message("Can't find egg, removing from hunt.")
+      @warhorn_or_egg.delete('egg')
+      return false
+    end
+
+    return true
+  end
+
+  def use_warhorn?
+    use_warhorn = DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn).*\.$/,
+     /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/, /^What were you referring to/,
+     /^You need a free hand/, /^Remove what/)
+
+    case use_warhorn
+    when /^You get.*(?:warhorn).*\.$/, /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/
+      warhorn_activation = DRC.bput(@warhorn_activation_command, 'Something about the area inhibits',
+        'You sound a series of bursts from the', 'Your lungs are tired from having sounded a', 'not accomplishing much and looking rather silly')
+      if /Your lungs are tired from having sounded a/ =~ warhorn_activation
+        DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+        return false
+      end
+      waitrt?
+      DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+    when /^What were you referring to/
+      DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
+      @warhorn = nil
+      @warhorn_or_egg.delete(@warhorn)
+      return false
+    end
+
+    return true
+  end
 
   def check_paladin_skills
     return unless DRStats.paladin?
@@ -3601,7 +3604,7 @@ class AttackProcess
       /^This works best when you use a suitable weapon/,
       /^This works best when you are dual wielding suitable weapons/,
       # Maneuver requires a weapon but you're not wielding any
-      /^With your fist?  That might hurt/,
+      /^With your fist? That might hurt/,
       # You can't aim before powershot maneuver
       /^You are unable to focus on performing a maneuver while aiming at an enemy/
     ]

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -105,7 +105,7 @@ class SetupProcess
     game_state.update_room_npcs
     if game_state.dancing?
       DRC.message("USING warhorn in dance section")
-      use_warhorn_or_egg(game_state)
+      use_warhorn_or_egg(game_state) unless @warhorn_or_egg.empty?
       game_state.dance
     elsif game_state.retreating?
       determine_next_to_train(game_state, game_state.retreat_weapons, false)
@@ -183,8 +183,12 @@ class SetupProcess
     case use_egg
     when /The red light within the egg is dim and moves about sluggishly/
       return false
-    when /Something about the area inhibits/, /^What were you referring to/, /Invoke what?/
-      DRC.message "Egg not found or can't be used in this area."
+    when /Something about the area inhibits/
+      DRC.message("Egg can't be used in this area.")
+      return true
+    when /^What were you referring to/, /Invoke what?/
+      DRC.message("Can't find egg, removing from hunt.")
+      @warhorn_or_egg.delete(@egg)
       return true
     end
 
@@ -210,7 +214,7 @@ class SetupProcess
       DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
-      # @warhorn = nil
+      @warhorn_or_egg.delete(@warhorn)
       return true
     end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -424,6 +424,8 @@ custom_loot_type:
 last_rites: false
 # define the noun to turn on warhorn usage every 5 minutes in combat
 warhorn:
+# Set the cooldown of your warhorn in seconds. Default is 20 minutes. Some horns are 15.
+@warhorn_cooldown: 1200
 # noun of the prayer mat to use in training_abilities
 prayer_mat:
 # optional container to bypass default mat storage in theurgy_supply_container

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -422,10 +422,12 @@ tk_ammo:
 custom_loot_type:
 # perform last_rites or not?
 last_rites: false
-# define the noun to turn on warhorn usage every 5 minutes in combat
+# define the noun to turn on warhorn usage in combat.
 warhorn:
 # Set the cooldown of your warhorn in seconds. Default is 20 minutes. Some horns are 15.
 warhorn_cooldown: 1200
+# Define the noun to turn on egg usage in combat. Cooldown is 15 minutes.
+egg:
 # noun of the prayer mat to use in training_abilities
 prayer_mat:
 # optional container to bypass default mat storage in theurgy_supply_container


### PR DESCRIPTION
Refactors egg and warhorn use, allows rotating of each.

~~Draft until final cleanup.~~ Ready for review.

A request in Discord by user Sharkbait requested the ability to rotate warhorn and egg use in combat. Legacy use of a warhorn or egg existed in `class GameState` and relied on a game state of `dancing` in order to fire. You could only use one or the other. It relied on a single yaml setting: `warhorn:`. 

After much discussion we settled upon a few things:

- A warhorn effect is a room effect that lasts 10 minutes
- Warhorn and egg use should be independent. Since the room effect is every 10 minutes, with egg cooldown being 15 minutes and warhorn cooldown being 15 - 20 minutes, rotation of the two would allow a permanent room effect every 10 minutes.
- Warhorn cooldown should be configurable. Most are 20 minutes, but some are 15 minutes.
- Warhorn/egg use should not rely on a game state of `dancing`
- We should move the code logic from `class GameState` to `class AbilityProcess`. This functions essentially like an ability. A paladin's use of a prayer badge is code-analogous and that exists in AbilityProcess.

The logic was also heavily refactored. The code allows the legacy use of `warhorn: egg` in order for backward compatibility. Timers were moved to UserVars to allow persistence between CT sessions. Allows rotation of a warhorn and egg and picks the one with the shortest timer to start. Has failsafes if the warhorn or egg can't be used, and removes them from the array for that CT session. Considers both the room effect cooldown of 10 minutes as well as each individual warhorn/egg cooldown, attempting to use the effect on timers as tightly as possible.