### PR TITLE
[script][athletics] Add skip arg, send hib hometown to shard

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -28,11 +28,15 @@ class Athletics
         { name: 'xalas', regex: /^xala.*/i, optional: true, description: 'Climb xalas in zoluren in instead of undergondola' },
         { name: 'stationary', regex: /^stat.*/i, optional: true, description: 'Stand still and use a climbing rope' },
         { name: 'cliffs', regex: /^cliff.*/i, optional: true, description: 'Climb undergondola without attempting branch' },
+        { name: 'skip', regex: /^skip/i, optional: true, description: 'Skip outdoorsmanship wait loop, pick your nose instead.'},
         { name: 'max', regex: /^max/i, optional: true, description: 'Keep training until 32/34+' }
       ]
     ]
 
     args = parse_args(arg_definitions)
+    @skip = args.skip
+    Flags.add('research-done', 'Breakthrough', 'you forget what you were researching')
+
 
     @end_exp = 32 if args.max
     start_script('skill-recorder') unless Script.running?('skill-recorder')
@@ -57,15 +61,25 @@ class Athletics
     elsif @settings.hometown == 'Shard'
       shard_athletics
     elsif @settings.hometown == 'Hibarnhvidar'
-      hib_athletics
+      shard_athletics
     elsif @settings.hometown == 'Ratha'
       ratha_athletics
+    end
+    if @skip && !Flags['research-done']
+      if /You are currently/i =~ DRC.bput('appraise focus check', 'You are currently', 'You have completed', 'You currently feel', 'You feel ready')
+        waitfor('Breakthrough')
+      end
     end
 
     stow_athletics_items
   end
 
   def outdoorsmanship_waiting(n)
+    if @skip
+      DRC.message("Picking thy nose for about a minute")
+      pause 62
+      return
+    end
     start = Time.now
     DRCT.walk_to(@outdoorsmanship_rooms.sample) unless @outdoorsmanship_rooms.empty?
     stow_athletics_items


### PR DESCRIPTION
Adds skip arg to athletics to allow for focus appraisal in t2. Could plausibly work that into alternative routines (lockpicking?)
Lets hib hometown use shard's superior athletics training options. The river is just a bad/dangerous way to train athletics, #changemymind

NOT choosing skip doesn't affect default behavior, so this is just an added feature geared towards appraisal focus.