### PR TITLE
[script][smelt-deeds] New redeem

### DIFF
--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -97,12 +97,12 @@ class SmeltDeeds
   end
 
   def tap_deed?
-    case DRC.bput('tap my deed', 'You pick up', 'The worker explains', 'drag it over in front of you')
+    case DRC.bput('tap my deed', /^You pick up/, /^The worker explains/, /^The ingot rests safely at your feet/, /)
     when 'The worker explains'
       DRC.bput('stow my deed', 'You put')
       return false
-    when 'drag it over in front of you'
-      DRC.bput('get my ingot', 'You pick up') unless DRC.left_hand || DRC.right_hand
+    when /The ingot rests safely at your feet/ # Anything heavy enough to not be picked up is almost certainly an ingot here
+      DRC.bput('get my ingot', 'You pick up')
       waitrt?
       DRC.fix_standing
     end

--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -102,7 +102,7 @@ class SmeltDeeds
       DRC.bput('stow my deed', 'You put')
       return false
     when 'drag it over in front of you'
-      DRC.bput('get ingot', 'You pick up') unless DRC.left_hand || DRC.right_hand
+      DRC.bput('get my ingot', 'You pick up') unless DRC.left_hand || DRC.right_hand
       waitrt?
       DRC.fix_standing
     end

--- a/smelt-deeds.lic
+++ b/smelt-deeds.lic
@@ -97,7 +97,7 @@ class SmeltDeeds
   end
 
   def tap_deed?
-    case DRC.bput('tap my deed', /^You pick up/, /^The worker explains/, /^The ingot rests safely at your feet/, /)
+    case DRC.bput('tap my deed', /^You pick up/, /^The worker explains/, /^The ingot rests safely at your feet/)
     when 'The worker explains'
       DRC.bput('stow my deed', 'You put')
       return false


### PR DESCRIPTION
With the changes to deed redemption generally, redeemed deeds that are too heavy to be picked up automatically are now placed at your feet. This means that instead of the ingot(in this case) being the first item in the room, it's now the first item on your person, so the old "get ingot" just grabs what's in the crucible:
```
[smelt-deeds]>get my first gold deed

You get a deed for a gold ingot from inside your featherlette pack.

[smelt-deeds]>tap my deed

An attendant arrives, takes your deed and motions to two burly workers.  The workers carefully load a gold ingot onto a sled and drag it over in front of you.
You pick up the ingot.

[smelt-deeds]>put my gold ingot in cruc

You put your ingot in the granite crucible.

[smelt-deeds]>get my first gold deed

You get a deed for a gold ingot from inside your featherlette pack.
You feel fully rested.

[smelt-deeds]>tap my deed

An attendant arrives, takes your deed and motions to two burly workers.  The workers carefully load a gold ingot onto a sled and drag it over in front of you.
The ingot rests safely at your feet.

[smelt-deeds]>get ingot

You get a gold ingot from inside a granite crucible.
Baggs came through an oak door.
Baggs runs north.
Your feet are still soaked.

[smelt-deeds: *** No match was found after 15 seconds, dumping info]
```
Changing the match to target our behavior after the attendant does their work (in any case where the deed is ready to be redeemed) we can ensure we're properly interacting with the right ingot:
```
>get my ingot
You pick up the ingot lying at your feet.
```
