### PR TITLE
[script][magic-training] Add mana waggle at start of magic-training

### DIFF
--- a/magic-training.lic
+++ b/magic-training.lic
@@ -25,6 +25,7 @@ class MagicTraining
     args = parse_args(arg_definitions)
 
     load_settings
+    DRC.wait_for_script_to_complete('buff', ['mana'])
 
     @max_time = ((args.max_time || 60).to_i * 60) # convert to seconds
     @training_skills = args.training_skills.split(',').map { |skill| skill.strip.downcase.capitalize }


### PR DESCRIPTION
This is a teensy edit I've been using for some time on my Warmie, to throw out a fissure before starting my magic training. This would also likely be useful for empaths or rangers with access to raise power spell, perhaps for clerics, perhaps others. Just add the spell under waggle_set "mana", spell goes up, training commences.