### PR TITLE
sew.lic - typo in master book turn command

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -97,7 +97,7 @@ class Sew
       end
     else
       if @settings.master_crafting_book
-        DRC.bput("turn my #{@settings.master_crafting_book} to discipline tailoring}", 'You turn the') if @settings.master_crafting_book
+        DRC.bput("turn my #{@settings.master_crafting_book} to discipline tailoring", 'You turn the') if @settings.master_crafting_book
         DRC.bput("turn my #{@settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, @settings.master_crafting_book)}", 'You turn your', 'The .* is already')
         DRC.bput("study my #{@settings.master_crafting_book}", 'Roundtime')
       else


### PR DESCRIPTION
Removed `}` in this line:
`DRC.bput("turn my #{@settings.master_crafting_book} to discipline tailoring}", 'You turn the') if @settings.master_crafting_book`