### PR TITLE
[scripts][combat-trainer] Use DRCI for getting bundling rope

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -915,7 +915,7 @@ class LootProcess
         @equipment_manager.stow_weapon(game_state.weapon_name)
       end
 
-      if DRC.bput('get bundling rope', 'You get', 'What were you referring to', 'You need a free hand') == 'You get'
+      if DRCI.get_item_if_not_held?('bundling rope')
         DRC.bput('bundle', 'You bundle')
         DRCI.wear_item?('bundle')
         if @tie_bundle


### PR DESCRIPTION
There was a rope on the ground...
```
[combat-trainer: message: You pick up some bundling rope.]
[combat-trainer: checked against [/You get/i, /What were you referring to/i, /You need a free hand/i]]
[combat-trainer: for command get bundling rope]
```

As reported on Discord https://discord.com/channels/745675889622384681/745675890242879671/1035916880948502538