### PR TITLE
[data][base-lumber] Ilithi fixes for base-lumber

### DIFF
--- a/data/base-lumber.yaml
+++ b/data/base-lumber.yaml
@@ -194,6 +194,27 @@ lumber_buddy_rooms:
   - 9770
   - 9769
 # ILITHI
+  # Fang Cove - Estate holder/premium only
+  # Between serpents and yellow gremlins
+  fangs_shadow:
+  # tropical
+  - 8331
+  - 8332
+  - 8333
+  - 8334
+  - 8335
+  - 8336
+  - 8337
+  - 8338
+  # Estate Holder/Premium only
+  # Populated by Frostweavers (180-260)
+  dragons_spine:
+  # boreal
+  - 9621
+  - 9627
+  - 9625
+  - 9626
+  - 9622
   # North side of the gondola
   # Populated by Snowbeasts (80-105)
   gash:
@@ -207,9 +228,10 @@ lumber_buddy_rooms:
   - 2259
   - 2256
   - 2257
+  - 2258
   # Outside East Gate
   # Populated by Kobolds (35-50)
-  prairie:
+  prairie: # Wylder Spring
   # deciduous
   - 2745
   - 2749
@@ -217,7 +239,7 @@ lumber_buddy_rooms:
   - 2750
   - 2748
   # Outside North Gate
-  road_to_shard:
+  road_to_shard: # Southern Trade Road & Dragon's Breath Forest
   # coniferous
   - 2825
   - 2826
@@ -234,18 +256,18 @@ lumber_buddy_rooms:
   - 2836
   - 2851
   - 2899
-  # Under the Gondola
-  # Requires athletics
-  undergondola_river:
-  # tropical
-  - 11525
-  - 11524
-  - 11523
-  - 11522
-  - 11521
+  # # Under the Gondola
+  # # Requires athletics
+  # undergondola_river: # COMMENTED OUT BECAUSE NONE OF THESE ROOMS CONTAIN A FOREST
+  # # tropical
+  # - 11525
+  # - 11524
+  # - 11523
+  # - 11522
+  # - 11521
   # Under the Gondola
   # Populated by Red Leucros
-  undergondola_leucro:
+  undergondola_leucro: # Undergondola
   # coniferous
   - 19470
   - 19469
@@ -269,7 +291,7 @@ lumber_buddy_rooms:
   - 9526
   # South Gate
   # Populated by Adan'f Warriors (250-325) and Shadow Mages (250-370)
-  adanf_woods:
+  adanf_woods: # Whistling Woods
   # boreal
   - 9458
   - 9459
@@ -325,7 +347,7 @@ lumber_buddy_rooms:
   - 15353
   # South Gate
   # Populated by Rock Trolls and further south Eidolon Steeds (100-160)
-  darkling_woods:
+  darkling_woods: # Whistling Woods
   # boreal
   - 2659
   - 2660


### PR DESCRIPTION
Added Fang Cove forest (Fang's Shadow, Estate Holder only)
Added Dragon's Spine (Estate Holder only)
Added comments to reflect known forest names on https://elanthipedia.play.net/Lumberjacking
Commented out underground_river (no rooms in that list contained a forest)
Added a room to gash