### PR TITLE
Create rag-watcher.lic

### DIFF
--- a/rag-watcher.lic
+++ b/rag-watcher.lic
@@ -1,0 +1,69 @@
+=begin
+  Settings in your yaml
+
+  rag_tracker_weapons:
+  - hammer
+  - iltesh
+  - staff
+
+  Generates a file called Yourname-rag-tracker.txt in the lich folder. You can open it and edit if you know how many charges are remaining.
+
+=end
+
+custom_require.call(%w[events])
+
+no_pause_all
+no_kill_all
+
+class RagWatcher
+    def initialize
+        # array of weapon nouns
+        @@weapons = get_settings.rag_tracker_weapons
+        @@charge_hash = {}
+        @@flag_list = []
+        # if there is already a file, read it
+        if File.exists?("#{checkname}-rag-tracker.txt")
+            # opens the file, creates an array of entries ["weapon: ###", "secondweapon: ###"]
+            file = File.open("#{checkname}-rag-tracker.txt", 'r').readlines.map(&:chomp)
+        else
+            file = []
+        end
+        @@weapons.each do |weapon| 
+            # formatting to allow adjective/noun pairs if people use them mistakenly
+            weapon = weapon.split.last
+            # flag for each weapon with <noun>-tracker
+            Flags.add("#{weapon}-watcher", /#{weapon} yowls ravenously/)
+            @@flag_list << "#{weapon}-watcher"
+            # creates a hash of weapons and charges
+            if element = file.find { |entry| /#{weapon}:/ =~ entry }
+                # uses the recorded remaining charges for the hash
+                @@charge_hash.store(weapon,element.split(': ').last.to_i)
+            else
+                #creates new pair for weapons without previous entries eg new weapons
+                @@charge_hash.store(weapon,500)
+            end
+            DRC.message("#{weapon} has #{@@charge_hash[weapon]} charges remaining")
+        end
+        monitor
+    end
+
+    def monitor
+        loop do
+            # sits until flag captures the text we're looking for, then saves the flag name(weapon-watcher) to charge_used
+            pause 1 until charge_used = @@flag_list.find { |flag| Flags[flag] }
+            Flags.reset(charge_used)
+            weapon = charge_used.sub("-watcher", "") # cuts out text, leaving us with just the weapon noun
+            @@charge_hash[weapon] -= 1 # reduce charges by 1 for the selected weapon
+            echo("#{weapon} used 1 charge, remaining charges: #{@@charge_hash[weapon]}")
+        end
+    end
+    
+    before_dying do
+        write_to_file = []
+        @@flag_list.each { |flag| Flags.delete(flag) }
+        @@charge_hash.each { |k,v| write_to_file << "#{k}: #{v}" }
+        File.write("#{checkname}-rag-tracker.txt", write_to_file.join("\n"))
+    end
+end
+
+RagWatcher.new


### PR DESCRIPTION
Those little vampiric rags, 500 charges of health/mana/spirit/fatigue stealing, don't show any indication of remaining charges, or even the existence of the enchantment, on your weapons. So I wrote a little passive tracker, best as an autostart, to track the charges as they're used. It writes the charges to a text file in your lich folder, called Yourname-rag-tracker.txt, contents of which look like this:
```
hammer: 494
iltesh: 495
staff: 499
```
Provides an easy reference you can check anytime to find out how many charges are left for each weapon. Prints out a quick list of weapons/charges on startup(presumably when you log in if it's on autostart):
```
>;rag-w
--- Lich: rag-watcher active.
hammer has 494 charges remaining
iltesh has 495 charges remaining
staff has 499 charges remaining
```
When a charge is used:
```
>jab
< You jab an engraved steel war hammer with a spiraled golden handle at a grass eel.  A grass eel fails to evade.  The hammer yowls ravenously, glowing with a sinister green glow and lands a devastating hit (That'll leave a mark!) that punches a hole through the skin on its side, lightly stunning it.  The grass eel is stunned!
[You're bruised, weak, incredibly balanced and overwhelming opponent.]
[Roundtime 1 sec.]
>
[rag-watcher: hammer used 1 charge, remaining charges: 495]
```

The message "<weapon> yowls ravenously" is the same on the two at this su helmas, and likely the same with the others that have been released.