### PR TITLE
[script][bescort] - Fix edge case for Ice Road collect rocks

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1067,9 +1067,12 @@ class Bescort
       move_fast = false if Flags['bescort-move-slow']
 
       unless move_fast
-        DRC.collect('rock')
-        DRC.kick_pile? # don't litter the ice road
-        waitrt?
+        fput('collect rock')
+        if waitrt?
+          DRC.kick_pile? # don't litter the ice road
+        else
+          pause 15
+        end
       end
     end
 


### PR DESCRIPTION
Fixes an edge case where we fail to collect rocks and thus move too quickly.

Prior behavior would not pause if we somehow failed to collect rocks. This could be because your hands were full, ~~or you were playing an instrument~~, etc. This change favors a brute-force `fput('collect rock')`, and then detecting whether we're in RT. If so, we're collecting and we kick the pile and move on. If not, it pauses 15 (the same duration as a collect), so that we don't move quickly and get injured.