### PR TITLE
[script][common-crafting] Cost calculator for crafting

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -198,7 +198,7 @@ module DRCC
   end
   
   def crafting_cost(recipe, material, parts, quantity, hometown)
-    total = 0
+    total = 1000 #added to account for consumables
     currency = DRCM.town_currency(hometown)
 
     unless ["alabaster", "granite", "marble"].any? { |x| material == x }

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -202,7 +202,7 @@ module DRCC
     currency = DRCM.town_currency(hometown)
     data = get_data('crafting')['stock'] #fetch parts data
 
-    if ["alabaster", "granite", "marble"].any? { |x| material['stock-name'] == x } #stone isn't stackable, so just calculate stock*quantity
+    if material && ["alabaster", "granite", "marble"].any? { |x| material['stock-name'] == x } #stone isn't stackable, so just calculate stock*quantity
       total += material['stock-value']*quantity
     elsif material #alchemy and remedies doesn't have materials_info, those are handled by parts below
       number_per_item = ((recipe['volume']/material['stock-volume'].to_f)*quantity).ceil

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -197,15 +197,16 @@ module DRCC
     true
   end
   
-  def crafting_cost(recipe, material, parts, quantity, hometown)
-    total = 1000 #added to account for consumables
+  def crafting_cost(recipe, material = false, parts, quantity, hometown)
+    total = 1000 #added to account for consumables, water, coal, etc
     currency = DRCM.town_currency(hometown)
+    data = get_data('crafting')['stock'] #fetch parts data
 
-    unless ["alabaster", "granite", "marble"].any? { |x| material['stock-name'] == x }
+    if ["alabaster", "granite", "marble"].any? { |x| material['stock-name'] == x } #stone isn't stackable, so just calculate stock*quantity
+      total += material['stock-value']*quantity
+    elsif material #alchemy and remedies doesn't have materials_info, those are handled by parts below
       number_per_item = ((recipe['volume']/material['stock-volume'].to_f)*quantity).ceil
       total += (number_per_item*material['stock-value'])
-    else
-      total += material['stock-value']*quantity
     end
     
     if parts
@@ -215,8 +216,8 @@ module DRCC
         'unity sigil-scroll','congruence sigil-scroll','ring','evolution sigil-scroll','gwethdesuan','brazier','burin',
         'ascension sigil-scroll','ingot', 'mechanism']
       
-      parts.reject! { |part| parts_cannot_purchase.include?(part) }
-      parts.each { |part| total += data[part]['stock-value']*quantity }
+      parts.reject! { |part| parts_cannot_purchase.include?(part) } #excludes things you cannot purchase, so won't error if you've got these.
+      parts.each { |part| total += data[part]['stock-value']*quantity } #adds the cost of each purchasable part to the total
     end
 
     if currency == 'kronars'

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -201,7 +201,7 @@ module DRCC
     total = 1000 #added to account for consumables
     currency = DRCM.town_currency(hometown)
 
-    unless ["alabaster", "granite", "marble"].any? { |x| material == x }
+    unless ["alabaster", "granite", "marble"].any? { |x| material['stock-name'] == x }
       number_per_item = ((recipe['volume']/material['stock-volume'].to_f)*quantity).ceil
       total += (number_per_item*material['stock-value'])
     else

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -198,15 +198,14 @@ module DRCC
   end
   
   def crafting_cost(recipe, material = false, parts, quantity, hometown)
-    total = 1000 #added to account for consumables, water, coal, etc
     currency = DRCM.town_currency(hometown)
     data = get_data('crafting')['stock'] #fetch parts data
 
     if material && ["alabaster", "granite", "marble"].any? { |x| material['stock-name'] == x } #stone isn't stackable, so just calculate stock*quantity
       total += material['stock-value']*quantity
     elsif material #alchemy and remedies doesn't have materials_info, those are handled by parts below
-      number_per_item = ((recipe['volume']/material['stock-volume'].to_f)*quantity).ceil
-      total += (number_per_item*material['stock-value'])
+      stock_to_order = ((recipe['volume']/material['stock-volume'].to_f)*quantity).ceil
+      total += (stock_to_order*material['stock-value'])
     end
     
     if parts
@@ -219,6 +218,8 @@ module DRCC
       parts.reject! { |part| parts_cannot_purchase.include?(part) } #excludes things you cannot purchase, so won't error if you've got these.
       parts.each { |part| total += data[part]['stock-value']*quantity } #adds the cost of each purchasable part to the total
     end
+    
+    total += 1000 #added to account for consumables, water, coal, etc
 
     if currency == 'kronars'
       return total

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -196,6 +196,37 @@ module DRCC
     end
     true
   end
+  
+  def crafting_cost(recipe, material, parts, quantity, hometown)
+    total = 0
+    currency = DRCM.town_currency(hometown)
+
+    unless ["alabaster", "granite", "marble"].any? { |x| material == x }
+      number_per_item = ((recipe['volume']/material['stock-volume'].to_f)*quantity).ceil
+      total += (number_per_item*material['stock-value'])
+    else
+      total += material['stock-value']*quantity
+    end
+    
+    if parts
+      parts_cannot_purchase = ['sufil','blue flower','muljin','belradi','dioica','hulnik','aloe','eghmok','lujeakave','yelith',
+        'cebi','blocil','hulij','nuloe','hisan','gem','paradox sigil-scroll','metamorphosis sigil-scroll','pebble',
+        'integration sigil-scroll','clarification sigil-scroll','antipode sigil-scroll','decay sigil-scroll','nurture sigil-scroll',
+        'unity sigil-scroll','congruence sigil-scroll','ring','evolution sigil-scroll','gwethdesuan','brazier','burin',
+        'ascension sigil-scroll','ingot', 'mechanism']
+      
+      parts.reject! { |part| parts_cannot_purchase.include?(part) }
+      parts.each { |part| total += data[part]['stock-value']*quantity }
+    end
+
+    if currency == 'kronars'
+      return total
+    elsif currency == 'lirums'
+      return (total*0.800).ceil
+    elsif currency == 'dokoras'
+      return (total*0.7216).ceil
+    end
+  end
 
   def check_consumables(name, room, number, bag, bag_items, belt)
     current = Room.current.id

--- a/craft.lic
+++ b/craft.lic
@@ -159,7 +159,7 @@ class Craft
 
     if rank <= 25 # Tier 1  Extremely Easy
       # Buy red flowers and nemoih root
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some blister cream/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some blister cream/ }
       DRCM.ensure_copper_on_hand(2000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb2_stock'])
@@ -170,7 +170,7 @@ class Craft
       DRCI.dispose_trash('cream', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 50 # Tier 2 - Very Easy
       # Buy red flowers and plovik leaf
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some moisturizing ointment/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some moisturizing ointment/ }
       DRCM.ensure_copper_on_hand(2000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb2_stock'])
@@ -181,7 +181,7 @@ class Craft
       DRCI.dispose_trash('ointment', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 100 # Tier 3 - Easy
       # Buy plovik leaves
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some chest salve/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some chest salve/ }
       DRCM.ensure_copper_on_hand(2000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
@@ -191,7 +191,7 @@ class Craft
       DRCI.dispose_trash('salve', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 175 # Tier 4 - Simple
       # Buy riolur leaves
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /a neck potion/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /a neck potion/ }
       DRCM.ensure_copper_on_hand(2000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
@@ -201,7 +201,7 @@ class Craft
       DRCI.dispose_trash('potion', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 300 # Tier 5 - Basic
       # Buy jadice flower
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some limb salve/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some limb salve/ }
       DRCM.ensure_copper_on_hand(2000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
@@ -211,7 +211,7 @@ class Craft
       DRCI.dispose_trash('salve', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 425 # Tier 6 - Somewhat Challenging
       # Buy plovik leaves
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some chest ungent/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some chest ungent/ }
       DRCM.ensure_copper_on_hand(4000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
@@ -221,7 +221,7 @@ class Craft
       DRCI.dispose_trash('ungent', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 550 # Tier 7 - Challenging
       # Buy riolur leaves
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some neck tonic/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some neck tonic/ }
       DRCM.ensure_copper_on_hand(4000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
@@ -231,7 +231,7 @@ class Craft
       DRCI.dispose_trash('tonic', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 700 # Tier 8 - Complicated
       # Buy aevaes leaves
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some eye tonic/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some eye tonic/ }
       DRCM.ensure_copper_on_hand(4000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
@@ -241,7 +241,7 @@ class Craft
       DRCI.dispose_trash('tonic', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 850 # Tier 9 - Intricate
       # Buy ojhenik root
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /a body elixir/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /a body elixir/ }
       DRCM.ensure_copper_on_hand(4000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
@@ -251,7 +251,7 @@ class Craft
       DRCI.dispose_trash('elixir', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 1175 # Tier 10 - Difficult
       # Forage belradi moss
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /a general elixir/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /a general elixir/ }
       DRCM.ensure_copper_on_hand(4000, @settings)
       DRC.wait_for_script_to_complete('alchemy',['belradi', 'forage', '25'])
       DRC.wait_for_script_to_complete('alchemy',['belradi', 'prepare'])
@@ -262,7 +262,7 @@ class Craft
       DRCI.dispose_trash('elixir', @worn_trashcan, @worn_trashcan_verb)
     elsif rank <= 1400 # Tier 11  Very Difficult
       # Forage blue flowers and belradi moss
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some refreshment elixir/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some refreshment elixir/ }
       DRCM.ensure_copper_on_hand(4000, @settings)
       DRC.wait_for_script_to_complete('alchemy',['blue', 'forage', '25'])
       DRC.wait_for_script_to_complete('alchemy',['belradi', 'forage', '5'])
@@ -275,7 +275,7 @@ class Craft
       DRCI.dispose_trash('elixir', @worn_trashcan, @worn_trashcan_verb)
     else # Tier 12 - Extremely Difficult
       # Buy red flowers and forage dioica sap
-      recipe = get_data('recipes').crafting_recipes.find { |recipe| recipe['name'] =~ /some vigor poultices/ }
+      recipe = get_data('recipes')['remedies'].find { |recipe| recipe['name'] =~ /some vigor poultices/ }
       DRCM.ensure_copper_on_hand(4000, @settings)
       DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
       DRC.wait_for_script_to_complete('alchemy',['dioica', 'forage', '5'])
@@ -287,7 +287,7 @@ class Craft
       DRCI.dispose_trash('poultices', @worn_trashcan, @worn_trashcan_verb)
     end
   end
-
+  
   def train_enchanting
     crafting_data = get_data('crafting')
     rank = DRSkill.getrank('Enchanting')

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -177,7 +177,7 @@ stock:
     stock-value: 1500
   bone totem:
     stock-volume: 1
-    stock-number: 6
+    stock-number: 16
     stock-name: bone totem
     stock-value: 125
   small backing:

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -180,6 +180,52 @@ stock:
     stock-number: 6
     stock-name: bone totem
     stock-value: 125
+  small backing:
+    stock-value: 150
+  large backing:
+    stock-value: 312
+  small padding:
+    stock-value: 62
+  long pole:
+    stock-value: 125
+  short pole:
+    stock-value: 100
+  long cord:
+    stock-value: 150
+  short cord:
+    stock-value: 150
+  large padding:
+    stock-value: 150
+  hilt:
+    stock-value: 125
+  haft:
+    stock-value: 125
+  leather shield handle:
+    stock-value: 125
+  shield handle:
+    stock-value: 212
+  bow string:
+    stock-value: 150
+  bone backer:
+    stock-value: 100
+  leather strip:
+    stock-value: 625
+  arrow flights:
+    stock-value: 62
+  bolt flights:
+    stock-value: 62
+  backing:
+    stock-value: 125
+  rod:
+    stock-value: 312
+  bead:
+    stock-value: 187
+  runestone:
+    stock-value: 187
+  sphere:
+    stock-value: 150
+  wand:
+    stock-value: 125
   
 blacksmithing:
   Crossing: &zoluren_blacksmithing

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -75,6 +75,111 @@ stock:
     stock-number: 11
     stock-name: balsa
     stock-value: 562
+  water:
+    stock-volume: 10
+    stock-number: 1
+    stock-name: water
+    stock-value: 62
+  alcohol:
+    stock-volume: 10
+    stock-number: 2
+    stock-name: alcohol
+    stock-value: 81
+  nemoih:
+    stock-volume: 25
+    stock-number: 3
+    stock-name: nemoih
+    stock-value: 250
+  plovik:
+    stock-volume: 25
+    stock-number: 4
+    stock-name: plovik
+    stock-value: 312
+  jadice:
+    stock-volume: 25
+    stock-number: 5
+    stock-name: jadice
+    stock-value: 375
+  nilos:
+    stock-volume: 25
+    stock-number: 6
+    stock-name: nilos
+    stock-value: 437
+  georin:
+    stock-volume: 25
+    stock-number: 7
+    stock-name: georin
+    stock-value: 437
+  riolur:
+    stock-volume: 25
+    stock-number: 8
+    stock-name: riolur
+    stock-value: 562
+  junliar:
+    stock-volume: 25
+    stock-number: 9
+    stock-name: junliar
+    stock-value: 531
+  aevaes:
+    stock-volume: 25
+    stock-number: 10
+    stock-name: aevaes
+    stock-value: 537
+  genich stem:
+    stock-volume: 25
+    stock-number: 11
+    stock-name: genich stem
+    stock-value: 650
+  ojhenik:
+    stock-volume: 25
+    stock-number: 12
+    stock-name: ojhenik
+    stock-value: 1000
+  red flowers:
+    stock-volume: 25
+    stock-number: 13
+    stock-name: red flowers
+    stock-value: 343
+  ithor root:
+    stock-volume: 4
+    stock-number: 14
+    stock-name: ithor root
+    stock-value: 100
+  qun pollen:
+    stock-volume: 4
+    stock-number: 15
+    stock-name: qun pollen
+    stock-value: 106
+  induction sigil-scroll:
+    stock-volume: 1
+    stock-number: 1
+    stock-name: induction sigil-scroll
+    stock-value: 625
+  abolution sigil-scroll:
+    stock-volume: 1
+    stock-number: 2
+    stock-name: abolution sigil-scroll
+    stock-value: 625
+  congruence sigil-scroll:
+    stock-volume: 1
+    stock-number: 3
+    stock-name: congruence sigil-scroll
+    stock-value: 625
+  permutation sigil-scroll:
+    stock-volume: 1
+    stock-number: 4
+    stock-name: permutation sigil-scroll
+    stock-value: 312
+  rarefaction sigil-scroll:
+    stock-volume: 1
+    stock-number: 5
+    stock-name: rarefaction sigil-scroll
+    stock-value: 1500
+  bone totem:
+    stock-volume: 1
+    stock-number: 6
+    stock-name: bone totem
+    stock-value: 125
   
 blacksmithing:
   Crossing: &zoluren_blacksmithing

--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -1,8188 +1,7109 @@
 ---
-crafting_recipes:
-##### Page numbers are as of 2/20/2021 15:48 ET #####
-##################################
-##### Forging section begins #####
-##################################
-# Armorsmithing Chapter 1 recipes
-- name: a metal ring aventail
-  noun: aventail
-  volume: 5
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring mask
-  noun: mask
-  volume: 3
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain aventail
-  noun: aventail
-  volume: 6
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring cap
-  noun: cap
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain mask
-  noun: mask
-  volume: 4
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring gloves
-  noun: gloves
-  volume: 6
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring greaves
-  noun: greaves
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring helm
-  noun: helm
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail aventail
-  noun: aventail
-  volume: 7
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain cap
-  noun: cap
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail mask
-  noun: mask
-  volume: 5
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain gloves
-  noun: gloves
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail gloves
-  noun: gloves
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring tasset
-  noun: tasset
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring vambraces
-  noun: vambraces
-  volume: 19
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain greaves
-  noun: greaves
-  volume: 15
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring balaclava
-  noun: balaclava
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain helm
-  noun: helm
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail cap
-  noun: cap
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring lorica
-  noun: lorica
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal ring mantle
-  noun: mantle
-  volume: 21
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal ring vest
-  noun: vest
-  volume: 18
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain tasset
-  noun: tasset
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring sleeves
-  noun: sleeves
-  volume: 21
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain vambraces
-  noun: vambraces
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain balaclava
-  noun: balaclava
-  volume: 20
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail helm
-  noun: helm
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a mail balaclava
-  noun: balaclava
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small backing
-- name: a metal ring shirt
-  noun: shirt
-  volume: 43
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal ring robe
-  noun: robe
-  volume: 38
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal chain lorica
-  noun: lorica
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain mantle
-  noun: mantle
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain vest
-  noun: vest
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail tasset
-  noun: tasset
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain sleeves
-  noun: sleeves
-  volume: 26
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail vambraces
-  noun: vambraces
-  volume: 23
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring hauberk
-  noun: hauberk
-  volume: 70
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal chain shirt
-  noun: shirt
-  volume: 50
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal chain robe
-  noun: robe
-  volume: 45
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail lorica
-  noun: lorica
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail mantle
-  noun: mantle
-  volume: 27
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail vest
-  noun: vest
-  volume: 22
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: some metal mail sleeves
-  noun: sleeves
-  volume: 31
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain hauberk
-  noun: hauberk
-  volume: 80
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal mail shirt
-  noun: shirt
-  volume: 57
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail robe
-  noun: robe
-  volume: 52
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal bar-mail hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-# Armorsmithing Chapter 2 recipes
-- name: a metal scale aventail
-  noun: aventail
-  volume: 9
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale mask
-  noun: mask
-  volume: 5
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale cap
-  noun: cap
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine aventail
-  noun: aventail
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine mask
-  noun: mask
-  volume: 6
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some metal scale gloves
-  noun: gloves
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale helm
-  noun: helm
-  volume: 21
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine cap
-  noun: cap
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar aventail
-  noun: aventail
-  volume: 11
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: a metal lamellar mask
-  noun: mask
-  volume: 7
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some metal scale greaves
-  noun: greaves
-  volume: 15
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: some brigandine gloves
-  noun: gloves
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale tasset
-  noun: tasset
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some metal scale vambraces
-  noun: vambraces
-  volume: 22
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale balaclava
-  noun: balaclava
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine helm
-  noun: helm
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar cap
-  noun: cap
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some brigandine greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some metal lamellar gloves
-  noun: gloves
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: a metal brigandine tasset
-  noun: tasset
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some brigandine vambraces
-  noun: vambraces
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a brigandine balaclava
-  noun: balaclava
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar helm
-  noun: helm
-  volume: 27
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some lamellar greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: some metal scale sleeves
-  noun: sleeves
-  volume: 30
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale lorica
-  noun: lorica
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale mantle
-  noun: mantle
-  volume: 33
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale vest
-  noun: vest
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal lamellar tasset
-  noun: tasset
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: some lamellar vambraces
-  noun: vambraces
-  volume: 28
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: a metal lamellar balaclava
-  noun: balaclava
-  volume: 34
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some brigandine sleeves
-  noun: sleeves
-  volume: 35
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale shirt
-  noun: shirt
-  volume: 56
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale robe
-  noun: robe
-  volume: 49
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-- name: a metal brigandine lorica
-  noun: lorica
-  volume: 38
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal brigandine mantle
-  noun: mantle
-  volume: 36
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal brigandine vest
-  noun: vest
-  volume: 26
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: some lamellar sleeves
-  noun: sleeves
-  volume: 40
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: a brigandine robe
-  noun: robe
-  volume: 56
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-- name: a brigandine shirt
-  noun: shirt
-  volume: 63
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale hauberk
-  noun: hauberk
-  volume: 80
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal lamellar lorica
-  noun: lorica
-  volume: 42
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar mantle
-  noun: mantle
-  volume: 39
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar vest
-  noun: vest
-  volume: 28
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar robe
-  noun: robe
-  volume: 63
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-- name: a brigandine hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal lamellar shirt
-  noun: shirt
-  volume: 70
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a lamellar hauberk
-  noun: hauberk
-  volume: 100
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: a laminar hauberk
-  noun: hauberk
-  volume: 100
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-  - small backing
-# Armorsmithing Chapter 3 recipes
-- name: a light plate aventail
-  noun: aventail
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a light plate mask
-  noun: mask
-  volume: 7
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some light plate gauntlets
-  noun: gauntlets
-  volume: 13
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a plate aventail
-  noun: aventail
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal dome helm
-  noun: helm
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a plate mask
-  noun: mask
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal bascinet
-  noun: bascinet
-  volume: 23
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some plate gauntlets
-  noun: gauntlets
-  volume: 15
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate aventail
-  noun: aventail
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal morion
-  noun: morion
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate mask
-  noun: mask
-  volume: 9
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a light plate fauld
-  noun: fauld
-  volume: 13
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small padding
-- name: a light backplate
-  noun: backplate
-  volume: 10
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some light plate vambraces
-  noun: vambraces
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal visored helm
-  noun: helm
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: heavy plate gauntlets
-  noun: gauntlets
-  volume: 17
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal barbute
-  noun: barbute
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some light plate greaves
-  noun: greaves
-  volume: 19
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal sallet
-  noun: sallet
-  volume: 35
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a light breastplate
-  noun: breastplate
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a plate fauld
-  noun: fauld
-  volume: 15
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal backplate
-  noun: backplate
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some light plate sleeves
-  noun: sleeves
-  volume: 39
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some plate vambraces
-  noun: vambraces
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some plate greaves
-  noun: greaves
-  volume: 22
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal armet
-  noun: armet
-  volume: 40
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal closed helm
-  noun: helm
-  volume: 29
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a light plate cuirass
-  noun: cuirass
-  volume: 39
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - large padding
-- name: a metal breastplate
-  noun: breastplate
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate fauld
-  noun: fauld
-  volume: 17
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal heavy backplate
-  noun: backplate
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some plate sleeves
-  noun: sleeves
-  volume: 45
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate vambraces
-  noun: vambraces
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate greaves
-  noun: greaves
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal great helm
-  noun: helm
-  volume: 45
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some light half plate
-  noun: plate
-  volume: 65
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - large padding
-- name: some light field plate
-  noun: plate
-  volume: 58
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - large padding
-- name: a plate cuirass
-  noun: cuirass
-  volume: 45
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-- name: a heavy breastplate
-  noun: breastplate
-  volume: 20
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate sleeves
-  noun: sleeves
-  volume: 51
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some light full plate
-  noun: plate
-  volume: 100
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - small padding
-  - large padding
-- name: some half plate
-  noun: plate
-  volume: 75
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-  - large backing
-- name: some field plate
-  noun: plate
-  volume: 67
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-  - large backing
-- name: a heavy plate cuirass
-  noun: cuirass
-  volume: 51
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - large backing
-- name: some heavy half plate
-  noun: plate
-  volume: 85
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large padding
-  - small padding
-- name: some full plate
-  noun: plate
-  volume: 110
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: some heavy field plate
-  noun: plate
-  volume: 76
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-- name: some heavy full plate
-  noun: plate
-  volume: 120
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: some heavy fluted plate
-  noun: plate
-  volume: 120
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-# Armorsmithing Chapter 4 recipes
-- name: a metal shield handle
-  noun: handle
-  volume: 2
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-- name: a metal shield boss
-  noun: boss
-  volume: 3
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-- name: a metal target shield
-  noun: shield
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal round sipar
-  noun: sipar
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal ordinary shield
-  noun: shield
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal targe
-  noun: targe
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal triangular sipar
-  noun: sipar
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal medium shield
-  noun: shield
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal ceremonial shield
-  noun: shield
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal curved shield
-  noun: shield
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal circular buckler
-  noun: buckler
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal medium buckler
-  noun: buckler
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal oval shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a simple parry stick
-  noun: stick
-  volume: 7
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - small backing
-- name: a metal jousting shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal skirmisher's shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal kite shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal warrior's shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal valnik shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal tower shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal battle shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal heater shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal aegis
-  noun: aegis
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal war shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-# Blacksmithing Chapter 2 recipes
-- name: a diagonal-peen mallet
-  noun: mallet
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a curved metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: a diagonal-peen hammer
-  noun: hammer
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - short pole
-- name: a stout metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some straight metal tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: a metal cross-peen hammer
-  noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a narrow metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a square metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: some curved metal tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some flat-bladed tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: a tapered metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: some angular metal tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: a straight-peen hammer
-  noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a straight-peen mallet
-  noun: mallet
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - short pole
-- name: a slender metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some metal bolt tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: a flat-headed metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a sturdy metal shovel
-  noun: shovel
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a ball-peen hammer
-  noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a wide metal shovel
-  noun: shovel
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some segmented tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: a weighted metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some box-jaw tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some articulated tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: a ball-peen mallet
-  noun: mallet
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - short pole
-# Blacksmithing Chapter 3 recipes
-- name: a short metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: some short metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: a long metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a metal straight wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal straight bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a thin metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some square metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: some long metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: a flat metal shaper
-  noun: shaper
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some plain metal pliers
-  noun: pliers
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some squat metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: thin metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: a rough metal wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a sturdy metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a metal curved wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal curved bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some curved metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a coarse metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some sturdy metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: curved metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some curved metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: some reinforced chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: a sharpened metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a metal slender wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal slender bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some rough metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a textured metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal beveled wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: some thick metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a flat metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some elongated rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: some sharpened chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: thick metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: a metal tapered wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal tapered bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some hooked metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a tapered metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal jagged wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a metal serrated wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal serrated bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: precise metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-# Blacksmithing Chapter 4 recipes
-- name: a stout metal yardstick
-  noun: yardstick
-  volume: 6
-  chapter: 4
-  type: blacksmithing
-  work_order: false
-- name: some smooth knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a metal hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some straight metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some plain sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some curved metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a flat metal yardstick
-  noun: yardstick
-  volume: 6
-  chapter: 4
-  type: blacksmithing
-  work_order: false
-- name: some tapered knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a pointed metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a curved hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some ribbed sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some bent metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a rectangular yardstick
-  noun: yardstick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 4
-- name: some knobby sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some squat knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a narrow metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some polished knitting needles
-  noun: needles
-  volume: 4
-  chapter: 4
-  type: blacksmithing
-  work_order: true
-- name: a compact metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a serrated hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some serrated scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a detailed yardstick
-  noun: yardstick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 4
-- name: a slender metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some thin sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-# Blacksmithing Chapter 5 recipes
-- name: a small metal brazier
-  noun: brazier
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a tapered pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a flat mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a square wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a tapered mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a flat pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a metal brazier
-  noun: brazier
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a triangular wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a round mixing stick
-  noun: stick
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a round pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a grooved pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: an oblong wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a grooved mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a trapezoidal wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-# Blacksmithing Chapter 6 recipes
-- name: a metal rod
-  noun: rod
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a shallow metal cup
-  noun: cup
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal horseshoe
-  noun: horseshoe
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a soft metal keyblank
-  noun: keyblank
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a short metal mug
-  noun: mug
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a tall metal mug
-  noun: mug
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a large metal horseshoe
-  noun: horseshoe
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: some metal barbells
-  noun: barbells
-  volume: 80
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a back scratcher
-  noun: scratcher
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal bolt box
-  noun: box
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal origami case
-  noun: case
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal lockpick case
-  noun: case
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal ankle band
-  noun: band
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a small metal flask
-  noun: flask
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal talisman case
-  noun: case
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal razor
-  noun: razor
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal flights box
-  noun: box
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal jewelry box
-  noun: box
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal herbal case
-  noun: case
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal lockpick ring
-  noun: ring
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal oil lantern
-  noun: lantern
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal flask
-  noun: flask
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal chest
-  noun: chest
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal instrument case
-  noun: case
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal armband
-  noun: armband
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a large metal flask
-  noun: flask
-  volume: 7
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: some metal clippers
-  noun: clippers
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal starchart tube
-  noun: tube
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-  part:
-  - short cord
-- name: a metal backtube
-  noun: backtube
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-  part:
-  - long cord
-- name: a metal crown
-  noun: crown
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal mask
-  noun: mask
-  volume: 5
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-  part:
-  - short cord
-- name: a metal torque
-  noun: torque
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal headdress
-  noun: headdress
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-# Weaponsmithing Chapter 1 recipes
-- name: a metal briquet
-  noun: briquet
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal carving knife
-  noun: knife
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal dagger
-  noun: dagger
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal misericorde
-  noun: misericorde
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal katar
-  noun: katar
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal short sword
-  noun: sword
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal pugio
-  noun: pugio
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal poignard
-  noun: poignard
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal stiletto
-  noun: stiletto
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal dart
-  noun: dart
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-- name: a metal throwing dagger
-  noun: dagger
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal falcata
-  noun: falcata
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal nehlata
-  noun: nehlata
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal telek
-  noun: telek
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal leaf blade sword
-  noun: sword
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal jambiya
-  noun: jambiya
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal takouba
-  noun: takouba
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal kris
-  noun: kris
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal thrusting blade
-  noun: blade
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal pasabas
-  noun: pasabas
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal rapier
-  noun: rapier
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal koummya
-  noun: koummya
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal oben
-  noun: oben
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal kythe
-  noun: kythe
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal dao
-  noun: dao
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal kasai
-  noun: kasai
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal sunblade
-  noun: sunblade
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal foil
-  noun: foil
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal baselard
-  noun: baselard
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal gladius
-  noun: gladius
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal mambeli
-  noun: mambeli
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal sashqa
-  noun: sashqa
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal adze
-  noun: adze
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal curlade
-  noun: curlade
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal parang
-  noun: parang
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hanger
-  noun: hanger
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal sabre
-  noun: sabre
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal scimitar
-  noun: scimitar
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal shotel
-  noun: shotel
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal cutlass
-  noun: cutlass
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hatchet
-  noun: hatchet
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hand axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - haft
-- name: a light throwing axe
-  noun: axe
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - haft
-- name: a metal iltesh
-  noun: iltesh
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-# Weaponsmithing Chapter 2 recipes
-- name: a metal condottiere
-  noun: condottiere
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal nehdalata
-  noun: nehdalata
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal round axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-- name: a metal longsword
-  noun: longsword
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal spatha
-  noun: spatha
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal kudalata
-  noun: kudalata
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal arzfilt
-  noun: arzfilt
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal broadsword
-  noun: broadsword
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal schiavona
-  noun: schiavona
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal falchion
-  noun: falchion
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal robe sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal battle axe
-  noun: axe
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-- name: a metal recade
-  noun: recade
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal back-sword
-  noun: back-sword
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal nimsha
-  noun: nimsha
-  volume: 8
-  type: weaponsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - hilt
-- name: a metal hunting sword
-  noun: sword
-  volume: 8
-  type: weaponsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - hilt
-- name: a metal namkomba
-  noun: namkomba
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal dagesse
-  noun: dagesse
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal abassi
-  noun: abassi
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal cinquedea
-  noun: cinquedea
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal hurling axe
-  noun: axe
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-# Weaponsmithing Chapter 3 recipes
-- name: a metal twin-point axe
-  noun: axe
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal karambit
-  noun: karambit
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal claymore
-  noun: claymore
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal greataxe
-  noun: greataxe
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal marauder blade
-  noun: blade
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal warring axe
-  noun: axe
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal two-handed sword
-  noun: sword
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal double axe
-  noun: axe
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal periperiu sword
-  noun: sword
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal flamberge
-  noun: flamberge
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal greatsword
-  noun: greatsword
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal shh'oi'ata
-  noun: shh'oi'ata
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal kaskara
-  noun: kaskara
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal igorat axe
-  noun: axe
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-# Weaponsmithing Chapter 4 recipes
-- name: a metal gavel
-  noun: gavel
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal cosh
-  noun: cosh
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal prod
-  noun: prod
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal cudgel
-  noun: cudgel
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal zubke
-  noun: zubke
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal scepter
-  noun: scepter
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal hand mallet
-  noun: mallet
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal bludgeon
-  noun: bludgeon
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal garz
-  noun: garz
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a ridged metal gauntlet
-  noun: gauntlet
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal hand mace
-  noun: mace
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal club
-  noun: club
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a short metal hammer
-  noun: hammer
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal gauntlet
-  noun: gauntlet
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal bulhawf
-  noun: bulhawf
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal cuska
-  noun: cuska
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal bola
-  noun: bola
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - long cord
-- name: a metal throwing club
-  noun: club
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal mallet
-  noun: mallet
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal war club
-  noun: club
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal boko
-  noun: boko
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal boomerang
-  noun: boomerang
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal war hammer
-  noun: hammer
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal belaying pin
-  noun: pin
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal mace
-  noun: mace
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal marlingspike
-  noun: marlingspike
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal mace
-  noun: mace
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal hammer
-  noun: hammer
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal club
-  noun: club
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal hhr'tami
-  noun: hhr'tami
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal komno
-  noun: komno
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal k'trinni sha-tai
-  noun: sha-tai
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a flanged metal mace
-  noun: mace
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-# Weaponsmithing Chapter 5 recipes
-- name: a metal imperial war hammer
-  noun: hammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a heavy metal mace
-  noun: mace
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal greathammer
-  noun: greathammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal ball and chain
-  noun: ball
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a heavy metal chain
-  noun: chain
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-- name: a metal horseman's flail
-  noun: flail
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal ukabi
-  noun: ukabi
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a spiked ball and chain
-  noun: ball
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a spiked metal hara
-  noun: hara
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal morning star
-  noun: star
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal sledgehammer
-  noun: sledgehammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a heavy metal mallet
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal hara
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a double-headed hammer
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal hhr'ata
-  noun: hhr'ata
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a hurlable war hammer
-  noun: hammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal throwing mallet
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal throwing hammer
-  noun: hammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-# Weaponsmithing Chapter 6 recipes
-- name: a metal vilks kodur
-  noun: kodur
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal war mattock
-  noun: mattock
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: double-sided ball and chain
-  noun: ball
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal akabo
-  noun: akabo
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal footman's flail
-  noun: flail
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal dire mace
-  noun: mace
-  volume: 16
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a heavy sledgehammer
-  noun: sledgehammer
-  volume: 16
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal maul
-  noun: maul
-  volume: 16
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal two-headed hammer
-  noun: hammer
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a giant metal mallet
-  noun: mallet
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-# Weaponsmithing Chapter 7 recipes
-- name: a light metal spear
-  noun: spear
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal javelin
-  noun: javelin
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal spear
-  noun: spear
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal allarh
-  noun: allarh
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal hunthsleg
-  noun: hunthsleg
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal awgravet ava
-  noun: ava
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal coresca
-  noun: coresca
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal tzece
-  noun: tzece
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal halberd
-  noun: halberd
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal guisarme
-  noun: guisarme
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal lochaber axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal bardiche
-  noun: bardiche
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal scythe
-  noun: scythe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal duraka skefne
-  noun: skefne
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal military fork
-  noun: fork
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal partisan
-  noun: partisan
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal khuj
-  noun: khuj
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a two-pronged halberd
-  noun: halberd
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal glaive
-  noun: glaive
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ngalio
-  noun: ngalio
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal fauchard
-  noun: fauchard
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal pole axe
-  noun: axe
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ilglaiks skefne
-  noun: skefne
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ranseur
-  noun: ranseur
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal spetum
-  noun: spetum
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal lance
-  noun: lance
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal pike
-  noun: pike
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal voulge
-  noun: voulge
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a short-hafted halberd
-  noun: halberd
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - short pole
-- name: a metal awl pike
-  noun: pike
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-# Weaponsmithing Chapter 8 recipes
-- name: a metal nightstick
-  noun: nightstick
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal cane
-  noun: cane
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal quarterstaff
-  noun: quarterstaff
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal pike staff
-  noun: staff
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal knuckles
-  noun: knuckles
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some weighted metal footwraps
-  noun: footwraps
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal knee spikes
-  noun: spikes
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: some metal elbow spikes
-  noun: spikes
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: some spiked metal footwraps
-  noun: footwraps
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some spiked metal knuckles
-  noun: knuckles
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a weighted staff
-  noun: staff
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal hand claws
-  noun: claws
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-# Weaponsmithing Chapter 9 recipes
-- name: a metal throwing spike
-  noun: spike
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-- name: a metal bar mace
-  noun: mace
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a metal broadaxe
-  noun: broadaxe
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a metal war sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal bastard sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal boarding axe
-  noun: axe
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal splitting maul
-  noun: maul
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a thin-bladed metal fan
-  noun: fan
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-- name: a metal half-handled riste
-  noun: riste
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a thick-bladed metal fan
-  noun: fan
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-- name: a metal riste
-  noun: riste
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-###############################
-##### Forging section end #####
-###############################
+armorsmithing:
+  ##################################
+  ##### Forging section begins #####
+  ##################################
+  # Armorsmithing Chapter 1 recipes
+  - name: a metal ring aventail
+    noun: aventail
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring mask
+    noun: mask
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain aventail
+    noun: aventail
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring cap
+    noun: cap
+    volume: 8
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain mask
+    noun: mask
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring gloves
+    noun: gloves
+    volume: 6
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring helm
+    noun: helm
+    volume: 12
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail aventail
+    noun: aventail
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain cap
+    noun: cap
+    volume: 10
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail mask
+    noun: mask
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain gloves
+    noun: gloves
+    volume: 8
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal mail gloves
+    noun: gloves
+    volume: 10
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring vambraces
+    noun: vambraces
+    volume: 19
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain greaves
+    noun: greaves
+    volume: 15
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring balaclava
+    noun: balaclava
+    volume: 16
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain helm
+    noun: helm
+    volume: 14
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail cap
+    noun: cap
+    volume: 12
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring lorica
+    noun: lorica
+    volume: 26
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal ring mantle
+    noun: mantle
+    volume: 21
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal ring vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal chain tasset
+    noun: tasset
+    volume: 10
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring sleeves
+    noun: sleeves
+    volume: 21
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain vambraces
+    noun: vambraces
+    volume: 20
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal mail greaves
+    noun: greaves
+    volume: 18
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain balaclava
+    noun: balaclava
+    volume: 20
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail helm
+    noun: helm
+    volume: 16
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a mail balaclava
+    noun: balaclava
+    volume: 24
+    work_order: true
+    chapter: 1
+    part:
+    - small backing
+  - name: a metal ring shirt
+    noun: shirt
+    volume: 43
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal ring robe
+    noun: robe
+    volume: 38
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal chain lorica
+    noun: lorica
+    volume: 30
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal chain mantle
+    noun: mantle
+    volume: 24
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal chain vest
+    noun: vest
+    volume: 20
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal mail tasset
+    noun: tasset
+    volume: 12
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain sleeves
+    noun: sleeves
+    volume: 26
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal mail vambraces
+    noun: vambraces
+    volume: 23
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring hauberk
+    noun: hauberk
+    volume: 70
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal chain shirt
+    noun: shirt
+    volume: 50
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal chain robe
+    noun: robe
+    volume: 45
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal mail lorica
+    noun: lorica
+    volume: 34
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal mail mantle
+    noun: mantle
+    volume: 27
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal mail vest
+    noun: vest
+    volume: 22
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: some metal mail sleeves
+    noun: sleeves
+    volume: 31
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain hauberk
+    noun: hauberk
+    volume: 80
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal mail shirt
+    noun: shirt
+    volume: 57
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal mail robe
+    noun: robe
+    volume: 52
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal mail hauberk
+    noun: hauberk
+    volume: 90
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal bar-mail hauberk
+    noun: hauberk
+    volume: 90
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  # Armorsmithing Chapter 2 recipes
+  - name: a metal scale aventail
+    noun: aventail
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale mask
+    noun: mask
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale cap
+    noun: cap
+    volume: 12
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine aventail
+    noun: aventail
+    volume: 10
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine mask
+    noun: mask
+    volume: 6
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some metal scale gloves
+    noun: gloves
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale helm
+    noun: helm
+    volume: 21
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine cap
+    noun: cap
+    volume: 14
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal lamellar aventail
+    noun: aventail
+    volume: 11
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: a metal lamellar mask
+    noun: mask
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some metal scale greaves
+    noun: greaves
+    volume: 15
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: some brigandine gloves
+    noun: gloves
+    volume: 10
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale tasset
+    noun: tasset
+    volume: 10
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some metal scale vambraces
+    noun: vambraces
+    volume: 22
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale balaclava
+    noun: balaclava
+    volume: 26
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine helm
+    noun: helm
+    volume: 24
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal lamellar cap
+    noun: cap
+    volume: 16
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some brigandine greaves
+    noun: greaves
+    volume: 18
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some metal lamellar gloves
+    noun: gloves
+    volume: 12
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: a metal brigandine tasset
+    noun: tasset
+    volume: 12
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some brigandine vambraces
+    noun: vambraces
+    volume: 25
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a brigandine balaclava
+    noun: balaclava
+    volume: 30
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal lamellar helm
+    noun: helm
+    volume: 27
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some lamellar greaves
+    noun: greaves
+    volume: 18
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: some metal scale sleeves
+    noun: sleeves
+    volume: 30
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale lorica
+    noun: lorica
+    volume: 34
+    work_order: false
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale mantle
+    noun: mantle
+    volume: 33
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale vest
+    noun: vest
+    volume: 24
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal lamellar tasset
+    noun: tasset
+    volume: 14
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: some lamellar vambraces
+    noun: vambraces
+    volume: 28
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: a metal lamellar balaclava
+    noun: balaclava
+    volume: 34
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some brigandine sleeves
+    noun: sleeves
+    volume: 35
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale shirt
+    noun: shirt
+    volume: 56
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale robe
+    noun: robe
+    volume: 49
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+  - name: a metal brigandine lorica
+    noun: lorica
+    volume: 38
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal brigandine mantle
+    noun: mantle
+    volume: 36
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal brigandine vest
+    noun: vest
+    volume: 26
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: some lamellar sleeves
+    noun: sleeves
+    volume: 40
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: a brigandine robe
+    noun: robe
+    volume: 56
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+  - name: a brigandine shirt
+    noun: shirt
+    volume: 63
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale hauberk
+    noun: hauberk
+    volume: 80
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal lamellar lorica
+    noun: lorica
+    volume: 42
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+  - name: a metal lamellar mantle
+    noun: mantle
+    volume: 39
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+  - name: a metal lamellar vest
+    noun: vest
+    volume: 28
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+  - name: a metal lamellar robe
+    noun: robe
+    volume: 63
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+    - small backing
+  - name: a brigandine hauberk
+    noun: hauberk
+    volume: 90
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal lamellar shirt
+    noun: shirt
+    volume: 70
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a lamellar hauberk
+    noun: hauberk
+    volume: 100
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+    - small backing
+    - small backing
+  - name: a laminar hauberk
+    noun: hauberk
+    volume: 100
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+    - small backing
+    - small backing
+  # Armorsmithing Chapter 3 recipes
+  - name: a light plate aventail
+    noun: aventail
+    volume: 12
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a light plate mask
+    noun: mask
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some light plate gauntlets
+    noun: gauntlets
+    volume: 13
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a plate aventail
+    noun: aventail
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal dome helm
+    noun: helm
+    volume: 16
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a plate mask
+    noun: mask
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a metal bascinet
+    noun: bascinet
+    volume: 23
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some plate gauntlets
+    noun: gauntlets
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a heavy plate aventail
+    noun: aventail
+    volume: 16
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal morion
+    noun: morion
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a heavy plate mask
+    noun: mask
+    volume: 9
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a light plate fauld
+    noun: fauld
+    volume: 13
+    work_order: true
+    chapter: 3
+    part:
+    - small padding
+  - name: a light backplate
+    noun: backplate
+    volume: 10
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some light plate vambraces
+    noun: vambraces
+    volume: 26
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a metal visored helm
+    noun: helm
+    volume: 26
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: heavy plate gauntlets
+    noun: gauntlets
+    volume: 17
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal barbute
+    noun: barbute
+    volume: 20
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: some light plate greaves
+    noun: greaves
+    volume: 19
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a metal sallet
+    noun: sallet
+    volume: 35
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a light breastplate
+    noun: breastplate
+    volume: 16
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a plate fauld
+    noun: fauld
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal backplate
+    noun: backplate
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: some light plate sleeves
+    noun: sleeves
+    volume: 39
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some plate vambraces
+    noun: vambraces
+    volume: 30
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: some plate greaves
+    noun: greaves
+    volume: 22
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal armet
+    noun: armet
+    volume: 40
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal closed helm
+    noun: helm
+    volume: 29
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a light plate cuirass
+    noun: cuirass
+    volume: 39
+    work_order: false
+    chapter: 3
+    part:
+    - large padding
+  - name: a metal breastplate
+    noun: breastplate
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a heavy plate fauld
+    noun: fauld
+    volume: 17
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal heavy backplate
+    noun: backplate
+    volume: 14
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some plate sleeves
+    noun: sleeves
+    volume: 45
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some heavy plate vambraces
+    noun: vambraces
+    volume: 34
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some heavy plate greaves
+    noun: greaves
+    volume: 25
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal great helm
+    noun: helm
+    volume: 45
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some light half plate
+    noun: plate
+    volume: 65
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+    - large padding
+  - name: some light field plate
+    noun: plate
+    volume: 58
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+    - large padding
+  - name: a plate cuirass
+    noun: cuirass
+    volume: 45
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+  - name: a heavy breastplate
+    noun: breastplate
+    volume: 20
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some heavy plate sleeves
+    noun: sleeves
+    volume: 51
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some light full plate
+    noun: plate
+    volume: 100
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+    - small padding
+    - large padding
+  - name: some half plate
+    noun: plate
+    volume: 75
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+    - large backing
+  - name: some field plate
+    noun: plate
+    volume: 67
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+    - large backing
+  - name: a heavy plate cuirass
+    noun: cuirass
+    volume: 51
+    work_order: false
+    chapter: 3
+    part:
+    - large backing
+  - name: some heavy half plate
+    noun: plate
+    volume: 85
+    work_order: true
+    chapter: 3
+    part:
+    - large padding
+    - small padding
+  - name: some full plate
+    noun: plate
+    volume: 110
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+    - small backing
+  - name: some heavy field plate
+    noun: plate
+    volume: 76
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+  - name: some heavy full plate
+    noun: plate
+    volume: 120
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+    - small backing
+  - name: some heavy fluted plate
+    noun: plate
+    volume: 120
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+    - small backing
+  # Armorsmithing Chapter 4 recipes
+  - name: a metal shield handle
+    noun: handle
+    volume: 2
+    work_order: true
+    chapter: 4
+  - name: a metal shield boss
+    noun: boss
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: a metal target shield
+    noun: shield
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal round sipar
+    noun: sipar
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal ordinary shield
+    noun: shield
+    volume: 16
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal targe
+    noun: targe
+    volume: 16
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal triangular sipar
+    noun: sipar
+    volume: 14
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal medium shield
+    noun: shield
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal ceremonial shield
+    noun: shield
+    volume: 16
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal curved shield
+    noun: shield
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal circular buckler
+    noun: buckler
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal medium buckler
+    noun: buckler
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal oval shield
+    noun: shield
+    volume: 25
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a simple parry stick
+    noun: stick
+    volume: 7
+    work_order: false
+    chapter: 4
+    part:
+    - small backing
+  - name: a metal jousting shield
+    noun: shield
+    volume: 25
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal skirmisher's shield
+    noun: shield
+    volume: 25
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal kite shield
+    noun: shield
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal warrior's shield
+    noun: shield
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal valnik shield
+    noun: shield
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal tower shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal battle shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal heater shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal aegis
+    noun: aegis
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal war shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  # Blacksmithing Chapter 2 recipes
+blacksmithing:
+  - name: a diagonal-peen mallet
+    noun: mallet
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a curved metal shovel
+    noun: shovel
+    volume: 8
+    chapter: 2
+    work_order: false
+    part:
+    - long pole
+  - name: a diagonal-peen hammer
+    noun: hammer
+    volume: 12
+    work_order: false
+    chapter: 2
+    part:
+    - short pole
+  - name: a stout metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some straight metal tongs
+    noun: tongs
+    volume: 10
+    chapter: 2
+    work_order: false
+  - name: a metal cross-peen hammer
+    noun: hammer
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a narrow metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: a square metal shovel
+    noun: shovel
+    volume: 8
+    chapter: 2
+    work_order: false
+    part:
+    - long pole
+  - name: some curved metal tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: some flat-bladed tongs
+    noun: tongs
+    volume: 10
+    chapter: 2
+    work_order: false
+  - name: a tapered metal shovel
+    noun: shovel
+    volume: 8
+    chapter: 2
+    work_order: false
+    part:
+    - long pole
+  - name: some angular metal tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: a straight-peen hammer
+    noun: hammer
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a straight-peen mallet
+    noun: mallet
+    volume: 12
+    work_order: false
+    chapter: 2
+    part:
+    - short pole
+  - name: a slender metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some metal bolt tongs
+    noun: tongs
+    volume: 10
+    chapter: 2
+    work_order: false
+  - name: a flat-headed metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: a sturdy metal shovel
+    noun: shovel
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: a ball-peen hammer
+    noun: hammer
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a wide metal shovel
+    noun: shovel
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some segmented tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: a weighted metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some box-jaw tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: some articulated tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: a ball-peen mallet
+    noun: mallet
+    volume: 12
+    work_order: false
+    chapter: 2
+    part:
+    - short pole
+  # Blacksmithing Chapter 3 recipes
+  - name: a short metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: some short metal chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: a long metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: a metal straight wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal straight bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a thin metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some square metal rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: some long metal chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: a flat metal shaper
+    noun: shaper
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: some plain metal pliers
+    noun: pliers
+    volume: 5
+    work_order: true
+    chapter: 3
+  - name: some squat metal rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: thin metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: a rough metal wood shaper
+    noun: shaper
+    volume: 4
+    chapter: 3
+    work_order: true
+  - name: a sturdy metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: a metal curved wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal curved bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some curved metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a coarse metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some sturdy metal chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: curved metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: some curved metal rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: some reinforced chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: a sharpened metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: a metal slender wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal slender bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some rough metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a textured metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal beveled wood shaper
+    noun: shaper
+    volume: 4
+    chapter: 3
+    work_order: true
+  - name: some thick metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a flat metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some elongated rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: some sharpened chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: thick metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: a metal tapered wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal tapered bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some hooked metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a tapered metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal jagged wood shaper
+    noun: shaper
+    volume: 4
+    chapter: 3
+    work_order: true
+  - name: a metal serrated wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal serrated bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: precise metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  # Blacksmithing Chapter 4 recipes
+  - name: a stout metal yardstick
+    noun: yardstick
+    volume: 6
+    chapter: 4
+    work_order: false
+  - name: some smooth knitting needles
+    noun: needles
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal hide scraper
+    noun: scraper
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some straight metal scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: some plain sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some curved metal scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a flat metal yardstick
+    noun: yardstick
+    volume: 6
+    chapter: 4
+    work_order: false
+  - name: some tapered knitting needles
+    noun: needles
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a pointed metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a curved hide scraper
+    noun: scraper
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some ribbed sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some bent metal scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a rectangular yardstick
+    noun: yardstick
+    volume: 6
+    work_order: false
+    chapter: 4
+  - name: some knobby sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some squat knitting needles
+    noun: needles
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a narrow metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: some polished knitting needles
+    noun: needles
+    volume: 4
+    chapter: 4
+    work_order: true
+  - name: a compact metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a serrated hide scraper
+    noun: scraper
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some serrated scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a detailed yardstick
+    noun: yardstick
+    volume: 6
+    work_order: false
+    chapter: 4
+  - name: a slender metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: some thin sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  # Blacksmithing Chapter 5 recipes
+  - name: a small metal brazier
+    noun: brazier
+    volume: 10
+    work_order: false
+    chapter: 5
+  - name: a tapered pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: a flat mixing stick
+    noun: stick
+    volume: 6
+    work_order: false
+    chapter: 5
+  - name: a square wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  - name: a tapered mixing stick
+    noun: stick
+    volume: 6
+    work_order: false
+    chapter: 5
+  - name: a flat pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: a metal brazier
+    noun: brazier
+    volume: 10
+    work_order: false
+    chapter: 5
+  - name: a triangular wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  - name: a round mixing stick
+    noun: stick
+    volume: 5
+    work_order: true
+    chapter: 5
+  - name: a round pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: a grooved pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: an oblong wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  - name: a grooved mixing stick
+    noun: stick
+    volume: 6
+    work_order: false
+    chapter: 5
+  - name: a trapezoidal wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  # Blacksmithing Chapter 6 recipes
+  - name: a metal rod
+    noun: rod
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a shallow metal cup
+    noun: cup
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a metal horseshoe
+    noun: horseshoe
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a soft metal keyblank
+    noun: keyblank
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a short metal mug
+    noun: mug
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a tall metal mug
+    noun: mug
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a large metal horseshoe
+    noun: horseshoe
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: some metal barbells
+    noun: barbells
+    volume: 80
+    work_order: false
+    chapter: 6
+  - name: a back scratcher
+    noun: scratcher
+    volume: 3
+    work_order: true
+    chapter: 6
+  - name: a metal bolt box
+    noun: box
+    volume: 10
+    work_order: false
+    chapter: 6
+  - name: a metal origami case
+    noun: case
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: a metal lockpick case
+    noun: case
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: a metal ankle band
+    noun: band
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a small metal flask
+    noun: flask
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal talisman case
+    noun: case
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal razor
+    noun: razor
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a metal flights box
+    noun: box
+    volume: 10
+    work_order: false
+    chapter: 6
+  - name: a metal jewelry box
+    noun: box
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a metal herbal case
+    noun: case
+    volume: 8
+    work_order: false
+    chapter: 6
+  - name: a metal lockpick ring
+    noun: ring
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a metal oil lantern
+    noun: lantern
+    volume: 6
+    work_order: false
+    chapter: 6
+  - name: a metal flask
+    noun: flask
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal chest
+    noun: chest
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: a metal instrument case
+    noun: case
+    volume: 8
+    work_order: false
+    chapter: 6
+  - name: a metal armband
+    noun: armband
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a large metal flask
+    noun: flask
+    volume: 7
+    work_order: false
+    chapter: 6
+  - name: some metal clippers
+    noun: clippers
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a metal starchart tube
+    noun: tube
+    volume: 8
+    work_order: false
+    chapter: 6
+    part:
+    - short cord
+  - name: a metal backtube
+    noun: backtube
+    volume: 10
+    work_order: false
+    chapter: 6
+    part:
+    - long cord
+  - name: a metal crown
+    noun: crown
+    volume: 10
+    work_order: false
+    chapter: 6
+  - name: a metal mask
+    noun: mask
+    volume: 5
+    work_order: false
+    chapter: 6
+    part:
+    - short cord
+  - name: a metal torque
+    noun: torque
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal headdress
+    noun: headdress
+    volume: 10
+    work_order: false
+    chapter: 6
+  # Weaponsmithing Chapter 1 recipes
+weaponsmithing:
+  - name: a metal briquet
+    noun: briquet
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal carving knife
+    noun: knife
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal dagger
+    noun: dagger
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal misericorde
+    noun: misericorde
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal katar
+    noun: katar
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal short sword
+    noun: sword
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal pugio
+    noun: pugio
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal poignard
+    noun: poignard
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal stiletto
+    noun: stiletto
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal dart
+    noun: dart
+    volume: 2
+    work_order: true
+    chapter: 1
+  - name: a metal throwing dagger
+    noun: dagger
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal falcata
+    noun: falcata
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal nehlata
+    noun: nehlata
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal telek
+    noun: telek
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal leaf blade sword
+    noun: sword
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal jambiya
+    noun: jambiya
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal takouba
+    noun: takouba
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal kris
+    noun: kris
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal thrusting blade
+    noun: blade
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal pasabas
+    noun: pasabas
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal rapier
+    noun: rapier
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal koummya
+    noun: koummya
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal oben
+    noun: oben
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal kythe
+    noun: kythe
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal dao
+    noun: dao
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal kasai
+    noun: kasai
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal sunblade
+    noun: sunblade
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal foil
+    noun: foil
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal baselard
+    noun: baselard
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal gladius
+    noun: gladius
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal mambeli
+    noun: mambeli
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal sashqa
+    noun: sashqa
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal adze
+    noun: adze
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal curlade
+    noun: curlade
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal parang
+    noun: parang
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal hanger
+    noun: hanger
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal sabre
+    noun: sabre
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal scimitar
+    noun: scimitar
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal shotel
+    noun: shotel
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal cutlass
+    noun: cutlass
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal hatchet
+    noun: hatchet
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal hand axe
+    noun: axe
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - haft
+  - name: a light throwing axe
+    noun: axe
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - haft
+  - name: a metal iltesh
+    noun: iltesh
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  # Weaponsmithing Chapter 2 recipes
+  - name: a metal condottiere
+    noun: condottiere
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal nehdalata
+    noun: nehdalata
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal round axe
+    noun: axe
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - haft
+  - name: a metal longsword
+    noun: longsword
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal spatha
+    noun: spatha
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal kudalata
+    noun: kudalata
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal arzfilt
+    noun: arzfilt
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal broadsword
+    noun: broadsword
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal schiavona
+    noun: schiavona
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal falchion
+    noun: falchion
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal robe sword
+    noun: sword
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal battle axe
+    noun: axe
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - haft
+  - name: a metal recade
+    noun: recade
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal back-sword
+    noun: back-sword
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal nimsha
+    noun: nimsha
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal hunting sword
+    noun: sword
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal namkomba
+    noun: namkomba
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal dagesse
+    noun: dagesse
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal abassi
+    noun: abassi
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal cinquedea
+    noun: cinquedea
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal hurling axe
+    noun: axe
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - haft
+  # Weaponsmithing Chapter 3 recipes
+  - name: a metal twin-point axe
+    noun: axe
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal karambit
+    noun: karambit
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal claymore
+    noun: claymore
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal greataxe
+    noun: greataxe
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal marauder blade
+    noun: blade
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal warring axe
+    noun: axe
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal two-handed sword
+    noun: sword
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal double axe
+    noun: axe
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal periperiu sword
+    noun: sword
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal flamberge
+    noun: flamberge
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal greatsword
+    noun: greatsword
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal shh'oi'ata
+    noun: shh'oi'ata
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal kaskara
+    noun: kaskara
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal igorat axe
+    noun: axe
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  # Weaponsmithing Chapter 4 recipes
+  - name: a metal gavel
+    noun: gavel
+    volume: 4
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal cosh
+    noun: cosh
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal prod
+    noun: prod
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal cudgel
+    noun: cudgel
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal zubke
+    noun: zubke
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal scepter
+    noun: scepter
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal hand mallet
+    noun: mallet
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal bludgeon
+    noun: bludgeon
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal garz
+    noun: garz
+    volume: 6
+    work_order: true
+    chapter: 4
+  - name: a ridged metal gauntlet
+    noun: gauntlet
+    volume: 6
+    work_order: true
+    chapter: 4
+  - name: a metal hand mace
+    noun: mace
+    volume: 6
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal club
+    noun: club
+    volume: 6
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a short metal hammer
+    noun: hammer
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal gauntlet
+    noun: gauntlet
+    volume: 5
+    work_order: true
+    chapter: 4
+  - name: a metal bulhawf
+    noun: bulhawf
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal cuska
+    noun: cuska
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal bola
+    noun: bola
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - long cord
+  - name: a metal throwing club
+    noun: club
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal mallet
+    noun: mallet
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal war club
+    noun: club
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal boko
+    noun: boko
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: a metal boomerang
+    noun: boomerang
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: a metal war hammer
+    noun: hammer
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal belaying pin
+    noun: pin
+    volume: 8
+    work_order: true
+    chapter: 4
+  - name: a metal mace
+    noun: mace
+    volume: 8
+    work_order: true
+    chapter: 4
+  - name: a metal marlingspike
+    noun: marlingspike
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal mace
+    noun: mace
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal hammer
+    noun: hammer
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal club
+    noun: club
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal hhr'tami
+    noun: hhr'tami
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal komno
+    noun: komno
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal k'trinni sha-tai
+    noun: sha-tai
+    volume: 9
+    work_order: true
+    chapter: 4
+  - name: a flanged metal mace
+    noun: mace
+    volume: 9
+    work_order: true
+    chapter: 4
+  # Weaponsmithing Chapter 5 recipes
+  - name: a metal imperial war hammer
+    noun: hammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a heavy metal mace
+    noun: mace
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal greathammer
+    noun: greathammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal ball and chain
+    noun: chain
+    volume: 9
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a heavy metal chain
+    noun: chain
+    volume: 9
+    work_order: true
+    chapter: 5
+  - name: a metal horseman's flail
+    noun: flail
+    volume: 9
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal ukabi
+    noun: ukabi
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a spiked ball and chain
+    noun: ukabi
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a spiked metal hara
+    noun: hara
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal morning star
+    noun: star
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal sledgehammer
+    noun: sledgehammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a heavy metal mallet
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal hara
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a double-headed hammer
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal hhr'ata
+    noun: hhr'ata
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a hurlable war hammer
+    noun: hammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal throwing mallet
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal throwing hammer
+    noun: hammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  # Weaponsmithing Chapter 6 recipes
+  - name: a metal vilks kodur
+    noun: kodur
+    volume: 14
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal war mattock
+    noun: mattock
+    volume: 14
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: double-sided ball and chain
+    noun: chain
+    volume: 13
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal akabo
+    noun: akabo
+    volume: 13
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal footman's flail
+    noun: flail
+    volume: 13
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal dire mace
+    noun: mace
+    volume: 16
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a heavy sledgehammer
+    noun: sledgehammer
+    volume: 16
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal maul
+    noun: maul
+    volume: 16
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal two-headed hammer
+    noun: hammer
+    volume: 15
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a giant metal mallet
+    noun: hammer
+    volume: 15
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  # Weaponsmithing Chapter 7 recipes
+  - name: a light metal spear
+    noun: spear
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal javelin
+    noun: javelin
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal spear
+    noun: spear
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal allarh
+    noun: allarh
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal hunthsleg
+    noun: hunthsleg
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal awgravet ava
+    noun: ava
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal coresca
+    noun: coresca
+    volume: 12
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal tzece
+    noun: tzece
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal halberd
+    noun: halberd
+    volume: 12
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal guisarme
+    noun: guisarme
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal lochaber axe
+    noun: axe
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal bardiche
+    noun: bardiche
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal scythe
+    noun: scythe
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal duraka skefne
+    noun: skefne
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal military fork
+    noun: fork
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal partisan
+    noun: partisan
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal khuj
+    noun: khuj
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a two-pronged halberd
+    noun: halberd
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal glaive
+    noun: glaive
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal ngalio
+    noun: ngalio
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal fauchard
+    noun: fauchard
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal pole axe
+    noun: axe
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal ilglaiks skefne
+    noun: skefne
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal ranseur
+    noun: ranseur
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal spetum
+    noun: spetum
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal lance
+    noun: lance
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal pike
+    noun: pike
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal voulge
+    noun: voulge
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a short-hafted halberd
+    noun: halberd
+    volume: 9
+    work_order: true
+    chapter: 7
+    part:
+    - short pole
+  - name: a metal awl pike
+    noun: pike
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  # Weaponsmithing Chapter 8 recipes
+  - name: a metal nightstick
+    noun: nightstick
+    volume: 7
+    work_order: true
+    chapter: 8
+  - name: a metal cane
+    noun: cane
+    volume: 8
+    work_order: true
+    chapter: 8
+  - name: a metal quarterstaff
+    noun: quarterstaff
+    volume: 10
+    work_order: true
+    chapter: 8
+  - name: a metal pike staff
+    noun: staff
+    volume: 11
+    work_order: true
+    chapter: 8
+  - name: some metal knuckles
+    noun: knuckles
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: some weighted metal footwraps
+    noun: footwraps
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: some metal knee spikes
+    noun: spikes
+    volume: 4
+    work_order: true
+    chapter: 8
+    part:
+    - short cord
+  - name: some metal elbow spikes
+    noun: spikes
+    volume: 4
+    work_order: true
+    chapter: 8
+    part:
+    - short cord
+  - name: some spiked metal footwraps
+    noun: footwraps
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: some spiked metal knuckles
+    noun: knuckles
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: a weighted staff
+    noun: staff
+    volume: 10
+    work_order: true
+    chapter: 8
+  - name: some metal hand claws
+    noun: claws
+    volume: 4
+    work_order: true
+    chapter: 8
+    part:
+    - short cord
+  # Weaponsmithing Chapter 9 recipes
+  - name: a metal throwing spike
+    noun: spike
+    volume: 4
+    work_order: true
+    chapter: 9
+  - name: a metal bar mace
+    noun: mace
+    volume: 12
+    work_order: true
+    chapter: 9
+    part:
+    - haft
+  - name: a metal broadaxe
+    noun: broadaxe
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - haft
+  - name: a metal war sword
+    noun: sword
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a metal bastard sword
+    noun: sword
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a metal boarding axe
+    noun: axe
+    volume: 10
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a metal splitting maul
+    noun: maul
+    volume: 15
+    work_order: true
+    chapter: 9
+    part:
+    - haft
+  - name: a thin-bladed metal fan
+    noun: fan
+    volume: 4
+    work_order: true
+    chapter: 9
+  - name: a metal half-handled riste
+    noun: riste
+    volume: 7
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a thick-bladed metal fan
+    noun: fan
+    volume: 6
+    work_order: true
+    chapter: 9
+  - name: a metal riste
+    noun: riste
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+carving:
 ######################################
 ##### Engineering section begins #####
 ######################################
 # Carving Chapter 1 recipes
-- name: a small stone block
-  noun: block
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a large stone block
-  noun: block
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: a thin stone slab
-  noun: slab
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a short stone pole
-  noun: pole
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a thick stone slab
-  noun: slab
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: a smooth slickstone
-  noun: slickstone
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a stout stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a shallow stone basin
-  noun: basin
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a long stone pole
-  noun: pole
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: slender stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a deep stone basin
-  noun: basin
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: a small stone sphere
-  noun: sphere
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 2
-  material: stone
-- name: a flat slickstone
-  noun: slickstone
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a large stone sphere
-  noun: sphere
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: grooved stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a polished slickstone
-  noun: slickstone
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: notched stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a forked stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-# Carving Chapter 3 recipes
-- name: some smooth stones
-  noun: stones
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone bludgeon
-  noun: bludgeon
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: a stone carving knife
-  noun: knife
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: some elongated stones
-  noun: stones
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone hand axe
-  noun: axe
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: a stone war club
-  noun: club
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - short pole
-- name: some balanced stones
-  noun: stones
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone war hammer
-  noun: hammer
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - short pole
-- name: some stone spikes
-  noun: spikes
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: some stone shards
-  noun: shards
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone bola
-  noun: bola
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long cord
-- name: a stone hand sword
-  noun: sword
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: a heavy stone mallet
-  noun: mallet
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone javelin
-  noun: javelin
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone spear
-  noun: spear
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone war mattock
-  noun: mattock
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone maul
-  noun: maul
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone flail
-  noun: flail
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long cord
-  - long pole
-# Carving Chapter 4 recipes
-- name: a stone band
-  noun: band
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 1
-  material: stone
-- name: a stone toe ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 1
-  material: stone
-- name: a stone nose ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 1
-  material: stone
-- name: a stone pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone anklet
-  noun: anklet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone tailband
-  noun: tailband
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone hairpin
-  noun: hairpin
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone cloak pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a pair of stone earrings
-  noun: earrings
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone medallion
-  noun: medallion
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone amulet
-  noun: amulet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone pendant
-  noun: pendant
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-  part:
-  - short cord
-- name: a stone brooch
-  noun: brooch
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone earcuff
-  noun: earcuff
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone belt buckle
-  noun: buckle
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone armband
-  noun: armband
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: an articulated stone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone tiara
-  noun: tiara
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone locket
-  noun: locket
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-  part:
-  - short cord
-- name: a stone choker
-  noun: choker
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone diadem
-  noun: diadem
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone circlet
-  noun: circlet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-  part:
-  - short cord
-- name: an articulated stone necklace
-  noun: necklace
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone crown
-  noun: crown
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: an articulated stone belt
-  noun: belt
-  work_order: false
-  type: carving
-  chapter: 4
-  volume: 4
-  material: stone
-- name: a stone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-  part:
-  - short cord
-- name: a segmented stone shirt
-  noun: shirt
-  work_order: false
-  type: carving
-  chapter: 4
-  volume: 5
-  material: stone
-# Carving Chapter 5 recipes
-- name: a bone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: bone
-- name: a stone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a detailed bone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: bone
-- name: a detailed stone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a bone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: bone
-- name: a stone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: stone
-- name: a detailed bone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: bone
-- name: a detailed stone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: stone
-- name: a bone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a stone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a basic runestone
-  noun: runestone
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a bone wand
-  noun: wand
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a stone wand
-  noun: wand
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a bone rod
-  noun: rod
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a stone rod
-  noun: rod
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a detailed bone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a detailed stone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a bone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: bone
-- name: a stone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: a fine runestone
-  noun: runestone
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a detailed bone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 8
-  material: bone
-- name: detailed stone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: a bone statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 20
-  material: bone
-- name: a stone statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: a detailed bone statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 20
-  material: bone
-- name: a detailed statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: an ornate runestone
-  noun: runestone
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-# Carving Chapter 6 recipes
-- name: a short bone pole
-  noun: pole
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-- name: a simple bone burin
-  noun: burin
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-- name: a long bone pole
-  noun: pole
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 6
-  material: bone
-- name: a fine bone burin
-  noun: burin
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-- name: an ornate bone burin
-  noun: burin
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-# Carving Chapter 8 recipes
-- name: a bone bludgeon
-  noun: bludgeon
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 5
-  material: bone
-- name: a bone carving knife
-  noun: knife
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 2
-  material: bone
-- name: a bone hand axe
-  noun: axe
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 6
-  material: bone
-- name: a bone war club
-  noun: club
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 7
-  material: bone
-- name: a bone shiv
-  noun: shiv
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 3
-  material: bone
-- name: a bone hand sword
-  noun: sword
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 4
-  material: bone
-- name: a bone mallet
-  noun: mallet
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 8
-  material: bone
-- name: a bone javelin
-  noun: javelin
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 8
-  material: bone
-- name: a light bone spear
-  noun: spear
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 7
-  material: bone
-- name: a bone maul
-  noun: maul
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 16
-  material: bone
-- name: a bone mattock
-  noun: mattock
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 17
-  material: bone
-- name: a bone flail
-  noun: flail
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 11
-  material: bone
-# Carving Chapter 9 recipes
-- name: a bone band
-  noun: band
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-- name: a bone nose ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-- name: a bone toe ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-- name: a bone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone anklet
-  noun: anklet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone cloak pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone hairpin
-  noun: hairpin
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone tailband
-  noun: tailband
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a shallow bone cup
-  noun: cup
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone pendant
-  noun: pendant
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-  part:
-  - short cord
-- name: a bone amulet
-  noun: amulet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone medallion
-  noun: medallion
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a pair of bone earrings
-  noun: earrings
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone earcuff
-  noun: earcuff
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone brooch
-  noun: brooch
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone armband
-  noun: armband
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone belt buckle
-  noun: buckle
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone choker
-  noun: choker
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone locket
-  noun: locket
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-  part:
-  - short cord
-- name: a bone tiara
-  noun: tiara
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: an articulated bone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: some bone bangles
-  noun: bangles
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 5
-  material: bone
-- name: an articulated bone necklace
-  noun: necklace
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone circlet
-  noun: circlet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-  part:
-  - short cord
-- name: a bone crown
-  noun: crown
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone comb
-  noun: comb
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone haircomb
-  noun: haircomb
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a paneled shirt
-  noun: shirt
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 13
-  material: bone
-# Carving Chapter 10 recipes
-- name: a segmented bone aventail
-  noun: aventail
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 4
-  material: bone
-- name: a segmented bone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 3
-  material: bone
-- name: some segmented bone gloves
-  noun: gloves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 5
-  material: bone
-- name: a segmented bone cap
-  noun: cap
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 8
-  material: bone
-- name: a notched bone aventail
-  noun: aventail
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 4
-  material: bone
-- name: a notched bone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 3
-  material: bone
-- name: a segmented bone helm
-  noun: helm
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some notched bone gloves
-  noun: gloves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 5
-  material: bone
-- name: a notched bone cap
-  noun: cap
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 8
-  material: bone
-- name: a ribbed bone aventail
-  noun: aventail
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 4
-  material: bone
-- name: a ribbed bone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 3
-  material: bone
-- name: a segmented bone tasset
-  noun: tasset
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some segmented vambraces
-  noun: vambraces
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 16
-  material: bone
-- name: some segmented bone greaves
-  noun: greaves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a segmented bone balaclava
-  noun: balaclava
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a notched bone helm
-  noun: helm
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some ribbed bone gloves
-  noun: gloves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 5
-  material: bone
-- name: a ribbed bone cap
-  noun: cap
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 8
-  material: bone
-- name: a segmented bone tabard
-  noun: tabard
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 30
-  material: bone
-- name: a segmented bone mantle
-  noun: mantle
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 24
-  material: bone
-- name: a segmented bone vest
-  noun: vest
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 20
-  material: bone
-- name: a notched bone tasset
-  noun: tasset
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some segmented bone sleeves
-  noun: sleeves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 21
-  material: bone
-- name: some notched vambraces
-  noun: vambraces
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 16
-  material: bone
-- name: some notched bone greaves
-  noun: greaves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a notched bone balaclava
-  noun: balaclava
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a ribbed bone helm
-  noun: helm
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: a segmented bone coat
-  noun: coat
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 46
-  material: bone
-- name: a segmented bone robe
-  noun: robe
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 42
-  material: bone
-- name: a notched bone tabard
-  noun: tabard
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 30
-  material: bone
-- name: a notched bone mantle
-  noun: mantle
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 24
-  material: bone
-- name: a notched bone vest
-  noun: vest
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 20
-  material: bone
-- name: a ribbed bone tasset
-  noun: tasset
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some notched bone sleeves
-  noun: sleeves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 21
-  material: bone
-- name: some ribbed vambraces
-  noun: vambraces
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 16
-  material: bone
-- name: some ribbed bone greaves
-  noun: greaves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a ribbed bone balaclava
-  noun: balaclava
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a segmented bone hauberk
-  noun: hauberk
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 58
-  material: bone
-- name: a notched bone coat
-  noun: coat
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 46
-  material: bone
-- name: a notched bone robe
-  noun: robe
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 42
-  material: bone
-- name: a ribbed bone tabard
-  noun: tabard
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 30
-  material: bone
-- name: a ribbed bone mantle
-  noun: mantle
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 24
-  material: bone
-- name: a ribbed bone vest
-  noun: vest
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 20
-  material: bone
-- name: some ribbed bone sleeves
-  noun: sleeves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 21
-  material: bone
-- name: a notched bone hauberk
-  noun: hauberk
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 58
-  material: bone
-- name: a ribbed bone coat
-  noun: coat
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 46
-  material: bone
-- name: a ribbed bone robe
-  noun: robe
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 42
-  material: bone
-- name: a ribbed bone hauberk
-  noun: hauberk
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 58
-  material: bone
+  - name: a small stone block
+    noun: block
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a large stone block
+    noun: block
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: a thin stone slab
+    noun: slab
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a short stone pole
+    noun: pole
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a thick stone slab
+    noun: slab
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: a smooth slickstone
+    noun: slickstone
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a stout stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a shallow stone basin
+    noun: basin
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a long stone pole
+    noun: pole
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: slender stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a deep stone basin
+    noun: basin
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: a small stone sphere
+    noun: sphere
+    work_order: true
+    chapter: 1
+    volume: 2
+    material: stone
+  - name: a flat slickstone
+    noun: slickstone
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a large stone sphere
+    noun: sphere
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: grooved stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a polished slickstone
+    noun: slickstone
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: notched stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a forked stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  # Carving Chapter 3 recipes
+  - name: some smooth stones
+    noun: stones
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone bludgeon
+    noun: bludgeon
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: a stone carving knife
+    noun: knife
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: some elongated stones
+    noun: stones
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone hand axe
+    noun: axe
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: a stone war club
+    noun: club
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - short pole
+  - name: some balanced stones
+    noun: stones
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone war hammer
+    noun: hammer
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - short pole
+  - name: some stone spikes
+    noun: spikes
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: some stone shards
+    noun: shards
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone bola
+    noun: bola
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long cord
+  - name: a stone hand sword
+    noun: sword
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: a heavy stone mallet
+    noun: mallet
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone javelin
+    noun: javelin
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone spear
+    noun: spear
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone war mattock
+    noun: mattock
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone maul
+    noun: maul
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone flail
+    noun: flail
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long cord
+    - long pole
+  # Carving Chapter 4 recipes
+  - name: a stone band
+    noun: band
+    work_order: true
+    chapter: 4
+    volume: 1
+    material: stone
+  - name: a stone toe ring
+    noun: ring
+    work_order: true
+    chapter: 4
+    volume: 1
+    material: stone
+  - name: a stone nose ring
+    noun: ring
+    work_order: true
+    chapter: 4
+    volume: 1
+    material: stone
+  - name: a stone pin
+    noun: pin
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone anklet
+    noun: anklet
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone tailband
+    noun: tailband
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone hairpin
+    noun: hairpin
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone cloak pin
+    noun: pin
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a pair of stone earrings
+    noun: earrings
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone medallion
+    noun: medallion
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone amulet
+    noun: amulet
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone pendant
+    noun: pendant
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+    part:
+    - short cord
+  - name: a stone brooch
+    noun: brooch
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone earcuff
+    noun: earcuff
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone belt buckle
+    noun: buckle
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone armband
+    noun: armband
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: an articulated stone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone tiara
+    noun: tiara
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone locket
+    noun: locket
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+    part:
+    - short cord
+  - name: a stone choker
+    noun: choker
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone diadem
+    noun: diadem
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone circlet
+    noun: circlet
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+    part:
+    - short cord
+  - name: an articulated stone necklace
+    noun: necklace
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone crown
+    noun: crown
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: an articulated stone belt
+    noun: belt
+    work_order: false
+    chapter: 4
+    volume: 4
+    material: stone
+  - name: a stone mask
+    noun: mask
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+    part:
+    - short cord
+  - name: a segmented stone shirt
+    noun: shirt
+    work_order: false
+    chapter: 4
+    volume: 5
+    material: stone
+  # Carving Chapter 5 recipes
+  - name: a bone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: bone
+  - name: a stone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a detailed bone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: bone
+  - name: a detailed stone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a bone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: bone
+  - name: a stone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: stone
+  - name: a detailed bone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: bone
+  - name: a detailed stone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: stone
+  - name: a bone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a stone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a basic runestone
+    noun: runestone
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a bone wand
+    noun: wand
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a stone wand
+    noun: wand
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a bone rod
+    noun: rod
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a stone rod
+    noun: rod
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a detailed bone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a detailed stone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a bone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: bone
+  - name: a stone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: a fine runestone
+    noun: runestone
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a detailed bone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 8
+    material: bone
+  - name: detailed stone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: a bone statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 20
+    material: bone
+  - name: a stone statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: a detailed bone statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 20
+    material: bone
+  - name: a detailed statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: an ornate runestone
+    noun: runestone
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  # Carving Chapter 6 recipes
+  - name: a short bone pole
+    noun: pole
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  - name: a simple bone burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  - name: a long bone pole
+    noun: pole
+    work_order: true
+    chapter: 6
+    volume: 6
+    material: bone
+  - name: a fine bone burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  - name: an ornate bone burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  # Carving Chapter 8 recipes
+  - name: a bone bludgeon
+    noun: bludgeon
+    work_order: true
+    chapter: 8
+    volume: 5
+    material: bone
+  - name: a bone carving knife
+    noun: knife
+    work_order: true
+    chapter: 8
+    volume: 2
+    material: bone
+  - name: a bone hand axe
+    noun: axe
+    work_order: true
+    chapter: 8
+    volume: 6
+    material: bone
+  - name: a bone war club
+    noun: club
+    work_order: true
+    chapter: 8
+    volume: 7
+    material: bone
+  - name: a bone shiv
+    noun: shiv
+    work_order: true
+    chapter: 8
+    volume: 3
+    material: bone
+  - name: a bone hand sword
+    noun: sword
+    work_order: true
+    chapter: 8
+    volume: 4
+    material: bone
+  - name: a bone mallet
+    noun: mallet
+    work_order: true
+    chapter: 8
+    volume: 8
+    material: bone
+  - name: a bone javelin
+    noun: javelin
+    work_order: true
+    chapter: 8
+    volume: 8
+    material: bone
+  - name: a light bone spear
+    noun: spear
+    work_order: true
+    chapter: 8
+    volume: 7
+    material: bone
+  - name: a bone maul
+    noun: maul
+    work_order: true
+    chapter: 8
+    volume: 16
+    material: bone
+  - name: a bone mattock
+    noun: mattock
+    work_order: true
+    chapter: 8
+    volume: 17
+    material: bone
+  - name: a bone flail
+    noun: flail
+    work_order: true
+    chapter: 8
+    volume: 11
+    material: bone
+  # Carving Chapter 9 recipes
+  - name: a bone band
+    noun: band
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+  - name: a bone nose ring
+    noun: ring
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+  - name: a bone toe ring
+    noun: ring
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+  - name: a bone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone anklet
+    noun: anklet
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone pin
+    noun: pin
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone cloak pin
+    noun: pin
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone hairpin
+    noun: hairpin
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone tailband
+    noun: tailband
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a shallow bone cup
+    noun: cup
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone pendant
+    noun: pendant
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+    part:
+    - short cord
+  - name: a bone amulet
+    noun: amulet
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone medallion
+    noun: medallion
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a pair of bone earrings
+    noun: earrings
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone earcuff
+    noun: earcuff
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone brooch
+    noun: brooch
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone armband
+    noun: armband
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone belt buckle
+    noun: buckle
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone choker
+    noun: choker
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone locket
+    noun: locket
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+    part:
+    - short cord
+  - name: a bone tiara
+    noun: tiara
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: an articulated bone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: some bone bangles
+    noun: bangles
+    work_order: true
+    chapter: 9
+    volume: 5
+    material: bone
+  - name: an articulated bone necklace
+    noun: necklace
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone circlet
+    noun: circlet
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+    part:
+    - short cord
+  - name: a bone crown
+    noun: crown
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone comb
+    noun: comb
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone haircomb
+    noun: haircomb
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a paneled shirt
+    noun: shirt
+    work_order: true
+    chapter: 9
+    volume: 13
+    material: bone
+  # Carving Chapter 10 recipes
+  - name: a segmented bone aventail
+    noun: aventail
+    work_order: true
+    chapter: 10
+    volume: 4
+    material: bone
+  - name: a segmented bone mask
+    noun: mask
+    work_order: true
+    chapter: 10
+    volume: 3
+    material: bone
+  - name: some segmented bone gloves
+    noun: gloves
+    work_order: true
+    chapter: 10
+    volume: 5
+    material: bone
+  - name: a segmented bone cap
+    noun: cap
+    work_order: true
+    chapter: 10
+    volume: 8
+    material: bone
+  - name: a notched bone aventail
+    noun: aventail
+    work_order: true
+    chapter: 10
+    volume: 4
+    material: bone
+  - name: a notched bone mask
+    noun: mask
+    work_order: true
+    chapter: 10
+    volume: 3
+    material: bone
+  - name: a segmented bone helm
+    noun: helm
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some notched bone gloves
+    noun: gloves
+    work_order: true
+    chapter: 10
+    volume: 5
+    material: bone
+  - name: a notched bone cap
+    noun: cap
+    work_order: true
+    chapter: 10
+    volume: 8
+    material: bone
+  - name: a ribbed bone aventail
+    noun: aventail
+    work_order: true
+    chapter: 10
+    volume: 4
+    material: bone
+  - name: a ribbed bone mask
+    noun: mask
+    work_order: true
+    chapter: 10
+    volume: 3
+    material: bone
+  - name: a segmented bone tasset
+    noun: tasset
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some segmented vambraces
+    noun: vambraces
+    work_order: true
+    chapter: 10
+    volume: 16
+    material: bone
+  - name: some segmented bone greaves
+    noun: greaves
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a segmented bone balaclava
+    noun: balaclava
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a notched bone helm
+    noun: helm
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some ribbed bone gloves
+    noun: gloves
+    work_order: true
+    chapter: 10
+    volume: 5
+    material: bone
+  - name: a ribbed bone cap
+    noun: cap
+    work_order: true
+    chapter: 10
+    volume: 8
+    material: bone
+  - name: a segmented bone tabard
+    noun: tabard
+    work_order: true
+    chapter: 10
+    volume: 30
+    material: bone
+  - name: a segmented bone mantle
+    noun: mantle
+    work_order: true
+    chapter: 10
+    volume: 24
+    material: bone
+  - name: a segmented bone vest
+    noun: vest
+    work_order: true
+    chapter: 10
+    volume: 20
+    material: bone
+  - name: a notched bone tasset
+    noun: tasset
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some segmented bone sleeves
+    noun: sleeves
+    work_order: true
+    chapter: 10
+    volume: 21
+    material: bone
+  - name: some notched vambraces
+    noun: vambraces
+    work_order: true
+    chapter: 10
+    volume: 16
+    material: bone
+  - name: some notched bone greaves
+    noun: greaves
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a notched bone balaclava
+    noun: balaclava
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a ribbed bone helm
+    noun: helm
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: a segmented bone coat
+    noun: coat
+    work_order: true
+    chapter: 10
+    volume: 46
+    material: bone
+  - name: a segmented bone robe
+    noun: robe
+    work_order: true
+    chapter: 10
+    volume: 42
+    material: bone
+  - name: a notched bone tabard
+    noun: tabard
+    work_order: true
+    chapter: 10
+    volume: 30
+    material: bone
+  - name: a notched bone mantle
+    noun: mantle
+    work_order: true
+    chapter: 10
+    volume: 24
+    material: bone
+  - name: a notched bone vest
+    noun: vest
+    work_order: true
+    chapter: 10
+    volume: 20
+    material: bone
+  - name: a ribbed bone tasset
+    noun: tasset
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some notched bone sleeves
+    noun: sleeves
+    work_order: true
+    chapter: 10
+    volume: 21
+    material: bone
+  - name: some ribbed vambraces
+    noun: vambraces
+    work_order: true
+    chapter: 10
+    volume: 16
+    material: bone
+  - name: some ribbed bone greaves
+    noun: greaves
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a ribbed bone balaclava
+    noun: balaclava
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a segmented bone hauberk
+    noun: hauberk
+    work_order: true
+    chapter: 10
+    volume: 58
+    material: bone
+  - name: a notched bone coat
+    noun: coat
+    work_order: true
+    chapter: 10
+    volume: 46
+    material: bone
+  - name: a notched bone robe
+    noun: robe
+    work_order: true
+    chapter: 10
+    volume: 42
+    material: bone
+  - name: a ribbed bone tabard
+    noun: tabard
+    work_order: true
+    chapter: 10
+    volume: 30
+    material: bone
+  - name: a ribbed bone mantle
+    noun: mantle
+    work_order: true
+    chapter: 10
+    volume: 24
+    material: bone
+  - name: a ribbed bone vest
+    noun: vest
+    work_order: true
+    chapter: 10
+    volume: 20
+    material: bone
+  - name: some ribbed bone sleeves
+    noun: sleeves
+    work_order: true
+    chapter: 10
+    volume: 21
+    material: bone
+  - name: a notched bone hauberk
+    noun: hauberk
+    work_order: true
+    chapter: 10
+    volume: 58
+    material: bone
+  - name: a ribbed bone coat
+    noun: coat
+    work_order: true
+    chapter: 10
+    volume: 46
+    material: bone
+  - name: a ribbed bone robe
+    noun: robe
+    work_order: true
+    chapter: 10
+    volume: 42
+    material: bone
+  - name: a ribbed bone hauberk
+    noun: hauberk
+    work_order: true
+    chapter: 10
+    volume: 58
+    material: bone
+shaping:
 # Shaping Chapter 2 recipes
-- name: a toy bow
-  noun: bow
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a toy bow
+    noun: bow
+    volume: 3
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a practice shortbow
+    noun: shortbow
+    volume: 4
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a simple shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a light shortbow
+    noun: shortbow
+    volume: 3
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a farmer's bow
+    noun: bow
+    volume: 4
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a sturdy shortbow
+    noun: shortbow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: an alpine shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a saddle bow
+    noun: bow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a flight bow
+    noun: bow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a steppe bow
+    noun: bow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a battle shortbow
+    noun: shortbow
+    volume: 7
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a forester's shortbow
+    noun: shortbow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a Nisha shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a competition shortbow
+    noun: shortbow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  # Shaping Chapter 3 recipes
+  - name: a simple longbow
+    noun: longbow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a practice longbow
+    noun: longbow
+    volume: 6
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a longbow
+    noun: longbow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a sturdy longbow
+    noun: longbow
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a flatbow
+    noun: flatbow
+    volume: 7
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a skirmisher's bow
+    noun: bow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a reflex longbow
+    noun: longbow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a self bow
+    noun: bow
+    volume: 7
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a recurve longbow
+    noun: longbow
+    volume: 8
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a forester's longbow
+    noun: longbow
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a battle longbow
+    noun: longbow
+    volume: 8
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a competition longbow
+    noun: longbow
+    volume: 8
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  # Shaping Chapter 4 recipes
+  - name: a composite bow
+    noun: bow
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a double-backed bow
+    noun: bow
+    volume: 9
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a recurve bow
+    noun: bow
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a forester's bow
+    noun: bow
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a reflex bow
+    noun: bow
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a savannah bow
+    noun: bow
+    volume: 9
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a footman's bow
+    noun: bow
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a horseman's bow
+    noun: bow
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a battle bow
+    noun: bow
+    volume: 10
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a competition bow
+    noun: bow
+    volume: 10
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  # Shaping Chapter 5 recipes are arrows and covered with the arrows.lic script.
+  # Shaping Chapter 6 recipes are Enhancements and Materials.
+  - name: a simple wood burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+  - name: a fine wood burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+  - name: an ornate wood burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+  # Shaping Chapter 7 recipes
+  - name: a wood band
+    noun: band
+    volume: 1
+    work_order: true
+    chapter: 7
+  - name: a wood nose ring
+    noun: ring
+    volume: 1
+    work_order: true
+    chapter: 7
+  - name: a wood toe ring
+    noun: ring
+    volume: 1
+    work_order: true
+    chapter: 7
+  - name: a wood bracelet
+    noun: bracelet
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood anklet
+    noun: anklet
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood pin
+    noun: pin
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood cloak pin
+    noun: pin
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a shallow wood cup
+    noun: cup
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood hairpin
+    noun: hairpin
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood tailband
+    noun: tailband
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood pendant
+    noun: pendant
+    volume: 1
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: a wood amulet
+    noun: amulet
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood medallion
+    noun: medallion
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a pair of wood earrings
+    noun: earrings
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood earcuff
+    noun: earcuff
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood brooch
+    noun: brooch
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood armband
+    noun: armband
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood belt buckle
+    noun: buckle
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood choker
+    noun: choker
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood locket
+    noun: locket
+    volume: 2
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: some wood bangles
+    noun: bangles
+    volume: 5
+    work_order: true
+    chapter: 7
+  - name: a wood tiara
+    noun: tiara
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: an articulated wood bracelet
+    noun: bracelet
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood circlet
+    noun: circlet
+    volume: 3
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: an articulated wood necklace
+    noun: necklace
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood crown
+    noun: crown
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood mask
+    noun: mask
+    volume: 3
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: a wood comb
+    noun: comb
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood haircomb
+    noun: haircomb
+    volume: 3
+    work_order: true
+    chapter: 7
+  # Shaping Chapter 8 recipes
+  - name: a wood bead
+    noun: bead
+    volume: 1
+    work_order: false
+    chapter: 8
+  - name: a detailed wood bead
+    noun: bead
+    volume: 1
+    work_order: false
+    chapter: 8
+  - name: a wood totem
+    noun: totem
+    volume: 2
+    work_order: false
+    chapter: 8
+  - name: a detailed wood totem
+    noun: totem
+    volume: 2
+    work_order: false
+    chapter: 8
+  - name: a wood figurine
+    noun: figurine
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a wood wand
+    noun: wand
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a wood rod
+    noun: rod
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a detailed wood figurine
+    noun: figurine
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a wood statuette
+    noun: statuette
+    volume: 8
+    work_order: false
+    chapter: 8
+  - name: a detailed wood statuette
+    noun: statuette
+    volume: 8
+    work_order: false
+    chapter: 8
+  - name: a wood statue
+    noun: statue
+    volume: 20
+    work_order: false
+    chapter: 8
+  - name: a detailed wood statue
+    noun: statue
+    volume: 20
+    work_order: false
+    chapter: 8
+  # Shaping Chapter 9 recipes
+  - name: a wood cane
+    noun: cane
+    volume: 7
+    work_order: true
+    chapter: 9
+  - name: a wood nightstick
+    noun: nightstick
+    volume: 6
+    work_order: true
+    chapter: 9
+    part:
+    - leather strip
+  - name: a wood quarterstaff
+    noun: quarterstaff
+    volume: 9
+    work_order: true
+    chapter: 9
+  - name: a wood walking cane
+    noun: cane
+    volume: 6
+    work_order: true
+    chapter: 9
+  - name: a wood crook
+    noun: crook
+    volume: 5
+    work_order: true
+    chapter: 9
+  - name: a wood bo staff
+    noun: staff
+    volume: 8
+    work_order: true
+    chapter: 9
+    part:
+    - leather strip
+  - name: a weighted staff
+    noun: staff
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - leather strip
+  # Shaping Chapter 10 recipes
+  - name: a rough wood table
+    noun: table
+    volume: 15
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a low wood table
+    noun: table
+    volume: 18
+    work_order: false
+    chapter: 10
+    part:
+    - short pole
+    - short pole
+    - short pole
+    - short pole
+  - name: a high wood table
+    noun: table
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a round wood table
+    noun: table
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a square wood table
+    noun: table
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a long wood table
+    noun: table
+    volume: 25
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: an oval wood table
+    noun: table
+    volume: 25
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood dining table
+    noun: table
+    volume: 30
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood buffet table
+    noun: table
+    volume: 30
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood refectory table
+    noun: table
+    volume: 30
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood parquet table
+    noun: table
+    volume: 32
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood meditation table
+    noun: table
+    volume: 32
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+tinkering:
+  # Tinkering Chapter 2
+  - name: a toy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 6
+    part:
+    - mechanism
     - bow string
-- name: a practice shortbow
-  noun: shortbow
-  volume: 4
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a practice crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 7
+    part:
+    - mechanism
     - bow string
-- name: a simple shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a simple crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 7
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a light shortbow
-  noun: shortbow
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a slim crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 6
+    part:
+    - mechanism
     - bow string
-- name: a farmer's bow
-  noun: bow
-  volume: 4
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a farmer's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 7
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a light crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a sturdy shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a sturdy light crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: an alpine shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: an alpine crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a saddle bow
-  noun: bow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a saddle crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a flight bow
-  noun: bow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a flight crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a steppe bow
-  noun: bow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a steppe crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a battle shortbow
-  noun: shortbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a light battle crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a forester's shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a light forester's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a Nisha shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a lockbow
+    noun: lockbow
+    work_order: true
+    chapter: 2
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a competition shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a latchbow
+    noun: latchbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-# Shaping Chapter 3 recipes
-- name: a simple longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  # Tinkering Chapter 3
+  - name: a simple heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a practice longbow
-  noun: longbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: practice heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 14
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: sturdy heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a sturdy longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: a heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a flatbow
-  noun: flatbow
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a slurbow
+    noun: slurbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a skirmisher's bow
-  noun: bow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: skirmisher's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a reflex longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: a flat crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a self bow
-  noun: bow
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a battle crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a recurve longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a forester's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a forester's longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: a recurve crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a battle longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: an arena crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a competition longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a competition crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-# Shaping Chapter 4 recipes
-- name: a composite bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  # Tinkering Chapter 4
+  - name: a reinforced arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 19
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a double-backed bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: an arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a recurve bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a siege arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a forester's bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
+  - name: a forester's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a reflex bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a recurve arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a savannah bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a horseman's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a footman's bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
+  - name: a footman's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 19
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a horseman's bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
+  - name: a mariner's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 19
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a battle bow
-  noun: bow
-  volume: 10
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a competition arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 20
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a competition bow
-  noun: bow
-  volume: 10
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a battle arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 20
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-# Shaping Chapter 5 recipes are arrows and covered with the arrows.lic script.
-# Shaping Chapter 6 recipes are Enhancements and Materials.
-- name: a simple wood burin
-  noun: burin
-  work_order: true
-  type: shaping
-  chapter: 6
-  volume: 4
-- name: a fine wood burin
-  noun: burin
-  work_order: true
-  type: shaping
-  chapter: 6
-  volume: 4
-- name: an ornate wood burin
-  noun: burin
-  work_order: true
-  type: shaping
-  chapter: 6
-  volume: 4
-# Shaping Chapter 7 recipes
-- name: a wood band
-  noun: band
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood nose ring
-  noun: ring
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood toe ring
-  noun: ring
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood bracelet
-  noun: bracelet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood anklet
-  noun: anklet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood pin
-  noun: pin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood cloak pin
-  noun: pin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a shallow wood cup
-  noun: cup
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood hairpin
-  noun: hairpin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood tailband
-  noun: tailband
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood pendant
-  noun: pendant
-  volume: 1
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: a wood amulet
-  noun: amulet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood medallion
-  noun: medallion
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a pair of wood earrings
-  noun: earrings
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood earcuff
-  noun: earcuff
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood brooch
-  noun: brooch
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood armband
-  noun: armband
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood belt buckle
-  noun: buckle
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood choker
-  noun: choker
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood locket
-  noun: locket
-  volume: 2
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: some wood bangles
-  noun: bangles
-  volume: 5
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood tiara
-  noun: tiara
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: an articulated wood bracelet
-  noun: bracelet
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood circlet
-  noun: circlet
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: an articulated wood necklace
-  noun: necklace
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood crown
-  noun: crown
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood mask
-  noun: mask
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: a wood comb
-  noun: comb
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood haircomb
-  noun: haircomb
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-# Shaping Chapter 8 recipes
-- name: a wood bead
-  noun: bead
-  volume: 1
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood bead
-  noun: bead
-  volume: 1
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood totem
-  noun: totem
-  volume: 2
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood totem
-  noun: totem
-  volume: 2
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood figurine
-  noun: figurine
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood wand
-  noun: wand
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood rod
-  noun: rod
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood figurine
-  noun: figurine
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood statuette
-  noun: statuette
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood statuette
-  noun: statuette
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood statue
-  noun: statue
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood statue
-  noun: statue
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 8
-# Shaping Chapter 9 recipes
-- name: a wood cane
-  noun: cane
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood nightstick
-  noun: nightstick
-  volume: 6
-  type: shaping
-  work_order: true
-  chapter: 9
-  part:
-  - leather strip
-- name: a wood quarterstaff
-  noun: quarterstaff
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood walking cane
-  noun: cane
-  volume: 6
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood crook
-  noun: crook
-  volume: 5
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood bo staff
-  noun: staff
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 9
-  part:
-  - leather strip
-- name: a weighted staff
-  noun: staff
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 9
-  part:
-  - leather strip
-# Shaping Chapter 10 recipes
-- name: a rough wood table
-  noun: table
-  volume: 15
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a low wood table
-  noun: table
-  volume: 18
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - short pole
-  - short pole
-  - short pole
-  - short pole
-- name: a high wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a round wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a square wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a long wood table
-  noun: table
-  volume: 25
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: an oval wood table
-  noun: table
-  volume: 25
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood dining table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood buffet table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood refectory table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood parquet table
-  noun: table
-  volume: 32
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood meditation table
-  noun: table
-  volume: 32
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-# Tinkering Chapter 2
-- name: a toy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 6
-  part:
-  - mechanism
-  - bow string
-- name: a practice crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 7
-  part:
-  - mechanism
-  - bow string
-- name: a simple crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 7
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a slim crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 6
-  part:
-  - mechanism
-  - bow string
-- name: a farmer's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 7
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a light crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a sturdy light crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: an alpine crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a saddle crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a flight crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a steppe crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a light battle crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a light forester's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a lockbow
-  noun: lockbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a latchbow
-  noun: latchbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 3
-- name: a simple heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: practice heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 14
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: sturdy heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a slurbow
-  noun: slurbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: skirmisher's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a flat crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a battle crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a forester's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a recurve crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: an arena crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a competition crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 4
-- name: a reinforced arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 19
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: an arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a siege arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a forester's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a recurve arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a horseman's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a footman's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 19
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a mariner's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 19
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a competition arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 20
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a battle arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 20
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 5
-- name: simple stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 7
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a sturdy stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a lobbing stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a saddle stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: an alpine stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a slingbow
-  noun: slingbow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: forester's stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a battle stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a steppe stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a pelletbow
-  noun: pelletbow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 6 Siege Wapon Crafting - Blank
-# Tinkering Chapter 7 Bolts - use bolts.lic script
-# Tinkering Chapter 8 Tinkered Enhancement
-# Tinkering Chapter 9
-- name: a small music box
-  noun: box
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 2
-  part:
-  - mechanism
-- name: miniature male soldier
-  noun: soldier
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 3
-  part:
-  - mechanism
-- name: miniature female soldier
-  noun: soldier
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 3
-  part:
-  - mechanism
-- name: a simple telescope
-  noun: telescope
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 5
-  part:
-  - mechanism
-  - lenses
-- name: a musical box
-  noun: box
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 3
-  part:
-  - mechanism
-- name: a telescope
-  noun: telescope
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 5
-  part:
-  - mechanism
-  - mechanism
-  - lenses
-- name: a clockwork telescope
-  noun: telescope
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 6
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - lenses
-# Tinkering Chapter 10 Locksmithing - blank
-####################################
-##### Engineering section ends #####
-####################################
+  # Tinkering Chapter 5
+  - name: simple stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 7
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a sturdy stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a lobbing stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a saddle stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: an alpine stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a slingbow
+    noun: slingbow
+    work_order: true
+    chapter: 5
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: forester's stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a battle stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a steppe stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a pelletbow
+    noun: pelletbow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  # Tinkering Chapter 6 Siege Wapon Crafting - Blank
+  # Tinkering Chapter 7 Bolts - use bolts.lic script
+  # Tinkering Chapter 8 Tinkered Enhancement
+  # Tinkering Chapter 9
+  - name: a small music box
+    noun: box
+    work_order: true
+    chapter: 9
+    volume: 2
+    part:
+    - mechanism
+  - name: miniature male soldier
+    noun: soldier
+    work_order: true
+    chapter: 9
+    volume: 3
+    part:
+    - mechanism
+  - name: miniature female soldier
+    noun: soldier
+    work_order: true
+    chapter: 9
+    volume: 3
+    part:
+    - mechanism
+  - name: a simple telescope
+    noun: telescope
+    work_order: true
+    chapter: 9
+    volume: 5
+    part:
+    - mechanism
+    - lenses
+  - name: a musical box
+    noun: box
+    work_order: true
+    chapter: 9
+    volume: 3
+    part:
+    - mechanism
+  - name: a telescope
+    noun: telescope
+    work_order: true
+    chapter: 9
+    volume: 5
+    part:
+    - mechanism
+    - mechanism
+    - lenses
+  - name: a clockwork telescope
+    noun: telescope
+    work_order: true
+    chapter: 9
+    volume: 6
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - lenses
+  # Tinkering Chapter 10 Locksmithing - blank
+  ####################################
+  ##### Engineering section ends #####
+  ####################################
+tailoring:
 ####################################
 ##### Outfitting section ends  #####
 ####################################
 # Tailoring Chapter 2 recipes
-- name: some cloth socks
-  noun: socks
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth ankle socks
-  noun: socks
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth armband
-  noun: armband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth fingerless gloves
-  noun: gloves
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth ankleband
-  noun: ankleband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth eyepatch
-  noun: eyepatch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth knee socks
-  noun: socks
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some pleated cloth gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some elbow-length gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth headband
-  noun: headband
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth scarf
-  noun: scarf
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some elegant cloth gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth slippers
-  noun: slippers
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth field shoes
-  noun: shoes
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth hat
-  noun: hat
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dunce hat
-  noun: hat
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a segmented cloth belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dress belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth commoner's cloak
-  noun: 6
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth head scarf
-  noun: scarf
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth veil
-  noun: veil
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a floppy cloth hat
-  noun: hat
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a double-wrapped belt
-  noun: belt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth pants
-  noun: pants
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth skirt
-  noun: skirt
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth kilt
-  noun: kilt
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth sash
-  noun: sash
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a sleeveless cloth shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth cloak
-  noun: cloak
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dress hat
-  noun: hat
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth top hat
-  noun: hat
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some baggy cloth pants
-  noun: pants
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dress
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a knee-length cloth dress
-  noun: 8
-  volume:
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a front-laced cloth dress
-  noun: dress
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a billowing cloth shirt
-  noun: shirt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a baggy cloth shirt
-  noun: shirt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth tunic
-  noun: tunic
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth robes
-  noun: robes
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth dress pants
-  noun: pants
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a floor-length cloth dress
-  noun: dress
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth gown
-  noun: gown
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth dress shirt
-  noun: shirt
-  volume: 4
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a short-sleeved tunic
-  noun: tunic
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a formal cloth tunic
-  noun: tunic
-  volume: 5
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth tabard
-  noun: tabard
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a hooded cloth cloak
-  noun: cloak
-  volume: 8
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth cape
-  noun: cape
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some hooded cloth robes
-  noun: robes
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a deeply-hooded cloak
-  noun: cloak
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth mage's robe
-  noun: robe
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: some flowing cloth robes
-  noun: robes
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth shaman's robe
-  noun: robe
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-# Tailoring Chapter 3 recipes
-- name: a cloth napkin
-  noun: napkin
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth hip pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth rag
-  noun: rag
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth gem pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth weapon strap
-  noun: strap
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth pouch
-  noun: pouch
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth thigh bag
-  noun: bag
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth towel
-  noun: towel
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth herb pouch
-  noun: pouch
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth talisman pouch
-  noun: pouch
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth arm pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth bag
-  noun: bag
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth sack
-  noun: sack
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth utility belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth charm bag
-  noun: bag
-  volume: 3
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth backpack
-  noun: backpack
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth knapsack
-  noun: knapsack
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth carryall
-  noun: carryall
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth blanket
-  noun: blanket
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth duffel bag
-  noun: duffel.bag
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth haversack
-  noun: haversack
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth bandolier
-  noun: bandolier
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a small cloth rucksack
-  noun: small.rucksack
-  volume: 7
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth mining belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth saddle pad
-  noun: pad
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth rucksack
-  noun: rucksack
-  volume: 8
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth survival belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth saddle blanket
-  noun: blanket
-  volume: 12
-  type: tailoring
-  work_order: true
-  chapter: 3
-  part:
-  - small padding
-- name: a cloth artisan's belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth saddle shabrack
-  noun: shabrack
-  volume: 12
-  type: tailoring
-  work_order: true
-  chapter: 3
-  part:
-  - small padding
-# Tailoring Chapter 4 recipes
-- name: a quilted cloth aventail
-  noun: aventail
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth mask
-  noun: mask
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth gloves
-  noun: gloves
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth aventail
-  noun: aventail
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth mask
-  noun: mask
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth hood
-  noun: hood
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth gloves
-  noun: gloves
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth aventail
-  noun: aventail
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth mask
-  noun: mask
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth pants
-  noun: pants
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth hood
-  noun: hood
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some insulated cloth gloves
-  noun: gloves
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth pants
-  noun: pants
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth vambraces
-  noun: vambraces
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth tasset
-  noun: tasset
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth tabard
-  noun: tabard
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth hood
-  noun: hood
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some insulated cloth pants
-  noun: pants
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth vambraces
-  noun: vambraces
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth sleeves
-  noun: sleeves
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth tasset
-  noun: tasset
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth vest
-  noun: vest
-  volume: 14
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth mantle
-  noun: mantle
-  volume: 17
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth robe
-  noun: robe
-  volume: 32
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a quilted cloth shirt
-  noun: shirt
-  volume: 34
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a padded cloth tabard
-  noun: tabard
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: some insulated cloth vambraces
-  noun: vambraces
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth sleeves
-  noun: sleeves
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth tasset
-  noun: tasset
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth vest
-  noun: vest
-  volume: 14
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth mantle
-  noun: mantle
-  volume: 17
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth robe
-  noun: robe
-  volume: 32
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a quilted cloth hauberk
-  noun: hauberk
-  volume: 44
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a padded cloth shirt
-  noun: shirt
-  volume: 34
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth tabard
-  noun: tabard
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: some insulated cloth sleeves
-  noun: sleeves
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth vest
-  noun: vest
-  volume: 14
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth mantle
-  noun: mantle
-  volume: 17
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth robe
-  noun: robe
-  volume: 32
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a padded cloth hauberk
-  noun: hauberk
-  volume: 44
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth shirt
-  noun: shirt
-  volume: 34
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth hauberk
-  noun: hauberk
-  volume: 44
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-# Tailoring Chapter 5 recipes
-- name: a knitted ankleband
-  noun: ankleband
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted socks
-  noun: socks
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted armband
-  noun: armband
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted napkin
-  noun: napkin
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted mittens
-  noun: mittens
-  volume: 13
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted headband
-  noun: headband
-  volume: 13
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted slippers
-  noun: slippers
-  volume: 26
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted scarf
-  noun: scarf
-  volume: 26
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted hat
-  noun: hat
-  volume: 30
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted booties
-  noun: booties
-  volume: 30
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted hood
-  noun: hood
-  volume: 30
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted towel
-  noun: towel
-  volume: 40
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted legwarmers
-  noun: legwarmers
-  volume: 60
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted gloves
-  noun: gloves
-  volume: 16
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted shirt
-  noun: shirt
-  volume: 40
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted skirt
-  noun: skirt
-  volume: 60
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted sweater
-  noun: sweater
-  volume: 50
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted hose
-  noun: hose
-  volume: 60
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted cloak
-  noun: cloak
-  volume: 70
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted blanket
-  noun: blanket
-  volume: 90
-  type: tailoring
-  work_order: true
-  chapter: 5
-# Tailoring Chapter 6 recipes
-# No recipes
-# Tailoring Chapter 7 recipes
-- name: a leather armband
-  noun: armband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather ankleband
-  noun: ankleband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some fingerless gloves
-  noun: gloves
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some elbow-length gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather eyepatch
-  noun: eyepatch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather headband
-  noun: headband
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some leather moccasins
-  noun: moccasins
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some leather shoes
-  noun: shoes
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather hat
-  noun: hat
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a commoner's cloak
-  noun: cloak
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a sleeveless leather shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a segmented belt
-  noun: belt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather dress belt
-  noun: belt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather skirt
-  noun: skirt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather cloak
-  noun: cloak
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather tunic
-  noun: tunic
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather dress
-  noun: dress
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a double-wrapped belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather cape
-  noun: cape
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather utility belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a hooded leather cloak
-  noun: cloak
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a deeply-hooded cloak
-  noun: cloak
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather hunting shirt
-  noun: shirt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather dueling shirt
-  noun: shirt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather mining belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather war belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather artisan's belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-# Tailoring Chapter 8 recipes
-- name: a leather hip pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather weapon strap
-  noun: strap
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather saddle
-  noun: saddle
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather sidesaddle
-  noun: sidesaddle
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather jousting saddle
-  noun: saddle
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 8
-# Tailoring Chapter 9 recipes
-- name: a rugged leather aventail
-  noun: aventail
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather mask
-  noun: mask
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged gloves
-  noun: gloves
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather aventail
-  noun: aventail
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather mask
-  noun: mask
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather aventail
-  noun: aventail
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather helm
-  noun: helm
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some thick gloves
-  noun: gloves
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather mask
-  noun: mask
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather tasset
-  noun: tasset
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged vambraces
-  noun: vambraces
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged greaves
-  noun: greaves
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather cowl
-  noun: cowl
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather helm
-  noun: helm
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse gloves
-  noun: gloves
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather jerkin
-  noun: 28
-  volume:
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a thick leather tasset
-  noun: tasset
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather mantle
-  noun: mantle
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather vest
-  noun: vest
-  volume: 18
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged leather sleeves
-  noun: sleeves
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some thick vambraces
-  noun: vambraces
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some thick greaves
-  noun: greaves
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather cowl
-  noun: cowl
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather helm
-  noun: helm
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather mantle
-  noun: mantle
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather coat
-  noun: coat
-  volume: 43
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a rugged leather robe
-  noun: robe
-  volume: 40
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a thick leather jerkin
-  noun: jerkin
-  volume: 28
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some thick leather sleeves
-  noun: sleeves
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather vest
-  noun: vest
-  volume: 18
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather tasset
-  noun: tasset
-  volume:
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse vambraces
-  noun: vambraces
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse greaves
-  noun: greaves
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather cowl
-  noun: cowl
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather robe
-  noun: robe
-  volume: 40
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some rugged leathers
-  noun: leathers
-  volume: 55
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a thick leather coat
-  noun: coat
-  volume: 43
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a coarse leather jerkin
-  noun: jerkin
-  volume: 28
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a coarse leather mantle
-  noun: mantle
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse leather sleeves
-  noun: sleeves
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather vest
-  noun: vest
-  volume: 18
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather robe
-  volume: 40
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some thick leathers
-  noun: leathers
-  volume: 55
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a coarse leather coat
-  noun: coat
-  volume: 43
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some coarse leathers
-  noun: leathers
-  volume: 55
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-# Tailoring Chapter 10 recipes
-- name: a leather target handle
-  noun: shield
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 10
-- name: a long leather cord
-  noun: shield
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 10
-- name: a leather target shield
-  noun: shield
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: an ordinary leather shield
-  noun: shield
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a small leather shield
-  noun: shield
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - leather shield handle
-  - long cord
-- name: a leather buckler
-  noun: buckler
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a leather targe
-  noun: targe
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a leather oval shield
-  noun: shield
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a medium leather shield
-  noun: shield
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a leather kite shield
-  noun: shield
-  volume: 24
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
+  - name: some cloth socks
+    noun: socks
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: some cloth ankle socks
+    noun: socks
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: a cloth armband
+    noun: armband
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: some cloth fingerless gloves
+    noun: gloves
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: a cloth ankleband
+    noun: ankleband
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: a cloth eyepatch
+    noun: eyepatch
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some cloth knee socks
+    noun: socks
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some pleated cloth gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some elbow-length gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth headband
+    noun: headband
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth scarf
+    noun: scarf
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: some elegant cloth gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some cloth slippers
+    noun: slippers
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: some cloth field shoes
+    noun: shoes
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth hat
+    noun: hat
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth dunce hat
+    noun: hat
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a segmented cloth belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth dress belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth commoner's cloak
+    noun: 6
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth head scarf
+    noun: scarf
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth veil
+    noun: veil
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a floppy cloth hat
+    noun: hat
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a double-wrapped belt
+    noun: belt
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: some cloth pants
+    noun: pants
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth skirt
+    noun: skirt
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth kilt
+    noun: kilt
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth sash
+    noun: sash
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a sleeveless cloth shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth cloak
+    noun: cloak
+    volume: 7
+    work_order: false
+    chapter: 2
+  - name: a cloth dress hat
+    noun: hat
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a cloth top hat
+    noun: hat
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: some baggy cloth pants
+    noun: pants
+    volume: 7
+    work_order: false
+    chapter: 2
+  - name: a cloth dress
+    volume: 8
+    work_order: false
+    chapter: 2
+  - name: a knee-length cloth dress
+    noun: 8
+    volume:
+    work_order: false
+    chapter: 2
+  - name: a front-laced cloth dress
+    noun: dress
+    volume: 8
+    work_order: false
+    chapter: 2
+  - name: a billowing cloth shirt
+    noun: shirt
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a baggy cloth shirt
+    noun: shirt
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a cloth tunic
+    noun: tunic
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: some cloth robes
+    noun: robes
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: some cloth dress pants
+    noun: pants
+    volume: 6
+    work_order: true
+    chapter: 2
+  - name: a floor-length cloth dress
+    noun: dress
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: a cloth gown
+    noun: gown
+    volume: 9
+    work_order: true
+    chapter: 2
+  - name: a cloth dress shirt
+    noun: shirt
+    volume: 4
+    work_order: true
+    chapter: 2
+  - name: a short-sleeved tunic
+    noun: tunic
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a formal cloth tunic
+    noun: tunic
+    volume: 5
+    work_order: true
+    chapter: 2
+  - name: a cloth tabard
+    noun: tabard
+    volume: 6
+    work_order: true
+    chapter: 2
+  - name: a hooded cloth cloak
+    noun: cloak
+    volume: 8
+    work_order: true
+    chapter: 2
+  - name: a cloth cape
+    noun: cape
+    volume: 7
+    work_order: false
+    chapter: 2
+  - name: some hooded cloth robes
+    noun: robes
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: a deeply-hooded cloak
+    noun: cloak
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: a cloth mage's robe
+    noun: robe
+    volume: 9
+    work_order: true
+    chapter: 2
+  - name: some flowing cloth robes
+    noun: robes
+    volume: 9
+    work_order: true
+    chapter: 2
+  - name: a cloth shaman's robe
+    noun: robe
+    volume: 9
+    work_order: true
+    chapter: 2
+  # Tailoring Chapter 3 recipes
+  - name: a cloth napkin
+    noun: napkin
+    volume: 1
+    work_order: false
+    chapter: 3
+  - name: a cloth hip pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth rag
+    noun: rag
+    volume: 1
+    work_order: false
+    chapter: 3
+  - name: a cloth gem pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth weapon strap
+    noun: strap
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth pouch
+    noun: pouch
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth thigh bag
+    noun: bag
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth towel
+    noun: towel
+    volume: 4
+    work_order: false
+    chapter: 3
+  - name: a cloth herb pouch
+    noun: pouch
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth talisman pouch
+    noun: pouch
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth arm pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth bag
+    noun: bag
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth sack
+    noun: sack
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth utility belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 3
+  - name: a cloth charm bag
+    noun: bag
+    volume: 3
+    work_order: true
+    chapter: 3
+  - name: a cloth backpack
+    noun: backpack
+    volume: 5
+    work_order: false
+    chapter: 3
+  - name: a cloth knapsack
+    noun: knapsack
+    volume: 5
+    work_order: false
+    chapter: 3
+  - name: a cloth carryall
+    noun: carryall
+    volume: 5
+    work_order: false
+    chapter: 3
+  - name: a cloth blanket
+    noun: blanket
+    volume: 9
+    work_order: true
+    chapter: 3
+  - name: a cloth duffel bag
+    noun: duffel.bag
+    volume: 6
+    work_order: true
+    chapter: 3
+  - name: a cloth haversack
+    noun: haversack
+    volume: 6
+    work_order: true
+    chapter: 3
+  - name: a cloth bandolier
+    noun: bandolier
+    volume: 6
+    work_order: true
+    chapter: 3
+  - name: a small cloth rucksack
+    noun: small.rucksack
+    volume: 7
+    work_order: true
+    chapter: 3
+  - name: a cloth mining belt
+    noun: belt
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: a cloth saddle pad
+    noun: pad
+    volume: 10
+    work_order: true
+    chapter: 3
+  - name: a cloth rucksack
+    noun: rucksack
+    volume: 8
+    work_order: true
+    chapter: 3
+  - name: a cloth survival belt
+    noun: belt
+    volume: 5
+    work_order: true
+    chapter: 3
+  - name: a cloth saddle blanket
+    noun: blanket
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - small padding
+  - name: a cloth artisan's belt
+    noun: belt
+    volume: 5
+    work_order: true
+    chapter: 3
+  - name: a cloth saddle shabrack
+    noun: shabrack
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - small padding
+  # Tailoring Chapter 4 recipes
+  - name: a quilted cloth aventail
+    noun: aventail
+    volume: 3
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth mask
+    noun: mask
+    volume: 2
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth gloves
+    noun: gloves
+    volume: 4
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth aventail
+    noun: aventail
+    volume: 3
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth mask
+    noun: mask
+    volume: 2
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth hood
+    noun: hood
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth gloves
+    noun: gloves
+    volume: 4
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth aventail
+    noun: aventail
+    volume: 3
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth mask
+    noun: mask
+    volume: 2
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth pants
+    noun: pants
+    volume: 10
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth hood
+    noun: hood
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some insulated cloth gloves
+    noun: gloves
+    volume: 4
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth pants
+    noun: pants
+    volume: 10
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth vambraces
+    noun: vambraces
+    volume: 12
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth tabard
+    noun: tabard
+    volume: 22
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth hood
+    noun: hood
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some insulated cloth pants
+    noun: pants
+    volume: 10
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth vambraces
+    noun: vambraces
+    volume: 12
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth sleeves
+    noun: sleeves
+    volume: 16
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth vest
+    noun: vest
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth mantle
+    noun: mantle
+    volume: 17
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth robe
+    noun: robe
+    volume: 32
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a quilted cloth shirt
+    noun: shirt
+    volume: 34
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a padded cloth tabard
+    noun: tabard
+    volume: 22
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: some insulated cloth vambraces
+    noun: vambraces
+    volume: 12
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth sleeves
+    noun: sleeves
+    volume: 16
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth vest
+    noun: vest
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth mantle
+    noun: mantle
+    volume: 17
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth robe
+    noun: robe
+    volume: 32
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a quilted cloth hauberk
+    noun: hauberk
+    volume: 44
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a padded cloth shirt
+    noun: shirt
+    volume: 34
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth tabard
+    noun: tabard
+    volume: 22
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: some insulated cloth sleeves
+    noun: sleeves
+    volume: 16
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth vest
+    noun: vest
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth mantle
+    noun: mantle
+    volume: 17
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth robe
+    noun: robe
+    volume: 32
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a padded cloth hauberk
+    noun: hauberk
+    volume: 44
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth shirt
+    noun: shirt
+    volume: 34
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth hauberk
+    noun: hauberk
+    volume: 44
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  # Tailoring Chapter 5 recipes
+  - name: a knitted ankleband
+    noun: ankleband
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: some knitted socks
+    noun: socks
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: a knitted armband
+    noun: armband
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: a knitted napkin
+    noun: napkin
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: some knitted mittens
+    noun: mittens
+    volume: 13
+    work_order: true
+    chapter: 5
+  - name: a knitted headband
+    noun: headband
+    volume: 13
+    work_order: true
+    chapter: 5
+  - name: some knitted slippers
+    noun: slippers
+    volume: 26
+    work_order: true
+    chapter: 5
+  - name: a knitted scarf
+    noun: scarf
+    volume: 26
+    work_order: true
+    chapter: 5
+  - name: a knitted hat
+    noun: hat
+    volume: 30
+    work_order: true
+    chapter: 5
+  - name: some knitted booties
+    noun: booties
+    volume: 30
+    work_order: true
+    chapter: 5
+  - name: a knitted hood
+    noun: hood
+    volume: 30
+    work_order: true
+    chapter: 5
+  - name: a knitted towel
+    noun: towel
+    volume: 40
+    work_order: true
+    chapter: 5
+  - name: some knitted legwarmers
+    noun: legwarmers
+    volume: 60
+    work_order: true
+    chapter: 5
+  - name: some knitted gloves
+    noun: gloves
+    volume: 16
+    work_order: true
+    chapter: 5
+  - name: a knitted shirt
+    noun: shirt
+    volume: 40
+    work_order: true
+    chapter: 5
+  - name: a knitted skirt
+    noun: skirt
+    volume: 60
+    work_order: true
+    chapter: 5
+  - name: a knitted sweater
+    noun: sweater
+    volume: 50
+    work_order: true
+    chapter: 5
+  - name: some knitted hose
+    noun: hose
+    volume: 60
+    work_order: true
+    chapter: 5
+  - name: a knitted cloak
+    noun: cloak
+    volume: 70
+    work_order: true
+    chapter: 5
+  - name: a knitted blanket
+    noun: blanket
+    volume: 90
+    work_order: true
+    chapter: 5
+  # Tailoring Chapter 6 recipes
+  # No recipes
+  # Tailoring Chapter 7 recipes
+  - name: a leather armband
+    noun: armband
+    volume: 1
+    work_order: false
+    chapter: 7
+  - name: a leather ankleband
+    noun: ankleband
+    volume: 1
+    work_order: false
+    chapter: 7
+  - name: some fingerless gloves
+    noun: gloves
+    volume: 1
+    work_order: false
+    chapter: 7
+  - name: some elbow-length gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a leather eyepatch
+    noun: eyepatch
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a leather headband
+    noun: headband
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a leather belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: some leather moccasins
+    noun: moccasins
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: some leather shoes
+    noun: shoes
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a leather hat
+    noun: hat
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a commoner's cloak
+    noun: cloak
+    volume: 6
+    work_order: false
+    chapter: 7
+  - name: a leather shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a sleeveless leather shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a segmented belt
+    noun: belt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a leather dress belt
+    noun: belt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a leather skirt
+    noun: skirt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather cloak
+    noun: cloak
+    volume: 7
+    work_order: false
+    chapter: 7
+  - name: a leather tunic
+    noun: tunic
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a leather dress
+    noun: dress
+    volume: 7
+    work_order: false
+    chapter: 7
+  - name: a double-wrapped belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a leather cape
+    noun: cape
+    volume: 7
+    work_order: false
+    chapter: 7
+  - name: a leather utility belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a hooded leather cloak
+    noun: cloak
+    volume: 8
+    work_order: false
+    chapter: 7
+  - name: a deeply-hooded cloak
+    noun: cloak
+    volume: 8
+    work_order: false
+    chapter: 7
+  - name: a leather hunting shirt
+    noun: shirt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather dueling shirt
+    noun: shirt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather mining belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a leather war belt
+    noun: belt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather artisan's belt
+    noun: belt
+    volume: 5
+    work_order: false
+    chapter: 7
+  # Tailoring Chapter 8 recipes
+  - name: a leather hip pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 8
+  - name: a leather weapon strap
+    noun: strap
+    volume: 1
+    work_order: false
+    chapter: 8
+  - name: a leather saddle
+    noun: saddle
+    volume: 9
+    work_order: false
+    chapter: 8
+  - name: a leather sidesaddle
+    noun: sidesaddle
+    volume: 9
+    work_order: false
+    chapter: 8
+  - name: a leather jousting saddle
+    noun: saddle
+    volume: 10
+    work_order: false
+    chapter: 8
+  # Tailoring Chapter 9 recipes
+  - name: a rugged leather aventail
+    noun: aventail
+    volume: 4
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather mask
+    noun: mask
+    volume: 3
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged gloves
+    noun: gloves
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather aventail
+    noun: aventail
+    volume: 4
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather mask
+    noun: mask
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather aventail
+    noun: aventail
+    volume: 4
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather helm
+    noun: helm
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some thick gloves
+    noun: gloves
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather mask
+    noun: mask
+    volume: 3
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather tasset
+    noun: tasset
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged vambraces
+    noun: vambraces
+    volume: 16
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather cowl
+    noun: cowl
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather helm
+    noun: helm
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse gloves
+    noun: gloves
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather jerkin
+    noun: 28
+    volume:
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a thick leather tasset
+    noun: tasset
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather mantle
+    noun: mantle
+    volume: 22
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged leather sleeves
+    noun: sleeves
+    volume: 20
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some thick vambraces
+    noun: vambraces
+    volume: 16
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some thick greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather cowl
+    noun: cowl
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather helm
+    noun: helm
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather mantle
+    noun: mantle
+    volume: 22
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather coat
+    noun: coat
+    volume: 43
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a rugged leather robe
+    noun: robe
+    volume: 40
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a thick leather jerkin
+    noun: jerkin
+    volume: 28
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some thick leather sleeves
+    noun: sleeves
+    volume: 20
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather tasset
+    noun: tasset
+    volume:
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse vambraces
+    noun: vambraces
+    volume: 16
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather cowl
+    noun: cowl
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather robe
+    noun: robe
+    volume: 40
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some rugged leathers
+    noun: leathers
+    volume: 55
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a thick leather coat
+    noun: coat
+    volume: 43
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a coarse leather jerkin
+    noun: jerkin
+    volume: 28
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a coarse leather mantle
+    noun: mantle
+    volume: 22
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse leather sleeves
+    noun: sleeves
+    volume: 20
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather robe
+    volume: 40
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some thick leathers
+    noun: leathers
+    volume: 55
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a coarse leather coat
+    noun: coat
+    volume: 43
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some coarse leathers
+    noun: leathers
+    volume: 55
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  # Tailoring Chapter 10 recipes
+  - name: a leather target handle
+    noun: shield
+    volume: 2
+    work_order: false
+    chapter: 10
+  - name: a long leather cord
+    noun: shield
+    volume: 2
+    work_order: false
+    chapter: 10
+  - name: a leather target shield
+    noun: shield
+    volume: 12
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: an ordinary leather shield
+    noun: shield
+    volume: 8
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a small leather shield
+    noun: shield
+    volume: 8
+    work_order: false
+    chapter: 10
+    part:
+    - leather shield handle
+    - long cord
+  - name: a leather buckler
+    noun: buckler
+    volume: 12
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a leather targe
+    noun: targe
+    volume: 10
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a leather oval shield
+    noun: shield
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a medium leather shield
+    noun: shield
+    volume: 16
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a leather kite shield
+    noun: shield
+    volume: 24
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+remedies:
 ####################################
 ##### Outfitting section ends  #####
 ####################################
@@ -8190,1478 +7111,1273 @@ crafting_recipes:
 ##### Alchemy section begins#####
 #################################
 # Remedies Chapter 2 recipes
-- name: some blister cream
-  noun: cream
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: nemoih
-  herb2_stock: 3
-- name: some moisturizing ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: plovik
-  herb2_stock: 4
-  liquid: alcohol
-- name: some itch salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: jadice
-  herb2_stock: 5
-- name: some wart salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: sufil
-  herb2_stock:
-- name: some stomach tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: muljin
-  herb2_stock:
-- name: some lip balm
-  noun: balm
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: nilos
-  herb2_stock: 6
-- name: some mouth wash
-  noun: wash
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: riolur
-  herb2_stock: 8
-- name: some eye wash
-  noun: wash
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: aevaes
-  herb2_stock:
-- name: some hangover potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: ojhenik
-  herb2_stock: 12
-- name: some refreshment elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: belradi
-  herb2_stock:
-  catalyst: coal nugget
-  catalyst_stock: 2
-  catalyst_volume: 10
-- name: some vigor poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: red flower
-  herb1_stock: 13
-  herb2: dioica
-  herb2_stock:
-# Remedies Chapter 3 recipes
-- name: some neck salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: georin
-  herb1_stock: 7
-- name: some abdominal salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: nilos
-  herb1_stock: 6
-- name: some chest salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: plovik
-  herb1_stock: 4
-- name: some head salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: nemoih
-  herb1_stock: 3
-- name: some back salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: hulnik
-  herb1_stock:
-- name: some eye salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: sufil
-  herb1_stock:
-- name: some skin salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: aloe
-  herb1_stock:
-- name: some limb salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: jadice
-  herb1_stock: 5
-- name: some neck ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: georin
-  herb1_stock: 7
-- name: some abdominal ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: nilos
-  herb1_stock: 6
-- name: some chest ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: plovik
-  herb1_stock: 4
-- name: some back ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: hulnik
-  herb1_stock:
-- name: some eye ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: sufil
-  herb1_stock:
-- name: some skin ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: aloe
-  herb1_stock:
-- name: some limb ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: jadice
-  herb1_stock: 5
-# Remedies Chapter 4 recipes
-- name: a neck potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: riolur
-  herb1_stock: 8
-- name: an abdomen potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: muljin
-  herb1_stock:
-- name: a chest potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: ithor
-  herb1_stock: 14
-- name: a head potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: eghmok
-  herb1_stock:
-- name: a back potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: jun
-  herb1_stock: 9
-- name: an eye potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: aevaes
-  herb1_stock: 10
-- name: a skin potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: lujeakave
-  herb1_stock:
-- name: a limb potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: yelith
-  herb1_stock:
-- name: some neck tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: riolur
-  herb1_stock: 8
-- name: some abdominal tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: muljin
-  herb1_stock:
-- name: some chest tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: ithor
-  herb1_stock: 14
-- name: some head tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: eghmok
-  herb1_stock:
-- name: some back tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: jun
-  herb1_stock: 9
-- name: some eye tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: aevaes
-  herb1_stock: 10
-- name: some skin tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: lujeakave
-  herb1_stock:
-- name: some limb tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: yelith
-  herb1_stock:
-# Remedies Chapter 5 recipes
-- name: some face ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: qun
-  herb1_stock: 15
-  liquid: alcohol
-- name: some body ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: genich
-  herb1_stock: 11
-  liquid: alcohol
-- name: some limb ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: blocil
-  herb1_stock:
-  liquid: alcohol
-- name: some face poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: qun
-  herb1_stock: 15
-  liquid: alcohol
-- name: some skin ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: cebi
-  herb1_stock:
-  liquid: alcohol
-- name: some body poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: genich
-  herb1_stock: 11
-  liquid: alcohol
-- name: some general purpose ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: dioica
-  herb1_stock:
-  liquid: alcohol
-- name: some skin poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: cebi
-  herb1_stock:
-  liquid: alcohol
-- name: some limb poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: blocil
-  herb1_stock:
-  liquid: alcohol
-- name: some general poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: dioica
-  herb1_stock:
-  liquid: alcohol
-- name: a body draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 6
-  container: bowl
-  herb1: ojhenik
-  herb1_stock: 12
-  liquid: alcohol
-# Remedies Chapter 6 recipes
-- name: a face draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hulij
-  herb1_stock:
-  liquid: alcohol
-- name: a limb draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: nuloe
-  herb1_stock:
-  liquid: alcohol
-- name: a skin draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hisan
-  herb1_stock:
-  liquid: alcohol
-- name: a general purpose draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: belradi
-  herb1_stock:
-  liquid: alcohol
-- name: a skin elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hisan
-  herb1_stock:
-  liquid: alcohol
-- name: a limb elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: nuloe
-  herb1_stock:
-  liquid: alcohol
-- name: a body elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 6
-  container: bowl
-  herb1: ojhenik
-  herb1_stock: 12
-  liquid: alcohol
-- name: a face elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hulij
-  herb1_stock:
-  liquid: alcohol
-- name: a general elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: belradi
-  herb1-stock:
-  liquid: alcohol
+  - name: some blister cream
+    noun: cream
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - nemoih
+  - name: some moisturizing ointment
+    noun: ointment
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - plovik
+    - alcohol
+  - name: some itch salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - jadice
+  - name: some wart salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - sufil
+  - name: some stomach tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - muljin
+  - name: some lip balm
+    noun: balm
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - nilos
+  - name: some mouth wash
+    noun: wash
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - riolur
+  - name: some eye wash
+    noun: wash
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - aevaes
+  - name: some hangover potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - ojhenik
+  - name: some refreshment elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - belradi
+    - coal
+  - name: some vigor poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - red flower
+    - dioica
+  # Remedies Chapter 3 recipes
+  - name: some neck salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - georin
+  - name: some abdominal salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - nilos
+  - name: some chest salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - plovik
+  - name: some head salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - nemoih
+  - name: some back salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - hulnik
+  - name: some eye salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - sufil
+  - name: some skin salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - aloe
+  - name: some limb salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - jadice
+  - name: some neck ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - georin
+  - name: some abdominal ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - nilos
+  - name: some chest ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - plovik
+  - name: some back ungent
+    noun: ungent
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - hulnik
+  - name: some eye ungent
+    noun: ungent
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - sufil
+  - name: some skin ungent
+    noun: ungent
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - aloe
+  - name: some limb ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - jadice
+  # Remedies Chapter 4 recipes
+  - name: a neck potion
+    noun: potion
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - riolur
+  - name: an abdomen potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - muljin
+  - name: a chest potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - ithor
+  - name: a head potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - eghmok
+  - name: a back potion
+    noun: potion
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - junliar
+  - name: an eye potion
+    noun: potion
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - aevaes
+  - name: a skin potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - lujeakave
+  - name: a limb potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - yelith
+  - name: some neck tonic
+    noun: tonic
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - riolur
+  - name: some abdominal tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - muljin
+  - name: some chest tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - ithor
+  - name: some head tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - eghmok
+  - name: some back tonic
+    noun: tonic
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - junliar
+  - name: some eye tonic
+    noun: tonic
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - aevaes
+  - name: some skin tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - lujeakave
+  - name: some limb tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - yelith
+  # Remedies Chapter 5 recipes
+  - name: some face ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - qun pollen
+    - alcohol
+  - name: some body ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - genich stem
+    - alcohol
+  - name: some limb ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - blocil
+    - alcohol
+  - name: some face poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - qun pollen
+    - alcohol
+  - name: some skin ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - cebi
+    - alcohol
+  - name: some body poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - genich stem
+    - alcohol
+  - name: some general purpose ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - dioica
+    - alcohol
+  - name: some skin poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - cebi
+    - alcohol
+  - name: some limb poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - blocil
+    - alcohol
+  - name: some general poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - dioica
+    - alcohol
+  - name: a body draught
+    noun: draught
+    volume: 1
+    work_order: true
+    chapter: 6
+    container: bowl
+    part:
+    - ojhenik
+    - alcohol
+  # Remedies Chapter 6 recipes
+  - name: a face draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hulij
+    - alcohol
+  - name: a limb draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - nuloe
+    - alcohol
+  - name: a skin draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hisan
+    - alcohol
+  - name: a general purpose draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - belradi
+    - alcohol
+  - name: a skin elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hisan
+    - alcohol
+  - name: a limb elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - nuloe
+    - alcohol
+  - name: a body elixir
+    noun: elixir
+    volume: 1
+    work_order: true
+    chapter: 6
+    container: bowl
+    part:
+    - ojhenik
+    - alcohol
+  - name: a face elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hulij
+    - alcohol
+  - name: a general elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - belradi
+    - alcohol
+artificing:
 ####################################
 ##### Enchanting section ends #####
 ####################################
 # Artificing Chapter 2 recipes
-- name: a radiant trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 2
-  item: 6
-- name: a mana trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 2
-  enchant_stock2: 3
-  item: 6
-- name: a flash trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 1
-  item: 6
-- name: a cambrinth retuner
-  noun: bobcat rod
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 3
-  part:
-  - bobcat rod
-- name: a celestial beacon
-  noun: heron bead
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  part:
-  - bead
-- name: a wind trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 5
-  item: 6
-- name: simple devourer
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  part:
-  - gem
-  secondary:
-  - metamorphosis
-- name: Eluned's Scry
-  noun: bone
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  enchant_stock2: 4
-- name: an earth trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 4
-  item: 6
-- name: Garden's Vision
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  part:
-  - A sapphire or amethyst gem
-  secondary:
-  - antipode
-- name: a fire trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 1
-  item: 6
-  secondary:
-  - paradox
-- name: Mirkik sokis
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 5
-  enchant_stock2: 1
-  part:
-  - An ordinary gem of sufficient value
-- name: a water trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - ascension
-- name: an aura device
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - paradox
-- name: a magic gem
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 4
-  part:
-  - gem
-  secondary:
-  - unity
-- name: nemmiro stone
-  noun: stone
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item:
-  part:
-  - pebble
-  secondary:
-  - any
-  - any
-- name: a shatter sigil
-  noun: ingot
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: ingot
-  secondary:
-  - decay
-  - antipode
-- name: simple gwethsmasher
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - metamorphosis
-- name: a mining stone
-  noun: stone
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 5
-  item:
-  part:
-  - pebble
-  secondary:
-  - integration
-  - antipode
-- name: Ring of Glory Charisma
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 4
-  item:
-  part:
-  - ring
-  secondary:
-  - paradox
-  - clarification
-- name: Ring of Glory Stamina
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item:
-  part:
-  - ring
-  secondary:
-  - integration
-  - nurture
-- name: Astoshe's Eclipse
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 3
-  item:
-  part:
-  - ring
-  secondary:
-  - unity
-- name: Ring of Glory Wisdom
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 1
-  item:
-  part:
-  - ring
-  secondary:
-  - metamorphosis
-  - evolution
-- name: Ring of Glory Intelligence
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item:
-  part:
-  - ring
-  secondary:
-  - paradox
-  - clarification
-- name: unleashed gwethsmasher
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - metamorphosis
-- name: Ring of Glory Discipline
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 4
-  item:
-  part:
-  - ring
-  secondary:
-  - nurture
-  - decay
-- name: Ring of Glory Reflex
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 3
-  item:
-  part:
-  - ring
-  secondary:
-  - metamorphosis
-  - evolution
-- name: Ring of Glory Agility
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 5
-  item:
-  part:
-  - ring
-  secondary:
-  - nurture
-  - integration
-- name: Ring of Glory Strength
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 1
-  item:
-  part:
-  - ring
-  secondary:
-  - antipode
-  - evolution
-# Artificing Chapter 3 recipes
-- name: training ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 5
-  item: 6
-- name: a basic lunar ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 3
-  item: 6
-- name: basic elemental ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 3
-  item: 6
-- name: basic life ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 1
-  enchant_stock2: 3
-  item: 6
-- name: an accurate focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 4
-  item: 6
-  secondary:
-  - nurture
-  - decay
-- name: basic holy ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 2
-  enchant_stock2: 3
-  item: 6
-- name: an efficient focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 1
-  item: 6
-  secondary:
-  - metamorphosis
-  - ascension
-- name: advanced lunar ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - paradox
-- name: basic untuned ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - nurture
-- name: a lethal focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - paradox
-  - clarification
-- name: advanced elemental ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - evolution
-- name: a destructive focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - decay
-  - antipode
-- name: advanced life ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - ascension
-- name: a fire focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  item: 6
-  secondary:
-  - evolution
-  - integration
-  - nurture
-- name: advanced holy ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - unity
-- name: a frost focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  item: 6
-  secondary:
-  - evolution
-  - metamorphosis
-  - unity
-- name: advanced AP ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - decay
-- name: an electric focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  item: 6
-  secondary:
-  - evolution
-  - ascension
-  - paradox
-- name: advanced untuned ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 2
-  enchant_stock2: 3
-  item: 6
-  secondary:
-  - unity
-# Artificing Chapter 4 recipes
-- name: common material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: true
-  enchant_stock1: 3
-  part:
-  - sphere
-- name: common material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: true
-  enchant_stock1: 3
-  enchant_stock2: 2
-  part:
-  - sphere
-- name: uncommon material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - paradox
-- name: common material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: true
-  enchant_stock1: 3
-  enchant_stock2: 5
-  part:
-  - sphere
-- name: common material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  part:
-  - sphere
-  secondary:
-  - evolution
-- name: rare material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - nurture
-- name: uncommon material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - nurture
-- name: ultra rare material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - nurture
-- name: uncommon material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - integration
-- name: rare material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - decay
-- name: uncommon material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - clarification
-- name: ultra rare material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - decay
-- name: rare material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - paradox
-- name: ultra rare material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - paradox
-- name: rare material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - evolution
-- name: ultra rare material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - ascension
-# Artificing Chapter 5 recipes
-- name: an unfocused burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  part:
-  - burin
-- name: a focused burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  enchant_stock2: 5
-  part:
-  - burin
-- name: oval augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: a gwethdesuan
-  noun: gwethdesuan
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  part:
-  - gwethdesuan
-  secondary:
-  - ascension
-  item:
-  - gwethdesuan
-- name: a small enchanter's brazier
-  noun: brazier
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 5
-  enchant_stock2: 3
-  item:
-  part:
-  - brazier
-- name: oblong augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  enchant_stock2: 4
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: simple imbuement rod
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  secondary:
-  - evolution
-- name: an abstract burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  enchant_stock2: 5
-  part:
-  - burin
-  secondary:
-  - unity
-- name: circular augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  enchant_stock2: 5
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: stout imbuement rod
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 2
-  secondary:
-  - paradox
-  - nurture
-- name: a precise burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  enchant_stock2: 5
-  part:
-  - burin
-  secondary:
-  - integration
-- name: flat augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  enchant_stock2: 1
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: precise imbuement rod
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 5
-  secondary:
-  - antipode
-  - metamorphosis
-# Artificing Chapter 6 recipes
-- name: a bubble wand
-  noun: wand
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  part:
-  - wand
-- name: ease burden runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: seal cambrinth runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 1
-  enchant_stock2: 3
-  item:
-  part:
-  - runestone
-- name: burden runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 5
-  item:
-  part:
-  - runestone
-- name: manifest force runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: strange arrow runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 5
-  item:
-  part:
-  - runestone
-- name: gauge flow runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 2
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: dispel runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: a lore arcana wand
-  noun: wand
-  type: artificing
-  chapter: 6
-  work_order: false
-  enchant_stock1: 1
-  part:
-  - wand
-  secondary:
-  - ascension
-  - evolution
-- name: lay ward runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
+  - name: a radiant trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - bone totem
+  - name: a mana trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: a flash trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - induction sigil-scroll
+    - bone totem
+  - name: a cambrinth retuner
+    noun: bobcat rod
+    chapter: 2
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - bobcat rod
+  - name: a celestial beacon
+    noun: heron bead
+    chapter: 2
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - bead
+  - name: a wind trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - bone totem
+  - name: simple devourer
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - gem
+    - metamorphosis sigil-scroll
+  - name: Eluned's Scry
+    noun: bone
+    chapter: 2
+    work_order: false
+    part:
+    - bone
+    - abolution sigil-scroll
+    - permutation sigil-scroll
+  - name: an earth trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - bone totem
+  - name: Garden's Vision
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - A sapphire or amethyst gem
+    - antipode sigil-scroll
+  - name: a fire trinket
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - bone totem
+    - paradox sigil-scroll 
+  - name: Mirkik sokis
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - An ordinary gem of sufficient value
+  - name: a water trinket
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - ascension sigil-scroll
+  - name: an aura device
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - paradox sigil-scroll
+  - name: a magic gem
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - gem
+    - unity sigil-scroll
+  - name: nemmiro stone
+    noun: stone
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - pebble
+    - any
+    - any
+  - name: a shatter sigil
+    noun: ingot
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - ingot
+    - decay sigil-scroll
+    - antipode sigil-scroll
+  - name: simple gwethsmasher
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - metamorphosis sigil-scroll
+  - name: a mining stone
+    noun: stone
+    chapter: 2
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - pebble
+    - integration sigil-scroll
+    - antipode sigil-scroll
+  - name: Ring of Glory Charisma
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - ring
+    - paradox sigil-scroll
+    - clarification sigil-scroll
+  - name: Ring of Glory Stamina
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - ring
+    - integration sigil-scroll
+    - nurture sigil-scroll
+  - name: Astoshe's Eclipse
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - ring
+    - unity sigil-scroll
+  - name: Ring of Glory Wisdom
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - ring
+    - metamorphosis sigil-scroll
+    - evolution sigil-scroll
+  - name: Ring of Glory Intelligence
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - ring
+    - paradox sigil-scroll
+    - clarification sigil-scroll
+  - name: unleashed gwethsmasher
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - metamorphosis sigil-scroll
+  - name: Ring of Glory Discipline
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - ring
+    - nurture sigil-scroll
+    - decay sigil-scroll
+  - name: Ring of Glory Reflex
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - ring
+    - metamorphosis sigil-scroll
+    - evolution sigil-scroll
+  - name: Ring of Glory Agility
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - ring
+    - nurture sigil-scroll
+    - integration sigil-scroll
+  - name: Ring of Glory Strength
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - ring
+    - antipode sigil-scroll
+    - evolution sigil-scroll
+  # Artificing Chapter 3 recipes
+  - name: training ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - bone totem
+  - name: a basic lunar ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: basic elemental ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: basic life ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - induction sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: an accurate focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - bone totem
+    - nurture sigil-scroll
+    - decay sigil-scroll
+  - name: basic holy ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: an efficient focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - bone totem
+    - metamorphosis sigil-scroll
+    - ascension sigil-scroll
+  - name: advanced lunar ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - paradox sigil-scroll
+  - name: basic untuned ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - nurture sigil-scroll
+  - name: a lethal focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - paradox sigil-scroll
+    - clarification sigil-scroll
+  - name: advanced elemental ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - evolution sigil-scroll
+  - name: a destructive focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - decay sigil-scroll
+    - antipode sigil-scroll
+  - name: advanced life ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - ascension sigil-scroll
+  - name: a fire focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - bone totem
+    - evolution sigil-scroll
+    - integration sigil-scroll
+    - nurture sigil-scroll
+  - name: advanced holy ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - unity sigil-scroll
+  - name: a frost focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - bone totem
+    - evolution sigil-scroll
+    - metamorphosis sigil-scroll
+    - unity sigil-scroll
+  - name: advanced AP ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - decay sigil-scroll
+  - name: an electric focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - bone totem
+    - evolution sigil-scroll
+    - ascension sigil-scroll
+    - paradox sigil-scroll
+  - name: advanced untuned ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+    - unity sigil-scroll
+  # Artificing Chapter 4 recipes
+  - name: common material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - sphere
+  - name: common material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - abolution sigil-scroll
+    - sphere
+  - name: uncommon material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - paradox sigil-scroll
+  - name: common material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - rarefaction sigil-scroll
+    - sphere
+  - name: common material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - sphere
+    - evolution sigil-scroll
+  - name: rare material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - nurture sigil-scroll
+  - name: uncommon material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - nurture sigil-scroll
+  - name: ultra rare material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - nurture sigil-scroll
+  - name: uncommon material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - integration sigil-scroll
+  - name: rare material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - decay sigil-scroll
+  - name: uncommon material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - clarification sigil-scroll
+  - name: ultra rare material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - decay sigil-scroll
+  - name: rare material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - paradox sigil-scroll
+  - name: ultra rare material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - paradox sigil-scroll
+  - name: rare material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - evolution sigil-scroll
+  - name: ultra rare material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - ascension sigil-scroll
+  # Artificing Chapter 5 recipes
+  - name: an unfocused burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - burin
+  - name: a focused burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - rarefaction sigil-scroll
+    - burin
+  - name: oval augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: a gwethdesuan
+    noun: gwethdesuan
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - gwethdesuan
+    - ascension sigil-scroll
+    - gwethdesuan
+  - name: a small enchanter's brazier
+    noun: brazier
+    chapter: 5
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - congruence sigil-scroll
+    - brazier
+  - name: oblong augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - permutation sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: simple imbuement rod
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - evolution sigil-scroll
+  - name: an abstract burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - rarefaction sigil-scroll
+    - burin
+    - unity sigil-scroll
+  - name: circular augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - rarefaction sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: stout imbuement rod
+    chapter: 5
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - paradox sigil-scroll
+    - nurture sigil-scroll
+  - name: a precise burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - rarefaction sigil-scroll
+    - burin
+    - integration sigil-scroll
+  - name: flat augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - induction sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: precise imbuement rod
+    chapter: 5
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - antipode sigil-scroll
+    - metamorphosis sigil-scroll
+  # Artificing Chapter 6 recipes
+  - name: a bubble wand
+    noun: wand
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - wand
+  - name: ease burden runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: seal cambrinth runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - induction sigil-scroll
+    - congruence sigil-scroll
+    - runestone
+  - name: burden runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - rarefaction sigil-scroll
+    - runestone
+  - name: manifest force runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: strange arrow runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - rarefaction sigil-scroll
+    - runestone
+  - name: gauge flow runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: dispel runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: a lore arcana wand
+    noun: wand
+    chapter: 6
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - wand
+    - ascension sigil-scroll
+    - evolution sigil-scroll
+  - name: lay ward runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - runestone

--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -1,7109 +1,8188 @@
 ---
-armorsmithing:
-  ##################################
-  ##### Forging section begins #####
-  ##################################
-  # Armorsmithing Chapter 1 recipes
-  - name: a metal ring aventail
-    noun: aventail
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal ring mask
-    noun: mask
-    volume: 3
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal chain aventail
-    noun: aventail
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal ring cap
-    noun: cap
-    volume: 8
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal chain mask
-    noun: mask
-    volume: 4
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal ring gloves
-    noun: gloves
-    volume: 6
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal ring greaves
-    noun: greaves
-    volume: 12
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal ring helm
-    noun: helm
-    volume: 12
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal mail aventail
-    noun: aventail
-    volume: 7
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal chain cap
-    noun: cap
-    volume: 10
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal mail mask
-    noun: mask
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal chain gloves
-    noun: gloves
-    volume: 8
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal mail gloves
-    noun: gloves
-    volume: 10
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal ring tasset
-    noun: tasset
-    volume: 8
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal ring vambraces
-    noun: vambraces
-    volume: 19
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal chain greaves
-    noun: greaves
-    volume: 15
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal ring balaclava
-    noun: balaclava
-    volume: 16
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal chain helm
-    noun: helm
-    volume: 14
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal mail cap
-    noun: cap
-    volume: 12
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal ring lorica
-    noun: lorica
-    volume: 26
-    work_order: false
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal ring mantle
-    noun: mantle
-    volume: 21
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal ring vest
-    noun: vest
-    volume: 18
-    work_order: false
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal chain tasset
-    noun: tasset
-    volume: 10
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal ring sleeves
-    noun: sleeves
-    volume: 21
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal chain vambraces
-    noun: vambraces
-    volume: 20
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal mail greaves
-    noun: greaves
-    volume: 18
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal chain balaclava
-    noun: balaclava
-    volume: 20
-    work_order: false
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal mail helm
-    noun: helm
-    volume: 16
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a mail balaclava
-    noun: balaclava
-    volume: 24
-    work_order: true
-    chapter: 1
-    part:
-    - small backing
-  - name: a metal ring shirt
-    noun: shirt
-    volume: 43
-    work_order: false
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-  - name: a metal ring robe
-    noun: robe
-    volume: 38
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-  - name: a metal chain lorica
-    noun: lorica
-    volume: 30
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal chain mantle
-    noun: mantle
-    volume: 24
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal chain vest
-    noun: vest
-    volume: 20
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal mail tasset
-    noun: tasset
-    volume: 12
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal chain sleeves
-    noun: sleeves
-    volume: 26
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: some metal mail vambraces
-    noun: vambraces
-    volume: 23
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal ring hauberk
-    noun: hauberk
-    volume: 70
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-    - small padding
-  - name: a metal chain shirt
-    noun: shirt
-    volume: 50
-    work_order: false
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-  - name: a metal chain robe
-    noun: robe
-    volume: 45
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-  - name: a metal mail lorica
-    noun: lorica
-    volume: 34
-    work_order: false
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal mail mantle
-    noun: mantle
-    volume: 27
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-  - name: a metal mail vest
-    noun: vest
-    volume: 22
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-  - name: some metal mail sleeves
-    noun: sleeves
-    volume: 31
-    work_order: true
-    chapter: 1
-    part:
-    - small padding
-  - name: a metal chain hauberk
-    noun: hauberk
-    volume: 80
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-    - small padding
-  - name: a metal mail shirt
-    noun: shirt
-    volume: 57
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-  - name: a metal mail robe
-    noun: robe
-    volume: 52
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-  - name: a metal mail hauberk
-    noun: hauberk
-    volume: 90
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-    - small padding
-  - name: a metal bar-mail hauberk
-    noun: hauberk
-    volume: 90
-    work_order: true
-    chapter: 1
-    part:
-    - large padding
-    - small padding
-    - small padding
-  # Armorsmithing Chapter 2 recipes
-  - name: a metal scale aventail
-    noun: aventail
-    volume: 9
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal scale mask
-    noun: mask
-    volume: 5
-    work_order: false
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal scale cap
-    noun: cap
-    volume: 12
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal brigandine aventail
-    noun: aventail
-    volume: 10
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal brigandine mask
-    noun: mask
-    volume: 6
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: some metal scale gloves
-    noun: gloves
-    volume: 8
-    work_order: false
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal scale helm
-    noun: helm
-    volume: 21
-    work_order: false
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal brigandine cap
-    noun: cap
-    volume: 14
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal lamellar aventail
-    noun: aventail
-    volume: 11
-    work_order: true
-    chapter: 2
-    part:
-    - small backing
-  - name: a metal lamellar mask
-    noun: mask
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - small backing
-  - name: some metal scale greaves
-    noun: greaves
-    volume: 15
-    work_order: false
-    chapter: 2
-    part:
-    - small padding
-  - name: some brigandine gloves
-    noun: gloves
-    volume: 10
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal scale tasset
-    noun: tasset
-    volume: 10
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: some metal scale vambraces
-    noun: vambraces
-    volume: 22
-    work_order: false
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal scale balaclava
-    noun: balaclava
-    volume: 26
-    work_order: false
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal brigandine helm
-    noun: helm
-    volume: 24
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal lamellar cap
-    noun: cap
-    volume: 16
-    work_order: true
-    chapter: 2
-    part:
-    - small backing
-  - name: some brigandine greaves
-    noun: greaves
-    volume: 18
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: some metal lamellar gloves
-    noun: gloves
-    volume: 12
-    work_order: true
-    chapter: 2
-    part:
-    - small backing
-  - name: a metal brigandine tasset
-    noun: tasset
-    volume: 12
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: some brigandine vambraces
-    noun: vambraces
-    volume: 25
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a brigandine balaclava
-    noun: balaclava
-    volume: 30
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal lamellar helm
-    noun: helm
-    volume: 27
-    work_order: true
-    chapter: 2
-    part:
-    - small backing
-  - name: some lamellar greaves
-    noun: greaves
-    volume: 18
-    work_order: false
-    chapter: 2
-    part:
-    - small backing
-  - name: some metal scale sleeves
-    noun: sleeves
-    volume: 30
-    work_order: false
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal scale lorica
-    noun: lorica
-    volume: 34
-    work_order: false
-    chapter: 2
-    part:
-    - large padding
-  - name: a metal scale mantle
-    noun: mantle
-    volume: 33
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: a metal scale vest
-    noun: vest
-    volume: 24
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: a metal lamellar tasset
-    noun: tasset
-    volume: 14
-    work_order: false
-    chapter: 2
-    part:
-    - small backing
-  - name: some lamellar vambraces
-    noun: vambraces
-    volume: 28
-    work_order: false
-    chapter: 2
-    part:
-    - small backing
-  - name: a metal lamellar balaclava
-    noun: balaclava
-    volume: 34
-    work_order: true
-    chapter: 2
-    part:
-    - small backing
-  - name: some brigandine sleeves
-    noun: sleeves
-    volume: 35
-    work_order: true
-    chapter: 2
-    part:
-    - small padding
-  - name: a metal scale shirt
-    noun: shirt
-    volume: 56
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: a metal scale robe
-    noun: robe
-    volume: 49
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-    - small padding
-  - name: a metal brigandine lorica
-    noun: lorica
-    volume: 38
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: a metal brigandine mantle
-    noun: mantle
-    volume: 36
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: a metal brigandine vest
-    noun: vest
-    volume: 26
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: some lamellar sleeves
-    noun: sleeves
-    volume: 40
-    work_order: false
-    chapter: 2
-    part:
-    - small backing
-  - name: a brigandine robe
-    noun: robe
-    volume: 56
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-    - small padding
-  - name: a brigandine shirt
-    noun: shirt
-    volume: 63
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: a metal scale hauberk
-    noun: hauberk
-    volume: 80
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-    - small padding
-    - small padding
-  - name: a metal lamellar lorica
-    noun: lorica
-    volume: 42
-    work_order: true
-    chapter: 2
-    part:
-    - large backing
-  - name: a metal lamellar mantle
-    noun: mantle
-    volume: 39
-    work_order: true
-    chapter: 2
-    part:
-    - large backing
-  - name: a metal lamellar vest
-    noun: vest
-    volume: 28
-    work_order: true
-    chapter: 2
-    part:
-    - large backing
-  - name: a metal lamellar robe
-    noun: robe
-    volume: 63
-    work_order: true
-    chapter: 2
-    part:
-    - large backing
-    - small backing
-  - name: a brigandine hauberk
-    noun: hauberk
-    volume: 90
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-    - small padding
-    - small padding
-  - name: a metal lamellar shirt
-    noun: shirt
-    volume: 70
-    work_order: true
-    chapter: 2
-    part:
-    - large padding
-  - name: a lamellar hauberk
-    noun: hauberk
-    volume: 100
-    work_order: true
-    chapter: 2
-    part:
-    - large backing
-    - small backing
-    - small backing
-  - name: a laminar hauberk
-    noun: hauberk
-    volume: 100
-    work_order: true
-    chapter: 2
-    part:
-    - large backing
-    - small backing
-    - small backing
-  # Armorsmithing Chapter 3 recipes
-  - name: a light plate aventail
-    noun: aventail
-    volume: 12
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a light plate mask
-    noun: mask
-    volume: 7
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: some light plate gauntlets
-    noun: gauntlets
-    volume: 13
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a plate aventail
-    noun: aventail
-    volume: 14
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal dome helm
-    noun: helm
-    volume: 16
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a plate mask
-    noun: mask
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a metal bascinet
-    noun: bascinet
-    volume: 23
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: some plate gauntlets
-    noun: gauntlets
-    volume: 15
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a heavy plate aventail
-    noun: aventail
-    volume: 16
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal morion
-    noun: morion
-    volume: 18
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a heavy plate mask
-    noun: mask
-    volume: 9
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a light plate fauld
-    noun: fauld
-    volume: 13
-    work_order: true
-    chapter: 3
-    part:
-    - small padding
-  - name: a light backplate
-    noun: backplate
-    volume: 10
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: some light plate vambraces
-    noun: vambraces
-    volume: 26
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a metal visored helm
-    noun: helm
-    volume: 26
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: heavy plate gauntlets
-    noun: gauntlets
-    volume: 17
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal barbute
-    noun: barbute
-    volume: 20
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: some light plate greaves
-    noun: greaves
-    volume: 19
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a metal sallet
-    noun: sallet
-    volume: 35
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a light breastplate
-    noun: breastplate
-    volume: 16
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: a plate fauld
-    noun: fauld
-    volume: 15
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal backplate
-    noun: backplate
-    volume: 12
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: some light plate sleeves
-    noun: sleeves
-    volume: 39
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-  - name: some plate vambraces
-    noun: vambraces
-    volume: 30
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: some plate greaves
-    noun: greaves
-    volume: 22
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal armet
-    noun: armet
-    volume: 40
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal closed helm
-    noun: helm
-    volume: 29
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a light plate cuirass
-    noun: cuirass
-    volume: 39
-    work_order: false
-    chapter: 3
-    part:
-    - large padding
-  - name: a metal breastplate
-    noun: breastplate
-    volume: 18
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a heavy plate fauld
-    noun: fauld
-    volume: 17
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal heavy backplate
-    noun: backplate
-    volume: 14
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: some plate sleeves
-    noun: sleeves
-    volume: 45
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: some heavy plate vambraces
-    noun: vambraces
-    volume: 34
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: some heavy plate greaves
-    noun: greaves
-    volume: 25
-    work_order: true
-    chapter: 3
-    part:
-    - small backing
-  - name: a metal great helm
-    noun: helm
-    volume: 45
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: some light half plate
-    noun: plate
-    volume: 65
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-    - large padding
-  - name: some light field plate
-    noun: plate
-    volume: 58
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-    - large padding
-  - name: a plate cuirass
-    noun: cuirass
-    volume: 45
-    work_order: true
-    chapter: 3
-    part:
-    - large backing
-  - name: a heavy breastplate
-    noun: breastplate
-    volume: 20
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: some heavy plate sleeves
-    noun: sleeves
-    volume: 51
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-  - name: some light full plate
-    noun: plate
-    volume: 100
-    work_order: false
-    chapter: 3
-    part:
-    - small padding
-    - small padding
-    - large padding
-  - name: some half plate
-    noun: plate
-    volume: 75
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-    - large backing
-  - name: some field plate
-    noun: plate
-    volume: 67
-    work_order: false
-    chapter: 3
-    part:
-    - small backing
-    - large backing
-  - name: a heavy plate cuirass
-    noun: cuirass
-    volume: 51
-    work_order: false
-    chapter: 3
-    part:
-    - large backing
-  - name: some heavy half plate
-    noun: plate
-    volume: 85
-    work_order: true
-    chapter: 3
-    part:
-    - large padding
-    - small padding
-  - name: some full plate
-    noun: plate
-    volume: 110
-    work_order: true
-    chapter: 3
-    part:
-    - large backing
-    - small backing
-    - small backing
-  - name: some heavy field plate
-    noun: plate
-    volume: 76
-    work_order: true
-    chapter: 3
-    part:
-    - large backing
-    - small backing
-  - name: some heavy full plate
-    noun: plate
-    volume: 120
-    work_order: true
-    chapter: 3
-    part:
-    - large backing
-    - small backing
-    - small backing
-  - name: some heavy fluted plate
-    noun: plate
-    volume: 120
-    work_order: true
-    chapter: 3
-    part:
-    - large backing
-    - small backing
-    - small backing
-  # Armorsmithing Chapter 4 recipes
-  - name: a metal shield handle
-    noun: handle
-    volume: 2
-    work_order: true
-    chapter: 4
-  - name: a metal shield boss
-    noun: boss
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: a metal target shield
-    noun: shield
-    volume: 14
-    work_order: false
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal round sipar
-    noun: sipar
-    volume: 14
-    work_order: false
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal ordinary shield
-    noun: shield
-    volume: 16
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal targe
-    noun: targe
-    volume: 16
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal triangular sipar
-    noun: sipar
-    volume: 14
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal medium shield
-    noun: shield
-    volume: 20
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal ceremonial shield
-    noun: shield
-    volume: 16
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal curved shield
-    noun: shield
-    volume: 20
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal circular buckler
-    noun: buckler
-    volume: 20
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal medium buckler
-    noun: buckler
-    volume: 20
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal oval shield
-    noun: shield
-    volume: 25
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a simple parry stick
-    noun: stick
-    volume: 7
-    work_order: false
-    chapter: 4
-    part:
-    - small backing
-  - name: a metal jousting shield
-    noun: shield
-    volume: 25
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal skirmisher's shield
-    noun: shield
-    volume: 25
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal kite shield
-    noun: shield
-    volume: 30
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal warrior's shield
-    noun: shield
-    volume: 30
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal valnik shield
-    noun: shield
-    volume: 30
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal tower shield
-    noun: shield
-    volume: 40
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal battle shield
-    noun: shield
-    volume: 40
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal heater shield
-    noun: shield
-    volume: 40
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal aegis
-    noun: aegis
-    volume: 30
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  - name: a metal war shield
-    noun: shield
-    volume: 40
-    work_order: true
-    chapter: 4
-    part:
-    - shield handle
-    - long cord
-  # Blacksmithing Chapter 2 recipes
-blacksmithing:
-  - name: a diagonal-peen mallet
-    noun: mallet
-    volume: 12
-    chapter: 2
-    work_order: false
-    part:
-    - short pole
-  - name: a curved metal shovel
-    noun: shovel
-    volume: 8
-    chapter: 2
-    work_order: false
-    part:
-    - long pole
-  - name: a diagonal-peen hammer
-    noun: hammer
-    volume: 12
-    work_order: false
-    chapter: 2
-    part:
-    - short pole
-  - name: a stout metal pickaxe
-    noun: pickaxe
-    volume: 10
-    work_order: false
-    chapter: 2
-    part:
-    - long pole
-  - name: some straight metal tongs
-    noun: tongs
-    volume: 10
-    chapter: 2
-    work_order: false
-  - name: a metal cross-peen hammer
-    noun: hammer
-    volume: 12
-    chapter: 2
-    work_order: false
-    part:
-    - short pole
-  - name: a narrow metal pickaxe
-    noun: pickaxe
-    volume: 10
-    work_order: false
-    chapter: 2
-    part:
-    - long pole
-  - name: a square metal shovel
-    noun: shovel
-    volume: 8
-    chapter: 2
-    work_order: false
-    part:
-    - long pole
-  - name: some curved metal tongs
-    noun: tongs
-    volume: 10
-    work_order: false
-    chapter: 2
-  - name: some flat-bladed tongs
-    noun: tongs
-    volume: 10
-    chapter: 2
-    work_order: false
-  - name: a tapered metal shovel
-    noun: shovel
-    volume: 8
-    chapter: 2
-    work_order: false
-    part:
-    - long pole
-  - name: some angular metal tongs
-    noun: tongs
-    volume: 10
-    work_order: false
-    chapter: 2
-  - name: a straight-peen hammer
-    noun: hammer
-    volume: 12
-    chapter: 2
-    work_order: false
-    part:
-    - short pole
-  - name: a straight-peen mallet
-    noun: mallet
-    volume: 12
-    work_order: false
-    chapter: 2
-    part:
-    - short pole
-  - name: a slender metal pickaxe
-    noun: pickaxe
-    volume: 10
-    work_order: false
-    chapter: 2
-    part:
-    - long pole
-  - name: some metal bolt tongs
-    noun: tongs
-    volume: 10
-    chapter: 2
-    work_order: false
-  - name: a flat-headed metal pickaxe
-    noun: pickaxe
-    volume: 10
-    work_order: false
-    chapter: 2
-    part:
-    - long pole
-  - name: a sturdy metal shovel
-    noun: shovel
-    volume: 8
-    work_order: false
-    chapter: 2
-    part:
-    - long pole
-  - name: a ball-peen hammer
-    noun: hammer
-    volume: 12
-    chapter: 2
-    work_order: false
-    part:
-    - short pole
-  - name: a wide metal shovel
-    noun: shovel
-    volume: 8
-    work_order: false
-    chapter: 2
-    part:
-    - long pole
-  - name: some segmented tongs
-    noun: tongs
-    volume: 10
-    work_order: false
-    chapter: 2
-  - name: a weighted metal pickaxe
-    noun: pickaxe
-    volume: 10
-    work_order: false
-    chapter: 2
-    part:
-    - long pole
-  - name: some box-jaw tongs
-    noun: tongs
-    volume: 10
-    work_order: false
-    chapter: 2
-  - name: some articulated tongs
-    noun: tongs
-    volume: 10
-    work_order: false
-    chapter: 2
-  - name: a ball-peen mallet
-    noun: mallet
-    volume: 12
-    work_order: false
-    chapter: 2
-    part:
-    - short pole
-  # Blacksmithing Chapter 3 recipes
-  - name: a short metal drawknife
-    noun: drawknife
-    volume: 5
-    work_order: true
-    chapter: 3
-    part:
-    - short pole
-  - name: some short metal chisels
-    noun: chisels
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: a long metal drawknife
-    noun: drawknife
-    volume: 5
-    work_order: true
-    chapter: 3
-    part:
-    - short pole
-  - name: a metal straight wood saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a metal straight bone saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a thin metal rasp
-    noun: rasp
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: some square metal rifflers
-    noun: rifflers
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: some long metal chisels
-    noun: chisels
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: a flat metal shaper
-    noun: shaper
-    volume: 4
-    work_order: true
-    chapter: 3
-  - name: some plain metal pliers
-    noun: pliers
-    volume: 5
-    work_order: true
-    chapter: 3
-  - name: some squat metal rifflers
-    noun: rifflers
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: thin metal tinker's tools
-    noun: tools
-    volume: 4
-    work_order: true
-    chapter: 3
-  - name: a rough metal wood shaper
-    noun: shaper
-    volume: 4
-    chapter: 3
-    work_order: true
-  - name: a sturdy metal drawknife
-    noun: drawknife
-    volume: 5
-    work_order: true
-    chapter: 3
-    part:
-    - short pole
-  - name: a metal curved wood saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a metal curved bone saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: some curved metal pliers
-    noun: pliers
-    volume: 5
-    chapter: 3
-    work_order: true
-  - name: a coarse metal rasp
-    noun: rasp
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: some sturdy metal chisels
-    noun: chisels
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: curved metal tinker's tools
-    noun: tools
-    volume: 4
-    work_order: true
-    chapter: 3
-  - name: some curved metal rifflers
-    noun: rifflers
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: some reinforced chisels
-    noun: chisels
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: a sharpened metal drawknife
-    noun: drawknife
-    volume: 5
-    work_order: true
-    chapter: 3
-    part:
-    - short pole
-  - name: a metal slender wood saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a metal slender bone saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: some rough metal pliers
-    noun: pliers
-    volume: 5
-    chapter: 3
-    work_order: true
-  - name: a textured metal rasp
-    noun: rasp
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a metal beveled wood shaper
-    noun: shaper
-    volume: 4
-    chapter: 3
-    work_order: true
-  - name: some thick metal pliers
-    noun: pliers
-    volume: 5
-    chapter: 3
-    work_order: true
-  - name: a flat metal rasp
-    noun: rasp
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: some elongated rifflers
-    noun: rifflers
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: some sharpened chisels
-    noun: chisels
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-    - short cord
-  - name: thick metal tinker's tools
-    noun: tools
-    volume: 4
-    work_order: true
-    chapter: 3
-  - name: a metal tapered wood saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a metal tapered bone saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: some hooked metal pliers
-    noun: pliers
-    volume: 5
-    chapter: 3
-    work_order: true
-  - name: a tapered metal rasp
-    noun: rasp
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a metal jagged wood shaper
-    noun: shaper
-    volume: 4
-    chapter: 3
-    work_order: true
-  - name: a metal serrated wood saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: a metal serrated bone saw
-    noun: saw
-    volume: 8
-    work_order: false
-    chapter: 3
-  - name: precise metal tinker's tools
-    noun: tools
-    volume: 4
-    work_order: true
-    chapter: 3
-  # Blacksmithing Chapter 4 recipes
-  - name: a stout metal yardstick
-    noun: yardstick
-    volume: 6
-    chapter: 4
-    work_order: false
-  - name: some smooth knitting needles
-    noun: needles
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a metal hide scraper
-    noun: scraper
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: some straight metal scissors
-    noun: scissors
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: some plain sewing needles
-    noun: needles
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: some curved metal scissors
-    noun: scissors
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a flat metal yardstick
-    noun: yardstick
-    volume: 6
-    chapter: 4
-    work_order: false
-  - name: some tapered knitting needles
-    noun: needles
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a pointed metal awl
-    noun: awl
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a curved hide scraper
-    noun: scraper
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: some ribbed sewing needles
-    noun: needles
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: some bent metal scissors
-    noun: scissors
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a rectangular yardstick
-    noun: yardstick
-    volume: 6
-    work_order: false
-    chapter: 4
-  - name: some knobby sewing needles
-    noun: needles
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: some squat knitting needles
-    noun: needles
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a narrow metal awl
-    noun: awl
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: some polished knitting needles
-    noun: needles
-    volume: 4
-    chapter: 4
-    work_order: true
-  - name: a compact metal awl
-    noun: awl
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a serrated hide scraper
-    noun: scraper
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: some serrated scissors
-    noun: scissors
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a detailed yardstick
-    noun: yardstick
-    volume: 6
-    work_order: false
-    chapter: 4
-  - name: a slender metal awl
-    noun: awl
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: some thin sewing needles
-    noun: needles
-    volume: 3
-    work_order: true
-    chapter: 4
-  # Blacksmithing Chapter 5 recipes
-  - name: a small metal brazier
-    noun: brazier
-    volume: 10
-    work_order: false
-    chapter: 5
-  - name: a tapered pestle
-    noun: pestle
-    volume: 1
-    work_order: true
-    chapter: 5
-  - name: a flat mixing stick
-    noun: stick
-    volume: 6
-    work_order: false
-    chapter: 5
-  - name: a square wire sieve
-    noun: sieve
-    volume: 3
-    work_order: true
-    chapter: 5
-  - name: a tapered mixing stick
-    noun: stick
-    volume: 6
-    work_order: false
-    chapter: 5
-  - name: a flat pestle
-    noun: pestle
-    volume: 1
-    work_order: true
-    chapter: 5
-  - name: a metal brazier
-    noun: brazier
-    volume: 10
-    work_order: false
-    chapter: 5
-  - name: a triangular wire sieve
-    noun: sieve
-    volume: 3
-    work_order: true
-    chapter: 5
-  - name: a round mixing stick
-    noun: stick
-    volume: 5
-    work_order: true
-    chapter: 5
-  - name: a round pestle
-    noun: pestle
-    volume: 1
-    work_order: true
-    chapter: 5
-  - name: a grooved pestle
-    noun: pestle
-    volume: 1
-    work_order: true
-    chapter: 5
-  - name: an oblong wire sieve
-    noun: sieve
-    volume: 3
-    work_order: true
-    chapter: 5
-  - name: a grooved mixing stick
-    noun: stick
-    volume: 6
-    work_order: false
-    chapter: 5
-  - name: a trapezoidal wire sieve
-    noun: sieve
-    volume: 3
-    work_order: true
-    chapter: 5
-  # Blacksmithing Chapter 6 recipes
-  - name: a metal rod
-    noun: rod
-    volume: 1
-    work_order: true
-    chapter: 6
-  - name: a shallow metal cup
-    noun: cup
-    volume: 1
-    work_order: true
-    chapter: 6
-  - name: a metal horseshoe
-    noun: horseshoe
-    volume: 4
-    work_order: true
-    chapter: 6
-  - name: a soft metal keyblank
-    noun: keyblank
-    volume: 2
-    work_order: true
-    chapter: 6
-  - name: a short metal mug
-    noun: mug
-    volume: 1
-    work_order: true
-    chapter: 6
-  - name: a tall metal mug
-    noun: mug
-    volume: 1
-    work_order: true
-    chapter: 6
-  - name: a large metal horseshoe
-    noun: horseshoe
-    volume: 12
-    work_order: false
-    chapter: 6
-  - name: some metal barbells
-    noun: barbells
-    volume: 80
-    work_order: false
-    chapter: 6
-  - name: a back scratcher
-    noun: scratcher
-    volume: 3
-    work_order: true
-    chapter: 6
-  - name: a metal bolt box
-    noun: box
-    volume: 10
-    work_order: false
-    chapter: 6
-  - name: a metal origami case
-    noun: case
-    volume: 12
-    work_order: false
-    chapter: 6
-  - name: a metal lockpick case
-    noun: case
-    volume: 12
-    work_order: false
-    chapter: 6
-  - name: a metal ankle band
-    noun: band
-    volume: 4
-    work_order: true
-    chapter: 6
-  - name: a small metal flask
-    noun: flask
-    volume: 5
-    work_order: true
-    chapter: 6
-  - name: a metal talisman case
-    noun: case
-    volume: 5
-    work_order: true
-    chapter: 6
-  - name: a metal razor
-    noun: razor
-    volume: 2
-    work_order: true
-    chapter: 6
-  - name: a metal flights box
-    noun: box
-    volume: 10
-    work_order: false
-    chapter: 6
-  - name: a metal jewelry box
-    noun: box
-    volume: 4
-    work_order: true
-    chapter: 6
-  - name: a metal herbal case
-    noun: case
-    volume: 8
-    work_order: false
-    chapter: 6
-  - name: a metal lockpick ring
-    noun: ring
-    volume: 2
-    work_order: true
-    chapter: 6
-  - name: a metal oil lantern
-    noun: lantern
-    volume: 6
-    work_order: false
-    chapter: 6
-  - name: a metal flask
-    noun: flask
-    volume: 5
-    work_order: true
-    chapter: 6
-  - name: a metal chest
-    noun: chest
-    volume: 12
-    work_order: false
-    chapter: 6
-  - name: a metal instrument case
-    noun: case
-    volume: 8
-    work_order: false
-    chapter: 6
-  - name: a metal armband
-    noun: armband
-    volume: 4
-    work_order: true
-    chapter: 6
-  - name: a large metal flask
-    noun: flask
-    volume: 7
-    work_order: false
-    chapter: 6
-  - name: some metal clippers
-    noun: clippers
-    volume: 2
-    work_order: true
-    chapter: 6
-  - name: a metal starchart tube
-    noun: tube
-    volume: 8
-    work_order: false
-    chapter: 6
-    part:
-    - short cord
-  - name: a metal backtube
-    noun: backtube
-    volume: 10
-    work_order: false
-    chapter: 6
-    part:
-    - long cord
-  - name: a metal crown
-    noun: crown
-    volume: 10
-    work_order: false
-    chapter: 6
-  - name: a metal mask
-    noun: mask
-    volume: 5
-    work_order: false
-    chapter: 6
-    part:
-    - short cord
-  - name: a metal torque
-    noun: torque
-    volume: 5
-    work_order: true
-    chapter: 6
-  - name: a metal headdress
-    noun: headdress
-    volume: 10
-    work_order: false
-    chapter: 6
-  # Weaponsmithing Chapter 1 recipes
-weaponsmithing:
-  - name: a metal briquet
-    noun: briquet
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal carving knife
-    noun: knife
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal dagger
-    noun: dagger
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal misericorde
-    noun: misericorde
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal katar
-    noun: katar
-    volume: 3
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal short sword
-    noun: sword
-    volume: 3
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal pugio
-    noun: pugio
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal poignard
-    noun: poignard
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal stiletto
-    noun: stiletto
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal dart
-    noun: dart
-    volume: 2
-    work_order: true
-    chapter: 1
-  - name: a metal throwing dagger
-    noun: dagger
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal falcata
-    noun: falcata
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal nehlata
-    noun: nehlata
-    volume: 4
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal telek
-    noun: telek
-    volume: 2
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal leaf blade sword
-    noun: sword
-    volume: 4
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal jambiya
-    noun: jambiya
-    volume: 4
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal takouba
-    noun: takouba
-    volume: 3
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal kris
-    noun: kris
-    volume: 4
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal thrusting blade
-    noun: blade
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal pasabas
-    noun: pasabas
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal rapier
-    noun: rapier
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal koummya
-    noun: koummya
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal oben
-    noun: oben
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal kythe
-    noun: kythe
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal dao
-    noun: dao
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal kasai
-    noun: kasai
-    volume: 3
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal sunblade
-    noun: sunblade
-    volume: 3
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal foil
-    noun: foil
-    volume: 5
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal baselard
-    noun: baselard
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal gladius
-    noun: gladius
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal mambeli
-    noun: mambeli
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal sashqa
-    noun: sashqa
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal adze
-    noun: adze
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal curlade
-    noun: curlade
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal parang
-    noun: parang
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal hanger
-    noun: hanger
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal sabre
-    noun: sabre
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal scimitar
-    noun: scimitar
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal shotel
-    noun: shotel
-    volume: 7
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal cutlass
-    noun: cutlass
-    volume: 7
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal hatchet
-    noun: hatchet
-    volume: 7
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  - name: a metal hand axe
-    noun: axe
-    volume: 7
-    work_order: true
-    chapter: 1
-    part:
-    - haft
-  - name: a light throwing axe
-    noun: axe
-    volume: 6
-    work_order: true
-    chapter: 1
-    part:
-    - haft
-  - name: a metal iltesh
-    noun: iltesh
-    volume: 7
-    work_order: true
-    chapter: 1
-    part:
-    - hilt
-  # Weaponsmithing Chapter 2 recipes
-  - name: a metal condottiere
-    noun: condottiere
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal nehdalata
-    noun: nehdalata
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal round axe
-    noun: axe
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - haft
-  - name: a metal longsword
-    noun: longsword
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal spatha
-    noun: spatha
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal kudalata
-    noun: kudalata
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal arzfilt
-    noun: arzfilt
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal broadsword
-    noun: broadsword
-    volume: 7
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal schiavona
-    noun: schiavona
-    volume: 9
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal falchion
-    noun: falchion
-    volume: 9
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal robe sword
-    noun: sword
-    volume: 9
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal battle axe
-    noun: axe
-    volume: 9
-    work_order: true
-    chapter: 2
-    part:
-    - haft
-  - name: a metal recade
-    noun: recade
-    volume: 8
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal back-sword
-    noun: back-sword
-    volume: 8
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal nimsha
-    noun: nimsha
-    volume: 8
-    work_order: false
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal hunting sword
-    noun: sword
-    volume: 8
-    work_order: false
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal namkomba
-    noun: namkomba
-    volume: 8
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal dagesse
-    noun: dagesse
-    volume: 8
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal abassi
-    noun: abassi
-    volume: 8
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal cinquedea
-    noun: cinquedea
-    volume: 8
-    work_order: true
-    chapter: 2
-    part:
-    - hilt
-  - name: a metal hurling axe
-    noun: axe
-    volume: 8
-    work_order: true
-    chapter: 2
-    part:
-    - haft
-  # Weaponsmithing Chapter 3 recipes
-  - name: a metal twin-point axe
-    noun: axe
-    volume: 14
-    work_order: true
-    chapter: 3
-    part:
-    - haft
-  - name: a metal karambit
-    noun: karambit
-    volume: 14
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal claymore
-    noun: claymore
-    volume: 14
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal greataxe
-    noun: greataxe
-    volume: 12
-    work_order: true
-    chapter: 3
-    part:
-    - haft
-  - name: a metal marauder blade
-    noun: blade
-    volume: 12
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal warring axe
-    noun: axe
-    volume: 12
-    work_order: true
-    chapter: 3
-    part:
-    - haft
-  - name: a metal two-handed sword
-    noun: sword
-    volume: 12
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal double axe
-    noun: axe
-    volume: 18
-    work_order: true
-    chapter: 3
-    part:
-    - haft
-  - name: a metal periperiu sword
-    noun: sword
-    volume: 18
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal flamberge
-    noun: flamberge
-    volume: 18
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal greatsword
-    noun: greatsword
-    volume: 18
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal shh'oi'ata
-    noun: shh'oi'ata
-    volume: 15
-    work_order: true
-    chapter: 3
-    part:
-    - haft
-  - name: a metal kaskara
-    noun: kaskara
-    volume: 15
-    work_order: true
-    chapter: 3
-    part:
-    - hilt
-  - name: a metal igorat axe
-    noun: axe
-    volume: 15
-    work_order: true
-    chapter: 3
-    part:
-    - haft
-  # Weaponsmithing Chapter 4 recipes
-  - name: a metal gavel
-    noun: gavel
-    volume: 4
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal cosh
-    noun: cosh
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a metal prod
-    noun: prod
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a metal cudgel
-    noun: cudgel
-    volume: 4
-    work_order: true
-    chapter: 4
-  - name: a metal zubke
-    noun: zubke
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal scepter
-    noun: scepter
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal hand mallet
-    noun: mallet
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal bludgeon
-    noun: bludgeon
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal garz
-    noun: garz
-    volume: 6
-    work_order: true
-    chapter: 4
-  - name: a ridged metal gauntlet
-    noun: gauntlet
-    volume: 6
-    work_order: true
-    chapter: 4
-  - name: a metal hand mace
-    noun: mace
-    volume: 6
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal club
-    noun: club
-    volume: 6
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a short metal hammer
-    noun: hammer
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a spiked metal gauntlet
-    noun: gauntlet
-    volume: 5
-    work_order: true
-    chapter: 4
-  - name: a metal bulhawf
-    noun: bulhawf
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal cuska
-    noun: cuska
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal bola
-    noun: bola
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - long cord
-  - name: a metal throwing club
-    noun: club
-    volume: 5
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal mallet
-    noun: mallet
-    volume: 7
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal war club
-    noun: club
-    volume: 7
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal boko
-    noun: boko
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: a metal boomerang
-    noun: boomerang
-    volume: 3
-    work_order: true
-    chapter: 4
-  - name: a metal war hammer
-    noun: hammer
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal belaying pin
-    noun: pin
-    volume: 8
-    work_order: true
-    chapter: 4
-  - name: a metal mace
-    noun: mace
-    volume: 8
-    work_order: true
-    chapter: 4
-  - name: a metal marlingspike
-    noun: marlingspike
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a spiked metal mace
-    noun: mace
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a spiked metal hammer
-    noun: hammer
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a spiked metal club
-    noun: club
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal hhr'tami
-    noun: hhr'tami
-    volume: 7
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal komno
-    noun: komno
-    volume: 7
-    work_order: true
-    chapter: 4
-    part:
-    - haft
-  - name: a metal k'trinni sha-tai
-    noun: sha-tai
-    volume: 9
-    work_order: true
-    chapter: 4
-  - name: a flanged metal mace
-    noun: mace
-    volume: 9
-    work_order: true
-    chapter: 4
-  # Weaponsmithing Chapter 5 recipes
-  - name: a metal imperial war hammer
-    noun: hammer
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a heavy metal mace
-    noun: mace
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal greathammer
-    noun: greathammer
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal ball and chain
-    noun: chain
-    volume: 9
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a heavy metal chain
-    noun: chain
-    volume: 9
-    work_order: true
-    chapter: 5
-  - name: a metal horseman's flail
-    noun: flail
-    volume: 9
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal ukabi
-    noun: ukabi
-    volume: 11
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a spiked ball and chain
-    noun: ukabi
-    volume: 11
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a spiked metal hara
-    noun: hara
-    volume: 11
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal morning star
-    noun: star
-    volume: 11
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal sledgehammer
-    noun: sledgehammer
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a heavy metal mallet
-    noun: mallet
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal hara
-    noun: mallet
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a double-headed hammer
-    noun: mallet
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal hhr'ata
-    noun: hhr'ata
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a hurlable war hammer
-    noun: hammer
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal throwing mallet
-    noun: mallet
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  - name: a metal throwing hammer
-    noun: hammer
-    volume: 10
-    work_order: true
-    chapter: 5
-    part:
-    - haft
-  # Weaponsmithing Chapter 6 recipes
-  - name: a metal vilks kodur
-    noun: kodur
-    volume: 14
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a metal war mattock
-    noun: mattock
-    volume: 14
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: double-sided ball and chain
-    noun: chain
-    volume: 13
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a metal akabo
-    noun: akabo
-    volume: 13
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a metal footman's flail
-    noun: flail
-    volume: 13
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a metal dire mace
-    noun: mace
-    volume: 16
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a heavy sledgehammer
-    noun: sledgehammer
-    volume: 16
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a metal maul
-    noun: maul
-    volume: 16
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a metal two-headed hammer
-    noun: hammer
-    volume: 15
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  - name: a giant metal mallet
-    noun: hammer
-    volume: 15
-    work_order: true
-    chapter: 6
-    part:
-    - haft
-  # Weaponsmithing Chapter 7 recipes
-  - name: a light metal spear
-    noun: spear
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal javelin
-    noun: javelin
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal spear
-    noun: spear
-    volume: 10
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal allarh
-    noun: allarh
-    volume: 10
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal hunthsleg
-    noun: hunthsleg
-    volume: 10
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal awgravet ava
-    noun: ava
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal coresca
-    noun: coresca
-    volume: 12
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal tzece
-    noun: tzece
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal halberd
-    noun: halberd
-    volume: 12
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal guisarme
-    noun: guisarme
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal lochaber axe
-    noun: axe
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal bardiche
-    noun: bardiche
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal scythe
-    noun: scythe
-    volume: 7
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal duraka skefne
-    noun: skefne
-    volume: 10
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal military fork
-    noun: fork
-    volume: 10
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal partisan
-    noun: partisan
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal khuj
-    noun: khuj
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a two-pronged halberd
-    noun: halberd
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal glaive
-    noun: glaive
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal ngalio
-    noun: ngalio
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal fauchard
-    noun: fauchard
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal pole axe
-    noun: axe
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal ilglaiks skefne
-    noun: skefne
-    volume: 15
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal ranseur
-    noun: ranseur
-    volume: 15
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal spetum
-    noun: spetum
-    volume: 15
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal lance
-    noun: lance
-    volume: 15
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal pike
-    noun: pike
-    volume: 15
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a metal voulge
-    noun: voulge
-    volume: 13
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  - name: a short-hafted halberd
-    noun: halberd
-    volume: 9
-    work_order: true
-    chapter: 7
-    part:
-    - short pole
-  - name: a metal awl pike
-    noun: pike
-    volume: 15
-    work_order: true
-    chapter: 7
-    part:
-    - long pole
-  # Weaponsmithing Chapter 8 recipes
-  - name: a metal nightstick
-    noun: nightstick
-    volume: 7
-    work_order: true
-    chapter: 8
-  - name: a metal cane
-    noun: cane
-    volume: 8
-    work_order: true
-    chapter: 8
-  - name: a metal quarterstaff
-    noun: quarterstaff
-    volume: 10
-    work_order: true
-    chapter: 8
-  - name: a metal pike staff
-    noun: staff
-    volume: 11
-    work_order: true
-    chapter: 8
-  - name: some metal knuckles
-    noun: knuckles
-    volume: 4
-    work_order: true
-    chapter: 8
-  - name: some weighted metal footwraps
-    noun: footwraps
-    volume: 4
-    work_order: true
-    chapter: 8
-  - name: some metal knee spikes
-    noun: spikes
-    volume: 4
-    work_order: true
-    chapter: 8
-    part:
-    - short cord
-  - name: some metal elbow spikes
-    noun: spikes
-    volume: 4
-    work_order: true
-    chapter: 8
-    part:
-    - short cord
-  - name: some spiked metal footwraps
-    noun: footwraps
-    volume: 4
-    work_order: true
-    chapter: 8
-  - name: some spiked metal knuckles
-    noun: knuckles
-    volume: 4
-    work_order: true
-    chapter: 8
-  - name: a weighted staff
-    noun: staff
-    volume: 10
-    work_order: true
-    chapter: 8
-  - name: some metal hand claws
-    noun: claws
-    volume: 4
-    work_order: true
-    chapter: 8
-    part:
-    - short cord
-  # Weaponsmithing Chapter 9 recipes
-  - name: a metal throwing spike
-    noun: spike
-    volume: 4
-    work_order: true
-    chapter: 9
-  - name: a metal bar mace
-    noun: mace
-    volume: 12
-    work_order: true
-    chapter: 9
-    part:
-    - haft
-  - name: a metal broadaxe
-    noun: broadaxe
-    volume: 9
-    work_order: true
-    chapter: 9
-    part:
-    - haft
-  - name: a metal war sword
-    noun: sword
-    volume: 9
-    work_order: true
-    chapter: 9
-    part:
-    - hilt
-  - name: a metal bastard sword
-    noun: sword
-    volume: 9
-    work_order: true
-    chapter: 9
-    part:
-    - hilt
-  - name: a metal boarding axe
-    noun: axe
-    volume: 10
-    work_order: true
-    chapter: 9
-    part:
-    - hilt
-  - name: a metal splitting maul
-    noun: maul
-    volume: 15
-    work_order: true
-    chapter: 9
-    part:
-    - haft
-  - name: a thin-bladed metal fan
-    noun: fan
-    volume: 4
-    work_order: true
-    chapter: 9
-  - name: a metal half-handled riste
-    noun: riste
-    volume: 7
-    work_order: true
-    chapter: 9
-    part:
-    - hilt
-  - name: a thick-bladed metal fan
-    noun: fan
-    volume: 6
-    work_order: true
-    chapter: 9
-  - name: a metal riste
-    noun: riste
-    volume: 9
-    work_order: true
-    chapter: 9
-    part:
-    - hilt
-carving:
+crafting_recipes:
+##### Page numbers are as of 2/20/2021 15:48 ET #####
+##################################
+##### Forging section begins #####
+##################################
+# Armorsmithing Chapter 1 recipes
+- name: a metal ring aventail
+  noun: aventail
+  volume: 5
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring mask
+  noun: mask
+  volume: 3
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain aventail
+  noun: aventail
+  volume: 6
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring cap
+  noun: cap
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain mask
+  noun: mask
+  volume: 4
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal ring gloves
+  noun: gloves
+  volume: 6
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal ring greaves
+  noun: greaves
+  volume: 12
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring helm
+  noun: helm
+  volume: 12
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal mail aventail
+  noun: aventail
+  volume: 7
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain cap
+  noun: cap
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal mail mask
+  noun: mask
+  volume: 5
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain gloves
+  noun: gloves
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal mail gloves
+  noun: gloves
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring tasset
+  noun: tasset
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal ring vambraces
+  noun: vambraces
+  volume: 19
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain greaves
+  noun: greaves
+  volume: 15
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring balaclava
+  noun: balaclava
+  volume: 16
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain helm
+  noun: helm
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal mail cap
+  noun: cap
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring lorica
+  noun: lorica
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+- name: a metal ring mantle
+  noun: mantle
+  volume: 21
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal ring vest
+  noun: vest
+  volume: 18
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+- name: a metal chain tasset
+  noun: tasset
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal ring sleeves
+  noun: sleeves
+  volume: 21
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain vambraces
+  noun: vambraces
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal mail greaves
+  noun: greaves
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain balaclava
+  noun: balaclava
+  volume: 20
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - small padding
+- name: a metal mail helm
+  noun: helm
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a mail balaclava
+  noun: balaclava
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small backing
+- name: a metal ring shirt
+  noun: shirt
+  volume: 43
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal ring robe
+  noun: robe
+  volume: 38
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal chain lorica
+  noun: lorica
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal chain mantle
+  noun: mantle
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal chain vest
+  noun: vest
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal mail tasset
+  noun: tasset
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal chain sleeves
+  noun: sleeves
+  volume: 26
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: some metal mail vambraces
+  noun: vambraces
+  volume: 23
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal ring hauberk
+  noun: hauberk
+  volume: 70
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal chain shirt
+  noun: shirt
+  volume: 50
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal chain robe
+  noun: robe
+  volume: 45
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal mail lorica
+  noun: lorica
+  volume: 34
+  type: armorsmithing
+  work_order: false
+  chapter: 1
+  part:
+  - large padding
+- name: a metal mail mantle
+  noun: mantle
+  volume: 27
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: a metal mail vest
+  noun: vest
+  volume: 22
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+- name: some metal mail sleeves
+  noun: sleeves
+  volume: 31
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - small padding
+- name: a metal chain hauberk
+  noun: hauberk
+  volume: 80
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal mail shirt
+  noun: shirt
+  volume: 57
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal mail robe
+  noun: robe
+  volume: 52
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+- name: a metal mail hauberk
+  noun: hauberk
+  volume: 90
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal bar-mail hauberk
+  noun: hauberk
+  volume: 90
+  type: armorsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - large padding
+  - small padding
+  - small padding
+# Armorsmithing Chapter 2 recipes
+- name: a metal scale aventail
+  noun: aventail
+  volume: 9
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale mask
+  noun: mask
+  volume: 5
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale cap
+  noun: cap
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine aventail
+  noun: aventail
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine mask
+  noun: mask
+  volume: 6
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some metal scale gloves
+  noun: gloves
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale helm
+  noun: helm
+  volume: 21
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine cap
+  noun: cap
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal lamellar aventail
+  noun: aventail
+  volume: 11
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: a metal lamellar mask
+  noun: mask
+  volume: 7
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some metal scale greaves
+  noun: greaves
+  volume: 15
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: some brigandine gloves
+  noun: gloves
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale tasset
+  noun: tasset
+  volume: 10
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some metal scale vambraces
+  noun: vambraces
+  volume: 22
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale balaclava
+  noun: balaclava
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal brigandine helm
+  noun: helm
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal lamellar cap
+  noun: cap
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some brigandine greaves
+  noun: greaves
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some metal lamellar gloves
+  noun: gloves
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: a metal brigandine tasset
+  noun: tasset
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: some brigandine vambraces
+  noun: vambraces
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a brigandine balaclava
+  noun: balaclava
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal lamellar helm
+  noun: helm
+  volume: 27
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some lamellar greaves
+  noun: greaves
+  volume: 18
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: some metal scale sleeves
+  noun: sleeves
+  volume: 30
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale lorica
+  noun: lorica
+  volume: 34
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale mantle
+  noun: mantle
+  volume: 33
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale vest
+  noun: vest
+  volume: 24
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal lamellar tasset
+  noun: tasset
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: some lamellar vambraces
+  noun: vambraces
+  volume: 28
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: a metal lamellar balaclava
+  noun: balaclava
+  volume: 34
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small backing
+- name: some brigandine sleeves
+  noun: sleeves
+  volume: 35
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - small padding
+- name: a metal scale shirt
+  noun: shirt
+  volume: 56
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale robe
+  noun: robe
+  volume: 49
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+- name: a metal brigandine lorica
+  noun: lorica
+  volume: 38
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal brigandine mantle
+  noun: mantle
+  volume: 36
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal brigandine vest
+  noun: vest
+  volume: 26
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: some lamellar sleeves
+  noun: sleeves
+  volume: 40
+  type: armorsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - small backing
+- name: a brigandine robe
+  noun: robe
+  volume: 56
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+- name: a brigandine shirt
+  noun: shirt
+  volume: 63
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a metal scale hauberk
+  noun: hauberk
+  volume: 80
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal lamellar lorica
+  noun: lorica
+  volume: 42
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+- name: a metal lamellar mantle
+  noun: mantle
+  volume: 39
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+- name: a metal lamellar vest
+  noun: vest
+  volume: 28
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+- name: a metal lamellar robe
+  noun: robe
+  volume: 63
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+  - small backing
+- name: a brigandine hauberk
+  noun: hauberk
+  volume: 90
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+  - small padding
+  - small padding
+- name: a metal lamellar shirt
+  noun: shirt
+  volume: 70
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large padding
+- name: a lamellar hauberk
+  noun: hauberk
+  volume: 100
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+  - small backing
+  - small backing
+- name: a laminar hauberk
+  noun: hauberk
+  volume: 100
+  type: armorsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - large backing
+  - small backing
+  - small backing
+# Armorsmithing Chapter 3 recipes
+- name: a light plate aventail
+  noun: aventail
+  volume: 12
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a light plate mask
+  noun: mask
+  volume: 7
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some light plate gauntlets
+  noun: gauntlets
+  volume: 13
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a plate aventail
+  noun: aventail
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal dome helm
+  noun: helm
+  volume: 16
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a plate mask
+  noun: mask
+  volume: 8
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a metal bascinet
+  noun: bascinet
+  volume: 23
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some plate gauntlets
+  noun: gauntlets
+  volume: 15
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a heavy plate aventail
+  noun: aventail
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal morion
+  noun: morion
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a heavy plate mask
+  noun: mask
+  volume: 9
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a light plate fauld
+  noun: fauld
+  volume: 13
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small padding
+- name: a light backplate
+  noun: backplate
+  volume: 10
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some light plate vambraces
+  noun: vambraces
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a metal visored helm
+  noun: helm
+  volume: 26
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: heavy plate gauntlets
+  noun: gauntlets
+  volume: 17
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: a metal barbute
+  noun: barbute
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: some light plate greaves
+  noun: greaves
+  volume: 19
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a metal sallet
+  noun: sallet
+  volume: 35
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a light breastplate
+  noun: breastplate
+  volume: 16
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: a plate fauld
+  noun: fauld
+  volume: 15
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal backplate
+  noun: backplate
+  volume: 12
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: some light plate sleeves
+  noun: sleeves
+  volume: 39
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+- name: some plate vambraces
+  noun: vambraces
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: some plate greaves
+  noun: greaves
+  volume: 22
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal armet
+  noun: armet
+  volume: 40
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: a metal closed helm
+  noun: helm
+  volume: 29
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a light plate cuirass
+  noun: cuirass
+  volume: 39
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - large padding
+- name: a metal breastplate
+  noun: breastplate
+  volume: 18
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a heavy plate fauld
+  noun: fauld
+  volume: 17
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: a metal heavy backplate
+  noun: backplate
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some plate sleeves
+  noun: sleeves
+  volume: 45
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some heavy plate vambraces
+  noun: vambraces
+  volume: 34
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some heavy plate greaves
+  noun: greaves
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - small backing
+- name: a metal great helm
+  noun: helm
+  volume: 45
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some light half plate
+  noun: plate
+  volume: 65
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+  - large padding
+- name: some light field plate
+  noun: plate
+  volume: 58
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+  - large padding
+- name: a plate cuirass
+  noun: cuirass
+  volume: 45
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+- name: a heavy breastplate
+  noun: breastplate
+  volume: 20
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some heavy plate sleeves
+  noun: sleeves
+  volume: 51
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+- name: some light full plate
+  noun: plate
+  volume: 100
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small padding
+  - small padding
+  - large padding
+- name: some half plate
+  noun: plate
+  volume: 75
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+  - large backing
+- name: some field plate
+  noun: plate
+  volume: 67
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - small backing
+  - large backing
+- name: a heavy plate cuirass
+  noun: cuirass
+  volume: 51
+  type: armorsmithing
+  work_order: false
+  chapter: 3
+  part:
+  - large backing
+- name: some heavy half plate
+  noun: plate
+  volume: 85
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large padding
+  - small padding
+- name: some full plate
+  noun: plate
+  volume: 110
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+  - small backing
+- name: some heavy field plate
+  noun: plate
+  volume: 76
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+- name: some heavy full plate
+  noun: plate
+  volume: 120
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+  - small backing
+- name: some heavy fluted plate
+  noun: plate
+  volume: 120
+  type: armorsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - large backing
+  - small backing
+  - small backing
+# Armorsmithing Chapter 4 recipes
+- name: a metal shield handle
+  noun: handle
+  volume: 2
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+- name: a metal shield boss
+  noun: boss
+  volume: 3
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+- name: a metal target shield
+  noun: shield
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal round sipar
+  noun: sipar
+  volume: 14
+  type: armorsmithing
+  work_order: false
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal ordinary shield
+  noun: shield
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal targe
+  noun: targe
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal triangular sipar
+  noun: sipar
+  volume: 14
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal medium shield
+  noun: shield
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal ceremonial shield
+  noun: shield
+  volume: 16
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal curved shield
+  noun: shield
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal circular buckler
+  noun: buckler
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal medium buckler
+  noun: buckler
+  volume: 20
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal oval shield
+  noun: shield
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a simple parry stick
+  noun: stick
+  volume: 7
+  type: armorsmithing
+  work_order: false
+  chapter: 4
+  part:
+  - small backing
+- name: a metal jousting shield
+  noun: shield
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal skirmisher's shield
+  noun: shield
+  volume: 25
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal kite shield
+  noun: shield
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal warrior's shield
+  noun: shield
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal valnik shield
+  noun: shield
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal tower shield
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal battle shield
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal heater shield
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal aegis
+  noun: aegis
+  volume: 30
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+- name: a metal war shield
+  noun: shield
+  volume: 40
+  type: armorsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - shield handle
+  - long cord
+# Blacksmithing Chapter 2 recipes
+- name: a diagonal-peen mallet
+  noun: mallet
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a curved metal shovel
+  noun: shovel
+  volume: 8
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - long pole
+- name: a diagonal-peen hammer
+  noun: hammer
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - short pole
+- name: a stout metal pickaxe
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some straight metal tongs
+  noun: tongs
+  volume: 10
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+- name: a metal cross-peen hammer
+  noun: hammer
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a narrow metal pickaxe
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: a square metal shovel
+  noun: shovel
+  volume: 8
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - long pole
+- name: some curved metal tongs
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: some flat-bladed tongs
+  noun: tongs
+  volume: 10
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+- name: a tapered metal shovel
+  noun: shovel
+  volume: 8
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - long pole
+- name: some angular metal tongs
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: a straight-peen hammer
+  noun: hammer
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a straight-peen mallet
+  noun: mallet
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - short pole
+- name: a slender metal pickaxe
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some metal bolt tongs
+  noun: tongs
+  volume: 10
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+- name: a flat-headed metal pickaxe
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: a sturdy metal shovel
+  noun: shovel
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: a ball-peen hammer
+  noun: hammer
+  volume: 12
+  chapter: 2
+  type: blacksmithing
+  work_order: false
+  part:
+  - short pole
+- name: a wide metal shovel
+  noun: shovel
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some segmented tongs
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: a weighted metal pickaxe
+  noun: pickaxe
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - long pole
+- name: some box-jaw tongs
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: some articulated tongs
+  noun: tongs
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+- name: a ball-peen mallet
+  noun: mallet
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 2
+  part:
+  - short pole
+# Blacksmithing Chapter 3 recipes
+- name: a short metal drawknife
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: some short metal chisels
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: a long metal drawknife
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: a metal straight wood saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal straight bone saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a thin metal rasp
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some square metal rifflers
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: some long metal chisels
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: a flat metal shaper
+  noun: shaper
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: some plain metal pliers
+  noun: pliers
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: some squat metal rifflers
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: thin metal tinker's tools
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: a rough metal wood shaper
+  noun: shaper
+  volume: 4
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a sturdy metal drawknife
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: a metal curved wood saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal curved bone saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some curved metal pliers
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a coarse metal rasp
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some sturdy metal chisels
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: curved metal tinker's tools
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: some curved metal rifflers
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: some reinforced chisels
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: a sharpened metal drawknife
+  noun: drawknife
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+  part:
+  - short pole
+- name: a metal slender wood saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal slender bone saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some rough metal pliers
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a textured metal rasp
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal beveled wood shaper
+  noun: shaper
+  volume: 4
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: some thick metal pliers
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a flat metal rasp
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some elongated rifflers
+  noun: rifflers
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: some sharpened chisels
+  noun: chisels
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+  part:
+  - short cord
+- name: thick metal tinker's tools
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+- name: a metal tapered wood saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal tapered bone saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: some hooked metal pliers
+  noun: pliers
+  volume: 5
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a tapered metal rasp
+  noun: rasp
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal jagged wood shaper
+  noun: shaper
+  volume: 4
+  chapter: 3
+  type: blacksmithing
+  work_order: true
+- name: a metal serrated wood saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: a metal serrated bone saw
+  noun: saw
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 3
+- name: precise metal tinker's tools
+  noun: tools
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 3
+# Blacksmithing Chapter 4 recipes
+- name: a stout metal yardstick
+  noun: yardstick
+  volume: 6
+  chapter: 4
+  type: blacksmithing
+  work_order: false
+- name: some smooth knitting needles
+  noun: needles
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a metal hide scraper
+  noun: scraper
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some straight metal scissors
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some plain sewing needles
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some curved metal scissors
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a flat metal yardstick
+  noun: yardstick
+  volume: 6
+  chapter: 4
+  type: blacksmithing
+  work_order: false
+- name: some tapered knitting needles
+  noun: needles
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a pointed metal awl
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a curved hide scraper
+  noun: scraper
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some ribbed sewing needles
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some bent metal scissors
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a rectangular yardstick
+  noun: yardstick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 4
+- name: some knobby sewing needles
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some squat knitting needles
+  noun: needles
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a narrow metal awl
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some polished knitting needles
+  noun: needles
+  volume: 4
+  chapter: 4
+  type: blacksmithing
+  work_order: true
+- name: a compact metal awl
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a serrated hide scraper
+  noun: scraper
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some serrated scissors
+  noun: scissors
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: a detailed yardstick
+  noun: yardstick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 4
+- name: a slender metal awl
+  noun: awl
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+- name: some thin sewing needles
+  noun: needles
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 4
+# Blacksmithing Chapter 5 recipes
+- name: a small metal brazier
+  noun: brazier
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a tapered pestle
+  noun: pestle
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a flat mixing stick
+  noun: stick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a square wire sieve
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a tapered mixing stick
+  noun: stick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a flat pestle
+  noun: pestle
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a metal brazier
+  noun: brazier
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a triangular wire sieve
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a round mixing stick
+  noun: stick
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a round pestle
+  noun: pestle
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a grooved pestle
+  noun: pestle
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: an oblong wire sieve
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+- name: a grooved mixing stick
+  noun: stick
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 5
+- name: a trapezoidal wire sieve
+  noun: sieve
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 5
+# Blacksmithing Chapter 6 recipes
+- name: a metal rod
+  noun: rod
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a shallow metal cup
+  noun: cup
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal horseshoe
+  noun: horseshoe
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a soft metal keyblank
+  noun: keyblank
+  volume: 2
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a short metal mug
+  noun: mug
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a tall metal mug
+  noun: mug
+  volume: 1
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a large metal horseshoe
+  noun: horseshoe
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: some metal barbells
+  noun: barbells
+  volume: 80
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a back scratcher
+  noun: scratcher
+  volume: 3
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal bolt box
+  noun: box
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal origami case
+  noun: case
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal lockpick case
+  noun: case
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal ankle band
+  noun: band
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a small metal flask
+  noun: flask
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal talisman case
+  noun: case
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal razor
+  noun: razor
+  volume: 2
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal flights box
+  noun: box
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal jewelry box
+  noun: box
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal herbal case
+  noun: case
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal lockpick ring
+  noun: ring
+  volume: 2
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal oil lantern
+  noun: lantern
+  volume: 6
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal flask
+  noun: flask
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal chest
+  noun: chest
+  volume: 12
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal instrument case
+  noun: case
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal armband
+  noun: armband
+  volume: 4
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a large metal flask
+  noun: flask
+  volume: 7
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: some metal clippers
+  noun: clippers
+  volume: 2
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal starchart tube
+  noun: tube
+  volume: 8
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+  part:
+  - short cord
+- name: a metal backtube
+  noun: backtube
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+  part:
+  - long cord
+- name: a metal crown
+  noun: crown
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+- name: a metal mask
+  noun: mask
+  volume: 5
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+  part:
+  - short cord
+- name: a metal torque
+  noun: torque
+  volume: 5
+  type: blacksmithing
+  work_order: true
+  chapter: 6
+- name: a metal headdress
+  noun: headdress
+  volume: 10
+  type: blacksmithing
+  work_order: false
+  chapter: 6
+# Weaponsmithing Chapter 1 recipes
+- name: a metal briquet
+  noun: briquet
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal carving knife
+  noun: knife
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal dagger
+  noun: dagger
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal misericorde
+  noun: misericorde
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal katar
+  noun: katar
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal short sword
+  noun: sword
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal pugio
+  noun: pugio
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal poignard
+  noun: poignard
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal stiletto
+  noun: stiletto
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal dart
+  noun: dart
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+- name: a metal throwing dagger
+  noun: dagger
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal falcata
+  noun: falcata
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal nehlata
+  noun: nehlata
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal telek
+  noun: telek
+  volume: 2
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal leaf blade sword
+  noun: sword
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal jambiya
+  noun: jambiya
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal takouba
+  noun: takouba
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal kris
+  noun: kris
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal thrusting blade
+  noun: blade
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal pasabas
+  noun: pasabas
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal rapier
+  noun: rapier
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal koummya
+  noun: koummya
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal oben
+  noun: oben
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal kythe
+  noun: kythe
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal dao
+  noun: dao
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal kasai
+  noun: kasai
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal sunblade
+  noun: sunblade
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal foil
+  noun: foil
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal baselard
+  noun: baselard
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal gladius
+  noun: gladius
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal mambeli
+  noun: mambeli
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal sashqa
+  noun: sashqa
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal adze
+  noun: adze
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal curlade
+  noun: curlade
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal parang
+  noun: parang
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal hanger
+  noun: hanger
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal sabre
+  noun: sabre
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal scimitar
+  noun: scimitar
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal shotel
+  noun: shotel
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal cutlass
+  noun: cutlass
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal hatchet
+  noun: hatchet
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+- name: a metal hand axe
+  noun: axe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - haft
+- name: a light throwing axe
+  noun: axe
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - haft
+- name: a metal iltesh
+  noun: iltesh
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 1
+  part:
+  - hilt
+# Weaponsmithing Chapter 2 recipes
+- name: a metal condottiere
+  noun: condottiere
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal nehdalata
+  noun: nehdalata
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal round axe
+  noun: axe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - haft
+- name: a metal longsword
+  noun: longsword
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal spatha
+  noun: spatha
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal kudalata
+  noun: kudalata
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal arzfilt
+  noun: arzfilt
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal broadsword
+  noun: broadsword
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal schiavona
+  noun: schiavona
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal falchion
+  noun: falchion
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal robe sword
+  noun: sword
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal battle axe
+  noun: axe
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - haft
+- name: a metal recade
+  noun: recade
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal back-sword
+  noun: back-sword
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal nimsha
+  noun: nimsha
+  volume: 8
+  type: weaponsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - hilt
+- name: a metal hunting sword
+  noun: sword
+  volume: 8
+  type: weaponsmithing
+  work_order: false
+  chapter: 2
+  part:
+  - hilt
+- name: a metal namkomba
+  noun: namkomba
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal dagesse
+  noun: dagesse
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal abassi
+  noun: abassi
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal cinquedea
+  noun: cinquedea
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - hilt
+- name: a metal hurling axe
+  noun: axe
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 2
+  part:
+  - haft
+# Weaponsmithing Chapter 3 recipes
+- name: a metal twin-point axe
+  noun: axe
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal karambit
+  noun: karambit
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal claymore
+  noun: claymore
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal greataxe
+  noun: greataxe
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal marauder blade
+  noun: blade
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal warring axe
+  noun: axe
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal two-handed sword
+  noun: sword
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal double axe
+  noun: axe
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal periperiu sword
+  noun: sword
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal flamberge
+  noun: flamberge
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal greatsword
+  noun: greatsword
+  volume: 18
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal shh'oi'ata
+  noun: shh'oi'ata
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+- name: a metal kaskara
+  noun: kaskara
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - hilt
+- name: a metal igorat axe
+  noun: axe
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 3
+  part:
+  - haft
+# Weaponsmithing Chapter 4 recipes
+- name: a metal gavel
+  noun: gavel
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal cosh
+  noun: cosh
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal prod
+  noun: prod
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal cudgel
+  noun: cudgel
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal zubke
+  noun: zubke
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal scepter
+  noun: scepter
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal hand mallet
+  noun: mallet
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal bludgeon
+  noun: bludgeon
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal garz
+  noun: garz
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a ridged metal gauntlet
+  noun: gauntlet
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal hand mace
+  noun: mace
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal club
+  noun: club
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a short metal hammer
+  noun: hammer
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal gauntlet
+  noun: gauntlet
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal bulhawf
+  noun: bulhawf
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal cuska
+  noun: cuska
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal bola
+  noun: bola
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - long cord
+- name: a metal throwing club
+  noun: club
+  volume: 5
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal mallet
+  noun: mallet
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal war club
+  noun: club
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal boko
+  noun: boko
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal boomerang
+  noun: boomerang
+  volume: 3
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal war hammer
+  noun: hammer
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal belaying pin
+  noun: pin
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal mace
+  noun: mace
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a metal marlingspike
+  noun: marlingspike
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal mace
+  noun: mace
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal hammer
+  noun: hammer
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a spiked metal club
+  noun: club
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal hhr'tami
+  noun: hhr'tami
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal komno
+  noun: komno
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+  part:
+  - haft
+- name: a metal k'trinni sha-tai
+  noun: sha-tai
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+- name: a flanged metal mace
+  noun: mace
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 4
+# Weaponsmithing Chapter 5 recipes
+- name: a metal imperial war hammer
+  noun: hammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a heavy metal mace
+  noun: mace
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal greathammer
+  noun: greathammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal ball and chain
+  noun: ball
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a heavy metal chain
+  noun: chain
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+- name: a metal horseman's flail
+  noun: flail
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal ukabi
+  noun: ukabi
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a spiked ball and chain
+  noun: ball
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a spiked metal hara
+  noun: hara
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal morning star
+  noun: star
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal sledgehammer
+  noun: sledgehammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a heavy metal mallet
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal hara
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a double-headed hammer
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal hhr'ata
+  noun: hhr'ata
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a hurlable war hammer
+  noun: hammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal throwing mallet
+  noun: mallet
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+- name: a metal throwing hammer
+  noun: hammer
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 5
+  part:
+  - haft
+# Weaponsmithing Chapter 6 recipes
+- name: a metal vilks kodur
+  noun: kodur
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal war mattock
+  noun: mattock
+  volume: 14
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: double-sided ball and chain
+  noun: ball
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal akabo
+  noun: akabo
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal footman's flail
+  noun: flail
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal dire mace
+  noun: mace
+  volume: 16
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a heavy sledgehammer
+  noun: sledgehammer
+  volume: 16
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal maul
+  noun: maul
+  volume: 16
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a metal two-headed hammer
+  noun: hammer
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+- name: a giant metal mallet
+  noun: mallet
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 6
+  part:
+  - haft
+# Weaponsmithing Chapter 7 recipes
+- name: a light metal spear
+  noun: spear
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal javelin
+  noun: javelin
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal spear
+  noun: spear
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal allarh
+  noun: allarh
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal hunthsleg
+  noun: hunthsleg
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal awgravet ava
+  noun: ava
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal coresca
+  noun: coresca
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal tzece
+  noun: tzece
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal halberd
+  noun: halberd
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal guisarme
+  noun: guisarme
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal lochaber axe
+  noun: axe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal bardiche
+  noun: bardiche
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal scythe
+  noun: scythe
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal duraka skefne
+  noun: skefne
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal military fork
+  noun: fork
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal partisan
+  noun: partisan
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal khuj
+  noun: khuj
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a two-pronged halberd
+  noun: halberd
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal glaive
+  noun: glaive
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal ngalio
+  noun: ngalio
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal fauchard
+  noun: fauchard
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal pole axe
+  noun: axe
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal ilglaiks skefne
+  noun: skefne
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal ranseur
+  noun: ranseur
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal spetum
+  noun: spetum
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal lance
+  noun: lance
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal pike
+  noun: pike
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a metal voulge
+  noun: voulge
+  volume: 13
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+- name: a short-hafted halberd
+  noun: halberd
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - short pole
+- name: a metal awl pike
+  noun: pike
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 7
+  part:
+  - long pole
+# Weaponsmithing Chapter 8 recipes
+- name: a metal nightstick
+  noun: nightstick
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: a metal cane
+  noun: cane
+  volume: 8
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: a metal quarterstaff
+  noun: quarterstaff
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: a metal pike staff
+  noun: staff
+  volume: 11
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some metal knuckles
+  noun: knuckles
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some weighted metal footwraps
+  noun: footwraps
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some metal knee spikes
+  noun: spikes
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+  part:
+  - short cord
+- name: some metal elbow spikes
+  noun: spikes
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+  part:
+  - short cord
+- name: some spiked metal footwraps
+  noun: footwraps
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some spiked metal knuckles
+  noun: knuckles
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: a weighted staff
+  noun: staff
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+- name: some metal hand claws
+  noun: claws
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 8
+  part:
+  - short cord
+# Weaponsmithing Chapter 9 recipes
+- name: a metal throwing spike
+  noun: spike
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+- name: a metal bar mace
+  noun: mace
+  volume: 12
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - haft
+- name: a metal broadaxe
+  noun: broadaxe
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - haft
+- name: a metal war sword
+  noun: sword
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - hilt
+- name: a metal bastard sword
+  noun: sword
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - hilt
+- name: a metal boarding axe
+  noun: axe
+  volume: 10
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - hilt
+- name: a metal splitting maul
+  noun: maul
+  volume: 15
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - haft
+- name: a thin-bladed metal fan
+  noun: fan
+  volume: 4
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+- name: a metal half-handled riste
+  noun: riste
+  volume: 7
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - hilt
+- name: a thick-bladed metal fan
+  noun: fan
+  volume: 6
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+- name: a metal riste
+  noun: riste
+  volume: 9
+  type: weaponsmithing
+  work_order: true
+  chapter: 9
+  part:
+  - hilt
+###############################
+##### Forging section end #####
+###############################
 ######################################
 ##### Engineering section begins #####
 ######################################
 # Carving Chapter 1 recipes
-  - name: a small stone block
-    noun: block
-    work_order: true
-    chapter: 1
-    volume: 3
-    material: stone
-  - name: a large stone block
-    noun: block
-    work_order: false
-    chapter: 1
-    volume: 5
-    material: stone
-  - name: a thin stone slab
-    noun: slab
-    work_order: true
-    chapter: 1
-    volume: 3
-    material: stone
-  - name: a short stone pole
-    noun: pole
-    work_order: true
-    chapter: 1
-    volume: 3
-    material: stone
-  - name: a thick stone slab
-    noun: slab
-    work_order: false
-    chapter: 1
-    volume: 5
-    material: stone
-  - name: a smooth slickstone
-    noun: slickstone
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  - name: a stout stone stirring rod
-    noun: rod
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  - name: a shallow stone basin
-    noun: basin
-    work_order: true
-    chapter: 1
-    volume: 3
-    material: stone
-  - name: a long stone pole
-    noun: pole
-    work_order: false
-    chapter: 1
-    volume: 5
-    material: stone
-  - name: slender stone stirring rod
-    noun: rod
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  - name: a deep stone basin
-    noun: basin
-    work_order: false
-    chapter: 1
-    volume: 5
-    material: stone
-  - name: a small stone sphere
-    noun: sphere
-    work_order: true
-    chapter: 1
-    volume: 2
-    material: stone
-  - name: a flat slickstone
-    noun: slickstone
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  - name: a large stone sphere
-    noun: sphere
-    work_order: false
-    chapter: 1
-    volume: 5
-    material: stone
-  - name: grooved stone stirring rod
-    noun: rod
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  - name: a polished slickstone
-    noun: slickstone
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  - name: notched stone stirring rod
-    noun: rod
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  - name: a forked stone stirring rod
-    noun: rod
-    work_order: false
-    chapter: 1
-    volume: 4
-    material: stone
-  # Carving Chapter 3 recipes
-  - name: some smooth stones
-    noun: stones
-    work_order: true
-    chapter: 3
-    volume: 2
-    material: stone
-  - name: a stone bludgeon
-    noun: bludgeon
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-  - name: a stone carving knife
-    noun: knife
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-  - name: some elongated stones
-    noun: stones
-    work_order: true
-    chapter: 3
-    volume: 2
-    material: stone
-  - name: a stone hand axe
-    noun: axe
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-  - name: a stone war club
-    noun: club
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - short pole
-  - name: some balanced stones
-    noun: stones
-    work_order: true
-    chapter: 3
-    volume: 2
-    material: stone
-  - name: a stone war hammer
-    noun: hammer
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - short pole
-  - name: some stone spikes
-    noun: spikes
-    work_order: true
-    chapter: 3
-    volume: 2
-    material: stone
-  - name: some stone shards
-    noun: shards
-    work_order: true
-    chapter: 3
-    volume: 2
-    material: stone
-  - name: a stone bola
-    noun: bola
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - long cord
-  - name: a stone hand sword
-    noun: sword
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-  - name: a heavy stone mallet
-    noun: mallet
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - long pole
-  - name: a stone javelin
-    noun: javelin
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - long pole
-  - name: a stone spear
-    noun: spear
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - long pole
-  - name: a stone war mattock
-    noun: mattock
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - long pole
-  - name: a stone maul
-    noun: maul
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - long pole
-  - name: a stone flail
-    noun: flail
-    work_order: true
-    chapter: 3
-    volume: 3
-    material: stone
-    part:
-    - long cord
-    - long pole
-  # Carving Chapter 4 recipes
-  - name: a stone band
-    noun: band
-    work_order: true
-    chapter: 4
-    volume: 1
-    material: stone
-  - name: a stone toe ring
-    noun: ring
-    work_order: true
-    chapter: 4
-    volume: 1
-    material: stone
-  - name: a stone nose ring
-    noun: ring
-    work_order: true
-    chapter: 4
-    volume: 1
-    material: stone
-  - name: a stone pin
-    noun: pin
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone anklet
-    noun: anklet
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone bracelet
-    noun: bracelet
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone tailband
-    noun: tailband
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: a stone hairpin
-    noun: hairpin
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone cloak pin
-    noun: pin
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a pair of stone earrings
-    noun: earrings
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone medallion
-    noun: medallion
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone amulet
-    noun: amulet
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone pendant
-    noun: pendant
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-    part:
-    - short cord
-  - name: a stone brooch
-    noun: brooch
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone earcuff
-    noun: earcuff
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone belt buckle
-    noun: buckle
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-  - name: a stone armband
-    noun: armband
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: an articulated stone bracelet
-    noun: bracelet
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: a stone tiara
-    noun: tiara
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: a stone locket
-    noun: locket
-    work_order: true
-    chapter: 4
-    volume: 2
-    material: stone
-    part:
-    - short cord
-  - name: a stone choker
-    noun: choker
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: a stone diadem
-    noun: diadem
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: a stone circlet
-    noun: circlet
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-    part:
-    - short cord
-  - name: an articulated stone necklace
-    noun: necklace
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: a stone crown
-    noun: crown
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-  - name: an articulated stone belt
-    noun: belt
-    work_order: false
-    chapter: 4
-    volume: 4
-    material: stone
-  - name: a stone mask
-    noun: mask
-    work_order: true
-    chapter: 4
-    volume: 3
-    material: stone
-    part:
-    - short cord
-  - name: a segmented stone shirt
-    noun: shirt
-    work_order: false
-    chapter: 4
-    volume: 5
-    material: stone
-  # Carving Chapter 5 recipes
-  - name: a bone bead
-    noun: bead
-    work_order: true
-    chapter: 5
-    volume: 1
-    material: bone
-  - name: a stone bead
-    noun: bead
-    work_order: true
-    chapter: 5
-    volume: 1
-    material: stone
-  - name: a detailed bone bead
-    noun: bead
-    work_order: true
-    chapter: 5
-    volume: 1
-    material: bone
-  - name: a detailed stone bead
-    noun: bead
-    work_order: true
-    chapter: 5
-    volume: 1
-    material: stone
-  - name: a bone totem
-    noun: totem
-    work_order: true
-    chapter: 5
-    volume: 2
-    material: bone
-  - name: a stone totem
-    noun: totem
-    work_order: true
-    chapter: 5
-    volume: 2
-    material: stone
-  - name: a detailed bone totem
-    noun: totem
-    work_order: true
-    chapter: 5
-    volume: 2
-    material: bone
-  - name: a detailed stone totem
-    noun: totem
-    work_order: true
-    chapter: 5
-    volume: 2
-    material: stone
-  - name: a bone figurine
-    noun: figurine
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: bone
-  - name: a stone figurine
-    noun: figurine
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: stone
-  - name: a basic runestone
-    noun: runestone
-    work_order: true
-    chapter: 5
-    volume: 1
-    material: stone
-  - name: a bone wand
-    noun: wand
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: bone
-  - name: a stone wand
-    noun: wand
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: stone
-  - name: a bone rod
-    noun: rod
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: bone
-  - name: a stone rod
-    noun: rod
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: stone
-  - name: a detailed bone figurine
-    noun: figurine
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: bone
-  - name: a detailed stone figurine
-    noun: figurine
-    work_order: true
-    chapter: 5
-    volume: 3
-    material: stone
-  - name: a bone statuette
-    noun: statuette
-    work_order: false
-    chapter: 5
-    volume: 4
-    material: bone
-  - name: a stone statuette
-    noun: statuette
-    work_order: false
-    chapter: 5
-    volume: 4
-    material: stone
-  - name: a fine runestone
-    noun: runestone
-    work_order: true
-    chapter: 5
-    volume: 1
-    material: stone
-  - name: a detailed bone statuette
-    noun: statuette
-    work_order: false
-    chapter: 5
-    volume: 8
-    material: bone
-  - name: detailed stone statuette
-    noun: statuette
-    work_order: false
-    chapter: 5
-    volume: 4
-    material: stone
-  - name: a bone statue
-    noun: statue
-    work_order: false
-    chapter: 5
-    volume: 20
-    material: bone
-  - name: a stone statue
-    noun: statue
-    work_order: false
-    chapter: 5
-    volume: 4
-    material: stone
-  - name: a detailed bone statue
-    noun: statue
-    work_order: false
-    chapter: 5
-    volume: 20
-    material: bone
-  - name: a detailed statue
-    noun: statue
-    work_order: false
-    chapter: 5
-    volume: 4
-    material: stone
-  - name: an ornate runestone
-    noun: runestone
-    work_order: true
-    chapter: 5
-    volume: 1
-    material: stone
-  # Carving Chapter 6 recipes
-  - name: a short bone pole
-    noun: pole
-    work_order: true
-    chapter: 6
-    volume: 4
-    material: bone
-  - name: a simple bone burin
-    noun: burin
-    work_order: true
-    chapter: 6
-    volume: 4
-    material: bone
-  - name: a long bone pole
-    noun: pole
-    work_order: true
-    chapter: 6
-    volume: 6
-    material: bone
-  - name: a fine bone burin
-    noun: burin
-    work_order: true
-    chapter: 6
-    volume: 4
-    material: bone
-  - name: an ornate bone burin
-    noun: burin
-    work_order: true
-    chapter: 6
-    volume: 4
-    material: bone
-  # Carving Chapter 8 recipes
-  - name: a bone bludgeon
-    noun: bludgeon
-    work_order: true
-    chapter: 8
-    volume: 5
-    material: bone
-  - name: a bone carving knife
-    noun: knife
-    work_order: true
-    chapter: 8
-    volume: 2
-    material: bone
-  - name: a bone hand axe
-    noun: axe
-    work_order: true
-    chapter: 8
-    volume: 6
-    material: bone
-  - name: a bone war club
-    noun: club
-    work_order: true
-    chapter: 8
-    volume: 7
-    material: bone
-  - name: a bone shiv
-    noun: shiv
-    work_order: true
-    chapter: 8
-    volume: 3
-    material: bone
-  - name: a bone hand sword
-    noun: sword
-    work_order: true
-    chapter: 8
-    volume: 4
-    material: bone
-  - name: a bone mallet
-    noun: mallet
-    work_order: true
-    chapter: 8
-    volume: 8
-    material: bone
-  - name: a bone javelin
-    noun: javelin
-    work_order: true
-    chapter: 8
-    volume: 8
-    material: bone
-  - name: a light bone spear
-    noun: spear
-    work_order: true
-    chapter: 8
-    volume: 7
-    material: bone
-  - name: a bone maul
-    noun: maul
-    work_order: true
-    chapter: 8
-    volume: 16
-    material: bone
-  - name: a bone mattock
-    noun: mattock
-    work_order: true
-    chapter: 8
-    volume: 17
-    material: bone
-  - name: a bone flail
-    noun: flail
-    work_order: true
-    chapter: 8
-    volume: 11
-    material: bone
-  # Carving Chapter 9 recipes
-  - name: a bone band
-    noun: band
-    work_order: true
-    chapter: 9
-    volume: 1
-    material: bone
-  - name: a bone nose ring
-    noun: ring
-    work_order: true
-    chapter: 9
-    volume: 1
-    material: bone
-  - name: a bone toe ring
-    noun: ring
-    work_order: true
-    chapter: 9
-    volume: 1
-    material: bone
-  - name: a bone bracelet
-    noun: bracelet
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone anklet
-    noun: anklet
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone pin
-    noun: pin
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone cloak pin
-    noun: pin
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone hairpin
-    noun: hairpin
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone tailband
-    noun: tailband
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: a shallow bone cup
-    noun: cup
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone pendant
-    noun: pendant
-    work_order: true
-    chapter: 9
-    volume: 1
-    material: bone
-    part:
-    - short cord
-  - name: a bone amulet
-    noun: amulet
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone medallion
-    noun: medallion
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a pair of bone earrings
-    noun: earrings
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone earcuff
-    noun: earcuff
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone brooch
-    noun: brooch
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone armband
-    noun: armband
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: a bone belt buckle
-    noun: buckle
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone choker
-    noun: choker
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: a bone locket
-    noun: locket
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-    part:
-    - short cord
-  - name: a bone tiara
-    noun: tiara
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: an articulated bone bracelet
-    noun: bracelet
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: some bone bangles
-    noun: bangles
-    work_order: true
-    chapter: 9
-    volume: 5
-    material: bone
-  - name: an articulated bone necklace
-    noun: necklace
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: a bone circlet
-    noun: circlet
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-    part:
-    - short cord
-  - name: a bone crown
-    noun: crown
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: a bone comb
-    noun: comb
-    work_order: true
-    chapter: 9
-    volume: 2
-    material: bone
-  - name: a bone haircomb
-    noun: haircomb
-    work_order: true
-    chapter: 9
-    volume: 3
-    material: bone
-  - name: a paneled shirt
-    noun: shirt
-    work_order: true
-    chapter: 9
-    volume: 13
-    material: bone
-  # Carving Chapter 10 recipes
-  - name: a segmented bone aventail
-    noun: aventail
-    work_order: true
-    chapter: 10
-    volume: 4
-    material: bone
-  - name: a segmented bone mask
-    noun: mask
-    work_order: true
-    chapter: 10
-    volume: 3
-    material: bone
-  - name: some segmented bone gloves
-    noun: gloves
-    work_order: true
-    chapter: 10
-    volume: 5
-    material: bone
-  - name: a segmented bone cap
-    noun: cap
-    work_order: true
-    chapter: 10
-    volume: 8
-    material: bone
-  - name: a notched bone aventail
-    noun: aventail
-    work_order: true
-    chapter: 10
-    volume: 4
-    material: bone
-  - name: a notched bone mask
-    noun: mask
-    work_order: true
-    chapter: 10
-    volume: 3
-    material: bone
-  - name: a segmented bone helm
-    noun: helm
-    work_order: true
-    chapter: 10
-    volume: 10
-    material: bone
-  - name: some notched bone gloves
-    noun: gloves
-    work_order: true
-    chapter: 10
-    volume: 5
-    material: bone
-  - name: a notched bone cap
-    noun: cap
-    work_order: true
-    chapter: 10
-    volume: 8
-    material: bone
-  - name: a ribbed bone aventail
-    noun: aventail
-    work_order: true
-    chapter: 10
-    volume: 4
-    material: bone
-  - name: a ribbed bone mask
-    noun: mask
-    work_order: true
-    chapter: 10
-    volume: 3
-    material: bone
-  - name: a segmented bone tasset
-    noun: tasset
-    work_order: true
-    chapter: 10
-    volume: 10
-    material: bone
-  - name: some segmented vambraces
-    noun: vambraces
-    work_order: true
-    chapter: 10
-    volume: 16
-    material: bone
-  - name: some segmented bone greaves
-    noun: greaves
-    work_order: true
-    chapter: 10
-    volume: 12
-    material: bone
-  - name: a segmented bone balaclava
-    noun: balaclava
-    work_order: true
-    chapter: 10
-    volume: 12
-    material: bone
-  - name: a notched bone helm
-    noun: helm
-    work_order: true
-    chapter: 10
-    volume: 10
-    material: bone
-  - name: some ribbed bone gloves
-    noun: gloves
-    work_order: true
-    chapter: 10
-    volume: 5
-    material: bone
-  - name: a ribbed bone cap
-    noun: cap
-    work_order: true
-    chapter: 10
-    volume: 8
-    material: bone
-  - name: a segmented bone tabard
-    noun: tabard
-    work_order: true
-    chapter: 10
-    volume: 30
-    material: bone
-  - name: a segmented bone mantle
-    noun: mantle
-    work_order: true
-    chapter: 10
-    volume: 24
-    material: bone
-  - name: a segmented bone vest
-    noun: vest
-    work_order: true
-    chapter: 10
-    volume: 20
-    material: bone
-  - name: a notched bone tasset
-    noun: tasset
-    work_order: true
-    chapter: 10
-    volume: 10
-    material: bone
-  - name: some segmented bone sleeves
-    noun: sleeves
-    work_order: true
-    chapter: 10
-    volume: 21
-    material: bone
-  - name: some notched vambraces
-    noun: vambraces
-    work_order: true
-    chapter: 10
-    volume: 16
-    material: bone
-  - name: some notched bone greaves
-    noun: greaves
-    work_order: true
-    chapter: 10
-    volume: 12
-    material: bone
-  - name: a notched bone balaclava
-    noun: balaclava
-    work_order: true
-    chapter: 10
-    volume: 12
-    material: bone
-  - name: a ribbed bone helm
-    noun: helm
-    work_order: true
-    chapter: 10
-    volume: 10
-    material: bone
-  - name: a segmented bone coat
-    noun: coat
-    work_order: true
-    chapter: 10
-    volume: 46
-    material: bone
-  - name: a segmented bone robe
-    noun: robe
-    work_order: true
-    chapter: 10
-    volume: 42
-    material: bone
-  - name: a notched bone tabard
-    noun: tabard
-    work_order: true
-    chapter: 10
-    volume: 30
-    material: bone
-  - name: a notched bone mantle
-    noun: mantle
-    work_order: true
-    chapter: 10
-    volume: 24
-    material: bone
-  - name: a notched bone vest
-    noun: vest
-    work_order: true
-    chapter: 10
-    volume: 20
-    material: bone
-  - name: a ribbed bone tasset
-    noun: tasset
-    work_order: true
-    chapter: 10
-    volume: 10
-    material: bone
-  - name: some notched bone sleeves
-    noun: sleeves
-    work_order: true
-    chapter: 10
-    volume: 21
-    material: bone
-  - name: some ribbed vambraces
-    noun: vambraces
-    work_order: true
-    chapter: 10
-    volume: 16
-    material: bone
-  - name: some ribbed bone greaves
-    noun: greaves
-    work_order: true
-    chapter: 10
-    volume: 12
-    material: bone
-  - name: a ribbed bone balaclava
-    noun: balaclava
-    work_order: true
-    chapter: 10
-    volume: 12
-    material: bone
-  - name: a segmented bone hauberk
-    noun: hauberk
-    work_order: true
-    chapter: 10
-    volume: 58
-    material: bone
-  - name: a notched bone coat
-    noun: coat
-    work_order: true
-    chapter: 10
-    volume: 46
-    material: bone
-  - name: a notched bone robe
-    noun: robe
-    work_order: true
-    chapter: 10
-    volume: 42
-    material: bone
-  - name: a ribbed bone tabard
-    noun: tabard
-    work_order: true
-    chapter: 10
-    volume: 30
-    material: bone
-  - name: a ribbed bone mantle
-    noun: mantle
-    work_order: true
-    chapter: 10
-    volume: 24
-    material: bone
-  - name: a ribbed bone vest
-    noun: vest
-    work_order: true
-    chapter: 10
-    volume: 20
-    material: bone
-  - name: some ribbed bone sleeves
-    noun: sleeves
-    work_order: true
-    chapter: 10
-    volume: 21
-    material: bone
-  - name: a notched bone hauberk
-    noun: hauberk
-    work_order: true
-    chapter: 10
-    volume: 58
-    material: bone
-  - name: a ribbed bone coat
-    noun: coat
-    work_order: true
-    chapter: 10
-    volume: 46
-    material: bone
-  - name: a ribbed bone robe
-    noun: robe
-    work_order: true
-    chapter: 10
-    volume: 42
-    material: bone
-  - name: a ribbed bone hauberk
-    noun: hauberk
-    work_order: true
-    chapter: 10
-    volume: 58
-    material: bone
-shaping:
+- name: a small stone block
+  noun: block
+  work_order: true
+  type: carving
+  chapter: 1
+  volume: 3
+  material: stone
+- name: a large stone block
+  noun: block
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 5
+  material: stone
+- name: a thin stone slab
+  noun: slab
+  work_order: true
+  type: carving
+  chapter: 1
+  volume: 3
+  material: stone
+- name: a short stone pole
+  noun: pole
+  work_order: true
+  type: carving
+  chapter: 1
+  volume: 3
+  material: stone
+- name: a thick stone slab
+  noun: slab
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 5
+  material: stone
+- name: a smooth slickstone
+  noun: slickstone
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+- name: a stout stone stirring rod
+  noun: rod
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+- name: a shallow stone basin
+  noun: basin
+  work_order: true
+  type: carving
+  chapter: 1
+  volume: 3
+  material: stone
+- name: a long stone pole
+  noun: pole
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 5
+  material: stone
+- name: slender stone stirring rod
+  noun: rod
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+- name: a deep stone basin
+  noun: basin
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 5
+  material: stone
+- name: a small stone sphere
+  noun: sphere
+  work_order: true
+  type: carving
+  chapter: 1
+  volume: 2
+  material: stone
+- name: a flat slickstone
+  noun: slickstone
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+- name: a large stone sphere
+  noun: sphere
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 5
+  material: stone
+- name: grooved stone stirring rod
+  noun: rod
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+- name: a polished slickstone
+  noun: slickstone
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+- name: notched stone stirring rod
+  noun: rod
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+- name: a forked stone stirring rod
+  noun: rod
+  work_order: false
+  type: carving
+  chapter: 1
+  volume: 4
+  material: stone
+# Carving Chapter 3 recipes
+- name: some smooth stones
+  noun: stones
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 2
+  material: stone
+- name: a stone bludgeon
+  noun: bludgeon
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+- name: a stone carving knife
+  noun: knife
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+- name: some elongated stones
+  noun: stones
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 2
+  material: stone
+- name: a stone hand axe
+  noun: axe
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+- name: a stone war club
+  noun: club
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - short pole
+- name: some balanced stones
+  noun: stones
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 2
+  material: stone
+- name: a stone war hammer
+  noun: hammer
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - short pole
+- name: some stone spikes
+  noun: spikes
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 2
+  material: stone
+- name: some stone shards
+  noun: shards
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 2
+  material: stone
+- name: a stone bola
+  noun: bola
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - long cord
+- name: a stone hand sword
+  noun: sword
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+- name: a heavy stone mallet
+  noun: mallet
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - long pole
+- name: a stone javelin
+  noun: javelin
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - long pole
+- name: a stone spear
+  noun: spear
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - long pole
+- name: a stone war mattock
+  noun: mattock
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - long pole
+- name: a stone maul
+  noun: maul
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - long pole
+- name: a stone flail
+  noun: flail
+  work_order: true
+  type: carving
+  chapter: 3
+  volume: 3
+  material: stone
+  part:
+  - long cord
+  - long pole
+# Carving Chapter 4 recipes
+- name: a stone band
+  noun: band
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 1
+  material: stone
+- name: a stone toe ring
+  noun: ring
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 1
+  material: stone
+- name: a stone nose ring
+  noun: ring
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 1
+  material: stone
+- name: a stone pin
+  noun: pin
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone anklet
+  noun: anklet
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone bracelet
+  noun: bracelet
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone tailband
+  noun: tailband
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: a stone hairpin
+  noun: hairpin
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone cloak pin
+  noun: pin
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a pair of stone earrings
+  noun: earrings
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone medallion
+  noun: medallion
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone amulet
+  noun: amulet
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone pendant
+  noun: pendant
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+  part:
+  - short cord
+- name: a stone brooch
+  noun: brooch
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone earcuff
+  noun: earcuff
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone belt buckle
+  noun: buckle
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+- name: a stone armband
+  noun: armband
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: an articulated stone bracelet
+  noun: bracelet
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: a stone tiara
+  noun: tiara
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: a stone locket
+  noun: locket
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 2
+  material: stone
+  part:
+  - short cord
+- name: a stone choker
+  noun: choker
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: a stone diadem
+  noun: diadem
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: a stone circlet
+  noun: circlet
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+  part:
+  - short cord
+- name: an articulated stone necklace
+  noun: necklace
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: a stone crown
+  noun: crown
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+- name: an articulated stone belt
+  noun: belt
+  work_order: false
+  type: carving
+  chapter: 4
+  volume: 4
+  material: stone
+- name: a stone mask
+  noun: mask
+  work_order: true
+  type: carving
+  chapter: 4
+  volume: 3
+  material: stone
+  part:
+  - short cord
+- name: a segmented stone shirt
+  noun: shirt
+  work_order: false
+  type: carving
+  chapter: 4
+  volume: 5
+  material: stone
+# Carving Chapter 5 recipes
+- name: a bone bead
+  noun: bead
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 1
+  material: bone
+- name: a stone bead
+  noun: bead
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 1
+  material: stone
+- name: a detailed bone bead
+  noun: bead
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 1
+  material: bone
+- name: a detailed stone bead
+  noun: bead
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 1
+  material: stone
+- name: a bone totem
+  noun: totem
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 2
+  material: bone
+- name: a stone totem
+  noun: totem
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 2
+  material: stone
+- name: a detailed bone totem
+  noun: totem
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 2
+  material: bone
+- name: a detailed stone totem
+  noun: totem
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 2
+  material: stone
+- name: a bone figurine
+  noun: figurine
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: bone
+- name: a stone figurine
+  noun: figurine
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: stone
+- name: a basic runestone
+  noun: runestone
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 1
+  material: stone
+- name: a bone wand
+  noun: wand
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: bone
+- name: a stone wand
+  noun: wand
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: stone
+- name: a bone rod
+  noun: rod
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: bone
+- name: a stone rod
+  noun: rod
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: stone
+- name: a detailed bone figurine
+  noun: figurine
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: bone
+- name: a detailed stone figurine
+  noun: figurine
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 3
+  material: stone
+- name: a bone statuette
+  noun: statuette
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 4
+  material: bone
+- name: a stone statuette
+  noun: statuette
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 4
+  material: stone
+- name: a fine runestone
+  noun: runestone
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 1
+  material: stone
+- name: a detailed bone statuette
+  noun: statuette
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 8
+  material: bone
+- name: detailed stone statuette
+  noun: statuette
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 4
+  material: stone
+- name: a bone statue
+  noun: statue
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 20
+  material: bone
+- name: a stone statue
+  noun: statue
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 4
+  material: stone
+- name: a detailed bone statue
+  noun: statue
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 20
+  material: bone
+- name: a detailed statue
+  noun: statue
+  work_order: false
+  type: carving
+  chapter: 5
+  volume: 4
+  material: stone
+- name: an ornate runestone
+  noun: runestone
+  work_order: true
+  type: carving
+  chapter: 5
+  volume: 1
+  material: stone
+# Carving Chapter 6 recipes
+- name: a short bone pole
+  noun: pole
+  work_order: true
+  type: carving
+  chapter: 6
+  volume: 4
+  material: bone
+- name: a simple bone burin
+  noun: burin
+  work_order: true
+  type: carving
+  chapter: 6
+  volume: 4
+  material: bone
+- name: a long bone pole
+  noun: pole
+  work_order: true
+  type: carving
+  chapter: 6
+  volume: 6
+  material: bone
+- name: a fine bone burin
+  noun: burin
+  work_order: true
+  type: carving
+  chapter: 6
+  volume: 4
+  material: bone
+- name: an ornate bone burin
+  noun: burin
+  work_order: true
+  type: carving
+  chapter: 6
+  volume: 4
+  material: bone
+# Carving Chapter 8 recipes
+- name: a bone bludgeon
+  noun: bludgeon
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 5
+  material: bone
+- name: a bone carving knife
+  noun: knife
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 2
+  material: bone
+- name: a bone hand axe
+  noun: axe
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 6
+  material: bone
+- name: a bone war club
+  noun: club
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 7
+  material: bone
+- name: a bone shiv
+  noun: shiv
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 3
+  material: bone
+- name: a bone hand sword
+  noun: sword
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 4
+  material: bone
+- name: a bone mallet
+  noun: mallet
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 8
+  material: bone
+- name: a bone javelin
+  noun: javelin
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 8
+  material: bone
+- name: a light bone spear
+  noun: spear
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 7
+  material: bone
+- name: a bone maul
+  noun: maul
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 16
+  material: bone
+- name: a bone mattock
+  noun: mattock
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 17
+  material: bone
+- name: a bone flail
+  noun: flail
+  work_order: true
+  type: carving
+  chapter: 8
+  volume: 11
+  material: bone
+# Carving Chapter 9 recipes
+- name: a bone band
+  noun: band
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 1
+  material: bone
+- name: a bone nose ring
+  noun: ring
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 1
+  material: bone
+- name: a bone toe ring
+  noun: ring
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 1
+  material: bone
+- name: a bone bracelet
+  noun: bracelet
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone anklet
+  noun: anklet
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone pin
+  noun: pin
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone cloak pin
+  noun: pin
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone hairpin
+  noun: hairpin
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone tailband
+  noun: tailband
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: a shallow bone cup
+  noun: cup
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone pendant
+  noun: pendant
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 1
+  material: bone
+  part:
+  - short cord
+- name: a bone amulet
+  noun: amulet
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone medallion
+  noun: medallion
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a pair of bone earrings
+  noun: earrings
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone earcuff
+  noun: earcuff
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone brooch
+  noun: brooch
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone armband
+  noun: armband
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: a bone belt buckle
+  noun: buckle
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone choker
+  noun: choker
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: a bone locket
+  noun: locket
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+  part:
+  - short cord
+- name: a bone tiara
+  noun: tiara
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: an articulated bone bracelet
+  noun: bracelet
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: some bone bangles
+  noun: bangles
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 5
+  material: bone
+- name: an articulated bone necklace
+  noun: necklace
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: a bone circlet
+  noun: circlet
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+  part:
+  - short cord
+- name: a bone crown
+  noun: crown
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: a bone comb
+  noun: comb
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 2
+  material: bone
+- name: a bone haircomb
+  noun: haircomb
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 3
+  material: bone
+- name: a paneled shirt
+  noun: shirt
+  work_order: true
+  type: carving
+  chapter: 9
+  volume: 13
+  material: bone
+# Carving Chapter 10 recipes
+- name: a segmented bone aventail
+  noun: aventail
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 4
+  material: bone
+- name: a segmented bone mask
+  noun: mask
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 3
+  material: bone
+- name: some segmented bone gloves
+  noun: gloves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 5
+  material: bone
+- name: a segmented bone cap
+  noun: cap
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 8
+  material: bone
+- name: a notched bone aventail
+  noun: aventail
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 4
+  material: bone
+- name: a notched bone mask
+  noun: mask
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 3
+  material: bone
+- name: a segmented bone helm
+  noun: helm
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 10
+  material: bone
+- name: some notched bone gloves
+  noun: gloves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 5
+  material: bone
+- name: a notched bone cap
+  noun: cap
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 8
+  material: bone
+- name: a ribbed bone aventail
+  noun: aventail
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 4
+  material: bone
+- name: a ribbed bone mask
+  noun: mask
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 3
+  material: bone
+- name: a segmented bone tasset
+  noun: tasset
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 10
+  material: bone
+- name: some segmented vambraces
+  noun: vambraces
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 16
+  material: bone
+- name: some segmented bone greaves
+  noun: greaves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 12
+  material: bone
+- name: a segmented bone balaclava
+  noun: balaclava
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 12
+  material: bone
+- name: a notched bone helm
+  noun: helm
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 10
+  material: bone
+- name: some ribbed bone gloves
+  noun: gloves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 5
+  material: bone
+- name: a ribbed bone cap
+  noun: cap
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 8
+  material: bone
+- name: a segmented bone tabard
+  noun: tabard
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 30
+  material: bone
+- name: a segmented bone mantle
+  noun: mantle
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 24
+  material: bone
+- name: a segmented bone vest
+  noun: vest
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 20
+  material: bone
+- name: a notched bone tasset
+  noun: tasset
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 10
+  material: bone
+- name: some segmented bone sleeves
+  noun: sleeves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 21
+  material: bone
+- name: some notched vambraces
+  noun: vambraces
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 16
+  material: bone
+- name: some notched bone greaves
+  noun: greaves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 12
+  material: bone
+- name: a notched bone balaclava
+  noun: balaclava
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 12
+  material: bone
+- name: a ribbed bone helm
+  noun: helm
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 10
+  material: bone
+- name: a segmented bone coat
+  noun: coat
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 46
+  material: bone
+- name: a segmented bone robe
+  noun: robe
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 42
+  material: bone
+- name: a notched bone tabard
+  noun: tabard
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 30
+  material: bone
+- name: a notched bone mantle
+  noun: mantle
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 24
+  material: bone
+- name: a notched bone vest
+  noun: vest
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 20
+  material: bone
+- name: a ribbed bone tasset
+  noun: tasset
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 10
+  material: bone
+- name: some notched bone sleeves
+  noun: sleeves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 21
+  material: bone
+- name: some ribbed vambraces
+  noun: vambraces
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 16
+  material: bone
+- name: some ribbed bone greaves
+  noun: greaves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 12
+  material: bone
+- name: a ribbed bone balaclava
+  noun: balaclava
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 12
+  material: bone
+- name: a segmented bone hauberk
+  noun: hauberk
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 58
+  material: bone
+- name: a notched bone coat
+  noun: coat
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 46
+  material: bone
+- name: a notched bone robe
+  noun: robe
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 42
+  material: bone
+- name: a ribbed bone tabard
+  noun: tabard
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 30
+  material: bone
+- name: a ribbed bone mantle
+  noun: mantle
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 24
+  material: bone
+- name: a ribbed bone vest
+  noun: vest
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 20
+  material: bone
+- name: some ribbed bone sleeves
+  noun: sleeves
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 21
+  material: bone
+- name: a notched bone hauberk
+  noun: hauberk
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 58
+  material: bone
+- name: a ribbed bone coat
+  noun: coat
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 46
+  material: bone
+- name: a ribbed bone robe
+  noun: robe
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 42
+  material: bone
+- name: a ribbed bone hauberk
+  noun: hauberk
+  work_order: true
+  type: carving
+  chapter: 10
+  volume: 58
+  material: bone
 # Shaping Chapter 2 recipes
-  - name: a toy bow
-    noun: bow
-    volume: 3
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a practice shortbow
-    noun: shortbow
-    volume: 4
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a simple shortbow
-    noun: shortbow
-    volume: 5
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a light shortbow
-    noun: shortbow
-    volume: 3
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a farmer's bow
-    noun: bow
-    volume: 4
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a shortbow
-    noun: shortbow
-    volume: 5
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a sturdy shortbow
-    noun: shortbow
-    volume: 6
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: an alpine shortbow
-    noun: shortbow
-    volume: 5
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a saddle bow
-    noun: bow
-    volume: 5
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a flight bow
-    noun: bow
-    volume: 5
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a steppe bow
-    noun: bow
-    volume: 6
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a battle shortbow
-    noun: shortbow
-    volume: 7
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a forester's shortbow
-    noun: shortbow
-    volume: 6
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a Nisha shortbow
-    noun: shortbow
-    volume: 5
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  - name: a competition shortbow
-    noun: shortbow
-    volume: 6
-    work_order: false
-    chapter: 2
-    part:
-      - bow string
-  # Shaping Chapter 3 recipes
-  - name: a simple longbow
-    noun: longbow
-    volume: 7
-    work_order: false
-    chapter: 3
-    part:
-      - bow string
-  - name: a practice longbow
-    noun: longbow
-    volume: 6
-    work_order: false
-    chapter: 3
-    part:
-      - bow string
-  - name: a longbow
-    noun: longbow
-    volume: 7
-    work_order: false
-    chapter: 3
-    part:
-      - bow string
-  - name: a sturdy longbow
-    noun: longbow
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-      - bow string
-  - name: a flatbow
-    noun: flatbow
-    volume: 7
-    work_order: true
-    chapter: 3
-    part:
-      - bow string
-  - name: a skirmisher's bow
-    noun: bow
-    volume: 7
-    work_order: false
-    chapter: 3
-    part:
-      - bow string
-  - name: a reflex longbow
-    noun: longbow
-    volume: 7
-    work_order: false
-    chapter: 3
-    part:
-      - bow string
-  - name: a self bow
-    noun: bow
-    volume: 7
-    work_order: true
-    chapter: 3
-    part:
-      - bow string
-  - name: a recurve longbow
-    noun: longbow
-    volume: 8
-    work_order: true
-    chapter: 3
-    part:
-      - bow string
-  - name: a forester's longbow
-    noun: longbow
-    volume: 8
-    work_order: false
-    chapter: 3
-    part:
-      - bow string
-  - name: a battle longbow
-    noun: longbow
-    volume: 8
-    work_order: true
-    chapter: 3
-    part:
-      - bow string
-  - name: a competition longbow
-    noun: longbow
-    volume: 8
-    work_order: true
-    chapter: 3
-    part:
-      - bow string
-  # Shaping Chapter 4 recipes
-  - name: a composite bow
-    noun: bow
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a double-backed bow
-    noun: bow
-    volume: 9
-    work_order: true
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a recurve bow
-    noun: bow
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a forester's bow
-    noun: bow
-    volume: 8
-    work_order: false
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a reflex bow
-    noun: bow
-    volume: 8
-    work_order: true
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a savannah bow
-    noun: bow
-    volume: 9
-    work_order: true
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a footman's bow
-    noun: bow
-    volume: 9
-    work_order: false
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a horseman's bow
-    noun: bow
-    volume: 9
-    work_order: false
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a battle bow
-    noun: bow
-    volume: 10
-    work_order: true
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  - name: a competition bow
-    noun: bow
-    volume: 10
-    work_order: true
-    chapter: 4
-    part:
-      - bow string
-      - bone backer
-  # Shaping Chapter 5 recipes are arrows and covered with the arrows.lic script.
-  # Shaping Chapter 6 recipes are Enhancements and Materials.
-  - name: a simple wood burin
-    noun: burin
-    work_order: true
-    chapter: 6
-    volume: 4
-  - name: a fine wood burin
-    noun: burin
-    work_order: true
-    chapter: 6
-    volume: 4
-  - name: an ornate wood burin
-    noun: burin
-    work_order: true
-    chapter: 6
-    volume: 4
-  # Shaping Chapter 7 recipes
-  - name: a wood band
-    noun: band
-    volume: 1
-    work_order: true
-    chapter: 7
-  - name: a wood nose ring
-    noun: ring
-    volume: 1
-    work_order: true
-    chapter: 7
-  - name: a wood toe ring
-    noun: ring
-    volume: 1
-    work_order: true
-    chapter: 7
-  - name: a wood bracelet
-    noun: bracelet
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood anklet
-    noun: anklet
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood pin
-    noun: pin
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood cloak pin
-    noun: pin
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a shallow wood cup
-    noun: cup
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood hairpin
-    noun: hairpin
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood tailband
-    noun: tailband
-    volume: 3
-    work_order: true
-    chapter: 7
-  - name: a wood pendant
-    noun: pendant
-    volume: 1
-    work_order: false
-    chapter: 7
-    part:
-    - short cord
-  - name: a wood amulet
-    noun: amulet
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood medallion
-    noun: medallion
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a pair of wood earrings
-    noun: earrings
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood earcuff
-    noun: earcuff
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood brooch
-    noun: brooch
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood armband
-    noun: armband
-    volume: 3
-    work_order: true
-    chapter: 7
-  - name: a wood belt buckle
-    noun: buckle
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood choker
-    noun: choker
-    volume: 3
-    work_order: true
-    chapter: 7
-  - name: a wood locket
-    noun: locket
-    volume: 2
-    work_order: false
-    chapter: 7
-    part:
-    - short cord
-  - name: some wood bangles
-    noun: bangles
-    volume: 5
-    work_order: true
-    chapter: 7
-  - name: a wood tiara
-    noun: tiara
-    volume: 3
-    work_order: true
-    chapter: 7
-  - name: an articulated wood bracelet
-    noun: bracelet
-    volume: 3
-    work_order: true
-    chapter: 7
-  - name: a wood circlet
-    noun: circlet
-    volume: 3
-    work_order: false
-    chapter: 7
-    part:
-    - short cord
-  - name: an articulated wood necklace
-    noun: necklace
-    volume: 3
-    work_order: true
-    chapter: 7
-  - name: a wood crown
-    noun: crown
-    volume: 3
-    work_order: true
-    chapter: 7
-  - name: a wood mask
-    noun: mask
-    volume: 3
-    work_order: false
-    chapter: 7
-    part:
-    - short cord
-  - name: a wood comb
-    noun: comb
-    volume: 2
-    work_order: true
-    chapter: 7
-  - name: a wood haircomb
-    noun: haircomb
-    volume: 3
-    work_order: true
-    chapter: 7
-  # Shaping Chapter 8 recipes
-  - name: a wood bead
-    noun: bead
-    volume: 1
-    work_order: false
-    chapter: 8
-  - name: a detailed wood bead
-    noun: bead
-    volume: 1
-    work_order: false
-    chapter: 8
-  - name: a wood totem
-    noun: totem
-    volume: 2
-    work_order: false
-    chapter: 8
-  - name: a detailed wood totem
-    noun: totem
-    volume: 2
-    work_order: false
-    chapter: 8
-  - name: a wood figurine
-    noun: figurine
-    volume: 3
-    work_order: false
-    chapter: 8
-  - name: a wood wand
-    noun: wand
-    volume: 3
-    work_order: false
-    chapter: 8
-  - name: a wood rod
-    noun: rod
-    volume: 3
-    work_order: false
-    chapter: 8
-  - name: a detailed wood figurine
-    noun: figurine
-    volume: 3
-    work_order: false
-    chapter: 8
-  - name: a wood statuette
-    noun: statuette
-    volume: 8
-    work_order: false
-    chapter: 8
-  - name: a detailed wood statuette
-    noun: statuette
-    volume: 8
-    work_order: false
-    chapter: 8
-  - name: a wood statue
-    noun: statue
-    volume: 20
-    work_order: false
-    chapter: 8
-  - name: a detailed wood statue
-    noun: statue
-    volume: 20
-    work_order: false
-    chapter: 8
-  # Shaping Chapter 9 recipes
-  - name: a wood cane
-    noun: cane
-    volume: 7
-    work_order: true
-    chapter: 9
-  - name: a wood nightstick
-    noun: nightstick
-    volume: 6
-    work_order: true
-    chapter: 9
-    part:
-    - leather strip
-  - name: a wood quarterstaff
-    noun: quarterstaff
-    volume: 9
-    work_order: true
-    chapter: 9
-  - name: a wood walking cane
-    noun: cane
-    volume: 6
-    work_order: true
-    chapter: 9
-  - name: a wood crook
-    noun: crook
-    volume: 5
-    work_order: true
-    chapter: 9
-  - name: a wood bo staff
-    noun: staff
-    volume: 8
-    work_order: true
-    chapter: 9
-    part:
-    - leather strip
-  - name: a weighted staff
-    noun: staff
-    volume: 9
-    work_order: true
-    chapter: 9
-    part:
-    - leather strip
-  # Shaping Chapter 10 recipes
-  - name: a rough wood table
-    noun: table
-    volume: 15
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a low wood table
-    noun: table
-    volume: 18
-    work_order: false
-    chapter: 10
-    part:
-    - short pole
-    - short pole
-    - short pole
-    - short pole
-  - name: a high wood table
-    noun: table
-    volume: 20
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a round wood table
-    noun: table
-    volume: 20
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a square wood table
-    noun: table
-    volume: 20
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a long wood table
-    noun: table
-    volume: 25
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: an oval wood table
-    noun: table
-    volume: 25
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a wood dining table
-    noun: table
-    volume: 30
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a wood buffet table
-    noun: table
-    volume: 30
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a wood refectory table
-    noun: table
-    volume: 30
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a wood parquet table
-    noun: table
-    volume: 32
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-  - name: a wood meditation table
-    noun: table
-    volume: 32
-    work_order: false
-    chapter: 10
-    part:
-    - long pole
-    - long pole
-    - long pole
-    - long pole
-tinkering:
-  # Tinkering Chapter 2
-  - name: a toy crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 6
-    part:
-    - mechanism
+- name: a toy bow
+  noun: bow
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a practice crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 7
-    part:
-    - mechanism
+- name: a practice shortbow
+  noun: shortbow
+  volume: 4
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a simple crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 7
-    part:
-    - mechanism
-    - mechanism
+- name: a simple shortbow
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a slim crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 6
-    part:
-    - mechanism
+- name: a light shortbow
+  noun: shortbow
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a farmer's crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 7
-    part:
-    - mechanism
-    - mechanism
+- name: a farmer's bow
+  noun: bow
+  volume: 4
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a light crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 8
-    part:
-    - mechanism
-    - mechanism
+- name: a shortbow
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a sturdy light crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
+- name: a sturdy shortbow
+  noun: shortbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: an alpine crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
+- name: an alpine shortbow
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a saddle crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 8
-    part:
-    - mechanism
-    - mechanism
+- name: a saddle bow
+  noun: bow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a flight crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
+- name: a flight bow
+  noun: bow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a steppe crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 10
-    part:
-    - mechanism
-    - mechanism
+- name: a steppe bow
+  noun: bow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a light battle crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 10
-    part:
-    - mechanism
-    - mechanism
+- name: a battle shortbow
+  noun: shortbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a light forester's crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 2
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
+- name: a forester's shortbow
+  noun: shortbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a lockbow
-    noun: lockbow
-    work_order: true
-    chapter: 2
-    volume: 8
-    part:
-    - mechanism
-    - mechanism
+- name: a Nisha shortbow
+  noun: shortbow
+  volume: 5
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  - name: a latchbow
-    noun: latchbow
-    work_order: true
-    chapter: 2
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
+- name: a competition shortbow
+  noun: shortbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 2
+  part:
     - bow string
-  # Tinkering Chapter 3
-  - name: a simple heavy crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 10
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+# Shaping Chapter 3 recipes
+- name: a simple longbow
+  noun: longbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
     - bow string
-  - name: practice heavy crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 14
-    part:
-    - mechanism
-    - mechanism
+- name: a practice longbow
+  noun: longbow
+  volume: 6
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
     - bow string
-  - name: sturdy heavy crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 16
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a longbow
+  noun: longbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
     - bow string
-  - name: a heavy crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 15
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a sturdy longbow
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
     - bow string
-  - name: a slurbow
-    noun: slurbow
-    work_order: true
-    chapter: 3
-    volume: 15
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a flatbow
+  noun: flatbow
+  volume: 7
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
     - bow string
-  - name: skirmisher's crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 15
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a skirmisher's bow
+  noun: bow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
     - bow string
-  - name: a flat crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 15
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a reflex longbow
+  noun: longbow
+  volume: 7
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
     - bow string
-  - name: a battle crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 16
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a self bow
+  noun: bow
+  volume: 7
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
     - bow string
-  - name: a forester's crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 16
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a recurve longbow
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
     - bow string
-  - name: a recurve crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 16
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a forester's longbow
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 3
+  part:
     - bow string
-  - name: an arena crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 15
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a battle longbow
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
     - bow string
-  - name: a competition crossbow
-    noun: crossbow
-    work_order: true
-    chapter: 3
-    volume: 16
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+- name: a competition longbow
+  noun: longbow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 3
+  part:
     - bow string
-  # Tinkering Chapter 4
-  - name: a reinforced arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 19
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+# Shaping Chapter 4 recipes
+- name: a composite bow
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
     - bow string
-  - name: an arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 18
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a double-backed bow
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
     - bow string
-  - name: a siege arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 18
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a recurve bow
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
     - bow string
-  - name: a forester's arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 18
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a forester's bow
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 4
+  part:
     - bow string
-  - name: a recurve arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 18
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a reflex bow
+  noun: bow
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
     - bow string
-  - name: a horseman's arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 18
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a savannah bow
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
     - bow string
-  - name: a footman's arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 19
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a footman's bow
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: false
+  chapter: 4
+  part:
     - bow string
-  - name: a mariner's arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 19
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a horseman's bow
+  noun: bow
+  volume: 9
+  type: shaping
+  work_order: false
+  chapter: 4
+  part:
     - bow string
-  - name: a competition arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 20
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a battle bow
+  noun: bow
+  volume: 10
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
     - bow string
-  - name: a battle arbalest
-    noun: arbalest
-    work_order: true
-    chapter: 4
-    volume: 20
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
-    - mechanism
+    - bone backer
+- name: a competition bow
+  noun: bow
+  volume: 10
+  type: shaping
+  work_order: true
+  chapter: 4
+  part:
     - bow string
-  # Tinkering Chapter 5
-  - name: simple stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 7
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a sturdy stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 8
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a lobbing stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a saddle stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 8
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: an alpine stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a slingbow
-    noun: slingbow
-    work_order: true
-    chapter: 5
-    volume: 8
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: forester's stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a battle stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 10
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a steppe stonebow
-    noun: stonebow
-    work_order: true
-    chapter: 5
-    volume: 10
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  - name: a pelletbow
-    noun: pelletbow
-    work_order: true
-    chapter: 5
-    volume: 9
-    part:
-    - mechanism
-    - mechanism
-    - bow string
-  # Tinkering Chapter 6 Siege Wapon Crafting - Blank
-  # Tinkering Chapter 7 Bolts - use bolts.lic script
-  # Tinkering Chapter 8 Tinkered Enhancement
-  # Tinkering Chapter 9
-  - name: a small music box
-    noun: box
-    work_order: true
-    chapter: 9
-    volume: 2
-    part:
-    - mechanism
-  - name: miniature male soldier
-    noun: soldier
-    work_order: true
-    chapter: 9
-    volume: 3
-    part:
-    - mechanism
-  - name: miniature female soldier
-    noun: soldier
-    work_order: true
-    chapter: 9
-    volume: 3
-    part:
-    - mechanism
-  - name: a simple telescope
-    noun: telescope
-    work_order: true
-    chapter: 9
-    volume: 5
-    part:
-    - mechanism
-    - lenses
-  - name: a musical box
-    noun: box
-    work_order: true
-    chapter: 9
-    volume: 3
-    part:
-    - mechanism
-  - name: a telescope
-    noun: telescope
-    work_order: true
-    chapter: 9
-    volume: 5
-    part:
-    - mechanism
-    - mechanism
-    - lenses
-  - name: a clockwork telescope
-    noun: telescope
-    work_order: true
-    chapter: 9
-    volume: 6
-    part:
-    - mechanism
-    - mechanism
-    - mechanism
-    - lenses
-  # Tinkering Chapter 10 Locksmithing - blank
-  ####################################
-  ##### Engineering section ends #####
-  ####################################
-tailoring:
+    - bone backer
+# Shaping Chapter 5 recipes are arrows and covered with the arrows.lic script.
+# Shaping Chapter 6 recipes are Enhancements and Materials.
+- name: a simple wood burin
+  noun: burin
+  work_order: true
+  type: shaping
+  chapter: 6
+  volume: 4
+- name: a fine wood burin
+  noun: burin
+  work_order: true
+  type: shaping
+  chapter: 6
+  volume: 4
+- name: an ornate wood burin
+  noun: burin
+  work_order: true
+  type: shaping
+  chapter: 6
+  volume: 4
+# Shaping Chapter 7 recipes
+- name: a wood band
+  noun: band
+  volume: 1
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood nose ring
+  noun: ring
+  volume: 1
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood toe ring
+  noun: ring
+  volume: 1
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood bracelet
+  noun: bracelet
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood anklet
+  noun: anklet
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood pin
+  noun: pin
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood cloak pin
+  noun: pin
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a shallow wood cup
+  noun: cup
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood hairpin
+  noun: hairpin
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood tailband
+  noun: tailband
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood pendant
+  noun: pendant
+  volume: 1
+  type: shaping
+  work_order: false
+  chapter: 7
+  part:
+  - short cord
+- name: a wood amulet
+  noun: amulet
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood medallion
+  noun: medallion
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a pair of wood earrings
+  noun: earrings
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood earcuff
+  noun: earcuff
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood brooch
+  noun: brooch
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood armband
+  noun: armband
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood belt buckle
+  noun: buckle
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood choker
+  noun: choker
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood locket
+  noun: locket
+  volume: 2
+  type: shaping
+  work_order: false
+  chapter: 7
+  part:
+  - short cord
+- name: some wood bangles
+  noun: bangles
+  volume: 5
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood tiara
+  noun: tiara
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: an articulated wood bracelet
+  noun: bracelet
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood circlet
+  noun: circlet
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 7
+  part:
+  - short cord
+- name: an articulated wood necklace
+  noun: necklace
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood crown
+  noun: crown
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood mask
+  noun: mask
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 7
+  part:
+  - short cord
+- name: a wood comb
+  noun: comb
+  volume: 2
+  type: shaping
+  work_order: true
+  chapter: 7
+- name: a wood haircomb
+  noun: haircomb
+  volume: 3
+  type: shaping
+  work_order: true
+  chapter: 7
+# Shaping Chapter 8 recipes
+- name: a wood bead
+  noun: bead
+  volume: 1
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood bead
+  noun: bead
+  volume: 1
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood totem
+  noun: totem
+  volume: 2
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood totem
+  noun: totem
+  volume: 2
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood figurine
+  noun: figurine
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood wand
+  noun: wand
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood rod
+  noun: rod
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood figurine
+  noun: figurine
+  volume: 3
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood statuette
+  noun: statuette
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood statuette
+  noun: statuette
+  volume: 8
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a wood statue
+  noun: statue
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 8
+- name: a detailed wood statue
+  noun: statue
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 8
+# Shaping Chapter 9 recipes
+- name: a wood cane
+  noun: cane
+  volume: 7
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood nightstick
+  noun: nightstick
+  volume: 6
+  type: shaping
+  work_order: true
+  chapter: 9
+  part:
+  - leather strip
+- name: a wood quarterstaff
+  noun: quarterstaff
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood walking cane
+  noun: cane
+  volume: 6
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood crook
+  noun: crook
+  volume: 5
+  type: shaping
+  work_order: true
+  chapter: 9
+- name: a wood bo staff
+  noun: staff
+  volume: 8
+  type: shaping
+  work_order: true
+  chapter: 9
+  part:
+  - leather strip
+- name: a weighted staff
+  noun: staff
+  volume: 9
+  type: shaping
+  work_order: true
+  chapter: 9
+  part:
+  - leather strip
+# Shaping Chapter 10 recipes
+- name: a rough wood table
+  noun: table
+  volume: 15
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a low wood table
+  noun: table
+  volume: 18
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - short pole
+  - short pole
+  - short pole
+  - short pole
+- name: a high wood table
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a round wood table
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a square wood table
+  noun: table
+  volume: 20
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a long wood table
+  noun: table
+  volume: 25
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: an oval wood table
+  noun: table
+  volume: 25
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood dining table
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood buffet table
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood refectory table
+  noun: table
+  volume: 30
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood parquet table
+  noun: table
+  volume: 32
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+- name: a wood meditation table
+  noun: table
+  volume: 32
+  type: shaping
+  work_order: false
+  chapter: 10
+  part:
+  - long pole
+  - long pole
+  - long pole
+  - long pole
+# Tinkering Chapter 2
+- name: a toy crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 6
+  part:
+  - mechanism
+  - bow string
+- name: a practice crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 7
+  part:
+  - mechanism
+  - bow string
+- name: a simple crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 7
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a slim crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 6
+  part:
+  - mechanism
+  - bow string
+- name: a farmer's crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 7
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a light crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 8
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a sturdy light crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: an alpine crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a saddle crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 8
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a flight crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a steppe crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 10
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a light battle crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 10
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a light forester's crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a lockbow
+  noun: lockbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 8
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a latchbow
+  noun: latchbow
+  work_order: true
+  type: tinkering
+  chapter: 2
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+# Tinkering Chapter 3
+- name: a simple heavy crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 10
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: practice heavy crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 14
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: sturdy heavy crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 16
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a heavy crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 15
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a slurbow
+  noun: slurbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 15
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: skirmisher's crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 15
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a flat crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 15
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a battle crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 16
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a forester's crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 16
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a recurve crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 16
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: an arena crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 15
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a competition crossbow
+  noun: crossbow
+  work_order: true
+  type: tinkering
+  chapter: 3
+  volume: 16
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+# Tinkering Chapter 4
+- name: a reinforced arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 19
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: an arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 18
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a siege arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 18
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a forester's arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 18
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a recurve arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 18
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a horseman's arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 18
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a footman's arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 19
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a mariner's arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 19
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a competition arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 20
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+- name: a battle arbalest
+  noun: arbalest
+  work_order: true
+  type: tinkering
+  chapter: 4
+  volume: 20
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - mechanism
+  - bow string
+# Tinkering Chapter 5
+- name: simple stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 7
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a sturdy stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 8
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a lobbing stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a saddle stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 8
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: an alpine stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a slingbow
+  noun: slingbow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 8
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: forester's stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a battle stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 10
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a steppe stonebow
+  noun: stonebow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 10
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+- name: a pelletbow
+  noun: pelletbow
+  work_order: true
+  type: tinkering
+  chapter: 5
+  volume: 9
+  part:
+  - mechanism
+  - mechanism
+  - bow string
+# Tinkering Chapter 6 Siege Wapon Crafting - Blank
+# Tinkering Chapter 7 Bolts - use bolts.lic script
+# Tinkering Chapter 8 Tinkered Enhancement
+# Tinkering Chapter 9
+- name: a small music box
+  noun: box
+  work_order: true
+  type: tinkering
+  chapter: 9
+  volume: 2
+  part:
+  - mechanism
+- name: miniature male soldier
+  noun: soldier
+  work_order: true
+  type: tinkering
+  chapter: 9
+  volume: 3
+  part:
+  - mechanism
+- name: miniature female soldier
+  noun: soldier
+  work_order: true
+  type: tinkering
+  chapter: 9
+  volume: 3
+  part:
+  - mechanism
+- name: a simple telescope
+  noun: telescope
+  work_order: true
+  type: tinkering
+  chapter: 9
+  volume: 5
+  part:
+  - mechanism
+  - lenses
+- name: a musical box
+  noun: box
+  work_order: true
+  type: tinkering
+  chapter: 9
+  volume: 3
+  part:
+  - mechanism
+- name: a telescope
+  noun: telescope
+  work_order: true
+  type: tinkering
+  chapter: 9
+  volume: 5
+  part:
+  - mechanism
+  - mechanism
+  - lenses
+- name: a clockwork telescope
+  noun: telescope
+  work_order: true
+  type: tinkering
+  chapter: 9
+  volume: 6
+  part:
+  - mechanism
+  - mechanism
+  - mechanism
+  - lenses
+# Tinkering Chapter 10 Locksmithing - blank
+####################################
+##### Engineering section ends #####
+####################################
 ####################################
 ##### Outfitting section ends  #####
 ####################################
 # Tailoring Chapter 2 recipes
-  - name: some cloth socks
-    noun: socks
-    volume: 1
-    work_order: false
-    chapter: 2
-  - name: some cloth ankle socks
-    noun: socks
-    volume: 1
-    work_order: false
-    chapter: 2
-  - name: a cloth armband
-    noun: armband
-    volume: 1
-    work_order: false
-    chapter: 2
-  - name: some cloth fingerless gloves
-    noun: gloves
-    volume: 1
-    work_order: false
-    chapter: 2
-  - name: a cloth ankleband
-    noun: ankleband
-    volume: 1
-    work_order: false
-    chapter: 2
-  - name: a cloth eyepatch
-    noun: eyepatch
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: some cloth knee socks
-    noun: socks
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: some pleated cloth gloves
-    noun: gloves
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: some elbow-length gloves
-    noun: gloves
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: a cloth headband
-    noun: headband
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: a cloth belt
-    noun: belt
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: a cloth scarf
-    noun: scarf
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: some elegant cloth gloves
-    noun: gloves
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: some cloth slippers
-    noun: slippers
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: some cloth field shoes
-    noun: shoes
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a cloth hat
-    noun: hat
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a cloth dunce hat
-    noun: hat
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a segmented cloth belt
-    noun: belt
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: a cloth dress belt
-    noun: belt
-    volume: 2
-    work_order: false
-    chapter: 2
-  - name: a cloth commoner's cloak
-    noun: 6
-    volume: 6
-    work_order: false
-    chapter: 2
-  - name: a cloth head scarf
-    noun: scarf
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a cloth veil
-    noun: veil
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a floppy cloth hat
-    noun: hat
-    volume: 4
-    work_order: false
-    chapter: 2
-  - name: a double-wrapped belt
-    noun: belt
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: some cloth pants
-    noun: pants
-    volume: 6
-    work_order: false
-    chapter: 2
-  - name: a cloth skirt
-    noun: skirt
-    volume: 6
-    work_order: false
-    chapter: 2
-  - name: a cloth kilt
-    noun: kilt
-    volume: 6
-    work_order: false
-    chapter: 2
-  - name: a cloth sash
-    noun: sash
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a sleeveless cloth shirt
-    noun: shirt
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a cloth shirt
-    noun: shirt
-    volume: 3
-    work_order: false
-    chapter: 2
-  - name: a cloth cloak
-    noun: cloak
-    volume: 7
-    work_order: false
-    chapter: 2
-  - name: a cloth dress hat
-    noun: hat
-    volume: 4
-    work_order: false
-    chapter: 2
-  - name: a cloth top hat
-    noun: hat
-    volume: 4
-    work_order: false
-    chapter: 2
-  - name: some baggy cloth pants
-    noun: pants
-    volume: 7
-    work_order: false
-    chapter: 2
-  - name: a cloth dress
-    volume: 8
-    work_order: false
-    chapter: 2
-  - name: a knee-length cloth dress
-    noun: 8
-    volume:
-    work_order: false
-    chapter: 2
-  - name: a front-laced cloth dress
-    noun: dress
-    volume: 8
-    work_order: false
-    chapter: 2
-  - name: a billowing cloth shirt
-    noun: shirt
-    volume: 4
-    work_order: false
-    chapter: 2
-  - name: a baggy cloth shirt
-    noun: shirt
-    volume: 4
-    work_order: false
-    chapter: 2
-  - name: a cloth tunic
-    noun: tunic
-    volume: 4
-    work_order: false
-    chapter: 2
-  - name: some cloth robes
-    noun: robes
-    volume: 9
-    work_order: false
-    chapter: 2
-  - name: some cloth dress pants
-    noun: pants
-    volume: 6
-    work_order: true
-    chapter: 2
-  - name: a floor-length cloth dress
-    noun: dress
-    volume: 9
-    work_order: false
-    chapter: 2
-  - name: a cloth gown
-    noun: gown
-    volume: 9
-    work_order: true
-    chapter: 2
-  - name: a cloth dress shirt
-    noun: shirt
-    volume: 4
-    work_order: true
-    chapter: 2
-  - name: a short-sleeved tunic
-    noun: tunic
-    volume: 4
-    work_order: false
-    chapter: 2
-  - name: a formal cloth tunic
-    noun: tunic
-    volume: 5
-    work_order: true
-    chapter: 2
-  - name: a cloth tabard
-    noun: tabard
-    volume: 6
-    work_order: true
-    chapter: 2
-  - name: a hooded cloth cloak
-    noun: cloak
-    volume: 8
-    work_order: true
-    chapter: 2
-  - name: a cloth cape
-    noun: cape
-    volume: 7
-    work_order: false
-    chapter: 2
-  - name: some hooded cloth robes
-    noun: robes
-    volume: 9
-    work_order: false
-    chapter: 2
-  - name: a deeply-hooded cloak
-    noun: cloak
-    volume: 9
-    work_order: false
-    chapter: 2
-  - name: a cloth mage's robe
-    noun: robe
-    volume: 9
-    work_order: true
-    chapter: 2
-  - name: some flowing cloth robes
-    noun: robes
-    volume: 9
-    work_order: true
-    chapter: 2
-  - name: a cloth shaman's robe
-    noun: robe
-    volume: 9
-    work_order: true
-    chapter: 2
-  # Tailoring Chapter 3 recipes
-  - name: a cloth napkin
-    noun: napkin
-    volume: 1
-    work_order: false
-    chapter: 3
-  - name: a cloth hip pouch
-    noun: pouch
-    volume: 2
-    work_order: false
-    chapter: 3
-  - name: a cloth rag
-    noun: rag
-    volume: 1
-    work_order: false
-    chapter: 3
-  - name: a cloth gem pouch
-    noun: pouch
-    volume: 2
-    work_order: false
-    chapter: 3
-  - name: a cloth weapon strap
-    noun: strap
-    volume: 2
-    work_order: false
-    chapter: 3
-  - name: a cloth pouch
-    noun: pouch
-    volume: 3
-    work_order: false
-    chapter: 3
-  - name: a cloth thigh bag
-    noun: bag
-    volume: 3
-    work_order: false
-    chapter: 3
-  - name: a cloth towel
-    noun: towel
-    volume: 4
-    work_order: false
-    chapter: 3
-  - name: a cloth herb pouch
-    noun: pouch
-    volume: 3
-    work_order: false
-    chapter: 3
-  - name: a cloth talisman pouch
-    noun: pouch
-    volume: 3
-    work_order: false
-    chapter: 3
-  - name: a cloth arm pouch
-    noun: pouch
-    volume: 2
-    work_order: false
-    chapter: 3
-  - name: a cloth bag
-    noun: bag
-    volume: 3
-    work_order: false
-    chapter: 3
-  - name: a cloth sack
-    noun: sack
-    volume: 3
-    work_order: false
-    chapter: 3
-  - name: a cloth utility belt
-    noun: belt
-    volume: 4
-    work_order: false
-    chapter: 3
-  - name: a cloth charm bag
-    noun: bag
-    volume: 3
-    work_order: true
-    chapter: 3
-  - name: a cloth backpack
-    noun: backpack
-    volume: 5
-    work_order: false
-    chapter: 3
-  - name: a cloth knapsack
-    noun: knapsack
-    volume: 5
-    work_order: false
-    chapter: 3
-  - name: a cloth carryall
-    noun: carryall
-    volume: 5
-    work_order: false
-    chapter: 3
-  - name: a cloth blanket
-    noun: blanket
-    volume: 9
-    work_order: true
-    chapter: 3
-  - name: a cloth duffel bag
-    noun: duffel.bag
-    volume: 6
-    work_order: true
-    chapter: 3
-  - name: a cloth haversack
-    noun: haversack
-    volume: 6
-    work_order: true
-    chapter: 3
-  - name: a cloth bandolier
-    noun: bandolier
-    volume: 6
-    work_order: true
-    chapter: 3
-  - name: a small cloth rucksack
-    noun: small.rucksack
-    volume: 7
-    work_order: true
-    chapter: 3
-  - name: a cloth mining belt
-    noun: belt
-    volume: 4
-    work_order: true
-    chapter: 3
-  - name: a cloth saddle pad
-    noun: pad
-    volume: 10
-    work_order: true
-    chapter: 3
-  - name: a cloth rucksack
-    noun: rucksack
-    volume: 8
-    work_order: true
-    chapter: 3
-  - name: a cloth survival belt
-    noun: belt
-    volume: 5
-    work_order: true
-    chapter: 3
-  - name: a cloth saddle blanket
-    noun: blanket
-    volume: 12
-    work_order: true
-    chapter: 3
-    part:
-    - small padding
-  - name: a cloth artisan's belt
-    noun: belt
-    volume: 5
-    work_order: true
-    chapter: 3
-  - name: a cloth saddle shabrack
-    noun: shabrack
-    volume: 12
-    work_order: true
-    chapter: 3
-    part:
-    - small padding
-  # Tailoring Chapter 4 recipes
-  - name: a quilted cloth aventail
-    noun: aventail
-    volume: 3
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth mask
-    noun: mask
-    volume: 2
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some quilted cloth gloves
-    noun: gloves
-    volume: 4
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth cap
-    noun: cap
-    volume: 6
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth aventail
-    noun: aventail
-    volume: 3
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth mask
-    noun: mask
-    volume: 2
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth hood
-    noun: hood
-    volume: 9
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some padded cloth gloves
-    noun: gloves
-    volume: 4
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth cap
-    noun: cap
-    volume: 6
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: an insulated cloth aventail
-    noun: aventail
-    volume: 3
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: an insulated cloth mask
-    noun: mask
-    volume: 2
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some quilted cloth pants
-    noun: pants
-    volume: 10
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth hood
-    noun: hood
-    volume: 9
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some insulated cloth gloves
-    noun: gloves
-    volume: 4
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: an insulated cloth cap
-    noun: cap
-    volume: 6
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some padded cloth pants
-    noun: pants
-    volume: 10
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some quilted cloth vambraces
-    noun: vambraces
-    volume: 12
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth tasset
-    noun: tasset
-    volume: 8
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth tabard
-    noun: tabard
-    volume: 22
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: an insulated cloth hood
-    noun: hood
-    volume: 9
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some insulated cloth pants
-    noun: pants
-    volume: 10
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some padded cloth vambraces
-    noun: vambraces
-    volume: 12
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some quilted cloth sleeves
-    noun: sleeves
-    volume: 16
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth tasset
-    noun: tasset
-    volume: 8
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth vest
-    noun: vest
-    volume: 14
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth mantle
-    noun: mantle
-    volume: 17
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a quilted cloth robe
-    noun: robe
-    volume: 32
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: a quilted cloth shirt
-    noun: shirt
-    volume: 34
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: a padded cloth tabard
-    noun: tabard
-    volume: 22
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: some insulated cloth vambraces
-    noun: vambraces
-    volume: 12
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: some padded cloth sleeves
-    noun: sleeves
-    volume: 16
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: an insulated cloth tasset
-    noun: tasset
-    volume: 8
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth vest
-    noun: vest
-    volume: 14
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth mantle
-    noun: mantle
-    volume: 17
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: a padded cloth robe
-    noun: robe
-    volume: 32
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: a quilted cloth hauberk
-    noun: hauberk
-    volume: 44
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: a padded cloth shirt
-    noun: shirt
-    volume: 34
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: an insulated cloth tabard
-    noun: tabard
-    volume: 22
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: some insulated cloth sleeves
-    noun: sleeves
-    volume: 16
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: an insulated cloth vest
-    noun: vest
-    volume: 14
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: an insulated cloth mantle
-    noun: mantle
-    volume: 17
-    work_order: false
-    chapter: 4
-    part:
-    - small padding
-  - name: an insulated cloth robe
-    noun: robe
-    volume: 32
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: a padded cloth hauberk
-    noun: hauberk
-    volume: 44
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: an insulated cloth shirt
-    noun: shirt
-    volume: 34
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  - name: an insulated cloth hauberk
-    noun: hauberk
-    volume: 44
-    work_order: false
-    chapter: 4
-    part:
-    - large padding
-  # Tailoring Chapter 5 recipes
-  - name: a knitted ankleband
-    noun: ankleband
-    volume: 10
-    work_order: true
-    chapter: 5
-  - name: some knitted socks
-    noun: socks
-    volume: 10
-    work_order: true
-    chapter: 5
-  - name: a knitted armband
-    noun: armband
-    volume: 10
-    work_order: true
-    chapter: 5
-  - name: a knitted napkin
-    noun: napkin
-    volume: 10
-    work_order: true
-    chapter: 5
-  - name: some knitted mittens
-    noun: mittens
-    volume: 13
-    work_order: true
-    chapter: 5
-  - name: a knitted headband
-    noun: headband
-    volume: 13
-    work_order: true
-    chapter: 5
-  - name: some knitted slippers
-    noun: slippers
-    volume: 26
-    work_order: true
-    chapter: 5
-  - name: a knitted scarf
-    noun: scarf
-    volume: 26
-    work_order: true
-    chapter: 5
-  - name: a knitted hat
-    noun: hat
-    volume: 30
-    work_order: true
-    chapter: 5
-  - name: some knitted booties
-    noun: booties
-    volume: 30
-    work_order: true
-    chapter: 5
-  - name: a knitted hood
-    noun: hood
-    volume: 30
-    work_order: true
-    chapter: 5
-  - name: a knitted towel
-    noun: towel
-    volume: 40
-    work_order: true
-    chapter: 5
-  - name: some knitted legwarmers
-    noun: legwarmers
-    volume: 60
-    work_order: true
-    chapter: 5
-  - name: some knitted gloves
-    noun: gloves
-    volume: 16
-    work_order: true
-    chapter: 5
-  - name: a knitted shirt
-    noun: shirt
-    volume: 40
-    work_order: true
-    chapter: 5
-  - name: a knitted skirt
-    noun: skirt
-    volume: 60
-    work_order: true
-    chapter: 5
-  - name: a knitted sweater
-    noun: sweater
-    volume: 50
-    work_order: true
-    chapter: 5
-  - name: some knitted hose
-    noun: hose
-    volume: 60
-    work_order: true
-    chapter: 5
-  - name: a knitted cloak
-    noun: cloak
-    volume: 70
-    work_order: true
-    chapter: 5
-  - name: a knitted blanket
-    noun: blanket
-    volume: 90
-    work_order: true
-    chapter: 5
-  # Tailoring Chapter 6 recipes
-  # No recipes
-  # Tailoring Chapter 7 recipes
-  - name: a leather armband
-    noun: armband
-    volume: 1
-    work_order: false
-    chapter: 7
-  - name: a leather ankleband
-    noun: ankleband
-    volume: 1
-    work_order: false
-    chapter: 7
-  - name: some fingerless gloves
-    noun: gloves
-    volume: 1
-    work_order: false
-    chapter: 7
-  - name: some elbow-length gloves
-    noun: gloves
-    volume: 2
-    work_order: false
-    chapter: 7
-  - name: a leather eyepatch
-    noun: eyepatch
-    volume: 2
-    work_order: false
-    chapter: 7
-  - name: a leather headband
-    noun: headband
-    volume: 2
-    work_order: false
-    chapter: 7
-  - name: a leather belt
-    noun: belt
-    volume: 2
-    work_order: false
-    chapter: 7
-  - name: some leather moccasins
-    noun: moccasins
-    volume: 3
-    work_order: false
-    chapter: 7
-  - name: some leather shoes
-    noun: shoes
-    volume: 3
-    work_order: false
-    chapter: 7
-  - name: a leather hat
-    noun: hat
-    volume: 2
-    work_order: false
-    chapter: 7
-  - name: a commoner's cloak
-    noun: cloak
-    volume: 6
-    work_order: false
-    chapter: 7
-  - name: a leather shirt
-    noun: shirt
-    volume: 3
-    work_order: false
-    chapter: 7
-  - name: a sleeveless leather shirt
-    noun: shirt
-    volume: 3
-    work_order: false
-    chapter: 7
-  - name: a segmented belt
-    noun: belt
-    volume: 3
-    work_order: false
-    chapter: 7
-  - name: a leather dress belt
-    noun: belt
-    volume: 3
-    work_order: false
-    chapter: 7
-  - name: a leather skirt
-    noun: skirt
-    volume: 5
-    work_order: false
-    chapter: 7
-  - name: a leather cloak
-    noun: cloak
-    volume: 7
-    work_order: false
-    chapter: 7
-  - name: a leather tunic
-    noun: tunic
-    volume: 4
-    work_order: false
-    chapter: 7
-  - name: a leather dress
-    noun: dress
-    volume: 7
-    work_order: false
-    chapter: 7
-  - name: a double-wrapped belt
-    noun: belt
-    volume: 4
-    work_order: false
-    chapter: 7
-  - name: a leather cape
-    noun: cape
-    volume: 7
-    work_order: false
-    chapter: 7
-  - name: a leather utility belt
-    noun: belt
-    volume: 4
-    work_order: false
-    chapter: 7
-  - name: a hooded leather cloak
-    noun: cloak
-    volume: 8
-    work_order: false
-    chapter: 7
-  - name: a deeply-hooded cloak
-    noun: cloak
-    volume: 8
-    work_order: false
-    chapter: 7
-  - name: a leather hunting shirt
-    noun: shirt
-    volume: 5
-    work_order: false
-    chapter: 7
-  - name: a leather dueling shirt
-    noun: shirt
-    volume: 5
-    work_order: false
-    chapter: 7
-  - name: a leather mining belt
-    noun: belt
-    volume: 4
-    work_order: false
-    chapter: 7
-  - name: a leather war belt
-    noun: belt
-    volume: 5
-    work_order: false
-    chapter: 7
-  - name: a leather artisan's belt
-    noun: belt
-    volume: 5
-    work_order: false
-    chapter: 7
-  # Tailoring Chapter 8 recipes
-  - name: a leather hip pouch
-    noun: pouch
-    volume: 2
-    work_order: false
-    chapter: 8
-  - name: a leather weapon strap
-    noun: strap
-    volume: 1
-    work_order: false
-    chapter: 8
-  - name: a leather saddle
-    noun: saddle
-    volume: 9
-    work_order: false
-    chapter: 8
-  - name: a leather sidesaddle
-    noun: sidesaddle
-    volume: 9
-    work_order: false
-    chapter: 8
-  - name: a leather jousting saddle
-    noun: saddle
-    volume: 10
-    work_order: false
-    chapter: 8
-  # Tailoring Chapter 9 recipes
-  - name: a rugged leather aventail
-    noun: aventail
-    volume: 4
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather mask
-    noun: mask
-    volume: 3
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some rugged gloves
-    noun: gloves
-    volume: 5
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather cap
-    noun: cap
-    volume: 6
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather aventail
-    noun: aventail
-    volume: 4
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather mask
-    noun: mask
-    volume: 5
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather aventail
-    noun: aventail
-    volume: 4
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather helm
-    noun: helm
-    volume: 10
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some thick gloves
-    noun: gloves
-    volume: 5
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather cap
-    noun: cap
-    volume: 6
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather mask
-    noun: mask
-    volume: 3
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather tasset
-    noun: tasset
-    volume: 10
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some rugged vambraces
-    noun: vambraces
-    volume: 16
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some rugged greaves
-    noun: greaves
-    volume: 12
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather cowl
-    noun: cowl
-    volume: 12
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather helm
-    noun: helm
-    volume: 10
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some coarse gloves
-    noun: gloves
-    volume: 5
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather cap
-    noun: cap
-    volume: 6
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather jerkin
-    noun: 28
-    volume:
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: a thick leather tasset
-    noun: tasset
-    volume: 10
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather mantle
-    noun: mantle
-    volume: 22
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather vest
-    noun: vest
-    volume: 18
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some rugged leather sleeves
-    noun: sleeves
-    volume: 20
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some thick vambraces
-    noun: vambraces
-    volume: 16
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some thick greaves
-    noun: greaves
-    volume: 12
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather cowl
-    noun: cowl
-    volume: 12
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather helm
-    noun: helm
-    volume: 10
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather mantle
-    noun: mantle
-    volume: 22
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a rugged leather coat
-    noun: coat
-    volume: 43
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: a rugged leather robe
-    noun: robe
-    volume: 40
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: a thick leather jerkin
-    noun: jerkin
-    volume: 28
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: some thick leather sleeves
-    noun: sleeves
-    volume: 20
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather vest
-    noun: vest
-    volume: 18
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather tasset
-    noun: tasset
-    volume:
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some coarse vambraces
-    noun: vambraces
-    volume: 16
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some coarse greaves
-    noun: greaves
-    volume: 12
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather cowl
-    noun: cowl
-    volume: 12
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a thick leather robe
-    noun: robe
-    volume: 40
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: some rugged leathers
-    noun: leathers
-    volume: 55
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: a thick leather coat
-    noun: coat
-    volume: 43
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: a coarse leather jerkin
-    noun: jerkin
-    volume: 28
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: a coarse leather mantle
-    noun: mantle
-    volume: 22
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: some coarse leather sleeves
-    noun: sleeves
-    volume: 20
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather vest
-    noun: vest
-    volume: 18
-    work_order: false
-    chapter: 9
-    part:
-    - small padding
-  - name: a coarse leather robe
-    volume: 40
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: some thick leathers
-    noun: leathers
-    volume: 55
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: a coarse leather coat
-    noun: coat
-    volume: 43
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  - name: some coarse leathers
-    noun: leathers
-    volume: 55
-    work_order: false
-    chapter: 9
-    part:
-    - large padding
-  # Tailoring Chapter 10 recipes
-  - name: a leather target handle
-    noun: shield
-    volume: 2
-    work_order: false
-    chapter: 10
-  - name: a long leather cord
-    noun: shield
-    volume: 2
-    work_order: false
-    chapter: 10
-  - name: a leather target shield
-    noun: shield
-    volume: 12
-    work_order: false
-    chapter: 10
-    part:
-    - shield handle
-    - long cord
-  - name: an ordinary leather shield
-    noun: shield
-    volume: 8
-    work_order: false
-    chapter: 10
-    part:
-    - shield handle
-    - long cord
-  - name: a small leather shield
-    noun: shield
-    volume: 8
-    work_order: false
-    chapter: 10
-    part:
-    - leather shield handle
-    - long cord
-  - name: a leather buckler
-    noun: buckler
-    volume: 12
-    work_order: false
-    chapter: 10
-    part:
-    - shield handle
-    - long cord
-  - name: a leather targe
-    noun: targe
-    volume: 10
-    work_order: false
-    chapter: 10
-    part:
-    - shield handle
-    - long cord
-  - name: a leather oval shield
-    noun: shield
-    volume: 20
-    work_order: false
-    chapter: 10
-    part:
-    - shield handle
-    - long cord
-  - name: a medium leather shield
-    noun: shield
-    volume: 16
-    work_order: false
-    chapter: 10
-    part:
-    - shield handle
-    - long cord
-  - name: a leather kite shield
-    noun: shield
-    volume: 24
-    work_order: false
-    chapter: 10
-    part:
-    - shield handle
-    - long cord
-remedies:
+- name: some cloth socks
+  noun: socks
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth ankle socks
+  noun: socks
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth armband
+  noun: armband
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth fingerless gloves
+  noun: gloves
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth ankleband
+  noun: ankleband
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth eyepatch
+  noun: eyepatch
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth knee socks
+  noun: socks
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some pleated cloth gloves
+  noun: gloves
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some elbow-length gloves
+  noun: gloves
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth headband
+  noun: headband
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth belt
+  noun: belt
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth scarf
+  noun: scarf
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some elegant cloth gloves
+  noun: gloves
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth slippers
+  noun: slippers
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth field shoes
+  noun: shoes
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth hat
+  noun: hat
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth dunce hat
+  noun: hat
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a segmented cloth belt
+  noun: belt
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth dress belt
+  noun: belt
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth commoner's cloak
+  noun: 6
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth head scarf
+  noun: scarf
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth veil
+  noun: veil
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a floppy cloth hat
+  noun: hat
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a double-wrapped belt
+  noun: belt
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth pants
+  noun: pants
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth skirt
+  noun: skirt
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth kilt
+  noun: kilt
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth sash
+  noun: sash
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a sleeveless cloth shirt
+  noun: shirt
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth shirt
+  noun: shirt
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth cloak
+  noun: cloak
+  volume: 7
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth dress hat
+  noun: hat
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth top hat
+  noun: hat
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some baggy cloth pants
+  noun: pants
+  volume: 7
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth dress
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a knee-length cloth dress
+  noun: 8
+  volume:
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a front-laced cloth dress
+  noun: dress
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a billowing cloth shirt
+  noun: shirt
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a baggy cloth shirt
+  noun: shirt
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth tunic
+  noun: tunic
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth robes
+  noun: robes
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some cloth dress pants
+  noun: pants
+  volume: 6
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: a floor-length cloth dress
+  noun: dress
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth gown
+  noun: gown
+  volume: 9
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: a cloth dress shirt
+  noun: shirt
+  volume: 4
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: a short-sleeved tunic
+  noun: tunic
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a formal cloth tunic
+  noun: tunic
+  volume: 5
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: a cloth tabard
+  noun: tabard
+  volume: 6
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: a hooded cloth cloak
+  noun: cloak
+  volume: 8
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: a cloth cape
+  noun: cape
+  volume: 7
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: some hooded cloth robes
+  noun: robes
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a deeply-hooded cloak
+  noun: cloak
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 2
+- name: a cloth mage's robe
+  noun: robe
+  volume: 9
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: some flowing cloth robes
+  noun: robes
+  volume: 9
+  type: tailoring
+  work_order: true
+  chapter: 2
+- name: a cloth shaman's robe
+  noun: robe
+  volume: 9
+  type: tailoring
+  work_order: true
+  chapter: 2
+# Tailoring Chapter 3 recipes
+- name: a cloth napkin
+  noun: napkin
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth hip pouch
+  noun: pouch
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth rag
+  noun: rag
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth gem pouch
+  noun: pouch
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth weapon strap
+  noun: strap
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth pouch
+  noun: pouch
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth thigh bag
+  noun: bag
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth towel
+  noun: towel
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth herb pouch
+  noun: pouch
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth talisman pouch
+  noun: pouch
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth arm pouch
+  noun: pouch
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth bag
+  noun: bag
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth sack
+  noun: sack
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth utility belt
+  noun: belt
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth charm bag
+  noun: bag
+  volume: 3
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth backpack
+  noun: backpack
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth knapsack
+  noun: knapsack
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth carryall
+  noun: carryall
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 3
+- name: a cloth blanket
+  noun: blanket
+  volume: 9
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth duffel bag
+  noun: duffel.bag
+  volume: 6
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth haversack
+  noun: haversack
+  volume: 6
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth bandolier
+  noun: bandolier
+  volume: 6
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a small cloth rucksack
+  noun: small.rucksack
+  volume: 7
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth mining belt
+  noun: belt
+  volume: 4
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth saddle pad
+  noun: pad
+  volume: 10
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth rucksack
+  noun: rucksack
+  volume: 8
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth survival belt
+  noun: belt
+  volume: 5
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth saddle blanket
+  noun: blanket
+  volume: 12
+  type: tailoring
+  work_order: true
+  chapter: 3
+  part:
+  - small padding
+- name: a cloth artisan's belt
+  noun: belt
+  volume: 5
+  type: tailoring
+  work_order: true
+  chapter: 3
+- name: a cloth saddle shabrack
+  noun: shabrack
+  volume: 12
+  type: tailoring
+  work_order: true
+  chapter: 3
+  part:
+  - small padding
+# Tailoring Chapter 4 recipes
+- name: a quilted cloth aventail
+  noun: aventail
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth mask
+  noun: mask
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some quilted cloth gloves
+  noun: gloves
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth cap
+  noun: cap
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth aventail
+  noun: aventail
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth mask
+  noun: mask
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth hood
+  noun: hood
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some padded cloth gloves
+  noun: gloves
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth cap
+  noun: cap
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: an insulated cloth aventail
+  noun: aventail
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: an insulated cloth mask
+  noun: mask
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some quilted cloth pants
+  noun: pants
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth hood
+  noun: hood
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some insulated cloth gloves
+  noun: gloves
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: an insulated cloth cap
+  noun: cap
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some padded cloth pants
+  noun: pants
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some quilted cloth vambraces
+  noun: vambraces
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth tasset
+  noun: tasset
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth tabard
+  noun: tabard
+  volume: 22
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: an insulated cloth hood
+  noun: hood
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some insulated cloth pants
+  noun: pants
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some padded cloth vambraces
+  noun: vambraces
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some quilted cloth sleeves
+  noun: sleeves
+  volume: 16
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth tasset
+  noun: tasset
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth vest
+  noun: vest
+  volume: 14
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth mantle
+  noun: mantle
+  volume: 17
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a quilted cloth robe
+  noun: robe
+  volume: 32
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: a quilted cloth shirt
+  noun: shirt
+  volume: 34
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: a padded cloth tabard
+  noun: tabard
+  volume: 22
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: some insulated cloth vambraces
+  noun: vambraces
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: some padded cloth sleeves
+  noun: sleeves
+  volume: 16
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: an insulated cloth tasset
+  noun: tasset
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth vest
+  noun: vest
+  volume: 14
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth mantle
+  noun: mantle
+  volume: 17
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: a padded cloth robe
+  noun: robe
+  volume: 32
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: a quilted cloth hauberk
+  noun: hauberk
+  volume: 44
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: a padded cloth shirt
+  noun: shirt
+  volume: 34
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: an insulated cloth tabard
+  noun: tabard
+  volume: 22
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: some insulated cloth sleeves
+  noun: sleeves
+  volume: 16
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: an insulated cloth vest
+  noun: vest
+  volume: 14
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: an insulated cloth mantle
+  noun: mantle
+  volume: 17
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - small padding
+- name: an insulated cloth robe
+  noun: robe
+  volume: 32
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: a padded cloth hauberk
+  noun: hauberk
+  volume: 44
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: an insulated cloth shirt
+  noun: shirt
+  volume: 34
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+- name: an insulated cloth hauberk
+  noun: hauberk
+  volume: 44
+  type: tailoring
+  work_order: false
+  chapter: 4
+  part:
+  - large padding
+# Tailoring Chapter 5 recipes
+- name: a knitted ankleband
+  noun: ankleband
+  volume: 10
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: some knitted socks
+  noun: socks
+  volume: 10
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted armband
+  noun: armband
+  volume: 10
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted napkin
+  noun: napkin
+  volume: 10
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: some knitted mittens
+  noun: mittens
+  volume: 13
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted headband
+  noun: headband
+  volume: 13
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: some knitted slippers
+  noun: slippers
+  volume: 26
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted scarf
+  noun: scarf
+  volume: 26
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted hat
+  noun: hat
+  volume: 30
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: some knitted booties
+  noun: booties
+  volume: 30
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted hood
+  noun: hood
+  volume: 30
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted towel
+  noun: towel
+  volume: 40
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: some knitted legwarmers
+  noun: legwarmers
+  volume: 60
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: some knitted gloves
+  noun: gloves
+  volume: 16
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted shirt
+  noun: shirt
+  volume: 40
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted skirt
+  noun: skirt
+  volume: 60
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted sweater
+  noun: sweater
+  volume: 50
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: some knitted hose
+  noun: hose
+  volume: 60
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted cloak
+  noun: cloak
+  volume: 70
+  type: tailoring
+  work_order: true
+  chapter: 5
+- name: a knitted blanket
+  noun: blanket
+  volume: 90
+  type: tailoring
+  work_order: true
+  chapter: 5
+# Tailoring Chapter 6 recipes
+# No recipes
+# Tailoring Chapter 7 recipes
+- name: a leather armband
+  noun: armband
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather ankleband
+  noun: ankleband
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: some fingerless gloves
+  noun: gloves
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: some elbow-length gloves
+  noun: gloves
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather eyepatch
+  noun: eyepatch
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather headband
+  noun: headband
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather belt
+  noun: belt
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: some leather moccasins
+  noun: moccasins
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: some leather shoes
+  noun: shoes
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather hat
+  noun: hat
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a commoner's cloak
+  noun: cloak
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather shirt
+  noun: shirt
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a sleeveless leather shirt
+  noun: shirt
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a segmented belt
+  noun: belt
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather dress belt
+  noun: belt
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather skirt
+  noun: skirt
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather cloak
+  noun: cloak
+  volume: 7
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather tunic
+  noun: tunic
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather dress
+  noun: dress
+  volume: 7
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a double-wrapped belt
+  noun: belt
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather cape
+  noun: cape
+  volume: 7
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather utility belt
+  noun: belt
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a hooded leather cloak
+  noun: cloak
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a deeply-hooded cloak
+  noun: cloak
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather hunting shirt
+  noun: shirt
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather dueling shirt
+  noun: shirt
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather mining belt
+  noun: belt
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather war belt
+  noun: belt
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 7
+- name: a leather artisan's belt
+  noun: belt
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 7
+# Tailoring Chapter 8 recipes
+- name: a leather hip pouch
+  noun: pouch
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 8
+- name: a leather weapon strap
+  noun: strap
+  volume: 1
+  type: tailoring
+  work_order: false
+  chapter: 8
+- name: a leather saddle
+  noun: saddle
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 8
+- name: a leather sidesaddle
+  noun: sidesaddle
+  volume: 9
+  type: tailoring
+  work_order: false
+  chapter: 8
+- name: a leather jousting saddle
+  noun: saddle
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 8
+# Tailoring Chapter 9 recipes
+- name: a rugged leather aventail
+  noun: aventail
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather mask
+  noun: mask
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some rugged gloves
+  noun: gloves
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather cap
+  noun: cap
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather aventail
+  noun: aventail
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather mask
+  noun: mask
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather aventail
+  noun: aventail
+  volume: 4
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather helm
+  noun: helm
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some thick gloves
+  noun: gloves
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather cap
+  noun: cap
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather mask
+  noun: mask
+  volume: 3
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather tasset
+  noun: tasset
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some rugged vambraces
+  noun: vambraces
+  volume: 16
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some rugged greaves
+  noun: greaves
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather cowl
+  noun: cowl
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather helm
+  noun: helm
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some coarse gloves
+  noun: gloves
+  volume: 5
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather cap
+  noun: cap
+  volume: 6
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather jerkin
+  noun: 28
+  volume:
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: a thick leather tasset
+  noun: tasset
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather mantle
+  noun: mantle
+  volume: 22
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather vest
+  noun: vest
+  volume: 18
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some rugged leather sleeves
+  noun: sleeves
+  volume: 20
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some thick vambraces
+  noun: vambraces
+  volume: 16
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some thick greaves
+  noun: greaves
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather cowl
+  noun: cowl
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather helm
+  noun: helm
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather mantle
+  noun: mantle
+  volume: 22
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a rugged leather coat
+  noun: coat
+  volume: 43
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: a rugged leather robe
+  noun: robe
+  volume: 40
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: a thick leather jerkin
+  noun: jerkin
+  volume: 28
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: some thick leather sleeves
+  noun: sleeves
+  volume: 20
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather vest
+  noun: vest
+  volume: 18
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather tasset
+  noun: tasset
+  volume:
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some coarse vambraces
+  noun: vambraces
+  volume: 16
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some coarse greaves
+  noun: greaves
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather cowl
+  noun: cowl
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a thick leather robe
+  noun: robe
+  volume: 40
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: some rugged leathers
+  noun: leathers
+  volume: 55
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: a thick leather coat
+  noun: coat
+  volume: 43
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: a coarse leather jerkin
+  noun: jerkin
+  volume: 28
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: a coarse leather mantle
+  noun: mantle
+  volume: 22
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: some coarse leather sleeves
+  noun: sleeves
+  volume: 20
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather vest
+  noun: vest
+  volume: 18
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - small padding
+- name: a coarse leather robe
+  volume: 40
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: some thick leathers
+  noun: leathers
+  volume: 55
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: a coarse leather coat
+  noun: coat
+  volume: 43
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+- name: some coarse leathers
+  noun: leathers
+  volume: 55
+  type: tailoring
+  work_order: false
+  chapter: 9
+  part:
+  - large padding
+# Tailoring Chapter 10 recipes
+- name: a leather target handle
+  noun: shield
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 10
+- name: a long leather cord
+  noun: shield
+  volume: 2
+  type: tailoring
+  work_order: false
+  chapter: 10
+- name: a leather target shield
+  noun: shield
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - shield handle
+  - long cord
+- name: an ordinary leather shield
+  noun: shield
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - shield handle
+  - long cord
+- name: a small leather shield
+  noun: shield
+  volume: 8
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - leather shield handle
+  - long cord
+- name: a leather buckler
+  noun: buckler
+  volume: 12
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - shield handle
+  - long cord
+- name: a leather targe
+  noun: targe
+  volume: 10
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - shield handle
+  - long cord
+- name: a leather oval shield
+  noun: shield
+  volume: 20
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - shield handle
+  - long cord
+- name: a medium leather shield
+  noun: shield
+  volume: 16
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - shield handle
+  - long cord
+- name: a leather kite shield
+  noun: shield
+  volume: 24
+  type: tailoring
+  work_order: false
+  chapter: 10
+  part:
+  - shield handle
+  - long cord
 ####################################
 ##### Outfitting section ends  #####
 ####################################
@@ -7111,1273 +8190,1478 @@ remedies:
 ##### Alchemy section begins#####
 #################################
 # Remedies Chapter 2 recipes
-  - name: some blister cream
-    noun: cream
-    volume: 1
-    work_order: true
-    chapter: 2
-    container: mortar
-    part:
-    - red flower
-    - nemoih
-  - name: some moisturizing ointment
-    noun: ointment
-    volume: 1
-    work_order: true
-    chapter: 2
-    container: mortar
-    part:
-    - red flower
-    - plovik
-    - alcohol
-  - name: some itch salve
-    noun: salve
-    volume: 1
-    work_order: true
-    chapter: 2
-    container: mortar
-    part:
-    - red flower
-    - jadice
-  - name: some wart salve
-    noun: salve
-    volume: 1
-    work_order: false
-    chapter: 2
-    container: mortar
-    part:
-    - red flower
-    - sufil
-  - name: some stomach tonic
-    noun: tonic
-    volume: 1
-    work_order: false
-    chapter: 2
-    container: bowl
-    part:
-    - blue flower
-    - muljin
-  - name: some lip balm
-    noun: balm
-    volume: 1
-    work_order: true
-    chapter: 2
-    container: mortar
-    part:
-    - red flower
-    - nilos
-  - name: some mouth wash
-    noun: wash
-    volume: 1
-    work_order: false
-    chapter: 2
-    container: bowl
-    part:
-    - blue flower
-    - riolur
-  - name: some eye wash
-    noun: wash
-    volume: 1
-    work_order: false
-    chapter: 2
-    container: bowl
-    part:
-    - blue flower
-    - aevaes
-  - name: some hangover potion
-    noun: potion
-    volume: 1
-    work_order: false
-    chapter: 2
-    container: bowl
-    part:
-    - blue flower
-    - ojhenik
-  - name: some refreshment elixir
-    noun: elixir
-    volume: 1
-    work_order: false
-    chapter: 2
-    container: bowl
-    part:
-    - blue flower
-    - belradi
-    - coal
-  - name: some vigor poultices
-    noun: poultices
-    volume: 1
-    work_order: false
-    chapter: 2
-    container: bowl
-    part:
-    - red flower
-    - dioica
-  # Remedies Chapter 3 recipes
-  - name: some neck salve
-    noun: salve
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - georin
-  - name: some abdominal salve
-    noun: salve
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - nilos
-  - name: some chest salve
-    noun: salve
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - plovik
-  - name: some head salve
-    noun: salve
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - nemoih
-  - name: some back salve
-    noun: salve
-    volume: 1
-    work_order: false
-    chapter: 3
-    container: mortar
-    part:
-    - hulnik
-  - name: some eye salve
-    noun: salve
-    volume: 1
-    work_order: false
-    chapter: 3
-    container: mortar
-    part:
-    - sufil
-  - name: some skin salve
-    noun: salve
-    volume: 1
-    work_order: false
-    chapter: 3
-    container: mortar
-    part:
-    - aloe
-  - name: some limb salve
-    noun: salve
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - jadice
-  - name: some neck ungent
-    noun: ungent
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - georin
-  - name: some abdominal ungent
-    noun: ungent
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - nilos
-  - name: some chest ungent
-    noun: ungent
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - plovik
-  - name: some back ungent
-    noun: ungent
-    volume: 1
-    work_order: false
-    chapter: 3
-    container: mortar
-    part:
-    - hulnik
-  - name: some eye ungent
-    noun: ungent
-    volume: 1
-    work_order: false
-    chapter: 3
-    container: mortar
-    part:
-    - sufil
-  - name: some skin ungent
-    noun: ungent
-    volume: 1
-    work_order: false
-    chapter: 3
-    container: mortar
-    part:
-    - aloe
-  - name: some limb ungent
-    noun: ungent
-    volume: 1
-    work_order: true
-    chapter: 3
-    container: mortar
-    part:
-    - jadice
-  # Remedies Chapter 4 recipes
-  - name: a neck potion
-    noun: potion
-    volume: 1
-    work_order: true
-    chapter: 4
-    container: bowl
-    part:
-    - riolur
-  - name: an abdomen potion
-    noun: potion
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - muljin
-  - name: a chest potion
-    noun: potion
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - ithor
-  - name: a head potion
-    noun: potion
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - eghmok
-  - name: a back potion
-    noun: potion
-    volume: 1
-    work_order: true
-    chapter: 4
-    container: bowl
-    part:
-    - junliar
-  - name: an eye potion
-    noun: potion
-    volume: 1
-    work_order: true
-    chapter: 4
-    container: bowl
-    part:
-    - aevaes
-  - name: a skin potion
-    noun: potion
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - lujeakave
-  - name: a limb potion
-    noun: potion
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - yelith
-  - name: some neck tonic
-    noun: tonic
-    volume: 1
-    work_order: true
-    chapter: 4
-    container: bowl
-    part:
-    - riolur
-  - name: some abdominal tonic
-    noun: tonic
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - muljin
-  - name: some chest tonic
-    noun: tonic
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - ithor
-  - name: some head tonic
-    noun: tonic
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - eghmok
-  - name: some back tonic
-    noun: tonic
-    volume: 1
-    work_order: true
-    chapter: 4
-    container: bowl
-    part:
-    - junliar
-  - name: some eye tonic
-    noun: tonic
-    volume: 1
-    work_order: true
-    chapter: 4
-    container: bowl
-    part:
-    - aevaes
-  - name: some skin tonic
-    noun: tonic
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - lujeakave
-  - name: some limb tonic
-    noun: tonic
-    volume: 1
-    work_order: false
-    chapter: 4
-    container: bowl
-    part:
-    - yelith
-  # Remedies Chapter 5 recipes
-  - name: some face ointment
-    noun: ointment
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - qun pollen
-    - alcohol
-  - name: some body ointment
-    noun: ointment
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - genich stem
-    - alcohol
-  - name: some limb ointment
-    noun: ointment
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - blocil
-    - alcohol
-  - name: some face poultices
-    noun: poultices
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - qun pollen
-    - alcohol
-  - name: some skin ointment
-    noun: ointment
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - cebi
-    - alcohol
-  - name: some body poultices
-    noun: poultices
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - genich stem
-    - alcohol
-  - name: some general purpose ointment
-    noun: ointment
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - dioica
-    - alcohol
-  - name: some skin poultices
-    noun: poultices
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - cebi
-    - alcohol
-  - name: some limb poultices
-    noun: poultices
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - blocil
-    - alcohol
-  - name: some general poultices
-    noun: poultices
-    volume: 1
-    work_order: false
-    chapter: 5
-    container: mortar
-    part:
-    - dioica
-    - alcohol
-  - name: a body draught
-    noun: draught
-    volume: 1
-    work_order: true
-    chapter: 6
-    container: bowl
-    part:
-    - ojhenik
-    - alcohol
-  # Remedies Chapter 6 recipes
-  - name: a face draught
-    noun: draught
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - hulij
-    - alcohol
-  - name: a limb draught
-    noun: draught
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - nuloe
-    - alcohol
-  - name: a skin draught
-    noun: draught
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - hisan
-    - alcohol
-  - name: a general purpose draught
-    noun: draught
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - belradi
-    - alcohol
-  - name: a skin elixir
-    noun: elixir
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - hisan
-    - alcohol
-  - name: a limb elixir
-    noun: elixir
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - nuloe
-    - alcohol
-  - name: a body elixir
-    noun: elixir
-    volume: 1
-    work_order: true
-    chapter: 6
-    container: bowl
-    part:
-    - ojhenik
-    - alcohol
-  - name: a face elixir
-    noun: elixir
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - hulij
-    - alcohol
-  - name: a general elixir
-    noun: elixir
-    volume: 1
-    work_order: false
-    chapter: 6
-    container: bowl
-    part:
-    - belradi
-    - alcohol
-artificing:
+- name: some blister cream
+  noun: cream
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 2
+  container: mortar
+  herb1: red flower
+  herb1_stock: 13
+  herb2: nemoih
+  herb2_stock: 3
+- name: some moisturizing ointment
+  noun: ointment
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 2
+  container: mortar
+  herb1: red flower
+  herb1_stock: 13
+  herb2: plovik
+  herb2_stock: 4
+  liquid: alcohol
+- name: some itch salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 2
+  container: mortar
+  herb1: red flower
+  herb1_stock: 13
+  herb2: jadice
+  herb2_stock: 5
+- name: some wart salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 2
+  container: mortar
+  herb1: red flower
+  herb1_stock: 13
+  herb2: sufil
+  herb2_stock:
+- name: some stomach tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 2
+  container: bowl
+  herb1: blue flower
+  herb1_stock:
+  herb2: muljin
+  herb2_stock:
+- name: some lip balm
+  noun: balm
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 2
+  container: mortar
+  herb1: red flower
+  herb1_stock: 13
+  herb2: nilos
+  herb2_stock: 6
+- name: some mouth wash
+  noun: wash
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 2
+  container: bowl
+  herb1: blue flower
+  herb1_stock:
+  herb2: riolur
+  herb2_stock: 8
+- name: some eye wash
+  noun: wash
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 2
+  container: bowl
+  herb1: blue flower
+  herb1_stock:
+  herb2: aevaes
+  herb2_stock:
+- name: some hangover potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 2
+  container: bowl
+  herb1: blue flower
+  herb1_stock:
+  herb2: ojhenik
+  herb2_stock: 12
+- name: some refreshment elixir
+  noun: elixir
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 2
+  container: bowl
+  herb1: blue flower
+  herb1_stock:
+  herb2: belradi
+  herb2_stock:
+  catalyst: coal nugget
+  catalyst_stock: 2
+  catalyst_volume: 10
+- name: some vigor poultices
+  noun: poultices
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 2
+  container: bowl
+  herb1: red flower
+  herb1_stock: 13
+  herb2: dioica
+  herb2_stock:
+# Remedies Chapter 3 recipes
+- name: some neck salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: georin
+  herb1_stock: 7
+- name: some abdominal salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: nilos
+  herb1_stock: 6
+- name: some chest salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: plovik
+  herb1_stock: 4
+- name: some head salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: nemoih
+  herb1_stock: 3
+- name: some back salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 3
+  container: mortar
+  herb1: hulnik
+  herb1_stock:
+- name: some eye salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 3
+  container: mortar
+  herb1: sufil
+  herb1_stock:
+- name: some skin salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 3
+  container: mortar
+  herb1: aloe
+  herb1_stock:
+- name: some limb salve
+  noun: salve
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: jadice
+  herb1_stock: 5
+- name: some neck ungent
+  noun: ungent
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: georin
+  herb1_stock: 7
+- name: some abdominal ungent
+  noun: ungent
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: nilos
+  herb1_stock: 6
+- name: some chest ungent
+  noun: ungent
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: plovik
+  herb1_stock: 4
+- name: some back ungent
+  noun: ungent
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 3
+  container: mortar
+  herb1: hulnik
+  herb1_stock:
+- name: some eye ungent
+  noun: ungent
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 3
+  container: mortar
+  herb1: sufil
+  herb1_stock:
+- name: some skin ungent
+  noun: ungent
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 3
+  container: mortar
+  herb1: aloe
+  herb1_stock:
+- name: some limb ungent
+  noun: ungent
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 3
+  container: mortar
+  herb1: jadice
+  herb1_stock: 5
+# Remedies Chapter 4 recipes
+- name: a neck potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 4
+  container: bowl
+  herb1: riolur
+  herb1_stock: 8
+- name: an abdomen potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: muljin
+  herb1_stock:
+- name: a chest potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: ithor
+  herb1_stock: 14
+- name: a head potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: eghmok
+  herb1_stock:
+- name: a back potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 4
+  container: bowl
+  herb1: jun
+  herb1_stock: 9
+- name: an eye potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 4
+  container: bowl
+  herb1: aevaes
+  herb1_stock: 10
+- name: a skin potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: lujeakave
+  herb1_stock:
+- name: a limb potion
+  noun: potion
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: yelith
+  herb1_stock:
+- name: some neck tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 4
+  container: bowl
+  herb1: riolur
+  herb1_stock: 8
+- name: some abdominal tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: muljin
+  herb1_stock:
+- name: some chest tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: ithor
+  herb1_stock: 14
+- name: some head tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: eghmok
+  herb1_stock:
+- name: some back tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 4
+  container: bowl
+  herb1: jun
+  herb1_stock: 9
+- name: some eye tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 4
+  container: bowl
+  herb1: aevaes
+  herb1_stock: 10
+- name: some skin tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: lujeakave
+  herb1_stock:
+- name: some limb tonic
+  noun: tonic
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 4
+  container: bowl
+  herb1: yelith
+  herb1_stock:
+# Remedies Chapter 5 recipes
+- name: some face ointment
+  noun: ointment
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: qun
+  herb1_stock: 15
+  liquid: alcohol
+- name: some body ointment
+  noun: ointment
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: genich
+  herb1_stock: 11
+  liquid: alcohol
+- name: some limb ointment
+  noun: ointment
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: blocil
+  herb1_stock:
+  liquid: alcohol
+- name: some face poultices
+  noun: poultices
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: qun
+  herb1_stock: 15
+  liquid: alcohol
+- name: some skin ointment
+  noun: ointment
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: cebi
+  herb1_stock:
+  liquid: alcohol
+- name: some body poultices
+  noun: poultices
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: genich
+  herb1_stock: 11
+  liquid: alcohol
+- name: some general purpose ointment
+  noun: ointment
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: dioica
+  herb1_stock:
+  liquid: alcohol
+- name: some skin poultices
+  noun: poultices
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: cebi
+  herb1_stock:
+  liquid: alcohol
+- name: some limb poultices
+  noun: poultices
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: blocil
+  herb1_stock:
+  liquid: alcohol
+- name: some general poultices
+  noun: poultices
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 5
+  container: mortar
+  herb1: dioica
+  herb1_stock:
+  liquid: alcohol
+- name: a body draught
+  noun: draught
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 6
+  container: bowl
+  herb1: ojhenik
+  herb1_stock: 12
+  liquid: alcohol
+# Remedies Chapter 6 recipes
+- name: a face draught
+  noun: draught
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: hulij
+  herb1_stock:
+  liquid: alcohol
+- name: a limb draught
+  noun: draught
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: nuloe
+  herb1_stock:
+  liquid: alcohol
+- name: a skin draught
+  noun: draught
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: hisan
+  herb1_stock:
+  liquid: alcohol
+- name: a general purpose draught
+  noun: draught
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: belradi
+  herb1_stock:
+  liquid: alcohol
+- name: a skin elixir
+  noun: elixir
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: hisan
+  herb1_stock:
+  liquid: alcohol
+- name: a limb elixir
+  noun: elixir
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: nuloe
+  herb1_stock:
+  liquid: alcohol
+- name: a body elixir
+  noun: elixir
+  volume: 1
+  type: remedies
+  work_order: true
+  chapter: 6
+  container: bowl
+  herb1: ojhenik
+  herb1_stock: 12
+  liquid: alcohol
+- name: a face elixir
+  noun: elixir
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: hulij
+  herb1_stock:
+  liquid: alcohol
+- name: a general elixir
+  noun: elixir
+  volume: 1
+  type: remedies
+  work_order: false
+  chapter: 6
+  container: bowl
+  herb1: belradi
+  herb1-stock:
+  liquid: alcohol
 ####################################
 ##### Enchanting section ends #####
 ####################################
 # Artificing Chapter 2 recipes
-  - name: a radiant trinket
-    noun: bone totem
-    chapter: 2
-    work_order: true
-    part:
-    - abolution sigil-scroll
-    - bone totem
-  - name: a mana trinket
-    noun: bone totem
-    chapter: 2
-    work_order: true
-    part:
-    - abolution sigil-scroll
-    - congruence sigil-scroll
-    - bone totem
-  - name: a flash trinket
-    noun: bone totem
-    chapter: 2
-    work_order: true
-    part:
-    - induction sigil-scroll
-    - bone totem
-  - name: a cambrinth retuner
-    noun: bobcat rod
-    chapter: 2
-    work_order: true
-    part:
-    - congruence sigil-scroll
-    - bobcat rod
-  - name: a celestial beacon
-    noun: heron bead
-    chapter: 2
-    work_order: true
-    part:
-    - abolution sigil-scroll
-    - bead
-  - name: a wind trinket
-    noun: bone totem
-    chapter: 2
-    work_order: true
-    part:
-    - rarefaction sigil-scroll
-    - bone totem
-  - name: simple devourer
-    noun: gem
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - gem
-    - metamorphosis sigil-scroll
-  - name: Eluned's Scry
-    noun: bone
-    chapter: 2
-    work_order: false
-    part:
-    - bone
-    - abolution sigil-scroll
-    - permutation sigil-scroll
-  - name: an earth trinket
-    noun: bone totem
-    chapter: 2
-    work_order: true
-    part:
-    - permutation sigil-scroll
-    - bone totem
-  - name: Garden's Vision
-    noun: gem
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - A sapphire or amethyst gem
-    - antipode sigil-scroll
-  - name: a fire trinket
-    noun: bone totem
-    chapter: 2
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - bone totem
-    - paradox sigil-scroll 
-  - name: Mirkik sokis
-    noun: gem
-    chapter: 2
-    work_order: false
-    part:
-    - rarefaction sigil-scroll
-    - induction sigil-scroll
-    - An ordinary gem of sufficient value
-  - name: a water trinket
-    noun: bone totem
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - bone totem
-    - ascension sigil-scroll
-  - name: an aura device
-    noun: bone totem
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - bone totem
-    - paradox sigil-scroll
-  - name: a magic gem
-    noun: gem
-    chapter: 2
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - gem
-    - unity sigil-scroll
-  - name: nemmiro stone
-    noun: stone
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - pebble
-    - any
-    - any
-  - name: a shatter sigil
-    noun: ingot
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - ingot
-    - decay sigil-scroll
-    - antipode sigil-scroll
-  - name: simple gwethsmasher
-    noun: bone totem
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - bone totem
-    - metamorphosis sigil-scroll
-  - name: a mining stone
-    noun: stone
-    chapter: 2
-    work_order: false
-    part:
-    - rarefaction sigil-scroll
-    - pebble
-    - integration sigil-scroll
-    - antipode sigil-scroll
-  - name: Ring of Glory Charisma
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - ring
-    - paradox sigil-scroll
-    - clarification sigil-scroll
-  - name: Ring of Glory Stamina
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - ring
-    - integration sigil-scroll
-    - nurture sigil-scroll
-  - name: Astoshe's Eclipse
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - ring
-    - unity sigil-scroll
-  - name: Ring of Glory Wisdom
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - ring
-    - metamorphosis sigil-scroll
-    - evolution sigil-scroll
-  - name: Ring of Glory Intelligence
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - ring
-    - paradox sigil-scroll
-    - clarification sigil-scroll
-  - name: unleashed gwethsmasher
-    noun: bone totem
-    chapter: 2
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - bone totem
-    - metamorphosis sigil-scroll
-  - name: Ring of Glory Discipline
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - ring
-    - nurture sigil-scroll
-    - decay sigil-scroll
-  - name: Ring of Glory Reflex
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - ring
-    - metamorphosis sigil-scroll
-    - evolution sigil-scroll
-  - name: Ring of Glory Agility
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - rarefaction sigil-scroll
-    - ring
-    - nurture sigil-scroll
-    - integration sigil-scroll
-  - name: Ring of Glory Strength
-    noun: ring
-    chapter: 2
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - ring
-    - antipode sigil-scroll
-    - evolution sigil-scroll
-  # Artificing Chapter 3 recipes
-  - name: training ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: true
-    part:
-    - rarefaction sigil-scroll
-    - bone totem
-  - name: a basic lunar ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: true
-    part:
-    - rarefaction sigil-scroll
-    - congruence sigil-scroll
-    - bone totem
-  - name: basic elemental ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: true
-    part:
-    - permutation sigil-scroll
-    - congruence sigil-scroll
-    - bone totem
-  - name: basic life ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: true
-    part:
-    - induction sigil-scroll
-    - congruence sigil-scroll
-    - bone totem
-  - name: an accurate focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - bone totem
-    - nurture sigil-scroll
-    - decay sigil-scroll
-  - name: basic holy ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: true
-    part:
-    - abolution sigil-scroll
-    - congruence sigil-scroll
-    - bone totem
-  - name: an efficient focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - bone totem
-    - metamorphosis sigil-scroll
-    - ascension sigil-scroll
-  - name: advanced lunar ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - bone totem
-    - paradox sigil-scroll
-  - name: basic untuned ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - bone totem
-    - nurture sigil-scroll
-  - name: a lethal focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - bone totem
-    - paradox sigil-scroll
-    - clarification sigil-scroll
-  - name: advanced elemental ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - bone totem
-    - evolution sigil-scroll
-  - name: a destructive focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - bone totem
-    - decay sigil-scroll
-    - antipode sigil-scroll
-  - name: advanced life ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - bone totem
-    - ascension sigil-scroll
-  - name: a fire focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - bone totem
-    - evolution sigil-scroll
-    - integration sigil-scroll
-    - nurture sigil-scroll
-  - name: advanced holy ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - bone totem
-    - unity sigil-scroll
-  - name: a frost focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - bone totem
-    - evolution sigil-scroll
-    - metamorphosis sigil-scroll
-    - unity sigil-scroll
-  - name: advanced AP ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - bone totem
-    - decay sigil-scroll
-  - name: an electric focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - bone totem
-    - evolution sigil-scroll
-    - ascension sigil-scroll
-    - paradox sigil-scroll
-  - name: advanced untuned ritual focus
-    noun: bone totem
-    chapter: 3
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - congruence sigil-scroll
-    - bone totem
-    - unity sigil-scroll
-  # Artificing Chapter 4 recipes
-  - name: common material minor fount
-    noun: small sphere
-    chapter: 4
-    work_order: true
-    part:
-    - congruence sigil-scroll
-    - sphere
-  - name: common material lesser fount
-    noun: small sphere
-    chapter: 4
-    work_order: true
-    part:
-    - congruence sigil-scroll
-    - abolution sigil-scroll
-    - sphere
-  - name: uncommon material minor fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - paradox sigil-scroll
-  - name: common material greater fount
-    noun: small sphere
-    chapter: 4
-    work_order: true
-    part:
-    - congruence sigil-scroll
-    - rarefaction sigil-scroll
-    - sphere
-  - name: common material major fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - sphere
-    - evolution sigil-scroll
-  - name: rare material minor fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - metamorphosis sigil-scroll
-    - nurture sigil-scroll
-  - name: uncommon material lesser fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - nurture sigil-scroll
-  - name: ultra rare material minor fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - decay sigil-scroll
-    - nurture sigil-scroll
-  - name: uncommon material greater fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - integration sigil-scroll
-  - name: rare material lesser fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - metamorphosis sigil-scroll
-    - decay sigil-scroll
-  - name: uncommon material major fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - clarification sigil-scroll
-  - name: ultra rare material lesser fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - decay sigil-scroll
-    - decay sigil-scroll
-  - name: rare material greater fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - metamorphosis sigil-scroll
-    - paradox sigil-scroll
-  - name: ultra rare material greater fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - decay sigil-scroll
-    - paradox sigil-scroll
-  - name: rare material major fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - metamorphosis sigil-scroll
-    - evolution sigil-scroll
-  - name: ultra rare material major fount
-    noun: small sphere
-    chapter: 4
-    work_order: false
-    part:
-    - congruence sigil-scroll
-    - congruence sigil-scroll
-    - sphere
-    - decay sigil-scroll
-    - ascension sigil-scroll
-  # Artificing Chapter 5 recipes
-  - name: an unfocused burin
-    noun: burin
-    chapter: 5
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - burin
-  - name: a focused burin
-    noun: burin
-    chapter: 5
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - rarefaction sigil-scroll
-    - burin
-  - name: oval augmenting loop
-    noun: loop
-    chapter: 5
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - short pole
-    - clarification sigil-scroll
-  - name: a gwethdesuan
-    noun: gwethdesuan
-    chapter: 5
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - gwethdesuan
-    - ascension sigil-scroll
-    - gwethdesuan
-  - name: a small enchanter's brazier
-    noun: brazier
-    chapter: 5
-    work_order: false
-    part:
-    - rarefaction sigil-scroll
-    - congruence sigil-scroll
-    - brazier
-  - name: oblong augmenting loop
-    noun: loop
-    chapter: 5
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - permutation sigil-scroll
-    - short pole
-    - clarification sigil-scroll
-  - name: simple imbuement rod
-    chapter: 5
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - evolution sigil-scroll
-  - name: an abstract burin
-    noun: burin
-    chapter: 5
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - rarefaction sigil-scroll
-    - burin
-    - unity sigil-scroll
-  - name: circular augmenting loop
-    noun: loop
-    chapter: 5
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - rarefaction sigil-scroll
-    - short pole
-    - clarification sigil-scroll
-  - name: stout imbuement rod
-    chapter: 5
-    work_order: false
-    part:
-    - abolution sigil-scroll
-    - paradox sigil-scroll
-    - nurture sigil-scroll
-  - name: a precise burin
-    noun: burin
-    chapter: 5
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - rarefaction sigil-scroll
-    - burin
-    - integration sigil-scroll
-  - name: flat augmenting loop
-    noun: loop
-    chapter: 5
-    work_order: false
-    part:
-    - permutation sigil-scroll
-    - induction sigil-scroll
-    - short pole
-    - clarification sigil-scroll
-  - name: precise imbuement rod
-    chapter: 5
-    work_order: false
-    part:
-    - rarefaction sigil-scroll
-    - antipode sigil-scroll
-    - metamorphosis sigil-scroll
-  # Artificing Chapter 6 recipes
-  - name: a bubble wand
-    noun: wand
-    chapter: 6
-    work_order: true
-    part:
-    - permutation sigil-scroll
-    - wand
-  - name: ease burden runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - permutation sigil-scroll
-    - induction sigil-scroll
-    - runestone
-  - name: seal cambrinth runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - induction sigil-scroll
-    - congruence sigil-scroll
-    - runestone
-  - name: burden runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - permutation sigil-scroll
-    - rarefaction sigil-scroll
-    - runestone
-  - name: manifest force runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - rarefaction sigil-scroll
-    - induction sigil-scroll
-    - runestone
-  - name: strange arrow runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - permutation sigil-scroll
-    - rarefaction sigil-scroll
-    - runestone
-  - name: gauge flow runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - abolution sigil-scroll
-    - induction sigil-scroll
-    - runestone
-  - name: dispel runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - rarefaction sigil-scroll
-    - induction sigil-scroll
-    - runestone
-  - name: a lore arcana wand
-    noun: wand
-    chapter: 6
-    work_order: false
-    part:
-    - induction sigil-scroll
-    - wand
-    - ascension sigil-scroll
-    - evolution sigil-scroll
-  - name: lay ward runestone
-    noun: basic runestone
-    chapter: 6
-    work_order: true
-    part:
-    - rarefaction sigil-scroll
-    - induction sigil-scroll
-    - runestone
+- name: a radiant trinket
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: true
+  enchant_stock1: 2
+  item: 6
+- name: a mana trinket
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: true
+  enchant_stock1: 2
+  enchant_stock2: 3
+  item: 6
+- name: a flash trinket
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: true
+  enchant_stock1: 1
+  item: 6
+- name: a cambrinth retuner
+  noun: bobcat rod
+  type: artificing
+  chapter: 2
+  work_order: true
+  enchant_stock1: 3
+  part:
+  - bobcat rod
+- name: a celestial beacon
+  noun: heron bead
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  part:
+  - bead
+- name: a wind trinket
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: true
+  enchant_stock1: 5
+  item: 6
+- name: simple devourer
+  noun: gem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  part:
+  - gem
+  secondary:
+  - metamorphosis
+- name: Eluned's Scry
+  noun: bone
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  enchant_stock2: 4
+- name: an earth trinket
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: true
+  enchant_stock1: 4
+  item: 6
+- name: Garden's Vision
+  noun: gem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  part:
+  - A sapphire or amethyst gem
+  secondary:
+  - antipode
+- name: a fire trinket
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 1
+  item: 6
+  secondary:
+  - paradox
+- name: Mirkik sokis
+  noun: gem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 5
+  enchant_stock2: 1
+  part:
+  - An ordinary gem of sufficient value
+- name: a water trinket
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item: 6
+  secondary:
+  - ascension
+- name: an aura device
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item: 6
+  secondary:
+  - paradox
+- name: a magic gem
+  noun: gem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 4
+  part:
+  - gem
+  secondary:
+  - unity
+- name: nemmiro stone
+  noun: stone
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item:
+  part:
+  - pebble
+  secondary:
+  - any
+  - any
+- name: a shatter sigil
+  noun: ingot
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item: ingot
+  secondary:
+  - decay
+  - antipode
+- name: simple gwethsmasher
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item: 6
+  secondary:
+  - metamorphosis
+- name: a mining stone
+  noun: stone
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 5
+  item:
+  part:
+  - pebble
+  secondary:
+  - integration
+  - antipode
+- name: Ring of Glory Charisma
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 4
+  item:
+  part:
+  - ring
+  secondary:
+  - paradox
+  - clarification
+- name: Ring of Glory Stamina
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item:
+  part:
+  - ring
+  secondary:
+  - integration
+  - nurture
+- name: Astoshe's Eclipse
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 3
+  item:
+  part:
+  - ring
+  secondary:
+  - unity
+- name: Ring of Glory Wisdom
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 1
+  item:
+  part:
+  - ring
+  secondary:
+  - metamorphosis
+  - evolution
+- name: Ring of Glory Intelligence
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item:
+  part:
+  - ring
+  secondary:
+  - paradox
+  - clarification
+- name: unleashed gwethsmasher
+  noun: bone totem
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 2
+  item: 6
+  secondary:
+  - metamorphosis
+- name: Ring of Glory Discipline
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 4
+  item:
+  part:
+  - ring
+  secondary:
+  - nurture
+  - decay
+- name: Ring of Glory Reflex
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 3
+  item:
+  part:
+  - ring
+  secondary:
+  - metamorphosis
+  - evolution
+- name: Ring of Glory Agility
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 5
+  item:
+  part:
+  - ring
+  secondary:
+  - nurture
+  - integration
+- name: Ring of Glory Strength
+  noun: ring
+  type: artificing
+  chapter: 2
+  work_order: false
+  enchant_stock1: 1
+  item:
+  part:
+  - ring
+  secondary:
+  - antipode
+  - evolution
+# Artificing Chapter 3 recipes
+- name: training ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: true
+  enchant_stock1: 5
+  item: 6
+- name: a basic lunar ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: true
+  enchant_stock1: 5
+  enchant_stock2: 3
+  item: 6
+- name: basic elemental ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: true
+  enchant_stock1: 4
+  enchant_stock2: 3
+  item: 6
+- name: basic life ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: true
+  enchant_stock1: 1
+  enchant_stock2: 3
+  item: 6
+- name: an accurate focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 4
+  item: 6
+  secondary:
+  - nurture
+  - decay
+- name: basic holy ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: true
+  enchant_stock1: 2
+  enchant_stock2: 3
+  item: 6
+- name: an efficient focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 1
+  item: 6
+  secondary:
+  - metamorphosis
+  - ascension
+- name: advanced lunar ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 3
+  item: 6
+  secondary:
+  - paradox
+- name: basic untuned ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 3
+  item: 6
+  secondary:
+  - nurture
+- name: a lethal focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 3
+  item: 6
+  secondary:
+  - paradox
+  - clarification
+- name: advanced elemental ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 3
+  item: 6
+  secondary:
+  - evolution
+- name: a destructive focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 2
+  item: 6
+  secondary:
+  - decay
+  - antipode
+- name: advanced life ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 3
+  item: 6
+  secondary:
+  - ascension
+- name: a fire focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  item: 6
+  secondary:
+  - evolution
+  - integration
+  - nurture
+- name: advanced holy ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 3
+  item: 6
+  secondary:
+  - unity
+- name: a frost focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  item: 6
+  secondary:
+  - evolution
+  - metamorphosis
+  - unity
+- name: advanced AP ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 3
+  item: 6
+  secondary:
+  - decay
+- name: an electric focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  item: 6
+  secondary:
+  - evolution
+  - ascension
+  - paradox
+- name: advanced untuned ritual focus
+  noun: bone totem
+  type: artificing
+  chapter: 3
+  work_order: false
+  enchant_stock1: 2
+  enchant_stock2: 3
+  item: 6
+  secondary:
+  - unity
+# Artificing Chapter 4 recipes
+- name: common material minor fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: true
+  enchant_stock1: 3
+  part:
+  - sphere
+- name: common material lesser fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: true
+  enchant_stock1: 3
+  enchant_stock2: 2
+  part:
+  - sphere
+- name: uncommon material minor fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - paradox
+- name: common material greater fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: true
+  enchant_stock1: 3
+  enchant_stock2: 5
+  part:
+  - sphere
+- name: common material major fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  part:
+  - sphere
+  secondary:
+  - evolution
+- name: rare material minor fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - metamorphosis
+  - nurture
+- name: uncommon material lesser fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - nurture
+- name: ultra rare material minor fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - decay
+  - nurture
+- name: uncommon material greater fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - integration
+- name: rare material lesser fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - metamorphosis
+  - decay
+- name: uncommon material major fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - clarification
+- name: ultra rare material lesser fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - decay
+  - decay
+- name: rare material greater fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - metamorphosis
+  - paradox
+- name: ultra rare material greater fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - decay
+  - paradox
+- name: rare material major fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - metamorphosis
+  - evolution
+- name: ultra rare material major fount
+  noun: small sphere
+  type: artificing
+  chapter: 4
+  work_order: false
+  enchant_stock1: 3
+  enchant_stock2: 3
+  part:
+  - sphere
+  secondary:
+  - decay
+  - ascension
+# Artificing Chapter 5 recipes
+- name: an unfocused burin
+  noun: burin
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 1
+  part:
+  - burin
+- name: a focused burin
+  noun: burin
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 1
+  enchant_stock2: 5
+  part:
+  - burin
+- name: oval augmenting loop
+  noun: loop
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 4
+  part:
+  - pole
+  secondary:
+  - clarification
+- name: a gwethdesuan
+  noun: gwethdesuan
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 1
+  part:
+  - gwethdesuan
+  secondary:
+  - ascension
+  item:
+  - gwethdesuan
+- name: a small enchanter's brazier
+  noun: brazier
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 5
+  enchant_stock2: 3
+  item:
+  part:
+  - brazier
+- name: oblong augmenting loop
+  noun: loop
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 4
+  enchant_stock2: 4
+  part:
+  - pole
+  secondary:
+  - clarification
+- name: simple imbuement rod
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 1
+  secondary:
+  - evolution
+- name: an abstract burin
+  noun: burin
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 1
+  enchant_stock2: 5
+  part:
+  - burin
+  secondary:
+  - unity
+- name: circular augmenting loop
+  noun: loop
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 4
+  enchant_stock2: 5
+  part:
+  - pole
+  secondary:
+  - clarification
+- name: stout imbuement rod
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 2
+  secondary:
+  - paradox
+  - nurture
+- name: a precise burin
+  noun: burin
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 1
+  enchant_stock2: 5
+  part:
+  - burin
+  secondary:
+  - integration
+- name: flat augmenting loop
+  noun: loop
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 4
+  enchant_stock2: 1
+  part:
+  - pole
+  secondary:
+  - clarification
+- name: precise imbuement rod
+  type: artificing
+  chapter: 5
+  work_order: false
+  enchant_stock1: 5
+  secondary:
+  - antipode
+  - metamorphosis
+# Artificing Chapter 6 recipes
+- name: a bubble wand
+  noun: wand
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 4
+  part:
+  - wand
+- name: ease burden runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 4
+  enchant_stock2: 1
+  item:
+  part:
+  - runestone
+- name: seal cambrinth runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 1
+  enchant_stock2: 3
+  item:
+  part:
+  - runestone
+- name: burden runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 4
+  enchant_stock2: 5
+  item:
+  part:
+  - runestone
+- name: manifest force runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 5
+  enchant_stock2: 1
+  item:
+  part:
+  - runestone
+- name: strange arrow runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 4
+  enchant_stock2: 5
+  item:
+  part:
+  - runestone
+- name: gauge flow runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 2
+  enchant_stock2: 1
+  item:
+  part:
+  - runestone
+- name: dispel runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 5
+  enchant_stock2: 1
+  item:
+  part:
+  - runestone
+- name: a lore arcana wand
+  noun: wand
+  type: artificing
+  chapter: 6
+  work_order: false
+  enchant_stock1: 1
+  part:
+  - wand
+  secondary:
+  - ascension
+  - evolution
+- name: lay ward runestone
+  noun: basic runestone
+  type: artificing
+  chapter: 6
+  work_order: true
+  enchant_stock1: 5
+  enchant_stock2: 1
+  item:
+  part:
+  - runestone

--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -1,8188 +1,7109 @@
 ---
-crafting_recipes:
-##### Page numbers are as of 2/20/2021 15:48 ET #####
-##################################
-##### Forging section begins #####
-##################################
-# Armorsmithing Chapter 1 recipes
-- name: a metal ring aventail
-  noun: aventail
-  volume: 5
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring mask
-  noun: mask
-  volume: 3
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain aventail
-  noun: aventail
-  volume: 6
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring cap
-  noun: cap
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain mask
-  noun: mask
-  volume: 4
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring gloves
-  noun: gloves
-  volume: 6
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring greaves
-  noun: greaves
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring helm
-  noun: helm
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail aventail
-  noun: aventail
-  volume: 7
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain cap
-  noun: cap
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail mask
-  noun: mask
-  volume: 5
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain gloves
-  noun: gloves
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail gloves
-  noun: gloves
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring tasset
-  noun: tasset
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring vambraces
-  noun: vambraces
-  volume: 19
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain greaves
-  noun: greaves
-  volume: 15
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring balaclava
-  noun: balaclava
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain helm
-  noun: helm
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail cap
-  noun: cap
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring lorica
-  noun: lorica
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal ring mantle
-  noun: mantle
-  volume: 21
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal ring vest
-  noun: vest
-  volume: 18
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain tasset
-  noun: tasset
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal ring sleeves
-  noun: sleeves
-  volume: 21
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain vambraces
-  noun: vambraces
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain balaclava
-  noun: balaclava
-  volume: 20
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - small padding
-- name: a metal mail helm
-  noun: helm
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a mail balaclava
-  noun: balaclava
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small backing
-- name: a metal ring shirt
-  noun: shirt
-  volume: 43
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal ring robe
-  noun: robe
-  volume: 38
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal chain lorica
-  noun: lorica
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain mantle
-  noun: mantle
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal chain vest
-  noun: vest
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail tasset
-  noun: tasset
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal chain sleeves
-  noun: sleeves
-  volume: 26
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: some metal mail vambraces
-  noun: vambraces
-  volume: 23
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal ring hauberk
-  noun: hauberk
-  volume: 70
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal chain shirt
-  noun: shirt
-  volume: 50
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal chain robe
-  noun: robe
-  volume: 45
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail lorica
-  noun: lorica
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail mantle
-  noun: mantle
-  volume: 27
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: a metal mail vest
-  noun: vest
-  volume: 22
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-- name: some metal mail sleeves
-  noun: sleeves
-  volume: 31
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - small padding
-- name: a metal chain hauberk
-  noun: hauberk
-  volume: 80
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal mail shirt
-  noun: shirt
-  volume: 57
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail robe
-  noun: robe
-  volume: 52
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-- name: a metal mail hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal bar-mail hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - large padding
-  - small padding
-  - small padding
-# Armorsmithing Chapter 2 recipes
-- name: a metal scale aventail
-  noun: aventail
-  volume: 9
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale mask
-  noun: mask
-  volume: 5
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale cap
-  noun: cap
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine aventail
-  noun: aventail
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine mask
-  noun: mask
-  volume: 6
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some metal scale gloves
-  noun: gloves
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale helm
-  noun: helm
-  volume: 21
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine cap
-  noun: cap
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar aventail
-  noun: aventail
-  volume: 11
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: a metal lamellar mask
-  noun: mask
-  volume: 7
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some metal scale greaves
-  noun: greaves
-  volume: 15
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: some brigandine gloves
-  noun: gloves
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale tasset
-  noun: tasset
-  volume: 10
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some metal scale vambraces
-  noun: vambraces
-  volume: 22
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale balaclava
-  noun: balaclava
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal brigandine helm
-  noun: helm
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar cap
-  noun: cap
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some brigandine greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some metal lamellar gloves
-  noun: gloves
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: a metal brigandine tasset
-  noun: tasset
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: some brigandine vambraces
-  noun: vambraces
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a brigandine balaclava
-  noun: balaclava
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal lamellar helm
-  noun: helm
-  volume: 27
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some lamellar greaves
-  noun: greaves
-  volume: 18
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: some metal scale sleeves
-  noun: sleeves
-  volume: 30
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale lorica
-  noun: lorica
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale mantle
-  noun: mantle
-  volume: 33
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale vest
-  noun: vest
-  volume: 24
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal lamellar tasset
-  noun: tasset
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: some lamellar vambraces
-  noun: vambraces
-  volume: 28
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: a metal lamellar balaclava
-  noun: balaclava
-  volume: 34
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small backing
-- name: some brigandine sleeves
-  noun: sleeves
-  volume: 35
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - small padding
-- name: a metal scale shirt
-  noun: shirt
-  volume: 56
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale robe
-  noun: robe
-  volume: 49
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-- name: a metal brigandine lorica
-  noun: lorica
-  volume: 38
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal brigandine mantle
-  noun: mantle
-  volume: 36
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal brigandine vest
-  noun: vest
-  volume: 26
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: some lamellar sleeves
-  noun: sleeves
-  volume: 40
-  type: armorsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - small backing
-- name: a brigandine robe
-  noun: robe
-  volume: 56
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-- name: a brigandine shirt
-  noun: shirt
-  volume: 63
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a metal scale hauberk
-  noun: hauberk
-  volume: 80
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal lamellar lorica
-  noun: lorica
-  volume: 42
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar mantle
-  noun: mantle
-  volume: 39
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar vest
-  noun: vest
-  volume: 28
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-- name: a metal lamellar robe
-  noun: robe
-  volume: 63
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-- name: a brigandine hauberk
-  noun: hauberk
-  volume: 90
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-  - small padding
-  - small padding
-- name: a metal lamellar shirt
-  noun: shirt
-  volume: 70
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large padding
-- name: a lamellar hauberk
-  noun: hauberk
-  volume: 100
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: a laminar hauberk
-  noun: hauberk
-  volume: 100
-  type: armorsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - large backing
-  - small backing
-  - small backing
-# Armorsmithing Chapter 3 recipes
-- name: a light plate aventail
-  noun: aventail
-  volume: 12
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a light plate mask
-  noun: mask
-  volume: 7
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some light plate gauntlets
-  noun: gauntlets
-  volume: 13
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a plate aventail
-  noun: aventail
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal dome helm
-  noun: helm
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a plate mask
-  noun: mask
-  volume: 8
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal bascinet
-  noun: bascinet
-  volume: 23
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some plate gauntlets
-  noun: gauntlets
-  volume: 15
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate aventail
-  noun: aventail
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal morion
-  noun: morion
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate mask
-  noun: mask
-  volume: 9
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a light plate fauld
-  noun: fauld
-  volume: 13
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small padding
-- name: a light backplate
-  noun: backplate
-  volume: 10
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some light plate vambraces
-  noun: vambraces
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal visored helm
-  noun: helm
-  volume: 26
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: heavy plate gauntlets
-  noun: gauntlets
-  volume: 17
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal barbute
-  noun: barbute
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some light plate greaves
-  noun: greaves
-  volume: 19
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a metal sallet
-  noun: sallet
-  volume: 35
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a light breastplate
-  noun: breastplate
-  volume: 16
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: a plate fauld
-  noun: fauld
-  volume: 15
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal backplate
-  noun: backplate
-  volume: 12
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some light plate sleeves
-  noun: sleeves
-  volume: 39
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-- name: some plate vambraces
-  noun: vambraces
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: some plate greaves
-  noun: greaves
-  volume: 22
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal armet
-  noun: armet
-  volume: 40
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal closed helm
-  noun: helm
-  volume: 29
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a light plate cuirass
-  noun: cuirass
-  volume: 39
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - large padding
-- name: a metal breastplate
-  noun: breastplate
-  volume: 18
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a heavy plate fauld
-  noun: fauld
-  volume: 17
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: a metal heavy backplate
-  noun: backplate
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some plate sleeves
-  noun: sleeves
-  volume: 45
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate vambraces
-  noun: vambraces
-  volume: 34
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate greaves
-  noun: greaves
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - small backing
-- name: a metal great helm
-  noun: helm
-  volume: 45
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some light half plate
-  noun: plate
-  volume: 65
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - large padding
-- name: some light field plate
-  noun: plate
-  volume: 58
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - large padding
-- name: a plate cuirass
-  noun: cuirass
-  volume: 45
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-- name: a heavy breastplate
-  noun: breastplate
-  volume: 20
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some heavy plate sleeves
-  noun: sleeves
-  volume: 51
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-- name: some light full plate
-  noun: plate
-  volume: 100
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small padding
-  - small padding
-  - large padding
-- name: some half plate
-  noun: plate
-  volume: 75
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-  - large backing
-- name: some field plate
-  noun: plate
-  volume: 67
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - small backing
-  - large backing
-- name: a heavy plate cuirass
-  noun: cuirass
-  volume: 51
-  type: armorsmithing
-  work_order: false
-  chapter: 3
-  part:
-  - large backing
-- name: some heavy half plate
-  noun: plate
-  volume: 85
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large padding
-  - small padding
-- name: some full plate
-  noun: plate
-  volume: 110
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: some heavy field plate
-  noun: plate
-  volume: 76
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-- name: some heavy full plate
-  noun: plate
-  volume: 120
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-- name: some heavy fluted plate
-  noun: plate
-  volume: 120
-  type: armorsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - large backing
-  - small backing
-  - small backing
-# Armorsmithing Chapter 4 recipes
-- name: a metal shield handle
-  noun: handle
-  volume: 2
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-- name: a metal shield boss
-  noun: boss
-  volume: 3
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-- name: a metal target shield
-  noun: shield
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal round sipar
-  noun: sipar
-  volume: 14
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal ordinary shield
-  noun: shield
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal targe
-  noun: targe
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal triangular sipar
-  noun: sipar
-  volume: 14
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal medium shield
-  noun: shield
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal ceremonial shield
-  noun: shield
-  volume: 16
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal curved shield
-  noun: shield
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal circular buckler
-  noun: buckler
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal medium buckler
-  noun: buckler
-  volume: 20
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal oval shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a simple parry stick
-  noun: stick
-  volume: 7
-  type: armorsmithing
-  work_order: false
-  chapter: 4
-  part:
-  - small backing
-- name: a metal jousting shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal skirmisher's shield
-  noun: shield
-  volume: 25
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal kite shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal warrior's shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal valnik shield
-  noun: shield
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal tower shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal battle shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal heater shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal aegis
-  noun: aegis
-  volume: 30
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-- name: a metal war shield
-  noun: shield
-  volume: 40
-  type: armorsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - shield handle
-  - long cord
-# Blacksmithing Chapter 2 recipes
-- name: a diagonal-peen mallet
-  noun: mallet
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a curved metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: a diagonal-peen hammer
-  noun: hammer
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - short pole
-- name: a stout metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some straight metal tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: a metal cross-peen hammer
-  noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a narrow metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a square metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: some curved metal tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some flat-bladed tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: a tapered metal shovel
-  noun: shovel
-  volume: 8
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - long pole
-- name: some angular metal tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: a straight-peen hammer
-  noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a straight-peen mallet
-  noun: mallet
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - short pole
-- name: a slender metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some metal bolt tongs
-  noun: tongs
-  volume: 10
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-- name: a flat-headed metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a sturdy metal shovel
-  noun: shovel
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: a ball-peen hammer
-  noun: hammer
-  volume: 12
-  chapter: 2
-  type: blacksmithing
-  work_order: false
-  part:
-  - short pole
-- name: a wide metal shovel
-  noun: shovel
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some segmented tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: a weighted metal pickaxe
-  noun: pickaxe
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - long pole
-- name: some box-jaw tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: some articulated tongs
-  noun: tongs
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-- name: a ball-peen mallet
-  noun: mallet
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 2
-  part:
-  - short pole
-# Blacksmithing Chapter 3 recipes
-- name: a short metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: some short metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: a long metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a metal straight wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal straight bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a thin metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some square metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: some long metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: a flat metal shaper
-  noun: shaper
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some plain metal pliers
-  noun: pliers
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some squat metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: thin metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: a rough metal wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a sturdy metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a metal curved wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal curved bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some curved metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a coarse metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some sturdy metal chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: curved metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: some curved metal rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: some reinforced chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: a sharpened metal drawknife
-  noun: drawknife
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-  part:
-  - short pole
-- name: a metal slender wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal slender bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some rough metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a textured metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal beveled wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: some thick metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a flat metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some elongated rifflers
-  noun: rifflers
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: some sharpened chisels
-  noun: chisels
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-  part:
-  - short cord
-- name: thick metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-- name: a metal tapered wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal tapered bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: some hooked metal pliers
-  noun: pliers
-  volume: 5
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a tapered metal rasp
-  noun: rasp
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal jagged wood shaper
-  noun: shaper
-  volume: 4
-  chapter: 3
-  type: blacksmithing
-  work_order: true
-- name: a metal serrated wood saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: a metal serrated bone saw
-  noun: saw
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 3
-- name: precise metal tinker's tools
-  noun: tools
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 3
-# Blacksmithing Chapter 4 recipes
-- name: a stout metal yardstick
-  noun: yardstick
-  volume: 6
-  chapter: 4
-  type: blacksmithing
-  work_order: false
-- name: some smooth knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a metal hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some straight metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some plain sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some curved metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a flat metal yardstick
-  noun: yardstick
-  volume: 6
-  chapter: 4
-  type: blacksmithing
-  work_order: false
-- name: some tapered knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a pointed metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a curved hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some ribbed sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some bent metal scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a rectangular yardstick
-  noun: yardstick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 4
-- name: some knobby sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some squat knitting needles
-  noun: needles
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a narrow metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some polished knitting needles
-  noun: needles
-  volume: 4
-  chapter: 4
-  type: blacksmithing
-  work_order: true
-- name: a compact metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a serrated hide scraper
-  noun: scraper
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some serrated scissors
-  noun: scissors
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: a detailed yardstick
-  noun: yardstick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 4
-- name: a slender metal awl
-  noun: awl
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-- name: some thin sewing needles
-  noun: needles
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 4
-# Blacksmithing Chapter 5 recipes
-- name: a small metal brazier
-  noun: brazier
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a tapered pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a flat mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a square wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a tapered mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a flat pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a metal brazier
-  noun: brazier
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a triangular wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a round mixing stick
-  noun: stick
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a round pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a grooved pestle
-  noun: pestle
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: an oblong wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-- name: a grooved mixing stick
-  noun: stick
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 5
-- name: a trapezoidal wire sieve
-  noun: sieve
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 5
-# Blacksmithing Chapter 6 recipes
-- name: a metal rod
-  noun: rod
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a shallow metal cup
-  noun: cup
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal horseshoe
-  noun: horseshoe
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a soft metal keyblank
-  noun: keyblank
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a short metal mug
-  noun: mug
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a tall metal mug
-  noun: mug
-  volume: 1
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a large metal horseshoe
-  noun: horseshoe
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: some metal barbells
-  noun: barbells
-  volume: 80
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a back scratcher
-  noun: scratcher
-  volume: 3
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal bolt box
-  noun: box
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal origami case
-  noun: case
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal lockpick case
-  noun: case
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal ankle band
-  noun: band
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a small metal flask
-  noun: flask
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal talisman case
-  noun: case
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal razor
-  noun: razor
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal flights box
-  noun: box
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal jewelry box
-  noun: box
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal herbal case
-  noun: case
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal lockpick ring
-  noun: ring
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal oil lantern
-  noun: lantern
-  volume: 6
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal flask
-  noun: flask
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal chest
-  noun: chest
-  volume: 12
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal instrument case
-  noun: case
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal armband
-  noun: armband
-  volume: 4
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a large metal flask
-  noun: flask
-  volume: 7
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: some metal clippers
-  noun: clippers
-  volume: 2
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal starchart tube
-  noun: tube
-  volume: 8
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-  part:
-  - short cord
-- name: a metal backtube
-  noun: backtube
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-  part:
-  - long cord
-- name: a metal crown
-  noun: crown
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-- name: a metal mask
-  noun: mask
-  volume: 5
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-  part:
-  - short cord
-- name: a metal torque
-  noun: torque
-  volume: 5
-  type: blacksmithing
-  work_order: true
-  chapter: 6
-- name: a metal headdress
-  noun: headdress
-  volume: 10
-  type: blacksmithing
-  work_order: false
-  chapter: 6
-# Weaponsmithing Chapter 1 recipes
-- name: a metal briquet
-  noun: briquet
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal carving knife
-  noun: knife
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal dagger
-  noun: dagger
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal misericorde
-  noun: misericorde
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal katar
-  noun: katar
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal short sword
-  noun: sword
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal pugio
-  noun: pugio
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal poignard
-  noun: poignard
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal stiletto
-  noun: stiletto
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal dart
-  noun: dart
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-- name: a metal throwing dagger
-  noun: dagger
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal falcata
-  noun: falcata
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal nehlata
-  noun: nehlata
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal telek
-  noun: telek
-  volume: 2
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal leaf blade sword
-  noun: sword
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal jambiya
-  noun: jambiya
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal takouba
-  noun: takouba
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal kris
-  noun: kris
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal thrusting blade
-  noun: blade
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal pasabas
-  noun: pasabas
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal rapier
-  noun: rapier
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal koummya
-  noun: koummya
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal oben
-  noun: oben
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal kythe
-  noun: kythe
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal dao
-  noun: dao
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal kasai
-  noun: kasai
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal sunblade
-  noun: sunblade
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal foil
-  noun: foil
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal baselard
-  noun: baselard
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal gladius
-  noun: gladius
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal mambeli
-  noun: mambeli
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal sashqa
-  noun: sashqa
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal adze
-  noun: adze
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal curlade
-  noun: curlade
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal parang
-  noun: parang
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hanger
-  noun: hanger
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal sabre
-  noun: sabre
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal scimitar
-  noun: scimitar
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal shotel
-  noun: shotel
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal cutlass
-  noun: cutlass
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hatchet
-  noun: hatchet
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-- name: a metal hand axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - haft
-- name: a light throwing axe
-  noun: axe
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - haft
-- name: a metal iltesh
-  noun: iltesh
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 1
-  part:
-  - hilt
-# Weaponsmithing Chapter 2 recipes
-- name: a metal condottiere
-  noun: condottiere
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal nehdalata
-  noun: nehdalata
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal round axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-- name: a metal longsword
-  noun: longsword
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal spatha
-  noun: spatha
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal kudalata
-  noun: kudalata
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal arzfilt
-  noun: arzfilt
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal broadsword
-  noun: broadsword
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal schiavona
-  noun: schiavona
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal falchion
-  noun: falchion
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal robe sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal battle axe
-  noun: axe
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-- name: a metal recade
-  noun: recade
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal back-sword
-  noun: back-sword
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal nimsha
-  noun: nimsha
-  volume: 8
-  type: weaponsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - hilt
-- name: a metal hunting sword
-  noun: sword
-  volume: 8
-  type: weaponsmithing
-  work_order: false
-  chapter: 2
-  part:
-  - hilt
-- name: a metal namkomba
-  noun: namkomba
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal dagesse
-  noun: dagesse
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal abassi
-  noun: abassi
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal cinquedea
-  noun: cinquedea
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - hilt
-- name: a metal hurling axe
-  noun: axe
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 2
-  part:
-  - haft
-# Weaponsmithing Chapter 3 recipes
-- name: a metal twin-point axe
-  noun: axe
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal karambit
-  noun: karambit
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal claymore
-  noun: claymore
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal greataxe
-  noun: greataxe
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal marauder blade
-  noun: blade
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal warring axe
-  noun: axe
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal two-handed sword
-  noun: sword
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal double axe
-  noun: axe
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal periperiu sword
-  noun: sword
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal flamberge
-  noun: flamberge
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal greatsword
-  noun: greatsword
-  volume: 18
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal shh'oi'ata
-  noun: shh'oi'ata
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-- name: a metal kaskara
-  noun: kaskara
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - hilt
-- name: a metal igorat axe
-  noun: axe
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 3
-  part:
-  - haft
-# Weaponsmithing Chapter 4 recipes
-- name: a metal gavel
-  noun: gavel
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal cosh
-  noun: cosh
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal prod
-  noun: prod
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal cudgel
-  noun: cudgel
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal zubke
-  noun: zubke
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal scepter
-  noun: scepter
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal hand mallet
-  noun: mallet
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal bludgeon
-  noun: bludgeon
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal garz
-  noun: garz
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a ridged metal gauntlet
-  noun: gauntlet
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal hand mace
-  noun: mace
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal club
-  noun: club
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a short metal hammer
-  noun: hammer
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal gauntlet
-  noun: gauntlet
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal bulhawf
-  noun: bulhawf
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal cuska
-  noun: cuska
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal bola
-  noun: bola
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - long cord
-- name: a metal throwing club
-  noun: club
-  volume: 5
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal mallet
-  noun: mallet
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal war club
-  noun: club
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal boko
-  noun: boko
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal boomerang
-  noun: boomerang
-  volume: 3
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal war hammer
-  noun: hammer
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal belaying pin
-  noun: pin
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal mace
-  noun: mace
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a metal marlingspike
-  noun: marlingspike
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal mace
-  noun: mace
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal hammer
-  noun: hammer
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a spiked metal club
-  noun: club
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal hhr'tami
-  noun: hhr'tami
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal komno
-  noun: komno
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-  part:
-  - haft
-- name: a metal k'trinni sha-tai
-  noun: sha-tai
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-- name: a flanged metal mace
-  noun: mace
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 4
-# Weaponsmithing Chapter 5 recipes
-- name: a metal imperial war hammer
-  noun: hammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a heavy metal mace
-  noun: mace
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal greathammer
-  noun: greathammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal ball and chain
-  noun: ball
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a heavy metal chain
-  noun: chain
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-- name: a metal horseman's flail
-  noun: flail
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal ukabi
-  noun: ukabi
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a spiked ball and chain
-  noun: ball
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a spiked metal hara
-  noun: hara
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal morning star
-  noun: star
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal sledgehammer
-  noun: sledgehammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a heavy metal mallet
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal hara
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a double-headed hammer
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal hhr'ata
-  noun: hhr'ata
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a hurlable war hammer
-  noun: hammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal throwing mallet
-  noun: mallet
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-- name: a metal throwing hammer
-  noun: hammer
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 5
-  part:
-  - haft
-# Weaponsmithing Chapter 6 recipes
-- name: a metal vilks kodur
-  noun: kodur
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal war mattock
-  noun: mattock
-  volume: 14
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: double-sided ball and chain
-  noun: ball
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal akabo
-  noun: akabo
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal footman's flail
-  noun: flail
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal dire mace
-  noun: mace
-  volume: 16
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a heavy sledgehammer
-  noun: sledgehammer
-  volume: 16
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal maul
-  noun: maul
-  volume: 16
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a metal two-headed hammer
-  noun: hammer
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-- name: a giant metal mallet
-  noun: hammer
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 6
-  part:
-  - haft
-# Weaponsmithing Chapter 7 recipes
-- name: a light metal spear
-  noun: spear
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal javelin
-  noun: javelin
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal spear
-  noun: spear
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal allarh
-  noun: allarh
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal hunthsleg
-  noun: hunthsleg
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal awgravet ava
-  noun: ava
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal coresca
-  noun: coresca
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal tzece
-  noun: tzece
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal halberd
-  noun: halberd
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal guisarme
-  noun: guisarme
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal lochaber axe
-  noun: axe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal bardiche
-  noun: bardiche
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal scythe
-  noun: scythe
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal duraka skefne
-  noun: skefne
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal military fork
-  noun: fork
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal partisan
-  noun: partisan
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal khuj
-  noun: khuj
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a two-pronged halberd
-  noun: halberd
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal glaive
-  noun: glaive
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ngalio
-  noun: ngalio
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal fauchard
-  noun: fauchard
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal pole axe
-  noun: axe
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ilglaiks skefne
-  noun: skefne
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal ranseur
-  noun: ranseur
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal spetum
-  noun: spetum
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal lance
-  noun: lance
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal pike
-  noun: pike
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a metal voulge
-  noun: voulge
-  volume: 13
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-- name: a short-hafted halberd
-  noun: halberd
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - short pole
-- name: a metal awl pike
-  noun: pike
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 7
-  part:
-  - long pole
-# Weaponsmithing Chapter 8 recipes
-- name: a metal nightstick
-  noun: nightstick
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal cane
-  noun: cane
-  volume: 8
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal quarterstaff
-  noun: quarterstaff
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a metal pike staff
-  noun: staff
-  volume: 11
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal knuckles
-  noun: knuckles
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some weighted metal footwraps
-  noun: footwraps
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal knee spikes
-  noun: spikes
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: some metal elbow spikes
-  noun: spikes
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-- name: some spiked metal footwraps
-  noun: footwraps
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some spiked metal knuckles
-  noun: knuckles
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: a weighted staff
-  noun: staff
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-- name: some metal hand claws
-  noun: claws
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 8
-  part:
-  - short cord
-# Weaponsmithing Chapter 9 recipes
-- name: a metal throwing spike
-  noun: spike
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-- name: a metal bar mace
-  noun: mace
-  volume: 12
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a metal broadaxe
-  noun: broadaxe
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a metal war sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal bastard sword
-  noun: sword
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal boarding axe
-  noun: axe
-  volume: 10
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a metal splitting maul
-  noun: maul
-  volume: 15
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - haft
-- name: a thin-bladed metal fan
-  noun: fan
-  volume: 4
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-- name: a metal half-handled riste
-  noun: riste
-  volume: 7
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-- name: a thick-bladed metal fan
-  noun: fan
-  volume: 6
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-- name: a metal riste
-  noun: riste
-  volume: 9
-  type: weaponsmithing
-  work_order: true
-  chapter: 9
-  part:
-  - hilt
-###############################
-##### Forging section end #####
-###############################
+armorsmithing:
+  ##################################
+  ##### Forging section begins #####
+  ##################################
+  # Armorsmithing Chapter 1 recipes
+  - name: a metal ring aventail
+    noun: aventail
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring mask
+    noun: mask
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain aventail
+    noun: aventail
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring cap
+    noun: cap
+    volume: 8
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain mask
+    noun: mask
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring gloves
+    noun: gloves
+    volume: 6
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring helm
+    noun: helm
+    volume: 12
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail aventail
+    noun: aventail
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain cap
+    noun: cap
+    volume: 10
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail mask
+    noun: mask
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain gloves
+    noun: gloves
+    volume: 8
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal mail gloves
+    noun: gloves
+    volume: 10
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring vambraces
+    noun: vambraces
+    volume: 19
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain greaves
+    noun: greaves
+    volume: 15
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring balaclava
+    noun: balaclava
+    volume: 16
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain helm
+    noun: helm
+    volume: 14
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail cap
+    noun: cap
+    volume: 12
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring lorica
+    noun: lorica
+    volume: 26
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal ring mantle
+    noun: mantle
+    volume: 21
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal ring vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal chain tasset
+    noun: tasset
+    volume: 10
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal ring sleeves
+    noun: sleeves
+    volume: 21
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain vambraces
+    noun: vambraces
+    volume: 20
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal mail greaves
+    noun: greaves
+    volume: 18
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain balaclava
+    noun: balaclava
+    volume: 20
+    work_order: false
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal mail helm
+    noun: helm
+    volume: 16
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a mail balaclava
+    noun: balaclava
+    volume: 24
+    work_order: true
+    chapter: 1
+    part:
+    - small backing
+  - name: a metal ring shirt
+    noun: shirt
+    volume: 43
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal ring robe
+    noun: robe
+    volume: 38
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal chain lorica
+    noun: lorica
+    volume: 30
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal chain mantle
+    noun: mantle
+    volume: 24
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal chain vest
+    noun: vest
+    volume: 20
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal mail tasset
+    noun: tasset
+    volume: 12
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal chain sleeves
+    noun: sleeves
+    volume: 26
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: some metal mail vambraces
+    noun: vambraces
+    volume: 23
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal ring hauberk
+    noun: hauberk
+    volume: 70
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal chain shirt
+    noun: shirt
+    volume: 50
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal chain robe
+    noun: robe
+    volume: 45
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal mail lorica
+    noun: lorica
+    volume: 34
+    work_order: false
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal mail mantle
+    noun: mantle
+    volume: 27
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: a metal mail vest
+    noun: vest
+    volume: 22
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+  - name: some metal mail sleeves
+    noun: sleeves
+    volume: 31
+    work_order: true
+    chapter: 1
+    part:
+    - small padding
+  - name: a metal chain hauberk
+    noun: hauberk
+    volume: 80
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal mail shirt
+    noun: shirt
+    volume: 57
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal mail robe
+    noun: robe
+    volume: 52
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+  - name: a metal mail hauberk
+    noun: hauberk
+    volume: 90
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal bar-mail hauberk
+    noun: hauberk
+    volume: 90
+    work_order: true
+    chapter: 1
+    part:
+    - large padding
+    - small padding
+    - small padding
+  # Armorsmithing Chapter 2 recipes
+  - name: a metal scale aventail
+    noun: aventail
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale mask
+    noun: mask
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale cap
+    noun: cap
+    volume: 12
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine aventail
+    noun: aventail
+    volume: 10
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine mask
+    noun: mask
+    volume: 6
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some metal scale gloves
+    noun: gloves
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale helm
+    noun: helm
+    volume: 21
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine cap
+    noun: cap
+    volume: 14
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal lamellar aventail
+    noun: aventail
+    volume: 11
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: a metal lamellar mask
+    noun: mask
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some metal scale greaves
+    noun: greaves
+    volume: 15
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: some brigandine gloves
+    noun: gloves
+    volume: 10
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale tasset
+    noun: tasset
+    volume: 10
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some metal scale vambraces
+    noun: vambraces
+    volume: 22
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale balaclava
+    noun: balaclava
+    volume: 26
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal brigandine helm
+    noun: helm
+    volume: 24
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal lamellar cap
+    noun: cap
+    volume: 16
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some brigandine greaves
+    noun: greaves
+    volume: 18
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some metal lamellar gloves
+    noun: gloves
+    volume: 12
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: a metal brigandine tasset
+    noun: tasset
+    volume: 12
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: some brigandine vambraces
+    noun: vambraces
+    volume: 25
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a brigandine balaclava
+    noun: balaclava
+    volume: 30
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal lamellar helm
+    noun: helm
+    volume: 27
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some lamellar greaves
+    noun: greaves
+    volume: 18
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: some metal scale sleeves
+    noun: sleeves
+    volume: 30
+    work_order: false
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale lorica
+    noun: lorica
+    volume: 34
+    work_order: false
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale mantle
+    noun: mantle
+    volume: 33
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale vest
+    noun: vest
+    volume: 24
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal lamellar tasset
+    noun: tasset
+    volume: 14
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: some lamellar vambraces
+    noun: vambraces
+    volume: 28
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: a metal lamellar balaclava
+    noun: balaclava
+    volume: 34
+    work_order: true
+    chapter: 2
+    part:
+    - small backing
+  - name: some brigandine sleeves
+    noun: sleeves
+    volume: 35
+    work_order: true
+    chapter: 2
+    part:
+    - small padding
+  - name: a metal scale shirt
+    noun: shirt
+    volume: 56
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale robe
+    noun: robe
+    volume: 49
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+  - name: a metal brigandine lorica
+    noun: lorica
+    volume: 38
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal brigandine mantle
+    noun: mantle
+    volume: 36
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal brigandine vest
+    noun: vest
+    volume: 26
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: some lamellar sleeves
+    noun: sleeves
+    volume: 40
+    work_order: false
+    chapter: 2
+    part:
+    - small backing
+  - name: a brigandine robe
+    noun: robe
+    volume: 56
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+  - name: a brigandine shirt
+    noun: shirt
+    volume: 63
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a metal scale hauberk
+    noun: hauberk
+    volume: 80
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal lamellar lorica
+    noun: lorica
+    volume: 42
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+  - name: a metal lamellar mantle
+    noun: mantle
+    volume: 39
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+  - name: a metal lamellar vest
+    noun: vest
+    volume: 28
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+  - name: a metal lamellar robe
+    noun: robe
+    volume: 63
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+    - small backing
+  - name: a brigandine hauberk
+    noun: hauberk
+    volume: 90
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+    - small padding
+    - small padding
+  - name: a metal lamellar shirt
+    noun: shirt
+    volume: 70
+    work_order: true
+    chapter: 2
+    part:
+    - large padding
+  - name: a lamellar hauberk
+    noun: hauberk
+    volume: 100
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+    - small backing
+    - small backing
+  - name: a laminar hauberk
+    noun: hauberk
+    volume: 100
+    work_order: true
+    chapter: 2
+    part:
+    - large backing
+    - small backing
+    - small backing
+  # Armorsmithing Chapter 3 recipes
+  - name: a light plate aventail
+    noun: aventail
+    volume: 12
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a light plate mask
+    noun: mask
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some light plate gauntlets
+    noun: gauntlets
+    volume: 13
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a plate aventail
+    noun: aventail
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal dome helm
+    noun: helm
+    volume: 16
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a plate mask
+    noun: mask
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a metal bascinet
+    noun: bascinet
+    volume: 23
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some plate gauntlets
+    noun: gauntlets
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a heavy plate aventail
+    noun: aventail
+    volume: 16
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal morion
+    noun: morion
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a heavy plate mask
+    noun: mask
+    volume: 9
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a light plate fauld
+    noun: fauld
+    volume: 13
+    work_order: true
+    chapter: 3
+    part:
+    - small padding
+  - name: a light backplate
+    noun: backplate
+    volume: 10
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some light plate vambraces
+    noun: vambraces
+    volume: 26
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a metal visored helm
+    noun: helm
+    volume: 26
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: heavy plate gauntlets
+    noun: gauntlets
+    volume: 17
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal barbute
+    noun: barbute
+    volume: 20
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: some light plate greaves
+    noun: greaves
+    volume: 19
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a metal sallet
+    noun: sallet
+    volume: 35
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a light breastplate
+    noun: breastplate
+    volume: 16
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: a plate fauld
+    noun: fauld
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal backplate
+    noun: backplate
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: some light plate sleeves
+    noun: sleeves
+    volume: 39
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+  - name: some plate vambraces
+    noun: vambraces
+    volume: 30
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: some plate greaves
+    noun: greaves
+    volume: 22
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal armet
+    noun: armet
+    volume: 40
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal closed helm
+    noun: helm
+    volume: 29
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a light plate cuirass
+    noun: cuirass
+    volume: 39
+    work_order: false
+    chapter: 3
+    part:
+    - large padding
+  - name: a metal breastplate
+    noun: breastplate
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a heavy plate fauld
+    noun: fauld
+    volume: 17
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal heavy backplate
+    noun: backplate
+    volume: 14
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some plate sleeves
+    noun: sleeves
+    volume: 45
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some heavy plate vambraces
+    noun: vambraces
+    volume: 34
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some heavy plate greaves
+    noun: greaves
+    volume: 25
+    work_order: true
+    chapter: 3
+    part:
+    - small backing
+  - name: a metal great helm
+    noun: helm
+    volume: 45
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some light half plate
+    noun: plate
+    volume: 65
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+    - large padding
+  - name: some light field plate
+    noun: plate
+    volume: 58
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+    - large padding
+  - name: a plate cuirass
+    noun: cuirass
+    volume: 45
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+  - name: a heavy breastplate
+    noun: breastplate
+    volume: 20
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some heavy plate sleeves
+    noun: sleeves
+    volume: 51
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+  - name: some light full plate
+    noun: plate
+    volume: 100
+    work_order: false
+    chapter: 3
+    part:
+    - small padding
+    - small padding
+    - large padding
+  - name: some half plate
+    noun: plate
+    volume: 75
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+    - large backing
+  - name: some field plate
+    noun: plate
+    volume: 67
+    work_order: false
+    chapter: 3
+    part:
+    - small backing
+    - large backing
+  - name: a heavy plate cuirass
+    noun: cuirass
+    volume: 51
+    work_order: false
+    chapter: 3
+    part:
+    - large backing
+  - name: some heavy half plate
+    noun: plate
+    volume: 85
+    work_order: true
+    chapter: 3
+    part:
+    - large padding
+    - small padding
+  - name: some full plate
+    noun: plate
+    volume: 110
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+    - small backing
+  - name: some heavy field plate
+    noun: plate
+    volume: 76
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+  - name: some heavy full plate
+    noun: plate
+    volume: 120
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+    - small backing
+  - name: some heavy fluted plate
+    noun: plate
+    volume: 120
+    work_order: true
+    chapter: 3
+    part:
+    - large backing
+    - small backing
+    - small backing
+  # Armorsmithing Chapter 4 recipes
+  - name: a metal shield handle
+    noun: handle
+    volume: 2
+    work_order: true
+    chapter: 4
+  - name: a metal shield boss
+    noun: boss
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: a metal target shield
+    noun: shield
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal round sipar
+    noun: sipar
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal ordinary shield
+    noun: shield
+    volume: 16
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal targe
+    noun: targe
+    volume: 16
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal triangular sipar
+    noun: sipar
+    volume: 14
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal medium shield
+    noun: shield
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal ceremonial shield
+    noun: shield
+    volume: 16
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal curved shield
+    noun: shield
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal circular buckler
+    noun: buckler
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal medium buckler
+    noun: buckler
+    volume: 20
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal oval shield
+    noun: shield
+    volume: 25
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a simple parry stick
+    noun: stick
+    volume: 7
+    work_order: false
+    chapter: 4
+    part:
+    - small backing
+  - name: a metal jousting shield
+    noun: shield
+    volume: 25
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal skirmisher's shield
+    noun: shield
+    volume: 25
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal kite shield
+    noun: shield
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal warrior's shield
+    noun: shield
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal valnik shield
+    noun: shield
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal tower shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal battle shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal heater shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal aegis
+    noun: aegis
+    volume: 30
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  - name: a metal war shield
+    noun: shield
+    volume: 40
+    work_order: true
+    chapter: 4
+    part:
+    - shield handle
+    - long cord
+  # Blacksmithing Chapter 2 recipes
+blacksmithing:
+  - name: a diagonal-peen mallet
+    noun: mallet
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a curved metal shovel
+    noun: shovel
+    volume: 8
+    chapter: 2
+    work_order: false
+    part:
+    - long pole
+  - name: a diagonal-peen hammer
+    noun: hammer
+    volume: 12
+    work_order: false
+    chapter: 2
+    part:
+    - short pole
+  - name: a stout metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some straight metal tongs
+    noun: tongs
+    volume: 10
+    chapter: 2
+    work_order: false
+  - name: a metal cross-peen hammer
+    noun: hammer
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a narrow metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: a square metal shovel
+    noun: shovel
+    volume: 8
+    chapter: 2
+    work_order: false
+    part:
+    - long pole
+  - name: some curved metal tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: some flat-bladed tongs
+    noun: tongs
+    volume: 10
+    chapter: 2
+    work_order: false
+  - name: a tapered metal shovel
+    noun: shovel
+    volume: 8
+    chapter: 2
+    work_order: false
+    part:
+    - long pole
+  - name: some angular metal tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: a straight-peen hammer
+    noun: hammer
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a straight-peen mallet
+    noun: mallet
+    volume: 12
+    work_order: false
+    chapter: 2
+    part:
+    - short pole
+  - name: a slender metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some metal bolt tongs
+    noun: tongs
+    volume: 10
+    chapter: 2
+    work_order: false
+  - name: a flat-headed metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: a sturdy metal shovel
+    noun: shovel
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: a ball-peen hammer
+    noun: hammer
+    volume: 12
+    chapter: 2
+    work_order: false
+    part:
+    - short pole
+  - name: a wide metal shovel
+    noun: shovel
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some segmented tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: a weighted metal pickaxe
+    noun: pickaxe
+    volume: 10
+    work_order: false
+    chapter: 2
+    part:
+    - long pole
+  - name: some box-jaw tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: some articulated tongs
+    noun: tongs
+    volume: 10
+    work_order: false
+    chapter: 2
+  - name: a ball-peen mallet
+    noun: mallet
+    volume: 12
+    work_order: false
+    chapter: 2
+    part:
+    - short pole
+  # Blacksmithing Chapter 3 recipes
+  - name: a short metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: some short metal chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: a long metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: a metal straight wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal straight bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a thin metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some square metal rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: some long metal chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: a flat metal shaper
+    noun: shaper
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: some plain metal pliers
+    noun: pliers
+    volume: 5
+    work_order: true
+    chapter: 3
+  - name: some squat metal rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: thin metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: a rough metal wood shaper
+    noun: shaper
+    volume: 4
+    chapter: 3
+    work_order: true
+  - name: a sturdy metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: a metal curved wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal curved bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some curved metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a coarse metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some sturdy metal chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: curved metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: some curved metal rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: some reinforced chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: a sharpened metal drawknife
+    noun: drawknife
+    volume: 5
+    work_order: true
+    chapter: 3
+    part:
+    - short pole
+  - name: a metal slender wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal slender bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some rough metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a textured metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal beveled wood shaper
+    noun: shaper
+    volume: 4
+    chapter: 3
+    work_order: true
+  - name: some thick metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a flat metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some elongated rifflers
+    noun: rifflers
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: some sharpened chisels
+    noun: chisels
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+    - short cord
+  - name: thick metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: a metal tapered wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal tapered bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: some hooked metal pliers
+    noun: pliers
+    volume: 5
+    chapter: 3
+    work_order: true
+  - name: a tapered metal rasp
+    noun: rasp
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal jagged wood shaper
+    noun: shaper
+    volume: 4
+    chapter: 3
+    work_order: true
+  - name: a metal serrated wood saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: a metal serrated bone saw
+    noun: saw
+    volume: 8
+    work_order: false
+    chapter: 3
+  - name: precise metal tinker's tools
+    noun: tools
+    volume: 4
+    work_order: true
+    chapter: 3
+  # Blacksmithing Chapter 4 recipes
+  - name: a stout metal yardstick
+    noun: yardstick
+    volume: 6
+    chapter: 4
+    work_order: false
+  - name: some smooth knitting needles
+    noun: needles
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal hide scraper
+    noun: scraper
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some straight metal scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: some plain sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some curved metal scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a flat metal yardstick
+    noun: yardstick
+    volume: 6
+    chapter: 4
+    work_order: false
+  - name: some tapered knitting needles
+    noun: needles
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a pointed metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a curved hide scraper
+    noun: scraper
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some ribbed sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some bent metal scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a rectangular yardstick
+    noun: yardstick
+    volume: 6
+    work_order: false
+    chapter: 4
+  - name: some knobby sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some squat knitting needles
+    noun: needles
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a narrow metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: some polished knitting needles
+    noun: needles
+    volume: 4
+    chapter: 4
+    work_order: true
+  - name: a compact metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a serrated hide scraper
+    noun: scraper
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: some serrated scissors
+    noun: scissors
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a detailed yardstick
+    noun: yardstick
+    volume: 6
+    work_order: false
+    chapter: 4
+  - name: a slender metal awl
+    noun: awl
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: some thin sewing needles
+    noun: needles
+    volume: 3
+    work_order: true
+    chapter: 4
+  # Blacksmithing Chapter 5 recipes
+  - name: a small metal brazier
+    noun: brazier
+    volume: 10
+    work_order: false
+    chapter: 5
+  - name: a tapered pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: a flat mixing stick
+    noun: stick
+    volume: 6
+    work_order: false
+    chapter: 5
+  - name: a square wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  - name: a tapered mixing stick
+    noun: stick
+    volume: 6
+    work_order: false
+    chapter: 5
+  - name: a flat pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: a metal brazier
+    noun: brazier
+    volume: 10
+    work_order: false
+    chapter: 5
+  - name: a triangular wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  - name: a round mixing stick
+    noun: stick
+    volume: 5
+    work_order: true
+    chapter: 5
+  - name: a round pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: a grooved pestle
+    noun: pestle
+    volume: 1
+    work_order: true
+    chapter: 5
+  - name: an oblong wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  - name: a grooved mixing stick
+    noun: stick
+    volume: 6
+    work_order: false
+    chapter: 5
+  - name: a trapezoidal wire sieve
+    noun: sieve
+    volume: 3
+    work_order: true
+    chapter: 5
+  # Blacksmithing Chapter 6 recipes
+  - name: a metal rod
+    noun: rod
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a shallow metal cup
+    noun: cup
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a metal horseshoe
+    noun: horseshoe
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a soft metal keyblank
+    noun: keyblank
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a short metal mug
+    noun: mug
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a tall metal mug
+    noun: mug
+    volume: 1
+    work_order: true
+    chapter: 6
+  - name: a large metal horseshoe
+    noun: horseshoe
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: some metal barbells
+    noun: barbells
+    volume: 80
+    work_order: false
+    chapter: 6
+  - name: a back scratcher
+    noun: scratcher
+    volume: 3
+    work_order: true
+    chapter: 6
+  - name: a metal bolt box
+    noun: box
+    volume: 10
+    work_order: false
+    chapter: 6
+  - name: a metal origami case
+    noun: case
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: a metal lockpick case
+    noun: case
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: a metal ankle band
+    noun: band
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a small metal flask
+    noun: flask
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal talisman case
+    noun: case
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal razor
+    noun: razor
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a metal flights box
+    noun: box
+    volume: 10
+    work_order: false
+    chapter: 6
+  - name: a metal jewelry box
+    noun: box
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a metal herbal case
+    noun: case
+    volume: 8
+    work_order: false
+    chapter: 6
+  - name: a metal lockpick ring
+    noun: ring
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a metal oil lantern
+    noun: lantern
+    volume: 6
+    work_order: false
+    chapter: 6
+  - name: a metal flask
+    noun: flask
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal chest
+    noun: chest
+    volume: 12
+    work_order: false
+    chapter: 6
+  - name: a metal instrument case
+    noun: case
+    volume: 8
+    work_order: false
+    chapter: 6
+  - name: a metal armband
+    noun: armband
+    volume: 4
+    work_order: true
+    chapter: 6
+  - name: a large metal flask
+    noun: flask
+    volume: 7
+    work_order: false
+    chapter: 6
+  - name: some metal clippers
+    noun: clippers
+    volume: 2
+    work_order: true
+    chapter: 6
+  - name: a metal starchart tube
+    noun: tube
+    volume: 8
+    work_order: false
+    chapter: 6
+    part:
+    - short cord
+  - name: a metal backtube
+    noun: backtube
+    volume: 10
+    work_order: false
+    chapter: 6
+    part:
+    - long cord
+  - name: a metal crown
+    noun: crown
+    volume: 10
+    work_order: false
+    chapter: 6
+  - name: a metal mask
+    noun: mask
+    volume: 5
+    work_order: false
+    chapter: 6
+    part:
+    - short cord
+  - name: a metal torque
+    noun: torque
+    volume: 5
+    work_order: true
+    chapter: 6
+  - name: a metal headdress
+    noun: headdress
+    volume: 10
+    work_order: false
+    chapter: 6
+  # Weaponsmithing Chapter 1 recipes
+weaponsmithing:
+  - name: a metal briquet
+    noun: briquet
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal carving knife
+    noun: knife
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal dagger
+    noun: dagger
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal misericorde
+    noun: misericorde
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal katar
+    noun: katar
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal short sword
+    noun: sword
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal pugio
+    noun: pugio
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal poignard
+    noun: poignard
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal stiletto
+    noun: stiletto
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal dart
+    noun: dart
+    volume: 2
+    work_order: true
+    chapter: 1
+  - name: a metal throwing dagger
+    noun: dagger
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal falcata
+    noun: falcata
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal nehlata
+    noun: nehlata
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal telek
+    noun: telek
+    volume: 2
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal leaf blade sword
+    noun: sword
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal jambiya
+    noun: jambiya
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal takouba
+    noun: takouba
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal kris
+    noun: kris
+    volume: 4
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal thrusting blade
+    noun: blade
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal pasabas
+    noun: pasabas
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal rapier
+    noun: rapier
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal koummya
+    noun: koummya
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal oben
+    noun: oben
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal kythe
+    noun: kythe
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal dao
+    noun: dao
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal kasai
+    noun: kasai
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal sunblade
+    noun: sunblade
+    volume: 3
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal foil
+    noun: foil
+    volume: 5
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal baselard
+    noun: baselard
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal gladius
+    noun: gladius
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal mambeli
+    noun: mambeli
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal sashqa
+    noun: sashqa
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal adze
+    noun: adze
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal curlade
+    noun: curlade
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal parang
+    noun: parang
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal hanger
+    noun: hanger
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal sabre
+    noun: sabre
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal scimitar
+    noun: scimitar
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal shotel
+    noun: shotel
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal cutlass
+    noun: cutlass
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal hatchet
+    noun: hatchet
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  - name: a metal hand axe
+    noun: axe
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - haft
+  - name: a light throwing axe
+    noun: axe
+    volume: 6
+    work_order: true
+    chapter: 1
+    part:
+    - haft
+  - name: a metal iltesh
+    noun: iltesh
+    volume: 7
+    work_order: true
+    chapter: 1
+    part:
+    - hilt
+  # Weaponsmithing Chapter 2 recipes
+  - name: a metal condottiere
+    noun: condottiere
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal nehdalata
+    noun: nehdalata
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal round axe
+    noun: axe
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - haft
+  - name: a metal longsword
+    noun: longsword
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal spatha
+    noun: spatha
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal kudalata
+    noun: kudalata
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal arzfilt
+    noun: arzfilt
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal broadsword
+    noun: broadsword
+    volume: 7
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal schiavona
+    noun: schiavona
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal falchion
+    noun: falchion
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal robe sword
+    noun: sword
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal battle axe
+    noun: axe
+    volume: 9
+    work_order: true
+    chapter: 2
+    part:
+    - haft
+  - name: a metal recade
+    noun: recade
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal back-sword
+    noun: back-sword
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal nimsha
+    noun: nimsha
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal hunting sword
+    noun: sword
+    volume: 8
+    work_order: false
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal namkomba
+    noun: namkomba
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal dagesse
+    noun: dagesse
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal abassi
+    noun: abassi
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal cinquedea
+    noun: cinquedea
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - hilt
+  - name: a metal hurling axe
+    noun: axe
+    volume: 8
+    work_order: true
+    chapter: 2
+    part:
+    - haft
+  # Weaponsmithing Chapter 3 recipes
+  - name: a metal twin-point axe
+    noun: axe
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal karambit
+    noun: karambit
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal claymore
+    noun: claymore
+    volume: 14
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal greataxe
+    noun: greataxe
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal marauder blade
+    noun: blade
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal warring axe
+    noun: axe
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal two-handed sword
+    noun: sword
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal double axe
+    noun: axe
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal periperiu sword
+    noun: sword
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal flamberge
+    noun: flamberge
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal greatsword
+    noun: greatsword
+    volume: 18
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal shh'oi'ata
+    noun: shh'oi'ata
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  - name: a metal kaskara
+    noun: kaskara
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - hilt
+  - name: a metal igorat axe
+    noun: axe
+    volume: 15
+    work_order: true
+    chapter: 3
+    part:
+    - haft
+  # Weaponsmithing Chapter 4 recipes
+  - name: a metal gavel
+    noun: gavel
+    volume: 4
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal cosh
+    noun: cosh
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal prod
+    noun: prod
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal cudgel
+    noun: cudgel
+    volume: 4
+    work_order: true
+    chapter: 4
+  - name: a metal zubke
+    noun: zubke
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal scepter
+    noun: scepter
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal hand mallet
+    noun: mallet
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal bludgeon
+    noun: bludgeon
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal garz
+    noun: garz
+    volume: 6
+    work_order: true
+    chapter: 4
+  - name: a ridged metal gauntlet
+    noun: gauntlet
+    volume: 6
+    work_order: true
+    chapter: 4
+  - name: a metal hand mace
+    noun: mace
+    volume: 6
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal club
+    noun: club
+    volume: 6
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a short metal hammer
+    noun: hammer
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal gauntlet
+    noun: gauntlet
+    volume: 5
+    work_order: true
+    chapter: 4
+  - name: a metal bulhawf
+    noun: bulhawf
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal cuska
+    noun: cuska
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal bola
+    noun: bola
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - long cord
+  - name: a metal throwing club
+    noun: club
+    volume: 5
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal mallet
+    noun: mallet
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal war club
+    noun: club
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal boko
+    noun: boko
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: a metal boomerang
+    noun: boomerang
+    volume: 3
+    work_order: true
+    chapter: 4
+  - name: a metal war hammer
+    noun: hammer
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal belaying pin
+    noun: pin
+    volume: 8
+    work_order: true
+    chapter: 4
+  - name: a metal mace
+    noun: mace
+    volume: 8
+    work_order: true
+    chapter: 4
+  - name: a metal marlingspike
+    noun: marlingspike
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal mace
+    noun: mace
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal hammer
+    noun: hammer
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a spiked metal club
+    noun: club
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal hhr'tami
+    noun: hhr'tami
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal komno
+    noun: komno
+    volume: 7
+    work_order: true
+    chapter: 4
+    part:
+    - haft
+  - name: a metal k'trinni sha-tai
+    noun: sha-tai
+    volume: 9
+    work_order: true
+    chapter: 4
+  - name: a flanged metal mace
+    noun: mace
+    volume: 9
+    work_order: true
+    chapter: 4
+  # Weaponsmithing Chapter 5 recipes
+  - name: a metal imperial war hammer
+    noun: hammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a heavy metal mace
+    noun: mace
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal greathammer
+    noun: greathammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal ball and chain
+    noun: chain
+    volume: 9
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a heavy metal chain
+    noun: chain
+    volume: 9
+    work_order: true
+    chapter: 5
+  - name: a metal horseman's flail
+    noun: flail
+    volume: 9
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal ukabi
+    noun: ukabi
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a spiked ball and chain
+    noun: ukabi
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a spiked metal hara
+    noun: hara
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal morning star
+    noun: star
+    volume: 11
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal sledgehammer
+    noun: sledgehammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a heavy metal mallet
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal hara
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a double-headed hammer
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal hhr'ata
+    noun: hhr'ata
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a hurlable war hammer
+    noun: hammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal throwing mallet
+    noun: mallet
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  - name: a metal throwing hammer
+    noun: hammer
+    volume: 10
+    work_order: true
+    chapter: 5
+    part:
+    - haft
+  # Weaponsmithing Chapter 6 recipes
+  - name: a metal vilks kodur
+    noun: kodur
+    volume: 14
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal war mattock
+    noun: mattock
+    volume: 14
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: double-sided ball and chain
+    noun: chain
+    volume: 13
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal akabo
+    noun: akabo
+    volume: 13
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal footman's flail
+    noun: flail
+    volume: 13
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal dire mace
+    noun: mace
+    volume: 16
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a heavy sledgehammer
+    noun: sledgehammer
+    volume: 16
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal maul
+    noun: maul
+    volume: 16
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a metal two-headed hammer
+    noun: hammer
+    volume: 15
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  - name: a giant metal mallet
+    noun: hammer
+    volume: 15
+    work_order: true
+    chapter: 6
+    part:
+    - haft
+  # Weaponsmithing Chapter 7 recipes
+  - name: a light metal spear
+    noun: spear
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal javelin
+    noun: javelin
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal spear
+    noun: spear
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal allarh
+    noun: allarh
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal hunthsleg
+    noun: hunthsleg
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal awgravet ava
+    noun: ava
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal coresca
+    noun: coresca
+    volume: 12
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal tzece
+    noun: tzece
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal halberd
+    noun: halberd
+    volume: 12
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal guisarme
+    noun: guisarme
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal lochaber axe
+    noun: axe
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal bardiche
+    noun: bardiche
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal scythe
+    noun: scythe
+    volume: 7
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal duraka skefne
+    noun: skefne
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal military fork
+    noun: fork
+    volume: 10
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal partisan
+    noun: partisan
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal khuj
+    noun: khuj
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a two-pronged halberd
+    noun: halberd
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal glaive
+    noun: glaive
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal ngalio
+    noun: ngalio
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal fauchard
+    noun: fauchard
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal pole axe
+    noun: axe
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal ilglaiks skefne
+    noun: skefne
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal ranseur
+    noun: ranseur
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal spetum
+    noun: spetum
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal lance
+    noun: lance
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal pike
+    noun: pike
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a metal voulge
+    noun: voulge
+    volume: 13
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  - name: a short-hafted halberd
+    noun: halberd
+    volume: 9
+    work_order: true
+    chapter: 7
+    part:
+    - short pole
+  - name: a metal awl pike
+    noun: pike
+    volume: 15
+    work_order: true
+    chapter: 7
+    part:
+    - long pole
+  # Weaponsmithing Chapter 8 recipes
+  - name: a metal nightstick
+    noun: nightstick
+    volume: 7
+    work_order: true
+    chapter: 8
+  - name: a metal cane
+    noun: cane
+    volume: 8
+    work_order: true
+    chapter: 8
+  - name: a metal quarterstaff
+    noun: quarterstaff
+    volume: 10
+    work_order: true
+    chapter: 8
+  - name: a metal pike staff
+    noun: staff
+    volume: 11
+    work_order: true
+    chapter: 8
+  - name: some metal knuckles
+    noun: knuckles
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: some weighted metal footwraps
+    noun: footwraps
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: some metal knee spikes
+    noun: spikes
+    volume: 4
+    work_order: true
+    chapter: 8
+    part:
+    - short cord
+  - name: some metal elbow spikes
+    noun: spikes
+    volume: 4
+    work_order: true
+    chapter: 8
+    part:
+    - short cord
+  - name: some spiked metal footwraps
+    noun: footwraps
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: some spiked metal knuckles
+    noun: knuckles
+    volume: 4
+    work_order: true
+    chapter: 8
+  - name: a weighted staff
+    noun: staff
+    volume: 10
+    work_order: true
+    chapter: 8
+  - name: some metal hand claws
+    noun: claws
+    volume: 4
+    work_order: true
+    chapter: 8
+    part:
+    - short cord
+  # Weaponsmithing Chapter 9 recipes
+  - name: a metal throwing spike
+    noun: spike
+    volume: 4
+    work_order: true
+    chapter: 9
+  - name: a metal bar mace
+    noun: mace
+    volume: 12
+    work_order: true
+    chapter: 9
+    part:
+    - haft
+  - name: a metal broadaxe
+    noun: broadaxe
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - haft
+  - name: a metal war sword
+    noun: sword
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a metal bastard sword
+    noun: sword
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a metal boarding axe
+    noun: axe
+    volume: 10
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a metal splitting maul
+    noun: maul
+    volume: 15
+    work_order: true
+    chapter: 9
+    part:
+    - haft
+  - name: a thin-bladed metal fan
+    noun: fan
+    volume: 4
+    work_order: true
+    chapter: 9
+  - name: a metal half-handled riste
+    noun: riste
+    volume: 7
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+  - name: a thick-bladed metal fan
+    noun: fan
+    volume: 6
+    work_order: true
+    chapter: 9
+  - name: a metal riste
+    noun: riste
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - hilt
+carving:
 ######################################
 ##### Engineering section begins #####
 ######################################
 # Carving Chapter 1 recipes
-- name: a small stone block
-  noun: block
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a large stone block
-  noun: block
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: a thin stone slab
-  noun: slab
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a short stone pole
-  noun: pole
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a thick stone slab
-  noun: slab
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: a smooth slickstone
-  noun: slickstone
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a stout stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a shallow stone basin
-  noun: basin
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 3
-  material: stone
-- name: a long stone pole
-  noun: pole
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: slender stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a deep stone basin
-  noun: basin
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: a small stone sphere
-  noun: sphere
-  work_order: true
-  type: carving
-  chapter: 1
-  volume: 2
-  material: stone
-- name: a flat slickstone
-  noun: slickstone
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a large stone sphere
-  noun: sphere
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 5
-  material: stone
-- name: grooved stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a polished slickstone
-  noun: slickstone
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: notched stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-- name: a forked stone stirring rod
-  noun: rod
-  work_order: false
-  type: carving
-  chapter: 1
-  volume: 4
-  material: stone
-# Carving Chapter 3 recipes
-- name: some smooth stones
-  noun: stones
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone bludgeon
-  noun: bludgeon
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: a stone carving knife
-  noun: knife
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: some elongated stones
-  noun: stones
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone hand axe
-  noun: axe
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: a stone war club
-  noun: club
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - short pole
-- name: some balanced stones
-  noun: stones
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone war hammer
-  noun: hammer
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - short pole
-- name: some stone spikes
-  noun: spikes
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: some stone shards
-  noun: shards
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 2
-  material: stone
-- name: a stone bola
-  noun: bola
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long cord
-- name: a stone hand sword
-  noun: sword
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-- name: a heavy stone mallet
-  noun: mallet
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone javelin
-  noun: javelin
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone spear
-  noun: spear
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone war mattock
-  noun: mattock
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone maul
-  noun: maul
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long pole
-- name: a stone flail
-  noun: flail
-  work_order: true
-  type: carving
-  chapter: 3
-  volume: 3
-  material: stone
-  part:
-  - long cord
-  - long pole
-# Carving Chapter 4 recipes
-- name: a stone band
-  noun: band
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 1
-  material: stone
-- name: a stone toe ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 1
-  material: stone
-- name: a stone nose ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 1
-  material: stone
-- name: a stone pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone anklet
-  noun: anklet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone tailband
-  noun: tailband
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone hairpin
-  noun: hairpin
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone cloak pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a pair of stone earrings
-  noun: earrings
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone medallion
-  noun: medallion
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone amulet
-  noun: amulet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone pendant
-  noun: pendant
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-  part:
-  - short cord
-- name: a stone brooch
-  noun: brooch
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone earcuff
-  noun: earcuff
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone belt buckle
-  noun: buckle
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-- name: a stone armband
-  noun: armband
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: an articulated stone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone tiara
-  noun: tiara
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone locket
-  noun: locket
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 2
-  material: stone
-  part:
-  - short cord
-- name: a stone choker
-  noun: choker
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone diadem
-  noun: diadem
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone circlet
-  noun: circlet
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-  part:
-  - short cord
-- name: an articulated stone necklace
-  noun: necklace
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: a stone crown
-  noun: crown
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-- name: an articulated stone belt
-  noun: belt
-  work_order: false
-  type: carving
-  chapter: 4
-  volume: 4
-  material: stone
-- name: a stone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 4
-  volume: 3
-  material: stone
-  part:
-  - short cord
-- name: a segmented stone shirt
-  noun: shirt
-  work_order: false
-  type: carving
-  chapter: 4
-  volume: 5
-  material: stone
-# Carving Chapter 5 recipes
-- name: a bone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: bone
-- name: a stone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a detailed bone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: bone
-- name: a detailed stone bead
-  noun: bead
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a bone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: bone
-- name: a stone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: stone
-- name: a detailed bone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: bone
-- name: a detailed stone totem
-  noun: totem
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 2
-  material: stone
-- name: a bone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a stone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a basic runestone
-  noun: runestone
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a bone wand
-  noun: wand
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a stone wand
-  noun: wand
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a bone rod
-  noun: rod
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a stone rod
-  noun: rod
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a detailed bone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: bone
-- name: a detailed stone figurine
-  noun: figurine
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 3
-  material: stone
-- name: a bone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: bone
-- name: a stone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: a fine runestone
-  noun: runestone
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-- name: a detailed bone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 8
-  material: bone
-- name: detailed stone statuette
-  noun: statuette
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: a bone statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 20
-  material: bone
-- name: a stone statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: a detailed bone statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 20
-  material: bone
-- name: a detailed statue
-  noun: statue
-  work_order: false
-  type: carving
-  chapter: 5
-  volume: 4
-  material: stone
-- name: an ornate runestone
-  noun: runestone
-  work_order: true
-  type: carving
-  chapter: 5
-  volume: 1
-  material: stone
-# Carving Chapter 6 recipes
-- name: a short bone pole
-  noun: pole
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-- name: a simple bone burin
-  noun: burin
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-- name: a long bone pole
-  noun: pole
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 6
-  material: bone
-- name: a fine bone burin
-  noun: burin
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-- name: an ornate bone burin
-  noun: burin
-  work_order: true
-  type: carving
-  chapter: 6
-  volume: 4
-  material: bone
-# Carving Chapter 8 recipes
-- name: a bone bludgeon
-  noun: bludgeon
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 5
-  material: bone
-- name: a bone carving knife
-  noun: knife
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 2
-  material: bone
-- name: a bone hand axe
-  noun: axe
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 6
-  material: bone
-- name: a bone war club
-  noun: club
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 7
-  material: bone
-- name: a bone shiv
-  noun: shiv
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 3
-  material: bone
-- name: a bone hand sword
-  noun: sword
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 4
-  material: bone
-- name: a bone mallet
-  noun: mallet
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 8
-  material: bone
-- name: a bone javelin
-  noun: javelin
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 8
-  material: bone
-- name: a light bone spear
-  noun: spear
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 7
-  material: bone
-- name: a bone maul
-  noun: maul
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 16
-  material: bone
-- name: a bone mattock
-  noun: mattock
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 17
-  material: bone
-- name: a bone flail
-  noun: flail
-  work_order: true
-  type: carving
-  chapter: 8
-  volume: 11
-  material: bone
-# Carving Chapter 9 recipes
-- name: a bone band
-  noun: band
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-- name: a bone nose ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-- name: a bone toe ring
-  noun: ring
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-- name: a bone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone anklet
-  noun: anklet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone cloak pin
-  noun: pin
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone hairpin
-  noun: hairpin
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone tailband
-  noun: tailband
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a shallow bone cup
-  noun: cup
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone pendant
-  noun: pendant
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 1
-  material: bone
-  part:
-  - short cord
-- name: a bone amulet
-  noun: amulet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone medallion
-  noun: medallion
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a pair of bone earrings
-  noun: earrings
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone earcuff
-  noun: earcuff
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone brooch
-  noun: brooch
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone armband
-  noun: armband
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone belt buckle
-  noun: buckle
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone choker
-  noun: choker
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone locket
-  noun: locket
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-  part:
-  - short cord
-- name: a bone tiara
-  noun: tiara
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: an articulated bone bracelet
-  noun: bracelet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: some bone bangles
-  noun: bangles
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 5
-  material: bone
-- name: an articulated bone necklace
-  noun: necklace
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone circlet
-  noun: circlet
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-  part:
-  - short cord
-- name: a bone crown
-  noun: crown
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a bone comb
-  noun: comb
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 2
-  material: bone
-- name: a bone haircomb
-  noun: haircomb
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 3
-  material: bone
-- name: a paneled shirt
-  noun: shirt
-  work_order: true
-  type: carving
-  chapter: 9
-  volume: 13
-  material: bone
-# Carving Chapter 10 recipes
-- name: a segmented bone aventail
-  noun: aventail
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 4
-  material: bone
-- name: a segmented bone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 3
-  material: bone
-- name: some segmented bone gloves
-  noun: gloves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 5
-  material: bone
-- name: a segmented bone cap
-  noun: cap
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 8
-  material: bone
-- name: a notched bone aventail
-  noun: aventail
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 4
-  material: bone
-- name: a notched bone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 3
-  material: bone
-- name: a segmented bone helm
-  noun: helm
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some notched bone gloves
-  noun: gloves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 5
-  material: bone
-- name: a notched bone cap
-  noun: cap
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 8
-  material: bone
-- name: a ribbed bone aventail
-  noun: aventail
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 4
-  material: bone
-- name: a ribbed bone mask
-  noun: mask
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 3
-  material: bone
-- name: a segmented bone tasset
-  noun: tasset
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some segmented vambraces
-  noun: vambraces
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 16
-  material: bone
-- name: some segmented bone greaves
-  noun: greaves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a segmented bone balaclava
-  noun: balaclava
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a notched bone helm
-  noun: helm
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some ribbed bone gloves
-  noun: gloves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 5
-  material: bone
-- name: a ribbed bone cap
-  noun: cap
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 8
-  material: bone
-- name: a segmented bone tabard
-  noun: tabard
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 30
-  material: bone
-- name: a segmented bone mantle
-  noun: mantle
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 24
-  material: bone
-- name: a segmented bone vest
-  noun: vest
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 20
-  material: bone
-- name: a notched bone tasset
-  noun: tasset
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some segmented bone sleeves
-  noun: sleeves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 21
-  material: bone
-- name: some notched vambraces
-  noun: vambraces
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 16
-  material: bone
-- name: some notched bone greaves
-  noun: greaves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a notched bone balaclava
-  noun: balaclava
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a ribbed bone helm
-  noun: helm
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: a segmented bone coat
-  noun: coat
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 46
-  material: bone
-- name: a segmented bone robe
-  noun: robe
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 42
-  material: bone
-- name: a notched bone tabard
-  noun: tabard
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 30
-  material: bone
-- name: a notched bone mantle
-  noun: mantle
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 24
-  material: bone
-- name: a notched bone vest
-  noun: vest
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 20
-  material: bone
-- name: a ribbed bone tasset
-  noun: tasset
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 10
-  material: bone
-- name: some notched bone sleeves
-  noun: sleeves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 21
-  material: bone
-- name: some ribbed vambraces
-  noun: vambraces
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 16
-  material: bone
-- name: some ribbed bone greaves
-  noun: greaves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a ribbed bone balaclava
-  noun: balaclava
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 12
-  material: bone
-- name: a segmented bone hauberk
-  noun: hauberk
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 58
-  material: bone
-- name: a notched bone coat
-  noun: coat
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 46
-  material: bone
-- name: a notched bone robe
-  noun: robe
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 42
-  material: bone
-- name: a ribbed bone tabard
-  noun: tabard
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 30
-  material: bone
-- name: a ribbed bone mantle
-  noun: mantle
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 24
-  material: bone
-- name: a ribbed bone vest
-  noun: vest
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 20
-  material: bone
-- name: some ribbed bone sleeves
-  noun: sleeves
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 21
-  material: bone
-- name: a notched bone hauberk
-  noun: hauberk
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 58
-  material: bone
-- name: a ribbed bone coat
-  noun: coat
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 46
-  material: bone
-- name: a ribbed bone robe
-  noun: robe
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 42
-  material: bone
-- name: a ribbed bone hauberk
-  noun: hauberk
-  work_order: true
-  type: carving
-  chapter: 10
-  volume: 58
-  material: bone
+  - name: a small stone block
+    noun: block
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a large stone block
+    noun: block
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: a thin stone slab
+    noun: slab
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a short stone pole
+    noun: pole
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a thick stone slab
+    noun: slab
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: a smooth slickstone
+    noun: slickstone
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a stout stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a shallow stone basin
+    noun: basin
+    work_order: true
+    chapter: 1
+    volume: 3
+    material: stone
+  - name: a long stone pole
+    noun: pole
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: slender stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a deep stone basin
+    noun: basin
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: a small stone sphere
+    noun: sphere
+    work_order: true
+    chapter: 1
+    volume: 2
+    material: stone
+  - name: a flat slickstone
+    noun: slickstone
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a large stone sphere
+    noun: sphere
+    work_order: false
+    chapter: 1
+    volume: 5
+    material: stone
+  - name: grooved stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a polished slickstone
+    noun: slickstone
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: notched stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  - name: a forked stone stirring rod
+    noun: rod
+    work_order: false
+    chapter: 1
+    volume: 4
+    material: stone
+  # Carving Chapter 3 recipes
+  - name: some smooth stones
+    noun: stones
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone bludgeon
+    noun: bludgeon
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: a stone carving knife
+    noun: knife
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: some elongated stones
+    noun: stones
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone hand axe
+    noun: axe
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: a stone war club
+    noun: club
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - short pole
+  - name: some balanced stones
+    noun: stones
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone war hammer
+    noun: hammer
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - short pole
+  - name: some stone spikes
+    noun: spikes
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: some stone shards
+    noun: shards
+    work_order: true
+    chapter: 3
+    volume: 2
+    material: stone
+  - name: a stone bola
+    noun: bola
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long cord
+  - name: a stone hand sword
+    noun: sword
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+  - name: a heavy stone mallet
+    noun: mallet
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone javelin
+    noun: javelin
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone spear
+    noun: spear
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone war mattock
+    noun: mattock
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone maul
+    noun: maul
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long pole
+  - name: a stone flail
+    noun: flail
+    work_order: true
+    chapter: 3
+    volume: 3
+    material: stone
+    part:
+    - long cord
+    - long pole
+  # Carving Chapter 4 recipes
+  - name: a stone band
+    noun: band
+    work_order: true
+    chapter: 4
+    volume: 1
+    material: stone
+  - name: a stone toe ring
+    noun: ring
+    work_order: true
+    chapter: 4
+    volume: 1
+    material: stone
+  - name: a stone nose ring
+    noun: ring
+    work_order: true
+    chapter: 4
+    volume: 1
+    material: stone
+  - name: a stone pin
+    noun: pin
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone anklet
+    noun: anklet
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone tailband
+    noun: tailband
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone hairpin
+    noun: hairpin
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone cloak pin
+    noun: pin
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a pair of stone earrings
+    noun: earrings
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone medallion
+    noun: medallion
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone amulet
+    noun: amulet
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone pendant
+    noun: pendant
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+    part:
+    - short cord
+  - name: a stone brooch
+    noun: brooch
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone earcuff
+    noun: earcuff
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone belt buckle
+    noun: buckle
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+  - name: a stone armband
+    noun: armband
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: an articulated stone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone tiara
+    noun: tiara
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone locket
+    noun: locket
+    work_order: true
+    chapter: 4
+    volume: 2
+    material: stone
+    part:
+    - short cord
+  - name: a stone choker
+    noun: choker
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone diadem
+    noun: diadem
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone circlet
+    noun: circlet
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+    part:
+    - short cord
+  - name: an articulated stone necklace
+    noun: necklace
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: a stone crown
+    noun: crown
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+  - name: an articulated stone belt
+    noun: belt
+    work_order: false
+    chapter: 4
+    volume: 4
+    material: stone
+  - name: a stone mask
+    noun: mask
+    work_order: true
+    chapter: 4
+    volume: 3
+    material: stone
+    part:
+    - short cord
+  - name: a segmented stone shirt
+    noun: shirt
+    work_order: false
+    chapter: 4
+    volume: 5
+    material: stone
+  # Carving Chapter 5 recipes
+  - name: a bone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: bone
+  - name: a stone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a detailed bone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: bone
+  - name: a detailed stone bead
+    noun: bead
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a bone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: bone
+  - name: a stone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: stone
+  - name: a detailed bone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: bone
+  - name: a detailed stone totem
+    noun: totem
+    work_order: true
+    chapter: 5
+    volume: 2
+    material: stone
+  - name: a bone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a stone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a basic runestone
+    noun: runestone
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a bone wand
+    noun: wand
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a stone wand
+    noun: wand
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a bone rod
+    noun: rod
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a stone rod
+    noun: rod
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a detailed bone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: bone
+  - name: a detailed stone figurine
+    noun: figurine
+    work_order: true
+    chapter: 5
+    volume: 3
+    material: stone
+  - name: a bone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: bone
+  - name: a stone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: a fine runestone
+    noun: runestone
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  - name: a detailed bone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 8
+    material: bone
+  - name: detailed stone statuette
+    noun: statuette
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: a bone statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 20
+    material: bone
+  - name: a stone statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: a detailed bone statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 20
+    material: bone
+  - name: a detailed statue
+    noun: statue
+    work_order: false
+    chapter: 5
+    volume: 4
+    material: stone
+  - name: an ornate runestone
+    noun: runestone
+    work_order: true
+    chapter: 5
+    volume: 1
+    material: stone
+  # Carving Chapter 6 recipes
+  - name: a short bone pole
+    noun: pole
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  - name: a simple bone burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  - name: a long bone pole
+    noun: pole
+    work_order: true
+    chapter: 6
+    volume: 6
+    material: bone
+  - name: a fine bone burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  - name: an ornate bone burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+    material: bone
+  # Carving Chapter 8 recipes
+  - name: a bone bludgeon
+    noun: bludgeon
+    work_order: true
+    chapter: 8
+    volume: 5
+    material: bone
+  - name: a bone carving knife
+    noun: knife
+    work_order: true
+    chapter: 8
+    volume: 2
+    material: bone
+  - name: a bone hand axe
+    noun: axe
+    work_order: true
+    chapter: 8
+    volume: 6
+    material: bone
+  - name: a bone war club
+    noun: club
+    work_order: true
+    chapter: 8
+    volume: 7
+    material: bone
+  - name: a bone shiv
+    noun: shiv
+    work_order: true
+    chapter: 8
+    volume: 3
+    material: bone
+  - name: a bone hand sword
+    noun: sword
+    work_order: true
+    chapter: 8
+    volume: 4
+    material: bone
+  - name: a bone mallet
+    noun: mallet
+    work_order: true
+    chapter: 8
+    volume: 8
+    material: bone
+  - name: a bone javelin
+    noun: javelin
+    work_order: true
+    chapter: 8
+    volume: 8
+    material: bone
+  - name: a light bone spear
+    noun: spear
+    work_order: true
+    chapter: 8
+    volume: 7
+    material: bone
+  - name: a bone maul
+    noun: maul
+    work_order: true
+    chapter: 8
+    volume: 16
+    material: bone
+  - name: a bone mattock
+    noun: mattock
+    work_order: true
+    chapter: 8
+    volume: 17
+    material: bone
+  - name: a bone flail
+    noun: flail
+    work_order: true
+    chapter: 8
+    volume: 11
+    material: bone
+  # Carving Chapter 9 recipes
+  - name: a bone band
+    noun: band
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+  - name: a bone nose ring
+    noun: ring
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+  - name: a bone toe ring
+    noun: ring
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+  - name: a bone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone anklet
+    noun: anklet
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone pin
+    noun: pin
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone cloak pin
+    noun: pin
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone hairpin
+    noun: hairpin
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone tailband
+    noun: tailband
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a shallow bone cup
+    noun: cup
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone pendant
+    noun: pendant
+    work_order: true
+    chapter: 9
+    volume: 1
+    material: bone
+    part:
+    - short cord
+  - name: a bone amulet
+    noun: amulet
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone medallion
+    noun: medallion
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a pair of bone earrings
+    noun: earrings
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone earcuff
+    noun: earcuff
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone brooch
+    noun: brooch
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone armband
+    noun: armband
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone belt buckle
+    noun: buckle
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone choker
+    noun: choker
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone locket
+    noun: locket
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+    part:
+    - short cord
+  - name: a bone tiara
+    noun: tiara
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: an articulated bone bracelet
+    noun: bracelet
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: some bone bangles
+    noun: bangles
+    work_order: true
+    chapter: 9
+    volume: 5
+    material: bone
+  - name: an articulated bone necklace
+    noun: necklace
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone circlet
+    noun: circlet
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+    part:
+    - short cord
+  - name: a bone crown
+    noun: crown
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a bone comb
+    noun: comb
+    work_order: true
+    chapter: 9
+    volume: 2
+    material: bone
+  - name: a bone haircomb
+    noun: haircomb
+    work_order: true
+    chapter: 9
+    volume: 3
+    material: bone
+  - name: a paneled shirt
+    noun: shirt
+    work_order: true
+    chapter: 9
+    volume: 13
+    material: bone
+  # Carving Chapter 10 recipes
+  - name: a segmented bone aventail
+    noun: aventail
+    work_order: true
+    chapter: 10
+    volume: 4
+    material: bone
+  - name: a segmented bone mask
+    noun: mask
+    work_order: true
+    chapter: 10
+    volume: 3
+    material: bone
+  - name: some segmented bone gloves
+    noun: gloves
+    work_order: true
+    chapter: 10
+    volume: 5
+    material: bone
+  - name: a segmented bone cap
+    noun: cap
+    work_order: true
+    chapter: 10
+    volume: 8
+    material: bone
+  - name: a notched bone aventail
+    noun: aventail
+    work_order: true
+    chapter: 10
+    volume: 4
+    material: bone
+  - name: a notched bone mask
+    noun: mask
+    work_order: true
+    chapter: 10
+    volume: 3
+    material: bone
+  - name: a segmented bone helm
+    noun: helm
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some notched bone gloves
+    noun: gloves
+    work_order: true
+    chapter: 10
+    volume: 5
+    material: bone
+  - name: a notched bone cap
+    noun: cap
+    work_order: true
+    chapter: 10
+    volume: 8
+    material: bone
+  - name: a ribbed bone aventail
+    noun: aventail
+    work_order: true
+    chapter: 10
+    volume: 4
+    material: bone
+  - name: a ribbed bone mask
+    noun: mask
+    work_order: true
+    chapter: 10
+    volume: 3
+    material: bone
+  - name: a segmented bone tasset
+    noun: tasset
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some segmented vambraces
+    noun: vambraces
+    work_order: true
+    chapter: 10
+    volume: 16
+    material: bone
+  - name: some segmented bone greaves
+    noun: greaves
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a segmented bone balaclava
+    noun: balaclava
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a notched bone helm
+    noun: helm
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some ribbed bone gloves
+    noun: gloves
+    work_order: true
+    chapter: 10
+    volume: 5
+    material: bone
+  - name: a ribbed bone cap
+    noun: cap
+    work_order: true
+    chapter: 10
+    volume: 8
+    material: bone
+  - name: a segmented bone tabard
+    noun: tabard
+    work_order: true
+    chapter: 10
+    volume: 30
+    material: bone
+  - name: a segmented bone mantle
+    noun: mantle
+    work_order: true
+    chapter: 10
+    volume: 24
+    material: bone
+  - name: a segmented bone vest
+    noun: vest
+    work_order: true
+    chapter: 10
+    volume: 20
+    material: bone
+  - name: a notched bone tasset
+    noun: tasset
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some segmented bone sleeves
+    noun: sleeves
+    work_order: true
+    chapter: 10
+    volume: 21
+    material: bone
+  - name: some notched vambraces
+    noun: vambraces
+    work_order: true
+    chapter: 10
+    volume: 16
+    material: bone
+  - name: some notched bone greaves
+    noun: greaves
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a notched bone balaclava
+    noun: balaclava
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a ribbed bone helm
+    noun: helm
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: a segmented bone coat
+    noun: coat
+    work_order: true
+    chapter: 10
+    volume: 46
+    material: bone
+  - name: a segmented bone robe
+    noun: robe
+    work_order: true
+    chapter: 10
+    volume: 42
+    material: bone
+  - name: a notched bone tabard
+    noun: tabard
+    work_order: true
+    chapter: 10
+    volume: 30
+    material: bone
+  - name: a notched bone mantle
+    noun: mantle
+    work_order: true
+    chapter: 10
+    volume: 24
+    material: bone
+  - name: a notched bone vest
+    noun: vest
+    work_order: true
+    chapter: 10
+    volume: 20
+    material: bone
+  - name: a ribbed bone tasset
+    noun: tasset
+    work_order: true
+    chapter: 10
+    volume: 10
+    material: bone
+  - name: some notched bone sleeves
+    noun: sleeves
+    work_order: true
+    chapter: 10
+    volume: 21
+    material: bone
+  - name: some ribbed vambraces
+    noun: vambraces
+    work_order: true
+    chapter: 10
+    volume: 16
+    material: bone
+  - name: some ribbed bone greaves
+    noun: greaves
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a ribbed bone balaclava
+    noun: balaclava
+    work_order: true
+    chapter: 10
+    volume: 12
+    material: bone
+  - name: a segmented bone hauberk
+    noun: hauberk
+    work_order: true
+    chapter: 10
+    volume: 58
+    material: bone
+  - name: a notched bone coat
+    noun: coat
+    work_order: true
+    chapter: 10
+    volume: 46
+    material: bone
+  - name: a notched bone robe
+    noun: robe
+    work_order: true
+    chapter: 10
+    volume: 42
+    material: bone
+  - name: a ribbed bone tabard
+    noun: tabard
+    work_order: true
+    chapter: 10
+    volume: 30
+    material: bone
+  - name: a ribbed bone mantle
+    noun: mantle
+    work_order: true
+    chapter: 10
+    volume: 24
+    material: bone
+  - name: a ribbed bone vest
+    noun: vest
+    work_order: true
+    chapter: 10
+    volume: 20
+    material: bone
+  - name: some ribbed bone sleeves
+    noun: sleeves
+    work_order: true
+    chapter: 10
+    volume: 21
+    material: bone
+  - name: a notched bone hauberk
+    noun: hauberk
+    work_order: true
+    chapter: 10
+    volume: 58
+    material: bone
+  - name: a ribbed bone coat
+    noun: coat
+    work_order: true
+    chapter: 10
+    volume: 46
+    material: bone
+  - name: a ribbed bone robe
+    noun: robe
+    work_order: true
+    chapter: 10
+    volume: 42
+    material: bone
+  - name: a ribbed bone hauberk
+    noun: hauberk
+    work_order: true
+    chapter: 10
+    volume: 58
+    material: bone
+shaping:
 # Shaping Chapter 2 recipes
-- name: a toy bow
-  noun: bow
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a toy bow
+    noun: bow
+    volume: 3
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a practice shortbow
+    noun: shortbow
+    volume: 4
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a simple shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a light shortbow
+    noun: shortbow
+    volume: 3
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a farmer's bow
+    noun: bow
+    volume: 4
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a sturdy shortbow
+    noun: shortbow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: an alpine shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a saddle bow
+    noun: bow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a flight bow
+    noun: bow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a steppe bow
+    noun: bow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a battle shortbow
+    noun: shortbow
+    volume: 7
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a forester's shortbow
+    noun: shortbow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a Nisha shortbow
+    noun: shortbow
+    volume: 5
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  - name: a competition shortbow
+    noun: shortbow
+    volume: 6
+    work_order: false
+    chapter: 2
+    part:
+      - bow string
+  # Shaping Chapter 3 recipes
+  - name: a simple longbow
+    noun: longbow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a practice longbow
+    noun: longbow
+    volume: 6
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a longbow
+    noun: longbow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a sturdy longbow
+    noun: longbow
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a flatbow
+    noun: flatbow
+    volume: 7
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a skirmisher's bow
+    noun: bow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a reflex longbow
+    noun: longbow
+    volume: 7
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a self bow
+    noun: bow
+    volume: 7
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a recurve longbow
+    noun: longbow
+    volume: 8
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a forester's longbow
+    noun: longbow
+    volume: 8
+    work_order: false
+    chapter: 3
+    part:
+      - bow string
+  - name: a battle longbow
+    noun: longbow
+    volume: 8
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  - name: a competition longbow
+    noun: longbow
+    volume: 8
+    work_order: true
+    chapter: 3
+    part:
+      - bow string
+  # Shaping Chapter 4 recipes
+  - name: a composite bow
+    noun: bow
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a double-backed bow
+    noun: bow
+    volume: 9
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a recurve bow
+    noun: bow
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a forester's bow
+    noun: bow
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a reflex bow
+    noun: bow
+    volume: 8
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a savannah bow
+    noun: bow
+    volume: 9
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a footman's bow
+    noun: bow
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a horseman's bow
+    noun: bow
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a battle bow
+    noun: bow
+    volume: 10
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  - name: a competition bow
+    noun: bow
+    volume: 10
+    work_order: true
+    chapter: 4
+    part:
+      - bow string
+      - bone backer
+  # Shaping Chapter 5 recipes are arrows and covered with the arrows.lic script.
+  # Shaping Chapter 6 recipes are Enhancements and Materials.
+  - name: a simple wood burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+  - name: a fine wood burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+  - name: an ornate wood burin
+    noun: burin
+    work_order: true
+    chapter: 6
+    volume: 4
+  # Shaping Chapter 7 recipes
+  - name: a wood band
+    noun: band
+    volume: 1
+    work_order: true
+    chapter: 7
+  - name: a wood nose ring
+    noun: ring
+    volume: 1
+    work_order: true
+    chapter: 7
+  - name: a wood toe ring
+    noun: ring
+    volume: 1
+    work_order: true
+    chapter: 7
+  - name: a wood bracelet
+    noun: bracelet
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood anklet
+    noun: anklet
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood pin
+    noun: pin
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood cloak pin
+    noun: pin
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a shallow wood cup
+    noun: cup
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood hairpin
+    noun: hairpin
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood tailband
+    noun: tailband
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood pendant
+    noun: pendant
+    volume: 1
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: a wood amulet
+    noun: amulet
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood medallion
+    noun: medallion
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a pair of wood earrings
+    noun: earrings
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood earcuff
+    noun: earcuff
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood brooch
+    noun: brooch
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood armband
+    noun: armband
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood belt buckle
+    noun: buckle
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood choker
+    noun: choker
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood locket
+    noun: locket
+    volume: 2
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: some wood bangles
+    noun: bangles
+    volume: 5
+    work_order: true
+    chapter: 7
+  - name: a wood tiara
+    noun: tiara
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: an articulated wood bracelet
+    noun: bracelet
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood circlet
+    noun: circlet
+    volume: 3
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: an articulated wood necklace
+    noun: necklace
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood crown
+    noun: crown
+    volume: 3
+    work_order: true
+    chapter: 7
+  - name: a wood mask
+    noun: mask
+    volume: 3
+    work_order: false
+    chapter: 7
+    part:
+    - short cord
+  - name: a wood comb
+    noun: comb
+    volume: 2
+    work_order: true
+    chapter: 7
+  - name: a wood haircomb
+    noun: haircomb
+    volume: 3
+    work_order: true
+    chapter: 7
+  # Shaping Chapter 8 recipes
+  - name: a wood bead
+    noun: bead
+    volume: 1
+    work_order: false
+    chapter: 8
+  - name: a detailed wood bead
+    noun: bead
+    volume: 1
+    work_order: false
+    chapter: 8
+  - name: a wood totem
+    noun: totem
+    volume: 2
+    work_order: false
+    chapter: 8
+  - name: a detailed wood totem
+    noun: totem
+    volume: 2
+    work_order: false
+    chapter: 8
+  - name: a wood figurine
+    noun: figurine
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a wood wand
+    noun: wand
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a wood rod
+    noun: rod
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a detailed wood figurine
+    noun: figurine
+    volume: 3
+    work_order: false
+    chapter: 8
+  - name: a wood statuette
+    noun: statuette
+    volume: 8
+    work_order: false
+    chapter: 8
+  - name: a detailed wood statuette
+    noun: statuette
+    volume: 8
+    work_order: false
+    chapter: 8
+  - name: a wood statue
+    noun: statue
+    volume: 20
+    work_order: false
+    chapter: 8
+  - name: a detailed wood statue
+    noun: statue
+    volume: 20
+    work_order: false
+    chapter: 8
+  # Shaping Chapter 9 recipes
+  - name: a wood cane
+    noun: cane
+    volume: 7
+    work_order: true
+    chapter: 9
+  - name: a wood nightstick
+    noun: nightstick
+    volume: 6
+    work_order: true
+    chapter: 9
+    part:
+    - leather strip
+  - name: a wood quarterstaff
+    noun: quarterstaff
+    volume: 9
+    work_order: true
+    chapter: 9
+  - name: a wood walking cane
+    noun: cane
+    volume: 6
+    work_order: true
+    chapter: 9
+  - name: a wood crook
+    noun: crook
+    volume: 5
+    work_order: true
+    chapter: 9
+  - name: a wood bo staff
+    noun: staff
+    volume: 8
+    work_order: true
+    chapter: 9
+    part:
+    - leather strip
+  - name: a weighted staff
+    noun: staff
+    volume: 9
+    work_order: true
+    chapter: 9
+    part:
+    - leather strip
+  # Shaping Chapter 10 recipes
+  - name: a rough wood table
+    noun: table
+    volume: 15
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a low wood table
+    noun: table
+    volume: 18
+    work_order: false
+    chapter: 10
+    part:
+    - short pole
+    - short pole
+    - short pole
+    - short pole
+  - name: a high wood table
+    noun: table
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a round wood table
+    noun: table
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a square wood table
+    noun: table
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a long wood table
+    noun: table
+    volume: 25
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: an oval wood table
+    noun: table
+    volume: 25
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood dining table
+    noun: table
+    volume: 30
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood buffet table
+    noun: table
+    volume: 30
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood refectory table
+    noun: table
+    volume: 30
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood parquet table
+    noun: table
+    volume: 32
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+  - name: a wood meditation table
+    noun: table
+    volume: 32
+    work_order: false
+    chapter: 10
+    part:
+    - long pole
+    - long pole
+    - long pole
+    - long pole
+tinkering:
+  # Tinkering Chapter 2
+  - name: a toy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 6
+    part:
+    - mechanism
     - bow string
-- name: a practice shortbow
-  noun: shortbow
-  volume: 4
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a practice crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 7
+    part:
+    - mechanism
     - bow string
-- name: a simple shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a simple crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 7
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a light shortbow
-  noun: shortbow
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a slim crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 6
+    part:
+    - mechanism
     - bow string
-- name: a farmer's bow
-  noun: bow
-  volume: 4
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a farmer's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 7
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a light crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a sturdy shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a sturdy light crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: an alpine shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: an alpine crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a saddle bow
-  noun: bow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a saddle crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a flight bow
-  noun: bow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a flight crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a steppe bow
-  noun: bow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a steppe crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a battle shortbow
-  noun: shortbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a light battle crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a forester's shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a light forester's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a Nisha shortbow
-  noun: shortbow
-  volume: 5
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a lockbow
+    noun: lockbow
+    work_order: true
+    chapter: 2
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a competition shortbow
-  noun: shortbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 2
-  part:
+  - name: a latchbow
+    noun: latchbow
+    work_order: true
+    chapter: 2
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
     - bow string
-# Shaping Chapter 3 recipes
-- name: a simple longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  # Tinkering Chapter 3
+  - name: a simple heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a practice longbow
-  noun: longbow
-  volume: 6
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: practice heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 14
+    part:
+    - mechanism
+    - mechanism
     - bow string
-- name: a longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: sturdy heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a sturdy longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: a heavy crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a flatbow
-  noun: flatbow
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a slurbow
+    noun: slurbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a skirmisher's bow
-  noun: bow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: skirmisher's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a reflex longbow
-  noun: longbow
-  volume: 7
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: a flat crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a self bow
-  noun: bow
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a battle crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a recurve longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a forester's crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a forester's longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 3
-  part:
+  - name: a recurve crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a battle longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: an arena crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 15
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-- name: a competition longbow
-  noun: longbow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 3
-  part:
+  - name: a competition crossbow
+    noun: crossbow
+    work_order: true
+    chapter: 3
+    volume: 16
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-# Shaping Chapter 4 recipes
-- name: a composite bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  # Tinkering Chapter 4
+  - name: a reinforced arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 19
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a double-backed bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: an arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a recurve bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a siege arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a forester's bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
+  - name: a forester's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a reflex bow
-  noun: bow
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a recurve arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a savannah bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a horseman's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 18
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a footman's bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
+  - name: a footman's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 19
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a horseman's bow
-  noun: bow
-  volume: 9
-  type: shaping
-  work_order: false
-  chapter: 4
-  part:
+  - name: a mariner's arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 19
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a battle bow
-  noun: bow
-  volume: 10
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a competition arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 20
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-- name: a competition bow
-  noun: bow
-  volume: 10
-  type: shaping
-  work_order: true
-  chapter: 4
-  part:
+  - name: a battle arbalest
+    noun: arbalest
+    work_order: true
+    chapter: 4
+    volume: 20
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - mechanism
     - bow string
-    - bone backer
-# Shaping Chapter 5 recipes are arrows and covered with the arrows.lic script.
-# Shaping Chapter 6 recipes are Enhancements and Materials.
-- name: a simple wood burin
-  noun: burin
-  work_order: true
-  type: shaping
-  chapter: 6
-  volume: 4
-- name: a fine wood burin
-  noun: burin
-  work_order: true
-  type: shaping
-  chapter: 6
-  volume: 4
-- name: an ornate wood burin
-  noun: burin
-  work_order: true
-  type: shaping
-  chapter: 6
-  volume: 4
-# Shaping Chapter 7 recipes
-- name: a wood band
-  noun: band
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood nose ring
-  noun: ring
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood toe ring
-  noun: ring
-  volume: 1
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood bracelet
-  noun: bracelet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood anklet
-  noun: anklet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood pin
-  noun: pin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood cloak pin
-  noun: pin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a shallow wood cup
-  noun: cup
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood hairpin
-  noun: hairpin
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood tailband
-  noun: tailband
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood pendant
-  noun: pendant
-  volume: 1
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: a wood amulet
-  noun: amulet
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood medallion
-  noun: medallion
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a pair of wood earrings
-  noun: earrings
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood earcuff
-  noun: earcuff
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood brooch
-  noun: brooch
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood armband
-  noun: armband
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood belt buckle
-  noun: buckle
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood choker
-  noun: choker
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood locket
-  noun: locket
-  volume: 2
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: some wood bangles
-  noun: bangles
-  volume: 5
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood tiara
-  noun: tiara
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: an articulated wood bracelet
-  noun: bracelet
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood circlet
-  noun: circlet
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: an articulated wood necklace
-  noun: necklace
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood crown
-  noun: crown
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood mask
-  noun: mask
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 7
-  part:
-  - short cord
-- name: a wood comb
-  noun: comb
-  volume: 2
-  type: shaping
-  work_order: true
-  chapter: 7
-- name: a wood haircomb
-  noun: haircomb
-  volume: 3
-  type: shaping
-  work_order: true
-  chapter: 7
-# Shaping Chapter 8 recipes
-- name: a wood bead
-  noun: bead
-  volume: 1
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood bead
-  noun: bead
-  volume: 1
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood totem
-  noun: totem
-  volume: 2
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood totem
-  noun: totem
-  volume: 2
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood figurine
-  noun: figurine
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood wand
-  noun: wand
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood rod
-  noun: rod
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood figurine
-  noun: figurine
-  volume: 3
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood statuette
-  noun: statuette
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood statuette
-  noun: statuette
-  volume: 8
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a wood statue
-  noun: statue
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 8
-- name: a detailed wood statue
-  noun: statue
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 8
-# Shaping Chapter 9 recipes
-- name: a wood cane
-  noun: cane
-  volume: 7
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood nightstick
-  noun: nightstick
-  volume: 6
-  type: shaping
-  work_order: true
-  chapter: 9
-  part:
-  - leather strip
-- name: a wood quarterstaff
-  noun: quarterstaff
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood walking cane
-  noun: cane
-  volume: 6
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood crook
-  noun: crook
-  volume: 5
-  type: shaping
-  work_order: true
-  chapter: 9
-- name: a wood bo staff
-  noun: staff
-  volume: 8
-  type: shaping
-  work_order: true
-  chapter: 9
-  part:
-  - leather strip
-- name: a weighted staff
-  noun: staff
-  volume: 9
-  type: shaping
-  work_order: true
-  chapter: 9
-  part:
-  - leather strip
-# Shaping Chapter 10 recipes
-- name: a rough wood table
-  noun: table
-  volume: 15
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a low wood table
-  noun: table
-  volume: 18
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - short pole
-  - short pole
-  - short pole
-  - short pole
-- name: a high wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a round wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a square wood table
-  noun: table
-  volume: 20
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a long wood table
-  noun: table
-  volume: 25
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: an oval wood table
-  noun: table
-  volume: 25
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood dining table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood buffet table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood refectory table
-  noun: table
-  volume: 30
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood parquet table
-  noun: table
-  volume: 32
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-- name: a wood meditation table
-  noun: table
-  volume: 32
-  type: shaping
-  work_order: false
-  chapter: 10
-  part:
-  - long pole
-  - long pole
-  - long pole
-  - long pole
-# Tinkering Chapter 2
-- name: a toy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 6
-  part:
-  - mechanism
-  - bow string
-- name: a practice crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 7
-  part:
-  - mechanism
-  - bow string
-- name: a simple crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 7
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a slim crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 6
-  part:
-  - mechanism
-  - bow string
-- name: a farmer's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 7
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a light crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a sturdy light crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: an alpine crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a saddle crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a flight crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a steppe crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a light battle crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a light forester's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a lockbow
-  noun: lockbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a latchbow
-  noun: latchbow
-  work_order: true
-  type: tinkering
-  chapter: 2
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 3
-- name: a simple heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: practice heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 14
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: sturdy heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a heavy crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a slurbow
-  noun: slurbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: skirmisher's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a flat crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a battle crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a forester's crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a recurve crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: an arena crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 15
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a competition crossbow
-  noun: crossbow
-  work_order: true
-  type: tinkering
-  chapter: 3
-  volume: 16
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 4
-- name: a reinforced arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 19
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: an arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a siege arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a forester's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a recurve arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a horseman's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 18
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a footman's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 19
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a mariner's arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 19
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a competition arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 20
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-- name: a battle arbalest
-  noun: arbalest
-  work_order: true
-  type: tinkering
-  chapter: 4
-  volume: 20
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 5
-- name: simple stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 7
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a sturdy stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a lobbing stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a saddle stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: an alpine stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a slingbow
-  noun: slingbow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 8
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: forester's stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a battle stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a steppe stonebow
-  noun: stonebow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 10
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-- name: a pelletbow
-  noun: pelletbow
-  work_order: true
-  type: tinkering
-  chapter: 5
-  volume: 9
-  part:
-  - mechanism
-  - mechanism
-  - bow string
-# Tinkering Chapter 6 Siege Wapon Crafting - Blank
-# Tinkering Chapter 7 Bolts - use bolts.lic script
-# Tinkering Chapter 8 Tinkered Enhancement
-# Tinkering Chapter 9
-- name: a small music box
-  noun: box
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 2
-  part:
-  - mechanism
-- name: miniature male soldier
-  noun: soldier
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 3
-  part:
-  - mechanism
-- name: miniature female soldier
-  noun: soldier
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 3
-  part:
-  - mechanism
-- name: a simple telescope
-  noun: telescope
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 5
-  part:
-  - mechanism
-  - lenses
-- name: a musical box
-  noun: box
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 3
-  part:
-  - mechanism
-- name: a telescope
-  noun: telescope
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 5
-  part:
-  - mechanism
-  - mechanism
-  - lenses
-- name: a clockwork telescope
-  noun: telescope
-  work_order: true
-  type: tinkering
-  chapter: 9
-  volume: 6
-  part:
-  - mechanism
-  - mechanism
-  - mechanism
-  - lenses
-# Tinkering Chapter 10 Locksmithing - blank
-####################################
-##### Engineering section ends #####
-####################################
+  # Tinkering Chapter 5
+  - name: simple stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 7
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a sturdy stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a lobbing stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a saddle stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: an alpine stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a slingbow
+    noun: slingbow
+    work_order: true
+    chapter: 5
+    volume: 8
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: forester's stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a battle stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a steppe stonebow
+    noun: stonebow
+    work_order: true
+    chapter: 5
+    volume: 10
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  - name: a pelletbow
+    noun: pelletbow
+    work_order: true
+    chapter: 5
+    volume: 9
+    part:
+    - mechanism
+    - mechanism
+    - bow string
+  # Tinkering Chapter 6 Siege Wapon Crafting - Blank
+  # Tinkering Chapter 7 Bolts - use bolts.lic script
+  # Tinkering Chapter 8 Tinkered Enhancement
+  # Tinkering Chapter 9
+  - name: a small music box
+    noun: box
+    work_order: true
+    chapter: 9
+    volume: 2
+    part:
+    - mechanism
+  - name: miniature male soldier
+    noun: soldier
+    work_order: true
+    chapter: 9
+    volume: 3
+    part:
+    - mechanism
+  - name: miniature female soldier
+    noun: soldier
+    work_order: true
+    chapter: 9
+    volume: 3
+    part:
+    - mechanism
+  - name: a simple telescope
+    noun: telescope
+    work_order: true
+    chapter: 9
+    volume: 5
+    part:
+    - mechanism
+    - lenses
+  - name: a musical box
+    noun: box
+    work_order: true
+    chapter: 9
+    volume: 3
+    part:
+    - mechanism
+  - name: a telescope
+    noun: telescope
+    work_order: true
+    chapter: 9
+    volume: 5
+    part:
+    - mechanism
+    - mechanism
+    - lenses
+  - name: a clockwork telescope
+    noun: telescope
+    work_order: true
+    chapter: 9
+    volume: 6
+    part:
+    - mechanism
+    - mechanism
+    - mechanism
+    - lenses
+  # Tinkering Chapter 10 Locksmithing - blank
+  ####################################
+  ##### Engineering section ends #####
+  ####################################
+tailoring:
 ####################################
 ##### Outfitting section ends  #####
 ####################################
 # Tailoring Chapter 2 recipes
-- name: some cloth socks
-  noun: socks
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth ankle socks
-  noun: socks
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth armband
-  noun: armband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth fingerless gloves
-  noun: gloves
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth ankleband
-  noun: ankleband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth eyepatch
-  noun: eyepatch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth knee socks
-  noun: socks
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some pleated cloth gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some elbow-length gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth headband
-  noun: headband
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth scarf
-  noun: scarf
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some elegant cloth gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth slippers
-  noun: slippers
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth field shoes
-  noun: shoes
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth hat
-  noun: hat
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dunce hat
-  noun: hat
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a segmented cloth belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dress belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth commoner's cloak
-  noun: 6
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth head scarf
-  noun: scarf
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth veil
-  noun: veil
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a floppy cloth hat
-  noun: hat
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a double-wrapped belt
-  noun: belt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth pants
-  noun: pants
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth skirt
-  noun: skirt
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth kilt
-  noun: kilt
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth sash
-  noun: sash
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a sleeveless cloth shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth cloak
-  noun: cloak
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dress hat
-  noun: hat
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth top hat
-  noun: hat
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some baggy cloth pants
-  noun: pants
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth dress
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a knee-length cloth dress
-  noun: 8
-  volume:
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a front-laced cloth dress
-  noun: dress
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a billowing cloth shirt
-  noun: shirt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a baggy cloth shirt
-  noun: shirt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth tunic
-  noun: tunic
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth robes
-  noun: robes
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some cloth dress pants
-  noun: pants
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a floor-length cloth dress
-  noun: dress
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth gown
-  noun: gown
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth dress shirt
-  noun: shirt
-  volume: 4
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a short-sleeved tunic
-  noun: tunic
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a formal cloth tunic
-  noun: tunic
-  volume: 5
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth tabard
-  noun: tabard
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a hooded cloth cloak
-  noun: cloak
-  volume: 8
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth cape
-  noun: cape
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: some hooded cloth robes
-  noun: robes
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a deeply-hooded cloak
-  noun: cloak
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 2
-- name: a cloth mage's robe
-  noun: robe
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: some flowing cloth robes
-  noun: robes
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-- name: a cloth shaman's robe
-  noun: robe
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 2
-# Tailoring Chapter 3 recipes
-- name: a cloth napkin
-  noun: napkin
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth hip pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth rag
-  noun: rag
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth gem pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth weapon strap
-  noun: strap
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth pouch
-  noun: pouch
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth thigh bag
-  noun: bag
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth towel
-  noun: towel
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth herb pouch
-  noun: pouch
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth talisman pouch
-  noun: pouch
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth arm pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth bag
-  noun: bag
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth sack
-  noun: sack
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth utility belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth charm bag
-  noun: bag
-  volume: 3
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth backpack
-  noun: backpack
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth knapsack
-  noun: knapsack
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth carryall
-  noun: carryall
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 3
-- name: a cloth blanket
-  noun: blanket
-  volume: 9
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth duffel bag
-  noun: duffel.bag
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth haversack
-  noun: haversack
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth bandolier
-  noun: bandolier
-  volume: 6
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a small cloth rucksack
-  noun: small.rucksack
-  volume: 7
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth mining belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth saddle pad
-  noun: pad
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth rucksack
-  noun: rucksack
-  volume: 8
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth survival belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth saddle blanket
-  noun: blanket
-  volume: 12
-  type: tailoring
-  work_order: true
-  chapter: 3
-  part:
-  - small padding
-- name: a cloth artisan's belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: true
-  chapter: 3
-- name: a cloth saddle shabrack
-  noun: shabrack
-  volume: 12
-  type: tailoring
-  work_order: true
-  chapter: 3
-  part:
-  - small padding
-# Tailoring Chapter 4 recipes
-- name: a quilted cloth aventail
-  noun: aventail
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth mask
-  noun: mask
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth gloves
-  noun: gloves
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth aventail
-  noun: aventail
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth mask
-  noun: mask
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth hood
-  noun: hood
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth gloves
-  noun: gloves
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth aventail
-  noun: aventail
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth mask
-  noun: mask
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth pants
-  noun: pants
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth hood
-  noun: hood
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some insulated cloth gloves
-  noun: gloves
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth pants
-  noun: pants
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth vambraces
-  noun: vambraces
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth tasset
-  noun: tasset
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth tabard
-  noun: tabard
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth hood
-  noun: hood
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some insulated cloth pants
-  noun: pants
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth vambraces
-  noun: vambraces
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some quilted cloth sleeves
-  noun: sleeves
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth tasset
-  noun: tasset
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth vest
-  noun: vest
-  volume: 14
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth mantle
-  noun: mantle
-  volume: 17
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a quilted cloth robe
-  noun: robe
-  volume: 32
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a quilted cloth shirt
-  noun: shirt
-  volume: 34
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a padded cloth tabard
-  noun: tabard
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: some insulated cloth vambraces
-  noun: vambraces
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: some padded cloth sleeves
-  noun: sleeves
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth tasset
-  noun: tasset
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth vest
-  noun: vest
-  volume: 14
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth mantle
-  noun: mantle
-  volume: 17
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: a padded cloth robe
-  noun: robe
-  volume: 32
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a quilted cloth hauberk
-  noun: hauberk
-  volume: 44
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a padded cloth shirt
-  noun: shirt
-  volume: 34
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth tabard
-  noun: tabard
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: some insulated cloth sleeves
-  noun: sleeves
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth vest
-  noun: vest
-  volume: 14
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth mantle
-  noun: mantle
-  volume: 17
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - small padding
-- name: an insulated cloth robe
-  noun: robe
-  volume: 32
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: a padded cloth hauberk
-  noun: hauberk
-  volume: 44
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth shirt
-  noun: shirt
-  volume: 34
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-- name: an insulated cloth hauberk
-  noun: hauberk
-  volume: 44
-  type: tailoring
-  work_order: false
-  chapter: 4
-  part:
-  - large padding
-# Tailoring Chapter 5 recipes
-- name: a knitted ankleband
-  noun: ankleband
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted socks
-  noun: socks
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted armband
-  noun: armband
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted napkin
-  noun: napkin
-  volume: 10
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted mittens
-  noun: mittens
-  volume: 13
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted headband
-  noun: headband
-  volume: 13
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted slippers
-  noun: slippers
-  volume: 26
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted scarf
-  noun: scarf
-  volume: 26
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted hat
-  noun: hat
-  volume: 30
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted booties
-  noun: booties
-  volume: 30
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted hood
-  noun: hood
-  volume: 30
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted towel
-  noun: towel
-  volume: 40
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted legwarmers
-  noun: legwarmers
-  volume: 60
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted gloves
-  noun: gloves
-  volume: 16
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted shirt
-  noun: shirt
-  volume: 40
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted skirt
-  noun: skirt
-  volume: 60
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted sweater
-  noun: sweater
-  volume: 50
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: some knitted hose
-  noun: hose
-  volume: 60
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted cloak
-  noun: cloak
-  volume: 70
-  type: tailoring
-  work_order: true
-  chapter: 5
-- name: a knitted blanket
-  noun: blanket
-  volume: 90
-  type: tailoring
-  work_order: true
-  chapter: 5
-# Tailoring Chapter 6 recipes
-# No recipes
-# Tailoring Chapter 7 recipes
-- name: a leather armband
-  noun: armband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather ankleband
-  noun: ankleband
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some fingerless gloves
-  noun: gloves
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some elbow-length gloves
-  noun: gloves
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather eyepatch
-  noun: eyepatch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather headband
-  noun: headband
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather belt
-  noun: belt
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some leather moccasins
-  noun: moccasins
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: some leather shoes
-  noun: shoes
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather hat
-  noun: hat
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a commoner's cloak
-  noun: cloak
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a sleeveless leather shirt
-  noun: shirt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a segmented belt
-  noun: belt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather dress belt
-  noun: belt
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather skirt
-  noun: skirt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather cloak
-  noun: cloak
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather tunic
-  noun: tunic
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather dress
-  noun: dress
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a double-wrapped belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather cape
-  noun: cape
-  volume: 7
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather utility belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a hooded leather cloak
-  noun: cloak
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a deeply-hooded cloak
-  noun: cloak
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather hunting shirt
-  noun: shirt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather dueling shirt
-  noun: shirt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather mining belt
-  noun: belt
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather war belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-- name: a leather artisan's belt
-  noun: belt
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 7
-# Tailoring Chapter 8 recipes
-- name: a leather hip pouch
-  noun: pouch
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather weapon strap
-  noun: strap
-  volume: 1
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather saddle
-  noun: saddle
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather sidesaddle
-  noun: sidesaddle
-  volume: 9
-  type: tailoring
-  work_order: false
-  chapter: 8
-- name: a leather jousting saddle
-  noun: saddle
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 8
-# Tailoring Chapter 9 recipes
-- name: a rugged leather aventail
-  noun: aventail
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather mask
-  noun: mask
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged gloves
-  noun: gloves
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather aventail
-  noun: aventail
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather mask
-  noun: mask
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather aventail
-  noun: aventail
-  volume: 4
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather helm
-  noun: helm
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some thick gloves
-  noun: gloves
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather mask
-  noun: mask
-  volume: 3
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather tasset
-  noun: tasset
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged vambraces
-  noun: vambraces
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged greaves
-  noun: greaves
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather cowl
-  noun: cowl
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather helm
-  noun: helm
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse gloves
-  noun: gloves
-  volume: 5
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather cap
-  noun: cap
-  volume: 6
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather jerkin
-  noun: 28
-  volume:
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a thick leather tasset
-  noun: tasset
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather mantle
-  noun: mantle
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather vest
-  noun: vest
-  volume: 18
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some rugged leather sleeves
-  noun: sleeves
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some thick vambraces
-  noun: vambraces
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some thick greaves
-  noun: greaves
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather cowl
-  noun: cowl
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather helm
-  noun: helm
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather mantle
-  noun: mantle
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a rugged leather coat
-  noun: coat
-  volume: 43
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a rugged leather robe
-  noun: robe
-  volume: 40
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a thick leather jerkin
-  noun: jerkin
-  volume: 28
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some thick leather sleeves
-  noun: sleeves
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather vest
-  noun: vest
-  volume: 18
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather tasset
-  noun: tasset
-  volume:
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse vambraces
-  noun: vambraces
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse greaves
-  noun: greaves
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather cowl
-  noun: cowl
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a thick leather robe
-  noun: robe
-  volume: 40
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some rugged leathers
-  noun: leathers
-  volume: 55
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a thick leather coat
-  noun: coat
-  volume: 43
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a coarse leather jerkin
-  noun: jerkin
-  volume: 28
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a coarse leather mantle
-  noun: mantle
-  volume: 22
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: some coarse leather sleeves
-  noun: sleeves
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather vest
-  noun: vest
-  volume: 18
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - small padding
-- name: a coarse leather robe
-  volume: 40
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some thick leathers
-  noun: leathers
-  volume: 55
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: a coarse leather coat
-  noun: coat
-  volume: 43
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-- name: some coarse leathers
-  noun: leathers
-  volume: 55
-  type: tailoring
-  work_order: false
-  chapter: 9
-  part:
-  - large padding
-# Tailoring Chapter 10 recipes
-- name: a leather target handle
-  noun: shield
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 10
-- name: a long leather cord
-  noun: shield
-  volume: 2
-  type: tailoring
-  work_order: false
-  chapter: 10
-- name: a leather target shield
-  noun: shield
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: an ordinary leather shield
-  noun: shield
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a small leather shield
-  noun: shield
-  volume: 8
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - leather shield handle
-  - long cord
-- name: a leather buckler
-  noun: buckler
-  volume: 12
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a leather targe
-  noun: targe
-  volume: 10
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a leather oval shield
-  noun: shield
-  volume: 20
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a medium leather shield
-  noun: shield
-  volume: 16
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
-- name: a leather kite shield
-  noun: shield
-  volume: 24
-  type: tailoring
-  work_order: false
-  chapter: 10
-  part:
-  - shield handle
-  - long cord
+  - name: some cloth socks
+    noun: socks
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: some cloth ankle socks
+    noun: socks
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: a cloth armband
+    noun: armband
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: some cloth fingerless gloves
+    noun: gloves
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: a cloth ankleband
+    noun: ankleband
+    volume: 1
+    work_order: false
+    chapter: 2
+  - name: a cloth eyepatch
+    noun: eyepatch
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some cloth knee socks
+    noun: socks
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some pleated cloth gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some elbow-length gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth headband
+    noun: headband
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth scarf
+    noun: scarf
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: some elegant cloth gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: some cloth slippers
+    noun: slippers
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: some cloth field shoes
+    noun: shoes
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth hat
+    noun: hat
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth dunce hat
+    noun: hat
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a segmented cloth belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth dress belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 2
+  - name: a cloth commoner's cloak
+    noun: 6
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth head scarf
+    noun: scarf
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth veil
+    noun: veil
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a floppy cloth hat
+    noun: hat
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a double-wrapped belt
+    noun: belt
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: some cloth pants
+    noun: pants
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth skirt
+    noun: skirt
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth kilt
+    noun: kilt
+    volume: 6
+    work_order: false
+    chapter: 2
+  - name: a cloth sash
+    noun: sash
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a sleeveless cloth shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 2
+  - name: a cloth cloak
+    noun: cloak
+    volume: 7
+    work_order: false
+    chapter: 2
+  - name: a cloth dress hat
+    noun: hat
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a cloth top hat
+    noun: hat
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: some baggy cloth pants
+    noun: pants
+    volume: 7
+    work_order: false
+    chapter: 2
+  - name: a cloth dress
+    volume: 8
+    work_order: false
+    chapter: 2
+  - name: a knee-length cloth dress
+    noun: 8
+    volume:
+    work_order: false
+    chapter: 2
+  - name: a front-laced cloth dress
+    noun: dress
+    volume: 8
+    work_order: false
+    chapter: 2
+  - name: a billowing cloth shirt
+    noun: shirt
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a baggy cloth shirt
+    noun: shirt
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a cloth tunic
+    noun: tunic
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: some cloth robes
+    noun: robes
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: some cloth dress pants
+    noun: pants
+    volume: 6
+    work_order: true
+    chapter: 2
+  - name: a floor-length cloth dress
+    noun: dress
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: a cloth gown
+    noun: gown
+    volume: 9
+    work_order: true
+    chapter: 2
+  - name: a cloth dress shirt
+    noun: shirt
+    volume: 4
+    work_order: true
+    chapter: 2
+  - name: a short-sleeved tunic
+    noun: tunic
+    volume: 4
+    work_order: false
+    chapter: 2
+  - name: a formal cloth tunic
+    noun: tunic
+    volume: 5
+    work_order: true
+    chapter: 2
+  - name: a cloth tabard
+    noun: tabard
+    volume: 6
+    work_order: true
+    chapter: 2
+  - name: a hooded cloth cloak
+    noun: cloak
+    volume: 8
+    work_order: true
+    chapter: 2
+  - name: a cloth cape
+    noun: cape
+    volume: 7
+    work_order: false
+    chapter: 2
+  - name: some hooded cloth robes
+    noun: robes
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: a deeply-hooded cloak
+    noun: cloak
+    volume: 9
+    work_order: false
+    chapter: 2
+  - name: a cloth mage's robe
+    noun: robe
+    volume: 9
+    work_order: true
+    chapter: 2
+  - name: some flowing cloth robes
+    noun: robes
+    volume: 9
+    work_order: true
+    chapter: 2
+  - name: a cloth shaman's robe
+    noun: robe
+    volume: 9
+    work_order: true
+    chapter: 2
+  # Tailoring Chapter 3 recipes
+  - name: a cloth napkin
+    noun: napkin
+    volume: 1
+    work_order: false
+    chapter: 3
+  - name: a cloth hip pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth rag
+    noun: rag
+    volume: 1
+    work_order: false
+    chapter: 3
+  - name: a cloth gem pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth weapon strap
+    noun: strap
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth pouch
+    noun: pouch
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth thigh bag
+    noun: bag
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth towel
+    noun: towel
+    volume: 4
+    work_order: false
+    chapter: 3
+  - name: a cloth herb pouch
+    noun: pouch
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth talisman pouch
+    noun: pouch
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth arm pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 3
+  - name: a cloth bag
+    noun: bag
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth sack
+    noun: sack
+    volume: 3
+    work_order: false
+    chapter: 3
+  - name: a cloth utility belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 3
+  - name: a cloth charm bag
+    noun: bag
+    volume: 3
+    work_order: true
+    chapter: 3
+  - name: a cloth backpack
+    noun: backpack
+    volume: 5
+    work_order: false
+    chapter: 3
+  - name: a cloth knapsack
+    noun: knapsack
+    volume: 5
+    work_order: false
+    chapter: 3
+  - name: a cloth carryall
+    noun: carryall
+    volume: 5
+    work_order: false
+    chapter: 3
+  - name: a cloth blanket
+    noun: blanket
+    volume: 9
+    work_order: true
+    chapter: 3
+  - name: a cloth duffel bag
+    noun: duffel.bag
+    volume: 6
+    work_order: true
+    chapter: 3
+  - name: a cloth haversack
+    noun: haversack
+    volume: 6
+    work_order: true
+    chapter: 3
+  - name: a cloth bandolier
+    noun: bandolier
+    volume: 6
+    work_order: true
+    chapter: 3
+  - name: a small cloth rucksack
+    noun: small.rucksack
+    volume: 7
+    work_order: true
+    chapter: 3
+  - name: a cloth mining belt
+    noun: belt
+    volume: 4
+    work_order: true
+    chapter: 3
+  - name: a cloth saddle pad
+    noun: pad
+    volume: 10
+    work_order: true
+    chapter: 3
+  - name: a cloth rucksack
+    noun: rucksack
+    volume: 8
+    work_order: true
+    chapter: 3
+  - name: a cloth survival belt
+    noun: belt
+    volume: 5
+    work_order: true
+    chapter: 3
+  - name: a cloth saddle blanket
+    noun: blanket
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - small padding
+  - name: a cloth artisan's belt
+    noun: belt
+    volume: 5
+    work_order: true
+    chapter: 3
+  - name: a cloth saddle shabrack
+    noun: shabrack
+    volume: 12
+    work_order: true
+    chapter: 3
+    part:
+    - small padding
+  # Tailoring Chapter 4 recipes
+  - name: a quilted cloth aventail
+    noun: aventail
+    volume: 3
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth mask
+    noun: mask
+    volume: 2
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth gloves
+    noun: gloves
+    volume: 4
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth aventail
+    noun: aventail
+    volume: 3
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth mask
+    noun: mask
+    volume: 2
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth hood
+    noun: hood
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth gloves
+    noun: gloves
+    volume: 4
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth aventail
+    noun: aventail
+    volume: 3
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth mask
+    noun: mask
+    volume: 2
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth pants
+    noun: pants
+    volume: 10
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth hood
+    noun: hood
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some insulated cloth gloves
+    noun: gloves
+    volume: 4
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth pants
+    noun: pants
+    volume: 10
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth vambraces
+    noun: vambraces
+    volume: 12
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth tabard
+    noun: tabard
+    volume: 22
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth hood
+    noun: hood
+    volume: 9
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some insulated cloth pants
+    noun: pants
+    volume: 10
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth vambraces
+    noun: vambraces
+    volume: 12
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some quilted cloth sleeves
+    noun: sleeves
+    volume: 16
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth vest
+    noun: vest
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth mantle
+    noun: mantle
+    volume: 17
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a quilted cloth robe
+    noun: robe
+    volume: 32
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a quilted cloth shirt
+    noun: shirt
+    volume: 34
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a padded cloth tabard
+    noun: tabard
+    volume: 22
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: some insulated cloth vambraces
+    noun: vambraces
+    volume: 12
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: some padded cloth sleeves
+    noun: sleeves
+    volume: 16
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth tasset
+    noun: tasset
+    volume: 8
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth vest
+    noun: vest
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth mantle
+    noun: mantle
+    volume: 17
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: a padded cloth robe
+    noun: robe
+    volume: 32
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a quilted cloth hauberk
+    noun: hauberk
+    volume: 44
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a padded cloth shirt
+    noun: shirt
+    volume: 34
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth tabard
+    noun: tabard
+    volume: 22
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: some insulated cloth sleeves
+    noun: sleeves
+    volume: 16
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth vest
+    noun: vest
+    volume: 14
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth mantle
+    noun: mantle
+    volume: 17
+    work_order: false
+    chapter: 4
+    part:
+    - small padding
+  - name: an insulated cloth robe
+    noun: robe
+    volume: 32
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: a padded cloth hauberk
+    noun: hauberk
+    volume: 44
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth shirt
+    noun: shirt
+    volume: 34
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  - name: an insulated cloth hauberk
+    noun: hauberk
+    volume: 44
+    work_order: false
+    chapter: 4
+    part:
+    - large padding
+  # Tailoring Chapter 5 recipes
+  - name: a knitted ankleband
+    noun: ankleband
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: some knitted socks
+    noun: socks
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: a knitted armband
+    noun: armband
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: a knitted napkin
+    noun: napkin
+    volume: 10
+    work_order: true
+    chapter: 5
+  - name: some knitted mittens
+    noun: mittens
+    volume: 13
+    work_order: true
+    chapter: 5
+  - name: a knitted headband
+    noun: headband
+    volume: 13
+    work_order: true
+    chapter: 5
+  - name: some knitted slippers
+    noun: slippers
+    volume: 26
+    work_order: true
+    chapter: 5
+  - name: a knitted scarf
+    noun: scarf
+    volume: 26
+    work_order: true
+    chapter: 5
+  - name: a knitted hat
+    noun: hat
+    volume: 30
+    work_order: true
+    chapter: 5
+  - name: some knitted booties
+    noun: booties
+    volume: 30
+    work_order: true
+    chapter: 5
+  - name: a knitted hood
+    noun: hood
+    volume: 30
+    work_order: true
+    chapter: 5
+  - name: a knitted towel
+    noun: towel
+    volume: 40
+    work_order: true
+    chapter: 5
+  - name: some knitted legwarmers
+    noun: legwarmers
+    volume: 60
+    work_order: true
+    chapter: 5
+  - name: some knitted gloves
+    noun: gloves
+    volume: 16
+    work_order: true
+    chapter: 5
+  - name: a knitted shirt
+    noun: shirt
+    volume: 40
+    work_order: true
+    chapter: 5
+  - name: a knitted skirt
+    noun: skirt
+    volume: 60
+    work_order: true
+    chapter: 5
+  - name: a knitted sweater
+    noun: sweater
+    volume: 50
+    work_order: true
+    chapter: 5
+  - name: some knitted hose
+    noun: hose
+    volume: 60
+    work_order: true
+    chapter: 5
+  - name: a knitted cloak
+    noun: cloak
+    volume: 70
+    work_order: true
+    chapter: 5
+  - name: a knitted blanket
+    noun: blanket
+    volume: 90
+    work_order: true
+    chapter: 5
+  # Tailoring Chapter 6 recipes
+  # No recipes
+  # Tailoring Chapter 7 recipes
+  - name: a leather armband
+    noun: armband
+    volume: 1
+    work_order: false
+    chapter: 7
+  - name: a leather ankleband
+    noun: ankleband
+    volume: 1
+    work_order: false
+    chapter: 7
+  - name: some fingerless gloves
+    noun: gloves
+    volume: 1
+    work_order: false
+    chapter: 7
+  - name: some elbow-length gloves
+    noun: gloves
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a leather eyepatch
+    noun: eyepatch
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a leather headband
+    noun: headband
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a leather belt
+    noun: belt
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: some leather moccasins
+    noun: moccasins
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: some leather shoes
+    noun: shoes
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a leather hat
+    noun: hat
+    volume: 2
+    work_order: false
+    chapter: 7
+  - name: a commoner's cloak
+    noun: cloak
+    volume: 6
+    work_order: false
+    chapter: 7
+  - name: a leather shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a sleeveless leather shirt
+    noun: shirt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a segmented belt
+    noun: belt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a leather dress belt
+    noun: belt
+    volume: 3
+    work_order: false
+    chapter: 7
+  - name: a leather skirt
+    noun: skirt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather cloak
+    noun: cloak
+    volume: 7
+    work_order: false
+    chapter: 7
+  - name: a leather tunic
+    noun: tunic
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a leather dress
+    noun: dress
+    volume: 7
+    work_order: false
+    chapter: 7
+  - name: a double-wrapped belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a leather cape
+    noun: cape
+    volume: 7
+    work_order: false
+    chapter: 7
+  - name: a leather utility belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a hooded leather cloak
+    noun: cloak
+    volume: 8
+    work_order: false
+    chapter: 7
+  - name: a deeply-hooded cloak
+    noun: cloak
+    volume: 8
+    work_order: false
+    chapter: 7
+  - name: a leather hunting shirt
+    noun: shirt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather dueling shirt
+    noun: shirt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather mining belt
+    noun: belt
+    volume: 4
+    work_order: false
+    chapter: 7
+  - name: a leather war belt
+    noun: belt
+    volume: 5
+    work_order: false
+    chapter: 7
+  - name: a leather artisan's belt
+    noun: belt
+    volume: 5
+    work_order: false
+    chapter: 7
+  # Tailoring Chapter 8 recipes
+  - name: a leather hip pouch
+    noun: pouch
+    volume: 2
+    work_order: false
+    chapter: 8
+  - name: a leather weapon strap
+    noun: strap
+    volume: 1
+    work_order: false
+    chapter: 8
+  - name: a leather saddle
+    noun: saddle
+    volume: 9
+    work_order: false
+    chapter: 8
+  - name: a leather sidesaddle
+    noun: sidesaddle
+    volume: 9
+    work_order: false
+    chapter: 8
+  - name: a leather jousting saddle
+    noun: saddle
+    volume: 10
+    work_order: false
+    chapter: 8
+  # Tailoring Chapter 9 recipes
+  - name: a rugged leather aventail
+    noun: aventail
+    volume: 4
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather mask
+    noun: mask
+    volume: 3
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged gloves
+    noun: gloves
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather aventail
+    noun: aventail
+    volume: 4
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather mask
+    noun: mask
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather aventail
+    noun: aventail
+    volume: 4
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather helm
+    noun: helm
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some thick gloves
+    noun: gloves
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather mask
+    noun: mask
+    volume: 3
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather tasset
+    noun: tasset
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged vambraces
+    noun: vambraces
+    volume: 16
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather cowl
+    noun: cowl
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather helm
+    noun: helm
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse gloves
+    noun: gloves
+    volume: 5
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather cap
+    noun: cap
+    volume: 6
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather jerkin
+    noun: 28
+    volume:
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a thick leather tasset
+    noun: tasset
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather mantle
+    noun: mantle
+    volume: 22
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some rugged leather sleeves
+    noun: sleeves
+    volume: 20
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some thick vambraces
+    noun: vambraces
+    volume: 16
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some thick greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather cowl
+    noun: cowl
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather helm
+    noun: helm
+    volume: 10
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather mantle
+    noun: mantle
+    volume: 22
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a rugged leather coat
+    noun: coat
+    volume: 43
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a rugged leather robe
+    noun: robe
+    volume: 40
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a thick leather jerkin
+    noun: jerkin
+    volume: 28
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some thick leather sleeves
+    noun: sleeves
+    volume: 20
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather tasset
+    noun: tasset
+    volume:
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse vambraces
+    noun: vambraces
+    volume: 16
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse greaves
+    noun: greaves
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather cowl
+    noun: cowl
+    volume: 12
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a thick leather robe
+    noun: robe
+    volume: 40
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some rugged leathers
+    noun: leathers
+    volume: 55
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a thick leather coat
+    noun: coat
+    volume: 43
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a coarse leather jerkin
+    noun: jerkin
+    volume: 28
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a coarse leather mantle
+    noun: mantle
+    volume: 22
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: some coarse leather sleeves
+    noun: sleeves
+    volume: 20
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather vest
+    noun: vest
+    volume: 18
+    work_order: false
+    chapter: 9
+    part:
+    - small padding
+  - name: a coarse leather robe
+    volume: 40
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some thick leathers
+    noun: leathers
+    volume: 55
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: a coarse leather coat
+    noun: coat
+    volume: 43
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  - name: some coarse leathers
+    noun: leathers
+    volume: 55
+    work_order: false
+    chapter: 9
+    part:
+    - large padding
+  # Tailoring Chapter 10 recipes
+  - name: a leather target handle
+    noun: shield
+    volume: 2
+    work_order: false
+    chapter: 10
+  - name: a long leather cord
+    noun: shield
+    volume: 2
+    work_order: false
+    chapter: 10
+  - name: a leather target shield
+    noun: shield
+    volume: 12
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: an ordinary leather shield
+    noun: shield
+    volume: 8
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a small leather shield
+    noun: shield
+    volume: 8
+    work_order: false
+    chapter: 10
+    part:
+    - leather shield handle
+    - long cord
+  - name: a leather buckler
+    noun: buckler
+    volume: 12
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a leather targe
+    noun: targe
+    volume: 10
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a leather oval shield
+    noun: shield
+    volume: 20
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a medium leather shield
+    noun: shield
+    volume: 16
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+  - name: a leather kite shield
+    noun: shield
+    volume: 24
+    work_order: false
+    chapter: 10
+    part:
+    - shield handle
+    - long cord
+remedies:
 ####################################
 ##### Outfitting section ends  #####
 ####################################
@@ -8190,1478 +7111,1273 @@ crafting_recipes:
 ##### Alchemy section begins#####
 #################################
 # Remedies Chapter 2 recipes
-- name: some blister cream
-  noun: cream
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: nemoih
-  herb2_stock: 3
-- name: some moisturizing ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: plovik
-  herb2_stock: 4
-  liquid: alcohol
-- name: some itch salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: jadice
-  herb2_stock: 5
-- name: some wart salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: sufil
-  herb2_stock:
-- name: some stomach tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: muljin
-  herb2_stock:
-- name: some lip balm
-  noun: balm
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 2
-  container: mortar
-  herb1: red flower
-  herb1_stock: 13
-  herb2: nilos
-  herb2_stock: 6
-- name: some mouth wash
-  noun: wash
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: riolur
-  herb2_stock: 8
-- name: some eye wash
-  noun: wash
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: aevaes
-  herb2_stock:
-- name: some hangover potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: ojhenik
-  herb2_stock: 12
-- name: some refreshment elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: blue flower
-  herb1_stock:
-  herb2: belradi
-  herb2_stock:
-  catalyst: coal nugget
-  catalyst_stock: 2
-  catalyst_volume: 10
-- name: some vigor poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 2
-  container: bowl
-  herb1: red flower
-  herb1_stock: 13
-  herb2: dioica
-  herb2_stock:
-# Remedies Chapter 3 recipes
-- name: some neck salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: georin
-  herb1_stock: 7
-- name: some abdominal salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: nilos
-  herb1_stock: 6
-- name: some chest salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: plovik
-  herb1_stock: 4
-- name: some head salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: nemoih
-  herb1_stock: 3
-- name: some back salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: hulnik
-  herb1_stock:
-- name: some eye salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: sufil
-  herb1_stock:
-- name: some skin salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: aloe
-  herb1_stock:
-- name: some limb salve
-  noun: salve
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: jadice
-  herb1_stock: 5
-- name: some neck ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: georin
-  herb1_stock: 7
-- name: some abdominal ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: nilos
-  herb1_stock: 6
-- name: some chest ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: plovik
-  herb1_stock: 4
-- name: some back ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: hulnik
-  herb1_stock:
-- name: some eye ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: sufil
-  herb1_stock:
-- name: some skin ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 3
-  container: mortar
-  herb1: aloe
-  herb1_stock:
-- name: some limb ungent
-  noun: ungent
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 3
-  container: mortar
-  herb1: jadice
-  herb1_stock: 5
-# Remedies Chapter 4 recipes
-- name: a neck potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: riolur
-  herb1_stock: 8
-- name: an abdomen potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: muljin
-  herb1_stock:
-- name: a chest potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: ithor
-  herb1_stock: 14
-- name: a head potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: eghmok
-  herb1_stock:
-- name: a back potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: jun
-  herb1_stock: 9
-- name: an eye potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: aevaes
-  herb1_stock: 10
-- name: a skin potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: lujeakave
-  herb1_stock:
-- name: a limb potion
-  noun: potion
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: yelith
-  herb1_stock:
-- name: some neck tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: riolur
-  herb1_stock: 8
-- name: some abdominal tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: muljin
-  herb1_stock:
-- name: some chest tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: ithor
-  herb1_stock: 14
-- name: some head tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: eghmok
-  herb1_stock:
-- name: some back tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: jun
-  herb1_stock: 9
-- name: some eye tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 4
-  container: bowl
-  herb1: aevaes
-  herb1_stock: 10
-- name: some skin tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: lujeakave
-  herb1_stock:
-- name: some limb tonic
-  noun: tonic
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 4
-  container: bowl
-  herb1: yelith
-  herb1_stock:
-# Remedies Chapter 5 recipes
-- name: some face ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: qun
-  herb1_stock: 15
-  liquid: alcohol
-- name: some body ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: genich
-  herb1_stock: 11
-  liquid: alcohol
-- name: some limb ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: blocil
-  herb1_stock:
-  liquid: alcohol
-- name: some face poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: qun
-  herb1_stock: 15
-  liquid: alcohol
-- name: some skin ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: cebi
-  herb1_stock:
-  liquid: alcohol
-- name: some body poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: genich
-  herb1_stock: 11
-  liquid: alcohol
-- name: some general purpose ointment
-  noun: ointment
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: dioica
-  herb1_stock:
-  liquid: alcohol
-- name: some skin poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: cebi
-  herb1_stock:
-  liquid: alcohol
-- name: some limb poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: blocil
-  herb1_stock:
-  liquid: alcohol
-- name: some general poultices
-  noun: poultices
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 5
-  container: mortar
-  herb1: dioica
-  herb1_stock:
-  liquid: alcohol
-- name: a body draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 6
-  container: bowl
-  herb1: ojhenik
-  herb1_stock: 12
-  liquid: alcohol
-# Remedies Chapter 6 recipes
-- name: a face draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hulij
-  herb1_stock:
-  liquid: alcohol
-- name: a limb draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: nuloe
-  herb1_stock:
-  liquid: alcohol
-- name: a skin draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hisan
-  herb1_stock:
-  liquid: alcohol
-- name: a general purpose draught
-  noun: draught
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: belradi
-  herb1_stock:
-  liquid: alcohol
-- name: a skin elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hisan
-  herb1_stock:
-  liquid: alcohol
-- name: a limb elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: nuloe
-  herb1_stock:
-  liquid: alcohol
-- name: a body elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: true
-  chapter: 6
-  container: bowl
-  herb1: ojhenik
-  herb1_stock: 12
-  liquid: alcohol
-- name: a face elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: hulij
-  herb1_stock:
-  liquid: alcohol
-- name: a general elixir
-  noun: elixir
-  volume: 1
-  type: remedies
-  work_order: false
-  chapter: 6
-  container: bowl
-  herb1: belradi
-  herb1-stock:
-  liquid: alcohol
+  - name: some blister cream
+    noun: cream
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - nemoih
+  - name: some moisturizing ointment
+    noun: ointment
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - plovik
+    - alcohol
+  - name: some itch salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - jadice
+  - name: some wart salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - sufil
+  - name: some stomach tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - muljin
+  - name: some lip balm
+    noun: balm
+    volume: 1
+    work_order: true
+    chapter: 2
+    container: mortar
+    part:
+    - red flower
+    - nilos
+  - name: some mouth wash
+    noun: wash
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - riolur
+  - name: some eye wash
+    noun: wash
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - aevaes
+  - name: some hangover potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - ojhenik
+  - name: some refreshment elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - blue flower
+    - belradi
+    - coal
+  - name: some vigor poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 2
+    container: bowl
+    part:
+    - red flower
+    - dioica
+  # Remedies Chapter 3 recipes
+  - name: some neck salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - georin
+  - name: some abdominal salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - nilos
+  - name: some chest salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - plovik
+  - name: some head salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - nemoih
+  - name: some back salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - hulnik
+  - name: some eye salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - sufil
+  - name: some skin salve
+    noun: salve
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - aloe
+  - name: some limb salve
+    noun: salve
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - jadice
+  - name: some neck ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - georin
+  - name: some abdominal ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - nilos
+  - name: some chest ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - plovik
+  - name: some back ungent
+    noun: ungent
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - hulnik
+  - name: some eye ungent
+    noun: ungent
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - sufil
+  - name: some skin ungent
+    noun: ungent
+    volume: 1
+    work_order: false
+    chapter: 3
+    container: mortar
+    part:
+    - aloe
+  - name: some limb ungent
+    noun: ungent
+    volume: 1
+    work_order: true
+    chapter: 3
+    container: mortar
+    part:
+    - jadice
+  # Remedies Chapter 4 recipes
+  - name: a neck potion
+    noun: potion
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - riolur
+  - name: an abdomen potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - muljin
+  - name: a chest potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - ithor
+  - name: a head potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - eghmok
+  - name: a back potion
+    noun: potion
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - junliar
+  - name: an eye potion
+    noun: potion
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - aevaes
+  - name: a skin potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - lujeakave
+  - name: a limb potion
+    noun: potion
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - yelith
+  - name: some neck tonic
+    noun: tonic
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - riolur
+  - name: some abdominal tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - muljin
+  - name: some chest tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - ithor
+  - name: some head tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - eghmok
+  - name: some back tonic
+    noun: tonic
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - junliar
+  - name: some eye tonic
+    noun: tonic
+    volume: 1
+    work_order: true
+    chapter: 4
+    container: bowl
+    part:
+    - aevaes
+  - name: some skin tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - lujeakave
+  - name: some limb tonic
+    noun: tonic
+    volume: 1
+    work_order: false
+    chapter: 4
+    container: bowl
+    part:
+    - yelith
+  # Remedies Chapter 5 recipes
+  - name: some face ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - qun pollen
+    - alcohol
+  - name: some body ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - genich stem
+    - alcohol
+  - name: some limb ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - blocil
+    - alcohol
+  - name: some face poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - qun pollen
+    - alcohol
+  - name: some skin ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - cebi
+    - alcohol
+  - name: some body poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - genich stem
+    - alcohol
+  - name: some general purpose ointment
+    noun: ointment
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - dioica
+    - alcohol
+  - name: some skin poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - cebi
+    - alcohol
+  - name: some limb poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - blocil
+    - alcohol
+  - name: some general poultices
+    noun: poultices
+    volume: 1
+    work_order: false
+    chapter: 5
+    container: mortar
+    part:
+    - dioica
+    - alcohol
+  - name: a body draught
+    noun: draught
+    volume: 1
+    work_order: true
+    chapter: 6
+    container: bowl
+    part:
+    - ojhenik
+    - alcohol
+  # Remedies Chapter 6 recipes
+  - name: a face draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hulij
+    - alcohol
+  - name: a limb draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - nuloe
+    - alcohol
+  - name: a skin draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hisan
+    - alcohol
+  - name: a general purpose draught
+    noun: draught
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - belradi
+    - alcohol
+  - name: a skin elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hisan
+    - alcohol
+  - name: a limb elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - nuloe
+    - alcohol
+  - name: a body elixir
+    noun: elixir
+    volume: 1
+    work_order: true
+    chapter: 6
+    container: bowl
+    part:
+    - ojhenik
+    - alcohol
+  - name: a face elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - hulij
+    - alcohol
+  - name: a general elixir
+    noun: elixir
+    volume: 1
+    work_order: false
+    chapter: 6
+    container: bowl
+    part:
+    - belradi
+    - alcohol
+artificing:
 ####################################
 ##### Enchanting section ends #####
 ####################################
 # Artificing Chapter 2 recipes
-- name: a radiant trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 2
-  item: 6
-- name: a mana trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 2
-  enchant_stock2: 3
-  item: 6
-- name: a flash trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 1
-  item: 6
-- name: a cambrinth retuner
-  noun: bobcat rod
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 3
-  part:
-  - bobcat rod
-- name: a celestial beacon
-  noun: heron bead
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  part:
-  - bead
-- name: a wind trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 5
-  item: 6
-- name: simple devourer
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  part:
-  - gem
-  secondary:
-  - metamorphosis
-- name: Eluned's Scry
-  noun: bone
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  enchant_stock2: 4
-- name: an earth trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: true
-  enchant_stock1: 4
-  item: 6
-- name: Garden's Vision
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  part:
-  - A sapphire or amethyst gem
-  secondary:
-  - antipode
-- name: a fire trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 1
-  item: 6
-  secondary:
-  - paradox
-- name: Mirkik sokis
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 5
-  enchant_stock2: 1
-  part:
-  - An ordinary gem of sufficient value
-- name: a water trinket
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - ascension
-- name: an aura device
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - paradox
-- name: a magic gem
-  noun: gem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 4
-  part:
-  - gem
-  secondary:
-  - unity
-- name: nemmiro stone
-  noun: stone
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item:
-  part:
-  - pebble
-  secondary:
-  - any
-  - any
-- name: a shatter sigil
-  noun: ingot
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: ingot
-  secondary:
-  - decay
-  - antipode
-- name: simple gwethsmasher
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - metamorphosis
-- name: a mining stone
-  noun: stone
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 5
-  item:
-  part:
-  - pebble
-  secondary:
-  - integration
-  - antipode
-- name: Ring of Glory Charisma
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 4
-  item:
-  part:
-  - ring
-  secondary:
-  - paradox
-  - clarification
-- name: Ring of Glory Stamina
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item:
-  part:
-  - ring
-  secondary:
-  - integration
-  - nurture
-- name: Astoshe's Eclipse
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 3
-  item:
-  part:
-  - ring
-  secondary:
-  - unity
-- name: Ring of Glory Wisdom
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 1
-  item:
-  part:
-  - ring
-  secondary:
-  - metamorphosis
-  - evolution
-- name: Ring of Glory Intelligence
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item:
-  part:
-  - ring
-  secondary:
-  - paradox
-  - clarification
-- name: unleashed gwethsmasher
-  noun: bone totem
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - metamorphosis
-- name: Ring of Glory Discipline
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 4
-  item:
-  part:
-  - ring
-  secondary:
-  - nurture
-  - decay
-- name: Ring of Glory Reflex
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 3
-  item:
-  part:
-  - ring
-  secondary:
-  - metamorphosis
-  - evolution
-- name: Ring of Glory Agility
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 5
-  item:
-  part:
-  - ring
-  secondary:
-  - nurture
-  - integration
-- name: Ring of Glory Strength
-  noun: ring
-  type: artificing
-  chapter: 2
-  work_order: false
-  enchant_stock1: 1
-  item:
-  part:
-  - ring
-  secondary:
-  - antipode
-  - evolution
-# Artificing Chapter 3 recipes
-- name: training ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 5
-  item: 6
-- name: a basic lunar ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 3
-  item: 6
-- name: basic elemental ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 3
-  item: 6
-- name: basic life ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 1
-  enchant_stock2: 3
-  item: 6
-- name: an accurate focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 4
-  item: 6
-  secondary:
-  - nurture
-  - decay
-- name: basic holy ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: true
-  enchant_stock1: 2
-  enchant_stock2: 3
-  item: 6
-- name: an efficient focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 1
-  item: 6
-  secondary:
-  - metamorphosis
-  - ascension
-- name: advanced lunar ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - paradox
-- name: basic untuned ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - nurture
-- name: a lethal focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - paradox
-  - clarification
-- name: advanced elemental ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - evolution
-- name: a destructive focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 2
-  item: 6
-  secondary:
-  - decay
-  - antipode
-- name: advanced life ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - ascension
-- name: a fire focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  item: 6
-  secondary:
-  - evolution
-  - integration
-  - nurture
-- name: advanced holy ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - unity
-- name: a frost focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  item: 6
-  secondary:
-  - evolution
-  - metamorphosis
-  - unity
-- name: advanced AP ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 3
-  item: 6
-  secondary:
-  - decay
-- name: an electric focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  item: 6
-  secondary:
-  - evolution
-  - ascension
-  - paradox
-- name: advanced untuned ritual focus
-  noun: bone totem
-  type: artificing
-  chapter: 3
-  work_order: false
-  enchant_stock1: 2
-  enchant_stock2: 3
-  item: 6
-  secondary:
-  - unity
-# Artificing Chapter 4 recipes
-- name: common material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: true
-  enchant_stock1: 3
-  part:
-  - sphere
-- name: common material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: true
-  enchant_stock1: 3
-  enchant_stock2: 2
-  part:
-  - sphere
-- name: uncommon material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - paradox
-- name: common material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: true
-  enchant_stock1: 3
-  enchant_stock2: 5
-  part:
-  - sphere
-- name: common material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  part:
-  - sphere
-  secondary:
-  - evolution
-- name: rare material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - nurture
-- name: uncommon material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - nurture
-- name: ultra rare material minor fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - nurture
-- name: uncommon material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - integration
-- name: rare material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - decay
-- name: uncommon material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - clarification
-- name: ultra rare material lesser fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - decay
-- name: rare material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - paradox
-- name: ultra rare material greater fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - paradox
-- name: rare material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - metamorphosis
-  - evolution
-- name: ultra rare material major fount
-  noun: small sphere
-  type: artificing
-  chapter: 4
-  work_order: false
-  enchant_stock1: 3
-  enchant_stock2: 3
-  part:
-  - sphere
-  secondary:
-  - decay
-  - ascension
-# Artificing Chapter 5 recipes
-- name: an unfocused burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  part:
-  - burin
-- name: a focused burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  enchant_stock2: 5
-  part:
-  - burin
-- name: oval augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: a gwethdesuan
-  noun: gwethdesuan
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  part:
-  - gwethdesuan
-  secondary:
-  - ascension
-  item:
-  - gwethdesuan
-- name: a small enchanter's brazier
-  noun: brazier
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 5
-  enchant_stock2: 3
-  item:
-  part:
-  - brazier
-- name: oblong augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  enchant_stock2: 4
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: simple imbuement rod
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  secondary:
-  - evolution
-- name: an abstract burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  enchant_stock2: 5
-  part:
-  - burin
-  secondary:
-  - unity
-- name: circular augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  enchant_stock2: 5
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: stout imbuement rod
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 2
-  secondary:
-  - paradox
-  - nurture
-- name: a precise burin
-  noun: burin
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 1
-  enchant_stock2: 5
-  part:
-  - burin
-  secondary:
-  - integration
-- name: flat augmenting loop
-  noun: loop
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 4
-  enchant_stock2: 1
-  part:
-  - pole
-  secondary:
-  - clarification
-- name: precise imbuement rod
-  type: artificing
-  chapter: 5
-  work_order: false
-  enchant_stock1: 5
-  secondary:
-  - antipode
-  - metamorphosis
-# Artificing Chapter 6 recipes
-- name: a bubble wand
-  noun: wand
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  part:
-  - wand
-- name: ease burden runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: seal cambrinth runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 1
-  enchant_stock2: 3
-  item:
-  part:
-  - runestone
-- name: burden runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 5
-  item:
-  part:
-  - runestone
-- name: manifest force runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: strange arrow runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 4
-  enchant_stock2: 5
-  item:
-  part:
-  - runestone
-- name: gauge flow runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 2
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: dispel runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
-- name: a lore arcana wand
-  noun: wand
-  type: artificing
-  chapter: 6
-  work_order: false
-  enchant_stock1: 1
-  part:
-  - wand
-  secondary:
-  - ascension
-  - evolution
-- name: lay ward runestone
-  noun: basic runestone
-  type: artificing
-  chapter: 6
-  work_order: true
-  enchant_stock1: 5
-  enchant_stock2: 1
-  item:
-  part:
-  - runestone
+  - name: a radiant trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - bone totem
+  - name: a mana trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: a flash trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - induction sigil-scroll
+    - bone totem
+  - name: a cambrinth retuner
+    noun: bobcat rod
+    chapter: 2
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - bobcat rod
+  - name: a celestial beacon
+    noun: heron bead
+    chapter: 2
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - bead
+  - name: a wind trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - bone totem
+  - name: simple devourer
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - gem
+    - metamorphosis sigil-scroll
+  - name: Eluned's Scry
+    noun: bone
+    chapter: 2
+    work_order: false
+    part:
+    - bone
+    - abolution sigil-scroll
+    - permutation sigil-scroll
+  - name: an earth trinket
+    noun: bone totem
+    chapter: 2
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - bone totem
+  - name: Garden's Vision
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - A sapphire or amethyst gem
+    - antipode sigil-scroll
+  - name: a fire trinket
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - bone totem
+    - paradox sigil-scroll 
+  - name: Mirkik sokis
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - An ordinary gem of sufficient value
+  - name: a water trinket
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - ascension sigil-scroll
+  - name: an aura device
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - paradox sigil-scroll
+  - name: a magic gem
+    noun: gem
+    chapter: 2
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - gem
+    - unity sigil-scroll
+  - name: nemmiro stone
+    noun: stone
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - pebble
+    - any
+    - any
+  - name: a shatter sigil
+    noun: ingot
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - ingot
+    - decay sigil-scroll
+    - antipode sigil-scroll
+  - name: simple gwethsmasher
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - metamorphosis sigil-scroll
+  - name: a mining stone
+    noun: stone
+    chapter: 2
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - pebble
+    - integration sigil-scroll
+    - antipode sigil-scroll
+  - name: Ring of Glory Charisma
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - ring
+    - paradox sigil-scroll
+    - clarification sigil-scroll
+  - name: Ring of Glory Stamina
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - ring
+    - integration sigil-scroll
+    - nurture sigil-scroll
+  - name: Astoshe's Eclipse
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - ring
+    - unity sigil-scroll
+  - name: Ring of Glory Wisdom
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - ring
+    - metamorphosis sigil-scroll
+    - evolution sigil-scroll
+  - name: Ring of Glory Intelligence
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - ring
+    - paradox sigil-scroll
+    - clarification sigil-scroll
+  - name: unleashed gwethsmasher
+    noun: bone totem
+    chapter: 2
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - metamorphosis sigil-scroll
+  - name: Ring of Glory Discipline
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - ring
+    - nurture sigil-scroll
+    - decay sigil-scroll
+  - name: Ring of Glory Reflex
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - ring
+    - metamorphosis sigil-scroll
+    - evolution sigil-scroll
+  - name: Ring of Glory Agility
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - ring
+    - nurture sigil-scroll
+    - integration sigil-scroll
+  - name: Ring of Glory Strength
+    noun: ring
+    chapter: 2
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - ring
+    - antipode sigil-scroll
+    - evolution sigil-scroll
+  # Artificing Chapter 3 recipes
+  - name: training ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - bone totem
+  - name: a basic lunar ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: basic elemental ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: basic life ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - induction sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: an accurate focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - bone totem
+    - nurture sigil-scroll
+    - decay sigil-scroll
+  - name: basic holy ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+  - name: an efficient focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - bone totem
+    - metamorphosis sigil-scroll
+    - ascension sigil-scroll
+  - name: advanced lunar ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - paradox sigil-scroll
+  - name: basic untuned ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - nurture sigil-scroll
+  - name: a lethal focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - paradox sigil-scroll
+    - clarification sigil-scroll
+  - name: advanced elemental ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - evolution sigil-scroll
+  - name: a destructive focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - bone totem
+    - decay sigil-scroll
+    - antipode sigil-scroll
+  - name: advanced life ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - ascension sigil-scroll
+  - name: a fire focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - bone totem
+    - evolution sigil-scroll
+    - integration sigil-scroll
+    - nurture sigil-scroll
+  - name: advanced holy ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - unity sigil-scroll
+  - name: a frost focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - bone totem
+    - evolution sigil-scroll
+    - metamorphosis sigil-scroll
+    - unity sigil-scroll
+  - name: advanced AP ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - bone totem
+    - decay sigil-scroll
+  - name: an electric focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - bone totem
+    - evolution sigil-scroll
+    - ascension sigil-scroll
+    - paradox sigil-scroll
+  - name: advanced untuned ritual focus
+    noun: bone totem
+    chapter: 3
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - congruence sigil-scroll
+    - bone totem
+    - unity sigil-scroll
+  # Artificing Chapter 4 recipes
+  - name: common material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - sphere
+  - name: common material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - abolution sigil-scroll
+    - sphere
+  - name: uncommon material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - paradox sigil-scroll
+  - name: common material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: true
+    part:
+    - congruence sigil-scroll
+    - rarefaction sigil-scroll
+    - sphere
+  - name: common material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - sphere
+    - evolution sigil-scroll
+  - name: rare material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - nurture sigil-scroll
+  - name: uncommon material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - nurture sigil-scroll
+  - name: ultra rare material minor fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - nurture sigil-scroll
+  - name: uncommon material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - integration sigil-scroll
+  - name: rare material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - decay sigil-scroll
+  - name: uncommon material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - clarification sigil-scroll
+  - name: ultra rare material lesser fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - decay sigil-scroll
+  - name: rare material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - paradox sigil-scroll
+  - name: ultra rare material greater fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - paradox sigil-scroll
+  - name: rare material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - metamorphosis sigil-scroll
+    - evolution sigil-scroll
+  - name: ultra rare material major fount
+    noun: small sphere
+    chapter: 4
+    work_order: false
+    part:
+    - congruence sigil-scroll
+    - congruence sigil-scroll
+    - sphere
+    - decay sigil-scroll
+    - ascension sigil-scroll
+  # Artificing Chapter 5 recipes
+  - name: an unfocused burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - burin
+  - name: a focused burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - rarefaction sigil-scroll
+    - burin
+  - name: oval augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: a gwethdesuan
+    noun: gwethdesuan
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - gwethdesuan
+    - ascension sigil-scroll
+    - gwethdesuan
+  - name: a small enchanter's brazier
+    noun: brazier
+    chapter: 5
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - congruence sigil-scroll
+    - brazier
+  - name: oblong augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - permutation sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: simple imbuement rod
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - evolution sigil-scroll
+  - name: an abstract burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - rarefaction sigil-scroll
+    - burin
+    - unity sigil-scroll
+  - name: circular augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - rarefaction sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: stout imbuement rod
+    chapter: 5
+    work_order: false
+    part:
+    - abolution sigil-scroll
+    - paradox sigil-scroll
+    - nurture sigil-scroll
+  - name: a precise burin
+    noun: burin
+    chapter: 5
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - rarefaction sigil-scroll
+    - burin
+    - integration sigil-scroll
+  - name: flat augmenting loop
+    noun: loop
+    chapter: 5
+    work_order: false
+    part:
+    - permutation sigil-scroll
+    - induction sigil-scroll
+    - short pole
+    - clarification sigil-scroll
+  - name: precise imbuement rod
+    chapter: 5
+    work_order: false
+    part:
+    - rarefaction sigil-scroll
+    - antipode sigil-scroll
+    - metamorphosis sigil-scroll
+  # Artificing Chapter 6 recipes
+  - name: a bubble wand
+    noun: wand
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - wand
+  - name: ease burden runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: seal cambrinth runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - induction sigil-scroll
+    - congruence sigil-scroll
+    - runestone
+  - name: burden runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - rarefaction sigil-scroll
+    - runestone
+  - name: manifest force runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: strange arrow runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - permutation sigil-scroll
+    - rarefaction sigil-scroll
+    - runestone
+  - name: gauge flow runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - abolution sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: dispel runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - runestone
+  - name: a lore arcana wand
+    noun: wand
+    chapter: 6
+    work_order: false
+    part:
+    - induction sigil-scroll
+    - wand
+    - ascension sigil-scroll
+    - evolution sigil-scroll
+  - name: lay ward runestone
+    noun: basic runestone
+    chapter: 6
+    work_order: true
+    part:
+    - rarefaction sigil-scroll
+    - induction sigil-scroll
+    - runestone

--- a/smith.lic
+++ b/smith.lic
@@ -33,7 +33,7 @@ class Smith
     @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
-    recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
+    recipes = get_data('recipes')[discipline]
     recipe = DRCC.recipe_lookup(recipes, args.item_name)
     return unless recipe
     

--- a/smith.lic
+++ b/smith.lic
@@ -56,7 +56,7 @@ class Smith
     buy_ingot(discipline) if buy
     DRCC.find_anvil(@hometown) unless stay
     DRC.wait_for_script_to_complete('buff', ['smith'])
-    DRC.wait_for_script_to_complete('forge', [type, recipe['chapter'], recipe['name'], material, recipe['noun'], stay ? 'skip' : nil])
+    DRC.wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun'], stay ? 'skip' : nil])
     stamp_item(recipe['noun']) if stamp
     DRC.wait_for_script_to_complete('forge', ['temper', recipe['noun']])  if temper
     DRC.wait_for_script_to_complete('forge', ['hone', recipe['noun']])    if hone

--- a/smith.lic
+++ b/smith.lic
@@ -56,7 +56,7 @@ class Smith
     buy_ingot(discipline) if buy
     DRCC.find_anvil(@hometown) unless stay
     DRC.wait_for_script_to_complete('buff', ['smith'])
-    DRC.wait_for_script_to_complete('forge', [type, recipe['chapter'], recipe['name'], material, recipe['noun']])
+    DRC.wait_for_script_to_complete('forge', [type, recipe['chapter'], recipe['name'], material, recipe['noun'], stay ? 'skip' : nil])
     stamp_item(recipe['noun']) if stamp
     DRC.wait_for_script_to_complete('forge', ['temper', recipe['noun']])  if temper
     DRC.wait_for_script_to_complete('forge', ['hone', recipe['noun']])    if hone

--- a/smith.lic
+++ b/smith.lic
@@ -18,6 +18,7 @@ class Smith
         { name: 'hone', regex: /^hone/i, optional: true, description: 'Hones crafted item(weapon only), reducing weight and impact' },
         { name: 'balance', regex: /^balance/i, optional: true, description: 'Balance crafted item (weapon only), increasing balance at the cost of suitability'},
         { name: 'lighten', regex: /^lighten/i, optional: true, description: 'Lightens crafted armor or shield, reducing weight only'},
+        { name: 'reinforce', regex: /^reinforce/i, optional: true, description: 'Improves some absorption/protection stats at the cost of increased weight and hinderance'},
         { name: 'buy', regex: /^buy/i, optional: true, description: 'Used to purchase the ingot' }
       ]
     ]
@@ -33,18 +34,18 @@ class Smith
     @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
-    type = ["blacksmithing", "armorsmithing", "weaponsmithing"].select { |x| get_data('recipes')[x].any? { |y| y['name'] =~ /#{args.item_name}/i } }
-    recipe = get_data('recipes')[type.first].select { |x| x['name'] =~ /#{args.item_name}/i }.first
+    recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
+    recipe = DRCC.recipe_lookup(recipes, args.item_name)
     return unless recipe
-    parts = recipe['part'] || []
     
-    total_cost = DRCC.crafting_cost(recipe, args.buy ? @materials_info : false, parts, 1, @settings.hometown)
-    DRCM.ensure_copper_on_hand(total_cost, @settings) unless args.here || Script.running?('workorders')
+    DRCM.ensure_copper_on_hand(3000, @settings) unless args.here
 
-    smith(args.material, discipline, recipe, type, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.here)
+    parts = recipe['part'] || []
+    parts << "leather strip" if args.reinforce # adds part to the list for reinforce
+    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.reinforce, args.here)
   end
 
-  def smith(material, discipline, recipe, type, parts, buy, stamp, temper, hone, balance, lighten, stay)
+  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten, reinforce, stay)
     if discipline['stock-volume'] < recipe['volume'] && buy
       echo '***You cannot buy an ingot large enough to craft this item.***'
       echo '***Automatically combining ingots via smelting is not yet supported.***'
@@ -62,6 +63,7 @@ class Smith
     DRC.wait_for_script_to_complete('forge', ['hone', recipe['noun'], stay ? 'skip' : nil])    if hone
     DRC.wait_for_script_to_complete('forge', ['balance', recipe['noun'], stay ? 'skip' : nil]) if balance
     DRC.wait_for_script_to_complete('forge', ['lighten', recipe['noun'], stay ? 'skip' : nil]) if lighten
+    DRC.wait_for_script_to_complete('forge', ['reinforce', recipe['noun'], stay ? 'skip' : nil]) if reinforce
     dispose_scrap(discipline, recipe) if buy
     dispose_parts(discipline, parts) unless stay
   end

--- a/smith.lic
+++ b/smith.lic
@@ -34,8 +34,8 @@ class Smith
     @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
-    recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
-    recipe = DRCC.recipe_lookup(recipes, args.item_name)
+    type = ["blacksmithing", "armorsmithing", "weaponsmithing"].select { |x| get_data('recipes')[x].any? { |y| y['name'] =~ /#{args.item_name}/i } }
+    recipe = get_data('recipes')[type.first].select { |x| x['name'] =~ /#{args.item_name}/i }.first
     return unless recipe
     
     DRCM.ensure_copper_on_hand(3000, @settings) unless args.here

--- a/smith.lic
+++ b/smith.lic
@@ -36,10 +36,11 @@ class Smith
     type = ["blacksmithing", "armorsmithing", "weaponsmithing"].select { |x| get_data('recipes')[x].any? { |y| y['name'] =~ /#{args.item_name}/i } }
     recipe = get_data('recipes')[type.first].select { |x| x['name'] =~ /#{args.item_name}/i }.first
     return unless recipe
-    
-    DRCM.ensure_copper_on_hand(3000, @settings) unless args.here
-
     parts = recipe['part'] || []
+    
+    total_cost = DRCC.crafting_cost(recipe, args.buy ? @materials_info : false, parts, 1, @settings.hometown)
+    DRCM.ensure_copper_on_hand(total_cost, @settings) unless args.here || Script.running?('workorders')
+
     smith(args.material, discipline, recipe, type, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.here)
   end
 

--- a/smith.lic
+++ b/smith.lic
@@ -34,7 +34,10 @@ class Smith
     @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
+    # This line below is looking to find the item we wish to make among our recipes, and saves the category in which it found a match (type)
     type = ["blacksmithing", "armorsmithing", "weaponsmithing"].select { |x| get_data('recipes')[x].any? { |y| y['name'] =~ /#{args.item_name}/i } }
+    # Taking the above information, we are fetching the recipe information for that item from our recipes. This is necessary only in smith, since
+    # this script can accept the name of the item only in order to craft it. having only the name, we have to work backwards, then forwards.
     recipe = get_data('recipes')[type.first].select { |x| x['name'] =~ /#{args.item_name}/i }.first
     return unless recipe
     

--- a/smith.lic
+++ b/smith.lic
@@ -33,17 +33,17 @@ class Smith
     @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
     @hometown = @settings.hometown
     @container = get_settings.crafting_container
-    recipes = get_data('recipes')[discipline]
-    recipe = DRCC.recipe_lookup(recipes, args.item_name)
+    type = ["blacksmithing", "armorsmithing", "weaponsmithing"].select { |x| get_data('recipes')[x].any? { |y| y['name'] =~ /#{args.item_name}/i } }
+    recipe = get_data('recipes')[type.first].select { |x| x['name'] =~ /#{args.item_name}/i }.first
     return unless recipe
     
     DRCM.ensure_copper_on_hand(3000, @settings) unless args.here
 
     parts = recipe['part'] || []
-    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.here)
+    smith(args.material, discipline, recipe, type, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.here)
   end
 
-  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten, stay)
+  def smith(material, discipline, recipe, type, parts, buy, stamp, temper, hone, balance, lighten, stay)
     if discipline['stock-volume'] < recipe['volume'] && buy
       echo '***You cannot buy an ingot large enough to craft this item.***'
       echo '***Automatically combining ingots via smelting is not yet supported.***'
@@ -55,7 +55,7 @@ class Smith
     buy_ingot(discipline) if buy
     DRCC.find_anvil(@hometown) unless stay
     DRC.wait_for_script_to_complete('buff', ['smith'])
-    DRC.wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun']])
+    DRC.wait_for_script_to_complete('forge', [type, recipe['chapter'], recipe['name'], material, recipe['noun']])
     stamp_item(recipe['noun']) if stamp
     DRC.wait_for_script_to_complete('forge', ['temper', recipe['noun']])  if temper
     DRC.wait_for_script_to_complete('forge', ['hone', recipe['noun']])    if hone

--- a/workorders.lic
+++ b/workorders.lic
@@ -50,7 +50,7 @@ class WorkOrders
     end
 
     recipes = if @recipe_overrides[discipline]
-                get_data('recipes')[discipline].select { |name| discipline['name'] =~ /#{name}/i }
+                get_data('recipes')[discipline].select { |recipe| @recipe_overrides[discipline].find { |name| recipe['name'] =~ /#{name}/i } }
               else
                 get_data('recipes')[discipline].select { |recipe| recipe['work_order'] }
               end

--- a/workorders.lic
+++ b/workorders.lic
@@ -124,12 +124,14 @@ class WorkOrders
       craft_method = :carve_items
     when 'remedies'
       skill = 'Alchemy'
+      materials_info = crafting_data['stock']
       @alchemy_room = @settings.alchemy_room
       tools = @settings.alchemy_tools
       @belt = @settings.alchemy_belt
       craft_method = :remedy_items
     when 'artificing'
       skill = 'Enchanting'
+      materials_info = crafting_data['stock']
       @enchanting_room = @settings.enchanting_room
       tools = @settings.enchanting_tools
       @belt = @settings.enchanting_belt
@@ -681,20 +683,13 @@ class WorkOrders
   end
 
   def enchanting_items(info, materials_info, recipe, quantity)
-    # Enchant Sigil #1
-    DRCC.order_enchant(info['stock-room'], quantity, recipe['enchant_stock1'], @bag, @belt)
-
-    # Enchant Sigil #2
-    DRCC.order_enchant(info['stock-room'], quantity, recipe['enchant_stock2'], @bag, @belt) unless recipe['enchant_stock2'].nil?
-
-    # Sigil 3
-    DRCC.order_enchant(info['stock-room'], quantity, recipe['enchant_stock3'], @bag, @belt) unless recipe['enchant_stock3'].nil?
-
-    # Enchant component #1
-    DRCC.order_enchant(info['stock-room'], quantity, recipe['item'], @bag, @belt) unless recipe['item'].nil?
-
-    # Parts #
-    order_parts(recipe['part'], quantity) if recipe['part']
+    recipe['part'].each { |part| 
+                        if ["sigil-scroll", "bone totem"].include?(part)
+                          DRCT.order_item(info['stock-room'], materials_info[part]['stock-number'])
+                        else
+                          DRCT.buy_item(info['stock-room'], part)
+                        end
+    }
 
     # Check for fount #
     DRCC.fount(info['tool-room'], 1, info['fount'], quantity, @bag, @bag_items, @belt)

--- a/workorders.lic
+++ b/workorders.lic
@@ -50,9 +50,9 @@ class WorkOrders
     end
 
     recipes = if @recipe_overrides[discipline]
-                get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && @recipe_overrides[discipline].find { |name| recipe['name'] =~ /#{name}/i } }
+                get_data('recipes').crafting_recipes[discipline].select { |name| discipline['name'] =~ /#{name}/i }
               else
-                get_data('recipes').crafting_recipes.select { |recipe| recipe['work_order'] && recipe['type'] =~ /#{discipline}/i }
+                get_data('recipes').crafting_recipes[discipline].select { |recipe| recipe['work_order'] }
               end
 
     if discipline == 'carving'

--- a/workorders.lic
+++ b/workorders.lic
@@ -685,7 +685,7 @@ class WorkOrders
 
   def enchanting_items(info, materials_info, recipe, quantity)
     recipe['part'].each { |part| 
-                        if ["sigil-scroll", "bone totem"].include?(part)
+                        if materials_info[part]['stock-number']
                           DRCT.order_item(info['stock-room'], materials_info[part]['stock-number'])
                         else
                           DRCT.buy_item(info['stock-room'], part)

--- a/workorders.lic
+++ b/workorders.lic
@@ -148,6 +148,7 @@ class WorkOrders
       exit
     end
     total_cost = DRCC.crafting_cost(item, materials_info, item['part'], quantity, @hometown)
+    total_cost += 5000 if @workorders_repair
     DRCM.ensure_copper_on_hand(total_cost, @settings)
 
     send(craft_method, info, materials_info, item, quantity)

--- a/workorders.lic
+++ b/workorders.lic
@@ -687,7 +687,7 @@ class WorkOrders
     recipe['part'].each { |part| 
                         if materials_info[part]['stock-number']
                           DRCT.order_item(info['stock-room'], materials_info[part]['stock-number'])
-                        else
+                        elsif materials_info[part]
                           DRCT.buy_item(info['stock-room'], part)
                         end
     }

--- a/workorders.lic
+++ b/workorders.lic
@@ -145,6 +145,8 @@ class WorkOrders
       echo("Exiting because your current mindstate for #{skill} over the set maximum craft_max_mindstate:#{@craft_max_mindstate}")
       exit
     end
+    total_cost = DRCC.crafting_cost(item, materials_info, item['part'], quantity, @hometown)
+    DRCM.ensure_copper_on_hand(total_cost, @settings)
 
     send(craft_method, info, materials_info, item, quantity)
 
@@ -212,7 +214,6 @@ class WorkOrders
   end
 
   def carve_items(info, materials_info, item, quantity)
-    DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(materials_info, item, quantity)
     material_noun = %w[deed pebble stone rock rock boulder]
     material_volume = 0
@@ -286,7 +287,6 @@ class WorkOrders
   end
 
   def shape_items(info, materials_info, item, quantity)
-    DRCM.ensure_copper_on_hand(@cash_on_hand || 10_000, @settings)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(materials_info, item, quantity)
 
     quantity.times do |count|
@@ -373,7 +373,6 @@ class WorkOrders
   end
 
   def sew_items(info, materials_info, recipe, quantity)
-    DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
 
     existing = if DRC.bput("get #{materials_info['stock-name']} cloth from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
@@ -404,7 +403,6 @@ class WorkOrders
   end
 
   def knit_items(info, materials_info, recipe, quantity)
-    DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
 
     existing = if DRC.bput("get yarn from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
@@ -528,7 +526,6 @@ class WorkOrders
   end
 
   def remedy_items(info, materials_info, recipe, quantity)
-    DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
     herb2_needed = ''
     liquid_used = ''
 
@@ -586,8 +583,6 @@ class WorkOrders
   def forge_items(info, materials_info, item, quantity)
     recipe, items_per_stock, spare_stock, scrap = find_recipe(materials_info, item, quantity)
     remaining_volume = 0
-
-    DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings)
 
     quantity.times do
       if remaining_volume < recipe['volume']
@@ -686,7 +681,6 @@ class WorkOrders
   end
 
   def enchanting_items(info, materials_info, recipe, quantity)
-    DRCM.ensure_copper_on_hand(@cash_on_hand || 20_000, @settings)
     # Enchant Sigil #1
     DRCC.order_enchant(info['stock-room'], quantity, recipe['enchant_stock1'], @bag, @belt)
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -50,9 +50,9 @@ class WorkOrders
     end
 
     recipes = if @recipe_overrides[discipline]
-                get_data('recipes').crafting_recipes[discipline].select { |name| discipline['name'] =~ /#{name}/i }
+                get_data('recipes')[discipline].select { |name| discipline['name'] =~ /#{name}/i }
               else
-                get_data('recipes').crafting_recipes[discipline].select { |recipe| recipe['work_order'] }
+                get_data('recipes')[discipline].select { |recipe| recipe['work_order'] }
               end
 
     if discipline == 'carving'

--- a/workorders.lic
+++ b/workorders.lic
@@ -147,7 +147,7 @@ class WorkOrders
       echo("Exiting because your current mindstate for #{skill} over the set maximum craft_max_mindstate:#{@craft_max_mindstate}")
       exit
     end
-    total_cost = DRCC.crafting_cost(item, materials_info, item['part'], quantity, @hometown)
+    total_cost = DRCC.crafting_cost(item, skill == 'Forging' && @use_own_ingot_type ? false : materials_info, item['part'], quantity, @hometown)
     total_cost += 5000 if @workorders_repair
     DRCM.ensure_copper_on_hand(total_cost, @settings)
 


### PR DESCRIPTION
Overview:
Adds crafting_cost method to common-crafting, which utilizes changes to base-recipes and base-crafting to draw parts lists, parts costs, and materials costs, to calculate an exact cost for a given craft routine.

Why:
With the changes to workorders materials, some of the choices are more expensive, and require more cash on hand to complete your workorder. Furthermore, each craft script that handles grunt scripts (craft,smith,eventually others) has numerous calls to common-money for amounts which are rough estimates of what's required. These estimates ignore denomination and, since the workorders change, often too low even then. This would allow for handler scripts to simply send the relevant information to this method, and get back an exact cost for determining whether we have enough coin on hand.

Major changes:
Added to 'stock' section of base-crafting to include enchanting items, various parts, and the costs associated with all of them, in Kronars.
Rearranged base-recipes under discipline headings (blacksmithing,remedies,artificing,etc)
Within these headings, each recipe loses 'type', as this is functionally now the header.
Each recipe has it's parts organized under 'part' for easy reference.

Attempted to capture all the relevant references, sure I probably missed one(or three).