### PR TITLE
Ratha revival

### DIFF
--- a/data/base-athletics.yaml
+++ b/data/base-athletics.yaml
@@ -185,14 +185,70 @@ practice_options:
 ##########  QI'RESHALIA   ##########
 ##########                ##########
 ####################################
-  ratha_rock_gorge:
+  ratha_rock_gorge:  #45
       id: 5287
+      hide: true    
       target: rock gorge
-      hide: true
-  ratha_deep_crack:
+
+  ratha_vines: #100
+      id: 4954
+      hide: false    
+      target: thick vines
+
+  ratha_lattice: #110
+      id: 4804
+      hide: false    
+      target: ivy-covered lattice
+
+  ratha_ladderone: #155
+      id: 5087
+      hide: false    
+      target: rope ladder
+
+  ratha_laddertwo: #165
+      id: 5013
+      hide: false    
+      target: rope ladder
+
+  ratha_overhangone: #245
+      id: 4986
+      hide: false    
+      target: rocky overhang
+
+  ratha_deep_crack: #180
       id: 5143
-      target: deep crack
-      hide: true
+      hide: true    
+      target: deep crack  
+
+  ratha_overhangtwo: #255
+      id: 4858
+      hide: false    
+      target: rocky overhang
+
+  ratha_tunnelone: #295
+      id: 5072
+      hide: false    
+      target: steep tunnel in door
+
+  ratha_tunneltwo: #310 
+      id: 4794
+      hide: false    
+      target: steep tunnel
+
+  ratha_hedge: #600
+      id: 5060
+      hide: false    
+      target: maintained hedges
+
+  ratha_cliff: #615
+      id: 4603
+      hide: false    
+      target: cliff face
+
+  ratha_cobra_rope:  #1100 - must run through gale and hurricane drakes to get here
+      id: 16943
+      hide: false    
+      target: steelsilk rope
 
 
 ####################################

--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -366,10 +366,57 @@ Ratha:
   gather_sirese:
     id: 5196
   plant_sirese:
+    id: 4947
+  bath:
+    id:  7489
+    path_in: 
+      - go pool
+    path_out:
+      - climb edge
+  altar:
+    id: 7489
+  dirt_foraging:
+    id: 4947
+  holy_water:
+    id: 5006
+    noun: basin    
   favor_altars:
+    #more available outside town but these are safest
+    Asketi:
+      id: 13005
+      adjective: simple   
     Berengaria:
-      id: 7151
-      adjective: altar
+      id: 13004
+      adjective: alabaster
+    Chadatru:
+      id: 17045
+      adjective: white
+    Damaris:
+      id: 17043
+      adjective: #none
+    # Drogor: noun is shrine not altar
+    Eluned:
+      id: 7489
+      adjective: turquoise
+    Everild:
+      id: 17048
+      adjective: stone
+    Glythtide:
+      id: 4943
+      adjective: oak
+    # Hav'roth: noun is shrine not altar
+    Hodierna:
+      id: 4737
+      adjective: marble
+    Kertigen:
+      id: 7469
+      adjective: chrysocolla
+    Phelim:
+      id: 5015
+      adjective: marble
+    Urrem'tier:
+      id: 11101
+      adjective: dark
       
 Shard:
   herbs:

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -962,6 +962,8 @@ Hvaral:
     id: 3751
 Ratha:
   currency: lirums
+  vault:
+    id: 14433  
   leather_repair: &raven
     id: 10752
     name: Raven

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -962,14 +962,10 @@ Hvaral:
     id: 3751
 Ratha:
   currency: lirums
-  vault:
-    id: 14433
-  leather_repair:
+  leather_repair: &raven
     id: 10752
     name: Raven
-  metal_repair:
-    id: 10743
-    name: Krrikt'k
+  metal_repair: *raven
   deposit:
     id: 7207
   exchange:
@@ -994,6 +990,8 @@ Ratha:
     id: 13577
   theurgy_supplies:
     id: 13108
+  favor_altar:
+    id: 4737    
   attunement_rooms:
     - 4690
     - 4651
@@ -1031,6 +1029,8 @@ Ratha:
   stamina:
     outer_room: 12688
     inner_room:
+  almsbox:
+    id: 12961      
   guild_leaders:
     Barbarian:
       name: Anhh'shre
@@ -1043,13 +1043,13 @@ Ratha:
       id: 12700
     Empath: #rotates between aesry and ratha
       name: Alris
-      id:
+      id: 11930
     Necromancer:
       name:
       id:
     Paladin:
       name: Eamonn
-      id: 12691
+      id: 17049
     Thief:
       name: Dwillig
       id: 13577

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -961,6 +961,7 @@ Hvaral:
   trader_outpost:
     id: 3751
 Ratha:
+#todo - handling for two debt and two jails
   currency: lirums
   vault:
     id: 14433  

--- a/tithe.lic
+++ b/tithe.lic
@@ -35,9 +35,11 @@ class TitheActions
 
     wait_for_script_to_complete('pay-debt')
 
+    @almsbox_noun = get_data('town')[@hometown]['almsbox']['noun'] || 'almsbox'
+
     UserVars.tithe_timer = Time.now
     walk_to(almsbox)
-    bput("put 5 silver #{currency} in almsbox", 'You drop', 'But you do not', 'attend to thy own woes')
+    bput("put 5 silver #{currency} in #{@almsbox_noun}", 'You drop', 'But you do not', 'attend to thy own woes')
   end
 
   def check_chadatru


### PR DESCRIPTION
Add several Ratha variables for existing theurgy rituals.
Update town details like repair shops, almsbox, and favor altar.
Add 11 new athletics targets from TT 130 and 116 - mapdb updated earlier on 9/17.
Update ;tithe to accept optional almsbox noun for nonstandard towns.