### PR TITLE
tarantula - Fixed typo in match

### DIFF
--- a/tarantula.lic
+++ b/tarantula.lic
@@ -37,7 +37,7 @@ class Tarantula
 
   def check_last
     DRC.message("*** Checking last skillset used ***") if @debug
-    DRC.bput("study #{@tarantula_noun}", /knowledge of (.*) techniques/, /current set to consume .* experience\./) =~ /knowledge of (.*) techniques/
+    DRC.bput("study #{@tarantula_noun}", /knowledge of (.*) techniques/, /currently set to consume .* experience\./) =~ /knowledge of (.*) techniques/
     @last = Regexp.last_match(1)
     @last = @last.sub(/s$/, '')
     UserVars.tarantula_last_skillset = @last


### PR DESCRIPTION
The previous match was not matching `The tarantula is currently set to consume Alchemy experience.`
`/current set to consume .* experience\./`

Updated to:
`/currently set to consume .* experience\./`

This fix matters for 1st use of a new tarantula.  I still need to go test it out on the test server on a character without one to make another change.