### PR TITLE
Correct Turmar Illumination abbrev

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -2997,7 +2997,7 @@ spell_data:
     mana_type: lunar
     prep: prepare
   Turmar Illumination:
-    abbrev: TU IL
+    abbrev: TURI
     mana: 5
     guild: Trader
     skill: Augmentation


### PR DESCRIPTION
The correct abbreviation is TURI, not TU IL