### PR TITLE
[data][base-lumber] Zoluren updates and minor Ilithi notations

### DIFF
--- a/data/base-lumber.yaml
+++ b/data/base-lumber.yaml
@@ -2,7 +2,7 @@
 lumber_buddy_rooms:
 # ZOLUREN
   # Northeast Gate
-  neg_to_kaerna:
+  neg_to_kaerna: # NTR Wilderness
   # coniferous
   - 1001
   - 1008
@@ -75,7 +75,7 @@ lumber_buddy_rooms:
   - 8990
   # Outside Northeast Gate
   # Populated by Wind Hounds (45-73) and Faenrae Reavers (35-55)
-  wilds_and_reavers:
+  wilds_and_reavers: # NTR Wilderness
   # coniferous
   - 1167
   - 1168
@@ -131,9 +131,19 @@ lumber_buddy_rooms:
 #  - 7969
 #  - 7965
   # Leth Deriel
+  # Estate Holder/Premium only
+  # Populated by Treehopper Toads (300-370)
+  white_laurel_grove:
+  # deciduous
+  - 50262
+  - 50263
+  - 16850
+  - 50265
+  - 50266
+  - 50267
   # Populated by Blood Dryads (25-40)
-  blood_dryads:
-  # boreal
+  blood_dryads: # Forest of Night Blood Nyad/Blood Dryad
+  # boreal, tropical
   - 9366
   - 19201
   - 9367
@@ -182,8 +192,8 @@ lumber_buddy_rooms:
   - 10046
   # Leth Deriel
   # Populated by Twisted Dryads (175-220)
-  twisted_dryads:
-  # boreal
+  twisted_dryads: # Forest of Night Dryad Priestess/Twisted Dryads
+  # boreal, tropical
   - 9766
   - 9774
   - 9773
@@ -218,7 +228,7 @@ lumber_buddy_rooms:
   # North side of the gondola
   # Populated by Snowbeasts (80-105)
   gash:
-  # coniferous
+  # coniferous, deciduous
   - 2254
   - 2255
   - 2266
@@ -240,7 +250,7 @@ lumber_buddy_rooms:
   - 2748
   # Outside North Gate
   road_to_shard: # Southern Trade Road & Dragon's Breath Forest
-  # coniferous
+  # coniferous 
   - 2825
   - 2826
   - 2827
@@ -268,7 +278,7 @@ lumber_buddy_rooms:
   # Under the Gondola
   # Populated by Red Leucros
   undergondola_leucro: # Undergondola
-  # coniferous
+  # coniferous, tropical, deciduous
   - 19470
   - 19469
   - 19474


### PR DESCRIPTION
Several changes:
- Added notations beside many forest areas for easier reference when comparing them to the list found at https://elanthipedia.play.net/Lumberjacking#Forest_Groupings
- Changed notations of what trees are present when multiple tree types are indicated by https://elanthipedia.play.net/Lumberjacking#Forest_Groupings
- Added white_laurel_grove, an Estate Holder forest in Zoluren.