### PR TITLE
[script][common-crafting] Stow when repair aborted

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -292,9 +292,13 @@ module DRCC
             next #oil done, next tool
         when 'You cannot do that while engaged!'
           DRC.message("Cannot repair in combat")
+          DRCC.stow_crafting_item(tool_name, bag, belt)
+          DRCC.stow_crafting_item(x, bag, belt)
           return
         when 'cannot figure out how'
           DRC.message("Something has gone wrong, exiting repair")
+          DRCC.stow_crafting_item(tool_name, bag, belt)
+          DRCC.stow_crafting_item(x, bag, belt)
           return
         end
       end


### PR DESCRIPTION
Noticed today that if repair is aborted, method doesn't stow your tool or brush. This edit sorts that.