### PR TITLE
Add base-healingherbs and update herb-stock to utilize it

### DIFF
--- a/data/base-healingherbs.yaml
+++ b/data/base-healingherbs.yaml
@@ -1,0 +1,255 @@
+herb_stocks:
+  Crossing:
+    - name: jadice flower
+      size: 6
+      stackable: true
+      room: 8259
+      price: 812
+      quantity: 12
+    - name: plovik leaf
+      size: 6
+      stackable: true
+      room: 8259
+      price: 812
+      quantity: 12
+    - name: nilos salve
+      size: 6
+      stackable: true
+      room: 8259
+      price: 812
+      quantity: 12
+    - name: hulnik grass
+      size: 6
+      stackable: true
+      room: 8259
+      price: 812
+      quantity: 12
+    - name: nemoih root
+      size: 6
+      stackable: true
+      room: 8259
+      price: 875
+      quantity: 12
+    - name: georin salve
+      size: 6
+      stackable: true
+      room: 8259
+      price: 875
+      quantity: 12
+    - name: sufil sap
+      size: 6
+      stackable: true
+      room: 8259
+      price: 875
+      quantity: 12
+    - name: yelith root
+      size: 6
+      stackable: false
+      room: 8259
+      price: 937
+      quantity: 12
+    - name: ithor potion
+      size: 6
+      stackable: true
+      room: 8259
+      price: 937
+      quantity: 12
+    - name: muljin sap
+      size: 6
+      stackable: true
+      room: 8259
+      price: 937
+      quantity: 12
+    - name: junliar stem
+      size: 6
+      stackable: true
+      room: 8259
+      price: 937
+      quantity: 12
+    - name: blocil potion
+      size: 6
+      stackable: false
+      room: 8259
+      price: 937
+      quantity: 12
+    - name: riolur leaf
+      size: 6
+      stackable: true
+      room: 8259
+      price: 1000
+      quantity: 12
+    - name: qun pollen
+      size: 6
+      stackable: true
+      room: 1898
+      price: 500
+      quantity: 12
+    - name: genich stem
+      size: 6
+      stackable: false
+      room: 1898
+      price: 500
+      quantity: 12
+    - name: nuloe stem
+      size: 6
+      stackable: true
+      room: 1898
+      price: 500
+      quantity: 12
+    - name: cebi root
+      size: 6
+      stackable: true
+      room: 1898
+      price: 625
+      quantity: 12
+    - name: hulij elixir
+      size: 6
+      stackable: false
+      room: 1898
+      price: 563
+      quantity: 12
+    - name: hisan salve
+      size: 6
+      stackable: true
+      room: 1898
+      price: 625
+      quantity: 12
+    - name: jadice pollen
+      size: 6
+      stackable: true
+      room: 1898
+      price: 500
+      quantity: 12
+    - name: ojhenik potion
+      size: 6
+      stackable: false
+      room: 1898
+      price: 562
+      quantity: 12   
+  Shard:
+    - name: jadice flower
+      size: 6
+      stackable: true
+      room: 13997
+      price: 586
+      quantity: 12
+    - name: plovik leaf
+      size: 6
+      stackable: true
+      room: 13997
+      price: 586
+      quantity: 12
+    - name: nilos salve
+      size: 6
+      stackable: true
+      room: 13997
+      price: 586
+      quantity: 12
+    - name: hulnik grass
+      size: 6
+      stackable: true
+      room: 13997
+      price: 586
+      quantity: 12
+    - name: nemoih root
+      size: 6
+      stackable: true
+      room: 13997
+      price: 631
+      quantity: 12
+    - name: georin salve
+      size: 6
+      stackable: true
+      room: 13997
+      price: 631
+      quantity: 12
+    - name: sufil sap
+      size: 6
+      stackable: true
+      room: 13997
+      price: 631
+      quantity: 12
+    - name: yelith root
+      size: 6
+      stackable: false
+      room: 13997
+      price: 676
+      quantity: 12
+    - name: ithor potion
+      size: 6
+      stackable: true
+      room: 13997
+      price: 676
+      quantity: 12
+    - name: muljin sap
+      size: 6
+      stackable: true
+      room: 13997
+      price: 676
+      quantity: 12
+    - name: junliar stem
+      size: 6
+      stackable: true
+      room: 13997
+      price: 676
+      quantity: 12
+    - name: blocil potion
+      size: 6
+      stackable: false
+      room: 28522
+      price: 676
+      quantity: 12
+    - name: riolur leaf
+      size: 6
+      stackable: true
+      room: 13997
+      price: 721
+      quantity: 12
+    - name: qun pollen
+      size: 6
+      stackable: true
+      room: 13997
+      price: 405
+      quantity: 12
+    - name: genich stem
+      size: 6
+      stackable: false
+      room: 13997
+      price: 405
+      quantity: 12
+    - name: nuloe stem
+      size: 6
+      stackable: true
+      room: 13997
+      price: 451
+      quantity: 12
+    - name: cebi root
+      size: 6
+      stackable: true
+      room: 13997
+      price: 451
+      quantity: 12
+    - name: hulij elixir
+      size: 6
+      stackable: false
+      room: 13997
+      price: 586
+      quantity: 12
+    - name: hisan salve
+      size: 6
+      stackable: true
+      room: 13997
+      price: 541
+      quantity: 12
+    - name: jadice pollen
+      size: 6
+      stackable: true
+      room: 13997
+      price: 451
+      quantity: 12
+    - name: ojhenik potion
+      size: 6
+      stackable: false
+      room: 13997
+      price: 451
+      quantity: 12

