### PR TITLE
[scripts][common-items] Adding basin trash receptacle

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -11,7 +11,7 @@ module DRCI
   module_function
 
   ## How to add new trash receptacles https://github.com/rpherbig/dr-scripts/wiki/Adding-new-trash-receptacles
-  @@trash_storage = %w[basket bin gloop barrel bucket urn log arms stump tree statue chamberpot birdbath turtle puddle hole tangle]
+  @@trash_storage = %w[arms barrel basin basket bin birdbath bucket chamberpot gloop hole log puddle statue stump tangle tree turtle urn]
 
   @@drop_trash_success_patterns = [
     /^You drop/,
@@ -386,6 +386,8 @@ module DRCI
         trashcan = 'stone turtle'
       elsif trashcan == 'tree'
         trashcan = 'hollow' if DRRoom.room_objs.include?('dead tree with a darkened hollow near its base')
+      elsif trashcan == 'basin'
+        trashcan = 'stone basin' if DRRoom.room_objs.include?('hollow stone basin')
       elsif trashcan == 'tangle'
         trashcan = 'dark gap' if DRRoom.room_objs.include?('tangle of thick roots forming a dark gap')
       elsif XMLData.room_title == '[[A Junk Yard]]'


### PR DESCRIPTION
I also re-ordered `@@trash_storage` to be alphabetical, and validated again that <https://github.com/rpherbig/dr-scripts/wiki/Adding-new-trash-receptacles> works as described.

Before:
```
>;eq DRCI.dispose_trash("rock")
[exec1]>drop my rock
You drop a rock.
```
After:
```
>;eq DRCI.dispose_trash("rock")
[exec1]>put my rock in stone basin
You drop a rock in a hollow stone basin.
```