### PR TITLE
[scripts][tarantula] Unpause unless we get expected results

### DIFF
--- a/tarantula.lic
+++ b/tarantula.lic
@@ -92,7 +92,7 @@ class Tarantula
       check_last
       use_tarantula
       return false
-    when /You should stop practicing your Athletics/, /You don't seem to be able to move to do that/
+    else
       DRC.safe_unpause_list(@scripts_to_unpause)
       return false
     end


### PR DESCRIPTION
```
[tarantula]>turn my harvester spider to Brawling

[tarantula: *** No match was found after 15 seconds, dumping info]

[tarantula: messages seen length: 0]

[tarantula: checked against [/your changes snap into place/, /^\[You need to vary which skillset/, /^You should stop practicing your Athletics/, /^You don't seem to be able to move to do that/, /^You need to concentrate on your climbing, not that/]]

[tarantula: for command turn my harvester spider to Brawling]
```

Unknown why, but the command never returned any output, which in turn meant the case never exited cleanly, so... we didn't unpause. This ensures that unless we get expected results, we unpause, and return false.