--- a/data/base-healingherbs.yaml
+++ b/data/base-healingherbs.yaml
@@ -125,7 +125,28 @@ herb_stocks:
       stackable: false
       room: 1898
       price: 562
-      quantity: 12   
+      quantity: 12
+    - name: lujeakave elixir
+      location: Riverhaven
+      size: 6
+      stackable: false
+      room: 15019
+      price: 870
+      quantity: 9      
+    - name: eghmok potion
+      location: Riverhaven
+      size: 6
+      stackable: false
+      room: 15019
+      price: 720
+      quantity: 9
+    - name: aevaes solution
+      location: Riverhaven
+      size: 6
+      stackable: false
+      room: 15019
+      price: 740
+      quantity: 9
   Shard:
     - name: jadice flower
       size: 6

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -2,29 +2,38 @@
 
 custom_require.call(%w[common common-items common-travel common-money])
 
-class Herbstock
-  include DRC
-  include DRCM
-  include DRCI
-  include DRCT
-
+class HerbStock
   def initialize
-    setup
-    items = parse_restockable_items
+    arg_definitions = [
+      [
+        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town to restock in' }
+      ]
+    ]
+    args = parse_args(arg_definitions)
 
-    custom_loc_items = items.select { |k| k['hometown'] }
+    @settings = get_settings
+    @hometown = DRC.get_town_name(args.town || @settings.hometown)
+    amount, denom = @settings.sell_loot_money_on_hand.split(' ')
+    @keep_copper = DRCM.convert_to_copper(amount, denom)
+    @remedy_container = @settings.remedy_container
 
-    items -= custom_loc_items
-    restock_items(items, @settings.hometown)
-
-    custom_loc_items.map { |k| k['hometown'] }.uniq
-                    .each do |_hometown|
-      custom_loc_items.group_by { |v| v['hometown'] }
-                      .each { |hometown, items| restock_items(items, hometown) }
+    if @hometown == 'Riverhaven' && DRSkill.getrank('Athletics') > 140
+      @hometown = 'Crossing'
     end
+
+    if(@hometown != 'Crossing' && @hometown != 'Shard')
+      echo 'Only Crossing, Riverhaven (with over 140 Athletics), and Shard hometowns supported. You may provide Crossing or Shard as an argument to override your hometown.'
+      exit
+    end
+
+    herbs = get_data('healingherbs').herb_stocks[@hometown]
+
+    @settings.storage_containers.each { |container| fput("open my #{container}") }
+
+    restock_items(herbs)
   end
 
-  def restock_items(item_list, town)
+  def restock_items(item_list)
     items_to_restock = []
     coin_needed = 0
 
@@ -38,53 +47,31 @@ class Herbstock
       items_to_restock.push(item)
     end
 
-    DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
+    if items_to_restock.length == 0
+      echo '*** No Herbs Needed ***'
+      exit
+    end
+
+    DRCM.ensure_copper_on_hand(coin_needed, @settings, @hometown)
 
     items_to_restock.each do |item|
       item['buy_num'].times do
-        stow_hands
+        DRCI.stow_hands
         DRCI.get_item?(item['name'], @remedy_container) if item['stackable']
         DRCT.buy_item(item['room'], item['name'])
         split_name = item['name'].split(' ')
-        bput("combine #{split_name.last} with #{split_name.last}", 'You combine', 'You must be holding') if item['stackable']
+        DRC.bput("combine #{split_name.last} with #{split_name.last}", 'You combine', 'You must be holding') if item['stackable']
         [DRC.left_hand, DRC.right_hand].compact.each { DRCI.put_away_item?(item['name'], @remedy_container) }
       end
     end
-    deposit_coins(@keep_copper, @settings, "#{town}")
-  end
 
