### PR TITLE
[data][base-spells] Remove expire from certain ranger spells

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -2795,7 +2795,6 @@ spell_data:
     mana: 30
     recast: -1
     guild: Ranger
-    expire: Your green-shadowed reveries grow distant
     mana_type: life
     prep: prepare
   Wisdom of the Pack:
@@ -2804,7 +2803,6 @@ spell_data:
     mana: 15
     recast: 1
     guild: Ranger
-    expire: With a slight jolt, you suddenly feel disconnected from the pack.
     mana_type: life
     prep: prepare
   Wolf Scent:


### PR DESCRIPTION
So a number of spells in our lexicon do NOT show up on active spells list, some examples being Zephyr and Ethereal Fissure. In order for combat trainer to maintain these spells, it assigns a flag to that spell when cast at the start of combat, so that it knows when the spell falls (since it can't be tracked with active_spells). Flag sees expire, triggers recast. However, if a spell IS present when checking active_spells, CT can treat that spell like any other, periodic checks against active spells, recast #, etc. 

So far so great. What happens when a spell is on both lists? Spells like SK and WOTP, for example? 

What happens is that, regardless of whether you have that spell up, CT is going to start combat buffing by FIRST checking whether a spell has an expire message, and then FORCE a cast of that spell. This is functionally necessary for most of these spells, but for spells on your active_spells list, it will attempt to recast it even if it's up, even if it was cast as part of your prehunt_buffs, even if there is a version still running. This is why, for rangers, WOTP is almost always cast out the gate in CT, despite it being present on the active_spells list. 

This is a problem for two reasons:
1. Magic tert attunement is pretty awful, every wasted cast, esp a big buff, slows everything else down.
2. Buffing what's already buffed means NOT buffing something else, NOT casting TM, NOT casting debil.

Since both of the spells edited here are fetched via active_spells, there is zero reason to create the flag, thus zero reason to have expire messages defined in base-spells. 

I suspect Read the Ripples and Nexus are two other examples, but I don't have those spells, so I won't mess with them. Anything with an expire message doesn't need a recast, and vice versa, but it's possible these fields are handled differently for these specific spells in other scripts.