### PR TITLE
[scripts][common-moonmage] Use "cast ambient" when no moons available  for Cage of Light

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -326,8 +326,10 @@ module DRCMM
     moon = visible_moons.first
     if moon
       data['cast'] = "cast #{moon}"
+    elsif !moon && data['name'].downcase == 'cage of light'
+      data['cast'] = "cast ambient"
     else
-      echo "No moon available to cast #{data['abbrev']}"
+      echo "No moon available to cast #{data['name']}"
       data = nil
     end
     data


### PR DESCRIPTION
Caters specifically to moonie spell Cage of Light which can be cast at a moon, but can also be "cast ambient" as an alternative when no moons are available.