### PR TITLE
Updated buff to list waggle set names and list spells for a given set

### DIFF
--- a/buff.lic
+++ b/buff.lic
@@ -9,6 +9,8 @@ class Waggle
   def initialize
     arg_definitions = [
       [
+        { name: 'set', regex: /(set=(\w+))/, optional: true, description: 'list of defined spell sets' },
+        { name: 'list', regex: /list/, optional: true, description: 'list of defined spell sets' },
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
         { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' }
       ]
@@ -16,6 +18,23 @@ class Waggle
 
     args = parse_args(arg_definitions)
     settings = get_settings
+
+    if (args.set)
+      set = args.set.split('=')[1]
+      DRC.message("Spells under Waggle set \"#{set}\"")
+      settings.waggle_sets[set].each_key do |key|
+        DRC.message("#{key}")
+      end
+      exit
+    end
+
+    if (args.list)
+      DRC.message("Waggle Sets Available")
+      settings.waggle_sets.each_key do |key|
+        DRC.message("#{key}")
+      end
+      exit
+    end
 
     setname = args.spells || 'default'
 

--- a/buff.lic
+++ b/buff.lic
@@ -23,7 +23,7 @@ class Waggle
       set = args.set.split('=')[1]
       DRC.message("Spells under Waggle set \"#{set}\"")
       settings.waggle_sets[set].each_key do |key|
-        DRC.message("#{key}")
+        DRC.message(" - #{key}")
       end
       exit
     end
@@ -31,7 +31,7 @@ class Waggle
     if (args.list)
       DRC.message("Waggle Sets Available")
       settings.waggle_sets.each_key do |key|
-        DRC.message("#{key}")
+        DRC.message(" - #{key}")
       end
       exit
     end


### PR DESCRIPTION
```
;buff list
--- Lich: buff active.
| Waggle Sets Available
|  - pre
|  - default
|  - noum
|  - finesse
|  - trade
|  - pvp
--- Lich: buff has exited.
```
```
>;buff set=pre
--- Lich: buff active.
| Spells under Waggle set "pre"
|  - Trabe Chalice
|  - Noumena
|  - Blur
|  - Last Gift of Vithwok IV
|  - Finesse
|  - Iridius Rod
--- Lich: buff has exited.
```