### PR TITLE
[script][common-items] - Support counting multiple use items

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -507,6 +507,7 @@ module DRCI
       /and see there (?:is|are) (.+) left\./,
       /There (?:is|are) (?:only )?(.+) parts? left/,
       /There's (?:only )?(.+) parts? left/,
+      /The (?:.+) has (.+) uses remaining./,
       /There are enough left to create (.+) more/
     ]
     count = 0
@@ -522,7 +523,12 @@ module DRCI
         count = count_items(item)
         break
       when *match_messages
-        count += DRC.text2num(Regexp.last_match(1).tr('-', ' '))
+        countval = Regexp.last_match(1).tr('-', '')
+        if countval.match? /\A\d+\z/
+          count += Integer(countval)
+        else
+          count += DRC.text2num(countval)
+        end
       end
       waitrt?
     end


### PR DESCRIPTION
Fix for case of counting holy oil or other things that have multiple uses, and include ability to handle numeric responses rather than textual representation of numbers.

Example:
> count my oil
The oil has 50 uses remaining.