### PR TITLE
[script][sew] Allow missing stamp

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -281,7 +281,7 @@ class Sew
 
   def finish
     if @stamp
-      swap_tool('stamp')
+      swap_tool('stamp', true)
       DRC.bput("mark my #{@noun} with my stamp", 'Roundtime')
       DRCC.stow_crafting_item('stamp', @bag, @belt)
     end


### PR DESCRIPTION
If you misplaced your stamp, or left it somewhere, this allows the script to finish even if it can't find it. important if you're having the script log/stow the items.