### PR TITLE
[scripts][first-aid] Add scholarship to requisite skill check to break first-aid early.

### DIFF
--- a/first-aid.lic
+++ b/first-aid.lic
@@ -70,7 +70,7 @@ class FirstAid
             DRC.bput("get my #{@booktype}", 'You get', 'You are already holding')
           end
           waitrt?
-          break if DRSkill.getxp('First Aid') >= 32
+          break if DRSkill.getxp('First Aid') >= 32 && DRSkill.getxp('Scholarship') >= 32
         end
       end
   end


### PR DESCRIPTION
Currently, first-aid ends early if your First Aid mindstate is over 32. However, first-aid is also used to train scholarship. This adds a Scholarship mindstate check in addition to the First Aid mindstate check, both of which must be passed for an early termination.

If preferred, I could create a new script (fa-scholarship or something) out of this instead, if it's determined that editing this would mess too much with people's First Aid training.