### PR TITLE
[script][taskmaster] Open up town choice for anvils

### DIFF
--- a/taskmaster.lic
+++ b/taskmaster.lic
@@ -25,6 +25,7 @@ class TaskMaster
         @gem = @settings.gem_pouch_adjective
         @cube = @settings.cube_armor_piece
         @no_repair = @settings.task_no_repair
+        @anvil_town = @settings.crafting_hometown || "Crossing"
         @self_repair = @settings.task_self_repair
         @pickup_tools = @settings.task_get_tools_on_completion
         @boost = @settings.task_use_boost
@@ -332,7 +333,7 @@ class TaskMaster
     def forge_item(item, count, type)
         info = get_data('crafting')['blacksmithing']["Crossing"]
         DRCC.check_consumables('oil', info['finisher-room'], info['finisher-number'], @bag, @bag_items, nil, count)
-        DRCC.find_anvil("Crossing")
+        DRCC.find_anvil(@anvil_town)
         count.times do
             DRC.wait_for_script_to_complete('forge', ['instructions', type, item, 'skip'])
             DRC.bput("put my #{item} in my #{@bag}", "You put")


### PR DESCRIPTION
can use fang cove for the anvil via yaml setting:
```yaml
crafting_hometown: Fang Cove
```
For premies only, any other town but crossing or fang cove would become troublesome, with currency.