### PR TITLE
[script][combat-trainer] Safe Sorcery

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1188,6 +1188,9 @@ class SpellProcess
     @runestone_storage = settings.runestone_storage
     echo("  @runestone_storage: #{@runestone_storage}") if $debug_mode_ct
 
+    @safe_sorcery = settings.safe_sorcery
+    echo("  @safe_sorcery: #{@safe_sorcery}") if $debug_mode_ct
+
     @perc_health_timer = Time.now
     @aura_timer = 0
     @avtalia_timer = Time.now - 290
@@ -1594,6 +1597,7 @@ class SpellProcess
   end
 
   def spell_is_sorcery?(spell_data)
+    return false if @safe_sorcery
     return true  if spell_data['sorcery']
     return false unless spell_data['mana_type']
     return false if DRStats.native_mana.casecmp(spell_data['mana_type']).zero?

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -925,16 +925,3 @@ water_holder:
     - carve-bead
   specific_descriptions:
     carve-bead:
-
-card_bags:
-  description: Bags you use to collect and store cards
-  example: red backpack
-  referenced_by:
-    - card-collector
-  specific_descriptions:
-    card-collector: Sets bag to draw cards from (fresh) and bag to place duplicates and your case(duplicates)
-    
-safe_sorcery:
-  description: Prevents combat-trainer from stowing weapons before sorcery casts. Advanced option, edit with maximum caution.
-  referenced_by:
-    - combat-trainer

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -790,6 +790,11 @@ safe_room:
   specific_descriptions:
     athletics: If specified, walks to your safe room first for athletics training.
 
+safe_sorcery:
+  description: Prevents combat-trainer from stowing weapons before sorcery casts. Advanced option, edit with maximum caution.
+  referenced_by:
+    - combat-trainer
+
 shaping_tools:
   description: List of tools used for shaping.
   example: "- carving knife, - shaper, - drawknife"

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -933,3 +933,8 @@ card_bags:
     - card-collector
   specific_descriptions:
     card-collector: Sets bag to draw cards from (fresh) and bag to place duplicates and your case(duplicates)
+    
+safe_sorcery:
+  description: Prevents combat-trainer from stowing weapons before sorcery casts. Advanced option, edit with maximum caution.
+  referenced_by:
+    - combat-trainer

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -377,6 +377,8 @@ aiming_trainables:
 left_hand_free: false
 # allow melee offhand weapon training while aiming crossbow in aiming_trainables
 using_light_crossbow: false
+# prevents combat-trainer stowing your weapon for sorcery casts. ADVANCED OPTION, edit with maximum caution.
+safe_sorcery: false
 # use attack overrides for main hand attacks
 attack_overrides:
 # use attack overrides for aiming trainable skills


### PR DESCRIPTION
Allows yaml setting:
```yaml
safe_sorcery: true
```
to prevent combat-trainer from stowing your hands for a sorcery cast. Defaults to false. This is a setting for those who are certain their sorcerous casts won't result in backlash over tier 0, and thus won't lose a hand, drop a weapon, etc.. 