### PR TITLE
[scripts][workorders] Only drop items after trying to dispose of them properly

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -836,9 +836,9 @@ class WorkOrders
       when 'You realize you have items bundled with the logbook'
         DRC.bput('untie my logbook', 'You untie')
         if DRC.left_hand.include?('logbook')
-          fput("drop my #{DRC.right_hand}")
+          fput("drop my #{DRC.right_hand}") unless DRCI.dispose_trash(DRC.right_hand)
         else
-          fput("drop my #{DRC.left_hand}")
+          fput("drop my #{DRC.left_hand}") unless DRCI.dispose_trash(DRC.left_hand)
         end
         fput('get logbook') unless [DRC.left_hand, DRC.right_hand].grep(/logbook/i).any?
       end

--- a/workorders.lic
+++ b/workorders.lic
@@ -838,7 +838,7 @@ class WorkOrders
         if DRC.left_hand.include?('logbook')
           DRCI.dispose_trash(DRC.right_hand)
         else
-          DRCI.dispose_trash(DRC.right_hand)
+          DRCI.dispose_trash(DRC.left_hand)
         end
         fput('get logbook') unless [DRC.left_hand, DRC.right_hand].grep(/logbook/i).any?
       end

--- a/workorders.lic
+++ b/workorders.lic
@@ -838,7 +838,7 @@ class WorkOrders
         if DRC.left_hand.include?('logbook')
           DRCI.dispose_trash(DRC.right_hand)
         else
-          fput("drop my #{DRC.left_hand}") unless DRCI.dispose_trash(DRC.left_hand)
+          DRCI.dispose_trash(DRC.right_hand)
         end
         fput('get logbook') unless [DRC.left_hand, DRC.right_hand].grep(/logbook/i).any?
       end

--- a/workorders.lic
+++ b/workorders.lic
@@ -836,7 +836,7 @@ class WorkOrders
       when 'You realize you have items bundled with the logbook'
         DRC.bput('untie my logbook', 'You untie')
         if DRC.left_hand.include?('logbook')
-          fput("drop my #{DRC.right_hand}") unless DRCI.dispose_trash(DRC.right_hand)
+          DRCI.dispose_trash(DRC.right_hand)
         else
           fput("drop my #{DRC.left_hand}") unless DRCI.dispose_trash(DRC.left_hand)
         end


### PR DESCRIPTION
This prevents workorders from dropping stuff when there is a viable trash receptacle in the room (or worn, which is my personal use case.)