### PR TITLE
[script][forge] Add missing match

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -263,7 +263,7 @@ class Forge
                 'set using tongs', 'sets using tongs', 'into wire using a mandrel or mold set', 'metal is in need of some gentle bending',
                 'The grinding has left many nicks and burs', 'not spinning fast enough',
                 'must be pounded free', 'the armor now needs reassembly with a hammer', 'looks ready to be pounded',
-                'appears ready for more pounding', 'anything that would obstruct pounding of the metal',
+                'appears ready for more pounding', 'anything that would obstruct pounding of the metal', 'appears ready for pounding the assembled handle',
                 'ready for grinding away of the excess metal', 'now appears ready for grinding and polishing',
                 'thinning the armor\'s metal at a grindstone', 'The armor is ready to be lightened', 'ready to be ground away',
                 'in the slack tub', 'The metal is ready to be cooled',
@@ -312,7 +312,7 @@ class Forge
         swap_tool('wire brush')
         @command = "rub my #{@item} with my brush"
       when 'must be pounded free', 'the armor now needs reassembly with a hammer', 'appears ready for more pounding', #hammer+tongs
-           'looks ready to be pounded', 'anything that would obstruct pounding of the metal'
+           'looks ready to be pounded', 'anything that would obstruct pounding of the metal', 'appears ready for pounding the assembled handle'
         DRC.bput("put my #{@item} on anvil", 'You put') if DRCI.in_hands?(@item)
         swap_tool(@hammer)
         swap_tool('tongs')


### PR DESCRIPTION
When resuming a shield you've started, but stopped at the assembly stage, analyze misses the match for assembly. This is what's required.