### PR TITLE
Record caravan stable state properly

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -292,7 +292,7 @@ class Trade
       DRC.message('Something has gone wrong!  Put in an issue at https://github.com/rpherbig/dr-scripts/issues/new with a log of this event!')
       exit
     end
-
+    UserVars.last_seen_caravan['stabled'] = true
     fput('exit') if @exit
     exit
   end


### PR DESCRIPTION
Script was not setting the caravan_last_seen:stabled to true, when exiting in the stabling method.

It now does so.

This allows it to find the caravan if its stabled, and you're not in the same town.