### PR TITLE
[scripts] [common] [common-items] Adding scroll search methods

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -552,6 +552,11 @@ module DRCI
     DRC.rummage('B', container)
   end
 
+
+  def get_scroll_list_in_container(container)
+    DRC.rummage('SC', container)
+  end
+
   # Takes in the noun of the configured necro material stacker, and returns the current material item count.
   def count_necro_stacker(necro_stacker)
     DRC.bput("study my #{necro_stacker}", /currently holds \d+ items/).scan(/\d+/).first.to_i

--- a/common-items.lic
+++ b/common-items.lic
@@ -552,7 +552,6 @@ module DRCI
     DRC.rummage('B', container)
   end
 
-
   def get_scroll_list_in_container(container)
     DRC.rummage('SC', container)
   end

--- a/common.lic
+++ b/common.lic
@@ -96,6 +96,7 @@ $NUM_MAP = {
 }
 
 $box_regex = /((?:brass|copper|deobar|driftwood|iron|ironwood|mahogany|oaken|pine|steel|wooden) (?:box|caddy|casket|chest|coffer|crate|skippet|strongbox|trunk))/
+$scroll_regex = /((?:\w*-?\w* (?:scroll|vellum|tablet|roll|parchment|papyrus|leaf)|ostracon|hhr'lav'geluhh bark))/
 
 custom_require.call(%w[spellmonitor drinfomon])
 
@@ -289,6 +290,8 @@ module DRC
     case parameter
     when 'B'
       box_list_to_adj_and_noun(text)
+    when 'SC'
+      scroll_list_to_adj_and_noun(text)
     else
       list_to_nouns(text)
     end
@@ -317,6 +320,10 @@ module DRC
   # And return an array ["wooden strongbox", "ironwood crate"]
   def box_list_to_adj_and_noun(list)
     list.strip.split($box_regex).reject(&:empty?).select{ |item| item =~ $box_regex}
+  end
+
+  def scroll_list_to_adj_and_noun(list)
+    list.strip.split($scroll_regex).reject(&:empty?).select{ |item| item =~ $scroll_regex}
   end
 
   # Take a game formatted list "an arrow, silver coins and a deobar strongbox"


### PR DESCRIPTION
I followed the convention used for boxes.I'll follow with using these in the various scroll stacking scripts.

```
[exec1]>rummage /SC my travel pack
>;eq echo DRC.rummage('SC', 'travel pack')
You rummage through a scuffed traveler's pack looking for scrolls and see a azure scroll labeled with Aura of Tongues, a hunter-green scroll labeled with Ice Patch, a hunter-green scroll labeled with Sovereign Destiny, a hunter-green scro
ll labeled with Senses of the Tiger, a hunter-green scroll labeled with Piercing Gaze, a hunter-green scroll labeled with Curse of the Wilds, a hunter-green scroll labeled with Eillie's Cry, a hunter-green scroll labeled with Eillie's Cry
, a hunter-green scroll labeled with Eillie's Cry, a azure scroll labeled with Eillie's Cry, a hunter-green scroll labeled with Essence of Yew, a hunter-green scroll labeled with Essence of Yew, a cream scroll labeled with Essence of Yew,
 a hunter-green scroll labeled with Iron Constitution, a hunter-green scroll labeled with Iron Constitution, a hunter-green scroll labeled with Iron Constitution, a hunter-green scroll labeled with Iron Constitution, a cream scroll labele
d with Iron Constitution, a cream scroll labeled with Iron Constitution, a cream scroll labeled with Iron Constitution and a hunter-green scroll labeled with Sanctify Pattern.
[exec1: ["azure scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "azure scroll", "hunter-green
 scroll", "hunter-green scroll", "cream scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "cream scroll", "cream scroll", "cream scroll", "hunter-green scroll"]]
```

```
[exec1]>rummage /SC my travel pack
>;eq echo DRCI.get_scroll_list_in_container('travel pack')
Maxlade raises his palms skyward, chanting.
You rummage through a scuffed traveler's pack looking for scrolls and see a azure scroll labeled with Aura of Tongues, a hunter-green scroll labeled with Ice Patch, a hunter-green scroll labeled with Sovereign Destiny, a hunter-green scro
ll labeled with Senses of the Tiger, a hunter-green scroll labeled with Piercing Gaze, a hunter-green scroll labeled with Curse of the Wilds, a hunter-green scroll labeled with Eillie's Cry, a hunter-green scroll labeled with Eillie's Cry
, a hunter-green scroll labeled with Eillie's Cry, a azure scroll labeled with Eillie's Cry, a hunter-green scroll labeled with Essence of Yew, a hunter-green scroll labeled with Essence of Yew, a cream scroll labeled with Essence of Yew,
 a hunter-green scroll labeled with Iron Constitution, a hunter-green scroll labeled with Iron Constitution, a hunter-green scroll labeled with Iron Constitution, a hunter-green scroll labeled with Iron Constitution, a cream scroll labele
d with Iron Constitution, a cream scroll labeled with Iron Constitution, a cream scroll labeled with Iron Constitution and a hunter-green scroll labeled with Sanctify Pattern.
Mahtra goes east.
[exec1: ["azure scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "azure scroll", "hunter-green
 scroll", "hunter-green scroll", "cream scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "hunter-green scroll", "cream scroll", "cream scroll", "cream scroll", "hunter-green scroll"]]
```