### PR TITLE
[scripts] [textsubs] Fix comma placement for textsubs_use_plat_grouping for platinum denominations

### DIFF
--- a/textsubs.lic
+++ b/textsubs.lic
@@ -806,7 +806,8 @@ end
 
 # Commas when dealing with coins
 if settings.textsubs_use_plat_grouping
-  TextSubs.add('(?!.*>)\d{1,3}(?=(\d{4})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')
+  TextSubs.add('(?!.*>)\d{1,3}(?=(\d{4})+(?!\d)(?! platinum).*(Kronar|Dokora|Lirum))', '\&,')
+  TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d) platinum.*(Kronar|Dokora|Lirum))', '\&,')
 else
   TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')
 end


### PR DESCRIPTION
As per title.

No script
```
58645 platinum, 2 gold, 9 silver, 3 bronze, and 7 copper Kronars
```
Default textsubs before change
```
58,645 platinum, 2 gold, 9 silver, 3 bronze, and 7 copper Kronars
```
With textsubs_use_plat_grouping before change
```
5,8645 platinum, 2 gold, 9 silver, 3 bronze, and 7 copper Kronars
```
With textsubs_use_plat_grouping after change
```
58,645 platinum, 2 gold, 9 silver, 3 bronze, and 7 copper Kronars
```
non-platinum denominations remain correct (same before and after change)
```
1 platinum, 5 gold and 2 silver Lirums (1,5200 copper Lirums).
1 platinum Dokoras (1,0000 copper Dokoras).
```