### PR TITLE
[script][outdoorsmanship] - Remove errant "s"

### DIFF
--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -64,7 +64,7 @@ class Outdoorsmanship
         crafting_magic_routine(@settings)
         collect(item)
         waitrt?
-        kick_pile? unless kick_pile?("#{item}s")
+        kick_pile? unless kick_pile?("#{item}")
       end
       attempt += 1
     end


### PR DESCRIPTION
In the attempt to `kick_pile?` after collecting an item, there was an errant string "s" after the plug-in of the collected item. Removing that "s". The script still moved on with a generic `kick pile` after the failure of the specific `kick #{item}`, but still...