### PR TITLE
[script][validate] - Don't harp on custom hunting zones

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -358,6 +358,7 @@ class DRYamlValidator
     zone_names
       .reject { |name| !hunting_zones.nil? && hunting_zones.include?(name) }
       .reject { |name| !escort_zones.nil? && escort_zones.include?(name) }
+      .reject { |name| !settings.custom_hunting_zones.nil? && settings.custom_hunting_zones.include?(name)}
       .each { |name| error("Hunting zone not found in hunting_zones or escort_zones. '#{name}'") }
   end
 

--- a/validate.lic
+++ b/validate.lic
@@ -359,7 +359,7 @@ class DRYamlValidator
       .reject { |name| !hunting_zones.nil? && hunting_zones.include?(name) }
       .reject { |name| !escort_zones.nil? && escort_zones.include?(name) }
       .reject { |name| !settings.custom_hunting_zones.nil? && settings.custom_hunting_zones.include?(name)}
-      .each { |name| error("Hunting zone not found in hunting_zones or escort_zones. '#{name}'") }
+      .each { |name| error("Hunting zone not found in hunting_zones, escort_zones, or custom-defined zones. '#{name}'") }
   end
 
   def assert_that_gear_sets_not_nil(settings)


### PR DESCRIPTION
Fixes validate to not throw an error if the user has a custom hunting zone specified.

I discovered this after helping a user in Discord define a custom hunting zone, and then he used validate to determine whether his yaml was "working" or not.

```
  CHECKING: 103 different potential errors in [Tironithay-setup.yaml]
[validate: ERROR:< Hunting zone not found in hunting_zones or escort_zones. 'gnarled_dryads'  >]
  WARNINGS:0 ERRORS:1
  All done!
```