### PR TITLE
[scripts][corn-maze]Flags to bput, and other updates

### DIFF
--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -298,18 +298,6 @@ class CornMaze
   def wait_for_command
     reset_flags
     Flags.reset('task_done')
-    # Flags.add('scarecrow', 'need to BUILD SCARECROW')
-    # Flags.add('mice', 'need to WAVE to scare off the mice')
-    # Flags.add('weeds', 'need to walk around the maze and PULL WEED')
-    # Flags.add('traps', 'need to first SEARCH out a trap in each room')
-    # Flags.add('grasshoppers', 'need to SEARCH in the rooms to find and catch the grasshoppers')
-    # Flags.add('scream', 'need to move to different rooms in the maze and SCREAM')
-    # Flags.add('landmarks', 'need to go around finding landmarks')
-    # Flags.add('tokens', 'move around and SEARCH to find golden tokens')
-    # Flags.add('corn', 'need to FORAGE CORN inside the maze')
-    # Flags.add('halflings', 'need to go up to each Halfling and POKE them')
-    # Flags.add('loot', 'You are not currently on a task in the Corn Maze')
-    # Flags.add('kill', 'Okay, we\'d like you to kill')
 
     case DRC.bput("TASK",
       /need to BUILD SCARECROW/,
@@ -555,8 +543,6 @@ class CornMaze
       end
       if DRRoom.npcs.include? 'Gor\'Tog'
         DRC.bput('poke gor\'tog', 'You poke a', 'What were you')
-        # pause 1
-        # waitrt?
         DRC.fix_standing
         recover_stun
         DRC.fix_standing
@@ -701,18 +687,6 @@ class CornMaze
   end
 
   def reset_flags
-    # Long maze flags
-    # Flags.reset('scarecrow')
-    # Flags.reset('mice')
-    # Flags.reset('weeds')
-    # Flags.reset('traps')
-    # Flags.reset('grasshoppers')
-    # Flags.reset('scream')
-    # Flags.reset('landmarks')
-    # Flags.reset('tokens')
-    # Flags.reset('corn')
-    # Flags.reset('halflings')
-    # Flags.reset('loot')
     # Short maze flags
     Flags.reset('task_build')
     Flags.reset('task_search')
@@ -772,18 +746,6 @@ end
 before_dying do
   kernel_count = DRC.bput("count my bottle", /^I could not find what you were referring to/, /^You count the number of kernels inside the bottle and find that there are \d+,?\d*/).tr(',','').scan(/\d+/).first.to_i
   DRC.message("CM: Exiting script with #{kernel_count} kernels.")
-  # Long maze flags
-  # Flags.delete('scarecrow')
-  # Flags.delete('mice')
-  # Flags.delete('weeds')
-  # Flags.delete('traps')
-  # Flags.delete('grasshoppers')
-  # Flags.delete('scream')
-  # Flags.delete('landmarks')
-  # Flags.delete('tokens')
-  # Flags.delete('corn')
-  # Flags.delete('halflings')
-  # Flags.delete('loot')
   Flags.delete('maze_done')
   Flags.delete('poisoned')
   Flags.delete('already_built')

--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -6,9 +6,6 @@
 custom_require.call(%w(common drinfomon common-travel events common-items))
 
 class CornMaze
-  include DRC
-  include DRCT
-  include DRCI
 
   def setup
     @done = false
@@ -199,6 +196,10 @@ class CornMaze
     DRCI.stow_hands
     manual_loot if args.manual
 
+    unless args.restart
+      DRC.log_window("***STATUS*** Starting Maze run with #{count_he_bottle} kernels", "familiar")
+    end
+
     if args.short
       run_short_maze
     else
@@ -264,6 +265,10 @@ class CornMaze
     end
   end
 
+  def count_he_bottle
+    DRC.bput("count my bottle", /^I could not find what you were referring to/, /^You count the number of kernels inside the bottle and find that there are \d+,?\d*/).tr(',','').scan(/\d+/).first.to_i
+  end
+
   def do_short_task(task)
     Flags.reset("task_#{task}")
     case task
@@ -293,45 +298,68 @@ class CornMaze
   def wait_for_command
     reset_flags
     Flags.reset('task_done')
-    Flags.add('scarecrow', 'need to BUILD SCARECROW')
-    Flags.add('mice', 'need to WAVE to scare off the mice')
-    Flags.add('weeds', 'need to walk around the maze and PULL WEED')
-    Flags.add('traps', 'need to first SEARCH out a trap in each room')
-    Flags.add('grasshoppers', 'need to SEARCH in the rooms to find and catch the grasshoppers')
-    Flags.add('scream', 'need to move to different rooms in the maze and SCREAM')
-    Flags.add('landmarks', 'need to go around finding landmarks')
-    Flags.add('tokens', 'move around and SEARCH to find golden tokens')
-    Flags.add('corn', 'need to FORAGE CORN inside the maze')
-    Flags.add('halflings', 'need to go up to each Halfling and POKE them')
-    Flags.add('loot', 'You are not currently on a task in the Corn Maze')
+    # Flags.add('scarecrow', 'need to BUILD SCARECROW')
+    # Flags.add('mice', 'need to WAVE to scare off the mice')
+    # Flags.add('weeds', 'need to walk around the maze and PULL WEED')
+    # Flags.add('traps', 'need to first SEARCH out a trap in each room')
+    # Flags.add('grasshoppers', 'need to SEARCH in the rooms to find and catch the grasshoppers')
+    # Flags.add('scream', 'need to move to different rooms in the maze and SCREAM')
+    # Flags.add('landmarks', 'need to go around finding landmarks')
+    # Flags.add('tokens', 'move around and SEARCH to find golden tokens')
+    # Flags.add('corn', 'need to FORAGE CORN inside the maze')
+    # Flags.add('halflings', 'need to go up to each Halfling and POKE them')
+    # Flags.add('loot', 'You are not currently on a task in the Corn Maze')
+    # Flags.add('kill', 'Okay, we\'d like you to kill')
 
-    fput "TASK"
-    pause 2
-    if Flags['scarecrow']
+    case DRC.bput("TASK",
+      /need to BUILD SCARECROW/,
+      /need to WAVE to scare off the mice/,
+      /need to walk around the maze and PULL WEED/,
+      /need to first SEARCH out a trap in each room/,
+      /need to SEARCH in the rooms to find and catch the grasshoppers/,
+      /need to move to different rooms in the maze and SCREAM/,
+      /need to go around finding landmarks/,
+      /move around and SEARCH to find golden tokens/,
+      /need to FORAGE CORN inside the maze/,
+      /need to go up to each Halfling and POKE them/,
+      /You are not currently on a task in the Corn Maze/,
+      /Okay, we'd like you to kill/
+    )
+    when /need to BUILD SCARECROW/
+      DRC.log_window("CM:Starting task BUILD SCARECROW", "familiar")
       scarecrow_task
-    elsif Flags['mice']
+    when /need to WAVE to scare off the mice/
+      DRC.log_window("CM:Starting task WAVE", "familiar")
       mice_task
-    elsif Flags['weeds']
+    when /need to walk around the maze and PULL WEED/
+      DRC.log_window("CM:Starting task PULL WEED", "familiar")
       weeds_task
-    elsif Flags['traps']
+    when /need to first SEARCH out a trap in each room/
+      DRC.log_window("CM:Starting task SEARCH TRAPS", "familiar")
       traps_task
-    elsif Flags['grasshoppers']
+    when /need to SEARCH in the rooms to find and catch the grasshoppers/
+      DRC.log_window("CM:Starting task SEARCH", "familiar")
       grasshopper_task
-    elsif Flags['scream']
+    when /need to move to different rooms in the maze and SCREAM/
+      DRC.log_window("CM:Starting task SCREAM", "familiar")
       scream_task
-    elsif Flags['landmarks']
+    when /need to go around finding landmarks/
+      DRC.log_window("CM:Starting task LANDMARKS", "familiar")
       landmarks_task
-    elsif Flags['tokens']
+    when /move around and SEARCH to find golden tokens/
+      DRC.log_window("CM:Starting task SEARCH TOKENS", "familiar")
       tokens_task
-    elsif Flags['corn']
+    when /need to FORAGE CORN inside the maze/
+      DRC.log_window("CM:Starting task FORAGE", "familiar")
       corn_task
-    elsif Flags['halflings']
+    when /need to go up to each Halfling and POKE them/
+      DRC.log_window("CM:Starting task POKE", "familiar")
       halfling_task
-    elsif Flags['loot']
+    when /You are not currently on a task in the Corn Maze/
       loot_task
-    else
-      echo "COMBAT TASK - CANCELING"
-    cancel_task
+    when /Okay, we'd like you to kill/
+      DRC.log_window("CM:KILL TASK - Cancelling task", "familiar")
+      cancel_task
     end
   end
 
@@ -350,7 +378,7 @@ class CornMaze
         case DRC.bput('search', 'You don\'t think there are any traps here', 'tiny black dots are jumping around inside', 'You notice', 'already looked for traps around here')
         when 'You notice'
           waitrt?
-          bput('disarm trap', 'You attempt to disarm', 'Disarm what')
+          DRC.bput('disarm trap', 'You attempt to disarm', 'Disarm what')
           pause 1
           waitrt?
           recover_stun
@@ -361,7 +389,7 @@ class CornMaze
         custom_move(x, true)
       end
     end
-    echo "TURNING IN TASK!"
+    DRC.message("TURNING IN TASK!")
     Flags.delete('poisoned')
     finish_task
   end
@@ -394,13 +422,13 @@ class CornMaze
         pause 1
         waitrt?
         DRC.fix_standing
-        fput "TASK"
+        fput("TASK")
         custom_move(x)
       else
         custom_move(x, true)
       end
     end
-    echo "TURNING IN TASK!"
+    DRC.message("TURNING IN TASK!")
     finish_task
   end
 
@@ -414,7 +442,7 @@ class CornMaze
         custom_move(x, true)
       end
     end
-    echo "TURNING IN TASK!"
+    DRC.message("TURNING IN TASK!")
     finish_task
   end
 
@@ -426,16 +454,16 @@ class CornMaze
         pause 1
         waitrt?
         while !checkstanding
-          fput 'stand'
+          DRC.fix_standing
         end
         DRC.fix_standing
-        fput "TASK"
+        fput("TASK")
         custom_move(x)
       else
         custom_move(x, true)
       end
     end
-    echo "TURNING IN TASK!"
+    DRC.message( "TURNING IN TASK!")
     finish_task
   end
 
@@ -446,7 +474,7 @@ class CornMaze
         DRC.bput('forage corn', 'You forage around for a moment', 'You\'ve already looked around here')
         pause 1
         waitrt?
-      fput('drop corn') if /corn/ =~ left_hand || /corn/ =~ right_hand
+      DRCI.dispose_trash('corn') if /corn/ =~ DRC.left_hand || /corn/ =~ DRC.right_hand
         DRC.fix_standing
         fput "TASK"
         custom_move(x)
@@ -466,13 +494,13 @@ class CornMaze
         pause 1
         waitrt?
         DRC.fix_standing
-        fput "TASK"
+        fput("TASK")
         custom_move(x)
       else
         custom_move(x, true)
       end
     end
-    echo "TURNING IN TASK!"
+    DRC.message( "TURNING IN TASK!")
     finish_task
   end
 
@@ -485,12 +513,12 @@ class CornMaze
         waitrt?
         DRC.fix_standing
         custom_move(x)
-        fput "TASK"
+        fput("TASK")
       else
         custom_move(x, true)
       end
     end
-    echo "TURNING IN TASK!"
+    DRC.message( "TURNING IN TASK!")
     finish_task
   end
 
@@ -512,7 +540,7 @@ class CornMaze
   def touch_room
     targets = DRRoom.room_objs.grep(@landmarks)
     targets.each do |target|
-      put("touch #{target.split.last}")
+      fput("touch #{target.split.last}")
     end
   end
 
@@ -521,18 +549,19 @@ class CornMaze
       next if x == 'loot'
       exit if Flags['maze_done']
       if DRRoom.npcs.include? 'Halfling'
-        bput('poke halfling', 'You poke a', 'What were you')
+        DRC.bput('poke halfling', 'You poke a', 'What were you')
         pause 1
-        put('TASK')
+        fput("TASK")
       end
       if DRRoom.npcs.include? 'Gor\'Tog'
-        bput('poke gor\'tog', 'You poke a', 'What were you')
-        pause 1
-        waitrt?
+        DRC.bput('poke gor\'tog', 'You poke a', 'What were you')
+        # pause 1
+        # waitrt?
+        DRC.fix_standing
         recover_stun
         DRC.fix_standing
         pause 1
-        put('TASK')
+        fput("TASK")
       end
       unless Flags['task_done']
         custom_move(x)
@@ -590,10 +619,7 @@ class CornMaze
   end
 
   def drop_item(item)
-    case bput("drop my #{item}", 'You drop', 'would damage it', 'smashing it to bits', 'Something appears different about')
-    when 'would damage it', 'Something appears different about'
-      drop_item(item)
-    end
+    DRCI.dispose_trash(item)
   end
 
   def wait_on_done_move
@@ -618,7 +644,7 @@ class CornMaze
     DRC.bput('ask halfling about task', '^A .+ Halfling smiles happily at you', '^To whom')
     echo "Task count = #{@task_count}"
     if @searching == false
-      case bput('ask halfling for task', 'A cheerful Halfling smiles happily', 'To whom are you', 'A cheerful Halfling looks at you and says')
+      case DRC.bput('ask halfling for task', 'A cheerful Halfling smiles happily', 'To whom are you', 'A cheerful Halfling looks at you and says')
       when 'A cheerful Halfling looks at you and says'
         fput('ask halfling for task cancel')
         fput('ask halfling for task cancel')
@@ -667,6 +693,8 @@ class CornMaze
   end
 
   def finish_task
+    DRC.log_window("Finished task.", "familiar")
+    fput('count my bottle')
     reset_flags
     @task_count = @task_count + 1
     get_task
@@ -674,17 +702,17 @@ class CornMaze
 
   def reset_flags
     # Long maze flags
-    Flags.reset('scarecrow')
-    Flags.reset('mice')
-    Flags.reset('weeds')
-    Flags.reset('traps')
-    Flags.reset('grasshoppers')
-    Flags.reset('scream')
-    Flags.reset('landmarks')
-    Flags.reset('tokens')
-    Flags.reset('corn')
-    Flags.reset('halflings')
-    Flags.reset('loot')
+    # Flags.reset('scarecrow')
+    # Flags.reset('mice')
+    # Flags.reset('weeds')
+    # Flags.reset('traps')
+    # Flags.reset('grasshoppers')
+    # Flags.reset('scream')
+    # Flags.reset('landmarks')
+    # Flags.reset('tokens')
+    # Flags.reset('corn')
+    # Flags.reset('halflings')
+    # Flags.reset('loot')
     # Short maze flags
     Flags.reset('task_build')
     Flags.reset('task_search')
@@ -704,7 +732,7 @@ class CornMaze
       put dir
       @current_type_ahead += 1
       if @type_ahead_size < @current_type_ahead
-        pause 0.35
+        pause 0.2
         @current_type_ahead = 0
       end
     else
@@ -714,35 +742,48 @@ class CornMaze
   end
 
   def stow_thing(thing)
-    @settings.cornmaze_containers.each do |container|
-      return if DRC.bput("put #{thing} in my #{container}", 'You put', 'What were you', 'There isn\'t any more room', 'too long', 'You just can\'t get') == 'You put'
+    if @settings.cornmaze_containers.any?
+      @settings.cornmaze_containers.each do |container|
+        unless DRCI.put_away_item?(thing, container)
+          unless DRCI.stow_item?(thing)
+            DRC.message("#{thing} didn't fit anywhere. Dropping it.")
+            DRCI.dispose_trash(thing)
+          end
+        end
+        return
+      end
+    else
+      unless DRCI.stow_item?(thing)
+        DRC.message("YOU'VE RUN OUT OF ROOM!  GET SOME MORE SPACE, YOU LAZY SLOB!")
+        DRCI.dispose_trash(thing)
+      end
+      return
     end
-    return if DRC.bput("stow #{thing}", 'You put', 'What were you', 'There isn\'t any more room', 'Stow what', 'too long', 'That cannot be placed') == 'You put'
-    pause 1
-    DRC.message("YOU'VE RUN OUT OF ROOM!  GET SOME MORE SPACE, YOU LAZY SLOB!")
-    DRC.bput("drop #{thing}", 'You drop', 'What were you')
   end
 
   def recover_stun
-    return if bput('stand', 'You are already standing', 'You are still stunned', 'You stand back up', 'You can\'t do that') == 'You are already standing'
+    return unless !checkstanding || stunned?
+    DRC.fix_standing
     pause 3
     recover_stun
   end
 end
 
 before_dying do
+  kernel_count = DRC.bput("count my bottle", /^I could not find what you were referring to/, /^You count the number of kernels inside the bottle and find that there are \d+,?\d*/).tr(',','').scan(/\d+/).first.to_i
+  DRC.message("CM: Exiting script with #{kernel_count} kernels.")
   # Long maze flags
-  Flags.delete('scarecrow')
-  Flags.delete('mice')
-  Flags.delete('weeds')
-  Flags.delete('traps')
-  Flags.delete('grasshoppers')
-  Flags.delete('scream')
-  Flags.delete('landmarks')
-  Flags.delete('tokens')
-  Flags.delete('corn')
-  Flags.delete('halflings')
-  Flags.delete('loot')
+  # Flags.delete('scarecrow')
+  # Flags.delete('mice')
+  # Flags.delete('weeds')
+  # Flags.delete('traps')
+  # Flags.delete('grasshoppers')
+  # Flags.delete('scream')
+  # Flags.delete('landmarks')
+  # Flags.delete('tokens')
+  # Flags.delete('corn')
+  # Flags.delete('halflings')
+  # Flags.delete('loot')
   Flags.delete('maze_done')
   Flags.delete('poisoned')
   Flags.delete('already_built')


### PR DESCRIPTION
Updated to common methods, remove flags for long maze, swapping with much more reliable bput case when.

Addresses specific issue brought up by Remyngton where the flag capture with the simple `else` made a person running through seem like a kill task.

Have run 70+ long maze runs with this version.