### PR TITLE
[script][dr-scripts_install] - Lich5 version check

### DIFF
--- a/dr-scripts_install.lic
+++ b/dr-scripts_install.lic
@@ -93,12 +93,17 @@
     fput('exit')
   end
 
-download_dependency
-install_dependency
-enable_use_lich_fork
-run_setupaliases
-download_narost_glass
-enable_autostarts
-display_information
-ensure_monsterbold
-log_out
+unless "#{LICH_VERSION}".chr == '5'
+  download_dependency
+  install_dependency
+  enable_use_lich_fork
+  run_setupaliases
+  download_narost_glass
+  enable_autostarts
+  display_information
+  ensure_monsterbold
+  log_out
+else
+  echo "You're on Lich version 5+. This setup script is deprecated. The Lich 5+ install should give you everything you need."
+  exit
+end


### PR DESCRIPTION
Adds a Lich5 version check, exits if on Lich5+. Script is deprecated.