### PR TITLE
[script][combat-trainer] Tweak warhorn use

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2177,32 +2177,30 @@ class AbilityProcess
     DRC.message("Time since last warhorn room effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"])/60}") if $debug_mode_ct
     DRC.message("Time since last warhorn use: #{(Time.now - UserVars.warhorn["last_warhorn"])/60}") if $debug_mode_ct
     DRC.message("Time since last egg use: #{(Time.now - UserVars.warhorn["last_egg"])/60}") if $debug_mode_ct
+    DRC.message("NPC count in the room is: #{DRRoom.npcs.size}") if $debug_mode_ct
 
     # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
     return unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
-
-    game_state.sheath_whirlwind_offhand
 
     noun = @warhorn_or_egg[0]
 
     # Check timers. Egg is always 15 minutes. Warhorn is 20 minutes, or configurable.
     if noun =~ /egg/i
       return unless Time.now > UserVars.warhorn["last_egg"] + 900
-      if use_egg?
+      if DRRoom.npcs.size < 3*(DRRoom.pcs.size + 1) && use_egg?
         DRC.message("SUCCESSFUL egg use") if $debug_mode_ct
         UserVars.warhorn["last_egg"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end
     else
       return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
-      if use_warhorn?
+      if DRRoom.npcs.size < 3*(DRRoom.pcs.size + 1) && use_warhorn?
+        DRC.message("Time since last horn use: #{Time.now - UserVars.warhorn["last_warhorn"]}")
         DRC.message("SUCCESSFUL horn use") if $debug_mode_ct
         UserVars.warhorn["last_warhorn"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end
     end
-
-    game_state.wield_whirlwind_offhand
 
     # Rotate array to rotate warhorn/egg use. If we only have one, this still works fine.
     @warhorn_or_egg.rotate!
@@ -2230,6 +2228,7 @@ class AbilityProcess
   end
 
   def use_warhorn?
+    game_state.sheath_whirlwind_offhand
     use_warhorn = DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn).*\.$/,
      /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/, /^What were you referring to/,
      /^You need a free hand/, /^Remove what/)
@@ -2240,7 +2239,7 @@ class AbilityProcess
         'You sound a series of bursts from the', 'Your lungs are tired from having sounded a', 'not accomplishing much and looking rather silly')
       if /Your lungs are tired from having sounded a/ =~ warhorn_activation
         stow_warhorn
-        return false
+        return true
       elsif /Something about the area inhibits/ =~ warhorn_activation
         DRC.message "Can't use #{@warhorn} in this area. Removing from hunt."
         stow_warhorn
@@ -2265,6 +2264,7 @@ class AbilityProcess
 
   def stow_warhorn
     DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
+    game_state.wield_whirlwind_offhand
   end
 
   def check_paladin_skills

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2193,7 +2193,7 @@ class AbilityProcess
       end
     else
       return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
-      if use_warhorn?
+      if use_warhorn?(game_state)
         DRC.message("SUCCESSFUL horn use") if $debug_mode_ct
         UserVars.warhorn["last_warhorn"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now
@@ -2225,7 +2225,7 @@ class AbilityProcess
     return true
   end
 
-  def use_warhorn?
+  def use_warhorn?(game_state)
     game_state.sheath_whirlwind_offhand
     use_warhorn = DRC.bput("#{@warhorn_get_verb} my #{@warhorn}", /^You get.*(?:warhorn).*\.$/,
      /^You remove.*(?:warhorn).*\.$/, /^You take.*(?:warhorn).*\.$/, /^What were you referring to/,
@@ -2236,21 +2236,21 @@ class AbilityProcess
       warhorn_activation = DRC.bput(@warhorn_activation_command, 'Something about the area inhibits',
         'You sound a series of bursts from the', 'Your lungs are tired from having sounded a', 'not accomplishing much and looking rather silly')
       if /Your lungs are tired from having sounded a/ =~ warhorn_activation
-        stow_warhorn
+        stow_warhorn(game_state)
         return true
       elsif /Something about the area inhibits/ =~ warhorn_activation
         DRC.message "Can't use #{@warhorn} in this area. Removing from hunt."
-        stow_warhorn
+        stow_warhorn(game_state)
         @warhorn_or_egg.delete(@warhorn)
         return false
       elsif /not accomplishing much and looking rather silly/ =~ warhorn_activation
         DRC.message "You can't use a warhorn. Removing from hunt."
-        stow_warhorn
+        stow_warhorn(game_state)
         @warhorn_or_egg.delete(@warhorn)
         return false
       end
       waitrt?
-      stow_warhorn
+      stow_warhorn(game_state)
     when /^What were you referring to/
       DRC.message "#{@warhorn} NOT FOUND! Removing from hunt."
       @warhorn_or_egg.delete(@warhorn)
@@ -2260,7 +2260,7 @@ class AbilityProcess
     return true
   end
 
-  def stow_warhorn
+  def stow_warhorn(game_state)
     DRC.bput("#{@warhorn_store_verb} my #{@warhorn}", 'You put', 'You attach')
     game_state.wield_whirlwind_offhand
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2177,7 +2177,6 @@ class AbilityProcess
     DRC.message("Time since last warhorn room effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"])/60}") if $debug_mode_ct
     DRC.message("Time since last warhorn use: #{(Time.now - UserVars.warhorn["last_warhorn"])/60}") if $debug_mode_ct
     DRC.message("Time since last egg use: #{(Time.now - UserVars.warhorn["last_egg"])/60}") if $debug_mode_ct
