### PR TITLE
[script][shape|forge|sew] stow book after study

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -146,7 +146,7 @@ class Forge
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
         DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
         DRC.bput('study my book', 'Roundtime')
-        DRCC.stow_crafting_item("book", @bag, @belt)
+        DRCC.stow_crafting_item("book", @bag, @forging_belt)
       end
     end
     swap_tool(@home_tool)

--- a/forge.lic
+++ b/forge.lic
@@ -146,6 +146,7 @@ class Forge
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
         DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
         DRC.bput('study my book', 'Roundtime')
+        DRCC.stow_crafting_item("book", @bag, @belt)
       end
     end
     swap_tool(@home_tool)

--- a/sew.lic
+++ b/sew.lic
@@ -107,6 +107,7 @@ class Sew
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
         DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
         DRC.bput('study my book', 'Roundtime')
+        DRCC.stow_crafting_item("tailoring book", @bag, @belt)
       end
     end
 

--- a/shape.lic
+++ b/shape.lic
@@ -98,6 +98,7 @@ class Shape
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
         DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
         DRC.bput('study my book', 'Roundtime')
+        DRCC.stow_crafting_item("shaping book", @bag, @belt)
       end
     end
     if @chapter == 6


### PR DESCRIPTION
Stows crafting book after studying it. Normally this is handled by swap_tool, but if you're holding the material to be crafted when you start, instead of an item to be enhanced, you don't stow the book.

From discord:
```
[shape]>turn my book to page 15
You turn your book to page 15, instructions for crafting a wood brooch.
>
[shape]>study my book
You scan the brooch instructions with a glance and confidently discern most of the design's minutiae.
You now feel ready to begin the crafting process.
Roundtime: 8 sec.
>
[shape]>put my apple lumber in my watersilk bag
You put your lumber in your watersilk bag.
>
[shape]>get my drawknife
You get a metal drawknife edged in glaes from inside your watersilk bag.
>
[shape]>get my apple lumber
You need a free hand to pick that up.
```
