### PR TITLE
[script][common-crafting] Prevent stockpiling

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -313,11 +313,11 @@ module DRCC
       if Regexp.last_match(1).to_i < count
         DRCT.dispose(name)
         DRCC.check_consumables(name, room, number, bag, bag_items, belt, count)
+        DRCC.stow_crafting_item(name, bag, belt)
       end
     else
       DRCT.order_item(room, number)
     end
-    DRCC.stow_crafting_item(name, bag, belt)
     DRCT.walk_to(current)
   end
 

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -313,8 +313,8 @@ module DRCC
       if Regexp.last_match(1).to_i < count
         DRCT.dispose(name)
         DRCC.check_consumables(name, room, number, bag, bag_items, belt, count)
-        DRCC.stow_crafting_item(name, bag, belt)
       end
+      DRCC.stow_crafting_item(name, bag, belt)
     else
       DRCT.order_item(room, number)
     end

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -312,7 +312,7 @@ module DRCC
       /(\d+)/ =~ DRC.bput("count my #{name}", 'The .* has (\d+) uses remaining', 'You count out (\d+) yards of material there')
       if Regexp.last_match(1).to_i < count
         DRCT.dispose(name)
-        DRCT.order_item(room, number)
+        DRCC.check_consumables(name, room, number, bag, bag_items, belt, count)
       end
     else
       DRCT.order_item(room, number)


### PR DESCRIPTION
So, originally, this would check the first flask of oil in your bag, and if you didn't have enough, would dump it and buy another. However, often enough this has happened more than once, and via logging, you'd cycle through oils already purchased, occasionally disposing of low-count oil, but ultimately racking up a half-dozen flasks of varying capacities. The idea behind this change is we dump the low-count oil, then run back through and check the NEXT oil in your bag, until either we run OUT of oil, and buy another, or FIND a flask with the necessary count.

OLD:
```
[workorders]>get my oil from my haversack
You get a big flask of oil painted with pitch-black stripes from inside your haversack.
>
[workorders]>count my oil
The oil has 3 uses remaining.
>
[workorders]>get my oil
You are already holding that.
>
[workorders]>drop my oil
You drop a big flask of oil painted with pitch-black stripes.
#### Travel to tool stand ####
[workorders]>order 6
The attendant says, "You can purchase a flask of oil for 721 Dokoras.  Just order it again and we'll see it done!"
>
[workorders]>order 6
>
The attendant takes some coins from you and hands you a flask of oil.
>
[workorders]>put my oil in my haversack
You put your oil in your haversack.
```
Despite my having four other flasks with sufficient oil, I still buy another.

NEW:
```
>;e echo DRCC.check_consumables("oil", 4436, 6, "haversack", nil, nil, 10)
--- Lich: exec1 active.
[exec1]>get my oil from my haversack
>
You get a flask of oil from inside your haversack.
>
[exec1]>count my oil
The oil has 8 uses remaining.
>
[exec1]>get my oil
You are already holding that.
>
[exec1]>drop my oil
You drop a flask of oil.
>
[exec1]>get my oil from my haversack
You get a flask of oil from inside your haversack.
>
[exec1]>count my oil
The oil has 46 uses remaining.
>
[exec1]>put my oil in my haversack
You put your oil in your haversack.
>
[exec1]>put my oil in my haversack
What were you referring to?
>
[exec1: true]
--- Lich: exec1 has exited.
```
Here, we dump the offending low-count oil and check the next, which has plenty of uses, so no need to purchase another flask. If we have NO flasks, or all flasks have low count:
```
>;e echo DRCC.check_consumables("oil", 4436, 6, "haversack", nil, nil, 10)
--- Lich: exec1 active.
[exec1]>get my oil from my haversack
What were you referring to?
>
[exec1]>order 6
The attendant says, "You can purchase a flask of oil for 721 Dokoras.  Just order it again and we'll see it done!"
>
[exec1]>order 6
>
The attendant takes some coins from you and hands you a flask of oil.
>
[exec1]>put my oil in my haversack
You put your oil in your haversack.
>
[exec1: true]
--- Lich: exec1 has exited.
```
Same with brushes (NEW):
```
>;e echo DRCC.check_consumables("brush", 4436, 10, "haversack", nil, nil,  18)
--- Lich: exec1 active.
[exec1]>get my brush from my haversack
You get a sturdy wire brush with stiff maroon bristles from inside your haversack.
>
[exec1]>count my brush
The wire brush has 16 uses remaining.
>
[exec1]>get my brush
You are already holding that.
>
[exec1]>drop my brush
You drop a sturdy wire brush with stiff maroon bristles.
>
[exec1]>get my brush from my haversack
You get a sturdy wire brush with stiff ochre bristles from inside your haversack.
>
[exec1]>count my brush
The wire brush has 29 uses remaining.
>
[exec1]>put my brush in my haversack
You put your brush in your haversack.
>
[exec1: true]
--- Lich: exec1 has exited.
```