### PR TITLE
[scripts][combat-trainer] Only list status of egg_or_warhorn during d…

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -852,12 +852,12 @@ class LootProcess
   end
 
   def dissected?(mob_noun, game_state)
-    if @dissect_for_thanatology 
+    if @dissect_for_thanatology
       return false if (DRSkill.getxp('Thanatology') == 34 && DRSkill.getxp('First Aid') == 34)
     else
       return false if DRSkill.getxp('First Aid') == 34
     end
-    
+
     case DRC.bput("dissect #{mob_noun}","You'll gain no insights from this attempt", 'You succeed in dissecting the corpse','What exactly are you trying to dissect',"You'll learn nothing",'While likely a fascinating study','You cannot dissect','would probably object',"should be left alone.","That'd be a waste of time.",'A skinned creature is worthless','You do not yet possess the knowledge', 'This ritual may only be performed on a corpse', /You learn something/i, 'A failed or completed ritual has rendered', 'You realize after a few seconds')
     when 'You succeed in dissecting the corpse', /You learn something/i
       return true
@@ -2125,7 +2125,7 @@ class AbilityProcess
     check_paladin_skills
     check_nonspell_buffs(game_state)
     check_battle_cries(game_state)
-    DRC.message("warhorn_or_egg array is: #{@warhorn_or_egg}")  if $debug_mode_ct
+    DRC.message("warhorn_or_egg array is: #{@warhorn_or_egg}")  if (@warhorn_or_egg && $debug_mode_ct)
     use_warhorn_or_egg(game_state) unless @warhorn_or_egg.nil? || @warhorn_or_egg.empty?
     false
   end


### PR DESCRIPTION
…ebug if defined

Was debugging an unrelated issue on a character with no egg, or warhorn and kept getting spammed.

This removes the spam.