### PR TITLE
[script][combat-trainer] support all magical training via combat_spell_training

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1595,8 +1595,7 @@ class SpellProcess
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| game_state.is_offense_allowed? || @training_spells[skill]['harmless'] }
-                     .select { |skill| ['Warding', 'Utility', 'Augmentation'].include?(skill)
-                                        || !@training_spells_combat_sorcery && skill == 'Sorcery' || !game_state.npcs.empty? }
+                     .select { |skill| ['Warding', 'Utility', 'Augmentation'].include?(skill) || !@training_spells_combat_sorcery && skill == 'Sorcery' || !game_state.npcs.empty? }
                      .select { |skill| DRSkill.getxp(skill) < @magic_exp_training_max_threshold }
                      .select { |skill| Time.now > (@training_spells[skill]['cyclic'] ? @training_cyclic_timer : @training_cast_timer) }
                      .select { |skill| @training_spells[skill]['night'] ? UserVars.sun['night'] : true }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1595,7 +1595,8 @@ class SpellProcess
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| game_state.is_offense_allowed? || @training_spells[skill]['harmless'] }
-                     .select { |skill| ['Warding', 'Utility', 'Augmentation'].include?(skill) || !@training_spells_combat_sorcery && skill == 'Sorcery' || !game_state.npcs.empty? }
+                     .select { |skill| ['Warding', 'Utility', 'Augmentation'].include?(skill)
+                                        || !@training_spells_combat_sorcery && skill == 'Sorcery' || !game_state.npcs.empty? }
                      .select { |skill| DRSkill.getxp(skill) < @magic_exp_training_max_threshold }
                      .select { |skill| Time.now > (@training_spells[skill]['cyclic'] ? @training_cyclic_timer : @training_cast_timer) }
                      .select { |skill| @training_spells[skill]['night'] ? UserVars.sun['night'] : true }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1146,6 +1146,9 @@ class SpellProcess
     @training_spell_mana_threshold = settings.training_spell_mana_threshold
     echo("  @training_spell_mana_threshold: #{@training_spell_mana_threshold}") if $debug_mode_ct
 
+    @training_spells_combat_sorcery = settings.training_spells_combat_sorcery
+    echo("  @training_spells_combat_sorcery: #{@training_spells_combat_sorcery}") if $debug_mode_ct
+
     @release_cyclic_on_low_mana = settings.release_cyclic_on_low_mana
     echo("  @release_cyclic_on_low_mana: #{@release_cyclic_on_low_mana}") if $debug_mode_ct
 
@@ -1592,10 +1595,12 @@ class SpellProcess
     needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
                      .select { |skill| @training_spells[skill] }
                      .select { |skill| game_state.is_offense_allowed? || @training_spells[skill]['harmless'] }
+                     .select { |skill| ['Warding', 'Utility', 'Augmentation'].include?(skill) || !@training_spells_combat_sorcery && skill == 'Sorcery' || !game_state.npcs.empty? }
                      .select { |skill| DRSkill.getxp(skill) < @magic_exp_training_max_threshold }
                      .select { |skill| Time.now > (@training_spells[skill]['cyclic'] ? @training_cyclic_timer : @training_cast_timer) }
                      .select { |skill| @training_spells[skill]['night'] ? UserVars.sun['night'] : true }
                      .select { |skill| @training_spells[skill]['day'] ? UserVars.sun['day'] : true }
+    DRC.message "all eligible training spells: #{needs_training}" if $debug_mode_ct
     needs_training = game_state.sort_by_rate_then_rank(needs_training).first
     return unless needs_training
     DRC.message "needs_training: #{needs_training}" if $debug_mode_ct
@@ -1617,6 +1622,7 @@ class SpellProcess
       game_state.casting_sorcery = true
     end
     prepare_spell(data, game_state)
+    Flags.reset('ct-spelllost')
   end
 
   def spell_is_sorcery?(spell_data)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -694,6 +694,7 @@ forage_item: rock
 # what item to braid in ;mech-lore
 braid_item:
 training_spells:
+training_spells_combat_sorcery: false
 cyclic_training_spells:
 cyclic_cycle_skills:
 train_with_spells: true


### PR DESCRIPTION
This is a change that allows all magical training with combat-trainer to happen via combat_spell_training, disregarding offensive_spells completely.

Why make this change?
I found that my magical training rates would be inconsistent. I would also have to tweak the combat_spell_timer to get things to be 'just right' - and they almost never were.

What are the results of the changes?
With these changes, all spells can live in combat_spell_training. offensive_spells can be left completely blank. When setup this wait, combat-trainer will do its best to just rotate through each skill, training the most appropriate selection each time.

What was actually changed?
I exclude TM, Debil, and combat-based Sorcery if there are no NPCs present when selecting the spell to train in check_training, otherwise it'll try to cast a spell without a target. Additionally, I had to add a reset to ct-spelllost in that method, otherwise if the target e.g. died before the spell could be cast, things would get screwy and it would try to prepare another spell, add more mana, and then usually backfire. There's a variable training_spells_combat_sorcery that defaults to false so that non-combat-based Sorcery spells will not check for NPCs.

There should be no backwards compatibility issues. For characters setup using offensive_spells, everything will continue to work the same as it used to. You would need to opt-in by adding the appropriate spells to combat_spell_training. Additionally, training_spells_combat_sorcery prevents any issues with people who are casting non-combat sorcery spells as part of their training routine today.