### PR TITLE
[script][forge] Ingot handling

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -151,8 +151,9 @@ class Forge
     end
     swap_tool(@home_tool)
     if @metal
+      @bag_items << "#{@metal} ingot"
       DRCC.get_crafting_item("#{@metal} ingot", @bag, @bag_items, @forging_belt)
-      DRC.bput('put my ingot on anvil', 'You put your')
+      DRC.bput("put my #{@metal} ingot on anvil", 'You put your')
       swap_tool(@hammer)
       swap_tool('tongs')
       @command = "pound ingot on anvil with my #{@hammer}"


### PR DESCRIPTION
Adds the metal-type ingot to your bag items before fetching, so that it always fetches from your crafting container, instead of grasping at any ol' metal-type ingot you might be carrying.