### PR TITLE
[scripts][common-items]Adding tie/untie succes/failures, and retry on dispose.

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -127,7 +127,8 @@ module DRCI
 
   @@tie_item_success_patterns = [
     /^You .* tie/,
-    /^You attach/
+    /^You attach/,
+    /^You untie/
   ]
 
   @@tie_item_failure_patterns = [
@@ -138,7 +139,8 @@ module DRCI
   ]
 
   @@untie_item_success_patterns = [
-    /you untie/
+    /you untie/,
+    /^You untie/
   ]
 
   @@untie_item_failure_patterns = [
@@ -350,7 +352,9 @@ module DRCI
     return if item.nil?
 
     if worn_trashcan
-      case DRC.bput("put my #{item} in my #{worn_trashcan}", @@drop_trash_retry_patterns, @@drop_trash_success_patterns, @@drop_trash_failure_patterns)
+      case DRC.bput("put my #{item} in my #{worn_trashcan}", @@drop_trash_retry_patterns, @@drop_trash_success_patterns, @@drop_trash_failure_patterns, /^Perhaps you should be holding that first/)
+      when /^Perhaps you should be holding that first/
+        return false unless DRCI.get_item?(item) && DRCI.dispose_trash(item)
       when *@@drop_trash_retry_patterns
         return true if dispose_trash(item, worn_trashcan, worn_trashcan_verb)
       when *@@drop_trash_success_patterns
@@ -394,7 +398,9 @@ module DRCI
         trashcan = 'bin'
       end
 
-      case DRC.bput("put my #{item} in #{trashcan}", @@drop_trash_success_patterns, @@drop_trash_failure_patterns, @@drop_trash_retry_patterns)
+      case DRC.bput("put my #{item} in #{trashcan}", @@drop_trash_success_patterns, @@drop_trash_failure_patterns, @@drop_trash_retry_patterns, /^Perhaps you should be holding that first/)
+      when /^Perhaps you should be holding that first/
+        return false unless DRCI.get_item?(item) && DRCI.dispose_trash(item)
       when *@@drop_trash_retry_patterns
         # If still didn't dispose of trash after retry
         # then don't return yet, will try to drop it later.
@@ -405,7 +411,9 @@ module DRCI
     end
 
     # No trash bins or not able to put item in a bin, just drop it.
-    case DRC.bput("drop my #{item}", @@drop_trash_success_patterns, @@drop_trash_failure_patterns, @@drop_trash_retry_patterns)
+    case DRC.bput("drop my #{item}", @@drop_trash_success_patterns, @@drop_trash_failure_patterns, @@drop_trash_retry_patterns, /^Perhaps you should be holding that first/)
+    when /^Perhaps you should be holding that first/
+      return false unless DRCI.get_item?(item) && DRCI.dispose_trash(item)
     when *@@drop_trash_retry_patterns
       return dispose_trash(item)
     when *@@drop_trash_success_patterns


### PR DESCRIPTION
Adds some matches for tie/untie successes, and in the case where you dropped an item (and it fell to your feet)  it'll retry. It's magic for all the HE games that eat your hands...

```
"[find-darkbox]>put my dark rockweed in bucket"
"Perhaps you should be holding that first."
"[find-darkbox]>get my dark rockweed "
"You pick up the rockweed lying at your feet."
"[find-darkbox]>put my dark rockweed in bucket"
"You drop a dark brown rockweed in a bucket of viscous gloop."
```
