### PR TITLE
[script][common] Add messaging to track pause/unpause behavior

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -759,10 +759,12 @@ module DRC
       s.pause
       paused_script_list << s.name
     end
+    DRC.message("Pausing #{paused_script_list} to run #{Script.self.name}")
     return paused_script_list
   end
 
   def unpause_all_list(scripts_to_unpause)
+    DRC.message("Unpausing #{scripts_to_unpause}, #{Script.self.name} has finished.")
     Script.running.find_all { |s| s.paused? && !s.no_pause_all && scripts_to_unpause.include?(s.name) }.each(&:unpause)
   end
 


### PR DESCRIPTION
This change spits out a list of scripts being paused by this method, then a list of scripts being unpaused. This is useful for user-level understanding of what's going on, as well as troubleshooting problems with script interactions.
```
--- Lich: t2 paused.
--- Lich: afk paused.
--- Lich: magic-training paused.
Pausing ["t2", "afk", "magic-training"] to run tessera
[tessera]>get my tessera 
You get a clear tessera from inside your backpack.
>
[tessera]>ask my tessera about invest
You send your clear tessera a wordless thought of acquiescence.
The clear tessera attempts to tap into your starlight aura, but finds it depleted.
>
[tessera]>stow my tessera
You put your tessera in your backpack.
>
Unpausing ["t2", "afk", "magic-training"], tessera has finished.
--- Lich: t2 unpaused.
--- Lich: afk unpaused.
--- Lich: magic-training unpaused.
```
