### PR TITLE
[script][drinfomon] Rework group_members

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.25'
+$DRINFOMON_VERSION = '2.0.26'
 
 no_kill_all
 no_pause_all

--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -1200,9 +1200,9 @@ status_hook = proc do |server_string|
     DRRoom.npcs = []
     DRRoom.dead_npcs = []
     DRRoom.room_objs = []
-  elsif server_string =~ /^you \w+ (west|east|north|south|northeast|northwest|southeast|southwest|out)\./i
+  elsif server_string =~ %r{<pushStream id="group"/>Members of your group:}
     DRRoom.group_members = []
-  elsif server_string =~ %r{<pushStream id="group"/>  (\w+): <popStream/>}
+  elsif server_string =~ %r{<pushStream id="group"/>  (\w+):}
     DRRoom.group_members << Regexp.last_match(1)
   elsif server_string =~ /Obvious exits:/ || server_string =~ /Obvious paths:/
     exit_string = server_string.gsub('<d>', '').gsub('</d>', '').gsub('Obvious exits: ', '').gsub('Obvious paths: ', '').delete('.').gsub("\r\n", '')


### PR DESCRIPTION
1. The xml stream we were trying to capture was part of two separate lines. 
```
<popStream/><pushStream id="group"/>  Reonin: Healthy.

<popStream/><pushStream id="group"/>  You (Leader): Healthy.
```
Limiting captures to what's on the first line above lets us match the string we're getting, not parts of two separate strings.

2. Now looking at the stream, every time there is a group change:
```
<clearStream id='group'/>

<pushStream id="group"/>Members of your group:

<popStream/><pushStream id="group"/>  You (Leader): Healthy.

<popStream/><pushStream id="group"/>There is 1 member in your group.

<popStream/><prompt time="1660369497">&gt;</prompt>
```
or 
```
<clearStream id='group'/>

<pushStream id="group"/>Members of your group:

<popStream/><pushStream id="group"/>  Reonin: Healthy.

<popStream/><pushStream id="group"/>  You (Leader): Healthy.

<popStream/><pushStream id="group"/>There are 2 members in your group.

<popStream/><prompt time="1660369959">&gt;</prompt>
```

We get a new list of group members to parse. If we just try to add them as they occur, and clear when we leave, we'll quickly hit the array cap with a bunch of duplicates. So, lets clear whenever we get a new group prompt like so:

```ruby
  elsif server_string =~ %r{<pushStream id="group"/>Members of your group:}
    DRRoom.group_members = []
```
and then populate that group with members:
```ruby
  elsif server_string =~ %r{<pushStream id="group"/>  (\w+):}
    DRRoom.group_members << Regexp.last_match(1)
```
