### PR TITLE
Update smoker

### DIFF
--- a/smoke.lic
+++ b/smoke.lic
@@ -125,7 +125,7 @@ class Smoker
 
   def smoke_cig
     inhale_counter = 0
-    while true
+    until Flags['new-cig']
       exit if Flags['new-cig']
 
       if @image

--- a/smoke.lic
+++ b/smoke.lic
@@ -103,7 +103,6 @@ class Smoker
 
     if @lighter_info['type'].include?('flint')
       DRCI.lower_ground(@cigar)
-      DRC.bput("guard #{@cigar}", 'You are a bit', 'You move into position')
       DRC.bput("wield my #{@lighter_info['blade']}", 'You get', 'What were', 'You are already', 'You draw')
     end
 

--- a/smoke.lic
+++ b/smoke.lic
@@ -1,4 +1,3 @@
-# quiet
 =begin
   * If smoke_image is not included with YAML setting, it will just smoke/inhale/exhale.
   * Can use flint or a lighter with YAML.

--- a/smoke.lic
+++ b/smoke.lic
@@ -125,8 +125,6 @@ class Smoker
   def smoke_cig
     inhale_counter = 0
     until Flags['new-cig']
-      exit if Flags['new-cig']
-
       if @image
         DRC.bput("inhale my #{@cigar}", 'You take', 'What were', 'out of your lungs first')
         exhale_smoke

--- a/smoke.lic
+++ b/smoke.lic
@@ -112,7 +112,7 @@ class Smoker
     else
       fput("light #{@cigar} with my #{@lighter_info['type']}")
       waitrt?
-      DRC.bput("sheath my #{@lighter_info['blade']}", 'You put')
+      DRC.bput("sheath my #{@lighter_info['blade']}", /You (sheath|put)/)
       DRC.bput("lift", 'You pick up')
     end
 

