### PR TITLE
[script][common] Add handling for IP from frostcrones

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -157,14 +157,14 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You don't seem to be able to move to do that/
-        room = Room.current.id
+      when /^You don't seem to be able to move to do that/ # Ice Patch immobilization
+        room = Room.current.id # To preserve hunting room if/when you slide out (frostcrones)
         next
-      when /^After failing to draw a breath for what feels like forever/
+      when /^After failing to draw a breath for what feels like forever/ # Coming out of Ice Patch immobilization
         fix_standing
         waitrt?
-        fput('stow feet')
-        wait_for_script_to_complete('go2', [room])
+        fput('stow feet') # stow any thrown weapons or ammo before moving
+        wait_for_script_to_complete('go2', [room]) # return to room you slid out of (frostcrones)
         put message
         timer = Time.now
         next

--- a/common.lic
+++ b/common.lic
@@ -178,7 +178,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/, /^You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/
+      when /^You must be standing/, /^You should stand up first/, /^You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/, /^After failing to draw a breath for what feels like forever/
         fix_standing
         waitrt?
         put message

--- a/common.lic
+++ b/common.lic
@@ -158,7 +158,7 @@ module DRC
         timer = Time.now
         next
       when /^You don't seem to be able to move to do that/ # Immobilization
-        next
+        next unless matches.include?(response) # If the source has a response for this match, we pass it back, otherwise, we wait for one of the phrases listed below
       when /^You can't do that while you are asleep./
         put 'wake'
         put message

--- a/common.lic
+++ b/common.lic
@@ -157,6 +157,17 @@ module DRC
         put message
         timer = Time.now
         next
+      when /^You don't seem to be able to move to do that/
+        room = Room.current.id
+        next
+      when /^After failing to draw a breath for what feels like forever/
+        fix_standing
+        waitrt?
+        fput('stow feet')
+        wait_for_script_to_complete('go2', [room])
+        put message
+        timer = Time.now
+        next
       when /^You can't do that while you are asleep./
         put 'wake'
         put message
@@ -178,7 +189,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/, /^You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/, /^After failing to draw a breath for what feels like forever/
+      when /^You must be standing/, /^You should stand up first/, /^You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/
         fix_standing
         waitrt?
         put message

--- a/common.lic
+++ b/common.lic
@@ -116,6 +116,7 @@ module DRC
     options = (matches.shift if matches.first.is_a?(Hash)) || {}
     options['timeout'] ||= 15
     options['ignore_rt'] ||= false
+    immobility = ["Soul Sickness", "Halt", "Ice Patch"]
 
     timeout = options['timeout']
     ignore_rt = options['ignore_rt']
