### PR TITLE
[script] [pick] Add match for glance

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -424,7 +424,7 @@ class Pick
     Flags.reset('glance-no-traps')
     Flags.reset('glance-no-locks')
 
-    DRC.bput("glance my #{box['noun']}", "Looking more closely you see", "It looks like there are no locks")
+    DRC.bput("glance my #{box['noun']}", "Looking more closely you see", "It looks like there are no locks", /^You glance/)
 
     box['trapped'] = false if Flags['glance-no-traps']
     box['locked'] = false if Flags['glance-no-locks']


### PR DESCRIPTION
User send9#9510 on Discord reports that even as a thief over level 13 he gets regular glance message. This doesn't fix anything, but it prevents the 15 second hang.

```
[pick]>glance my pine strongbox
You glance at a misshaped pine strongbox.
>
[pick: *** No match was found after 15 seconds, dumping info]
[pick: messages seen length: 11]
[pick: message: Khri Hasten  (4 roisaen)]
[pick: message: Khri Darken  (6 roisaen)]
[pick: message: Khri Focus  (6 roisaen)]
[pick: message: Khri Terrify  (Fading)]
[pick: message: Khri Dampen  (11 roisaen)]
[pick: message: Khri Hasten  (4 roisaen)]
[pick: message: Khri Darken  (6 roisaen)]
[pick: message: Khri Focus  (6 roisaen)]
[pick: message: Khri Terrify  (Fading)]
[pick: message: Khri Dampen  (11 roisaen)]
[pick: message: You glance at a misshaped pine strongbox.]
[pick: checked against [/Looking more closely you see/i, /It looks like there are no locks/i]]
[pick: for command glance my pine strongbox]
[pick]>pick my pine strongbox ident
An aged grandmother could open this in her sleep. (1/17)
Roundtime: 3 sec.
```