### PR TITLE
[script][burgle] Reasons

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -73,7 +73,7 @@ class Burgle
 
     #set yaml settings unless being overridden from the command line arguments
     @entry_type = args.entry || @burgle_settings['entry_type']
-    @burgle_room = args.roomid.to_i || @burgle_settings['room']
+    @burgle_room = args.roomid ? args.roomid.to_i : @burgle_settings['room']
     @loot_type = args.loot_type ||  @burgle_settings['loot']
     @hometown = args.hometown || @burgle_settings['hometown'] || @settings.burgle_town || @settings.fang_cove_override_town || @settings.hometown
     @burgle_before_scripts = @burgle_settings['before']


### PR DESCRIPTION
So, the original logic here only used the argument if it was defined. converting whatever is there to an integer turns nil into 0, so it was setting our burgle room to 0. This only converts if the argument is defined, otherwise uses burgle room from our yaml settings.