### PR TITLE
herb-stock additions and overrides

### DIFF
--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -43,9 +43,6 @@ class HerbStock
       herbs = (base_herbs + extra_herbs).uniq
     end
 
-    echo herbs
-    exit
-
     herbsWithLocations = herbs.select { |k| k['location'] } # find any herbs that have a specific location defined
 
     herbs -= herbsWithLocations

--- a/herb-stock.lic
+++ b/herb-stock.lic
@@ -1,4 +1,4 @@
-#   Documentation: https://elanthipedia.play.net/Lich_script_repository#restock
+#   Documentation: https://elanthipedia.play.net/Lich_script_repository#herb-stock
 
 custom_require.call(%w[common common-items common-travel common-money])
 
@@ -16,19 +16,35 @@ class HerbStock
     amount, denom = @settings.sell_loot_money_on_hand.split(' ')
     @keep_copper = DRCM.convert_to_copper(amount, denom)
     @remedy_container = @settings.remedy_container
+    herbs_override_herbstock = @settings.herbs_override_herbstock
+    user_herbs = @settings.herbs
 
     if @hometown == 'Riverhaven' && DRSkill.getrank('Athletics') > 140
       @hometown = 'Crossing'
     end
 
-    if(@hometown != 'Crossing' && @hometown != 'Shard')
+    if(@hometown != 'Crossing' && @hometown != 'Shard') && !(herbs_override_herbstock && user_herbs)
       echo 'Only Crossing, Riverhaven (with over 140 Athletics), and Shard hometowns supported. You may provide Crossing or Shard as an argument to override your hometown.'
+      echo 'Alternatively, define custom herbs in your yaml\'s herbs setting and set herbs_override_herbstock to true.'
       exit
     end
 
     @settings.storage_containers.each { |container| fput("open my #{container}") }
 
-    herbs = get_data('healingherbs').herb_stocks[@hometown]
+    herbs = []
+
+    if herbs_override_herbstock
+      herbs = parse_user_herbs(user_herbs)
+    else
+      base_herbs = get_data('healingherbs').herb_stocks[@hometown]
+
+      extra_herbs = parse_user_herbs(user_herbs)
+
+      herbs = (base_herbs + extra_herbs).uniq
+    end
+
+    echo herbs
+    exit
 
     herbsWithLocations = herbs.select { |k| k['location'] } # find any herbs that have a specific location defined
 
@@ -39,7 +55,11 @@ class HerbStock
     herbsWithLocations.group_by { |v| v['location'] }
       .each do |location, herbsToStock|
 
-        if location == "Riverhaven" && DRSkill.getrank('Athletics') < 150
+        if location != 'Crossing' && UserVars.subscription == 'F2P'
+          next
+        end
+
+        if location == 'Riverhaven' && DRSkill.getrank('Athletics') < 150
           next
         end
 
@@ -53,7 +73,7 @@ class HerbStock
     coin_needed = 0
 
     item_list.each do |item|
-      remaining = count_combinable_item(item['name'])
+      remaining = DRCI.count_item_parts(item['name'])
       next unless remaining < item['quantity']
       num_needed = item['quantity'] - remaining
       buy_num = (num_needed / item['size'].to_f).ceil
@@ -83,25 +103,33 @@ class HerbStock
     DRCM.deposit_coins(@keep_copper, @settings, town)
   end
 
-  def count_combinable_item(item)
-    count = 0
-    $ORDINALS.each do |ordinal|
-      count_msg = DRC.bput("count my #{ordinal} #{item}", 'I could not find what you were referring to.', 'tell you much of anything.', 'There is only one part', 'There are (.+) parts left of the ', 'You count out (.+) pieces ')
-      case count_msg
-      when 'I could not find what you were referring to.'
-        break
-      when 'tell you much of anything.'
-        echo "#{item} is marked as stackable but is not!"
-        break
-      when 'There is only one part'
-        count += 1
-      else
-        count_txt = count_msg.match(/There \w+ (.+) \w+ left of the / || /You count \w+ (.+) \w+ /).captures.first.tr('-', ' ')
-        count += DRC.text2num(count_txt)
-      end
-      waitrt?
+  # The original impementation of herb-stock / HerbUser setup the herb list as a hash, but there's no need to treat it this way.
+  # Checking for hashes to maintain backwards compatibility.
+  def parse_user_herbs(herbs)
+    extra_herbs = []
+
+    return extra_herbs unless herbs.kind_of?(Array) || herbs.kind_of?(Hash)    
+
+    if herbs.kind_of?(Array)
+      herbs.each { |herb| extra_herbs.push(herb) if valid_item_data?(herb) }
+    elsif herbs.kind_of?(Hash)
+      extra_herbs = process_herb_hash(herbs)
     end
-    count
+    extra_herbs
+  end
+
+  def process_herb_hash(herbs)
+    extra_herbs = []
+
+    herbs.each { |key, value| extra_herbs.push(value) if valid_item_data?(value) }
+
+    extra_herbs
+  end
+
+  def valid_item_data?(item_data)
+    echo "Validating custom item data: #{item_data}" if @debug
+
+    %w[name size room price stackable quantity].all? { |x| item_data.key?(x) }
   end
 end
 

