### PR TITLE
Add T2 Settings to Help

### DIFF
--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -493,6 +493,16 @@ engineering_room:
     bolts: Bolt making done here.
     clean-leather: Bone preserving done here.
 
+exp_timers:
+  description: Map of skill timers / cooldowns.
+  example: Map where keys are full skill names and values are timers in seconds.
+  referenced_by:
+    - t2
+    - crossing-training
+  specific_descriptions:
+    t2: Timers are used internally as cooldowns before executing skills / skill groups. See also https://github.com/rpherbig/dr-scripts/wiki/T2-Tutorial
+    crossing-training: Timers are used internally as cooldowns before working skills.
+
 favor_goal:
   description: Number of favors to shoot for.
   example: 30
@@ -868,6 +878,14 @@ symbiosis_setting:
   specific_descriptions:
     symbiosis: The symbiosis script will set the symboisis desired for spell casting.
 
+t2_avoids:
+  description: T2 training avoids list.
+  example: https://github.com/rpherbig/dr-scripts/wiki/T2-Tutorial
+  referenced_by:
+    - t2
+  specific_descriptions:
+    t2: Sets avoids once before running with avoid !<string>
+
 telescope_name:
   description: Noun of your telescope.
   example: telescope
@@ -939,6 +957,14 @@ theurgy_supply_container:
     - carve-bead
   specific_descriptions:
     carve-bead: Holds your bead carving materials.
+
+training_list:
+  description: Defines T2 skills to train and their options (other settings).
+  example: https://github.com/rpherbig/dr-scripts/wiki/T2-Tutorial
+  referenced_by:
+    - t2
+  specific_descriptions:
+    t2: The training_list settings is the main setting for T2. See training_list example link.
 
 waggle_force_cambrinth:
   description: Forces cambrinth use for waggle.


### PR DESCRIPTION
Added following settings to data/base-help.yaml:

- training_list
- t2_avoids
- exp_timers (also used by crossing-training)

Also revamped T2 wiki page referenced in training_list and t2_avoids - https://github.com/rpherbig/dr-scripts/wiki/T2-Tutorial.