### PR TITLE
[script][magic-training] Alternate solution, added function

### DIFF
--- a/magic-training.lic
+++ b/magic-training.lic
@@ -88,7 +88,7 @@ class MagicTraining
     if bleeding? || health_data['score'] >= saferoom || DRStats.health < [50, health].max || health_data['poisoned'] || health_data['diseased']
       DRC.message("You're injured! Stopping training")
       DRC.wait_for_script_to_complete('safe-room', ['force'])
-      finish
+      exit
     end
   end
 

--- a/magic-training.lic
+++ b/magic-training.lic
@@ -2,19 +2,13 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#magic-training
 =end
 
-custom_require.call(%w[common common-arcana common-healing common-moonmage drinfomon common-travel])
-
-# Track how long we've been training and how many mindstates we increase at the end.
-# These are defined with @@ so that they can be referenced in before_dying block.
-@@time_in = Time.now
-@@aug_in = DRSkill.getxp('Augmentation')
-@@ward_in = DRSkill.getxp('Warding')
-@@util_in = DRSkill.getxp('Utility')
-@@sorc_in = DRSkill.getxp('Sorcery')
+custom_require.call(%w[common common-arcana common-healing common-travel common-moonmage drinfomon])
 
 class MagicTraining
 
   def initialize
+    @@time_in = Time.now
+    @@mindstate_gains = {}
     arg_definitions = [
       [
         { name: 'max_time', regex: /\d+/, optional: true, description: 'Max time, in minutes, spent training. (Optional)' },
@@ -22,10 +16,11 @@ class MagicTraining
         { name: 'script_summary', optional: true, description:'Trains magic skills defined in Yaml setting training_skills' }
       ]
     ]
-
     args = parse_args(arg_definitions)
     max_time = ((args.max_time || 60).to_i * 60) # convert to seconds
     training_skills = args.training_skills ? args.training_skills.split(',').map { |skill| skill.strip.downcase.capitalize } : %w[Utility Warding Augmentation Sorcery]
+    training_skills += ["Attunement", "Arcana"]
+    training_skills.each { |skill| @@mindstate_gains.store(skill,0) }
 
     echo "Max training time: #{max_time} seconds"
     echo "Training skills: #{training_skills}"
@@ -45,6 +40,7 @@ class MagicTraining
   def train_magics?(training_skills)
     settings = get_settings
     DRCT.walk_to(settings.magic_training_room)
+    DRC.wait_for_script_to_complete('buff', ['mana'])
     exp_threshold = settings.magic_exp_training_max_threshold
     force_cambrinth = settings.waggle_force_cambrinth
     training_spells = settings.training_spells.empty? ? settings.magic_training : settings.training_spells
@@ -66,10 +62,18 @@ class MagicTraining
 
     skills_to_train.each do |skill|
       echo "Next skill to train: #{skill}"
-      before_xp = DRSkill.getxp(skill)
-      DRCA.check_discern(training_spells[skill], settings) if training_spells[skill]['use_auto_mana']
-      DRCA.cast_spells({ spell_name: training_spells[skill] }, settings, force_cambrinth)
-      echo("#{skill} gains: #{DRSkill.getxp(skill) - before_xp}")
+      spelldata = training_spells[skill]
+      before_xp = {}
+      gain = {}
+      DRCA.check_discern(spelldata, settings) if spelldata['use_auto_mana']
+      DRCA.prepare?(spelldata['abbrev'],spelldata['mana'],spelldata['symbiosis'],spelldata['prep'])
+      DRCA.find_charge_invoke_stow(settings.cambrinth, settings.stored_cambrinth, settings.cambrinth_cap, settings.dedicated_camb_use, spelldata['cambrinth'], settings.cambrinth_invoke_exact_amount)
+      DRC.bput('perceive', 'Roundtime') # added to eat a little time, since we're waiting anyways
+      waitcastrt?
+      training_skills.each { |s| before_xp.store(s,DRSkill.getxp(s)) } #snapshot of mindstates before casting
+      DRCA.cast?(spelldata['cast'], spelldata['symbiosis']) # casting our spell
+      training_skills.each { |s| gain.store(s,DRSkill.getxp(s) - before_xp[s]) && @@mindstate_gains[s] += gain[s] } # record the change in mindstates for all skills, to capture spell casts that train more than one
+      gain.each { |k,v| echo("Gained #{v} mindstates in #{k}") if v > 0 } # display mindstates gained in each skill that got mindstates
       waitrt?
       check_health(settings.health_threshold, settings.saferoom_health_threshold)
     end
@@ -84,23 +88,23 @@ class MagicTraining
     if bleeding? || health_data['score'] >= saferoom || DRStats.health < [50, health].max || health_data['poisoned'] || health_data['diseased']
       DRC.message("You're injured! Stopping training")
       DRC.wait_for_script_to_complete('safe-room', ['force'])
-      exit
+      finish
     end
   end
 
-end
+  before_dying do
+    DRC.bput('prepare symbiosis', 'You recall the exact details of the', 'But you\'ve already prepared', 'Please don\'t do that here')
+    DRC.bput('release symbiosis', 'You release', 'But you haven\'t prepared')
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell") unless checkprep == 'None'
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
 
