### PR TITLE
[scripts][dependency][validate] - Remind user of curated scripts with copy in custom folder

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1819,7 +1819,7 @@ def warn_custom_scripts
   end
 
   unless include_list.empty?
-    echo "WARNING: The following curated scripts are in your custom folder and will not receive updates"
+    echo "NOTE: The following curated scripts are in your custom folder and will not receive updates"
     echo "#{include_list}" unless include_list.empty?
   end
 end

--- a/dependency.lic
+++ b/dependency.lic
@@ -1835,9 +1835,6 @@ echo("Starting DRinfomon, this will take a few seconds.")
 custom_require.call('drinfomon')
 echo("DRinfomon ready.")
 
-# Remind user of curated scripts with a copy in custom folder
-warn_custom_scripts
-
 $manager.check_base_files
 $manager.check_data_files
 $manager.start_scripts
@@ -1853,6 +1850,9 @@ before_dying do
 end
 
 $setupfiles.reload
+
+# Remind user of curated scripts with a copy in custom folder
+warn_custom_scripts
 
 loop do
   if $turn_on_moon_watch && $moon_watch.nil?

--- a/dependency.lic
+++ b/dependency.lic
@@ -1809,6 +1809,21 @@ def clear_hometown
   $HOMETOWN = nil
 end
 
+def warn_custom_scripts
+  # Remind user of scripts in custom folder
+  custom_scripts = Dir.entries('./scripts/custom').reject { |f| File.directory?(f) }
+  curated_scripts = Dir.entries('./scripts').reject { |f| File.directory?(f) }
+  include_list = []
+
+  custom_scripts.each do | script |
+    include_list.push(script) if curated_scripts.include?(script)
+    # respond("   #{script}") if curated_scripts.include?(script)
+
+  end
+
+  echo "WARNING: The following curated scripts are in your custom folder: #{include_list}" unless include_list.empty?
+end
+
 full_install if install
 
 force_start_script('bootstrap', ['wipe_constants'])
@@ -1819,6 +1834,8 @@ force_start_script('bootstrap', ['wipe_constants'])
 echo("Starting DRinfomon, this will take a few seconds.")
 custom_require.call('drinfomon')
 echo("DRinfomon ready.")
+
+warn_custom_scripts
 
 $manager.check_base_files
 $manager.check_data_files

--- a/dependency.lic
+++ b/dependency.lic
@@ -1810,15 +1810,12 @@ def clear_hometown
 end
 
 def warn_custom_scripts
-  # Remind user of scripts in custom folder
   custom_scripts = Dir.entries('./scripts/custom').reject { |f| File.directory?(f) }
   curated_scripts = Dir.entries('./scripts').reject { |f| File.directory?(f) }
   include_list = []
 
   custom_scripts.each do | script |
     include_list.push(script) if curated_scripts.include?(script)
-    # respond("   #{script}") if curated_scripts.include?(script)
-
   end
 
   echo "WARNING: The following curated scripts are in your custom folder: #{include_list}" unless include_list.empty?
@@ -1835,6 +1832,7 @@ echo("Starting DRinfomon, this will take a few seconds.")
 custom_require.call('drinfomon')
 echo("DRinfomon ready.")
 
+# Remind user of curated scripts with a copy in custom folder
 warn_custom_scripts
 
 $manager.check_base_files

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.14'
+$DEPENDENCY_VERSION = '1.4.15'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all

--- a/dependency.lic
+++ b/dependency.lic
@@ -1818,7 +1818,10 @@ def warn_custom_scripts
     include_list.push(script) if curated_scripts.include?(script)
   end
 
-  echo "WARNING: The following curated scripts are in your custom folder: #{include_list}" unless include_list.empty?
+  unless include_list.empty?
+    echo "WARNING: The following curated scripts are in your custom folder and will not receive updates"
+    echo "#{include_list}" unless include_list.empty?
+  end
 end
 
 full_install if install

--- a/validate.lic
+++ b/validate.lic
@@ -51,6 +51,10 @@ class DRYamlValidator
       end
     }
 
+
+    respond("")
+    warn_custom_scripts
+
     respond("")
     respond("  CHECKING: #{assertions.size} different potential errors in [#{checkname}-setup.yaml]")
     assertions.each do |symbol|
@@ -1025,6 +1029,21 @@ class DRYamlValidator
   end
 
   private
+
+  def warn_custom_scripts
+    custom_scripts = Dir.entries('./scripts/custom').reject { |f| File.directory?(f) }
+    curated_scripts = Dir.entries('./scripts').reject { |f| File.directory?(f) }
+    include_list = []
+
+    custom_scripts.each do | script |
+      include_list.push(script) if curated_scripts.include?(script)
+    end
+
+    unless include_list.empty?
+      respond("  NOTE: The following curated scripts are in your custom folder and will not receive updates.")
+      respond("  #{include_list}") unless include_list.empty?
+    end
+  end
 
   def warn(message)
     echo(@test_symbol) if @test_symbol

--- a/validate.lic
+++ b/validate.lic
@@ -51,8 +51,6 @@ class DRYamlValidator
       end
     }
 
-
-    respond("")
     warn_custom_scripts
 
     respond("")
@@ -1040,6 +1038,7 @@ class DRYamlValidator
     end
 
     unless include_list.empty?
+      respond("")
       respond("  NOTE: The following curated scripts are in your custom folder and will not receive updates.")
       respond("  #{include_list}") unless include_list.empty?
     end


### PR DESCRIPTION
Implementation of the custom folder is awesome. But we now frequently have folks forget they have a copy there, and not get updates to scripts. This is a simple warning when dependency loads, listing any scripts in the custom folder that also exist as curated scripts.

```
>
[dependency: WARNING: The following curated scripts are in your custom folder and will not receive updates]
[dependency: ["bescort.lic", "crossing-training.lic", "dependency.lic", "events.lic", "go2.lic", "mining-buddy.lic", "mock.lic", "symbiosis.lic"]]
```