### PR TITLE
[scrip][common-arcana] Rework magic routine for new(old) yaml pattern

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -815,15 +815,21 @@ module DRCA
   end
 
   def crafting_magic_routine(settings)
-    training_spells = settings.crafting_training_spells
+    # declare array and hash, respectively, unless already populated
+    spells ||= []
+    skill_to_spell ||= {}
+    # get spells and settings, push a list of spell names into spells array
+    # retains information in training_spells for later use
+    training_spells = get_settings.crafting_training_spells.each { |k,v| spells << k } 
+    # take spells array and make it a hash, with keys for skills learned based on yaml settings so we can target spell based on skill needing training
+    spells.each { |x| skill_to_spell.store(training_spells[x]['skill'], x) } 
 
     return if training_spells.empty?
     return if DRStats.mana <= settings.waggle_spells_mana_threshold
 
     if !XMLData.prepared_spell.eql?('None') && checkcastrt == 0
       spell = XMLData.prepared_spell
-      skill = get_data('spells').spell_data[spell]['skill']
-      data = training_spells[skill]
+      data = training_spells[spell]
       crafting_cast_spell(data, settings)
     end
 
@@ -832,14 +838,14 @@ module DRCA
     needs_training = %w[Warding Utility Augmentation]
     needs_training.append("Sorcery") if (settings.crafting_training_spells_enable_sorcery && !Script.running?('forge')) ||
                                         (settings.crafting_training_spells_enable_sorcery && settings.crafting_training_spells_enable_sorcery_forging)
-    needs_training = needs_training.select { |skill| training_spells[skill] }
-                                   .select { |skill| DRSkill.getxp(skill) < 31 }
-                                   .sort_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
-                                   .first
+    needs_training = needs_training.select { |skill| skill_to_spell[skill] } # filters out skills not included in trainings list in yaml
+                                   .select { |skill| DRSkill.getxp(skill) < 31 } # filters out skills above training threshold of 31/34
+                                   .sort_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] } # sorts array with lowest current mindstate first
+                                   .first # discards any but the skill we want to train, result will be eg "Utility"
 
     return unless needs_training
-
-    crafting_prepare_spell(training_spells[needs_training], settings)
+    # now goes back and fetches all the data about the spell we want to use to train.
+    crafting_prepare_spell(training_spells[skill_to_spell[needs_training]], settings)
   end
 
   def do_buffs(settings, set_name)

--- a/magic-training.lic
+++ b/magic-training.lic
@@ -46,16 +46,15 @@ class MagicTraining
   end
 
   def train_magics?(training_skills)
+    spells ||= []
+    spell_to_skill ||= {}
     settings = get_settings
     exp_threshold = settings.magic_exp_training_max_threshold
     force_cambrinth = settings.waggle_force_cambrinth
-    load_settings # This is done purposely so you can adjust settings on the fly, it's great for finding mana values
-    spells ||= []
-    spell_to_skill ||= {}
     # get spells and settings, push a list of spell names into spells array
     # retains information in training_spells for later use
     training_spells = get_settings.training_spells.each { |k,v| spells << k }
-    # take spells array and make it a hash, with keys for skills learned based on yaml settings so we can target spell based on skill needing training
+    # take spells array and make it a hash, with keys for spells and corresponding skills for values.
     spells.each { |x| spell_to_skill.store(x, training_spells[x]['skill']) }
 
     

--- a/magic-training.lic
+++ b/magic-training.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#magic-training
 =end
 
-custom_require.call(%w[common common-arcana common-healing common-moonmage drinfomon])
+custom_require.call(%w[common common-arcana common-healing common-moonmage common-travel drinfomon])
 
 # Track how long we've been training and how many mindstates we increase at the end.
 # These are defined with @@ so that they can be referenced in before_dying block.
@@ -24,79 +24,72 @@ class MagicTraining
 
     args = parse_args(arg_definitions)
 
