### PR TITLE
Crafting hometown override

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -11,7 +11,7 @@ class Carve
 
   def initialize
     @settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['engineering'] || @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt

--- a/carve.lic
+++ b/carve.lic
@@ -11,6 +11,7 @@ class Carve
 
   def initialize
     @settings = get_settings
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt

--- a/craft.lic
+++ b/craft.lic
@@ -15,7 +15,7 @@ class Craft
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    @hometown = @settings.hometown
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
     @training_room = (@settings.training_rooms || [@settings.safe_room]).sample

--- a/craft.lic
+++ b/craft.lic
@@ -15,7 +15,7 @@ class Craft
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown[args.craft] || @settings.crafting_hometown || @settings.hometown
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
     @training_room = (@settings.training_rooms || [@settings.safe_room]).sample

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -917,27 +917,3 @@ water_holder:
     - carve-bead
   specific_descriptions:
     carve-bead:
-
-card_bags:
-  description: Bags you use to collect and store cards
-  example: red backpack
-  referenced_by:
-    - card-collector
-  specific_descriptions:
-    card-collector: Sets bag to draw cards from (fresh) and bag to place duplicates and your case(duplicates)
-     
-crafting_hometown:
-  description: Set a hometown for craft scripts
-  example: Hibarnhvidar
-  referenced_by:
-    - smith
-    - workorders
-    - tinker
-    - shape
-    - sew
-    - forge
-    - carve
-    - enchant
-    - remedy
-    - craft
-  

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -323,6 +323,21 @@ crafting_container:
     clean-lumber: Gets and stows lumber cleaning items from here.
     clerk-tools: Gets and stows tools in this container.
 
+crafting_hometown:
+  description: Set a hometown for craft scripts
+  example: Hibarnhvidar
+  referenced_by:
+    - smith
+    - workorders
+    - tinker
+    - shape
+    - sew
+    - forge
+    - carve
+    - enchant
+    - remedy
+    - craft
+
 crafting_items_in_container:
   description: List of items that are stored in your specific crafting_container.
   example: "- oil, - shaper"

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -324,8 +324,14 @@ crafting_container:
     clerk-tools: Gets and stows tools in this container.
 
 crafting_hometown:
