### PR TITLE
[script][common-healing] - Add tend handling for clay constructs

### DIFF
--- a/common-healing.lic
+++ b/common-healing.lic
@@ -334,7 +334,8 @@ module DRCH
     # You dislodged ammo or a parasite, discard it. Note, some parasites go away and don't
     # end up in your hand. Fine, it'll just fail to dispose.
     tend_dislodge = [
-      /^You \w+ remove (a|the|some) (.*) from/
+      /^You \w+ remove (a|the|some) (.*) from/,
+      /^As you reach for the clay fragment/
     ]
 
     result = DRC.bput("tend #{person} #{body_part}", *tend_success, *tend_failure, *tend_dislodge)


### PR DESCRIPTION
Missing bput message for clay fragment lodging.