### PR TITLE
[data] [base.yaml] Add athletics to wand_watcher_no_use_scripts

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2084,6 +2084,7 @@ wands:
 wand_watcher_no_use_scripts:
   - burgle
   - go2
+  - athletics
 
 # Don't try to grab any wands while in these rooms (genearlly anti-magic rooms), can use roomnumber, title or regex that matches the title.
 wand_watcher_no_use_rooms:


### PR DESCRIPTION
As per title.

As per https://github.com/rpherbig/dr-scripts/pull/5938, wand watcher doesn't like Athletics practice...