### PR TITLE
[script][athletics] Add wait condition for using app focus with athletics

### DIFF
--- a/athletics.lic
+++ b/athletics.lic
@@ -61,6 +61,13 @@ class Athletics
     elsif @settings.hometown == 'Ratha'
       ratha_athletics
     end
+    if /You are currently/i =~ DRC.bput('appraise focus check', 'You are currently', 'You have completed', 'You currently feel', 'You feel ready')
+      until Flags['research-done']
+        stow_athletics_items
+        @settings.held_athletics_items = []
+        outdoorsmanship_waiting(4)
+      end
+    end
 
     stow_athletics_items
   end


### PR DESCRIPTION
Resubmitting this as a stand-alone edit that handles changes to appraisal focus in https://github.com/rpherbig/dr-scripts/pull/6119.

At the end of athletics, if you have a focus project going, it loops outdoorsmanship until the research is complete. If not, it ends normally.