### PR TITLE
[script][sew] Remove conflicting resume definitions

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -189,8 +189,6 @@ class Sew
         command = "cut my #{@noun} with my scissors"
       when 'and could use some pins to', 'is in need of pinning to help arrange the material for further sewing'
         swap_tool('pins', true)
-        @home_tool = 'sewing needles'
-        @home_command = "push my #{@noun} with my sewing needles"
         command = "poke my #{@noun} with my pins"
       when 'deep crease develops along', 'wrinkles from all the handling and could use', 'Deep creases and wrinkles in the fabric',
           'A sufficient quantity of wax exists', 'Sealing wax now encases the material'


### PR DESCRIPTION
So in an attempt to speed up resume, home tool and home command were added under pins use, under the mistaken impression that that was limited to needles routines. Crops up frequently in lightening, so this was redefining our home tool inappropriately.  Removing this means an extra analyze on resume if it's next step is pins, but at least it won't redefine our home tool.