-  def setup
-    @settings = get_settings
-    @restock = @settings.herbs
-    @hometown = @settings.hometown
-    amount, denom = @settings.sell_loot_money_on_hand.split(' ')
-    @keep_copper = convert_to_copper(amount, denom)
-    @remedy_container = @settings.remedy_container
-    get_settings.storage_containers.each { |container| fput("open my #{container}") }
-  end
-
-  def parse_restockable_items
-    item_list = @restock
-    hometown_data = get_data('consumables')[@hometown]
-    items = []
-    item_list.each do |key, value|
-      if hometown_data.key?(key) && !value.key?('hometown')
-        ht_data = hometown_data[key]
-        data = ht_data.each_key { |k| ht_data[k] = value[k] if value.key?(k) }
-        items.push(data)
-      elsif valid_item_data?(value)
-        items.push(value)
-      else
-        echo "No hometown of explicit data for '#{key}'"
-      end
-    end
-    items
+    DRCM.deposit_coins(@keep_copper, @settings, @hometown)
   end
 
   def count_combinable_item(item)
     count = 0
     $ORDINALS.each do |ordinal|
-      count_msg = bput("count my #{ordinal} #{item}", 'I could not find what you were referring to.', 'tell you much of anything.', 'There is only one part', 'There are (.+) parts left of the ', 'You count out (.+) pieces ')
+      count_msg = DRC.bput("count my #{ordinal} #{item}", 'I could not find what you were referring to.', 'tell you much of anything.', 'There is only one part', 'There are (.+) parts left of the ', 'You count out (.+) pieces ')
       case count_msg
       when 'I could not find what you were referring to.'
         break
@@ -95,21 +82,12 @@ class Herbstock
         count += 1
       else
         count_txt = count_msg.match(/There \w+ (.+) \w+ left of the / || /You count \w+ (.+) \w+ /).captures.first.tr('-', ' ')
-        count += text2num(count_txt)
+        count += DRC.text2num(count_txt)
       end
       waitrt?
     end
     count
   end
-
-  def valid_item_data?(item_data)
-    return true if  item_data.key?('name') && \
-                    item_data.key?('size') && \
-                    item_data.key?('room') && \
-                    item_data.key?('price') && \
-                    item_data.key?('stackable') && \
-                    item_data.key?('quantity')
-    false
-  end
 end
-Herbstock.new
+
+HerbStock.new

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -26,14 +26,29 @@ class HerbStock
       exit
     end
 
-    herbs = get_data('healingherbs').herb_stocks[@hometown]
-
     @settings.storage_containers.each { |container| fput("open my #{container}") }
 
-    restock_items(herbs)
+    herbs = get_data('healingherbs').herb_stocks[@hometown]
+
+    herbsWithLocations = herbs.select { |k| k['location'] } # find any herbs that have a specific location defined
+
+    herbs -= herbsWithLocations
+
+    restock_items(herbs, @hometown) # restock herbs that do not have a specific location
+
+    herbsWithLocations.group_by { |v| v['location'] }
+      .each do |location, herbsToStock|
+
+        if location == "Riverhaven" && DRSkill.getrank('Athletics') < 150
+          next
+        end
+
+        restock_items(herbsToStock, location)
+      end
+
   end
 
-  def restock_items(item_list)
+  def restock_items(item_list, town)
     items_to_restock = []
     coin_needed = 0
 
@@ -48,11 +63,11 @@ class HerbStock
     end
 
     if items_to_restock.length == 0
-      echo '*** No Herbs Needed ***'
-      exit
+      echo "*** No Herbs Needed from #{town} ***"
+      return
     end
 
-    DRCM.ensure_copper_on_hand(coin_needed, @settings, @hometown)
+    DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
 
     items_to_restock.each do |item|
       item['buy_num'].times do
@@ -65,7 +80,7 @@ class HerbStock
       end
     end
 
-    DRCM.deposit_coins(@keep_copper, @settings, @hometown)
+    DRCM.deposit_coins(@keep_copper, @settings, town)
   end
 
   def count_combinable_item(item)


### PR DESCRIPTION
Added base-healingherbs.yaml with Crossing and Shard healing herb store information. Updated herb-stock.lic to utilize new data and cleaned up the script.

- Flattened the default Crossing herb data. Added Shard herb data.
- Added functionality to pull the herb data in for the appropriate town. Supported towns are Crossing and Shard. Riverhaven will go to Crossing if athletics are high enough. I'm unclear on if the islands offer herb restock options. If they do, we'd want to add that to the base data.
- Removed validate data method, since it's now being provided in a data file
- Prior script was setup to use herbs defined in the player's yaml or those found in consumables (looks like it originally used restock.lic as a baseline). In theory, the herbs could have been added to base-consumables and we could have just used restock, but that ship sailed long ago and this avoids breaking backwards compatibility. So, I removed all of the code around pulling herbs from the player's yaml and dropped the parsing of the data to figure out if it wanted to get them from the store defined in the yaml or from base-consumables.
- Overall cleanup of the script
- heal-remedy uses herbs to heal if the herbs setting in the player's yaml has data. So, once someone gets these changes, that will continue to work. Moving forward, using herbs to heal will simply require herbs: true in the yaml. I call herb-stock as part of my T2, which will work without any yaml changes. There could be a future opportunity to incorporate this into hunting-buddy.