### PR TITLE
Changed OM fullness string to reflect capital A

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -74,7 +74,7 @@ module DRCA
     return unless DRSpells.active_spells['Osrel Meraud'] && DRSpells.active_spells['Osrel Meraud'] < 90
     return unless amount
 
-    success = ['having reached its full capacity', 'a sense of fullness', 'Something in the area is interfering with your attempt to harness']
+    success = ['having reached its full capacity', 'A sense of fullness', 'Something in the area is interfering with your attempt to harness']
     failure = ['as if it hungers for more', 'Your infusion fails completely', 'You don\'t have enough harnessed mana to infuse that much', 'You have no harnessed']
 
     loop do


### PR DESCRIPTION
Replaced the 'a' with 'A' to avoid an extra harness/infuse step on a full OM orb.