### PR TITLE
Create script goback

### DIFF
--- a/goback.lic
+++ b/goback.lic
@@ -1,0 +1,37 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#goback
+=end
+
+custom_require.call %w[common]
+
+class GoBack
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'script_summary', optional: true, description: 'Returns you to the start room of the last go2 call. Relies on go2_start_room UserVar being set by go2.' }
+      ]
+    ]
+
+    args = parse_args(arg_definitions)
+
+    return_room = UserVars.go2_start_room
+    goback_to(return_room) if valid_return_room?(return_room)
+  end
+
+  def goback_to(return_room)
+    DRC.message("Returning to ;go2's last origin room: #{return_room}")
+    pause 1
+    DRC.wait_for_script_to_complete("go2", ["#{return_room}"])
+  end
+
+  def valid_return_room?(return_room)
+    if return_room.nil?
+      DRC.message("Unable to find a room to return to. The go2_start_room UserVar may have been deleted.")
+      return false
+      exit
+    end
+    true
+  end
+end
+
+GoBack.new


### PR DESCRIPTION
Simple script to return you to the room you started ;go2 in. Relies on #6127 , which stores the start room of go2 in a UserVar.

```
>;goback
--- Lich: goback active.
Returning to ;go2's last origin room: 9517
--- Lich: go2 active.
--- Lich: 'textsubs' has been stopped by go2.
[go2: ETA: 0:00:13 (70 rooms to move through)]
```