### PR TITLE
[script][dusk-labryinth] - Additional loot-only check

### DIFF
--- a/dusk-labyrinth.lic
+++ b/dusk-labyrinth.lic
@@ -86,7 +86,9 @@ class DuskLab
     echo("Checking room...") if $debug_mode_dl
     # Wait until we determine that this room either
     # doesn't have a pet, has a pet, we caught the pet, or the maze reshuffeld.
-    pause 1 until Flags['no-pet'] || Flags['pet'] || Flags['caught'] || Flags['maze-shuffled']
+    unless @loot_only
+      pause 1 until Flags['no-pet'] || Flags['pet'] || Flags['caught'] || Flags['maze-shuffled']
+    end
     # Maze changed, forget everything we knew.
     if Flags['maze-shuffled']
       echo("maze reshuffled") if $debug_mode_dl


### PR DESCRIPTION
Earlier I implemented a "loot only" option to run for loot and not a pet.

Turns out once you have a monkey, you don't get the pet scurrying messaging at all. Add an additional check for the loot only run and don't wait for any flags. Just run for loot right away.