### PR TITLE
[script][common] Reduce bput spam

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -146,7 +146,7 @@ module DRC
       case response
       when /(?:\.\.\.wait |Wait |\.\.\. wait )([0-9]+)/
         unless ignore_rt
-          pause(Regexp.last_match(1).to_i - 0.9)
+          pause(Regexp.last_match(1).to_i - 0.5)
           waitrt?
           put message
           timer = Time.now


### PR DESCRIPTION
Made this change for myself some weeks ago. Instead of removing 9/10ths of the remaining second of rt, it removes 1/2 of the last second, which significantly cuts down on the spam when you hit the rt wall at the top of 1 second. Before this, I'd have bput throw 3,4,5 attempts at pushing commands before resolving the last second of rt. This essentially eliminates that. Basically trading the sum of these tenths of a second for smaller logs and less spam.