### PR TITLE
[script][combat-trainer] Add whip support

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3258,6 +3258,7 @@ class AttackProcess
     attack_action += ' left' if game_state.offhand?
     bput(attack_action, 'roundtime', 'What are you trying to')
     waitrt?
+    return game_state.action_taken if attack_action.include?('whip')
 
     if game_state.weapon_name == 'blades'
       until /(Stow what|You put your)/ =~ bput('stow blade', 'Stow what', 'You pick up .*blade', 'You put your')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3384,6 +3384,7 @@ class AttackProcess
 
       actions.each do |action|
         break unless execute_aiming_action?(action, game_state)
+        next if atk.include?('whip')
         next unless skill.include?('Thrown')
         retrieve_action = "get my #{weapon_name}"
         retrieve_action = 'invoke' if action.include?('hurl')
@@ -3519,6 +3520,8 @@ class AttackProcess
       fput('engage')
       pause 2.5
     when 'What are you', 'There is nothing'
+      return false unless action.include?('whip')
+      fput('face next')
       return false
     end
     true

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -374,7 +374,7 @@ whirlwind_trainables:
 # a - list of weapon skills to pull out and use in offhand while waiting for a crossbow to aim.  Make sure they're light!
 aiming_trainables:
 # Keep left hand free during Bow for aiming_trainables
-left_hand_free: true
+left_hand_free: false
 # allow melee offhand weapon training while aiming crossbow in aiming_trainables
 using_light_crossbow: false
 # use attack overrides for main hand attacks

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -374,7 +374,7 @@ whirlwind_trainables:
 # a - list of weapon skills to pull out and use in offhand while waiting for a crossbow to aim.  Make sure they're light!
 aiming_trainables:
 # Keep left hand free during Bow for aiming_trainables
-left_hand_free: false
+left_hand_free: true
 # allow melee offhand weapon training while aiming crossbow in aiming_trainables
 using_light_crossbow: false
 # use attack overrides for main hand attacks


### PR DESCRIPTION
So, couple small edits to weapons handling for the whips and meteor hammers. First, normal behavior for thrown is to retrieve the weapon after throwing. This presents one redundancy, one problem. The redundancy is the attempt to retrieve a weapon that never left your hand. First two edits solve this in both mainhand use and offhand, by  ending the method in the first case (attack_thrown) and bumping to the next action for the second.

The problem created has to do with bows specifically, as they cannot be aimed with something in your left hand. Often, since normal lobbing offhand meant the weapon spent much of it's time out of your hand, this wasn't a big deal. However, with the whip, it never leaves your hand, so you're almost guaranteed to kill your aim. Here, if the user wishes to use the whip as an aiming trainable weapon, they'll need to set their yaml as follows:
```yaml
left_hand_free: true
```
Since it does this anyway for melee weapons, and you only really _get away with it with thrown_, I've added an adjustment to just make base set this true by default. Even regular thrown weapons will stop the aim on occasion, so it seems this should properly be true unless someone specifically wants to risk it.

Finally, there is a small bug with these whips that seems to only affect using them offhand, where if you whip something to death mid aim, it fails to automatically face the next engaged target, and instead replies with message indicating theres nothing to face:
```
[combat-trainer]>whip left
You whip your smokewhorl whip at an onyx gargoyle.  The smokewhorl whip lands a strong hit (6/23) to an onyx gargoyle's right leg.
An onyx gargoyle grumbles and falls over with a *THUD*.
Roundtime: 2 sec.
R>
* An onyx gargoyle slams down at you.  You dodge.  
[You're solidly balanced and in superior position.]
R>
[combat-trainer]>whip left
What are you trying to whip?
```
As you can see, theres clearly something there to whip. So:
```ruby
    when 'What are you', 'There is nothing'
      return false unless action.include?('whip')
      fput('face next')
      return false
```
This doesn't change normal behavior for any other thrown action, but if you're attempting to whip, and get this message, it will quickly attempt to reorient you towards the next opponent, to prevent an odd whip loop I won't share here.

I haven't tested this with the hammers, but since nothing is triggered off weapon name, only weapon action (whip) i don't see why it wouldn't work perfectly fine for them as well.

As far as yaml adjustments, you WILL need to override your thrown weapon attacks:
```yaml
attack_overrides:
 Light Thrown: whip
 ```
 and if you intend to offhand, you'll also need to set:
 ```yaml
 use_overrides_for_aiming_trainables: true
 ```
 