### PR TITLE
common-crafting - prefer exact match when multiple recipes found

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -152,6 +152,12 @@ module DRCC
     when 1
       recipes.find { |x| x['name'] =~ /#{item_name}/i }
     else
+      exact_matches = recipes.map { |x| x['name'] }.select { |x| x == item_name }
+
+      if exact_matches.length == 1
+        return recipes.find { |x| x['name'] == item_name }
+      end
+
       echo('Please select desired recipe ;send #')
       match_names.each_with_index { |x, i| respond "    #{i + 1}: #{x}" }
       line = get until line.strip =~ /^([0-9]+)$/

--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -158,6 +158,7 @@ module DRCC
         return recipes.find { |x| x['name'] == item_name }
       end
 
+      DRC.message("Using the full name of the item you wish to craft will avoid this in the future (e.g. 'a metal pike' vs 'metal pike')")
       echo('Please select desired recipe ;send #')
       match_names.each_with_index { |x, i| respond "    #{i + 1}: #{x}" }
       line = get until line.strip =~ /^([0-9]+)$/


### PR DESCRIPTION
When finding a matching recipe, if multiple matches are found, prefer an exact match, should it exist. If an exact match is not found, use previous logic to require user to select recipe.

I tested a couple 'normal' recipes without issue. Tested the specific problematic recipe by adding the following yaml:
workorder_recipes:
  weaponsmithing:
    - a metal pike

Here's the issue that sent me down this path, for reference. Note that upon getting 'a metal pike' from the forge person, smith is unsure which recipe I am trying to craft. As a result, smith hangs until it receives input.

```
[wo_forge]>ask Yalda for challenging weaponsmithing work
Yalda shuffles through some notes and says, "Alright, this is an order for a metal pike. I need 2 of superior quality, made from any material and due in 115 roisaen.  Please complete the items, bundle them with your logbook and then give me the logbook to complete this order.  Good luck!"

[smith: Please select desired recipe ;send #]
    1: a metal pike
    2: a metal pike staff
```