### PR TITLE
[data] [base.yaml] Add handling for Darkling Wood tree

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2310,3 +2310,33 @@ base_wayto_overrides:
     start_room: 27558
     end_room: 27556
     str_proc: start_script('bescort', ['asketis_mount', 'down']);wait_while{running?('bescort')};
+  darkling_wood_tree_south_to_north:
+    start_room: 2698
+    end_room: 2718
+    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
+    travel_time: 0.2
+  darkling_wood_branch_south_to_north:
+    start_room: 2718
+    end_room: 2717
+    str_proc: fput("climb branch"); fput("look"); fput("look"); waitrt?
+    travel_time: 0.2
+  darkling_wood_tree_south_to_final:
+    start_room: 2717
+    end_room: 2692
+    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
+    travel_time: 0.2
+  darkling_wood_tree_north_to_south:
+    start_room: 2692
+    end_room: 2717
+    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
+    travel_time: 0.2
+  darkling_wood_branch_north_to_south:
+    start_room: 2717
+    end_room: 2718
+    str_proc: fput("climb branch"); fput("look"); fput("look"); waitrt?
+    travel_time: 0.2
+  darkling_wood_tree_north_to_final:
+    start_room: 2718
+    end_room: 2698
+    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
+    travel_time: 0.2


### PR DESCRIPTION
The XML stream for this tree nests the `<nav/>` tag into the body of the room description, so movement isn't detected correctly. This slows things down a fraction of a second, and adds a double look (a single look wasn't enough...) so you don't go too fast, and fall off. This takes my once-nightly fall, to not falls at all. Thanks @asechrest for this!