### PR TITLE
base-hunting - typo fix for malchata zone

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1659,7 +1659,7 @@ hunting_zones:
   - 11380
   # https://elanthipedia.play.net/S%27sugi_malchata                      500-700
   # Caution: casts a strong fireball
-  ssgui_malchata:
+  ssugi_malchata:
   - 11018
   - 11017
   - 12176


### PR DESCRIPTION
Zone was labeled `ssgui_malchata`
Now it's `ssugi_malchata`