### PR TITLE
[script][forge] ingot fetching

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -151,7 +151,7 @@ class Forge
     end
     swap_tool(@home_tool)
     if @metal
-      DRCC.get_crafting_item("#{@metal} ingot", @bag, @bag_items, @forging_belt)
+      DRC.bput("get #{@metal} ingot from my #{@bag}", "^You get")
       DRC.bput('put my ingot on anvil', 'You put your')
       swap_tool(@hammer)
       swap_tool('tongs')


### PR DESCRIPTION
Specified fetching ingots from your crafting container. Smith stows it there, as does the new taskmaster, but the DRCC.get_crafting_item doesn't fetch from there unless it's on the list of items to get from your bag.
```ruby
DRCC.stow_crafting_item('ingot', @bag, @forging_belt)
```
This makes it a specific fetch from the same bag it should be in, instead of just from anywhere on your person.