### PR TITLE
[profile][base] Adding variables for Fang Cove/alternate hometown fixes

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2,6 +2,18 @@
 # See https://github.com/rpherbig/dr-scripts/wiki/YAML-Settings for documentation
 
 hometown: Crossing
+# If hometown is Fang Cove, some scripts (athletics, burgle, checkfavors, favor, and crossing-repair)
+# will not run properly at all, or require extra settings. This setting gives a town for all of
+# the above scripts to use as their desination.
+fang_cove_override_town:
+
+# The settings below do the same as fang_cove_override_town, but for individual scripts. These
+# are unnecessary if you set fang_cove_override_town. If you set both, these settings will take
+# precedence. (Crossing-repair has a setting called force_repair_town further down.)
+favor_town:
+burgle_town:
+athletics_town:
+
 # Cap on time crossing-training runs
 training_manager_town_duration:
 


### PR DESCRIPTION
Fang Cove has issues with several scripts. The revised versions of these scripts read the new variables and treat a city other than hometown: as their hometown, if set.