### PR TITLE
[script][go2] - Store Start Room

### DIFF
--- a/go2.lic
+++ b/go2.lic
@@ -450,6 +450,7 @@ for var in script.vars[1..-1]
       target_search_array.push(var)
    end
 end
+
 target_search_string = target_search_array.join(' ')
 
 #
@@ -538,6 +539,17 @@ end
 unless start_room = Room.current
    echo 'error: your current room was not found in the map database'
    exit
+end
+
+if target_search_string =~ /goback/i
+  last_start_room = UserVars.go2_start_room.to_s
+  if last_start_room
+    target_search_string = last_start_room
+    echo "Attempting to return to last start room of: #{last_start_room}"
+  else
+    echo "go2 does not have a stored start room from the last time it ran."
+    exit
+  end
 end
 
 #

--- a/go2.lic
+++ b/go2.lic
@@ -9,12 +9,14 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.33
+           version: 1.34
           required: Lich >= 4.6.14
 
    changelog:
+      1.34 (2022-11-26)
+        Add support to "goback" to the room go2 last started in.
       1.33 (2022-04-20):
-        Support overriding `timeto` for yaml-based map stringproc overrides
+        Support for yaml-based map timeto and stringproc overrides
         Only overrides `wayto` and/or `timeto` if that option specified in yaml
       1.32 (2022-03-22):
         For DR: add support for yaml-based map stringproc overrides
@@ -103,6 +105,7 @@ CharSettings['stop for dead']    = false if CharSettings['stop for dead'].nil?
 show_help = proc {
    output = "\n"
    output.concat "   #{$clean_lich_char}#{script.name} <target>                Takes you where you want to go using your saved options.\n"
+   output.concat "   #{$clean_lich_char}#{script.name} goback                  Takes you back to the room your last #{script.name} started in.\n"
    output.concat "   #{$clean_lich_char}#{script.name} <options> <target>      Takes you where you want to go, using the given options\n"
    output.concat "   #{''.rjust($clean_lich_char.length + script.name.length)}                          instead of your saved options.\n"
    output.concat "   #{$clean_lich_char}#{script.name} <options>               Saves the given options.\n"

--- a/go2.lic
+++ b/go2.lic
@@ -1001,6 +1001,9 @@ error_count  = 0
 $go2_restart = false
 first_move   = true
 
+# Store start room for future use
+UserVars.go2_start_room = start_room.id
+
 loop {
 
    moves_sent = $room_count


### PR DESCRIPTION
This is a really simple change. It stores the start room that you're in when calling `;go2 <target>` in a UserVar for future use. ~~I have a simple companion script called `;goback` that takes you back to the room you started in. Sometimes I'll need to head to a place and then go back right from whence I came. It's just kind of a little QOL script thing.~~

Now implements a `goback` feature within `;go2` itself.