### PR TITLE
[data][base-recipes] blacklisting codex recipes

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -4307,70 +4307,70 @@ crafting_recipes:
 # Carving Chapter 5 recipes
 - name: a bone bead
   noun: bead
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 1
   material: bone
 - name: a stone bead
   noun: bead
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 1
   material: stone
 - name: a detailed bone bead
   noun: bead
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 1
   material: bone
 - name: a detailed stone bead
   noun: bead
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 1
   material: stone
 - name: a bone totem
   noun: totem
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 2
   material: bone
 - name: a stone totem
   noun: totem
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 2
   material: stone
 - name: a detailed bone totem
   noun: totem
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 2
   material: bone
 - name: a detailed stone totem
   noun: totem
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 2
   material: stone
 - name: a bone figurine
   noun: figurine
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 3
   material: bone
 - name: a stone figurine
   noun: figurine
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 3
@@ -4412,14 +4412,14 @@ crafting_recipes:
   material: stone
 - name: a detailed bone figurine
   noun: figurine
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 3
   material: bone
 - name: a detailed stone figurine
   noun: figurine
-  work_order: true
+  work_order: false
   type: carving
   chapter: 5
   volume: 3


### PR DESCRIPTION
There's a series of recipes in chapter 5 that require the use of a codex in order ot craft, which neither workorders nor carve are set up to handle. These should not be on the default list for workorders recipes.