-before_dying do
-  fput('release spell')
-  fput('release mana')
-  fput('release symbiosis')
-
-  total_time = (Time.now - @@time_in) / 60
-  echo "Total time in Magic-Training: #{total_time.to_i} minutes"
-  echo "Total xp gained in Augmentation: #{DRSkill.getxp('Augmentation') - @@aug_in}"
-  echo "Total xp gained in Warding: #{DRSkill.getxp('Warding') - @@ward_in}"
-  echo "Total xp gained in Utility: #{DRSkill.getxp('Utility') - @@util_in}"
-  echo "Total xp gained in Sorcery: #{DRSkill.getxp('Sorcery') - @@sorc_in}"
+    total_time = (Time.now - @@time_in) / 60
+    echo "Total time in Magic-Training: #{total_time.to_i} minutes"
+    @@mindstate_gains.each do |k,v|
+      echo("Total xp gained in #{k}: #{v}")
+    end
+    exit
+  end
 end
 
 MagicTraining.new

--- a/magic-training.lic
+++ b/magic-training.lic
@@ -101,7 +101,7 @@ class MagicTraining
     total_time = (Time.now - @@time_in) / 60
     echo "Total time in Magic-Training: #{total_time.to_i} minutes"
     @@mindstate_gains.each do |k,v|
-      echo("Total xp gained in #{k}: #{v}")
+      echo("Total xp gained in #{k}: #{v}") if v > 0
     end
     exit
   end


### PR DESCRIPTION
Alternative solution to #6302 where we bring the exit code inside the class. This way we can use class variables without being outside the class.

Additionally, pulled some of the logic from arcana for the following:
1. added a quick perceive after the invoke, since we're waiting anyways.
2. takes a snapshot of mindstates right before casting, to capture accurate gains on the cast, and account for _most_ pulsing during prep.
3. takes a second snapshop of mindstates after casting, and spits out the change for each skill.
4. added attunement and arcana to skills tracked
5. added mana waggle check for Raise Power, ETF, etc.

```
[magic-training: Next skill to train: Utility]
[magic-training]>prepare symbiosis
You recall the exact details of the Chaos symbiosis, preparing to integrate it with the next spell you cast.
>
[magic-training]>prepare aot 6
That won't affect your current attunement very much.
With tense movements you prepare your body for the Aura of Tongues spell.  Casting rationality aside, you prepare to yoke unseen mana streams to fuel your sorcery.
>
[magic-training]>charge my prism 6
You harness a small amount of energy and attempt to channel it into your cambrinth prism.
You are able to channel all the energy into the prism.
The cambrinth prism absorbs all of the energy.
Roundtime: 2 sec.
>
You feel fully rested.
>
Raezar attaches a thick cambrinth armband shaped like braided stalks of wheat to his upper arm.
>
[magic-training]>invoke my prism 6 spell
The cambrinth prism pulses with Life energy.  You reach for its center and forge a magical link to it, attempting to ready 6 energy lines for your use.  You manage to attune yourself exactly as you intended to.  By directing your focus, you ensure that energy is drawn only when spells are cast.
Roundtime: 1 sec.
>
[magic-training]>perceive
You reach out with your senses and see lambent (12/21) streams of deep green and blue Life mana flowing through the area.
Letting your senses extend further, you feel there is pulsating (10/21) mana to the south.
Concentrating on the whispered phrases of "Aura of Tongues", you grow confident in your ability to understand the Olvi, Toggish, and Gamgweth languages, in addition to any others you already speak.  This effect will last for about fourteen roisaen.
You sense the Bloodthorns spell upon you, which will last for about twenty-three roisaen.
You are being protected by a weak Essence of Yew, which should last for twenty-five roisaen.
You are preparing the Aura of Tongues spell at six mana.
Roundtime: 3 sec.
>
You feel fully attuned to the mana streams again.
>
Raezar reveals himself.
>
You notice Raezar attempting to conceal his spell preparations despite his invisibility.
You see a sweeping movement out of the corner of your eye.
>
Gained: Arcana(+1)
>
 * Archaic Warrior Brachius snuck out of the shadow he was hiding in.
>
[magic-training]>cast
You gesture.
Your cambrinth prism emits a loud *snap* as it discharges as much power as necessary, leaving a great amount left for future use.
You twist the mana streams of your Aura of Tongues spell in a chaotic motion, inciting them into unpredictable patterns.
A myriad of disjointed sounds seem to linger aimlessly in the air for a few moments before they blend together into whispered phrases that you manage to recognize.
You hear a brief ringing in your ears.
Glancing at those others in the area, you find yourself more aware of their movements, the patterns in their speech, and feel sure that you can now understand more languages than you once could.  Somehow, however, your knowledge remains incomplete.
Emotional pain and exhaustion lingers in your mind, even after you regain rational control.
>
[magic-training: {"Utility"=>3, "Warding"=>0, "Augmentation"=>0, "Sorcery"=>3, "Attunement"=>0, "Arcana"=>2}]
[magic-training: Gained 3 in Utility]
[magic-training: Gained 3 in Sorcery]
[magic-training: Gained 2 in Arcana]
```

On exit:
```
>;ka
[magic-training]>prepare symbiosis
You recall the exact details of the Chaos symbiosis, preparing to integrate it with the next spell you cast.
>
[magic-training]>release symbiosis
You pause for a moment as the details of the Chaos symbiosis fade from your mind.
You release the Chaos symbiosis.
>
[magic-training]>release mana
You aren't harnessing any mana.
>
[magic-training: Total time in Magic-Training: 1 minutes]
[magic-training: Total xp gained in Utility: 3]
[magic-training: Total xp gained in Warding: 4]
[magic-training: Total xp gained in Augmentation: 0]
[magic-training: Total xp gained in Sorcery: 3]
[magic-training: Total xp gained in Attunement: 0]
[magic-training: Total xp gained in Arcana: 4]
--- Lich: magic-training has exited.
```