### PR TITLE
[script][buff-watcher] Thief Khri handling

### DIFF
--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -94,10 +94,14 @@ class BuffWatcher
   end
 
   def buffs_active?
+    #Reloads your waggle settings each time it checks for active spells so you can change on the fly them without killing buff-watcher
+    @settings = get_settings
     if DRStats.thief?
-      # Elements in the waggle set are ability names (strings) without the Khri prefix
+      # Cleaning up the various different styles of thief waggles
       spell_list = @settings.waggle_sets[@buff_set_name].join(' ').split(' ').map(&:capitalize)
+      # Removing elements that are not spells we want to check
       spell_list.reject! { |spell| spell =~ /delay|khri/i }
+      # Checking that each spell on our list is currently active
       return spell_list.all? { |name| DRSpells.active_spells["Khri #{name}"] }
     elsif DRStats.barbarian?
       # Elements in the waggle set are ability names (strings)

--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -96,7 +96,9 @@ class BuffWatcher
   def buffs_active?
     if DRStats.thief?
       # Elements in the waggle set are ability names (strings) without the Khri prefix
-      return @settings.waggle_sets[@buff_set_name].all? { |name| DRSpells.active_spells["Khri #{name}"] }
+      spell_list = @settings.waggle_sets[@buff_set_name].join(' ').split(' ').map(&:capitalize)
+      spell_list.reject! { |spell| spell =~ /delay|khri/i }
+      return spell_list.all? { |name| DRSpells.active_spells["Khri #{name}"] }
     elsif DRStats.barbarian?
       # Elements in the waggle set are ability names (strings)
       return @settings.waggle_sets[@buff_set_name].all? { |name| DRSpells.active_spells[name] }

--- a/buff-watcher.lic
+++ b/buff-watcher.lic
@@ -100,7 +100,7 @@ class BuffWatcher
       # Cleaning up the various different styles of thief waggles
       spell_list = @settings.waggle_sets[@buff_set_name].join(' ').split(' ').map(&:capitalize)
       # Removing elements that are not spells we want to check
-      spell_list.reject! { |spell| spell =~ /delay|khri/i }
+      spell_list.reject! { |spell| spell =~ /delay|khri|puncture|slice|impact|fire|cold|electric/i }
       # Checking that each spell on our list is currently active
       return spell_list.all? { |name| DRSpells.active_spells["Khri #{name}"] }
     elsif DRStats.barbarian?


### PR DESCRIPTION
So thief waggles are as mysterious as the thieves themselves, with variations on:
```yaml
waggle_sets:
  default:
    - Hasten
    - Delay Hasten
    - Hasten Focus
    - Delay Hasten Focus
    - Khri Hasten
    - Khri Delay Hasten
    - Khri Delay Hasten Focus
```
all of which is handle in common-arcana when buffs is called, but is not parsed appropriately in buff-watcher's active spells check:
```ruby
  def buffs_active?
    if DRStats.thief?
      # Elements in the waggle set are ability names (strings) without the Khri prefix
      return @settings.waggle_sets[@buff_set_name].all? { |name| DRSpells.active_spells["Khri #{name}"] }
```
For most of the variations listed above, minus the first, a check against active spells would return false even if they're running, because we're checking for:
```
["Khri Hasten"]
["Khri Delay Hasten"]
["Khri Hasten Focus"]
["Khri Delay Hasten Focus"]
etc
```
We're also not going to get matches if any of those Khri names aren't capitalized. This was causing buff watcher to continue quietly calling buff and not-so-quietly pausing and unpausing all your scripts, where buff would send the list to common-arcana, which would correctly parse the buffs and reply no, actually, these are all running. Then buff exits, buff-watcher concludes that buff cycle is complete, and it returns to it's passive delay. 15 seconds later, the cycle begins anew, the result:
```
[forge]>pound balaclava on anvil with my blunt hammer

You scoop up the balaclava with your tongs and heat it over the flames of the forge.  Once the metal is glowing hot you place it back upon the anvil and hammer it steadily with your hammer.  With expert precision the metal takes shape without any faults.

As you finish working the fire dims and produces less heat from the stifled coals.
Roundtime: 14 sec.

--- Lich: multi paused.

--- Lich: smith paused.

--- Lich: forge paused.


--- Lich: multi unpaused.

--- Lich: smith unpaused.

--- Lich: forge unpaused.


[forge]>tie my blunt hammer to my agonite toolstrap
```
Every 15 or so seconds, buff-watcher pauses, checks for the wrong spells, calls buff, etc.,etc.

This is the list I've given buff-watcher:
```yaml
waggle_sets:
  default:
    - delay focus Hasten Dampen
    - khri Plunder slight Silence
```
This is the list after the first line:
```
[buff-watcher: ["Delay", "Focus", "Hasten", "Dampen", "Khri", "Plunder", "Slight", "Silence"]]
```
We joined the two elements, then split each word into a separate element where there was a space, and capitalized everything. Next line:
```
[buff-watcher: ["Focus", "Hasten", "Dampen", "Plunder", "Slight", "Silence"]]
```
We simply pull out "khri" and "delay" as these aren't active spells, and finally send this clean array to be checked against active spells. The result:
```
>khri check
You are under the influence of the Dampen meditation, which should last around 37 roisaen.
You are under the influence of the Hasten meditation, which should last around 37 roisaen.
You continue playing on your kertig cowbell.
>;buff-watcher
--- Lich: buff-watcher active.
--- Lich: afk paused.
[buff-watcher]>Khri Delay Focus
With deep breaths, you recall your training and focus your mind to hone in on improving your physical dexterity.
Roundtime: 3 sec.
R>
[buff-watcher]>Khri Plunder Slight Silence
...wait 1 seconds.
R>
[buff-watcher]>Khri Plunder Slight Silence
Focusing intently, you mentally weave together three mantras, allowing the power contained within to slowly spread out from your core.
Your hand twitches slightly in anticipation as you focus your mind towards relieving others of their hard earned possessions.
Slipping into the proper mindset, you feel yourself become much less noticeable and memorable.
Turning inwards, you find the still silent spot within you.  Focusing on that point, you allow the silence to spread gently through your body and then out into the world, until you fade away from the world itself.
Roundtime: 5 sec.
R>
Focusing on the dark well at your core, you feel yourself become submerged in the rise and spill of silence.
IR>
--- Lich: afk unpaused.
```