### PR TITLE
[script][validate] - Add setup yaml file existence check

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -14,12 +14,21 @@ class DRYamlValidator
 
     settings = get_settings(args.flex)
     assertions = DRYamlValidator.instance_methods.select { |x| x.to_s =~ /^assert_that_/ && DRYamlValidator.instance_method(x).arity == 1 }
+    profiles = Dir['./scripts/profiles/*.*']
 
     setup_data
 
     respond("")
+    respond("  CHECKING: That #{checkname}-setup.yaml exists in the proper folder.")
+    if profiles.grep(/#{checkname}-setup/).empty?
+      echo "**WARNING**: No #{checkname}-setup.yaml file found in /scripts/profiles."
+      echo "This file is required. Check that the file exists and is in the correct folder."
+    else
+      respond("   PASSED")
+    end
+
+    respond("")
     respond("  CHECKING: That yaml file extensions are .yaml and not .yml")
-    profiles = Dir['./scripts/profiles/*.*']
 
     if !profiles.grep(/yml/).empty?
       echo "**WARNING**: You have yaml files with a .yml file extension. Lich requires the extension to be .yaml."


### PR DESCRIPTION
Adds a `Charname-setup.yaml` file exisence check in the proper folder. This will help us diagnose new users who have the file in the wrong folder.