### PR TITLE
[script][first-aid] - Allow training granularity for FA/Scholarship/Both

### DIFF
--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -218,6 +218,20 @@ bescort_hide:
   specific_descriptions:
     bescort: Hides while on ferries.
 
+bleed_bot:
+  description: The name of a character you're using as a first aid trainer bleed bottom.
+  example: Gildaren
+  referenced_by:
+    - first-aid
+  specific_descriptions:
+
+bleed_bot_room:
+  description: The room number where your bleed bot character lives.
+  example: 1234
+  referenced_by:
+    - first-aid
+  specific_descriptions:
+
 boggle_cash_on_hand:
   description: The amount of cash to withdraw for boggle Blast.
   example: 50 platinum
@@ -302,6 +316,14 @@ combat_training_abilities_target:
     - combat-trainer
   specific_descriptions:
     combat-trainer:
+
+compendium_type:
+  description: Specify the exact noun of your compendium.
+  example: compendium
+  referenced_by:
+    - first-aid
+  specific_descriptions:
+    first-aid:
 
 crafting_container:
   description: Noun for base container for storing crafting related items.
@@ -509,6 +531,14 @@ favor_god:
   specific_descriptions:
     checkfavors:
 
+firstaid_scholarship_modifier:
+  description: Allows manually defining the Effective Scholarship Modifier scale.
+  example: 'https://github.com/rpherbig/dr-scripts/wiki/First-Aid-Strategy#advanced-options '
+  referenced_by:
+    - first-aid
+  specific_descriptions:
+    first-aid: Adjusting the modifier to a smaller number would select higher ranked charts where a larger number would select lower ranked charts based on Elanthipedia Anatomy Chart data.
+
 flying_mount:
   description: Specify a flying mount.
   example: silk carpet
@@ -681,6 +711,14 @@ immortal_aspect:
   specific_descriptions:
     carve-bead:
 
