### PR TITLE
[scripts][burgle] Switching to guard clause instead of integer to string comparison

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -112,7 +112,7 @@ class Burgle
       DRC.message("You have empty burgle_settings.  These must be set before running.")
       return false
     end
-    if @burgle_room == nil || @burgle_room =~ /\D/
+    if @burgle_room == nil || @burgle_room.to_s =~ /\D/
       DRC.message("Invalid burgle_settings:room setting.  This must be room id of the room you want to burgle from.")
       return false
     end

--- a/burgle.lic
+++ b/burgle.lic
@@ -112,7 +112,7 @@ class Burgle
       DRC.message("You have empty burgle_settings.  These must be set before running.")
       return false
     end
-    if @burgle_room == nil || @burgle_room.to_s =~ /\D/
+    unless @burgle_room.is_a?(Integer)
       DRC.message("Invalid burgle_settings:room setting.  This must be room id of the room you want to burgle from.")
       return false
     end


### PR DESCRIPTION
As per title.

Integer to string comparisons no longer work in ruby3.2. I originally was going to just change to `@burgle_room.to_s` but @Raykyn55 suggested a guard clause and it's a better solution.