-    load_settings
+    max_time = ((args.max_time || 60).to_i * 60) # convert to seconds
+    training_skills = args.training_skills ? args.training_skills.split(',').map { |skill| skill.strip.downcase.capitalize } : nil
+    training_skills ||= %w[Utility Warding Augmentation Sorcery]
+    DRCT.walk_to(get_settings.magic_training_room) if get_settings.magic_training_room
+    DRC.wait_for_script_to_complete('buff', ['mana'])
 
-    @max_time = ((args.max_time || 60).to_i * 60) # convert to seconds
-    @training_skills = args.training_skills.split(',').map { |skill| skill.strip.downcase.capitalize }
-    @training_skills = %w[Utility Warding Augmentation Sorcery] if @training_skills.nil? || @training_skills.empty?
-
-    echo "Max training time: #{@max_time} seconds"
-    echo "Training skills: #{@training_skills}"
+    DRC.message("Max training time: #{max_time} seconds")
+    DRC.message("Training skills: #{training_skills}")
 
     loop do
-      if (Time.now - @@time_in) > @max_time
-        echo "Max time alloted for Magic Training reached. Now exiting..."
+      if (Time.now - @@time_in) > max_time
+        DRC.message("Max time alloted for Magic Training reached. Now exiting...")
         exit
       end
-      unless train_magics?
-        echo "Done training magics"
+      unless train_magics?(training_skills)
+        DRC.message("Done training magics")
         exit
       end
     end
   end
 
-  def load_settings
-    @settings = get_settings
-
-    # Stops training a specfic skill after reaching this mindstate threshold, and quits program when all skills are above
-    @exp_threshold = @settings.magic_exp_training_max_threshold
-
-    # Hash of magic skill (e.g. Warding) to spell to train with (same config as spells in waggle sets)
-    @training_spells = @settings.magic_training # original value from `;repos download magic-training`
-    @training_spells = @settings.training_spells if @training_spells.nil? || @training_spells.empty?
-
-    @force_cambrinth = @settings.waggle_force_cambrinth
-
-    @health_threshold = @settings.health_threshold # vitaltiy percentage
-    @saferoom_health_threshold = @settings.saferoom_health_threshold # wound severity threshold
-  end
-
-  def train_magics?
+  def train_magics?(training_skills)
+    settings = get_settings
+    exp_threshold = settings.magic_exp_training_max_threshold
+    force_cambrinth = settings.waggle_force_cambrinth
     load_settings # This is done purposely so you can adjust settings on the fly, it's great for finding mana values
+    spells ||= []
+    spell_to_skill ||= {}
+    # get spells and settings, push a list of spell names into spells array
+    # retains information in training_spells for later use
+    training_spells = get_settings.training_spells.each { |k,v| spells << k }
+    # take spells array and make it a hash, with keys for skills learned based on yaml settings so we can target spell based on skill needing training
+    spells.each { |x| spell_to_skill.store(x, training_spells[x]['skill']) }
 
-    magic_skills = @training_spells.keys
-    skills_to_train = magic_skills
-      .select { |skill| @training_skills.include?(skill) } # filter to skills you want to train
-      .select { |skill| DRCMM.update_astral_data(@training_spells[skill]) } # filter to spells you can cast now
-      .reject { |skill| DRSkill.getxp(skill) > @exp_threshold } # filter out skills you don't need to train
-      .sort_by do |skill|
+    
+    spells_to_train = spells
+      .select { |spell| DRCMM.update_astral_data(spell) } # filter to spells you can cast now
+      .reject { |spell| DRSkill.getxp(spell_to_skill[spell]) > exp_threshold } # filter out skills you don't need to train
+      .select { |spell| training_skills.include?(spell_to_skill[spell])}
+      .sort_by { |spell|
         [
-          DRSkill.getxp(skill),   # choose first by skills with lowest learning rate
-          DRSkill.getrank(skill)  # then choose by skills with lowest ranks
+          DRSkill.getxp(spell_to_skill[spell]),   # choose first by skills with lowest learning rate
+          DRSkill.getrank(spell_to_skill[spell])  # then choose by skills with lowest ranks
         ]
-      end
-
+      }
+    
     # Attained desired learning threshold in all magic skills to train
