### PR TITLE
enchant - add cube functionality

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -12,6 +12,7 @@ class Enchant
   def initialize
     @settings = get_settings
     @book_type = 'artificing'
+    @cube = @settings.cube_armor_piece
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.enchanting_belt
@@ -82,6 +83,7 @@ class Enchant
       end
     end
 
+    DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/) if @cube
     imbue
 
     get_item(@burin)


### PR DESCRIPTION
Added same cube functionality found in forge, sew, shape. Using the same code added to those (maybe should be a common-crafting method?). Ran through, it touched the cube as expected, triggering it before performing the crafting routines.