### PR TITLE
base-crafting - added new socities

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -644,7 +644,7 @@ blacksmithing:
     stock-room: 17694
     trash-room: 17690
     idle-room: 17689      
-  Hibarnhvidar: &forfedhar_blacksmithing
+  Hibarnhvidar: &forfedhdar_blacksmithing
     npc: Juln
     npc_last_name: Juln
     npc-rooms:
@@ -761,7 +761,7 @@ blacksmithing:
     trash-room: 8813
     idle-room: 8808
   Boar Clan:
-    << : *forfedhar_blacksmithing
+    << : *forfedhdar_blacksmithing
 tailoring:
   Crossing: &zoluren_tailoring
     npc: Milline
@@ -833,7 +833,7 @@ tailoring:
     << : *theren_tailoring
   Therenborough:
     << : *theren_tailoring
-  Shard: &ilithi_tailoring
+  Shard:
     npc: Jakke
     npc_last_name: Jakke
     npc-rooms:
@@ -1072,7 +1072,7 @@ shaping:
     glue-number: 13
     stain-number: 14
     idle-room:
-  Shard: &ilithi_shaping
+  Shard:
     npc: Master
     npc_last_name: Master
     npc-rooms:
@@ -1128,10 +1128,35 @@ shaping:
     glue-number: 13
     stain-number: 14
     idle-room: 11268
-  Hibarnhvidar:
-    << : *ilithi_shaping
+  Hibarnhvidar: &forfedhdar_shaping
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+    - 17150
+    - 17151
+    - 17152
+    - 17153
+    - 17154
+    - 17155
+    - 17156
+    - 17157
+    shaping-rooms:
+    - 17155
+    - 17156
+    - 17157
+    logbook: engineering
+    repair-room: 17153
+    repair-npc: clerk
+    stock-room: 17152
+    pattern-book: shaping
+    part-room: 17152
+    tool-room: 17154
+    clamps-number: 12
+    glue-number: 13
+    stain-number: 14
+    idle-room: 17152
   Boar Clan:
-    << : *ilithi_shaping
+    << : *forfedhdar_shaping
 carving:
   Crossing: &zoluren_carving
     npc: Talia
@@ -1170,7 +1195,7 @@ carving:
     << : *theren_carving
   Therenborough:
     << : *theren_carving
-  Shard: &ilithi_carving
+  Shard:
     npc: Master
     npc_last_name: Master
     npc-rooms:
@@ -1219,10 +1244,28 @@ carving:
     stock-room: 11272
     pattern-book: carving
     part-room: 11272
-  Hibarnhvidar:
-    << : *ilithi_carving
+  Hibarnhvidar: &forfedhdar_carving
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+    - 17150
+    - 17151
+    - 17152
+    - 17153
+    - 17154
+    - 17155
+    - 17156
+    - 17157
+    logbook: engineering
+    polish: polish
+    polish-room: 17154
+    polish-number: 4
+    repair-room: 17153
+    repair-npc: clerk
+    stock-room: 17152
+    pattern-book: carving
   Boar Clan:
-    << : *ilithi_carving
+    << : *forfedhdar_carving
   Fang Cove:
     npc: Brogir
     npc_last_name: Brogir
@@ -1314,7 +1357,7 @@ remedies:
     << : *theren_remedies
   Therenborough:
     << : *theren_remedies
-  Shard: &ilithi_remedies
+  Shard:
     npc: Benzia
     npc_last_name: Benzia
     npc-rooms:
@@ -1392,10 +1435,41 @@ remedies:
     press-grinder-rooms:
     - 12380
     idle-room: 12379
