### PR TITLE
base.yaml - added burgle to tarantula no use list

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2146,7 +2146,7 @@ tarantula_noun: biomechanical tarantula
 tarantula_startup_delay: 15
 tarantula_skip_alternate: false
 tarantula_no_use_scripts:
-- burgle
+  - burgle
 tarantula_debug: false
 
 ####################

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2146,6 +2146,7 @@ tarantula_noun: biomechanical tarantula
 tarantula_startup_delay: 15
 tarantula_skip_alternate: false
 tarantula_no_use_scripts:
+- burgle
 tarantula_debug: false
 
 ####################


### PR DESCRIPTION
Nothing should ever pause burgle and a smart pause all was recently added to tarantula.lic, so I added burgle to the tarantula no use script list.