### PR TITLE
register - Turn to contents after labeling pages.

### DIFF
--- a/register.lic
+++ b/register.lic
@@ -46,6 +46,7 @@ class Register
         find_unlabeled
       end
       stow_item(@pen)
+      turn_register?('contents')
     else
       turn_register?('contents')
       display_results( search(args.query) )


### PR DESCRIPTION
After labeling a page or all pages, script will turn the register back to the contents.