### PR TITLE
[scripts][combat-trainer] Add day and night settings for buffs

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1623,6 +1623,8 @@ class SpellProcess
                        .select { |_name, data| data['recast'] || data['recast_every'] || data['expire'] }
                        .select { |_name, data| data['expire'] ? Flags["ct-#{data['abbrev']}"] : true }
                        .select { |name, _data| check_buff_conditions?(name, game_state) }
+                       .select { |_name, data| data['night'] ? UserVars.sun['night'] : true }
+                       .select { |_name, data| data['day'] ?  UserVars.sun['day'] : true }
                        .select { |_name, data| data['starlight_threshold'] ? enough_starlight?(game_state, data) : true }
                        .reject { |name, data | data['cyclic'] && DRSpells.active_spells.include?(data['name']) && !data['recast_every'] }
 


### PR DESCRIPTION
As per title.

Allows moonies to set different buffs for day or night, as some spells only work during day, or night.