### PR TITLE
Update sigilharvest.lic

### DIFF
--- a/sigilharvest.lic
+++ b/sigilharvest.lic
@@ -360,7 +360,7 @@ class SigilHarvest
     @stock_scrolls ? target_scrolls = @stock_scrolls : target_scrolls = 25
 
     #Count scrolls and store number in a variable, set variable to 0 if scrolls are not found
-    if /^There are (.*) scrolls left for use with crafting\.$/ =~ DRC.bput("count my blank scrolls", 'I could not find', /^There are .* scrolls left for use with crafting\.$/)
+    if /^There (?:are|is) (.*) scrolls? left for use with crafting\.$/ =~ DRC.bput("count my blank scrolls", 'I could not find', /^There are .* scrolls left for use with crafting\.$/)
       num_scrolls = DRC.text2num($1)
     else
       num_scrolls = 0


### PR DESCRIPTION
Fix an issue where we don't correctly parse current blank scroll count when there is precisely one scroll in the scroll stack.
The existing regex fails to match against the string seen in the game text below
```
[sigilharvest]>count my blank scrolls
There is one scroll left for use with crafting.
>
Bloodwraith Brittanie came through a door frame.
>
[sigilharvest: *** No match was found after 15 seconds, dumping info]
[sigilharvest: messages seen length: 21]
```

The proposed regex should fix the issue.