### PR TITLE
[script][combat-trainer] Aim bug back

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3214,6 +3214,18 @@ class AttackProcess
   end
 
   def attack_aimed(charged_maneuver, game_state)
+    #This little conditional appears to have been the source of the aim bug, at least in part.
+    # The idea behind this as it is written was to reaquire a new target after a mob dies, with CT assuming you
+    # did the killing. The game_state checks were to ignore dead things that necros were playing with.
+    # However, in practice, when hunting with someone else, things get dead, things that have nothing
+    # to do with you aiming, and sometimes they persist for longer than is strictly necessary. CT would continue
+    # quietly returning to this little conditional in a vain attempt to see if you were ready to fire.
+    # CT hits this first which would tell CT, falsly, that your ranged weapon was unloaded.
+    # So CT dutifully attempted to reload, reaim, and then goes to check, again, if you're ready to fire. This
+    # loop only broke if both 1. the bodies departed and 2. CT had reason to reassess game_state.mob_died. Until
+    # both occurred, we looped. With this excluded, when a mob dies while we are aiming, we carry on with our aim_fillers
+    # until the timer expires, then shoot. If our target died, it's a snap shot at the next available mob. Otherwise, it's
+    # just business as usual, a fully aimed shot at our target.
     # if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
     #   game_state.loaded = false
     #   @firing_check = 0

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3214,10 +3214,10 @@ class AttackProcess
   end
 
   def attack_aimed(charged_maneuver, game_state)
-    if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
-      game_state.loaded = false
-      @firing_check = 0
-    end
+    # if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
+    #   game_state.loaded = false
+    #   @firing_check = 0
+    # end
 
     if Flags['ct-aim-failed']
       game_state.loaded = false


### PR DESCRIPTION
OK, so this I don't fully understand, but it appears the aim bug has to do with dead critters in the room, critters you didn't kill, which is why it showed up when hunting with other people. Previously this line was:
```ruby
game_state.loaded = false if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
game_state.clear_aim_queue if Flags['ct-ranged-ready']
```
When we made previous changes to the timer, this series of lines was changed to:
```ruby
if game_state.mob_died && !(game_state.casting_consume || game_state.prepare_consume)
  game_state.loaded = false
  @firing_check = 0
end
```
I threw in an echo at every point where firing check is reset and loaded = false and this conditional in attack_aimed was the culprit.
```
[combat-trainer]>aim

You turn to face a silver-grey cloud rat.
You begin to target a silver-grey cloud rat.

[combat-trainer: @firing_check: 0]

[combat-trainer: @firing_timer: 2022-07-20 22:26:53 -0400]

[combat-trainer: Check after test - @firing_timer: 2022-07-20 22:26:53 -0400]

[combat-trainer: action count: 3 vs 15]

[combat-trainer: skill exp: 4 vs 11]

[combat-trainer: Checking offensive spells:]

[combat-trainer: No battle cries met criteria]

[combat-trainer: ***Fatigue: 100***]

[combat-trainer: ***Target: 90***]

[combat-trainer: Firing check reset in attack_aimed]

[combat-trainer]>load my flamethorn shortbow

A silver-grey cloud rat stands perfectly still for a moment.
With weak timing, a silver-grey cloud rat lunges forward and slashes at Choshem.  Choshem evades, barely twisting out of a tight spot.  
Your flamethorn shortbow is already loaded with a boar-tusk arrow.

[combat-trainer: set_aim_queue {"Crossbow"=>["bob", "bob"], "Bow"=>["bob", "bob", "bob"], "Slings"=>["bob", "bob", "bob"]}:{}]

[combat-trainer]>aim

You are already targetting that!

[combat-trainer: @firing_check: 0]

[combat-trainer: @firing_timer: 2022-07-20 22:26:53 -0400]

[combat-trainer: Check after test - @firing_timer: 2022-07-20 22:26:53 -0400]

[combat-trainer: action count: 3 vs 15]

[combat-trainer: skill exp: 4 vs 11]

[combat-trainer: Checking offensive spells:]

[combat-trainer: No battle cries met criteria]

[combat-trainer: ***Fatigue: 100***]

[combat-trainer: ***Target: 90***]

[combat-trainer: Firing check reset in attack_aimed]

[combat-trainer]>load my flamethorn shortbow

Your flamethorn shortbow is already loaded with a boar-tusk arrow.

[combat-trainer: set_aim_queue {"Crossbow"=>["bob", "bob"], "Bow"=>["bob", "bob", "bob"], "Slings"=>["bob", "bob", "bob"]}:{}]

[combat-trainer]>aim

You are already targetting that!
```
commenting it out for a NON necro changes a few things, imo for the better.  If there's a dead thing in the room that becomes dead or is detected as dead in the course of aiming, you may or may not engage with it, eg skin/dissect, etc, but it doesn't change your aiming, doesn't reset your timer. Next time it runs a firing check, if it passes for time or for flags (ct-ranged-ready) it fires. 
```
You were aiming at a different target, but you fire anyway.
< Strongly, you fire a quartzite stone shard at a silver-grey cloud rat.  A silver-grey cloud rat fails to dodge.  The shard lands a strong hit (6/23) to the rat's right arm.
The stone shard falls to the ground!
[You're incredibly balanced and overwhelming opponent.]
[Roundtime 1 sec.]
```
This, it seems to me, is an improvement.

BIG caveat, though, in that I don't know how this affects necros. I don't know what consume or whatever is or does, but I cannot for the life of me understand what it could possibly have to do with lying to combat trainer about your loaded status. 