### PR TITLE
[script][buff] Add charge arg

### DIFF
--- a/buff.lic
+++ b/buff.lic
@@ -20,9 +20,9 @@ class Waggle
 
     setname = args.spells || 'default'
 
-    unless settings.waggle_sets[setname] || args.charge
+    unless settings.waggle_sets[setname]
       DRC.message("No waggle set found for name: #{setname}")
-      exit
+      exit unless args.charge
     end
 
     if args.force

--- a/buff.lic
+++ b/buff.lic
@@ -9,6 +9,7 @@ class Waggle
   def initialize
     arg_definitions = [
       [
+        { name: 'charge', regex: /charge/i, optional: true, description: 'Max out your elemental charge by summoning admittances' },
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
         { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' }
       ]
@@ -19,7 +20,7 @@ class Waggle
 
     setname = args.spells || 'default'
 
-    unless settings.waggle_sets[setname]
+    unless settings.waggle_sets[setname] || args.charge
       DRC.message("No waggle set found for name: #{setname}")
       exit
     end
@@ -31,6 +32,14 @@ class Waggle
     end
 
     DRCA.do_buffs(settings, setname)
+
+    if DRStats.warrior_mage? && (args.charge || settings.buff_max_elemental_charge)
+      unless /You have reached the limits/i =~ DRC.bput("Pathway sense", /^You have reached the limits/, /^Your body is aligned with the Elemental Plane/)
+        while /bigger charge/i =~ DRC.bput("summon admittance", /bigger charge/, /reached your limit/)
+        waitrt?
+        end
+      end
+    end
   end
 end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -409,6 +409,8 @@ combat_spell_timer: 45
 offensive_spell_mana_threshold: 40
 training_spell_mana_threshold: 50
 buff_spell_mana_threshold: 40
+# Optional elemental charge-up to max for warrior mages with buff script
+buff_max_elemental_charge: false
 # release any cyclic on low mana
 release_cyclic_on_low_mana: false
 # release any cyclic when below this mana threshold


### PR DESCRIPTION
Adds optional 'charge' arg to buff for warrior mages who use elemental weapons. This can be triggered via the argument, or a yaml setting:
```yaml
buff_max_elemental_charge: true
```
Allows standalone max of your charge with ;buff charge only(or really any word that isn't a waggle_set), complementary chargeup AFTER buffing with ;buff charge, or ;buff <waggle_set> charge. Finally, if the yaml is set, tacks on a max chargeup at the end of any use of buff script.