### PR TITLE
[scripts] [common] Adjust clean_instruments to make fewer assumptions.

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -681,7 +681,7 @@ module DRC
       end
     else
       unless DRCI.get_item?(instrument)
-        message("Could not get #{instrument} putting away cloth, and not trying to clean.")
+        DRC.message("Could not get #{instrument} putting away cloth, and not trying to clean.")
         DRCI.stow_item?(cloth)
         beep
         return false

--- a/common.lic
+++ b/common.lic
@@ -666,7 +666,7 @@ module DRC
     instrument = worn ? settings.worn_instrument : settings.instrument
 
     unless DRCI.get_item?(cloth)
-      message('You have no chamois cloth -- this could cause problems with playing an instrument!')
+      DRC.message('You have no chamois cloth -- this could cause problems with playing an instrument!')
       beep
       return false
     end

--- a/common.lic
+++ b/common.lic
@@ -666,45 +666,45 @@ module DRC
 
     unless DRCI.get_item?(cloth)
       DRC.message('You have no chamois cloth -- this could cause problems with playing an instrument!')
-      beep
+      DRC.beep
       return false
     end
-    stop_playing
+    DRC.stop_playing
 
     if worn
       unless DRCI.remove_item?(instrument)
         DRC.message("Could not remove #{instrument} putting away cloth, and not trying to clean.")
         DRCI.stow_item?(cloth)
-        beep
+        DRC.beep
         return false
       end
     else
       unless DRCI.get_item?(instrument)
         DRC.message("Could not get #{instrument} putting away cloth, and not trying to clean.")
         DRCI.stow_item?(cloth)
-        beep
+        DRC.beep
         return false
       end
     end
-    
+
     loop do
-      case bput("wipe my #{instrument} with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
+      case DRC.bput("wipe my #{instrument} with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
       when 'not in need of drying'
         break
       when 'You should be sitting up'
-        fix_standing
+        DRC.fix_standing
         next
       end
       pause 1
       waitrt?
 
-      until /you wring a dry/i =~ bput("wring my #{cloth}", 'You wring a dry', 'You wring out')
+      until /you wring a dry/i =~ DRC.bput("wring my #{cloth}", 'You wring a dry', 'You wring out')
         pause 1
         waitrt?
       end
     end
 
-    until /not in need of cleaning/i =~ bput("clean my #{instrument} with my #{cloth}", 'Roundtime', 'not in need of cleaning')
+    until /not in need of cleaning/i =~ DRC.bput("clean my #{instrument} with my #{cloth}", 'Roundtime', 'not in need of cleaning')
       pause 1
       waitrt?
     end

--- a/common.lic
+++ b/common.lic
@@ -674,7 +674,7 @@ module DRC
 
     if worn
       unless DRCI.remove_item?(instrument)
-        message("Could not remove #{instrument} putting away cloth, and not trying to clean.")
+        DRC.message("Could not remove #{instrument} putting away cloth, and not trying to clean.")
         DRCI.stow_item?(cloth)
         beep
         return false

--- a/common.lic
+++ b/common.lic
@@ -664,16 +664,30 @@ module DRC
   def clean_instrument(settings, worn = true)
     cloth = settings.cleaning_cloth
     instrument = worn ? settings.worn_instrument : settings.instrument
-    case bput("get my #{cloth}", 'You get', 'You are already holding', 'What were you')
-    when 'What were you'
-      echo('You have no chamois cloth -- this could cause problems with playing an instrument!')
+
+    unless DRCI.get_item?(cloth)
+      message('You have no chamois cloth -- this could cause problems with playing an instrument!')
       beep
       return false
     end
     stop_playing
 
-    worn ? bput("remove my #{instrument}", 'You slide', 'You remove') : bput("get #{instrument}", 'You get', 'What were you', 'You are already')
-
+    if worn
+      unless DRCI.remove_item?(instrument)
+        message("Could not remove #{instrument} putting away cloth, and not trying to clean.")
+        DRCI.stow_item?(cloth)
+        beep
+        return false
+      end
+    else
+      unless DRCI.get_item?(instrument)
+        message("Could not get #{instrument} putting away cloth, and not trying to clean.")
+        DRCI.stow_item?(cloth)
+        beep
+        return false
+      end
+    end
+    
     loop do
       case bput("wipe my #{instrument} with my #{cloth}", 'Roundtime', 'not in need of drying', 'You should be sitting up')
       when 'not in need of drying'
@@ -696,8 +710,8 @@ module DRC
       waitrt?
     end
 
-    bput("wear my #{instrument}", 'You slide', 'You attach') if worn
-    bput("stow my #{cloth}", 'You put')
+    DRCI.wear_item?(instrument) if worn
+    DRCI.stow_item?(cloth)
     true
   end
 


### PR DESCRIPTION
A mistimed pause causes a timeout, and since we aren't using very smart functions... success is assumed. 

This PR changes that, and doesn't proceed without success at getting cloth, or getting/removing the instrument to be cleaned.

```
[performance]>play sonata on my zills
--- Lich: sanowret-crystal paused.
--- Lich: play paused.
--- Lich: tarantula paused.
--- Lich: t2 paused.
Your zills's dirtiness may affect your performance.
You begin a quiet sonata on your copper zills with only the slightest hint of difficulty.
[performance]>get my chamois cloth
You get a white chamois cloth from inside your traveler's pack.
[performance]>stop play
[almanac]>get my almanac
You stop playing your song.
[performance]>remove my zills
You get an opulent Taisidon silkcress-bound almanac with diacan edged pages from inside your traveler's pack.
[almanac]>study my almanac
You need a free hand for that.
You set about studying your silkcress-bound almanac intently.  You believe you've learned something significant about Enchanting!
Roundtime: 10 seconds
[almanac]>stow my almanac
You put your almanac in your traveler's pack.
--- Lich: sanowret-crystal unpaused.
--- Lich: play unpaused.
--- Lich: tarantula unpaused.
--- Lich: t2 unpaused.
[performance: *** No match was found after 15 seconds, dumping info]
[performance: checked against [/You slide/i, /You remove/i]]
[performance: for command remove my zills]
[performance]>wipe my zills with my chamois cloth
You must be holding the copper zills to wipe the water from them
```