### PR TITLE
[script][craft] New overrides pattern

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -56,13 +56,13 @@ class Craft
 
   def train_outfitting
     rank = DRSkill.getrank('Outfitting')
-    info = @overrides['Outfitting']
-
-    if info
-      if info['type'].downcase.eql? 'sew'
-        sew(info['chapter'], info['item'], info['item'].split.last, info['volumes'])
+    if @overrides['Outfitting']
+      info = get_data('recipes')['crafting_recipes'].select { |recipe| recipe['name'].include?(@overrides['Outfitting']) }
+      info = DRCC.recipe_lookup(info, @overrides['Outfitting'])
+      if info['chapter'].eql? 5
+        knit(info['chapter'], info['name'], info['noun'])
       else
-        knit(info['chapter'], info['item'], info['item'].split.last)
+        sew(info['chapter'], info['name'], info['noun'], info['volume'])
       end
     elsif rank <= 25 # Tier 1  Extremely Easy
       knit(5, 'some knitted socks', 'socks')
@@ -89,10 +89,10 @@ class Craft
 
   def train_engineering
     rank = DRSkill.getrank('Engineering')
-    info = @overrides['Engineering']
-
-    if info
-      shape(info['chapter'], info['item'], info['item'].split.last)
+    if @overrides['Engineering']
+      info = get_data('recipes')['crafting_recipes'].select { |recipe| recipe['name'].include?(@overrides['Engineering']) }
+      info = DRCC.recipe_lookup(info, @overrides['Engineering'])
+      shape(info['chapter'], info['name'], info['noun'])
     elsif rank <= 25 # Tier 1  Extremely Easy
       shape(7, 'a wood band', 'band')
     elsif rank <= 50 # Tier 2 Very Easy
@@ -122,10 +122,9 @@ class Craft
 
   def train_forging
     rank = DRSkill.getrank('Forging')
-    info = @overrides['Forging']
-
-    if info
-      smith(info['item'])
+    if @overrides['Forging']
+      info = get_data('recipes')['crafting_recipes'].select { |recipe| recipe['name'].include?(@overrides['Forging']) }
+      info = DRCC.recipe_lookup(info, @overrides['Forging'])
     elsif rank <= 25 # Tier 1 - Extremely Easy
       smith('a shallow metal cup')
     elsif rank <= 50 # Tier 2 - Very Easy
@@ -518,7 +517,7 @@ class Craft
   end
 
   def check_fabric(fabric_volumes)
-    crafting_data = get_data('crafting')['tailoring'][@hometown]
+    crafting_data = get_data('crafting')
     existing = if DRC.bput("get burlap cloth from my #{@bag}", 'What were', 'You get') == 'What were'
                  0
                else
@@ -528,7 +527,7 @@ class Craft
                  DRC.bput("count my burlap cloth", 'You count out \d+ yards').scan(/\d+/).first.to_i
                end
     stock_needed = ((fabric_volumes - existing) / 10.0).ceil
-    order_fabric(crafting_data['stock-room'], stock_needed, crafting_data['stock']['burlap']['stock-number'], 'burlap cloth')
+    order_fabric(crafting_data['tailoring'][@hometown]['stock-room'], stock_needed, crafting_data['stock']['burlap']['stock-number'], 'burlap cloth')
   end
 
   def check_wood


### PR DESCRIPTION
Previous override setup required a pile of information we can fetch from base-recipes. This edit simplifies that to:
```yaml
craft_overrides:
  Outfitting: a cloth mining belt
  Forging: some hooked metal pliers
  Engineering: a wood comb
```
Also found problem with cloth purchasing further down, where it's not fetching the new base-crafting information for cloth stock. Just needed to be rearranged.