### PR TITLE
[script][craft.lic] - Quick fix for enchanting discipline

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -418,7 +418,7 @@ class Craft
 
       # Check for second sigil. Purcahse if required.
       quantity *= 2 if recipe['enchant_stock2_name'] == recipe['enchant_stock1_name']
-      tally += 1 if !DRCC.check_for_existing_sigil?(recipe['enchant_stock2_name'], recipe['enchant_stock2'], quantity, @bag, @belt, info)
+      tally += 1 if !DRCC.check_for_existing_sigil?(recipe['enchant_stock2_name'], recipe['enchant_stock2'], quantity, @bag, @belt, stock_room)
       DRCC.stow_crafting_item('sigil-scroll', @bag, @belt)
 
       # Exit craft if tally is greater than or equal to one. This means one of the above checks and purchasing failed.


### PR DESCRIPTION
As reported by Karathos in Discord, the script is broken for the enchanting discipline.

It passes a variable `info` into `DRCC.check_for_existing_sigil?`, but I don't see info defined locally within this def. Other calls to that method pass a simple `stock_room` variable, which looks for the stock room of your hometown.

In the other crafting disciplines, info is a variable that is populated with craft_overrides from your yaml. That variable is never created or populated in the enchanting discipline section of craft. I don't know whether that's on purpose. I'm too weak at crafting to know. But this is at least a fix to something currently broken.

Karathos tested this fix.