### PR TITLE
[script][workorders] Fixed part obtaining section in Enchanting.

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -761,13 +761,16 @@ class WorkOrders
     tmp_part_count = 0
     need_part = 0
     if recipe['part']
-      tmp_part_count = DRCI.count_items_in_container("#{recipe['part']}", @bag)
-      if tmp_part_count < quantity
-        need_part = quantity - tmp_part_count
-        # Found a weird challenge that made the temp_part_count equal 1 even though no "part" was in container
-        need_part += 1 if reget(3, "but there is nothing in there like that") && (need_comp + tmp_comp_count) != quantity
-        DRC.message("need_part with potiental plus 1 is #{need_part}.")
-        order_parts(recipe['part'], need_part)
+      for p in recipe['part']
+        p.to_s
+        tmp_part_count = DRCI.count_items_in_container(p.split.last, @bag)
+        if tmp_part_count < quantity
+          need_part = quantity - tmp_part_count
+          # Found a weird challenge that made the temp_part_count equal 1 even though no "part" was in container
+          need_part += 1 if reget(3, "but there is nothing in there like that") && (need_part + tmp_part_count) != quantity
+          DRC.message("need_part with potiental plus 1 is #{need_part}.")
+          order_parts(recipe['part'], need_part)
+        end
       end
     end
 


### PR DESCRIPTION
Made the array items into strings to work with rummage. Before, the array was read in as [rod] and rummage would sometimes not find the item due to the brackets. Made it so now the array item is converted to a string to pass into rummage without the brackets. penguin23 tested the fix (also found the challenge). 