--- a/profiles/Samples/HerbUser-setup.yaml
+++ b/profiles/Samples/HerbUser-setup.yaml
@@ -2,350 +2,144 @@
 # Sample settings to show implementation of storebought healing herbs from P1
 # Ensure that your store herbs settings is set for a pouch which remains open and accessible
 
-
-# Hunting settings
-training_manager_hunting_priority: true
-training_manager_priority_skills:
-- Small Edged
-hunting_info:
-- :zone: rats
-  stop_on:
-  - Small Edged
-  after:
-  - herb-stock               # This will restock your herbs immediately after a hunt, placed here for example only
-
-# Gear settings
-gear:
-- :adjective: rugged
-  :name: leathers
-  :is_leather: true
-  :hinders_lockpicking: false
-  :is_worn: true
-- :adjective: wide-bladed
-  :name: dagger
-  :is_leather: false
-  :hinders_lockpicking: true
-  :is_worn: true
-- :adjective: parry
-  :name: stick
-  :is_leather: false
-  :hinders_lockpicking: false
-  :is_worn: true
-
-gear_sets:
-  standard:
-  - rugged leathers
-  - parry stick
-
-# Combat settings
-dance_skill: Small Edged
 training_abilities:
   Herbs: 480                # This will check your health, then quickly apply any herbs
                             # If in active combat it will skip herbs which require removal from container
-  Stealth: 60
-  Tactics: 30
-weapon_training:
-  Small Edged: wide-bladed dagger
 
-#This section is for the restocking of herbs with herbstock
-#It will add items to your inventory, and some herbs are not stackable
+
+#This section is for the restocking of herbs with herbstock and using herbs to heal in heal-remedy.lic
+#To use the default settings, simply set herbs: true
+herbs: true
+
+# OR define the herbs you wish to use in herbs: - these can either be in addition to the base herbs or override them entirely
+# Set herbs_override_herbstock: true to use only the herbs defined here
+
+herbs_override_herbstock: true
+
 herbs:
-#  MAURIGAS BOTANICALS
-  jadice_flower:
-    name: jadice flower
+  - name: jadice flower
     size: 6
     stackable: true
     room: 8259
     price: 812
     quantity: 12
-  plovik_leaf:
-    name: plovik leaf
+  - name: plovik leaf
     size: 6
     stackable: true
     room: 8259
     price: 812
     quantity: 12
-  nilos_salve:
-    name: nilos salve
+  - name: nilos salve
     size: 6
     stackable: true
     room: 8259
     price: 812
     quantity: 12
-  hulnik_grass:
-    name: hulnik grass
+  - name: hulnik grass
     size: 6
     stackable: true
     room: 8259
     price: 812
     quantity: 12
-  nemoih_root:
-    name: nemoih root
+  - name: nemoih root
     size: 6
     stackable: true
     room: 8259
     price: 875
     quantity: 12
-  georin_salve:
-    name: georin salve
+  - name: georin salve
     size: 6
     stackable: true
     room: 8259
     price: 875
     quantity: 12
-  sufil_sap:
-    name: sufil sap
+  - name: sufil sap
     size: 6
     stackable: true
     room: 8259
     price: 875
     quantity: 12
-  yelith_root:
-    name: yelith root
-    size: 6
-    stackable: true
-    room: 8259
-    price: 937
-    quantity: 12
-  ithor_potion:
-    name: ithor potion
-    size: 6
-    stackable: true
-    room: 8259
-    price: 937
-    quantity: 12
-  muljin_sap:
-    name: muljin sap
-    size: 6
-    stackable: true
-    room: 8259
-    price: 937
-    quantity: 12
-  junliar_stem:
-    name: junliar stem
-    size: 6
-    stackable: true
-    room: 8259
-    price: 937
-    quantity: 12
-  blocil_potion:
-    name: blocil potion
+  - name: yelith root
     size: 6
     stackable: false
     room: 8259
     price: 937
     quantity: 12
-  riolur_leaf:
-    name: riolur leaf
+  - name: ithor potion
+    size: 6
+    stackable: true
+    room: 8259
+    price: 937
+    quantity: 12
+  - name: muljin sap
+    size: 6
+    stackable: true
+    room: 8259
+    price: 937
+    quantity: 12
+  - name: junliar stem
+    size: 6
+    stackable: true
+    room: 8259
+    price: 937
+    quantity: 12
+  - name: blocil potion
+    size: 6
+    stackable: false
+    room: 8259
+    price: 937
+    quantity: 12
+  - name: riolur leaf
     size: 6
     stackable: true
     room: 8259
     price: 1000
     quantity: 12
-
-#  MIDWIFE NESSAS COTTAGE
-  qun_pollen:
-    name: qun pollen
+  - name: qun pollen
     size: 6
     stackable: true
     room: 1898
     price: 500
     quantity: 12
-  genich_stem:
-    name: genich stem
+  - name: genich stem
     size: 6
     stackable: false
     room: 1898
     price: 500
     quantity: 12
