### PR TITLE
[script][common-arcana] Add low attunement failure to case statement

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -296,7 +296,7 @@ module DRCA
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
 
     case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
-    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/
+    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/, /You strain, but are too mentally fatigued/
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
       DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     when /You gesture/

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -296,7 +296,7 @@ module DRCA
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
 
     case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
-    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/, /You strain, but are too mentally fatigued/
+    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/, /^You strain, but are too mentally fatigued/
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
       DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     when /You gesture/


### PR DESCRIPTION
So I've been trying to track my ranger's nerve troubles for some time, and it appears that when you go to cast a spell, but your attunement isn't up to the job, for whatever reason, it's treated as a successful cast. The case statement already matches against this language from the list of potentials in base-spells, but doesn't treat it like a failure. This results in any harnessed mana just remaining harnessed, and slowly slipping away, to the detriment of your poor nerves:
```

You gesture.
You strain, but are too mentally fatigued to finish the pattern, and it slips away.

[combat-trainer]>attack

< You bash an engraved steel war hammer with a spiraled golden handle at a storm bull.  A storm bull badly fails to block with its long pearly horn.  The hammer lands a heavy strike (7/23) that knocks the bull's breath away with a loud *Whuff* as the stomach takes full force of the blow, lightly stunning it.
[You're winded, nimbly balanced and in dominating position.]
[Roundtime 2 sec.]
The storm bull closes to pole weapon range on you!

Gained: Small Blunt(+1)

[combat-trainer]>attack

Sparks of electricity shimmer around a storm bull's body as it sways dazedly.
< You swing an engraved steel war hammer with a spiraled golden handle at a storm bull.  A storm bull attempts to dodge.  The hammer lands a heavy strike (7/23) that bruises the chest with a blow to the ribcage.
[You're winded, nimbly balanced and in dominating position.]
[Roundtime 2 sec.]

Gained: Small Blunt(+1)

You sense a small amount of mana slip away from you.
```
This slippage can and does cause significant damage over time. Adding this to the case statement will catch those instances, and release any mana you're holding, so you can continue training attunement without the debilitating after effects.