### PR TITLE
[data][base-recipes] advanced AP ritual focus fix

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -9236,7 +9236,8 @@ crafting_recipes:
   type: artificing
   chapter: 3
   work_order: false
-  enchant_stock1: 3
+  enchant_stock1: 10
+  enchant_stock2: 3
   item: 16
   secondary:
   - decay


### PR DESCRIPTION
Odd one, maybe a one-off.

This recipe requires a secondary sigil to begin, then ANY sigil to complete it.

The issue is that as is, the script purchases congruence, but then looks for decay (secondary) to begin.

By adding enchant_stock1 to Decay, and enchant_stock2 to Congruence, this work order can be completed as expected.

Technically this PR could have been completed by just adding sigil 10, but I wanted to change the order to reflect Decay (Secondary) and #1 and Congruence (or any) as #2.