### PR TITLE
[script][taskmaster] Slight efficiency update

### DIFF
--- a/taskmaster.lic
+++ b/taskmaster.lic
@@ -100,8 +100,8 @@ class TaskMaster
                     find_npc(@rooms, @npc)
                 end
                 tailor_item(item, count, base, type)
-                complete_task(item, count)
                 DRCT.dispose("#{item} instructions", 16144)
+                complete_task(item, count)
                 break if Flags['wrap-up']
             end
             tool_pickup if @pickup_tools && DRCI.exists?("rangu ticket")


### PR DESCRIPTION
Moving the trash dump above completion saves us having to chase down the taskmaster twice in a row, once to turn in, then once again after trashing to get the next task.