### PR TITLE
[script][dependency] - Warn when yaml same name as arg

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -126,9 +126,23 @@ class ArgParser
 
     if flex
       args.flex = vars
+
+      # Check to see if a yaml profile has same name as script arg. Only matters when we're flexing
+      # args and attempting to call a yaml profile with the flexed arg.
+      profiles = Dir['./scripts/profiles/*.*']
+      profiles.each do |profile|
+        profile = profile[/.*#{checkname}-(\w*).yaml/, 1]
+        args.to_h.values.each do |arg|
+          if arg == profile
+            echo "WARNING: yaml profile '#{checkname}-#{arg}.yaml' matches script argument '#{arg}'."
+            echo "Favoring the script argument. Rename the file if you intend to call it as a flexed settings file."
+          end
+        end
+      end
     else
       return nil unless vars.empty?
     end
+
     args
   end
 


### PR DESCRIPTION
resolves #2925 

In rare cases, a user may have a yaml settings file named the same as a script argument. Example:

`Gildaren-construct.yaml` and calling `combat-trainer` with the `construct` script argument.

In these cases, it's unknown whether the user intends to call the script argument or flex the `Charname-construct.yaml` settings file. This change warns the user and advises we'll favor the script argument and they can rename the settings file if they intend to flex it.

Note: we only care about this if it's a script that allows flexing of the args, otherwise there is no conflict by definition. Thus, I have this embeded in the flex check.

Example output:

```
>;combat construct
--- Lich: combat-trainer active.
--- Lich: common-healing active.
--- Lich: common-healing-data active.
--- Lich: common-healing-data has exited.
--- Lich: common-healing has exited.
--- Lich: equipmanager active.
--- Lich: equipmanager has exited.
[combat-trainer: WARNING: yaml profile 'Gildaren-construct.yaml' matches script argument 'construct'.]
[combat-trainer: Favoring the script argument. Rename the file if you intend to call it.]
```