-  Hibarnhvidar:
-    << : *ilithi_remedies
+  Hibarnhvidar: &forfedhdar_remedies
+    npc: Thynik
+    npc_last_name: Thynik
+    npc-rooms:
+    - 17141
+    - 17142
+    - 17143
+    - 17144
+    - 17145
+    - 17146
+    - 17147
+    - 17148
+    - 17149
+    logbook: alchemy
+    repair-room: 17153 #temporarily using engineering society clerk because alchemy society has no clerk currently.
+    repair-npc: clerk
+    stock-room: 17143
+    stock-number: 1
+    stock-name: water
+    stock-volume: 10
+    stock-number-a: 2
+    stock-name-a: alcohol
+    stock-volume-a: 10
+    pattern-book: remed
+    catalyst: coal nugget
+    catalyst-room: 8894
+    catalyst_number: 2
+    catalyst_volume: 10
+    press-grinder-rooms:
+    - 17145
+    - 17147
+    - 17148
+    idle-room: 17149
   Boar Clan:
-    << : *ilithi_remedies
+    << : *forfedhdar_remedies
   Fang Cove:
     npc: Swetyne
     npc_last_name: Swetyne
@@ -1478,7 +1552,7 @@ artificing:
     repair-npc: Unspiek
     trash-room: 14767
     idle-room: 14770
-  Shard:  &ilithi_artificing
+  Shard:
     npc: Trainer
     npc_last_name: Trainer
     npc-rooms:
@@ -1523,7 +1597,7 @@ artificing:
     repair-npc: clerk
     trash-room: 14792
     idle-room: 14788
-  Hibarnhvidar:
+  Hibarnhvidar: &forfedhdar_artificing
     npc: Trainer
     npc_last_name: Trainer
     npc-rooms:
@@ -1547,6 +1621,8 @@ artificing:
     repair-room: 8887
     repair-npc: clerk
     idle-room: 15520
+  Boar Clan:
+    << : *forfedhdar_artificing
   Ratha:  
     npc: Trainer
     npc_last_name: Trainer
@@ -1649,7 +1725,7 @@ recipe_parts:
       part-room: 16409
       part-number:
     Boar Clan:
-      part-room: 8892
+      part-room: 8892 # Hibarnhvidar
       part-number:
     Hibarnhvidar:
       part-room: 8892
@@ -1680,7 +1756,7 @@ recipe_parts:
       part-room: 16409
       part-number:
     Boar Clan:
-      part-room: 8892
+      part-room: 8892 # Hibarnhvidar
       part-number:
     Hibarnhvidar:
       part-room: 8892
@@ -1720,7 +1796,7 @@ recipe_parts:
       part-room: 10755
       part-number:
     Boar Clan:
-      part-room: 8892
+      part-room: 8892 # Hibarnhvidar
       part-number:
     Hibarnhvidar:
       part-room: 8892
@@ -1840,7 +1916,7 @@ recipe_parts:
       part-room: 10755
       part-number:
     Boar Clan:
-      part-room: 8892
+      part-room: 8892 # Hibarnhvidar
       part-number: 
     Hibarnhvidar:
       part-room: 8892
@@ -1880,7 +1956,7 @@ recipe_parts:
       part-room: 16409
       part-number:
     Boar Clan:
-      part-room: 8892
+      part-room: 8892 # Hibarnhvidar
       part-number:
     Hibarnhvidar:
       part-room: 8892
@@ -2009,6 +2085,12 @@ recipe_parts:
     Shard:
       part-room: 10939
       part-number: 16
+    Hibarnhvidar:
+      part-room: 17134
+      part-number: 16
+    Boar Clan:
+      part-room: 17134 # Hibarnhvidar
+      part-number: 16
   shield handle:
     Crossing:
       part-room: 8776
@@ -2075,10 +2157,10 @@ recipe_parts:
       part-room: 10939
       part-number: 6
     Boar Clan:
-      part-room: 10939 # Shard
+      part-room: 17134 # Hibarnhvidar
       part-number: 6
     Hibarnhvidar:
-      part-room: 10939 # Shard
+      part-room: 17134
       part-number: 6
     Fang Cove:
       part-room: 9125
