### PR TITLE
[scripts] [equipmanager] Tighten bput matches for unloading weapon [2 of 2]

### DIFF
--- a/equipmanager.lic
+++ b/equipmanager.lic
@@ -465,8 +465,8 @@ class EquipmentManager
     #   (hidden) You unload your <weapon> while blended in with your surroundings, but cannot shake the feeling that you drew attention to yourself.
     #   (one hand empty) You unload the <weapon>.
     #   (hands full) Your <ammo> falls from your <weapon> to your feet.
-    case DRC.bput("unload my #{name}", 'You unload', 'Your .* fall.*', 'As you release the string', 'You .* unloading', 'But your .* isn\'t loaded', 'You can\'t unload such a weapon', 'You don\'t have a ranged weapon to unload', 'You must be holding the weapon to do that')
-    when /^(?:Your .*?\b(?<ammo>[\w]+)\b fall.* from your .* to your feet.)$/
+    case DRC.bput("unload my #{name}", /^You unload/, /^Your .* fall.*to your feet\.$/, 'As you release the string', /^You .* unloading/, 'But your .* isn\'t loaded', 'You can\'t unload such a weapon', 'You don\'t have a ranged weapon to unload', 'You must be holding the weapon to do that')
+    when /^(?:Your .*?\b(?<ammo>[\w]+)\b fall.* from your .* to your feet\.)$/
       # Ammo fell to ground because hands are full.
       # Lower weapon, stow ammo, then pick it back up.
       ammo = Regexp.last_match[:ammo]
@@ -474,7 +474,7 @@ class EquipmentManager
       DRC.bput("lower ground right", "You lower") if DRCI.in_right_hand?(name)
       DRCI.put_away_item?(ammo)
       DRC.bput("get my #{name}", "You get", "You pick")
-    when /(You unload|You .* unloading)/
+    when /^(You unload|You .* unloading)/
       # Ammo is in hand, stow whichever hand isn't holding the weapon.
       DRC.bput("stow left", "You put") unless DRCI.in_left_hand?(name)
       DRC.bput("stow right", "You put") unless DRCI.in_right_hand?(name)


### PR DESCRIPTION
~~Depends on https://github.com/rpherbig/dr-scripts/pull/5983~~

Addresses some loose matching in `def unload_weapon` which can lead to rare problematic events, as reported by `Tirost#3615` on Discord, whose weapon unload action was matched by a wyvern lifting his character up in the air.

```ruby
    case bput("unload my #{name}", 'You unload', 'Your .* fall.*', 'As you release the string', 'You .* unloading', 'But your .* isn\'t loaded', 'You can\'t unload such a weapon', 'You don\'t have a ranged weapon to unload', 'You must be 
holding the weapon to do that')
```
was matching on
```
[combat-trainer]>unload my shortbow
Your Grounding Field thrums with energy, empowering you.
You are momentarily blinded as the salt crystals around your left arm explode outward, cushioning against the blow.
The air around you solidifies into a blinding yellow luminescence and intercepts the attack with a shower of coruscating light.
An adult wyvern swoops at you suddenly, trying to pick you up in its razor-sharp talons!
You are suddenly snatched up by the adult wyvern's razor-sharp talons, and it flies to a dizzying height!  The creature's intent becomes clear as it simply lets you go.  You suddenly find yourself in freefall, plummeting toward the earth.
Acting on sheer desperation and instinct, you start flapping your feather wings rapidly in an attempt to soften the inevitable landing.  Remarkably, you do manage to slow your fall somewhat with your efforts.
```
as per https://rubular.com/r/9mYUjkFaDNLwIf
