### PR TITLE
[script][dependency] - Allow array of autostart scripts to remove

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.4.15'
+$DEPENDENCY_VERSION = '1.4.16'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all

--- a/dependency.lic
+++ b/dependency.lic
@@ -1620,11 +1620,15 @@ def autostart(script_names, global = true)
   script_names.each { |script| $manager.run_script(script) }
 end
 
-def stop_autostart(script)
-  if UserVars.autostart_scripts.include?(script)
-    UserVars.autostart_scripts.delete(script)
-  else
-    $manager.remove_global_auto(script)
+def stop_autostart(script_names)
+  script_names = [script_names] unless script_names.is_a?(Array)
+
+  script_names.each do |script|
+    if UserVars.autostart_scripts.include?(script)
+      UserVars.autostart_scripts.delete(script)
+    else
+      $manager.remove_global_auto(script)
+    end
   end
 end
 


### PR DESCRIPTION
Adding DR autostarts allows an array of scripts to autostart.

However, the `stop_autostart` method did not, only accepting a single script name. This just allows you to pass an array of scripts to stop autostart.

I'm working on an autostart management script that will utilize this improved method.

```
>;e echo list_autostarts
--- Lich: exec1 active.
[exec1: ["roomnumbers", "textsubs", "smartlisten", "sanowret-crystal", "afk"]]
--- Lich: exec1 has exited.
>
You continue playing on your copper zills.
>;e stop_autostart(['afk', 'sanowret-crystal'])
--- Lich: exec1 active.
--- Lich: exec1 has exited.
>;e echo list_autostarts
--- Lich: exec1 active.
[exec1: ["roomnumbers", "textsubs", "smartlisten"]]
--- Lich: exec1 has exited.
```