### PR TITLE
[script][heroic-tattoo] - Fix edge case script unpause failure

### DIFF
--- a/heroic-tattoo.lic
+++ b/heroic-tattoo.lic
@@ -34,7 +34,8 @@ loop do
         'as its magic washes over you',
         'Its magic appears depleted',
         'already under a heroic effect',
-        'Closing your eyes, you carefully bend')
+        'Closing your eyes, you carefully bend',
+        'seem to be able to move to do that', 'still stunned', 'while entangled')
     when 'as its magic washes over you'
         next_invoke = Time.now + timer
         DRC.message("Next attempt in #{(next_invoke - Time.now).to_i/60} minutes")

--- a/heroic-tattoo.lic
+++ b/heroic-tattoo.lic
@@ -35,7 +35,7 @@ loop do
         'Its magic appears depleted',
         'already under a heroic effect',
         'Closing your eyes, you carefully bend',
-        'seem to be able to move to do that', 'still stunned', 'while entangled')
+        'seem to be able to move to do that')
     when 'as its magic washes over you'
         next_invoke = Time.now + timer
         DRC.message("Next attempt in #{(next_invoke - Time.now).to_i/60} minutes")

--- a/heroic-tattoo.lic
+++ b/heroic-tattoo.lic
@@ -54,6 +54,10 @@ loop do
         fput('release spell')
         DRC.unpause_all_list(scripts)
         break
+    else
+        DRC.message("Something went wrong, we'll try again in 5 minutes")
+        next_invoke = Time.now + 300
+        DRC.unpause_all_list(scripts)
     end
     break if args.try
 end


### PR DESCRIPTION
User came to me with the following log:
```
--- Lich: feed-cloak active.
[feed-cloak]>feed my cloak
You relax your body, allowing the vines to roam downward to test the ground for nutrients.
 
The vines sink deeply into the dirt and begin to feed, binding you in place.
>
--- Lich: tarantula paused.
--- Lich: footwatch paused.
--- Lich: checkevader paused.
--- Lich: almanac paused.
--- Lich: t2 paused.
--- Lich: feed-cloak paused.
[heroic-tattoo]>invoke my tattoo
You don't seem to be able to move to do that.
>
The mass of feeding vines retract from the dirt, having their fill of the rich nutrients.  They rapidly slither back up around your body, allowing you to move once again.

>
[heroic-tattoo: *** No match was found after 15 seconds, dumping info]
[heroic-tattoo: messages seen length: 15]
[heroic-tattoo: message: Jhene stumbles only slightly as she continues to perform a tarantella on her razaksel zills.]
[heroic-tattoo: message: Darkcari exudes life and vitality, rutilant sparks dancing around him.]
[heroic-tattoo: message: Darkcari closes his eyes for a moment and grows still.]
[heroic-tattoo: message: Darkcari whispers, "Done!"]
[heroic-tattoo: message: Darkcari whispers, "Done!"]
[heroic-tattoo: message: You have a brief sensation that leaves your wounds tingling.]
[heroic-tattoo: message: You feel a warmth radiate from Darkcari's touch.]
[heroic-tattoo: message: Darkcari touches you.]
[heroic-tattoo: message:  * Soul Reaver Cordio Hawt-Seord joins the adventure.]
[heroic-tattoo: message: Your internal left eye scars feel fully healed.]
[heroic-tattoo: message: Your external left eye scars feel fully healed.]
[heroic-tattoo: message: Your internal left eye wounds feel fully healed.]
[heroic-tattoo: message: Your external left eye wounds feel fully healed.]
[heroic-tattoo: message: The mass of feeding vines retract from the dirt, having their fill of the rich nutrients.  They rapidly slither back up around your body, allowing you to move once again.]
[heroic-tattoo: message: You don't seem to be able to move to do that.]
[heroic-tattoo: checked against [/as its magic washes over you/i, /Its magic appears depleted/i, /already under a heroic effect/i, /Closing your eyes, you carefully bend/i]]
[heroic-tattoo: for command invoke my tattoo]
[heroic-tattoo]>invoke my tattoo
You brace yourself as you activate your tattoo, but nothing happens as you're already under a heroic effect.
>
Next attempt in 9 minutes
```
The current case statement doesn't account for failure due to the cloak interaction. Other failures are handled under bput, but this is not, so we get failure, loop swings back around and attempts to invoke again. However, this time, since all those scripts are still paused, we don't have a list of scripts to pause. We could just unpause at the end, but that would create a spammy cycle of pause/unpause until the state ends. Adding:
```ruby
    else
        DRC.message("Something went wrong, we'll try again in 5 minutes")
        next_invoke = Time.now + 300
        DRC.unpause_all_list(scripts)
```
allows for this specific case, and presumably any other unlisted failure, and just pushses the next attempt back 5 minutes.