### PR TITLE
[scripts][craft] Safer item disposal after smith

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -463,8 +463,7 @@ class Craft
 
   def smith(full_name)
     wait_for_script_to_complete('smith', ['bronze', full_name, 'buy'])
-    dispose_trash(right_hand, @worn_trashcan, @worn_trashcan_verb)
-    dispose_trash(left_hand, @worn_trashcan, @worn_trashcan_verb)
+    dispose_trash(left_hand, @worn_trashcan, @worn_trashcan_verb) if left_hand && full_name.include?(left_hand)
   end
 
   def buy_wood


### PR DESCRIPTION
Previous version dumped anything in your hands into the bucket, which, if something went wrong in smith, could potentially be catastrophic. Since forge update, anything crafted will be in your left hand, so if smith/forge didn't do something wrong, there will be an item in your left hand. IF that item matches what we were attempting to make, it gets dumped in the trash.

However, if something goes wrong, and there IS something in your left hand, that something has to match what we were attempting to make. Since nothing craft makes via forging is a forging tool, the chance of dumping someone's silversteel mallet in the garbage will be nil.  

nothing:
```
You move a book of master blacksmithing instructions to your right hand.
>;k smith
>;ua
--- Lich: craft unpaused.
--- Lich: craft has exited.
```
not the item we made:
```
>;ua
--- Lich: craft unpaused.
--- Lich: craft has exited.
```
normal behavior:
```
[craft]>put my knitting needles in bucket
You drop some squat bronze knitting needles in a large waste bucket.
>
--- Lich: craft has exited.
```