### PR TITLE
[script][common-crafting] Simplify clean_anvil matches

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -20,11 +20,11 @@ module DRCC
   end
 
   def clean_anvil?
-    case result = DRC.bput('look on anvil', 'surface looks clean and ready', "anvil you see an? (.*)\.", 'anvil you see')
+    case result = DRC.bput('look on anvil', 'surface looks clean and ready', "anvil you see (.*)\.")
     when /surface looks clean and ready/i
       true
-    when /anvil you see an?/
-      /anvil you see an? (.*)\./ =~ result
+    when /anvil you see/
+      /anvil you see (.*)\./ =~ result
       clutter = Regexp.last_match(1).split.last
       case DRC.bput('clean anvil', 'You drag the', 'remove them yourself')
       when /drag/
@@ -37,7 +37,7 @@ module DRCC
           fput('clean anvil')
           fput('clean anvil')
         when 'You get'
-          DRC.bput("put #{clutter} in bucket", 'You drop')
+         DRC.bput("put #{clutter} in bucket", 'You drop')
         else
           return false
         end


### PR DESCRIPTION
Looks like this method wasn't properly matching items on account of the an? portion of the match language. From discord:
```
[go2]>go east arch

[Reach Forge, Eastern Smithy]
Brilliant red-orange light glows from a side-vented forge crafted from a natural shelf on the northern wall.  Above it, an assortment of fire-blackened tools hangs just out of arm's reach and a few steps away the large, iron anvil waits patiently to help shape metal into the form of men's dreams.  You also see an arch, a grindstone, a pile of fuel, a slack tub filled with water and a large waste bucket.
Obvious exits: east.

Room Number: 16406

Room Exits: go arch


[go2: travel time: 0:00:00]

--- Lich: go2 has exited.

[smith]>look on anvil

On the iron anvil you see some tapered unfinished bronze knitting needles.

--- Lich: go2 active.

--- Lich: 'textsubs' has been stopped by go2.

[go2: ETA: 0:00:19 (71 rooms to move through)]

[go2]>go arch

[Reach Forge, Tunnel]
```
Here it's running find_anvil, logic of which is:
```ruby
DRCT.find_sorted_empty_room(anvils, idle_room, proc { (DRRoom.pcs - DRRoom.group_members).empty? && clean_anvil? })
```
so it finds an empty room, looks on the anvil, sees a work in progress, but since it's some, rather than an, the last match is chosen(anvil you see) rather than the regex version, so it passes to the next anvil.  Removing that match and slimming down the regex yields:
```
>;common-crafting
>;e echo DRCC.clean_anvil?
--- Lich: exec1 active.
[exec1]>look on anvil
On the iron anvil you see some unfinished steel hand claws.
>
[exec1]>clean anvil
You drag the waste bucket close and prepare to clean off the anvil.

[Do you really want to clean off the anvil?  Clean it one more time to destroy the contents.]
>
[exec1]>clean anvil
You stop working and clean off the anvil's surface, discarding some unfinished steel hand claws into the waste bucket.
Roundtime: 2 sec.
R>
[exec1: true]
--- Lich: exec1 has exited.
```
