### PR TITLE
[script][combat-trainer] - perform other actions when waiting for OM to be infused

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1131,6 +1131,9 @@ class SpellProcess
     @osrel_no_harness = settings.osrel_no_harness
     echo("  @osrel_no_harness: #{@osrel_no_harness}") if $debug_mode_ct
 
+    @osrel_need_mana = false
+    echo("  @osrel_need_mana: #{@osrel_need_mana}") if $debug_mode_ct
+
     @cast_only_to_train = settings.cast_only_to_train
     echo("  @cast_only_to_train: #{@cast_only_to_train}") if $debug_mode_ct
 
@@ -1271,7 +1274,11 @@ class SpellProcess
       game_state.casting = false
       Flags.reset('ct-spelllost')
     end
+
     check_osrel(game_state)
+    DRC.message("Skipping other spell processes until @osrel_need_mana is false") if @osrel_need_mana
+    return false if @osrel_need_mana
+
     if game_state.mob_died
       @offensive_spells
         .select { |spell| spell['expire'] }
@@ -1347,8 +1354,17 @@ class SpellProcess
     return if game_state.casting
     return unless @osrel_amount && DRSpells.active_spells['Osrel Meraud']
     return unless Time.now - @osrel_timer > 300
+
+    if DRStats.mana <= 40
+      DRC.message("Setting @osrel_need_mana to true until mana over 40. Current mana: #{DRStats.mana}")
+      @osrel_need_mana = true
+      return
+    end
+
     @osrel_timer = Time.now
     infuse_om(!@osrel_no_harness, @osrel_amount)
+    DRC.message("Setting @osrel_need_mana to false") if @osrel_need_mana
+    @osrel_need_mana = false
   end
 
   def check_timer(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1131,6 +1131,9 @@ class SpellProcess
     @osrel_no_harness = settings.osrel_no_harness
     echo("  @osrel_no_harness: #{@osrel_no_harness}") if $debug_mode_ct
 
+    @osrel_mana_threshold = settings.osrel_mana_threshold
+    echo("  @osrel_mana_threshold: #{@osrel_mana_threshold}") if $debug_mode_ct
+
     @osrel_need_mana = false
     echo("  @osrel_need_mana: #{@osrel_need_mana}") if $debug_mode_ct
 
@@ -1354,9 +1357,10 @@ class SpellProcess
     return if game_state.casting
     return unless @osrel_amount && DRSpells.active_spells['Osrel Meraud']
     return unless Time.now - @osrel_timer > 300
+    return unless DRSpells.active_spells['Osrel Meraud'] && DRSpells.active_spells['Osrel Meraud'] < 90
 
-    if DRStats.mana <= 40
-      DRC.message("Setting @osrel_need_mana to true until mana over 40. Current mana: #{DRStats.mana}")
+    if DRStats.mana <= @osrel_mana_threshold
+      DRC.message("Setting @osrel_need_mana to true until mana over #{@osrel_mana_threshold}. Current mana: #{DRStats.mana}")
       @osrel_need_mana = true
       return
     end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1334,6 +1334,8 @@ combat_trainer_herbs_allowhands: false
 osrel_no_harness: false
 osrel_amount:
 osrel_favor_god: Meraud
+# Minimum amount of mana character must have before starting to infuse OM 
+osrel_mana_threshold: 40
 
 tie_gem_pouches: true
 spare_gem_pouch_container:


### PR DESCRIPTION
When a character's mana is <= 40, allow other, non-spell related actions to be performed while waiting for the mana to increase.

@MahtraDR I ran this on a couple characters, and it ran fine, but I can't actually test the OM-related code. I'm reasonably confident it should perform as expected, if we can find a tester.

Possible fix for [Issue 6314](https://github.com/rpherbig/dr-scripts/issues/6314)