### PR TITLE
[scripts][jail-buddy] Revert to simple pauses without mutex

### DIFF
--- a/jail-buddy.lic
+++ b/jail-buddy.lic
@@ -61,10 +61,8 @@ def determine_province
 end
 
 def get_out_of_jail(old_loc)
-  until @scripts_to_unpause = DRC.safe_pause_list
-    echo("Cannot pause, trying again in 5 seconds.")
-    pause 5
-  end
+  pause 1 until DRC.pause_all
+
   stop_script('go2') if Script.running?('go2')
   echo('** DON\'T PANIC JAIL BUDDY HAS YOUR BACK! **')
 
@@ -95,7 +93,7 @@ def get_out_of_jail(old_loc)
 
   DRC.wait_for_script_to_complete('go2', [old_loc.to_s], force: true) if old_loc
 
-  DRC.safe_unpause_list(@scripts_to_unpause)
+  DRC.unpause_all
 end
 
 loop do


### PR DESCRIPTION
My dude was just arrested... on his way to go burgle. Burgle holds the mutex, jail-buddy couldn't pause.

This script should pause stuff without regard for the mutex.