### PR TITLE
[script][appraisal] Fix app focus

### DIFF
--- a/appraisal.lic
+++ b/appraisal.lic
@@ -10,8 +10,8 @@ class Appraisal
     arg_definitions = [
       [
         { name: 'focus', regex: /focus/i, description: 'Perform appraise focus on an item.' },
-        { name: 'item', regex: /\w+/i, description: 'Item to use appraise focus with.' },
-        { name: 'wait', regex: /^wait/i, optional: true, description: 'Waits for research to complete before exiting'},
+        { name: 'item', regex: /\w+/i, description: 'Item to use appraise focus with, use double quotation marks for multi-word items(eg "warring axe").' },
+        { name: 'wait', regex: /^wait/i, optional: true, description: 'Waits for focus project to complete before exiting'},
         { name: 'script_summary', optional: true, description: 'Trains the Appraisal skill by appraising your gear, zills, bundles, gem pouches, and studying the art in the Crossing art gallery.'}
       ],
       [

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -44,8 +44,7 @@ class Appraisal
         echo 'You need at least 200 Appraisal to use Appraise Focus.'
         exit
       end
-
-      appraise_focus(args.item)
+      focus(args.item)
     else
       train_list.each do |task|
         break if DRSkill.getxp('Appraisal') >= 30
@@ -155,37 +154,20 @@ class Appraisal
 	pause 1
   end
 
-  def appraise_focus(item)
-    focus_concepts = ["defense", "arcane", "recall", "logic", "offense", "magic", "khri", "inner fire"]
-    if focus_concepts.include?(item)
-      focus_concept(item)
-    else
-      focus(item)
-    end
-  end
-
-  def focus_concept(item)
-    waitrt?
-    focus_check(item)
-    case DRC.bput("appraise focus #{item}", 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem', 'You will lose your progress')
-    when 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem'
-      return
-    else
-      focus_concept(item)
-    end
-    waitrt?
-    focus_check(item)
-  end
-
   def focus(item)
     waitrt?
     focus_check(item)
 
-    case DRC.bput("appraise focus my #{item}", 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem', 'You will lose your progress', 'You resume focusing')
+    case DRC.bput("appraise focus #{item}", 'You carefully', 'You are already', 'You currently feel', /You can't seem/, 'You will lose your progress', 'You resume focusing')
     when 'You will lose your progress'
       DRC.message("Another project already ongoing")
-    when 'You currently feel', 'You can\'t seem', 'You cant seem'
+    when 'You currently feel', /You can't seem/
       DRC.message("Too recently completed a project")
+    end
+    if @wait_for_research_to_complete
+      waitfor('Breakthrough')
+      echo "You have completed focusing on your #{item} and now have increased learning!"
+      exit
     end
   end
 
@@ -204,7 +186,6 @@ class Appraisal
     when 'You currently feel muddled'
       echo "You have too recently used appraisal focus for this subject"
     end
-
     exit
   end
 end

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -11,6 +11,7 @@ class Appraisal
       [
         { name: 'focus', regex: /focus/i, description: 'Perform appraise focus on an item.' },
         { name: 'item', regex: /\w+/i, description: 'Item to use appraise focus with.' },
+        { name: 'wait', regex: /^wait/i, optional: true, description: 'Waits for research to complete before exiting'},
         { name: 'script_summary', optional: true, description: 'Trains the Appraisal skill by appraising your gear, zills, bundles, gem pouches, and studying the art in the Crossing art gallery.'}
       ],
       [
@@ -24,6 +25,7 @@ class Appraisal
     @equipment_manager = EquipmentManager.new
     settings = get_settings
     train_list = settings.appraisal_training
+    @wait_for_research_to_complete = args.wait
 
     if args.nonspecific
       pouch_adjective = nil
@@ -155,47 +157,55 @@ class Appraisal
 
   def appraise_focus(item)
     focus_concepts = ["defense", "arcane", "recall", "logic", "offense", "magic", "khri", "inner fire"]
-    if focus_concepts.include?(item)
+    if focus_concepts.include?(/#{item}/i)
       focus_concept(item)
     else
-      case DRC.bput("get my #{item}", "^You get.*#{item}", '^What were you referring', 'But that is already', 'You are already')
-      when 'But that is already', '^What were you referring'
-        echo "Cannot get the #{item} you are trying to focus upon. Exiting..."
-        exit
-      end
       focus(item)
     end
-    waitrt?
-    case DRC.bput('appraise focus check', 'You are currently', 'You have completed')
-    when 'You are currently'
-      waitfor('Breakthrough')
-      echo "You have completed focusing on your #{item} and now have increased learning!"
-    when 'You have completed'
-      echo 'You already have an active appraise focus boost. Wait a while before trying again.'
-    end
-
-    exit
   end
 
   def focus_concept(item)
     waitrt?
+    focus_check(item)
     case DRC.bput("appraise focus #{item}", 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem', 'You will lose your progress')
     when 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem'
       return
     else
       focus_concept(item)
     end
+    waitrt?
+    focus_check(item)
   end
 
   def focus(item)
     waitrt?
+    focus_check(item)
 
-    case DRC.bput("appraise focus my #{item}", 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem', 'You will lose your progress')
-    when 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem'
-      DRC.bput("stow my #{item}", "You put .*#{item}", 'You easily strap', "You don't seem to be able to move", 'You secure', 'is too small to hold that', 'You hang')
-    else
-      focus(item)
+    case DRC.bput("appraise focus my #{item}", 'You carefully', 'You are already', 'You currently feel', 'You can\'t seem', 'You cant seem', 'You will lose your progress', 'You resume focusing')
+    when 'You will lose your progress'
+      DRC.message("Another project already ongoing")
+    when 'You currently feel', 'You can\'t seem', 'You cant seem'
+      DRC.message("Too recently completed a project")
     end
+  end
+
+  def focus_check(item)
+    case DRC.bput('appraise focus check', 'You are currently', 'You have completed', 'You currently feel', 'You feel ready')
+    when 'You are currently'
+      if @wait_for_research_to_complete
+        waitfor('Breakthrough')
+        echo "You have completed focusing on your #{item} and now have increased learning!"
+      end
+      exit
+    when 'You feel ready'
+      return
+    when 'You have completed'
+      echo 'You already have an active appraise focus boost. Wait a while before trying again.'
+    when 'You currently feel muddled'
+      echo "You have too recently used appraisal focus for this subject"
+    end
+
+    exit
   end
 end
 

--- a/appraisal.lic
+++ b/appraisal.lic
@@ -157,7 +157,7 @@ class Appraisal
 
   def appraise_focus(item)
     focus_concepts = ["defense", "arcane", "recall", "logic", "offense", "magic", "khri", "inner fire"]
-    if focus_concepts.include?(/#{item}/i)
+    if focus_concepts.include?(item)
       focus_concept(item)
     else
       focus(item)


### PR DESCRIPTION
Couple changes.
1. add wait arg, since research is interrupted by any number of actions, no point doing focus without waiting, but if you have a followup sequence that doesn't affect, or accounts for, research (athletics?) you can opt in or out of the waiting.
2. Reworked focus:
  - Doesn't fetch the item, since that's unnecessary
  - Added a check for current research/research unavailable at the top of each focus section.
  - Moved the checks into it's own method.

Currently using this in conjunction with a modified version of athletics, but works as a standalone if managed properly, or if wait arg is used.