### PR TITLE
[script][burgle] Manual room id fix

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -73,7 +73,7 @@ class Burgle
 
     #set yaml settings unless being overridden from the command line arguments
     @entry_type = args.entry || @burgle_settings['entry_type']
-    @burgle_room = args.roomid || @burgle_settings['room']
+    @burgle_room = args.roomid.to_i || @burgle_settings['room']
     @loot_type = args.loot_type ||  @burgle_settings['loot']
     @hometown = args.hometown || @burgle_settings['hometown'] || @settings.burgle_town || @settings.fang_cove_override_town || @settings.hometown
     @burgle_before_scripts = @burgle_settings['before']


### PR DESCRIPTION
with the change to verification, inputting room via command line returns error:
```
>;burgle start rope 6871
--- Lich: burgle active.
--- Lich: tarantula paused.
[burgle: Pausing ["tarantula"] to run burgle]
Invalid burgle_settings:room setting.  This must be room id of the room you want to burgle from.
It is very important that you check the documentation before running: https://elanthipedia.play.net/Lich_script_repository#burgle 
This is a dangerous script to run if it's not understood.  If you get caught there are very high fines, and the loss of all your items is possible if you can't pay your debt.
```
this sorts that:
```
>;burgle start rope 6871
--- Lich: burgle active.
>
--- Lich: tarantula paused.
[burgle: Pausing ["tarantula"] to run burgle]
[burgle]>open my hitman's backpack
That is already open.
>
[burgle]>burgle recall
You take a moment to think, you believe...
You should wait at least 15 roisaen for the heat to die down.
>
[burgle: Unpausing ["tarantula"], burgle has finished.]
--- Lich: tarantula unpaused.
--- Lich: burgle has exited.
```