-    DRC.message("NPC count in the room is: #{DRRoom.npcs.size}") if $debug_mode_ct
 
     # Return if it hasn't been 10 minutes since last warhorn. Room effect lasts 10 minutes.
     return unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
@@ -2187,15 +2186,14 @@ class AbilityProcess
     # Check timers. Egg is always 15 minutes. Warhorn is 20 minutes, or configurable.
     if noun =~ /egg/i
       return unless Time.now > UserVars.warhorn["last_egg"] + 900
-      if DRRoom.npcs.size < 3*(DRRoom.pcs.size + 1) && use_egg?
+      if use_egg?
         DRC.message("SUCCESSFUL egg use") if $debug_mode_ct
         UserVars.warhorn["last_egg"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now
       end
     else
       return unless Time.now > (UserVars.warhorn["last_warhorn"] + @warhorn_cooldown)
-      if DRRoom.npcs.size < 3*(DRRoom.pcs.size + 1) && use_warhorn?
-        DRC.message("Time since last horn use: #{Time.now - UserVars.warhorn["last_warhorn"]}")
+      if use_warhorn?
         DRC.message("SUCCESSFUL horn use") if $debug_mode_ct
         UserVars.warhorn["last_warhorn"] = Time.now
         UserVars.warhorn["last_warhorn_or_egg"] = Time.now

--- a/tinker.lic
+++ b/tinker.lic
@@ -19,14 +19,15 @@ class Tinker
 
     arg_definitions = [
       [
+        { name: 'finish', options: %w[hold log stow trash], description: 'What to do with the finished item.' },
         { name: 'chapter', regex: /\d+/i, variable: true, description: 'Chapter containing the item.' },
         { name: 'recipe_name', display: 'recipe name', regex: /^[A-z\s\-']+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
         { name: 'material', regex: /\w+/i, variable: true, description: 'Type of material.' },
         { name: 'noun', regex: /\w+/i, variable: true },
-        { name: 'skip', regex: /skip/i, optional: true, description: 'Optional setting to skip restocking consumables if low (glue/stain)'},
         { name: 'mechanism', regex: /\w+/i, variable: true, optional: true, description: 'What metal mechanism to use -brass-oravir-etc. Optional.' }
       ],
       [
+        { name: 'finish', options: %w[hold stow], description: 'What to do with the finished item.' },
         { name: 'instructions', regex: /instructions/i, description: 'Instructions if using instructions'},
         { name: 'material', regex: /\w+/i, variable: true, description: 'Type of material to use.' },
         { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item being crafted' },
@@ -34,13 +35,11 @@ class Tinker
       ],
       [
         { name: 'resume', regex: /resume/i, variable: true, description: 'Attempts to resume work on an ongoing project, must be holding the item' },
-        { name: 'noun', regex: /\w+/i, variable: true, description: 'NOUN of the item you wish to resume.' },
-        { name: 'skip', regex: /skip/i, optional: true, description: 'Optional setting to skip restocking consumables if low (glue/stain)'}
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'NOUN of the item you wish to resume.' }
       ],
       [
         { name: 'recipe_name', display: 'enhancement', options: %w[laminate lighten cable], description: 'Enhancements to crafted bows' },
-        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item being enhanced.' },
-        { name: 'skip', regex: /skip/i, optional: true, description: 'Optional setting to skip restocking consumables if low (glue/stain)'}
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item being enhanced.' }
       ],
       [
         { name: 'mechanisms', regex: /mechanisms/i, description: 'Walk to an open gear press and make a single stack of mechanisms from an existing ingot.' },
@@ -55,7 +54,6 @@ class Tinker
     @chapter = args.chapter
     @material = args.material
     @mechanism = args.mechanism
-    @home_tool = 'shaper'
     @chapter = args.chapter ? args.chapter : 8
     @noun = args.noun
     args.number = args.number.to_i || 1
@@ -66,7 +64,7 @@ class Tinker
     @recipe_name = args.recipe_name
 
     DRC.wait_for_script_to_complete('buff', ['tinker'])
-    Flags.add('tinkering-assembly', /with.*(backer) material/, /You need another bone, wood or horn (backing) material/, /another finished bow (string)/, /another finished (long|short) wooden (pole)/, /another .* leather (strip|cord)/, /need another (lenses)/, /another finished (mechanism)/, /You must assemble the (strips)/)
+    Flags.add('tinkering-assembly', /laminated with (backer) material/, /You need another bone, wood or horn (backing) material/, /another finished bow (string)/, /another finished (long|short) wooden (pole)/, /another .* leather (strip|cord)/, /need another (lenses)/, /another finished (mechanism)/, /You must assemble the (strips)/)
     Flags.add('tinker-done', /Applying the final touches/, /the successful (lamination|lightening|cable-backing) process/)
     
     if args.resume
@@ -78,7 +76,7 @@ class Tinker
     else
       DRCC.check_consumables('stain', @info['tool-room'], @info['stain-number'], @bag, @bag_items, @belt) unless args.skip
       DRCC.check_consumables('glue', @info['tool-room'], @info['glue-number'], @bag, @bag_items, @belt) unless args.skip
-      work(prep)
+      tinker(prep)
     end
   end
 
@@ -153,7 +151,7 @@ class Tinker
       DRC.bput("push fuel with my #{DRC.right_hand}", /^Roundtime/)
       swap_tool("pliers")
       @noun = "mechanisms"
-      work('push my ingot with press')
+      tinker('push my ingot with press')
       if args.number > 1 && count < args.number
         DRCC.get_crafting_item('mechanisms', @bag, @bag_items, @belt, true)
         fput('combine')
@@ -168,28 +166,26 @@ class Tinker
   def assemble_part
     return unless Flags['tinkering-assembly']
 
+    tool = DRC.right_hand
+    DRCC.stow_crafting_item(tool, @bag, @belt)
     part = Flags['tinkering-assembly'].to_a[1..-1].join('.')
     part.sub!("backing", "backer")
     part.sub!("mechanism", "#{@mechanism} #{part}")
     swap_tool(part)
-    if part.include?("mechanism") 
-      until /is not required to continue crafting/ =~ DRC.bput("assemble my mechanism with my crossbow", /^You place your mechanisms/, /is not required to continue crafting/)
-        pause 0.05
-      end
-    else
-      DRC.bput("assemble my #{@noun} with my #{part}", 
-        'affix it securely in place', 'loop both ends', 'loop the string', 
-        'carefully mark where it will attach when you continue crafting', 
-        'add several marks indicating optimal locations')
-    end
+    DRC.bput("assemble my #{@noun} with my #{part}", 
+      'affix it securely in place', 'loop both ends', 'loop the string', 
+      'carefully mark where it will attach when you continue crafting', 
+      'add several marks indicating optimal locations')
+    swap_tool(tool)
     Flags.reset('tinkering-assembly')
   end
 
-  def work(command)
+  def tinker(command)
     DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/) if @cube
     loop do
       waitrt?
       DRCA.crafting_magic_routine(@settings)
+      assemble_part
       result = DRC.bput(command,
                 /a wood shaper is needed/, /haping with a wood shaper/, /apply some glue to your/, /^Using slow strokes you scrape/,
                 /continued knife carving/, /carved with a knife/, /with a carving knife/, /trimmed with a carving knife/,
@@ -207,34 +203,34 @@ class Tinker
       case result
       when /a wood shaper is needed/, /haping with a wood shaper/, /apply some glue to your/, /Using slow strokes you scrape/
         waitrt?
-        tool = 'shaper'
+        swap_tool('shaper')
         command = "shape my #{@noun} with my shaper"
       when /continued knife carving/, /carved with a knife/, /with a carving knife/, /trimmed with a carving knife/
         waitrt?
-        tool = 'carving knife'
+        swap_tool('carving knife')
         command = "carve my #{@noun} with my knife"
       when /rubbed out with a rasp/, /A cluster of small knots/
         waitrt?
-        tool = 'rasp'
+        swap_tool('rasp')
         command = "scrape my #{@noun} with my rasp"
       when /ready to be clamped/, /with clamps/
         waitrt?
-        tool = 'clamp'
+        swap_tool('clamp')
         command = "push my #{@noun} with my clamp"
       when /Glue should now be applied/, /glue to fasten it/, /application of glue/, /glue applied/
         waitrt?
-        tool = 'glue'
+        swap_tool('glue')
         command = "apply my glue to my #{@noun}"
       when /adjust(ing|ed) with some tinker's tools/
         waitrt?
-        tool = 'tinker tools'
+        swap_tool('tinker tools')
         command = "adjust my #{@noun} with my tinker tools"
       when /Some wood stain/, /application of stain/
         waitrt?
-        tool = 'stain'
+        swap_tool('stain')
         command = "apply my stain to my #{@noun}"
       when /mechanisms must be affixed/, /pulling them into place/
-        tool = 'pliers'
+        swap_tool('pliers')
         command = "pull my #{@noun} with my pliers"
       when /while it is inside of something/, /You fumble around but/
         echo '*** ERROR TRYING TO CRAFT, EXITING ***'
@@ -251,10 +247,8 @@ class Tinker
         echo '*** NOT ENOUGH MATERIAL, EXITING ***'
         exit
       end
+      waitrt?
       finish if Flags['tinker-done']
-      assemble_part
-      swap_tool(tool)
-      tool = @home_tool
     end
   end
 
@@ -270,12 +264,23 @@ class Tinker
     return unless @stamp
     swap_tool('stamp')
     DRC.bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+    pause
+    waitrt?
+    DRCC.stow_crafting_item(DRC.right_hand, @bag, nil)
   end
 
   def finish
     stamp
-    DRCC.stow_crafting_item(DRC.right_hand, @bag, nil)
-    DRC.message("#{@noun} complete!")
+    case @finish
+    when /log/
+      DRCC.logbook_item('engineering', @noun, @bag)
+    when /stow/
+      DRCI.stow_item?(@noun)
+    when /trash/
+      DRCI.dispose_trash(@noun)
+    when /hold/
+      DRC.message("#{@noun} complete!")
+    end
     DRC.bput("stow feet", /^You put/, /^Stow what/)
     magic_cleanup
     exit

--- a/tinker.lic
+++ b/tinker.lic
@@ -19,15 +19,14 @@ class Tinker
 
     arg_definitions = [
       [
-        { name: 'finish', options: %w[hold log stow trash], description: 'What to do with the finished item.' },
         { name: 'chapter', regex: /\d+/i, variable: true, description: 'Chapter containing the item.' },
         { name: 'recipe_name', display: 'recipe name', regex: /^[A-z\s\-']+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
         { name: 'material', regex: /\w+/i, variable: true, description: 'Type of material.' },
         { name: 'noun', regex: /\w+/i, variable: true },
+        { name: 'skip', regex: /skip/i, optional: true, description: 'Optional setting to skip restocking consumables if low (glue/stain)'},
         { name: 'mechanism', regex: /\w+/i, variable: true, optional: true, description: 'What metal mechanism to use -brass-oravir-etc. Optional.' }
       ],
       [
-        { name: 'finish', options: %w[hold stow], description: 'What to do with the finished item.' },
         { name: 'instructions', regex: /instructions/i, description: 'Instructions if using instructions'},
         { name: 'material', regex: /\w+/i, variable: true, description: 'Type of material to use.' },
         { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item being crafted' },
@@ -35,11 +34,13 @@ class Tinker
       ],
       [
         { name: 'resume', regex: /resume/i, variable: true, description: 'Attempts to resume work on an ongoing project, must be holding the item' },
-        { name: 'noun', regex: /\w+/i, variable: true, description: 'NOUN of the item you wish to resume.' }
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'NOUN of the item you wish to resume.' },
+        { name: 'skip', regex: /skip/i, optional: true, description: 'Optional setting to skip restocking consumables if low (glue/stain)'}
       ],
       [
         { name: 'recipe_name', display: 'enhancement', options: %w[laminate lighten cable], description: 'Enhancements to crafted bows' },
-        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item being enhanced.' }
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item being enhanced.' },
+        { name: 'skip', regex: /skip/i, optional: true, description: 'Optional setting to skip restocking consumables if low (glue/stain)'}
       ],
       [
         { name: 'mechanisms', regex: /mechanisms/i, description: 'Walk to an open gear press and make a single stack of mechanisms from an existing ingot.' },
@@ -54,6 +55,7 @@ class Tinker
     @chapter = args.chapter
     @material = args.material
     @mechanism = args.mechanism
+    @home_tool = 'shaper'
     @chapter = args.chapter ? args.chapter : 8
     @noun = args.noun
     args.number = args.number.to_i || 1
@@ -64,7 +66,7 @@ class Tinker
     @recipe_name = args.recipe_name
 
     DRC.wait_for_script_to_complete('buff', ['tinker'])
-    Flags.add('tinkering-assembly', /laminated with (backer) material/, /You need another bone, wood or horn (backing) material/, /another finished bow (string)/, /another finished (long|short) wooden (pole)/, /another .* leather (strip|cord)/, /need another (lenses)/, /another finished (mechanism)/, /You must assemble the (strips)/)
+    Flags.add('tinkering-assembly', /with.*(backer) material/, /You need another bone, wood or horn (backing) material/, /another finished bow (string)/, /another finished (long|short) wooden (pole)/, /another .* leather (strip|cord)/, /need another (lenses)/, /another finished (mechanism)/, /You must assemble the (strips)/)
     Flags.add('tinker-done', /Applying the final touches/, /the successful (lamination|lightening|cable-backing) process/)
     
     if args.resume
@@ -76,7 +78,7 @@ class Tinker
     else
       DRCC.check_consumables('stain', @info['tool-room'], @info['stain-number'], @bag, @bag_items, @belt) unless args.skip
       DRCC.check_consumables('glue', @info['tool-room'], @info['glue-number'], @bag, @bag_items, @belt) unless args.skip
-      tinker(prep)
+      work(prep)
     end
   end
 
@@ -151,7 +153,7 @@ class Tinker
       DRC.bput("push fuel with my #{DRC.right_hand}", /^Roundtime/)
       swap_tool("pliers")
       @noun = "mechanisms"
-      tinker('push my ingot with press')
+      work('push my ingot with press')
       if args.number > 1 && count < args.number
         DRCC.get_crafting_item('mechanisms', @bag, @bag_items, @belt, true)
         fput('combine')
@@ -166,26 +168,28 @@ class Tinker
   def assemble_part
     return unless Flags['tinkering-assembly']
 
-    tool = DRC.right_hand
-    DRCC.stow_crafting_item(tool, @bag, @belt)
     part = Flags['tinkering-assembly'].to_a[1..-1].join('.')
     part.sub!("backing", "backer")
     part.sub!("mechanism", "#{@mechanism} #{part}")
     swap_tool(part)
-    DRC.bput("assemble my #{@noun} with my #{part}", 
-      'affix it securely in place', 'loop both ends', 'loop the string', 
-      'carefully mark where it will attach when you continue crafting', 
-      'add several marks indicating optimal locations')
-    swap_tool(tool)
+    if part.include?("mechanism") 
+      until /is not required to continue crafting/ =~ DRC.bput("assemble my mechanism with my crossbow", /^You place your mechanisms/, /is not required to continue crafting/)
+        pause 0.05
+      end
+    else
+      DRC.bput("assemble my #{@noun} with my #{part}", 
+        'affix it securely in place', 'loop both ends', 'loop the string', 
+        'carefully mark where it will attach when you continue crafting', 
+        'add several marks indicating optimal locations')
+    end
     Flags.reset('tinkering-assembly')
   end
 
-  def tinker(command)
+  def work(command)
     DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/) if @cube
     loop do
       waitrt?
       DRCA.crafting_magic_routine(@settings)
-      assemble_part
       result = DRC.bput(command,
                 /a wood shaper is needed/, /haping with a wood shaper/, /apply some glue to your/, /^Using slow strokes you scrape/,
                 /continued knife carving/, /carved with a knife/, /with a carving knife/, /trimmed with a carving knife/,
@@ -203,34 +207,34 @@ class Tinker
       case result
       when /a wood shaper is needed/, /haping with a wood shaper/, /apply some glue to your/, /Using slow strokes you scrape/
         waitrt?
-        swap_tool('shaper')
+        tool = 'shaper'
         command = "shape my #{@noun} with my shaper"
       when /continued knife carving/, /carved with a knife/, /with a carving knife/, /trimmed with a carving knife/
         waitrt?
-        swap_tool('carving knife')
+        tool = 'carving knife'
         command = "carve my #{@noun} with my knife"
       when /rubbed out with a rasp/, /A cluster of small knots/
         waitrt?
-        swap_tool('rasp')
+        tool = 'rasp'
         command = "scrape my #{@noun} with my rasp"
       when /ready to be clamped/, /with clamps/
         waitrt?
-        swap_tool('clamp')
+        tool = 'clamp'
         command = "push my #{@noun} with my clamp"
       when /Glue should now be applied/, /glue to fasten it/, /application of glue/, /glue applied/
         waitrt?
-        swap_tool('glue')
+        tool = 'glue'
         command = "apply my glue to my #{@noun}"
       when /adjust(ing|ed) with some tinker's tools/
         waitrt?
-        swap_tool('tinker tools')
+        tool = 'tinker tools'
         command = "adjust my #{@noun} with my tinker tools"
       when /Some wood stain/, /application of stain/
         waitrt?
-        swap_tool('stain')
+        tool = 'stain'
         command = "apply my stain to my #{@noun}"
       when /mechanisms must be affixed/, /pulling them into place/
-        swap_tool('pliers')
+        tool = 'pliers'
         command = "pull my #{@noun} with my pliers"
       when /while it is inside of something/, /You fumble around but/
         echo '*** ERROR TRYING TO CRAFT, EXITING ***'
@@ -247,8 +251,10 @@ class Tinker
         echo '*** NOT ENOUGH MATERIAL, EXITING ***'
         exit
       end
-      waitrt?
       finish if Flags['tinker-done']
+      assemble_part
+      swap_tool(tool)
+      tool = @home_tool
     end
   end
 
@@ -264,23 +270,12 @@ class Tinker
     return unless @stamp
     swap_tool('stamp')
     DRC.bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
-    pause
-    waitrt?
-    DRCC.stow_crafting_item(DRC.right_hand, @bag, nil)
   end
 
   def finish
     stamp
-    case @finish
-    when /log/
-      DRCC.logbook_item('engineering', @noun, @bag)
-    when /stow/
-      DRCI.stow_item?(@noun)
-    when /trash/
-      DRCI.dispose_trash(@noun)
-    when /hold/
-      DRC.message("#{@noun} complete!")
-    end
+    DRCC.stow_crafting_item(DRC.right_hand, @bag, nil)
+    DRC.message("#{@noun} complete!")
     DRC.bput("stow feet", /^You put/, /^Stow what/)
     magic_cleanup
     exit


### PR DESCRIPTION
Stopping/restarting CT after successful warhorn use can lead to a time-wasting loop where you perform one action, then attempt to blow the warhorn over and over.

The changes:

1. Eliminate the loop. Failing to use the warhorn(lungs too tired) triggers the cooldown.
2. Move stow/wield for offhand weapon into warhorn get/stow.

We don't want to sheath/wield our offhand unless we're actually going to use the warhorn, and we don't want to do it at all if we're using the egg (because you can invoke it without holding it). Moving that into warhorn use, the stow before getting the warhorn, and the retrieve after stowing the warhorn, means we won't stow/retrieve weapons just to check if we're ready to use warhorn/egg.