### PR TITLE
[script][workorders] Tweak to ordering

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -59,18 +59,6 @@ class WorkOrders
       @outfitting_room = @settings.outfitting_room
       tools = @settings.outfitting_tools
       @belt = @settings.outfitting_belt
-      case item['chapter']
-      when 4, 2, 3
-        craft_method = :sew_items
-      when 5
-        materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
-        craft_method = :knit_items
-      else
-        if item['chapter']
-          echo("UNKNOWN CHAPTER FOR TAILORING ITEM #{item}")
-          exit
-        end
-      end
     when 'shaping'
       materials_info = crafting_data['stock'][@workorders_materials['wood_type']]
       skill = 'Engineering'
@@ -138,6 +126,21 @@ class WorkOrders
         item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], @settings.workorder_diff)
       end
       item = recipes.find { |r| r['name'] == item_name }
+    end
+    
+    if skill == 'Outfitting'
+      case item['chapter']
+      when 2,3,4
+        materials_info = crafting_data['stock'][@workorders_materials['fabric_type']]
+        @mat_type = 'cloth'
+      when 5
+        materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
+        craft_method = :knit_items
+        @mat_type = 'yarn'
+      else
+        materials_info = crafting_data['stock'][@workorders_materials['leather_type']]
+        @mat_type = 'leather'
+      end
     end
 
     return repair_items(info, tools) if repair


### PR DESCRIPTION
Recent PR moved hometown definitions and a few other items below the big case statement for crafts, which meant a variable (item) wasn't being defined before we needed it. This is used to determine fabric/yarn/leather, and get the relevant materials information. Moving this out of the main case statement and putting it below where item is defined sorts this out, and doesn't appear to have any other affect on the script, since the information does get defined before we start using it.  First use of materials_info, @mat_type, and craft_method are all still after this little case block.

An oversight on my part, this fixes it for me.