### PR TITLE
[script][common-arcana] Add low attunement failure to Flag['spell-fail']

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -291,12 +291,12 @@ module DRCA
 
     Flags.add('unknown-command', "Please rephrase that command")
     Flags.add('barrage-fail', "That was an invalid attack choice.", "Wouldn't it be better if you used a melee weapon?", "You'll need to be using a weapon to BARRAGE your target", "You must have a fully developed target matrix to make a barrage attack", "You are unable to muster the energy to do that", "You do not know how to manipulate that pathway.", "You cannot BARRAGE with that spell.")
-    Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell', 'There is nothing else to face')
+    Flags.add('spell-fail', 'Currently lacking the skill to complete the pattern', 'backfires', 'Something is interfering with the spell', 'There is nothing else to face', 'You strain, but are too mentally fatigued')
     Flags.add('cyclic-too-recent', 'The mental strain of initiating a cyclic spell so recently prevents you from formulating the spell pattern')
     Flags.add('spell-full-prep', /^This pattern may only be cast with full preparation/)
 
     case DRC.bput(cast_command || 'cast', get_data('spells').cast_messages)
-    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/, /^You strain, but are too mentally fatigued/
+    when /^Your target pattern dissipates/, /^You can't cast that at yourself/, /^You need to specify a body part to consume/, /^There is nothing else to face/
       DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
       DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
     when /You gesture/
@@ -318,7 +318,10 @@ module DRCA
     after.each { |action| DRC.bput(action['message'], action['matches']) }
 
     if symbiosis && Flags['spell-fail']
+      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
       DRC.bput('release symbiosis', 'You release', 'But you haven\'t prepared')
+    elsif Flags['spell-fail']
+      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")      
     end
 
     !Flags['spell-fail']


### PR DESCRIPTION
My previous fix for this problem wasn't effective because the match for this messaging was being hijacked by the match for You gesture, which was occurring a line above. Backfires and the like are handled with a flag already, adding this messaging should give it the same release treatment.

```
[buff]>cast
You gesture.
You strain, but are too mentally fatigued to finish the pattern, and it slips away.
>
[buff]>release mana
You aren't harnessing any mana.
```