### PR TITLE
[script][magic-training] Support for old settings patterns

### DIFF
--- a/magic-training.lic
+++ b/magic-training.lic
@@ -47,7 +47,7 @@ class MagicTraining
     DRCT.walk_to(settings.magic_training_room)
     exp_threshold = settings.magic_exp_training_max_threshold
     force_cambrinth = settings.waggle_force_cambrinth
-    training_spells = settings.training_spells || settings.magic_training
+    training_spells = settings.training_spells.empty? ? settings.magic_training : settings.training_spells
 
     magic_skills = training_spells.keys
     skills_to_train = magic_skills

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -43,6 +43,7 @@ empty_values:
   charged_maneuvers: {}
   training_nonspells: {}
   training_spells: {}
+  magic_training: {}
   research_training_spells: {}
   gear_sets: {}
   lichbot_buffs: []


### PR DESCRIPTION
Folks using exclusively magic_training were left out in the cold with the recent PR for magic-training, since the empty values in base-empty gave us {} for training_spells, even if it's not in their yaml. Fix is to check against empty instead of nil, and add magic_training to base-empty in case they've set neither.