### PR TITLE
[script][common-arcana] Respect yaml skill designation

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -825,8 +825,7 @@ module DRCA
 
     if !XMLData.prepared_spell.eql?('None') && checkcastrt == 0
       spell = XMLData.prepared_spell
-      skill = get_data('spells').spell_data[spell]['skill']
-      data = training_spells[skill]
+      data = training_spells.find { |skill,data| data['name'] == spell }.last
       crafting_cast_spell(data, settings)
     end
 


### PR DESCRIPTION
As it is, CA takes your prepared spell, then finds the skill in base-spells(say, for Centering, skill would be augmentation) then fetches the data from your Augmentation training spell key. IF you're a cleric, Centering would fall under Augmentation anyways, so you'd fetch the right information. If you're not a cleric, and casting it sorcerously, it will look for Centering under the Augmentation key, and probably find the data from a different spell.  There's some trick to fooling common arcana that I keep forgetting, and I'm tired of fighting it. 

This change gets the data from the block in your training spells where Centering is defined, be it Sorcery, Augmentation, or otherwise, because it's no longer fetching that from base-spells, but from your yaml.

Best part, even if your yaml is configured in the "fool CA" way, this will still work.