@@ -132,6 +133,9 @@ module DRC
     matches.flatten!
     matches.map! { |item| item.is_a?(Regexp) ? item : /#{item}/i }
     clear
+    while immobility.any? { |spell| DRSpells.active_spells[spell] }
+      pause 1
+    end
     put message
     timer = Time.now
     while (response = get?) || (Time.now - timer < timeout)
@@ -158,7 +162,7 @@ module DRC
         timer = Time.now
         next
       when /^You don't seem to be able to move to do that/ # Immobilization
-        next unless matches.include?(response) # If the source has a response for this match, we pass it back, otherwise, we wait for one of the phrases listed below
+        next unless matches.include?(response)
       when /^You can't do that while you are asleep./
         put 'wake'
         put message

--- a/common.lic
+++ b/common.lic
@@ -157,16 +157,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You don't seem to be able to move to do that/ # Ice Patch immobilization
-        room = Room.current.id # To preserve hunting room if/when you slide out (frostcrones)
-        next
-      when /^After failing to draw a breath for what feels like forever/ # Coming out of Ice Patch immobilization
-        fix_standing
-        waitrt?
-        fput('stow feet') # stow any thrown weapons or ammo before moving
-        wait_for_script_to_complete('go2', [room]) # return to room you slid out of (frostcrones)
-        put message
-        timer = Time.now
+      when /^You don't seem to be able to move to do that/ # Immobilization
         next
       when /^You can't do that while you are asleep./
         put 'wake'
@@ -189,7 +180,7 @@ module DRC
         put message
         timer = Time.now
         next
-      when /^You must be standing/, /^You should stand up first/, /^You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/
+      when /^You must be standing/, /^You should stand up first/, /^You'll need to stand up first/, /^You can't do that while (sitting|kneeling|lying)/, /^You should be sitting up/, /^You really should be standing to play/, /^The mass of feeding vines retract from the dirt/, /^You finally manage to clear away enough rubble/, /^After failing to draw a breath for what feels like forever/
         fix_standing
         waitrt?
         put message


### PR DESCRIPTION
So frostcrones cast IP, a dastardly spell that wreaks havoc with combat-trainer, hucking you onto your back, immobilizing you temporarily, then quickly sliding you out of the room. Great fun for them, not so much for you. I hesitate to work in a return to current room for one critter, but the hang-ups are solved by adding this handy little message in bput's case statement. The message added is what you invariably get once the immobilization effect wears off, allowing us to quickly stand up and re-send the last command.

BEFORE:
```
[combat-trainer]>get my throwing hammer

A shambling frostcrone gestures at you as her steely, sightless eyes fixate on you.
A sheet of slippery ice forms beneath you!
You slip and fall forward, slamming your face down on the ice.
The jolt to your spine knocks your breath right out of your lungs, leaving you gasping like a fish out of water!
You don't seem to be able to move to do that.
The churning rage inside of you continues unabated.
A shambling frostcrone gestures with stiffened limbs.
Ice crystals begin to form in the air.
Though chilling, you are able to withstand the frigid blast.
A shambling frostcrone chants a word of power.

* Moving in gracefully, a shambling frostcrone jabs a shimmering rime ice blade at you.  You fail to block with a round gladiator's shield with a razaksel boss.  The blade lands a light hit (1/23) to your right arm.
[Abandoned Farmhouse, Living Room]
Centered in the west wall, a wide fireplace displays a number of cracked hearthstones.  Several broken windows lined with glass fragments or boards limit the view outside.  The wreckage of furniture is scattered around the room, scraps of cloth and stuffing, splintered wood and iron nails littering the ground.  A single wooden chair sits facing the fireplace, entirely clean of dust and debris.  A narrow stairwell leads upstairs.  You also see a snowbeast and a snowbeast.
Obvious exits: south, west, up.
With a gleeful kick, the shambling frostcrone sends you skidding east on a sheet of ice!
[You're bruised, very badly balanced with opponent overwhelming you.]

Room Number: 16844

After failing to draw a breath for what feels like forever, you finally get air back into your lungs.
The snowbeast begins to advance on you!
The snowbeast advances from nearby and is closing steadily.
The snowbeast begins to advance on you!
The snowbeast advances from nearby and is closing steadily.
You notice the shambling frostcrone attempting to stealthily advance upon you!
The shambling frostcrone advances from nearby and is closing steadily.

Gained: Perception(+1)

You think you have your best shot possible now.
The snowbeast closes to melee range on you!
The snowbeast closes to melee range on you!
You notice a shambling frostcrone as it stealthily closes to melee range on you.
You point at a shambling frostcrone, ruining its attempt to advance unnoticed.

[combat-trainer: *** No match was found after 15 seconds, dumping info]
```
As you can see, the message comes pretty quickly, always within the 15 seconds, if only just on occasion. Any reports of STILL failing to find a match would indicate we need both messages, but as is:
```
[combat-trainer]>aim
You don't seem to be able to move to do that.
>
After failing to draw a breath for what feels like forever, you finally get air back into your lungs.
>
You notice a shambling frostcrone as it stealthily closes to melee range on you.
You point at a shambling frostcrone, ruining its attempt to advance unnoticed.
>
[combat-trainer]>stand
You stand back up.
>
[combat-trainer]>aim
You turn to face a shambling frostcrone.
You begin to target a shambling frostcrone.
```