@@ -2109,10 +2191,10 @@ recipe_parts:
       part-room: 10938
       part-number: 5
     Boar Clan:
-      part-room: 10938 # Shard
+      part-room: 17136 # Hibarnhvidar
       part-number: 5
     Hibarnhvidar:
-      part-room: 10938 # Shard
+      part-room: 17136
       part-number: 5
     Fang Cove:
       part-room: 9124
@@ -2143,10 +2225,10 @@ recipe_parts:
       part-room: 4436
       part-number:
     Boar Clan:
-      part-room: 4436 # Shard
+      part-room: 17152 # Hibarnhvidar
       part-number:
     Hibarnhvidar:
-      part-room: 4436 # Shard
+      part-room: 17152
       part-number:
     Fang Cove:
       part-room: 9118
@@ -2177,10 +2259,10 @@ recipe_parts:
       part-room: 10738
       part-number:
     Hibarnhvidar:
-      part-room: 19306 # Shard
+      part-room: 17152
       part-number:
     Boar Clan:
-      part-room: 19306 # Shard
+      part-room: 17152 # Hibarnhvidar
       part-number:
     Fang Cove:
       part-room: 9118
@@ -2214,10 +2296,10 @@ recipe_parts:
       part-room: 10738
       part-number:
     Hibarnhvidar:
-      part-room: 19306 # Shard
+      part-room: 17152
       part-number:
     Boar Clan:
-      part-room: 19306 # Shard
+      part-room: 17152 # Hibarnhvidar
       part-number:
     Fang Cove:
       part-room: 14793
@@ -2230,10 +2312,10 @@ recipe_parts:
       part-room: 14773
       part-number:
     Hibarnhvidar:
-      part-room: 14773 # Shard
+      part-room: 15523
       part-number:
     Boar Clan:
-      part-room: 14773 # Shard
+      part-room: 15523 # Hibarnhvidar
       part-number:
     Fang Cove:
       part-room: 14784
@@ -2246,7 +2328,7 @@ recipe_parts:
       part-room: 14773
       part-number:
     Hibarnhvidar:
-      part-room: 15523 # Hibarnhvidar
+      part-room: 15523
       part-number:
     Boar Clan:
       part-room: 15523 # Hibarnhvidar
@@ -2262,7 +2344,7 @@ recipe_parts:
       part-room: 14773
       part-number:
     Hibarnhvidar:
-      part-room: 15523 # Hibarnhvidar
+      part-room: 15523
       part-number:
     Boar Clan:
       part-room: 15523 # Hibarnhvidar
@@ -2278,7 +2360,7 @@ recipe_parts:
       part-room: 14773
       part-number:
     Hibarnhvidar:
-      part-room: 15523 # Hibarnhvidar
+      part-room: 15523
       part-number:
     Boar Clan:
       part-room: 15523 # Hibarnhvidar
@@ -2294,7 +2376,7 @@ recipe_parts:
       part-room: 14773
       part-number:
     Hibarnhvidar:
-      part-room: 15523 # Hibarnhvidar
+      part-room: 15523
       part-number:
     Boar Clan:
       part-room: 15523 # Hibarnhvidar
@@ -2310,7 +2392,7 @@ recipe_parts:
       part-room: 14773
       part-number:
     Hibarnhvidar:
-      part-room: 15523 # Hibarnhvidar
+      part-room: 15523
       part-number:
     Boar Clan:
       part-room: 15523 # Hibarnhvidar
@@ -2318,3 +2400,4 @@ recipe_parts:
     Fang Cove:
       part-room: 14784
       part-number:
+ 


### PR DESCRIPTION
Added the new Engineering (for both shaping and carving) and Alchemy societies in Hibarnhvidar and also added all of the recipe parts so there is no running back to Shard for parts.

I've only had a chance to test out shaping and alchemy, not carving yet.

I also removed the now unused ilithi anchors that were being used for Hib and Boar clan