### PR TITLE
[script][checkfavors] Fang Cove fix - checkfavors

### DIFF
--- a/checkfavors.lic
+++ b/checkfavors.lic
@@ -9,7 +9,7 @@ class CheckFavors
   def initialize
     @settings = get_settings
     town_data = get_data('town')
-    @character_hometown = @settings.favor_hometown || @settings.fang_cove_override_town || @settings.hometown
+    @character_hometown = @settings.favor_town || @settings.fang_cove_override_town || @settings.hometown
     @hometown = town_data[@character_hometown]
     check_favors
   end

--- a/checkfavors.lic
+++ b/checkfavors.lic
@@ -9,7 +9,8 @@ class CheckFavors
   def initialize
     @settings = get_settings
     town_data = get_data('town')
-    @hometown = town_data[@settings.hometown]
+    @character_hometown = @settings.favor_hometown || @settings.fang_cove_override_town || @settings.hometown
+    @hometown = town_data[@character_hometown]
     check_favors
   end
 

--- a/checkfavors.lic
+++ b/checkfavors.lic
@@ -9,8 +9,8 @@ class CheckFavors
   def initialize
     @settings = get_settings
     town_data = get_data('town')
-    @character_hometown = @settings.favor_town || @settings.fang_cove_override_town || @settings.hometown
-    @hometown = town_data[@character_hometown]
+    character_hometown = @settings.favor_town || @settings.fang_cove_override_town || @settings.hometown
+    @hometown = town_data[character_hometown]
     check_favors
   end
 

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -162,6 +162,12 @@ athletics_outdoorsmanship_rooms:
   specific_descriptions:
     athletics: Chooses a random room from this array to do outdoorsmanship while training athletics.
 
+athletics_town:
+  description: By default, athletics runs out of hometown. This allows for setting a different town from which Athletics will run.
+  example: Crossing
+  referenced by:
+    - athletics
+
 attunement_rooms:
   description: Array of roomnumbers to do attunement in.
   example: "- 2082, - 2081, - 2080"
@@ -264,6 +270,13 @@ burgle_settings:
     - burgle
   specific_descriptions:
     burgle: "Set the following: room, entry_type, max_priority_mindstate, rope_adjective, hometown, use_lockpick_ring, lockpick_container, max_search_count, retry, loot, loot_container, safe_mode, room_blacklist, item_whitelist, before, after."
+
+burgle_town:
+  description: By default, burgle runs from args, burgle-settings(hometown), or hometown, in that order. This is a top-level setting to change where burgle runs.
+  example: Crossing
+  referenced by:
+    - burgle
+  
 
 card_bags:
   description: Bags you use to collect and store cards
@@ -493,6 +506,16 @@ engineering_room:
     bolts: Bolt making done here.
     clean-leather: Bone preserving done here.
 
+fang_cove_override_town:
+  description: Multiple scripts won't run with Fang Cove as hometown, or require addtional settings to do so. This sets an alternate hometown for several such scripts, all at once. Individual script settings (like favor_town) are unnecessary with this, but if entered, they override this setting.
+  example: Crossing
+  referenced by:
+    - athletics
+    - burgle
+    - checkfavors
+    - crossing-repair
+    - favor
+
 favor_goal:
   description: Number of favors to shoot for.
   example: 30
@@ -508,6 +531,13 @@ favor_god:
     - checkfavors
   specific_descriptions:
     checkfavors:
+
+favor_town:
+  description: By default, favor and checkfavors run from hometown. This allows them to run from a town of your choosing.
+  example: Crossing
+  referenced by:
+    - checkfavors
+    - favor
 
 flying_mount:
   description: Specify a flying mount.

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2,6 +2,16 @@
 # See https://github.com/rpherbig/dr-scripts/wiki/YAML-Settings for documentation
 
 hometown: Crossing
+# If hometown is Fang Cove, some scripts (athletics, burgle, checkfavors, favor, and crossing-repair)
+# will not run properly at all, or require extra settings. This setting gives a town for all of
+# the above scripts to use as their desination.
+fang_cove_override_town:
+
+# The settings below do the same as fang_cove_override_town, but for individual scripts. These
+# are unnecessary if you set fang_cove_override_town. If you set both, these settings will take
+# precedence. (Crossing-repair has a setting called force_repair_town further down.)
+favor_town:
+
 # Cap on time crossing-training runs
 training_manager_town_duration:
 


### PR DESCRIPTION
checkfavors did not work properly with Fang Cove as hometown. Added fang_cove_override_town as a multi-script town override, and favor_town as a checkfavors-specific town override.