### PR TITLE
[scripts][common-healing] Add dead status to output

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -99,7 +99,7 @@ module DRCH
   def perceive_health_other(target)
     return unless DRStats.empath?
 
-    case DRC.bput("touch #{target}", 'Touch what', 'feels cold and you are unable to sense anything', 'avoids your touch', 'You sense a successful empathic link has been forged between you and (?<name>\w+)\.')
+    case DRC.bput("touch #{target}", 'Touch what', 'feels cold and you are unable to sense anything', 'avoids your touch', 'You sense a successful empathic link has been forged between you and (?<name>\w+)\.', /^(He|She) is dead\./)
     when 'avoids your touch', 'feels cold and you are unable to sense anything', 'Touch what'
       return nil
     when /You sense a successful empathic link has been forged between you and (?<name>\w+)\./
@@ -118,8 +118,9 @@ module DRCH
 
     pause 0.5 # Pause to wait for the full response to come back from the server
 
-    stop_line = target.nil? ? 'Your injuries include...' : "#{target}'s injuries include..."
+    stop_line = target.nil? ? 'Your injuries include...' : "You sense a successful empathic link has been forged between you and #{target}\."
     health_lines = reget(100).map(&:strip).reverse
+    echo("Health lines are #{health_lines}")
     if !health_lines.include?(stop_line)
       return
     end
@@ -138,17 +139,25 @@ module DRCH
       /^[\w]+ (?:body|skin) is covered (?:in|with) open oozing sores/
     ])
 
+    dead_regex = Regexp.union([
+      /^(He|She) is dead/
+    ])
+
     perceived_wounds = Hash.new { |h, k| h[k] = [] }
     perceived_parasites = Hash.new { |h, k| h[k] = [] }
     perceived_poison = false
     perceived_disease = false
     wound_body_part = nil
+    dead = false
 
+    echo(health_lines)
     health_lines
       .take_while { |line| line != stop_line }
       .reverse # put back in normal order so we parse <body part> line then <wound> lines
       .each do |line|
         case line
+        when dead_regex
+          dead = true
         when diseases_regex
           perceived_disease = true
         when poisons_regex
@@ -191,6 +200,7 @@ module DRCH
       'parasites' => perceived_parasites,
       'poisoned' => perceived_poison,
       'diseased' => perceived_disease,
+      'dead' => dead,
       'score' => calculate_score(wounds)
     }
   end

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -120,7 +120,6 @@ module DRCH
 
     stop_line = target.nil? ? 'Your injuries include...' : "You sense a successful empathic link has been forged between you and #{target}\."
     health_lines = reget(100).map(&:strip).reverse
-    echo("Health lines are #{health_lines}")
     if !health_lines.include?(stop_line)
       return
     end
@@ -150,7 +149,6 @@ module DRCH
     wound_body_part = nil
     dead = false
 
-    echo(health_lines)
     health_lines
       .take_while { |line| line != stop_line }
       .reverse # put back in normal order so we parse <body part> line then <wound> lines

--- a/common-healing.lic
+++ b/common-healing.lic
@@ -99,7 +99,7 @@ module DRCH
   def perceive_health_other(target)
     return unless DRStats.empath?
 
-    case DRC.bput("touch #{target}", 'Touch what', 'feels cold and you are unable to sense anything', 'avoids your touch', 'You sense a successful empathic link has been forged between you and (?<name>\w+)\.', /^(He|She) is dead\./)
+    case DRC.bput("touch #{target}", 'Touch what', 'feels cold and you are unable to sense anything', 'avoids your touch', 'You sense a successful empathic link has been forged between you and (?<name>\w+)\.')
     when 'avoids your touch', 'feels cold and you are unable to sense anything', 'Touch what'
       return nil
     when /You sense a successful empathic link has been forged between you and (?<name>\w+)\./


### PR DESCRIPTION
Allows us to detect whether our touch target is dead or not, and perhaps act accordingly.

```
2022-11-23-3.log:"[exec1: {\"wounds\"=>{}, \"parasites\"=>{}, \"poisoned\"=>false, \"diseased\"=>false, \"dead\"=>true, \"score\"=>0}]"
2022-11-23-3.log:"[exec1: {\"wounds\"=>{}, \"parasites\"=>{}, \"poisoned\"=>false, \"diseased\"=>false, \"dead\"=>false, \"score\"=>0}]"
```

In my case, I use it to determine whether I want to link unity (which will kill my empath if the person being healed is a corpse...) or take all quick, which won't kill my empath ever.