### PR TITLE
[scripts][almanac] Open almanac if it's closed

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -69,8 +69,12 @@ class Almanac
       DRC.bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
     end
 
-    DRC.bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what', 'interrupt your research', 'The pages of the .* seem worn')
-    waitrt?
+    case DRC.bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what', 'interrupt your research', 'The pages of the .* seem worn', /STUDY its contents\./)
+    when /STUDY its contents\./
+      DRC.bput("open my #{@almanac}", /^You open/)
+      DRC.bput("study my #{@almanac}", 'You set about', 'gleaned all the insight you can', 'Study what', 'interrupt your research', 'The pages of the .* seem worn')
+    end
+      waitrt?
 
     DRCI.put_away_item?(@almanac)
 


### PR DESCRIPTION
The issue:
```
[almanac: Pausing ["sanowret-crystal", "play", "tarantula"] to run almanac]
[almanac]>study my almanac
You believe you would learn something significant about a random lore skill if you were to OPEN the silkcress-bound almanac and STUDY its contents.
[almanac: *** No match was found after 15 seconds, dumping info]
[almanac: messages seen length: 12]
[almanac: message: You believe you would learn something significant about a random lore skill if you were to OPEN the silkcress-bound almanac and STUDY its contents.]
[almanac: checked against [/You set about/i, /gleaned all the insight you can/i, /Study what/i, /interrupt your research/i, /The pages of the .* seem worn/i]]
[almanac: for command study my almanac]
[almanac]>stow my almanac
You put your almanac in your traveler's pack.
[almanac: Unpausing ["sanowret-crystal", "play", "tarantula"], almanac has finished.]
```

The solution:
```
[almanac: Pausing [] to run almanac]
[almanac]>get my almanac 
You get an opulent Taisidon silkcress-bound almanac with diacan edged pages from inside your traveler's pack.
[almanac]>study my almanac
You believe you would learn something significant about a random lore skill if you were to OPEN the silkcress-bound almanac and STUDY its contents.
You've gleaned all the insight you can from the silkcress-bound almanac, for now.
[almanac]>open my almanac
You open the silkcress-bound almanac.
[almanac]>study my almanac
You've gleaned all the insight you can from the silkcress-bound almanac, for now.
[almanac]>stow my almanac
You put your almanac in your traveler's pack.
[almanac: Unpausing [], almanac has finished.]
```