### PR TITLE
[script][taskmaster] Edits to repair

### DIFF
--- a/taskmaster.lic
+++ b/taskmaster.lic
@@ -90,6 +90,7 @@ class TaskMaster
         elsif @marathon
             @npc = 'zasele'
             restock
+            tool_pickup if !@self_repair && DRCI.exists?("rangu ticket")
             DRCM.ensure_copper_on_hand(80000, @settings, "Crossing")
             loop do
                 item,count,volume_per_item,base,type = get_task
@@ -536,8 +537,7 @@ class TaskMaster
         while DRC.bput("get my Rangu ticket", 'You get', 'What were') == 'You get'
         pause 30 until DRC.bput('look at my ticket', 'should be ready by now', 'Looking at the') == 'should be ready by now'
         DRC.bput("give Rangu", 'You hand')
-        pause 1 # borrowed from workorders to give time for xml to catch up
-        tool = [DRC.right_hand,DRC.left_hand].compact.first
+        pause 0.01 until tool = [DRC.right_hand,DRC.left_hand].compact.first # waits for tool to hit your hand
         belts = [@settings.forging_belt, @settings.engineering_belt, @settings.outfitting_belt, @settings.alchemy_belt, @settings.enchanting_belt]
         toolbelt = belts.select { |belt| belt["items"].find { |name| name =~ /#{tool}/i } }.first # searches your toolbelts for the first one containing the tool.
         DRCC.stow_crafting_item(tool, @bag, toolbelt) # hopefully stows the tool appropriately. 


### PR DESCRIPTION
Two small edits: 
1. adds a quick pickup at the start of marathon, in case you have any tools left at the repair shop
2. reworked the pickup to speed it up a little. Previously had a hard 1 second pause, now it just waits until tool hits your hand in the xml. 

log for 2:
```
>;task pickup
--- Lich: taskmaster active.
>
[taskmaster]>tap my rangu ticket 
You tap a Rangu repair ticket inside your multi-strapped carryall.
>
[taskmaster]>get my Rangu ticket
You get a Rangu repair ticket from inside your multi-strapped carryall.
>
[taskmaster]>look at my ticket
Looking at the Rangu ticket you see it is for a set of bellows augmented with clockwork mechanisms.  You recall that your bellows should be ready by now.

Written at the bottom you see Rangu's Repair Shop, Engineering Society, Zoluren.
>
[taskmaster]>give Rangu
You hand Rangu your ticket and are handed back a set of bellows augmented with clockwork mechanisms.
>
[taskmaster]>tie my set bellows to my agonite toolstrap
You attach a set of bellows augmented with clockwork mechanisms to a strap on your agonite toolstrap.
>
[taskmaster]>get my Rangu ticket
>
You get a Rangu repair ticket from inside your multi-strapped carryall.
>
[taskmaster]>look at my ticket
Looking at the Rangu ticket you see it is for some clockwork-enhanced tongs with an attached shovel head.  You recall that your tongs should be ready by now.

Written at the bottom you see Rangu's Repair Shop, Engineering Society, Zoluren.
>
[taskmaster]>give Rangu
You hand Rangu your ticket and are handed back some clockwork-enhanced tongs with an attached shovel head.
>
[taskmaster]>tie my clockwork tongs to my agonite toolstrap
You attach some clockwork-enhanced tongs with an attached shovel head to a strap on your agonite toolstrap.
>
[taskmaster]>get my Rangu ticket
What were you referring to?
```