### PR TITLE
[profile][base] Fang Cove Fix updated comments to fang_cove_override_town

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2,9 +2,9 @@
 # See https://github.com/rpherbig/dr-scripts/wiki or https://elanthipedia.play.net/Lich_script_repository for documentation
 
 hometown: Crossing
-# If hometown is Fang Cove, some scripts (athletics, burgle, checkfavors, favor, and crossing-repair)
-# will not run properly at all, or require extra settings. This setting gives a town for all of
-# the above scripts to use as their desination.
+# If hometown is Fang Cove, some scripts (athletics, burgle, checkfavors, favor, and crossing-repair, among others - see base-help.yaml
+# for updated list) will not run properly at all, or require extra settings. This setting gives a town for all of
+# the above scripts to use as a faux hometown so they function properly. Make it close to where you usually enter Fang Cove.
 fang_cove_override_town:
 
 # The settings below do the same as fang_cove_override_town, but for individual scripts. These


### PR DESCRIPTION
The fang_cove_override_town comments were no longer complete, since more scripts are being added to use it. Edits simply refer readers to base-help.yaml for a complete list, as well as clarifying the setting's function just a bit.