### PR TITLE
[scripts][common-arcana]Remove unnecessary stance change.

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -242,7 +242,6 @@ module DRCA
   def ritual(data, settings)
     DRC.retreat(settings.ignored_npcs) unless data['skip_retreat']
     DRC.release_invisibility
-    DRC.set_stance('shield')
 
     command = 'prepare'
     command = data['prep'] if data['prep']


### PR DESCRIPTION
There is no need to change into shield stance for casting a ritual, and the method for changing into shield stance does not correctly use all available stance points anyway.