### PR TITLE
[scripts][pick] Fang Cove Fix - pick

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -65,7 +65,7 @@ class Pick
     @has_pick_waggle = @settings.waggle_sets['pick']
 
     picking_data = get_data('picking').picking
-    @lockpick_costs = picking_data['lockpick_costs'][@settings.hometown]
+    @lockpick_costs = picking_data['lockpick_costs'][@settings.fang_cove_override_town || @settings.hometown]
 
     @pick_identify_messages = picking_data['pick_messages_by_difficulty'];
     @pick_retry = picking_data['pick_retry']
@@ -319,7 +319,7 @@ class Pick
     end
 
     DRCM.ensure_copper_on_hand(cost * lockpicks_needed, @settings)
-    DRCT.refill_lockpick_container(@settings.lockpick_type, @settings.hometown, @lockpick_container, lockpicks_needed)
+    DRCT.refill_lockpick_container(@settings.lockpick_type, @settings.fang_cove_override_town || @settings.hometown, @lockpick_container, lockpicks_needed)
   end
 
   def attempt_open(box_noun)


### PR DESCRIPTION
Adds the fang_cove_override_town setting to pick so that `;pick refill` works properly with Fang Cove set as a hometown, similar to other Fang Cove Fix pull requests.