### PR TITLE
[script][card-collector] Create script card-collector

### DIFF
--- a/card-collector.lic
+++ b/card-collector.lic
@@ -22,7 +22,7 @@ class Cards
     cards_add(fresh,duplicates)
   end
 
-  def cards_add(fresh,duplicates)
+  def cards_add(fresh, duplicates)
     unless /referring/i =~ DRC.bput("get my collector case", 'You get', 'You are already', 'What were you referring to')
       DRC.bput('swap', 'You move') unless DRC.right_hand == "collector's case"
       loop do

--- a/card-collector.lic
+++ b/card-collector.lic
@@ -10,13 +10,13 @@ class Cards
     ]
 
     args = parse_args(arg_definitions)
-    @settings = get_settings
+    settings = get_settings
     unless @settings.card_bags
       DRC.message("No bags defined in your yaml, please run this script with argument 'help' for more information.")
       exit
     end
-    fresh = @settings.card_bags['fresh']
-    duplicates = @settings.card_bags['duplicates']
+    fresh = settings.card_bags['fresh']
+    duplicates = settings.card_bags['duplicates']
 
     DRCI.stow_hands
     cards_add(fresh,duplicates)

--- a/card-collector.lic
+++ b/card-collector.lic
@@ -19,6 +19,10 @@ class Cards
 
     args = parse_args(arg_definitions)
     @settings = get_settings
+    unless @settings.card_bags
+      DRC.message("No bags defined in your yaml, please run this script with argument 'help' for more information.")
+      exit
+    end
     @card_bag = @settings.card_bags
     
     DRCI.stow_hands

--- a/card-collector.lic
+++ b/card-collector.lic
@@ -5,15 +5,7 @@ class Cards
   def initialize
     arg_definitions = [
       [
-        { name: 'script_summary', optional: true, description:'***
-    YAML SETTINGS:
-    card_bags:
-      fresh: bag1
-      duplicates: bag2
-
-    Fresh bag (bag1) contains unsorted, newly collected cards. This is where script gets cards for sorting.
-    Duplicates bag(bag2) holds anything that doesn\'t fit in the collector\'s case. This also holds collector\'s case.
-    ***'}
+        { name: 'script_summary', optional: true, description:'Takes cards from a bag of freshly acquired cards and places them in your collector\'s cases' }
       ]
     ]
 
@@ -23,25 +15,26 @@ class Cards
       DRC.message("No bags defined in your yaml, please run this script with argument 'help' for more information.")
       exit
     end
-    @card_bag = @settings.card_bags
-    
+    fresh = @settings.card_bags['fresh']
+    duplicates = @settings.card_bags['duplicates']
+
     DRCI.stow_hands
-    cards_add
+    cards_add(fresh,duplicates)
   end
 
-  def cards_add
+  def cards_add(fresh,duplicates)
     unless /referring/i =~ DRC.bput("get my collector case", 'You get', 'You are already', 'What were you referring to')
       DRC.bput('swap', 'You move') unless DRC.right_hand == "collector's case"
       loop do
-        unless /referring/i =~ DRC.bput("get card from my #{@card_bag['fresh']}", 'You get', 'What were you referring')
+        unless /referring/i =~ DRC.bput("get card from my #{fresh}", 'You get', 'What were you referring')
           next unless /You don't have room/i =~ DRC.bput('cards add', 'You slide', "You don't have room")
-          DRC.bput("put my card in my #{@card_bag['duplicates']}", 'You put')
+          DRC.bput("put my card in my #{duplicates}", 'You put')
           next
         end
         break
       end
       DRC.bput('cards count', 'You have')
-      DRC.bput("put my case in my #{@card_bag['duplicates']}", 'You put')
+      DRC.bput("put my case in my #{duplicates}", 'You put')
     end
   end
 end

--- a/card-collector.lic
+++ b/card-collector.lic
@@ -19,7 +19,7 @@ class Cards
     duplicates = settings.card_bags['duplicates']
 
     DRCI.stow_hands
-    cards_add(fresh,duplicates)
+    cards_add(fresh, duplicates)
   end
 
   def cards_add(fresh, duplicates)

--- a/card-collector.lic
+++ b/card-collector.lic
@@ -1,0 +1,45 @@
+custom_require.call(%w[common common-crafting common-items])
+
+class Cards
+
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'script_summary', optional: true, description:'***
+    YAML SETTINGS:
+    card_bags:
+      fresh: bag1
+      duplicates: bag2
+
+    Fresh bag (bag1) contains unsorted, newly collected cards. This is where script gets cards for sorting.
+    Duplicates bag(bag2) holds anything that doesn\'t fit in the collector\'s case. This also holds collector\'s case.
+    ***'}
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
+    @settings = get_settings
+    @card_bag = @settings.card_bags
+    
+    DRCI.stow_hands
+    cards_add
+  end
+
+  def cards_add
+    unless /referring/i =~ DRC.bput("get my collector case", 'You get', 'You are already', 'What were you referring to')
+      DRC.bput('swap', 'You move') unless DRC.right_hand == "collector's case"
+      loop do
+        unless /referring/i =~ DRC.bput("get card from my #{@card_bag['fresh']}", 'You get', 'What were you referring')
+          next unless /You don't have room/i =~ DRC.bput('cards add', 'You slide', "You don't have room")
+          DRC.bput("put my card in my #{@card_bag['duplicates']}", 'You put')
+          next
+        end
+        break
+      end
+      DRC.bput('cards count', 'You have')
+      DRC.bput("put my case in my #{@card_bag['duplicates']}", 'You put')
+    end
+  end
+end
+
+Cards.new

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -924,4 +924,4 @@ card_bags:
   referenced_by:
     - card-collector
   specific_descriptions:
-    card-collector:
+    card-collector: Sets bag to draw cards from (fresh) and bag to place duplicates and your case(duplicates)

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -924,5 +924,4 @@ card_bags:
   referenced_by:
     - card-collector
   specific_descriptions:
-    fresh: Fresh bag contains unsorted, newly collected cards. This is where script gets cards for sorting.
-    duplicates: Duplicates bag(bag2) holds anything that doesn\'t fit in the collector\'s case. This also holds collector\'s case.
+    card-collector:

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -917,3 +917,12 @@ water_holder:
     - carve-bead
   specific_descriptions:
     carve-bead:
+
+card_bags:
+  description: Bags you use to collect and store cards
+  example: red backpack
+  referenced_by:
+    - card-collector
+  specific_descriptions:
+    fresh: Fresh bag contains unsorted, newly collected cards. This is where script gets cards for sorting.
+    duplicates: Duplicates bag(bag2) holds anything that doesn\'t fit in the collector\'s case. This also holds collector\'s case.

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2008,6 +2008,11 @@ sorter:
 
 stabbity:
 
+# Settings for script card-collector, defines bag to draw cards from(fresh) and bag to store duplicates and your case (duplicates)
+card_bags:
+  fresh:
+  duplicates:
+
 # TextSubs
 private_textsubs:
   # old text: new text


### PR DESCRIPTION
Useful fire-and-forget script if you're collecting cards. Doesn't take arguments, requires yaml settings:
```yaml
card_bags:
  fresh: bag1
  duplicates: bag2
```
Takes recently acquired cards from whatever bag you designate and attempts to file them in your collector's case. If they won't fit, puts them into a second bag you designate for duplicates. 