### PR TITLE
base-recipes - correct container on vigor poultice

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -8310,7 +8310,7 @@ crafting_recipes:
   type: remedies
   work_order: false
   chapter: 2
-  container: bowl
+  container: mortar
   herb1: red flower
   herb1_stock: 13
   herb2: dioica


### PR DESCRIPTION
Vigor poutices recipe needs to use a mortar, container was set to bowl by mistake.