### PR TITLE
[scripts][tarantula] Fix bad anchoring of regex.

### DIFF
--- a/tarantula.lic
+++ b/tarantula.lic
@@ -83,11 +83,11 @@ class Tarantula
     if skill =~ /(Lunar|Holy|Elemental|Life|Arcane|Inner) (Magic|Fire)/i
       skill = 'Magic'
     end
-    case DRC.bput("turn my #{@tarantula_noun} to #{skill}", /your changes snap into place/, /^You need to vary which skillset/, /^You should stop practicing your Athletics/, /^You don't seem to be able to move to do that/, /^You need to concentrate on your climbing, not that/)
+    case DRC.bput("turn my #{@tarantula_noun} to #{skill}", /your changes snap into place/, /^\[You need to vary which skillset/, /^You should stop practicing your Athletics/, /^You don't seem to be able to move to do that/, /^You need to concentrate on your climbing, not that/)
     when /your changes snap into place/
       DRC.message("*** Tarantula will now consume #{name} knowledge ***") if @debug
       return true
-    when /^You need to vary which skillset/
+    when /^\[You need to vary which skillset/
       DRC.message("*** Error, wrong skillset chosen. ***") if @debug
       check_last
       use_tarantula
@@ -120,7 +120,7 @@ class Tarantula
     end
     field = DRSkill.getxp(skill)
 
-    case DRC.bput("rub my #{@tarantula_noun}", /The .* comes alive in your hand/, /(\d+) roisae?n to generate enough venom/, /But you currently aren.t learning any/, /You need to vary which skillset/, /You should stop practicing your Athletics/)
+    case DRC.bput("rub my #{@tarantula_noun}", /The .* comes alive in your hand/, /(\d+) roisae?n to generate enough venom/, /But you currently aren.t learning any/, /^\[You need to vary which skillset/, /You should stop practicing your Athletics/)
     when /The .* comes alive in your hand/
       DRC.log_window("Tarantula successfully sacrificed #{field}/34 of #{skill} at #{Time.now.strftime("%T on %m/%d/%Y")}", "atmospherics")
       UserVars.tarantula_last_use = Time.now


### PR DESCRIPTION
In adding the anchoring, I missed that there was a `[` as the first character.

The actual line is 
```
[You need to vary which skillset you select with every use.  Magic was your last used skillset.]
```