### PR TITLE
[script][common-arcana] Symbiosis protections

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -640,6 +640,8 @@ module DRCA
     end
 
     release_cyclics if data['cyclic']
+    DRC.bput('prepare symbiosis', 'You recall the exact details of the', 'But you\'ve already prepared', 'Please don\'t do that here')
+    DRC.bput('release symbiosis', 'You release', 'But you haven\'t prepared')
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
     DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
 


### PR DESCRIPTION
This is an edit inspired by Binu. Simply put, it will protect you from frying your nerves if buff-watcher fires while you're using symbiosis. It first preps symbiosis, then releases symbiosis, so that you don't dump your memorized symbiosis if it's up, and releases any symbiosis already up, before buffing.

First, with just a spell prepped:
```
>prep aot
Since you're not feeding enough power into the spell pattern to make it coherent, you quickly work your way to the minimum required.
With rigid movements you prepare your body for the Aura of Tongues spell.  Casting rationality aside, you prepare to yoke unseen mana streams to fuel your sorcery.
>release heal
You feel the warmth in your flesh gradually subside.
>
The wind whistles through a small hollow midway up the trunk of the tree.

>
You feel fully attuned to the mana streams again.
>
[buff-watcher: Pausing [] to run buff-watcher]
[buff-watcher]>prepare symbiosis
You recall the exact details of the Chaos symbiosis, preparing to integrate it with the next spell you cast.
>
[buff-watcher]>release symbiosis
You pause for a moment as the details of the Chaos symbiosis fade from your mind.
You release the Chaos symbiosis.
>
[buff-watcher]>release spell
You let your concentration lapse and feel the spell's energies dissipate.
>
[buff-watcher]>release mana
You aren't harnessing any mana.
>
[buff-watcher]>prepare heal 15
```
Next, with both spell and symb:
```
>release heal
You feel the warmth in your flesh gradually subside.
>prep symb
You recall the exact details of the Chaos symbiosis, preparing to integrate it with the next spell you cast.
>prep aot
Since you're not feeding enough power into the spell pattern to make it coherent, you quickly work your way to the minimum required.
With rigid movements you prepare your body for the Aura of Tongues spell.  Casting rationality aside, you prepare to yoke unseen mana streams to fuel your sorcery.
>
You feel fully prepared to cast your spell.
>
[buff-watcher: Pausing [] to run buff-watcher]
[buff-watcher]>prepare symbiosis
But you've already prepared the Chaos symbiosis!
>
[buff-watcher]>release symbiosis
You pause for a moment as the details of the Chaos symbiosis fade from your mind.
You release the Chaos symbiosis.
>
[buff-watcher]>release spell
>
You let your concentration lapse and feel the spell's energies dissipate.
>
[buff-watcher]>release mana
You aren't harnessing any mana.
>
[buff-watcher]>prepare heal 15
```
Finally, no spell, just symb:
```

>prep symb
You recall the exact details of the Chaos symbiosis, preparing to integrate it with the next spell you cast.
>release heal
You feel the warmth in your flesh gradually subside.
>
Xibar slowly rises above the horizon.
>
The air around you shimmers with a weak yellow light that quickly disperses.
>
You've gained a new rank in your athletic ability.
>
[buff-watcher: Pausing [] to run buff-watcher]
[buff-watcher]>prepare symbiosis
But you've already prepared the Chaos symbiosis!
>
[buff-watcher]>release symbiosis
You pause for a moment as the details of the Chaos symbiosis fade from your mind.
You release the Chaos symbiosis.
>
[buff-watcher]>release mana
You aren't harnessing any mana.
>
[buff-watcher]>prepare heal 15
```