### PR TITLE
[script][combat-trainer] - Fix errant space

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3520,7 +3520,7 @@ class AttackProcess
       /^This works best when you use a suitable weapon/,
       /^This works best when you are dual wielding suitable weapons/,
       # Maneuver requires a weapon but you're not wielding any
-      /^With your fist?  That might hurt/,
+      /^With your fist? That might hurt/,
       # You can't aim before powershot maneuver
       /^You are unable to focus on performing a maneuver while aiming at an enemy/
     ]


### PR DESCRIPTION
Fixes an errant space in the maneuver failure message that causes the bput not to match.