### PR TITLE
[scripts][combat-trainer] Make use_analyze_combos respect combat_training_abilities_target

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4803,7 +4803,7 @@ class GameState
       brawling? ? 'gouge' : 'jab'
     # !offhand & !brawling are there because you can't use a weapon for brawling commands
     # This issue will cause problems with the combo array system
-    elsif @use_analyze_combos && !offhand? && !brawling?
+    elsif @use_analyze_combos && !offhand? && !brawling? && DRSkill.getxp('Tactics') <= @combat_training_abilities_target
       update_analyze_array if @analyze_combo_array.empty?
       @analyze_combo_array.empty? ? 'attack' : @analyze_combo_array.shift
     else


### PR DESCRIPTION
use_analyze_combos currently keeps going even when Tactics is above the target mindstate. This resolves that by adding Tactics mindstate vs combat_training_abilities_target as a check precedent to using an analyze combo.

Only affects non-barb combos. Barb combos untouched.