### PR TITLE
[script][trigger-watcher] - Add no_use_scripts

### DIFF
--- a/trigger-watcher.lic
+++ b/trigger-watcher.lic
@@ -282,22 +282,46 @@ pull_trigger_data
 until script.gets.nil?
   @trigger_data.each do | name, values |
     if Flags[name.to_s] && values['responses']  # If no trigger responses, don't bother processing trigger
-      scripts = values['use_with_scripts']
-      echo "USE WITH SCRIPTS: #{scripts}" if $debug_mode_tw
+      use_with_scripts = values['use_with_scripts'].collect(&:strip).reject(&:empty?)
+      echo "USE WITH SCRIPTS: #{use_with_scripts}" if $debug_mode_tw
+
+      no_use_scripts = values['no_use_scripts'].collect(&:strip).reject(&:empty?)
+      echo "NO USE SCRIPTS: #{no_use_scripts}" if $debug_mode_tw
+
+      use_with_scripts_continue = false
+      no_use_scripts_continue = true
 
       # If user has specified that this trigger should only run when certain scripts are running
-      unless values['use_with_scripts'].nil?
-        process_trigger = false
-        scripts.each do |script|
-          echo "checking if script is running: #{script}" if $debug_mode_tw
+      unless use_with_scripts.nil? || use_with_scripts.empty?
+        use_with_scripts.each do |script|
+          echo "checking if scripts are running for use_with_scripts: #{script}" if $debug_mode_tw
           if Script.running?("#{script}")
-            echo "We found #{script} running" if $debug_mode_tw
-            process_trigger = true
+            echo "We found #{script} running for use_with_scripts" if $debug_mode_tw
+            use_with_scripts_continue = true
           end
         end
       else
-        process_trigger = true
+        use_with_scripts_continue = true
       end
+
+      echo "use_with_scripts_continue: #{use_with_scripts_continue}" if $debug_mode_tw
+
+      # Check to see if any no_use_scripts are running
+      unless no_use_scripts.nil? || no_use_scripts.empty?
+        no_use_scripts.each do |script|
+          echo "checking if scripts are running for no_use_scripts: #{script}" if $debug_mode_tw
+          if Script.running?("#{script}")
+            echo "We found #{script} running for no_use_scripts" if $debug_mode_tw
+            no_use_scripts_continue = false
+          end
+        end
+      end
+
+      echo "no_use_scripts_continue: #{no_use_scripts_continue}" if $debug_mode_tw
+
+      # Final process trigger check
+      process_trigger = use_with_scripts_continue && no_use_scripts_continue
+      echo "process_trigger final is: #{process_trigger}" if $debug_mode_tw
 
       if process_trigger
         DRC.message("  PROCESSING TRIGGER NAMED: #{name.to_s}") if $debug_mode_tw


### PR DESCRIPTION
Adds a `no_use_scripts` section. Trigger responses will not fire if any of the scripts in `no_use_scripts` are running. If the user mistakenly has a script in both `use_with_scripts` and `no_use_scripts`, favors `no_use_scripts` for safety.


Example:
```yaml
lich_triggers:
  regex_sub_test:
    triggers:
      - You are (.*) years old
    use_with_scripts:
    no_use_scripts:
      - burgle
    responses:
      - =execw {go2 9517}
```