### PR TITLE
circlecheck.lic - improved sorting

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -686,8 +686,8 @@ end
 def get_skills_by_type(type)
   $Skills
     .select { |skill| skill[:type] == type }
-    .map { |skill| [skill[:name], DRSkill.getrank(skill[:name])] }
-    .sort_by(&:last)
+    .map { |skill| [skill[:name], DRSkill.getrank(skill[:name]), DRSkill.getpercent(skill[:name]).to_i] }
+    .sort_by { |skill| [skill[1], skill[2]] }
     .reverse
     .keep_if { |skill| skill.last > 0 || DRSkill.getpercent(skill.first).to_i > 0 }
 end


### PR DESCRIPTION
Minor change to skill sorting to include the skill's percent. This corrects an issue where for e.g. Weapon skills, circlecheck would often output the incorrect skill as the highest.