### PR TITLE
[script][crossing-training] - Fix Lich5 waitrt? failure

### DIFF
--- a/crossing-training.lic
+++ b/crossing-training.lic
@@ -647,8 +647,7 @@ class CrossingTraining
       5.times do
         break if bput('perceive health', 'You fail to sense', 'You sense:', 'You\'re not ready to do that again, yet') == 'You sense:'
         pause 1
-        rt = waitrt?
-        pause 5 if rt.nil? || rt.zero?
+        pause 5 unless waitrt?
         check_research
       end
       waitrt?


### PR DESCRIPTION
Reported by @xOni Zoey in Discord:

```
--- Lich: go2 has exited.
[crossing-training]>perceive health
You're not ready to do that again, yet.
>
--- Lich: error: undefined method zero?' for false:FalseClass
    crossing-training:651:in block (2 levels) in train_empathy'
    crossing-training:647:in `times'
--- Lich: crossing-training has exited.
```
The issue is that Lich5's predicate `waitrt?` function returns a boolean. `crossing-training` expects Lich4's version, which returns a float. This fix cleans it up for Lich5, and still functions in Lich4, though admittedly with some possible extra pause time.