### PR TITLE
[script][burgle] Fix for bank/dokt rooms

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -124,7 +124,7 @@ class Burgle
       case DRC.bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring', 'You can\'t do that', 'This is probably not the time nor place for that')
       when 'This is probably not the time nor place for that'
         if @follow
-          DRC.message("Couldn't verify your bag due to room restrictions. Allowing the script to continue assuming your bag is open and available.")
+          DRC.message("Couldn't verify your bag due to room restrictions. Allowing the script to continue assuming your #{@loot_container} is open and available.")
           return true
         else
           travel_to_burgle_room

--- a/burgle.lic
+++ b/burgle.lic
@@ -121,7 +121,11 @@ class Burgle
       return false
     end
     if @burgle_settings['max_search_count'] > 0
-      if /(already open|^You.+open|^You can't do that)/ !~ DRC.bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring', 'You can\'t do that')
+      case DRC.bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring', 'You can\'t do that', 'This is probably not the time nor place for that')
+      when 'This is probably not the time nor place for that'
+        DRCT.walk_to(@burgle_room)
+        return valid_burgle_settings?
+      when 'Please rephrase that command', 'What were you referring', 'You can\'t do that'
         DRC.message("You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.")
         return false
       end

--- a/burgle.lic
+++ b/burgle.lic
@@ -123,8 +123,13 @@ class Burgle
     if @burgle_settings['max_search_count'] > 0
       case DRC.bput("open my #{@loot_container}", 'already open', '^You.+open', '^You spread your arms, carefully holding your bag well away from your body', 'Please rephrase that command', 'What were you referring', 'You can\'t do that', 'This is probably not the time nor place for that')
       when 'This is probably not the time nor place for that'
-        DRCT.walk_to(@burgle_room)
-        return valid_burgle_settings?
+        if @follow
+          DRC.message("Couldn't verify your bag due to room restrictions. Allowing the script to continue assuming your bag is open and available.")
+          return true
+        else
+          travel_to_burgle_room
+          return valid_burgle_settings?
+        end
       when 'Please rephrase that command', 'What were you referring', 'You can\'t do that'
         DRC.message("You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.")
         return false
@@ -234,12 +239,7 @@ class Burgle
     end
 
     #don't bother heading to the right area, if following
-    if !@follow
-      if !DRCT.walk_to(@burgle_room)
-        DRC.message("Unable to get to your burgle room.  Exiting to prevent errors.")
-        end_burgle
-      end
-    end
+    travel_to_burgle_room unless @follow
 
     execute_extra_scripts(@burgle_before_scripts)
     get_entry(@entry_type) unless @follow
@@ -318,6 +318,13 @@ class Burgle
       end
     end
     return false #invalid entry type
+  end
+  
+  def travel_to_burgle_room
+    unless DRCT.walk_to(@burgle_room)
+      DRC.message("Unable to get to your burgle room.  Exiting to prevent errors.")
+      end_burgle
+    end
   end
 
   #selected cycle for entry_type, validate that you have the prioritized entry_type, and if not, fallback to other


### PR DESCRIPTION
If you're in the bank or at dokts' (or perhaps other select rooms) burgle hangs when trying to open your bag:
```
[burgle: Pausing ["t2", "afk"] to run burgle]

[burgle]>open my scavenger's pack

This is probably not the time nor place for that.
You notice your augmented reflex slip away.

[burgle: *** No match was found after 15 seconds, dumping info]
```
The original code was missing the match, but even adding it just means you get the wrong error and a failed burgle:
```
You do not have a burgle_settings:loot_container set/set to container you have.  Loot must have a place to be stored prior to exiting the house, even if dropping loot.
It is very important that you check the documentation before running: https://elanthipedia.play.net/Lich_script_repository#burgle 
This is a dangerous script to run if it's not understood.  If you get caught there are very high fines, and the loss of all your items is possible if you can't pay your debt.
```
Moved the if/or into a case statement where if you're in one of these rooms, moves you to your burgle room and checks settings again:
```
>;burgle start rope
--- Lich: burgle active.
[burgle: Pausing [] to run burgle]
[burgle]>open my scavenger's pack
This is probably not the time nor place for that.
>
--- Lich: go2 active.
[go2: ETA: 0:00:03 (17 rooms to move through)]
...TRAVEL...
[go2: travel time: 0:00:01]
--- Lich: go2 has exited.
[burgle]>open my scavenger's pack
That is already open.
>
[burgle]>burgle recall
You take a moment to think, you believe...
You should wait at least 16 roisaen for the heat to die down.
>
[burgle: Unpausing [], burgle has finished.]
--- Lich: burgle has exited.
```
Post fix normal burgle not in burgle room:
```
>;burgle start rope
--- Lich: burgle active.
[burgle: Pausing [] to run burgle]
[burgle]>open my scavenger's pack
That is already open.
>
[burgle]>burgle recall
You take a moment to think, you believe...
You should wait at least 7 roisaen for the heat to die down.
>
[burgle: Unpausing [], burgle has finished.]
--- Lich: burgle has exited.
```