### PR TITLE
[script][workorders] Removing redundant consumables checks

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -313,32 +313,6 @@ class WorkOrders
         end
         stow_tool('lumber')
 
-        case DRC.bput('get my glue', 'You get', 'What were')
-        when 'You get'
-          /(\d+)/ =~ DRC.bput('count my glue', 'The wood glue has *\d+ uses remaining')
-          if Regexp.last_match(1).to_i < quantity
-            stow_tool('glue')
-            DRCT.dispose('glue')
-            DRCT.order_item(info['tool-room'], info['glue-number'])
-          end
-        else
-          DRCT.order_item(info['tool-room'], info['glue-number'])
-        end
-        stow_tool('glue')
-
-        case DRC.bput('get my wood stain', 'What were', 'You get')
-        when 'You get'
-          /(\d+)/ =~ DRC.bput('count my wood stain', 'The wood stain has *\d+ uses remaining')
-          if Regexp.last_match(1).to_i < quantity
-            stow_tool('wood stain')
-            DRCT.dispose('wood stain')
-            DRCT.order_item(info['tool-room'], info['stain-number'])
-          end
-        else
-          DRCT.order_item(info['tool-room'], info['stain-number'])
-        end
-        stow_tool('wood stain')
-
         buy_parts(recipe['part'], info['part-room'])
         DRCC.find_shaping_room(@hometown, @engineering_room)
       end
@@ -412,19 +386,6 @@ class WorkOrders
     stock_needed = ((quantity * recipe['volume'] - existing) / 10.0).ceil
     order_fabric(info['stock-room'], stock_needed, materials_info['stock-number'], "#{materials_info['stock-name']} cloth")
     order_parts(recipe['part'], quantity) if recipe['part']
-
-    case DRC.bput('get my pins', 'You get', 'What were')
-    when 'You get'
-      /(\d+)/ =~ DRC.bput('count my pins', 'The .* pins has \d+ uses remaining')
-      if Regexp.last_match(1).to_i < 6
-        stow_tool('pins')
-        DRCT.dispose('pins')
-        DRCT.order_item(info['tool-room'], 5)
-      end
-    else
-      DRCT.order_item(info['tool-room'], 5)
-    end
-    stow_tool('pins')
 
     DRCC.find_sewing_room(@hometown, @outfitting_room)
 


### PR DESCRIPTION
These consumables, as of last night, are handled by corresponding grunt scripts, eg glue and stain are now handled by shape, pins handled by sew. 