### PR TITLE
base-spells - corrections and updates

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -864,17 +864,6 @@ spell_data:
     prep: prepare
     recast: 2
     guild: Bard
-  Will O Wisp:
-    skill: cantrip
-    abbrev: C W O W
-    prep_time: 0
-    cast: gesture
-    harmless: true
-    mana:
-    recast: 1
-    mana_type: elemental
-    prep: prepare
-    guild: Bard
 
 ####################
 #      Cleric      #
@@ -1191,13 +1180,6 @@ spell_data:
     recast: 3
     mana_type: holy
     prep: prepare
-    guild: Cleric
-  Smite Horde:
-    skill: Targeted Magic
-    abbrev: SMH
-    mana: 30
-    mana_type: holy
-    prep: target
     guild: Cleric
   Soul Attrition:
     skill: Targeted Magic
@@ -2126,6 +2108,12 @@ spell_data:
     mana_type: arcane
     prep: prepare
     guild: Necromancer
+  Ghoulflesh:
+    skill: Warding
+    mana: 15
+    mana_type: arcane
+    prep: prepare
+    guild: Necromancer
   Heighten Pain:
     skill: Debilitation
     harmless: true
@@ -2218,7 +2206,7 @@ spell_data:
     prep: prepare
     recast: -1
     guild: Necromancer
-  Rite of Forebearance:
+  Rite of Forbearance:
     skill: Utility # Also Debilitation
     abbrev: RoF
     cyclic: true
@@ -2477,6 +2465,13 @@ spell_data:
     mana: 1
     mana_type: holy
     prep: prepare
+    guild: Paladin
+  Smite Horde:
+    skill: Targeted Magic
+    abbrev: SMH
+    mana: 30
+    mana_type: holy
+    prep: target
     guild: Paladin
   Soldier's Prayer:
     skill: Warding
@@ -3562,6 +3557,17 @@ spell_data:
     recast: 1
     mana_type: elemental
     prep: prepare
+  Will O Wisp:
+    skill: cantrip
+    abbrev: C W O W
+    prep_time: 0
+    cast: gesture
+    harmless: true
+    mana:
+    recast: 1
+    mana_type: elemental
+    prep: prepare
+    guild: Warrior Mage
   Y'ntrel Sechra:
     skill: Augmentation
     abbrev: YS


### PR DESCRIPTION
Will O' Wisp cantrip is Warrior Mage, not Bard.
Rite of Forbearance was misspelled.
Ghoulflesh was missing.  Can someone with a necromancer check and make sure I got all the needed info?
Smite Horde is a Paladin spell, not Cleric.