--- a/smoke.lic
+++ b/smoke.lic
@@ -21,13 +21,13 @@ class Smoker
   def initialize
     arg_definitions = [
       [
-        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun. (Only thing required if using YAML settings.)' },
+        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun. (Only thing required if using YAML settings.)' }
       ],
       [
         { name: 'image', regex: /\w+/i, variable: true, description: 'Smoke image to learn, can be an ARRAY, will random one.' },
         { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun.' },
         { name: 'container', regex: /\w+/i, variable: true, description: "Cigar's container." },
-        { name: 'lighter', regex: /\w+/i, variable: true, description: "Lighter's noun." }        
+        { name: 'lighter', regex: /\w+/i, variable: true, description: "Lighter's noun." }
       ]
     ]
 
@@ -51,7 +51,7 @@ class Smoker
       end
       
       @lighter_info = smoke_settings['lighter']
-      @cigar_container = smoke_settings['cigar_container'] 
+      @cigar_container = smoke_settings['cigar_container']
     end
 
     Flags.add('new-cig', 'That was the last of your')

--- a/smoke.lic
+++ b/smoke.lic
@@ -114,7 +114,7 @@ class Smoker
       fput("light #{@cigar} with my #{@lighter_info['type']}")
       waitrt?
       DRC.bput("sheath my #{@lighter_info['blade']}", 'You put')
-      DRC.bput("get #{@cigar}", 'You pick up')
+      DRC.bput("lift", 'You pick up')
     end
 
     DRC.bput("put my #{@lighter_info['type']} in my #{@lighter_info['container']}", 'You put')

--- a/smoke.lic
+++ b/smoke.lic
@@ -1,8 +1,20 @@
-custom_require.call(%w[common events])
-
+# quiet
 =begin
-  Documentation: https://elanthipedia.play.net/Lich_script_repository#smoke
+  * If smoke_image is not included with YAML setting, it will just smoke/inhale/exhale.
+  * Can use flint or a lighter with YAML.
+  * Can random an image, supports array or single.
+  * Supports warrior mage cantrip Burning Touch.
+  Use YAML settings:
+    smoke:
+      cigar_container:
+      smoke_image:
+      lighter:
+        type:
+        container:
+        blade:
 =end
+
+custom_require.call(%w[common events])
 
 class Smoker
   include DRC
@@ -10,35 +22,42 @@ class Smoker
   def initialize
     arg_definitions = [
       [
-        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun. (Only thing required if using YAML settings.)' }
+        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun.' },
       ],
       [
-        { name: 'image', regex: /\w+/i, variable: true, description: 'Smoke image to learn.' },
+        { name: 'image', regex: /\w+/i, variable: true, description: 'Smoke image to learn, can be an ARRAY, will random one.' },
         { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun.' },
         { name: 'container', regex: /\w+/i, variable: true, description: "Cigar's container." },
-        { name: 'lighter', regex: /\w+/i, variable: true, description: "Lighter's noun." }
+        { name: 'lighter', regex: /\w+/i, variable: true, description: "Lighter's noun." }        
       ]
     ]
 
     args = parse_args(arg_definitions)
-
+    
     if args.image
       @image = args.image
       @cigar = args.cigar
       @cigar_container = args.container
-      @lighter = args.lighter
+      @lighter = args.lighter       
     else
       smoke_settings = get_settings.smoke
 
       @cigar = args.cigar
-      @image = smoke_settings['smoke_image'] if smoke_settings['smoke_image']
+      if smoke_settings['smoke_image']
+        if smoke_settings['smoke_image'].is_a? Array
+          @image = smoke_settings['smoke_image'].sample
+        else
+          @image = smoke_settings['smoke_image']
+        end
+      end
+      
       @lighter_info = smoke_settings['lighter']
-      @cigar_container = smoke_settings['cigar_container']
+      @cigar_container = smoke_settings['cigar_container'] 
     end
 
     Flags.add('new-cig', 'That was the last of your')
 
-    smoke_cig if get_cig? && light_cig?
+    smoke_cig if light_cig? if get_cig?
 
     Flags.delete('new-cig')
   end
@@ -46,7 +65,7 @@ class Smoker
   def get_cig?
     case bput("get #{@cigar} in my #{@cigar_container}", 'You get', 'What were', 'You need')
     when 'What were'
-      echo 'Out of cigars, exiting.'
+      message 'Out of cigars, exiting.'
       return false
     end
 
@@ -57,16 +76,29 @@ class Smoker
     pause 3
     output = 'exhale'
     output = "exhale line #{@image}" if @image
-    bput(output.to_s, 'Roundtime')
+    bput("#{output}", 'You blow', 'You breathe out', 'You cast', 'You need to have inhaled', 'You exhale')
   end
 
   def light_cig?
     output = "get my #{@lighter}"
     output = "get #{@lighter_info['type']} in my #{@lighter_info['container']}" unless @lighter_info.empty?
-
-    case bput(output.to_s, 'You get', 'What were', 'You are already')
+    output = "prep c b t" if @lighter_info['type'].eql?'cantrip'
+    
+    case bput("#{output}", 'You get', 'What were', 'You are already', 'You are now prepared', 'You have no idea')
+    when 'You have no idea'
+      message "You don't know the cantrip you are trying to you! EXITING!"
+      exit
+    when 'You are now prepared'
+      case bput("gesture my #{@cigar}", 'You touch')
+      when 'You touch'
+        Flags.reset('new-cig')
+        return true
+      when 'What were'
+        message 'Cigar missing! Exiting!'
+        exit
+      end
     when 'What were'
-      echo 'No lighter found! Exiting.'
+      message 'No lighter found! Exiting.'
       return false
     end
 
@@ -82,7 +114,7 @@ class Smoker
     else
       fput("light #{@cigar} with my #{@lighter_info['type']}")
       waitrt?
-      bput("sheath my #{@lighter_info['blade']}", 'You Sheath', 'You put')
+      bput("sheath my #{@lighter_info['blade']}", 'You put')
       bput("get #{@cigar}", 'You pick up')
     end
 
@@ -94,19 +126,18 @@ class Smoker
 
   def smoke_cig
     inhale_counter = 0
-    loop do
+    while true
       exit if Flags['new-cig']
 
       if @image
-        bput("inhale my #{@cigar}", 'You take', 'What were')
+        bput("inhale #{@cigar}", 'You take', 'What were', 'out of your lungs first')
         exhale_smoke
         waitrt?
-        fput('smoke list')
       else
         output = "smoke #{@cigar}"
-        output = "inhale #{@cigar}" if inhale_counter == 0
-        bput(output.to_s, 'You puff', 'You take', 'What were')
-        exhale_smoke if inhale_counter == 0
+        output = "inhale #{@cigar}" if (inhale_counter == 0)
+        bput("#{output}", "You puff", 'You take', 'What were')
+        exhale_smoke if (inhale_counter == 0)
         pause 15
         inhale_counter += 1
         inhale_counter = 0 if inhale_counter > 2
@@ -117,3 +148,4 @@ class Smoker
 end
 
 Smoker.new
+

--- a/smoke.lic
+++ b/smoke.lic
@@ -63,7 +63,6 @@ class Smoker
 
   def get_cig?
     Unless DRCI.get_item?(@cigar, @cigar_container)
-    when 'What were'
       DRC.message 'Out of cigars, exiting.'
       return false
     end

--- a/smoke.lic
+++ b/smoke.lic
@@ -62,7 +62,7 @@ class Smoker
   end
 
   def get_cig?
-    case DRC.bput("get #{@cigar} in my #{@cigar_container}", 'You get', 'What were', 'You need')
+    Unless DRCI.get_item?(@cigar, @cigar_container)
     when 'What were'
       DRC.message 'Out of cigars, exiting.'
       return false

--- a/smoke.lic
+++ b/smoke.lic
@@ -22,7 +22,7 @@ class Smoker
   def initialize
     arg_definitions = [
       [
-        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun.' },
+        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun. (Only thing required if using YAML settings.)' },
       ],
       [
         { name: 'image', regex: /\w+/i, variable: true, description: 'Smoke image to learn, can be an ARRAY, will random one.' },
@@ -33,12 +33,12 @@ class Smoker
     ]
 
     args = parse_args(arg_definitions)
-    
+
     if args.image
       @image = args.image
       @cigar = args.cigar
       @cigar_container = args.container
-      @lighter = args.lighter       
+      @lighter = args.lighter
     else
       smoke_settings = get_settings.smoke
 
@@ -63,9 +63,9 @@ class Smoker
   end
 
   def get_cig?
-    case bput("get #{@cigar} in my #{@cigar_container}", 'You get', 'What were', 'You need')
+    case DRC.bput("get #{@cigar} in my #{@cigar_container}", 'You get', 'What were', 'You need')
     when 'What were'
-      message 'Out of cigars, exiting.'
+      DRC.message 'Out of cigars, exiting.'
       return false
     end
 
@@ -76,7 +76,7 @@ class Smoker
     pause 3
     output = 'exhale'
     output = "exhale line #{@image}" if @image
-    bput("#{output}", 'You blow', 'You breathe out', 'You cast', 'You need to have inhaled', 'You exhale')
+    DRC.bput("#{output}", 'You blow', 'You breathe out', 'You cast', 'You need to have inhaled', 'You exhale')
   end
 
   def light_cig?
@@ -84,28 +84,28 @@ class Smoker
     output = "get #{@lighter_info['type']} in my #{@lighter_info['container']}" unless @lighter_info.empty?
     output = "prep c b t" if @lighter_info['type'].eql?'cantrip'
     
-    case bput("#{output}", 'You get', 'What were', 'You are already', 'You are now prepared', 'You have no idea')
+    case DRC.bput("#{output}", 'You get', 'What were', 'You are already', 'You are now prepared', 'You have no idea')
     when 'You have no idea'
-      message "You don't know the cantrip you are trying to you! EXITING!"
+      DRC.message "You don't know the cantrip you are trying to you! EXITING!"
       exit
     when 'You are now prepared'
-      case bput("gesture my #{@cigar}", 'You touch')
+      case DRC.bput("gesture my #{@cigar}", 'You touch')
       when 'You touch'
         Flags.reset('new-cig')
         return true
       when 'What were'
-        message 'Cigar missing! Exiting!'
+        DRC.message 'Cigar missing! Exiting!'
         exit
       end
     when 'What were'
-      message 'No lighter found! Exiting.'
+      DRC.message 'No lighter found! Exiting.'
       return false
     end
 
     if @lighter_info['type'].include?('flint')
-      bput("drop my #{@cigar}", 'You drop')
-      bput("guard #{@cigar}", 'You are a bit', 'You move into position')
-      bput("wield my #{@lighter_info['blade']}", 'You get', 'What were', 'You are already', 'You draw')
+      DRC.bput("drop my #{@cigar}", 'You drop')
+      DRC.bput("guard #{@cigar}", 'You are a bit', 'You move into position')
+      DRC.bput("wield my #{@lighter_info['blade']}", 'You get', 'What were', 'You are already', 'You draw')
     end
 
     if @lighter
@@ -114,11 +114,11 @@ class Smoker
     else
       fput("light #{@cigar} with my #{@lighter_info['type']}")
       waitrt?
-      bput("sheath my #{@lighter_info['blade']}", 'You put')
-      bput("get #{@cigar}", 'You pick up')
+      DRC.bput("sheath my #{@lighter_info['blade']}", 'You put')
+      DRC.bput("get #{@cigar}", 'You pick up')
     end
 
-    bput("put my #{@lighter_info['type']} in my #{@lighter_info['container']}", 'You put')
+    DRC.bput("put my #{@lighter_info['type']} in my #{@lighter_info['container']}", 'You put')
 
     Flags.reset('new-cig')
     true
@@ -130,13 +130,13 @@ class Smoker
       exit if Flags['new-cig']
 
       if @image
-        bput("inhale #{@cigar}", 'You take', 'What were', 'out of your lungs first')
+        DRC.bput("inhale my #{@cigar}", 'You take', 'What were', 'out of your lungs first')
         exhale_smoke
         waitrt?
       else
-        output = "smoke #{@cigar}"
-        output = "inhale #{@cigar}" if (inhale_counter == 0)
-        bput("#{output}", "You puff", 'You take', 'What were')
+        output = "smoke my #{@cigar}"
+        output = "inhale my #{@cigar}" if (inhale_counter == 0)
+        DRC.bput("#{output}", 'You puff', 'You take', 'What were')
         exhale_smoke if (inhale_counter == 0)
         pause 15
         inhale_counter += 1
@@ -148,4 +148,3 @@ class Smoker
 end
 
 Smoker.new
-

--- a/smoke.lic
+++ b/smoke.lic
@@ -76,7 +76,7 @@ class Smoker
     pause 3
     output = 'exhale'
     output = "exhale line #{@image}" if @image
-    DRC.bput("#{output}", 'You blow', 'You breathe out', 'You cast', 'You need to have inhaled', 'You exhale')
+    DRC.bput("#{output}", 'You (blow|breathe|exhale|loft|cast|need)')
   end
 
   def light_cig?

--- a/smoke.lic
+++ b/smoke.lic
@@ -102,7 +102,7 @@ class Smoker
     end
 
     if @lighter_info['type'].include?('flint')
-      DRC.bput("drop my #{@cigar}", 'You drop')
+      DRCI.lower_ground(@cigar)
       DRC.bput("guard #{@cigar}", 'You are a bit', 'You move into position')
       DRC.bput("wield my #{@lighter_info['blade']}", 'You get', 'What were', 'You are already', 'You draw')
     end

--- a/smoke.lic
+++ b/smoke.lic
@@ -13,7 +13,7 @@
         blade:
 =end
 
-custom_require.call(%w[common events])
+custom_require.call(%w[common common-items events])
 
 class Smoker
   include DRC


### PR DESCRIPTION
Made images a possible array to sample from. Added support for cantrips. Fixed some bugs.

Example YAML settings:
Using burning touch cantrip and a selection of smoke images from which to sample (choose 1 random).
```
smoke:
  cigar_container: pack
  smoke_image:
  - dragon
  - pixie
  - horse
  - bandit
  - stump
  - kitten
  - ship
  lighter:
    type: cantrip
```
Using flint and blade, and a couple possible smoke images.
```
smoke:
  cigar_container: pack
  smoke_image: 
  - pixie
  - ship
  lighter:
    type: flint
    container: pack
    blade: dagger
```
Using a lighter and a single smoke image.
```
smoke:
  cigar_container: pack
  smoke_image: pixie
  lighter:
    type: bee
    container: pack
    blade: 
```