### PR TITLE
[script][common-items] Repair routines in common items

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -1031,6 +1031,7 @@ module DRCI
   def repair_gear(town, settings, pickup = true)
     # Repairs items defined in your yaml under gear heading
     repair_info = get_data('town')[town]['metal_repair']
+    DRCT.walk_to(repair_info['id'])
     equipmanager = EquipmentManager.new
     equipmanager.items.each do |item|
       next unless equipmanager.get_item?(item)

--- a/common-items.lic
+++ b/common-items.lic
@@ -1023,6 +1023,44 @@ module DRCI
       false
     end
   end
+  
+  #########################################
+  # GEAR REPAIR
+  #########################################
+  
+  def repair_gear(town, settings, pickup = true)
+    # Repairs items defined in your yaml under gear heading
+    repair_info = get_data('town')[town]['metal_repair']
+    equipmanager = EquipmentManager.new
+    equipmanager.items.each do |item|
+      next unless equipmanager.get_item?(item)
+      case DRC.bput("give #{repair_info['name']}", /I don't repair those here/, /What is it/, /There isn't a scratch on that/, /Just give it to me again/, /I will not/, /I can't fix those/)
+      when /give it to me/
+        DRC.bput("give #{repair_info['name']}", 'repair ticket')
+        DRC.bput("stow #{repair_info['name']} ticket", 'You put')
+      else
+        equipmanager.return_held_gear
+      end
+    end
+    pickup_repaired_items(town, settings) if pickup
+  end
+
+  def pickup_repaired_items(town, settings)
+    repair_info = get_data('town')[town]['metal_repair']
+    equipmanager = EquipmentManager.new
+    DRCT.walk_to(repair_info['id'])
+    while get_item?("#{repair_info['name']} ticket")
+      pause 30 until DRC.bput('look at my ticket', /should be ready by now/, /^Looking at the/) == 'should be ready by now'
+      DRC.bput("give #{repair_info['name']}", /^You hand/, /takes your ticket/)
+      pause 0.01 until item = [DRC.right_hand,DRC.left_hand].compact.first # waits for repaired item to hit your hand
+      if toolbelt = [settings.forging_belt, settings.engineering_belt, settings.outfitting_belt, settings.alchemy_belt, settings.enchanting_belt].select { |belt| belt["items"].find { |name| name =~ /#{item}/i } }.first      
+        DRCC.stow_crafting_item(item, settings.crafting_container, toolbelt) # hopefully stows the tool appropriately.
+      elsif [settings.forging_tools, settings.tinkering_tools, settings.carving_tools, settings.shaping_tools, settings.outfitting_tools, settings.alchemy_tools, settings.enchanting_tools].any? { |tools| tools.any? { |name| name =~ /#{item}/i } }
+        DRCC.stow_crafting_item(item, settings.crafting_container, nil)
+      end
+      equipmanager.empty_hands
+    end
+  end
 
   #########################################
   # GEM POUCH HANDLING ROUTINES


### PR DESCRIPTION
First method functions the same as crossing-repair script, but allows us to opt out of picking up immediately, so can be worked into scripts like training-manager.

Notably theres no check for cash, though that could be worked in?