### PR TITLE
common-crafting - 2 new methods

### DIFF
--- a/common-crafting.lic
+++ b/common-crafting.lic
@@ -6,6 +6,16 @@
 $PRIMARY_SIGILS_PATTERN = /\b(?:abolition|congruence|induction|permutation|rarefaction) sigil\b/
 $SECONDARY_SIGILS_PATTERN = /\b(?:antipode|ascension|clarification|decay|evolution|integration|metamorphosis|nurture|paradox|unity) sigil\b/
 
+$VOL_MAP = {
+  'enormous' => 20,
+  'massive' => 10,
+  'huge' => 5,
+  'large' => 4,
+  'medium' => 3,
+  'small' => 2,
+  'tiny' => 1
+}
+
 custom_require.call(%w[common common-items common-travel drinfomon])
 
 module DRCC
@@ -178,6 +188,22 @@ module DRCC
     recipe = DRC.bput("read my #{book}", "Page \\d+:\\s(?:some|a|an)?\\s*#{match_string}").split('Page').find { |x| x =~ /#{match_string}/i }
     recipe =~ /(\d+):/
     Regexp.last_match(1)
+  end
+
+  def find_recipe2(chapter, match_string, book = 'book', discipline = nil)
+    DRC.bput("turn my #{book} to discipline #{discipline}", /^You turn the #{book} to the section on/) unless discipline.nil?
+    case DRC.bput("turn my #{book} to chapter #{chapter}", /^You turn your #{book} to chapter/, /^The #{book} is already turned to chapter/, /^You are too distracted to be doing that right now./)
+    when /^You are too distracted to be doing that right now./
+      echo '***CANNOT TURN BOOK, ASSUMING I AM ENGAGED IN COMBAT***'
+      fput('look')
+      fput('exit')
+    end
+
+    recipe = DRC.bput("read my #{book}", "Page \\d+:\\s(?:some|a|an)?\\s*#{match_string}").split('Page').find { |x| x =~ /#{match_string}/i }
+    recipe =~ /(\d+):/
+    page = Regexp.last_match(1)
+    DRC.bput("turn my #{book} to page #{page}", /^You turn your #{book} to page/, /^You are already on page/)
+    DRC.bput("study my #{book}", /^Roundtime/)
   end
 
   def get_crafting_item(name, bag, bag_items, belt, skip_exit = false)
@@ -502,6 +528,43 @@ module DRCC
         return false
       end
     end
+  end
+
+  def count_raw_metal(container, type = nil)
+    case DRC.bput("rummage /M #{container}", /crafting materials but there is nothing in there like that\.$/, /While it\'s closed/, /I don\'t know what you are referring to/, /You feel about/, /That would accomplish nothing/, /looking for crafting materials and see (.*)\.$/)
+    when /crafting materials but there is nothing in there like that\.$/
+      DRC.message("No materials found")
+      return
+    when /While it\'s closed/
+      return unless DRCI.open_container?(container)
+      count_raw_metal(container, type)
+    when /I don\'t know what you are referring to/
+      DRC.message("Container not found.")
+      return
+    when /You feel about/
+      DRC.message("Try again when you're not invisible.")
+      return
+    when /looking for crafting materials and see (.*)\.$/
+      h = Hash.new
+      list = Regexp.last_match(1).sub(' and ', ', ').split(', ')
+      list.each do |e|
+        metal = e.split[2]
+        volume = $VOL_MAP[e.split[1]]
+        if h.key?(metal)
+          h[metal][0] += volume
+          h[metal][1] += 1
+        else
+          h[metal] = [volume, 1]
+        end
+      end
+      h.each do |k,v|
+        DRC.message("#{k} - #{v[0]} volume - #{v[1]} pieces")
+      end
+    else
+      DRC.message("Please report this error to the dev team on discord.  Include a log snippet if possible.")
+      return
+    end
+    type.nil? ? (return h) : (return h[type])
   end
 
 end


### PR DESCRIPTION
Added a new method that finds the recipe and studies the book all in one, and is setup to work with master crafting books that are worn as wel. For now, I'm naming it `find_recipe2` since I'm not implementing it in any scripts yet and I don't want to break any of the crafting scripts. If anyone has a suggestion for a better method name, please comment.

`  def find_recipe2(chapter, match_string, book = 'book', discipline = nil)`

The discipline argument is only needed when you use a master crafting book.

These are the scripts that will need to be updated later to make use of this method: carve
enchant
forge
remedy
sew
shape
tinker

The second method I've added is for counting the volumes of raw metal in a container.  It can be used in a script later that will smelt all of a specified type of metal in your container, useful for miners.

`  def count_raw_metal(container, type = nil)`

If you don't specify a type, it'll output a list of all of the metals in your container with the volume of each.

Sample output:
```
coralite - 47 volume - 11 pieces
kadepa - 46 volume - 11 pieces
tyrium - 30 volume - 7 pieces
kertig - 43 volume - 10 pieces
telothian - 52 volume - 13 pieces
haledroth - 50 volume - 12 pieces
kelpzyte - 49 volume - 11 pieces
loimic - 42 volume - 11 pieces
kiralan - 40 volume - 10 pieces
vardite - 45 volume - 10 pieces
indurium - 51 volume - 13 pieces
silversteel - 43 volume - 10 pieces
agonite - 5 volume - 1 pieces
icesteel - 9 volume - 2 pieces
damite - 8 volume - 2 pieces

```
And this is a what it returns for use by the calling script:
```
[exec1: {"coralite"=>[47, 11], "kadepa"=>[46, 11], "tyrium"=>[30, 7], "kertig"=>[43, 10], "telothian"=>[52, 13], "haledroth"=>[50, 12], "kelpzyte"=>[49, 11], "loimic"=>[42, 11], "kiralan"=>[40, 10], "vardite"=>[45, 10], "indurium"=>[51, 13], "silversteel"=>[43, 10], "agonite"=>[5, 1], "icesteel"=>[9, 2], "damite"=>[8, 2]}]
```

If you specify a metal, currently it still outputs the full list of all metals in the container, but the return from the script is this.  I searched for damite here:
```
[exec1: [8, 2]]
```