### PR TITLE
tarantula - add failure message for turning

### DIFF
--- a/tarantula.lic
+++ b/tarantula.lic
@@ -83,7 +83,7 @@ class Tarantula
     if skill =~ /(Lunar|Holy|Elemental|Life|Arcane|Inner) (Magic|Fire)/i
       skill = 'Magic'
     end
-    case DRC.bput("turn my #{@tarantula_noun} to #{skill}", /your changes snap into place/, /You need to vary which skillset/, /You should stop practicing your Athletics/)
+    case DRC.bput("turn my #{@tarantula_noun} to #{skill}", /your changes snap into place/, /You need to vary which skillset/, /You should stop practicing your Athletics/, /You don't seem to be able to move to do that/)
     when /your changes snap into place/
       DRC.message("*** Tarantula will now consume #{name} knowledge ***") if @debug
       return true
@@ -92,7 +92,7 @@ class Tarantula
       check_last
       use_tarantula
       return false
-    when /You should stop practicing your Athletics/
+    when /You should stop practicing your Athletics/, /You don't seem to be able to move to do that/
       DRC.safe_unpause_list(@scripts_to_unpause)
       return false
     end


### PR DESCRIPTION
From discord:
While using `feed-cloak.lic`
```[tarantula: message: You don't seem to be able to move to do that.]
[tarantula: checked against [/your changes snap into place/, /You need to vary which skillset/, /You should stop practicing your Athletics/]]```

Added failure message.