### PR TITLE
[script][pay-debt] Fang Cove exchange messaging added.

### DIFF
--- a/pay-debt.lic
+++ b/pay-debt.lic
@@ -65,7 +65,7 @@ class PayDebt
         withdraw_amt = convert_currency(debt_amount - debt_currency_on_hand, @hometown_currency, @debt_currency, -@hometown_info['exchange']['fee'])
         deposit_coins(withdraw_amt, @settings)
         walk_to(@hometown_info['exchange']['id'])
-        bput("exchange all #{@hometown_currency} for #{@debt_currency}", 'The money-changer says', 'After collecting a modest fee', "You don't have that many")
+        bput("exchange all #{@hometown_currency} for #{@debt_currency}", 'After figuring a trivial fee', 'The money-changer says', 'After collecting a modest fee', "You don't have that many")
         amount, denom = @settings.sell_loot_money_on_hand.split(' ')
         deposit_coins(convert_to_copper(amount, denom), @settings)
       end


### PR DESCRIPTION
Using the exchange in Fang Cove generated messaging unrecognized by pay-debt. This should resolve that.