### PR TITLE
[script][combat-trainer][common-arcana][discern] - auto_mana for sorcery

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1495,10 +1495,12 @@ class SpellProcess
     if game_state.is_offense_allowed? || @prepared_spell['harmless']
       snapshot = DRSkill.getxp(@skill)
       success = cast?(@custom_cast, @symbiosis, @before, @after)
-      if @symbiosis && @use_auto_mana
+      if (@symbiosis || spell_is_sorcery?(@prepared_spell)) && @use_auto_mana
         if !success
           UserVars.discerns[@abbrev]['more'] = [UserVars.discerns[@abbrev]['more'] - 1, 0].max
-        elsif DRSkill.getxp(@skill) - snapshot < @symbiosis_learning_threshold
+          @prepared_spell['failed'] = true
+          DRC.message("Casting spell #{@abbrev} failed - will no longer automatically increase")
+        elsif DRSkill.getxp(@skill) - snapshot < @symbiosis_learning_threshold && !@prepared_spell['failed']
           UserVars.discerns[@abbrev]['more'] = UserVars.discerns[@abbrev]['more'] + 1
         end
       end
@@ -1855,7 +1857,7 @@ class SpellProcess
   def prepare_spell(data, game_state, force_cambrinth = false)
     return unless data
 
-    data = check_discern(data, @settings) if data['use_auto_mana']
+    data = check_discern(data, @settings, spell_is_sorcery?(data)) if data['use_auto_mana']
     game_state.cast_timer = Time.now
     @prep_time = data['prep_time']
     echo("prepare spell: #{data}") if $debug_mode_ct

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -689,17 +689,17 @@ module DRCA
     true
   end
 
-  def check_discern(data, settings)
+  def check_discern(data, settings, spell_is_sorcery = false, more_override = nil)
     UserVars.discerns = {} unless UserVars.discerns
     discern_data = UserVars.discerns[data['abbrev']] || {}
-    if data['symbiosis']
-      if discern_data.empty? || discern_data['min'].nil?
+    if data['symbiosis'] || spell_is_sorcery
+      if discern_data.empty? || discern_data['min'].nil? || more_override
         DRC.retreat
         /requires at minimum (\d+) mana streams/ =~ DRC.bput("discern #{data['abbrev']}", 'requires at minimum \d+ mana streams')
         discern_data['mana'] = Regexp.last_match(1).to_i
         discern_data['cambrinth'] = nil
         discern_data['min'] = Regexp.last_match(1).to_i
-        discern_data['more'] = 0
+        discern_data['more'] = (more_override ? more_override : 0)
       end
       calculate_mana(discern_data['min'], discern_data['more'], discern_data, false, settings)
     elsif discern_data.empty? || discern_data['time_stamp'].nil? || Time.now - discern_data['time_stamp'] > settings.check_discern_timer_in_hours * 60 * 60 || !discern_data['more'].nil?

--- a/discern.lic
+++ b/discern.lic
@@ -10,12 +10,26 @@ class Discern
     arg_definitions = [
       [
         { name: 'reset', regex: /^reset$/i, optional: true, description: 'Delete existing discern data and re-discern spells.' },
+      ],
+      [
+        { name: 'set', regex: /^set/i, description: 'update total mana for a spell discern for sorcery or symbiosis' },
+        { name: 'spell', regex: /^[A-z\s\-\']+$/i, description: 'spell to update (name or abbreviation) - must be in your yaml spell lists' },
+        { name: 'mana', regex: /\d+/, description: 'total mana to set' }
+      ],
+      [
+        { name: 'check', regex: /^check/i, description: 'Check current discern data for a spell' },
+        { name: 'spell', regex: /^[A-z\s\-\']+$/i, description: 'spell to check' }
       ]
     ]
 
     args = parse_args(arg_definitions)
 
     UserVars.discerns = {} if args.reset
+
+    if args.check
+      echo UserVars.discerns[args.spell]
+      exit
+    end
 
     settings = get_settings
 
@@ -27,6 +41,29 @@ class Discern
     spells << settings.crafting_training_spells.values
     spells << settings.waggle_sets.values.map(&:values)
     spells.flatten!
+
+    if args.set
+      spell_to_update = spells
+                          .select { |spell| spell['use_auto_mana'] }
+                          .find { |spell| spell['name'] == args.spell || spell['abbrev'] == args.spell }
+
+      if !spell_to_update
+        echo "Could not find spell #{args.spell}"
+        exit
+      end
+
+      spell_mana = spell_to_update['mana'].to_i
+      mana = args.mana.to_i
+
+      if mana <= spell_mana
+        echo 'Specified mana must be more than the minimum to cast the spell'
+        exit
+      end
+
+      DRCA.check_discern(spell_to_update, settings, true, mana - spell_mana)
+
+      exit
+    end
 
     discern_spells(spells, settings)
   end

--- a/discern.lic
+++ b/discern.lic
@@ -26,11 +26,6 @@ class Discern
 
     UserVars.discerns = {} if args.reset
 
-    if args.check
-      echo UserVars.discerns[args.spell]
-      exit
-    end
-
     settings = get_settings
 
     spells = []
@@ -42,13 +37,22 @@ class Discern
     spells << settings.waggle_sets.values.map(&:values)
     spells.flatten!
 
+    if args.check
+      spell_to_check = spells.find { |spell| spell['name'] =~ /#{args.spell}/i || spell['abbrev'] =~ /#{args.spell}/i }
+
+      echo spell_to_check
+      echo UserVars.discerns[spell_to_check['abbrev']]
+
+      exit
+    end
+
     if args.set
       spell_to_update = spells
                           .select { |spell| spell['use_auto_mana'] }
-                          .find { |spell| spell['name'] == args.spell || spell['abbrev'] == args.spell }
+                          .find { |spell| spell['name'] =~ /#{args.spell}/i || spell['abbrev'] =~ /#{args.spell}/i }
 
       if !spell_to_update
-        echo "Could not find spell #{args.spell}"
+        echo "Could not find spell #{args.spell}. It must be in one of the following spell lists: offensive_spells, buff_spells, combat_spell_training, training_spells, crafting_training_spells, waggle_sets."
         exit
       end
 
@@ -61,7 +65,6 @@ class Discern
       end
 
       DRCA.check_discern(spell_to_update, settings, true, mana - spell_mana)
-
       exit
     end
 


### PR DESCRIPTION
Changes to combat-trainer, common-arcana, and discern to implement auto_mana for sorcery using the existing approach to symbiosis.

Overall, the changes are pretty minor, since I'm using the existing logic used for symbiosis. Most changes are just adding an additional check for sorcery.

I did add one additional change to combat-trainer: if the spell fails to cast, we decrease the amount of mana and so that we can try again next time with less mana. If we have to do this, I set a flag on the spell ('failed'). I now check the 'failed' property when checking to see if we should increase the mana going into the spell because of the learning threshold. This addresses an issue where casting the spell provides less than the learning threshold, but any more mana causes the spell to fail. The script will get into a cycle where it constantly increases, decreases, and then again increases the mana. If the spell fails, the script will cease increasing for this session.

I've also extended discern in a couple ways:
set: this is a new argument that allows the user to set their mana at a reasonable level. Mahtra noted that the tuning for auto-mana for symbiosis (and now sorcery) is super slow, so this allows the user to set a baseline.
check: this is a simple argument that allows the user to output the discern values they have saved for a particular spell, rather than reading through the entire variable with ;vars list

I've been testing on two different characters - one with a sorcery spell set to auto_mana, one without. I've also tested with auto_mana symbiosis. All test cases worked as I expected, but I am going to evaluate a bit more.