-  description: Set a hometown for craft scripts
+  description: Set a hometown for craft scripts. This can be a single designation or a discipline by discipline setting (see specific descriptions
   example: Hibarnhvidar
+  specific_descriptions:
+    forging: town to use for forging
+    outfitting: town to use for outfitting
+    engineering: town to use for engineering
+    alchemy: town to use for alchemy
+    enchanting: town to use for enchanting
   referenced_by:
     - smith
     - workorders

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -925,3 +925,19 @@ card_bags:
     - card-collector
   specific_descriptions:
     card-collector: Sets bag to draw cards from (fresh) and bag to place duplicates and your case(duplicates)
+     
+crafting_hometown:
+  description: Set a hometown for craft scripts
+  example: Hibarnhvidar
+  referenced_by:
+    - smith
+    - workorders
+    - tinker
+    - shape
+    - sew
+    - forge
+    - carve
+    - enchant
+    - remedy
+    - craft
+  

--- a/enchant.lic
+++ b/enchant.lic
@@ -11,7 +11,7 @@ class Enchant
 
   def initialize
     @settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['enchanting'] || @settings.crafting_hometown || @settings.hometown
     @book_type = 'artificing'
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container

--- a/enchant.lic
+++ b/enchant.lic
@@ -11,6 +11,7 @@ class Enchant
 
   def initialize
     @settings = get_settings
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @book_type = 'artificing'
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container

--- a/forge.lic
+++ b/forge.lic
@@ -44,7 +44,7 @@ class Forge
     Flags.add('work-done', 'from the successful .* process', 'shows a slightly reduced weight', 'Applying the final touches', 'The .* was successfully balanced')
 
     settings = get_settings
-    @hometown = settings.hometown
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @stamp = settings.mark_crafted_goods
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container

--- a/forge.lic
+++ b/forge.lic
@@ -44,7 +44,7 @@ class Forge
     Flags.add('work-done', 'from the successful .* process', 'shows a slightly reduced weight', 'Applying the final touches', 'The .* was successfully balanced')
 
     settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['forging'] || @settings.crafting_hometown || @settings.hometown
     @stamp = settings.mark_crafted_goods
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2,6 +2,8 @@
 # See https://github.com/rpherbig/dr-scripts/wiki/YAML-Settings for documentation
 
 hometown: Crossing
+#allows you to set a different hometown for crafting training.
+crafting_hometown:
 # Cap on time crossing-training runs
 training_manager_town_duration:
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2,8 +2,15 @@
 # See https://github.com/rpherbig/dr-scripts/wiki/YAML-Settings for documentation
 
 hometown: Crossing
-#allows you to set a different hometown for crafting training.
+#allows you to set a different hometown for crafting training. This can be one town for all crafts, or a list of towns using the additional settings below
 crafting_hometown:
+# These added below crafting_hometown allow you to designate a specific town for each craft. Must include town for every craft you are training if you opt for this.
+#  engineering: Crossing
+#  forging: Crossing
+#  alchemy: Crossing
+#  outfitting: Shard
+#  enchanting: Fang Cove
+
 # Cap on time crossing-training runs
 training_manager_town_duration:
 

--- a/remedy.lic
+++ b/remedy.lic
@@ -17,11 +17,12 @@ class Remedy
 
   def initialize
     @settings = get_settings
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.alchemy_belt
     @training_spells = @settings.crafting_training_spells
-    @stock = get_data('crafting')['remedies'][@settings.hometown]
+    @stock = get_data('crafting')['remedies'][@hometown]
 
     arg_definitions = [
       [

--- a/remedy.lic
+++ b/remedy.lic
@@ -17,7 +17,7 @@ class Remedy
 
   def initialize
     @settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['alchemy'] || @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.alchemy_belt

--- a/sew.lic
+++ b/sew.lic
@@ -8,6 +8,7 @@ class Sew
 
   def initialize
     @settings = get_settings
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.outfitting_belt
@@ -50,7 +51,7 @@ class Sew
     @noun = args.noun
     @mat_type = args.material
     @chapter = args.chapter == nil ? 1 : args.chapter.to_i #chapter 5 for enhancements
-    @info = get_data('crafting')['tailoring'][@settings.hometown]
+    @info = get_data('crafting')['tailoring'][@hometown]
     @instructions = args.instructions
     @cloth = ['silk', 'wool', 'burlap', 'cotton', 'felt', 'linen', 'electroweave', 'steelsilk', 'arzumodine', 'bourde', 'dergatine', 'dragonar', 'faeweave', 'farandine', 'imperial weave', 'jaspe', 'khaddar', 'ruazin', 'titanese', 'zenganne']
 

--- a/sew.lic
+++ b/sew.lic
@@ -8,7 +8,7 @@ class Sew
 
   def initialize
     @settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['outfitting'] || @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.outfitting_belt

--- a/shape.lic
+++ b/shape.lic
@@ -8,7 +8,7 @@ class Shape
 
   def initialize
     @settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['engineering'] || @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt

--- a/shape.lic
+++ b/shape.lic
@@ -8,6 +8,7 @@ class Shape
 
   def initialize
     @settings = get_settings
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
@@ -49,7 +50,7 @@ class Shape
     @noun = args.noun
     @material = args.material
     @chapter = args.chapter == nil ? 6 : args.chapter.to_i
-    @info = get_data('crafting')['shaping'][@settings.hometown]
+    @info = get_data('crafting')['shaping'][@hometown]
 
     DRC.wait_for_script_to_complete('buff', ['shape'])
     Flags.add('shaping-assembly', 'appears ready to be reinforced with some (backer)', 'appears ready to be strengthened with some leather (strips)', 'assembly with the (backing) material can begin', 'You need another bone, wood or horn (backing) material', 'another finished bow (string)', 'another finished (long|short) wooden (pole)', 'another finished (leather strips)', 'another .* (long|short) leather (cord)', 'You must assemble the (backer)', 'You must assemble the (strips)', 'another (arrow flights)', 'another (.* arrowheads)')

--- a/smith.lic
+++ b/smith.lic
@@ -26,7 +26,7 @@ class Smith
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['forging'] || @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.forging_belt

--- a/smith.lic
+++ b/smith.lic
@@ -25,13 +25,13 @@ class Smith
     args = parse_args(arg_definitions)
 
     @settings = get_settings
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.forging_belt
-    discipline = get_data('crafting')['blacksmithing'][@settings.hometown]
+    discipline = get_data('crafting')['blacksmithing'][@hometown]
     workorders_materials = @settings.workorders_materials
     @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
-    @hometown = @settings.hometown
     @container = get_settings.crafting_container
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = DRCC.recipe_lookup(recipes, args.item_name)

--- a/smith.lic
+++ b/smith.lic
@@ -25,27 +25,26 @@ class Smith
 
     args = parse_args(arg_definitions)
 
-    @settings = get_settings
-    @hometown = @settings.crafting_hometown['forging'] || @settings.crafting_hometown || @settings.hometown
-    @bag = @settings.crafting_container
-    @bag_items = @settings.crafting_items_in_container
-    @belt = @settings.forging_belt
-    discipline = get_data('crafting')['blacksmithing'][@hometown]
-    workorders_materials = @settings.workorders_materials
-    @materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
-    @container = get_settings.crafting_container
+    settings = get_settings
+    hometown = settings.crafting_hometown['forging'] || settings.crafting_hometown || settings.hometown
+    @bag = settings.crafting_container
+    @bag_items = settings.crafting_items_in_container
+    @forging_belt = settings.forging_belt
+    discipline = get_data('crafting')['blacksmithing'][hometown]
+    workorders_materials = settings.workorders_materials
+    materials_info = get_data('crafting')['stock'][workorders_materials['metal_type']]
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = DRCC.recipe_lookup(recipes, args.item_name)
     return unless recipe
     
-    DRCM.ensure_copper_on_hand(3000, @settings) unless args.here
+    DRCM.ensure_copper_on_hand(3000, settings) unless args.here
 
     parts = recipe['part'] || []
     parts << "leather strip" if args.reinforce # adds part to the list for reinforce
-    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.reinforce, args.here)
+    smith(args.material, discipline, recipe, parts, args.buy, args.stamp, args.temper, args.hone, args.balance, args.lighten, args.reinforce, args.here, hometown, materials_info)
   end
 
-  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten, reinforce, stay)
+  def smith(material, discipline, recipe, parts, buy, stamp, temper, hone, balance, lighten, reinforce, stay, hometown, materials_info)
     if discipline['stock-volume'] < recipe['volume'] && buy
       echo '***You cannot buy an ingot large enough to craft this item.***'
       echo '***Automatically combining ingots via smelting is not yet supported.***'
@@ -53,9 +52,9 @@ class Smith
       exit
     end
     
-    buy_parts(parts) unless stay
-    buy_ingot(discipline) if buy
-    DRCC.find_anvil(@hometown) unless stay
+    buy_parts(parts, hometown) unless stay
+    buy_ingot(discipline, materials_info) if buy
+    DRCC.find_anvil(hometown) unless stay
     DRC.wait_for_script_to_complete('buff', ['smith'])
     DRC.wait_for_script_to_complete('forge', [recipe['type'], recipe['chapter'], recipe['name'], material, recipe['noun'], stay ? 'skip' : nil])
     stamp_item(recipe['noun']) if stamp
@@ -64,41 +63,41 @@ class Smith
     DRC.wait_for_script_to_complete('forge', ['balance', recipe['noun'], stay ? 'skip' : nil]) if balance
     DRC.wait_for_script_to_complete('forge', ['lighten', recipe['noun'], stay ? 'skip' : nil]) if lighten
     DRC.wait_for_script_to_complete('forge', ['reinforce', recipe['noun'], stay ? 'skip' : nil]) if reinforce
-    dispose_scrap(discipline, recipe) if buy
+    dispose_scrap(discipline, recipe, materials_info) if buy
     dispose_parts(discipline, parts) unless stay
   end
 
-  def buy_parts(parts)
+  def buy_parts(parts, hometown)
     DRCI.stow_hands
 
     parts.each do |part|
 
-      data = get_data('crafting')['recipe_parts'][part][@hometown]
+      data = get_data('crafting')['recipe_parts'][part][hometown]
       if data['part-number']
         DRCT.order_item(data['part-room'], data['part-number'])
       else
         DRCT.buy_item(data['part-room'], part)
       end
-      DRCC.stow_crafting_item(part, @bag, @belt)
+      DRCC.stow_crafting_item(part, @bag, @forging_belt)
     end
   end
 
-  def buy_ingot(discipline)
-    DRCT.order_item(discipline['stock-room'], @materials_info['stock-number'])
-    DRCC.stow_crafting_item('ingot', @bag, @belt)
+  def buy_ingot(discipline, materials_info)
+    DRCT.order_item(discipline['stock-room'], materials_info['stock-number'])
+    DRCC.stow_crafting_item('ingot', @bag, @forging_belt)
     DRCI.stow_hands
   end
 
   def stamp_item(noun)
-    DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
+    DRCC.get_crafting_item('stamp', @bag, @bag_items, @forging_belt)
     DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
-    DRCC.stow_crafting_item('stamp', @bag, @belt)
+    DRCC.stow_crafting_item('stamp', @bag, @forging_belt)
   end
 
-  def dispose_scrap(discipline, recipe)
-    return unless @materials_info['stock-volume'] > recipe['volume']
+  def dispose_scrap(discipline, recipe, materials_info)
+    return unless materials_info['stock-volume'] > recipe['volume']
 
-    DRCT.dispose("#{@materials_info['stock-name']} ingot", discipline['trash-room'])
+    DRCT.dispose("#{materials_info['stock-name']} ingot", discipline['trash-room'])
   end
 
   def dispose_parts(discipline, parts)

--- a/tinker.lic
+++ b/tinker.lic
@@ -15,7 +15,7 @@ class Tinker
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
-    @hometown = @settings.hometown
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @stamp = @settings.mark_crafted_goods
 
     arg_definitions = [

--- a/tinker.lic
+++ b/tinker.lic
@@ -15,7 +15,7 @@ class Tinker
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.engineering_belt
-    @hometown = @settings.crafting_hometown || @settings.hometown
+    @hometown = @settings.crafting_hometown['engineering'] || @settings.crafting_hometown || @settings.hometown
     @stamp = @settings.mark_crafted_goods
 
     arg_definitions = [

--- a/workorders.lic
+++ b/workorders.lic
@@ -43,7 +43,7 @@ class WorkOrders
     skill = ''
 
     case discipline
-    when 'blacksmithing', 'weaponsmithing', 'armorsmithing'
+    when 'blacksmithing', 'weaponsmithing'
       materials_info = crafting_data['stock'][@workorders_materials['metal_type']]
       skill = 'Forging'
       tools = @settings.forging_tools
@@ -114,18 +114,16 @@ class WorkOrders
     info = crafting_data[discipline][@hometown]
     if discipline == 'weaponsmithing'
       info = crafting_data['blacksmithing'][@hometown]
-    elsif discipline == 'armorsmithing'
-      info = crafting_data['blacksmithing'][@hometown]
     end
 
     recipes = if @recipe_overrides[discipline]
-                get_data('recipes')[discipline].select { |recipe| @recipe_overrides[discipline].find { |name| recipe['name'] =~ /#{name}/i } }
+                get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && @recipe_overrides[discipline].find { |name| recipe['name'] =~ /#{name}/i } }
               else
-                get_data('recipes')[discipline].select { |recipe| recipe['work_order'] }
+                get_data('recipes').crafting_recipes.select { |recipe| recipe['work_order'] && recipe['type'] =~ /#{discipline}/i }
               end
 
     if discipline == 'carving'
-      recipes = recipes['carving'].select { |x| x['material'] == @carving_type }
+      recipes = recipes.select { |x| x['material'] == @carving_type }
     end
 
     unless info

--- a/workorders.lic
+++ b/workorders.lic
@@ -43,7 +43,7 @@ class WorkOrders
     skill = ''
 
     case discipline
-    when 'blacksmithing', 'weaponsmithing'
+    when 'blacksmithing', 'weaponsmithing', armorsmithing
       materials_info = crafting_data['stock'][@workorders_materials['metal_type']]
       skill = 'Forging'
       tools = @settings.forging_tools

--- a/workorders.lic
+++ b/workorders.lic
@@ -24,8 +24,12 @@ class WorkOrders
     @recipe_parts = crafting_data['recipe_parts']
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @use_own_ingot_type = @settings.use_own_ingot_type
     @deed_own_ingot = @settings.deed_own_ingot
+    deeds_data = get_data('crafting').deeds[@hometown]
+    @deeds_room = deeds_data['room']
+    @deeds_number = deeds_data['medium_number']
     @carving_type = @settings.carving_workorder_material_type
     @min_items = @settings.workorder_min_items
     @max_items = @settings.workorder_max_items
@@ -36,7 +40,6 @@ class WorkOrders
     @workorders_repair = @settings.workorders_repair
     @workorders_override_store = @settings.workorders_override_store
     @workorders_materials = @settings.workorders_materials
-    Flags.add('proper-repair', 'Your excellent training in the ways of tool repair')
 
     DRC.wait_for_script_to_complete('safe-room', ['force']) if @settings.workorders_force_heal
 
@@ -44,7 +47,7 @@ class WorkOrders
     skill = ''
 
     case discipline
-    when 'blacksmithing', 'weaponsmithing'
+    when 'blacksmithing', 'weaponsmithing', 'armorsmithing'
       materials_info = crafting_data['stock'][@workorders_materials['metal_type']]
       skill = 'Forging'
       tools = @settings.forging_tools
@@ -55,22 +58,22 @@ class WorkOrders
                        :forge_items
                      end
     when 'tailoring'
-      craft_method = :sew_items
+      materials_info = crafting_data['stock'][@workorders_materials['fabric_type']]
       skill = 'Outfitting'
       @outfitting_room = @settings.outfitting_room
       tools = @settings.outfitting_tools
       @belt = @settings.outfitting_belt
       case item['chapter']
-      when 2,3,4
-        materials_info = crafting_data['stock'][@workorders_materials['fabric_type']]
-        @mat_type = 'cloth'
+      when 4, 2, 3
+        craft_method = :sew_items
       when 5
         materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
         craft_method = :knit_items
-        @mat_type = 'yarn'
       else
-        materials_info = crafting_data['stock'][@workorders_materials['leather_type']]
-        @mat_type = 'leather'
+        if item['chapter']
+          echo("UNKNOWN CHAPTER FOR TAILORING ITEM #{item}")
+          exit
+        end
       end
     when 'shaping'
       materials_info = crafting_data['stock'][@workorders_materials['wood_type']]
@@ -106,7 +109,7 @@ class WorkOrders
       echo 'No discipline found?'
       return
     end
-    
+            
     @hometown = @settings.crafting_hometown[skill.downcase] || @settings.crafting_hometown || @settings.hometown
     echo(@hometown)
     exit
@@ -117,6 +120,8 @@ class WorkOrders
 
     info = crafting_data[discipline][@hometown]
     if discipline == 'weaponsmithing'
+      info = crafting_data['blacksmithing'][@hometown]
+    elsif discipline == 'armorsmithing'
       info = crafting_data['blacksmithing'][@hometown]
     end
 
@@ -133,6 +138,15 @@ class WorkOrders
     unless info
       echo("No crafting settings found for discipline: #{discipline}")
       exit
+    end
+
+    unless repair
+      if @settings.workorder_diff.is_a?(Hash)
+        item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], @settings.workorder_diff[discipline])
+      else
+        item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], @settings.workorder_diff)
+      end
+      item = recipes.find { |r| r['name'] == item_name }
     end
 
     return repair_items(info, tools) if repair

--- a/workorders.lic
+++ b/workorders.lic
@@ -24,12 +24,8 @@ class WorkOrders
     @recipe_parts = crafting_data['recipe_parts']
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @hometown = @settings.crafting_hometown || @settings.hometown
     @use_own_ingot_type = @settings.use_own_ingot_type
     @deed_own_ingot = @settings.deed_own_ingot
-    deeds_data = get_data('crafting').deeds[@hometown]
-    @deeds_room = deeds_data['room']
-    @deeds_number = deeds_data['medium_number']
     @carving_type = @settings.carving_workorder_material_type
     @min_items = @settings.workorder_min_items
     @max_items = @settings.workorder_max_items

--- a/workorders.lic
+++ b/workorders.lic
@@ -25,7 +25,7 @@ class WorkOrders
     @recipe_parts = crafting_data['recipe_parts']
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @hometown = @settings.hometown
+    @hometown = @settings.crafting_hometown || @settings.hometown
     @use_own_ingot_type = @settings.use_own_ingot_type
     @deed_own_ingot = @settings.deed_own_ingot
     deeds_data = get_data('crafting').deeds[@hometown]

--- a/workorders.lic
+++ b/workorders.lic
@@ -43,7 +43,7 @@ class WorkOrders
     skill = ''
 
     case discipline
-    when 'blacksmithing', 'weaponsmithing', armorsmithing
+    when 'blacksmithing', 'weaponsmithing', 'armorsmithing'
       materials_info = crafting_data['stock'][@workorders_materials['metal_type']]
       skill = 'Forging'
       tools = @settings.forging_tools

--- a/workorders.lic
+++ b/workorders.lic
@@ -106,10 +106,7 @@ class WorkOrders
       return
     end
             
-    @hometown = @settings.crafting_hometown[skill.downcase] || @settings.crafting_hometown || @settings.hometown
-    echo(@hometown)
-    exit
-    
+    @hometown = @settings.crafting_hometown[skill.downcase] || @settings.crafting_hometown || @settings.hometown    
     deeds_data = get_data('crafting').deeds[@hometown]
     @deeds_room = deeds_data['room']
     @deeds_number = deeds_data['medium_number']

--- a/workorders.lic
+++ b/workorders.lic
@@ -1,4 +1,3 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#workorders
 =end
@@ -25,12 +24,8 @@ class WorkOrders
     @recipe_parts = crafting_data['recipe_parts']
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @hometown = @settings.crafting_hometown || @settings.hometown
     @use_own_ingot_type = @settings.use_own_ingot_type
     @deed_own_ingot = @settings.deed_own_ingot
-    deeds_data = get_data('crafting').deeds[@hometown]
-    @deeds_room = deeds_data['room']
-    @deeds_number = deeds_data['medium_number']
     @carving_type = @settings.carving_workorder_material_type
     @min_items = @settings.workorder_min_items
     @max_items = @settings.workorder_max_items
@@ -41,42 +36,15 @@ class WorkOrders
     @workorders_repair = @settings.workorders_repair
     @workorders_override_store = @settings.workorders_override_store
     @workorders_materials = @settings.workorders_materials
+    Flags.add('proper-repair', 'Your excellent training in the ways of tool repair')
 
     DRC.wait_for_script_to_complete('safe-room', ['force']) if @settings.workorders_force_heal
 
-    info = crafting_data[discipline][@hometown]
-    if discipline == 'weaponsmithing'
-      info = crafting_data['blacksmithing'][@hometown]
-    end
-
-    recipes = if @recipe_overrides[discipline]
-                get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && @recipe_overrides[discipline].find { |name| recipe['name'] =~ /#{name}/i } }
-              else
-                get_data('recipes').crafting_recipes.select { |recipe| recipe['work_order'] && recipe['type'] =~ /#{discipline}/i }
-              end
-
-    if discipline == 'carving'
-      recipes = recipes.select { |x| x['material'] == @carving_type }
-    end
-
-    unless info
-      echo("No crafting settings found for discipline: #{discipline}")
-      exit
-    end
-
-    unless repair
-      if @settings.workorder_diff.is_a?(Hash)
-        item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], @settings.workorder_diff[discipline])
-      else
-        item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], @settings.workorder_diff)
-      end
-      item = recipes.find { |r| r['name'] == item_name }
-    end
     tools = []
     skill = ''
 
     case discipline
-    when 'blacksmithing', 'weaponsmithing', 'armorsmithing'
+    when 'blacksmithing', 'weaponsmithing'
       materials_info = crafting_data['stock'][@workorders_materials['metal_type']]
       skill = 'Forging'
       tools = @settings.forging_tools
@@ -87,22 +55,22 @@ class WorkOrders
                        :forge_items
                      end
     when 'tailoring'
-      materials_info = crafting_data['stock'][@workorders_materials['fabric_type']]
+      craft_method = :sew_items
       skill = 'Outfitting'
       @outfitting_room = @settings.outfitting_room
       tools = @settings.outfitting_tools
       @belt = @settings.outfitting_belt
       case item['chapter']
-      when 4, 2, 3
-        craft_method = :sew_items
+      when 2,3,4
+        materials_info = crafting_data['stock'][@workorders_materials['fabric_type']]
+        @mat_type = 'cloth'
       when 5
         materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
         craft_method = :knit_items
+        @mat_type = 'yarn'
       else
-        if item['chapter']
-          echo("UNKNOWN CHAPTER FOR TAILORING ITEM #{item}")
-          exit
-        end
+        materials_info = crafting_data['stock'][@workorders_materials['leather_type']]
+        @mat_type = 'leather'
       end
     when 'shaping'
       materials_info = crafting_data['stock'][@workorders_materials['wood_type']]
@@ -137,6 +105,34 @@ class WorkOrders
     else
       echo 'No discipline found?'
       return
+    end
+    
+    @hometown = @settings.crafting_hometown[skill.downcase] || @settings.crafting_hometown || @settings.hometown
+    echo(@hometown)
+    exit
+    
+    deeds_data = get_data('crafting').deeds[@hometown]
+    @deeds_room = deeds_data['room']
+    @deeds_number = deeds_data['medium_number']
+
+    info = crafting_data[discipline][@hometown]
+    if discipline == 'weaponsmithing'
+      info = crafting_data['blacksmithing'][@hometown]
+    end
+
+    recipes = if @recipe_overrides[discipline]
+                get_data('recipes')[discipline].select { |recipe| @recipe_overrides[discipline].find { |name| recipe['name'] =~ /#{name}/i } }
+              else
+                get_data('recipes')[discipline].select { |recipe| recipe['work_order'] }
+              end
+
+    if discipline == 'carving'
+      recipes = recipes['carving'].select { |x| x['material'] == @carving_type }
+    end
+
+    unless info
+      echo("No crafting settings found for discipline: #{discipline}")
+      exit
     end
 
     return repair_items(info, tools) if repair


### PR DESCRIPTION
Simple enough change, if a bit wide-ranging. Idea here is to let folks pick a different town to do their crafting in, if the specific town doesn't support some or all of the crafts, or if the town is getting a little crowded (eg crossing)

Draws from the same information as hometown, only applies to the crafting scripts.

Change is pretty straightforward:
```ruby
@hometown = @settings.hometown
```
becomes
```ruby
@hometown = @settings.crafting_hometown || @settings.hometown
```
chooses your crafting hometown first. If undefined (as in base) sets it to your normal hometown. Yaml setting as follow:
```yaml
crafting_hometown: Shard
```
