### PR TITLE
[scripts][buff] Add strict arg to retry till the buff lands

### DIFF
--- a/buff.lic
+++ b/buff.lic
@@ -13,7 +13,7 @@ class Waggle
         { name: 'list', regex: /list/, optional: true, description: 'list of defined spell sets' },
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
         { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' },
-        { name: 'strict', regex: /strict/i, optional: true, description: 'Keep trying to spells until they stick. BE CAREFUL' }
+        { name: 'strict', regex: /strict/i, optional: true, description: 'Keep trying to cast buffs until they stick. BE CAREFUL' }
       ]
     ]
 

--- a/buff.lic
+++ b/buff.lic
@@ -12,7 +12,8 @@ class Waggle
         { name: 'set', regex: /(set=(\w+))/, optional: true, description: 'list of defined spell sets' },
         { name: 'list', regex: /list/, optional: true, description: 'list of defined spell sets' },
         { name: 'spells', regex: /\w+/, optional: true, description: 'Spell list to use, otherwise default' },
-        { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' }
+        { name: 'force', regex: /force/i, optional: true, description: 'Recast spells even if currently active' },
+        { name: 'strict', regex: /strict/i, optional: true, description: 'Keep trying to spells until they stick. BE CAREFUL' }
       ]
     ]
 
@@ -49,7 +50,14 @@ class Waggle
       end
     end
 
-    DRCA.do_buffs(settings, setname)
+    if args.strict
+      until (settings.waggle_sets[setname].keys - DRSpells.active_spells.keys).empty?
+        DRCA.do_buffs(settings, setname)
+      end
+    else
+      DRCA.do_buffs(settings, setname)
+    end
+
   end
 end
 


### PR DESCRIPTION
Causes buff.lic to retry casting  a buff until the buff lands. If you're casting on the edge of your skill, sometimes concentration (or arcana, in the case of a bad cambrinth invoke) can cause the cast to fail. This will retry until the buff lands. 