### PR TITLE
[data][base-crafting] Add trash room in shard

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -499,6 +499,7 @@ blacksmithing:
       - 17119
     stock-volume: 5
     stock-room: 4434
+    trash-room: 9611
     repair-room: 8013
     repair-npc: clerk
     idle-room: 4418


### PR DESCRIPTION
Conspicuously absent for this town. it's a crucible room, one west and through a door from the entrance.