### PR TITLE
[script][dependency][validate] - Exclude hidden files from custom script check; handles Apple Filesyst…

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1793,8 +1793,8 @@ def clear_hometown
 end
 
 def warn_custom_scripts
-  custom_scripts = Dir.entries('./scripts/custom').reject { |f| File.directory?(f) }
-  curated_scripts = Dir.entries('./scripts').reject { |f| File.directory?(f) }
+  custom_scripts = Dir.entries('./scripts/custom').reject { |f| File.directory?(f) || File.basename(f).start_with?(".")}
+  curated_scripts = Dir.entries('./scripts').reject { |f| File.directory?(f) || File.basename(f).start_with?(".")}
   include_list = []
 
   custom_scripts.each do | script |

--- a/validate.lic
+++ b/validate.lic
@@ -1029,8 +1029,8 @@ class DRYamlValidator
   private
 
   def warn_custom_scripts
-    custom_scripts = Dir.entries('./scripts/custom').reject { |f| File.directory?(f) }
-    curated_scripts = Dir.entries('./scripts').reject { |f| File.directory?(f) }
+    custom_scripts = Dir.entries('./scripts/custom').reject { |f| File.directory?(f) || File.basename(f).start_with?(".")}
+    curated_scripts = Dir.entries('./scripts').reject { |f| File.directory?(f) || File.basename(f).start_with?(".")}
     include_list = []
 
     custom_scripts.each do | script |


### PR DESCRIPTION
…em Store (.DS_Store) flagging in error

MacOS Filesystems keep a hidden file in each directory called `.DS_Store`, that tend to show up in the oddest places.  Today, it showed up in the custom script validator check.  Updated the check to exclude hidden (files that start with a .) files, which catches the .DS_Store, and likely nothing else.


```>
  CHECKING: That CharacterName-setup.yaml exists in the proper folder.
   PASSED
 
  CHECKING: That yaml file extensions are .yaml and not .yml
   PASSED
 
  CHECKING: That character yaml files contain valid YAML.
  CharacterName-setup.yaml PASSED
 
  NOTE: The following curated scripts are in your custom folder and will not receive updates.
  [".DS_Store"]
 
  CHECKING: 103 different potential errors in [CharacterName-setup.yaml]
  WARNINGS:0 ERRORS:0
  All done!
--- Lich: validate has exited.```