### PR TITLE
[scripts] [common-items] Add match for practicing, thus unable to get item

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -83,7 +83,8 @@ module DRCI
     /needs to be tended to be removed/, # ammo lodged in you
     /push you over the item limit/, # you're at item capacity
     /rapidly decays away/, # item disappears when try to get it
-    /cracks and rots away/ # item disappears when try to get it
+    /cracks and rots away/, # item disappears when try to get it
+    /^You should stop practicing your Athletics skill before you do that/
   ]
 
   @@wear_item_success_patterns = [


### PR DESCRIPTION
Annoyingly... this is one case I am unsure how to fix. This just prevents the hang, but wand-watcher will still exit instead of trying again later. I'll add athletics to the wand-watcher-no-use list I guess.

```
[wand-watcher]>glance
You glance down at your empty hands.
[wand-watcher]>get my second indurium phoenix from my weapon harness
You should stop practicing your Athletics skill before you do that.
You continue to practice your climbing skills.
Gained: Athletics(+1)
Rage of the Clans  (4 roisaen)
[wand-watcher: *** No match was found after 15 seconds, dumping info]
[wand-watcher: messages seen length: 3]
[wand-watcher: message: Rage of the Clans  (4 roisaen)]
[wand-watcher: message: You continue to practice your climbing skills.]
[wand-watcher: message: You should stop practicing your Athletics skill before you do that.]
[wand-watcher: checked against [/^You get/, /^You pick/, /^You pluck/, /^You slip/, /^You deftly remove/, /^You are already holding/, /^You fade in for a moment as you/, /^You need a free hand/, /^You can't pick that up with your hand that damaged/, /^Your (left|right) hand is too injured/, /^You just can't/, /^You stop as you realize the .* is not yours/, /^You can't reach that from here/, /^You don't seem to be able to move/, /^Get what/, /^I could not/, /^What were you/, /already in your inventory/, /needs to be tended to be removed/, /push you over the item limit/, /rapidly decays away/, /cracks and rots away/]]
[wand-watcher: for command get my second indurium phoenix from my weapon harness]
<pushBold/>Could not find correct number of wands for indurium phoenix in weapon harness.<popBold/>
<pushBold/>Double check your wand name, count, and container settings.<popBold/>
<pushBold/>Removing this wand from the list.<popBold/>
```