### PR TITLE
[data][base.yaml] Removing map overrides for Darkling Wood tree.

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2327,33 +2327,3 @@ base_wayto_overrides:
     start_room: 27558
     end_room: 27556
     str_proc: start_script('bescort', ['asketis_mount', 'down']);wait_while{running?('bescort')};
-  darkling_wood_tree_south_to_north:
-    start_room: 2698
-    end_room: 2718
-    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
-    travel_time: 0.2
-  darkling_wood_branch_south_to_north:
-    start_room: 2718
-    end_room: 2717
-    str_proc: fput("climb branch"); fput("look"); fput("look"); waitrt?
-    travel_time: 0.2
-  darkling_wood_tree_south_to_final:
-    start_room: 2717
-    end_room: 2692
-    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
-    travel_time: 0.2
-  darkling_wood_tree_north_to_south:
-    start_room: 2692
-    end_room: 2717
-    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
-    travel_time: 0.2
-  darkling_wood_branch_north_to_south:
-    start_room: 2717
-    end_room: 2718
-    str_proc: fput("climb branch"); fput("look"); fput("look"); waitrt?
-    travel_time: 0.2
-  darkling_wood_tree_north_to_final:
-    start_room: 2718
-    end_room: 2698
-    str_proc: fput("climb tree"); fput("look"); fput("look"); waitrt?
-    travel_time: 0.2


### PR DESCRIPTION
We've changed the map to route folks the long way round. No need to have these here.

```
>;e echo Room[2698].inspect
--- Lich: exec1 active.
[exec1: @unique_loot=nil
@check_location=nil
@tags=[]
@image_coords=[240, 362, 254, 376]
@image="Ilithi, 68a, Darkling Wood.gif"
@timeto={"2718"=>60, "2697"=>4.2, "2699"=>0.2}
@wayto={"2718"=>StringProc.new("fput(\"climb tree\"); fput(\"look\"); fput(\"look\"); waitrt?"), "2697"=>StringProc.new("move(\"east\");waitrt?"),
  "2699"=>StringProc.new("move(\"southwest\");waitrt?")}
@terrain=nil
@climate=nil
@location=nil
@uid=[]
@paths=["Obvious paths: east, southwest."]
@description=["The thick trunk of a white pine tree sugared with sticky sap twists upward from the slope below the road through the forest canopy, hungrily seeking
  the light of the sun.", "The thick trunk of a white pine tree sugared with sticky sap twists upward from the slope below the road through the forest canopy, eagerly
  seeking the open sky."]
@title=["[[Derelict Road, Darkling Wood]]"]
@id=2698]
--- Lich: exec1 has exited.
```
and
```
>;e echo Room[2718].inspect
--- Lich: exec1 active.
[exec1: @unique_loot=nil
@check_location=nil
@tags=[]
@image_coords=[208, 327, 226, 345]
@image="Ilithi, 68a, Darkling Wood.gif"
@timeto={"2717"=>0.2, "2698"=>60}
@wayto={"2717"=>StringProc.new("fput(\"climb branch\"); fput(\"look\"); fput(\"look\"); waitrt?"), "2698"=>StringProc.new("fput(\"climb tree\"); fput(\"look\");
  fput(\"look\"); waitrt?")}
@terrain=nil
@climate=nil
@location=nil
@uid=[]
@paths=["Obvious paths: none."]
@description=["Thin shafts of light filter through the blue-green needles, dancing along the tree's scaly trunk and making thick drips of sugary sap glisten softly
  like frosted jewels.  An ironwood's branches reach across the darkness and twine with the pine's reach."]
@title=["[[Darkling Wood, Pine Tree]]"]
@id=2718]
--- Lich: exec1 has exited.
```