+instrument:
+  description: Define an instrument to pick up before playing (if you're not using zills).
+  example: lute
+  referenced_by:
+    - first-aid
+  specific_descriptions:
+    first-aid: Used just as a Zills check. If you have this specified, first-aid won't try to pause playing.
+
 lootables:
   description: List of lootable items in base-items.yaml. Do not change. You can add lootables via loot_additions.
   example:
@@ -738,6 +776,13 @@ mark_crafted_goods:
 necro_redeemed:
   description:
 
+number_of_firstaid_charts:
+  description: Number of first aid charts to read.
+  example: 25
+  referenced_by:
+    - first-aid
+  specific_descriptions:
+
 outfitting_belt:
   description: Specify outfitting belt name and list of tools.
   example: https://github.com/rpherbig/dr-scripts/wiki/Crafting-Setup#tools (see Toolbelts section)
@@ -777,8 +822,10 @@ performance_pause:
   example: 3
   referenced_by:
     - athletics
+    - first-aid
   specific_descriptions:
     athletics: Adjust this higher if you are getting hangups starting performance in athletics.
+    first-aid: Adjust this higher if you are getting hangups starting performance in First Aid.
 
 priority_defense:
   description: Set a priority defense skill name to always use 100% of that defense when it's legal for your weapon.
@@ -883,6 +930,21 @@ telescope_storage:
     - astrology
   specific_descriptions:
     astrology: Gets and stores your telescope in this container.
+
+textbook:
+  description: Whether you're training with an actual textbook or instead a compendium or manual/guide.
+  example: true
+  referenced_by:
+    - first-aid
+  specific_descriptions:
+    first-aid: Set to true if using an actual textbook. Otherwise, false.
+
+textbook_type:
+  description: Specify the exact noun.
+  example: textbook
+  referenced_by:
+    - first-aid
+  specific_descriptions:
 
 thanatology:
   description: Necromancer setting for harvesting body parts.

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -219,7 +219,7 @@ bescort_hide:
     bescort: Hides while on ferries.
 
 bleed_bot:
-  description: The name of a character you're using as a first aid trainer bleed bottom.
+  description: The name of a character you're using as a first aid trainer bleed bot.
   example: Gildaren
   referenced_by:
     - first-aid

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -10,7 +10,7 @@ class FirstAid
   def initialize
     arg_definitions = [
       [
-        { name: 'skill_focus', regex: /first aid|scholarship|both/i, optional: true, description: 'Skill to focus on for training when studying charts. Defaults to first aid.' },
+        { name: 'skill_focus', regex: /first aid|scholarship|both/i, optional: true, description: 'Skill to focus on for training when studying charts (First Aid, Scholarship, Both). Defaults to First Aid.' },
         { name: 'script_summary', optional: true, description: 'Trains the First Aid skill by use of a bleed_bot (legacy) or reading compendiums or textbooks.' }
       ]
     ]

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -8,10 +8,23 @@ custom_require.call(%w[common common-travel drinfomon equipmanager])
 class FirstAid
 
   def initialize
+    arg_definitions = [
+      [
+        { name: 'skill_focus', regex: /first aid|scholarship|both/i, optional: true, description: 'Skill to focus on for training when studying charts. Defaults to first aid.' },
+        { name: 'script_summary', optional: true, description: 'Trains the First Aid skill by reading compendiums or textbooks.' }
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
+
+    @skill_focus = args.skill_focus || 'First Aid'
+
     @settings = get_settings
     @chart_data = get_data('anatomy-charts').first_aid_charts
     @performance_pause = @settings.performance_pause
     @num_charts = @settings.number_of_firstaid_charts
+
+    echo "Skill focus is: #{@skill_focus}"
 
     if @settings.bleed_bot
       DRCT.walk_to(@settings.bleed_bot_room)
@@ -70,7 +83,12 @@ class FirstAid
             DRC.bput("get my #{@booktype}", 'You get', 'You are already holding')
           end
           waitrt?
-          break if DRSkill.getxp('First Aid') >= 32
+
+          unless @skill_focus == 'both'
+            break if DRSkill.getxp("#{@skill_focus.split.map(&:capitalize).join(' ')}") >= 32
+          else
+            break if DRSkill.getxp('First Aid') >= 32 && DRSkill.getxp('Scholarship') >= 32
+          end
         end
       end
   end

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -10,8 +10,8 @@ class FirstAid
   def initialize
     arg_definitions = [
       [
-        { name: 'skill_focus', regex: /first aid|scholarship|both/i, optional: true, description: 'Skill to focus on for training when studying charts (First Aid, Scholarship, Both). Defaults to First Aid.' },
-        { name: 'script_summary', optional: true, description: 'Trains the First Aid skill by use of a bleed_bot (legacy) or reading compendiums or textbooks.' }
+        { name: 'skill_focus', regex: /scholarship|both/i, optional: true, description: 'Skill to focus on OTHER than first aid, which is the default. Specify "scholarship" or "both" to train otherwise.' },
+        { name: 'script_summary', optional: true, description: 'Trains the First Aid skill by reading compendiums or textbooks.' }
       ]
     ]
 
@@ -23,6 +23,8 @@ class FirstAid
     @chart_data = get_data('anatomy-charts').first_aid_charts
     @performance_pause = @settings.performance_pause
     @num_charts = @settings.number_of_firstaid_charts
+
+    echo "Skill focus is: #{@skill_focus}"
 
     if @settings.bleed_bot
       DRCT.walk_to(@settings.bleed_bot_room)

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -11,7 +11,7 @@ class FirstAid
     arg_definitions = [
       [
         { name: 'skill_focus', regex: /first aid|scholarship|both/i, optional: true, description: 'Skill to focus on for training when studying charts. Defaults to first aid.' },
-        { name: 'script_summary', optional: true, description: 'Trains the First Aid skill by reading compendiums or textbooks.' }
+        { name: 'script_summary', optional: true, description: 'Trains the First Aid skill by use of a bleed_bot (legacy) or reading compendiums or textbooks.' }
       ]
     ]
 

--- a/first-aid.lic
+++ b/first-aid.lic
@@ -24,8 +24,6 @@ class FirstAid
     @performance_pause = @settings.performance_pause
     @num_charts = @settings.number_of_firstaid_charts
 
-    echo "Skill focus is: #{@skill_focus}"
-
     if @settings.bleed_bot
       DRCT.walk_to(@settings.bleed_bot_room)
       start_script('tendother', [@settings.bleed_bot])


### PR DESCRIPTION
Adds args to allow you to focus on first aid, scholarship, or both. Also adds settings to base-help.yaml.

Defaults to checking `First Aid` skill if none is specified, to retain prior behavior.