-    return false if skills_to_train.empty?
+    return false if spells_to_train.empty?
 
-    skills_to_train.each do |skill|
-      echo "Next skill to train: #{skill}"
-      before_xp = DRSkill.getxp(skill)
-      DRCA.check_discern(@training_spells[skill], @settings) if @training_spells[skill]['use_auto_mana']
-      DRCA.cast_spells({ spell_name: @training_spells[skill] }, @settings, @force_cambrinth)
-      echo("#{skill} gains: #{DRSkill.getxp(skill) - before_xp}")
+    spells_to_train.each do |spell|
+      DRC.message("Next skill to train: #{spell_to_skill[spell]}")
+      before_xp = DRSkill.getxp(spell_to_skill[spell])
+      DRCA.check_discern(training_spells[spell], settings) if training_spells[spell]['use_auto_mana']
+      DRCA.cast_spells({ spell: training_spells[spell] }, settings, force_cambrinth)
       waitrt?
-      check_health
+      check_health(settings.health_threshold, settings.saferoom_health_threshold)
     end
 
     return true
   end
 
   # Needed when training sorcery as you may experience sorcerous backlash
-  def check_health
+  def check_health(health, saferoom)
     pause 0.5 while stunned?
     health_data = DRCH.check_health
-    if bleeding? || health_data['score'] >= @saferoom_health_threshold || DRStats.health < [50, @health_threshold].max || health_data['poisoned'] || health_data['diseased']
+    if bleeding? || health_data['score'] >= saferoom || DRStats.health < [50, health].max || health_data['poisoned'] || health_data['diseased']
       DRC.message("You're injured! Stopping training")
       DRC.wait_for_script_to_complete('safe-room', ['force'])
       exit


### PR DESCRIPTION
So as things stand, yaml settings for spells in waggle-sets, buffs, etc, are all set up one way:
```yaml
  Membrach's Greed:
    mana: 20
    cambrinth: [25,25]
```
while training spells are organized based on skill:
```yaml
  Augmentation:
    abbrev: meg
    symbiosis: true
    mana: 17
```
Normally no biggie, but the problem comes in when you're using a sorcery spell. Common-arcana grabs SOME information from your yaml, and the REST from base-spells, but since the magic routine is designed to just pick up where you left off if you have a spell prepped, it doesn't use your yaml for the cast. It searches base-spells for information on the spell you have prepped, and if*(edit) theres a mismatch, it doesn't find anything, and doesn't cast. 

Specifically, here:
```ruby
spell = XMLData.prepared_spell
data = training_spells[skill]
skill = get_data('spells').spell_data[spell]['skill']
```
So we get a spell name, lets say Aura of Tongues, a popular sorcery spell, which is actually a utility spell. AoT is prepped, so spell = Aura of Tongues. Then we go into our yaml and get the skill for that spell, this would be Sorcery, if you're casting it sorcerously. So data would contain all our information from that entry from our yaml (abbrev, symb, mana). Then we go to base-spells and look for a match of THAT spell (aot) with our YAML skill (sorcery) and find...nothing.

This went unnoticed for some time due to the fact that if you have a spell like AoT as a sorcery spell, and ALSO have a block for utility, it uses the AOT  spell for the prep, but the Utility block for the cast. I noticed this when using HW for utility on my empath, because AoT kept trying to cast skin. When I commented out the utility block (HT sungobund on discord), magic routine didn't even prep it.

Changing how we write training spells in our yamls is a significant change, but this brings it in line with how other spell groups are handled. This would allow for anchors to work with training spell lists.