-  nuloe_stem:
-    name: nuloe stem
+  - name: nuloe stem
     size: 6
     stackable: true
     room: 1898
     price: 500
     quantity: 12
-  cebi_root:
-    name: cebi root
+  - name: cebi root
     size: 6
     stackable: true
     room: 1898
     price: 625
     quantity: 12
-  hulij_elixir:
-    name: hulij elixir
+  - name: hulij elixir
     size: 6
     stackable: false
     room: 1898
     price: 563
     quantity: 12
-  hisan_salve:
-    name: hisan salve
+  - name: hisan salve
     size: 6
     stackable: true
     room: 1898
     price: 625
     quantity: 12
-  jadice_pollen:
-    name: jadice pollen
+  - name: jadice pollen
     size: 6
     stackable: true
     room: 1898
     price: 500
     quantity: 12
-  ojhenik_potion:
-    name: ojhenik potion
+  - name: ojhenik potion
     size: 6
     stackable: false
     room: 1898
     price: 562
     quantity: 12
-
-#  Shard Herb Shop - use one or the other, not both.
-  jadice_flower:
-    name: jadice flower
-    size: 6
-    stackable: true
-    room: 13997
-    price: 586
-    quantity: 20
-  plovik_leaf:
-    name: plovik leaf
-    size: 6
-    stackable: true
-    room: 13997
-    price: 586
-    quantity: 20
-  nilos_salve:
-    name: nilos salve
-    size: 6
-    stackable: true
-    room: 13997
-    price: 586
-    quantity: 6
-  hulnik_grass:
-    name: hulnik grass
-    size: 6
-    stackable: true
-    room: 13997
-    price: 586
-    quantity: 6
-  nemoih_root:
-    name: nemoih root
-    size: 6
-    stackable: true
-    room: 13997
-    price: 631
-    quantity: 6
-  georin_salve:
-    name: georin salve
-    size: 6
-    stackable: true
-    room: 13997
-    price: 631
-    quantity: 6
-  sufil_sap:
-    name: sufil sap
-    size: 6
-    stackable: true
-    room: 13997
-    price: 631
-    quantity: 6
-  yelith_root:
-    name: yelith root
-    size: 6
-    stackable: true
-    room: 13997
-    price: 676
-    quantity: 20
-  ithor_potion:
-    name: ithor potion
-    size: 6
-    stackable: true
-    room: 13997
-    price: 676
-    quantity: 20
-  muljin_sap:
-    name: muljin sap
-    size: 6
-    stackable: true
-    room: 13997
-    price: 937
-    quantity: 6
-  junliar_stem:
-    name: junliar stem
-    size: 6
-    stackable: true
-    room: 13997
-    price: 676
-    quantity: 6
-  # blocil_potion:  Not available in Shard.
-  #   name: blocil potion
-  #   size: 6
-  #   stackable: false
-  #   room: 13997
-  #   price: 937
-  #   quantity: 6
-  riolur_leaf:
-    name: riolur leaf
-    size: 6
-    stackable: true
-    room: 13997
-    price: 721
-    quantity: 6
-  qun_pollen:
-    name: qun pollen
-    size: 6
-    stackable: true
-    room: 13997
-    price: 405
-    quantity: 6
-  genich_stem:
-    name: genich stem
-    size: 6
-    stackable: false
-    room: 13997
-    price: 405
-    quantity: 20
-  nuloe_stem:
-    name: nuloe stem
-    size: 6
-    stackable: true
-    room: 13997
-    price: 451
-    quantity: 20
-  cebi_root:
-    name: cebi root
-    size: 6
-    stackable: true
-    room: 13997
-    price: 451
-    quantity: 6
-  hulij_elixir:
-    name: hulij elixir
-    size: 6
-    stackable: false
-    room: 13997
-    price: 4541
-    quantity: 6
-  hisan_salve:
-    name: hisan salve
-    size: 6
-    stackable: true
-    room: 13997
-    price: 541
-    quantity: 6
-  jadice_pollen:
-    name: jadice pollen
-    size: 6
-    stackable: true
-    room: 13997
-    price: 451
-    quantity: 20
-  ojhenik_potion:
-    name: ojhenik potion
-    size: 6
-    stackable: false
-    room: 13997
-    price: 451
-    quantity: 20     

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1319,8 +1319,12 @@ saferoom_health_threshold: 7
 # https://elanthipedia.play.net/Lich_script_repository#restock
 restock:
 
-# restock equivalent for combinable herbs, see profiles/HerbUser-setup.yaml
+# Set to true to restock herbs. Alternatively, a restock equivalent for combinable herbs, see profiles/HerbUser-setup.yaml.
+# By default, if herbs contains a list of herbs, they will be added as options for herb-restock.
+# Set herbs_override_herbstock to true to use herbs defined here exclusively.
 herbs:
+
+herbs_override_herbstock: false
 
 # Setting to override combat-trainer skipping herbs that require a hand to use while in combat
 combat_trainer_herbs_allowhands: false


### PR DESCRIPTION
Added the ability to add additional herbs to the list of restock herbs from the user's YAML or override the herbs altogether. Updated base.yaml as well as the HerbUser-setup.yaml example file.