### PR TITLE
Replaced textbook/compendium check with OR exists statements

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -201,7 +201,7 @@ class Trade
       wipe_skill('Performance', @lead_training_skills)
     end
     if @caravan_training_skills.include?('First Aid')
-      unless @settings.textbook ? exists?(@settings.textbook_type) : exists?('compendium')
+      unless exists?(@settings.textbook_type) || exists?(@settings.compendium_type)
         echo 'NO COMPENDIUM OR TEXTBOOK FOUND.  CHECK YOUR ;FIRST-AID SETTINGS'
         wipe_skill('First Aid', @lead_training_skills)
       end


### PR DESCRIPTION
Changed line 206 to look for existence of either textbook or compendium settings. Intended so that manuals/guides can be used with trade script first-aid call.