### PR TITLE
[script][combat-trainer] Removed return if @tk_ammo from CT

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1306,7 +1306,7 @@ class SpellProcess
   def check_slivers(game_state)
     return unless DRStats.moon_mage?
     return if game_state.casting
-    return if @tk_ammo
+    #return if @tk_ammo
     return unless @tk_spell
     return if DRSpells.slivers
     return if UserVars.moons['visible'].empty?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1308,7 +1308,7 @@ class SpellProcess
     return unless @tk_spell
     return if game_state.casting
     return if DRSpells.slivers
-    if UserVars.moons['visible'].empty?
+    unless UserVars.moons['visible'].any?
       DRC.message "There are NO moons available and you have NO TK_AMMO set! You need to fix this!" if !@tk_ammo && $debug_mode_ct
       return
     end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1197,7 +1197,6 @@ class SpellProcess
     @perc_health_timer = Time.now
     @aura_timer = 0
     @avtalia_timer = Time.now - 290
-    @sliver_error = false
 
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
@@ -1307,17 +1306,12 @@ class SpellProcess
   def check_slivers(game_state)
     return unless DRStats.moon_mage?
     return if game_state.casting
-    return unless @tk_spell
     return if DRSpells.slivers
-    if UserVars.moons['visible'].empty? && !@sliver_error
-      if @tk_ammo
-        DRC.message "No moons visible, using #{@tk_ammo} for casting."
-      else
-        DRC.message "There are NO moons available and you have NO TK_AMMO set! You need to fix this!"
-      end
-      @sliver_error = true
+    if UserVars.moons['visible'].empty?
+      DRC.message "There are NO moons available and you have NO TK_AMMO set! You need to fix this!" if !@tk_ammo && $debug_mode_ct
       return
     end
+    
     # With low skill you may fail to create the slivers
     # when breaking your moonblade. If so, keep retrying.
     retry_count = 0
@@ -1806,6 +1800,7 @@ class SpellProcess
                    .select { |spell| spell['cyclic'] ? !DRSpells.active_spells[spell['name']] : true }
                    .select { |spell| spell['night'] ? UserVars.sun['night'] : true }
                    .select { |spell| spell['day'] ? UserVars.sun['day'] : true }
+                   .select { |spell| spell['slivers'] ? DRSpells.slivers || @tk_ammo : true  }
                    .select { |spell| spell['starlight_threshold'] ? enough_starlight?(game_state, spell) : true }
     echo "Ready Spells: #{ready_spells.to_yaml}" if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1305,6 +1305,7 @@ class SpellProcess
 
   def check_slivers(game_state)
     return unless DRStats.moon_mage?
+    return unless @tk_spell
     return if game_state.casting
     return if DRSpells.slivers
     if UserVars.moons['visible'].empty?
@@ -1800,7 +1801,7 @@ class SpellProcess
                    .select { |spell| spell['cyclic'] ? !DRSpells.active_spells[spell['name']] : true }
                    .select { |spell| spell['night'] ? UserVars.sun['night'] : true }
                    .select { |spell| spell['day'] ? UserVars.sun['day'] : true }
-                   .select { |spell| spell['slivers'] ? DRSpells.slivers || @tk_ammo : true  }
+                   .select { |spell| spell['slivers'] ? DRSpells.slivers || @tk_ammo : true }
                    .select { |spell| spell['starlight_threshold'] ? enough_starlight?(game_state, spell) : true }
     echo "Ready Spells: #{ready_spells.to_yaml}" if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1797,7 +1797,6 @@ class SpellProcess
                    .select { |spell| spell['cyclic'] ? !DRSpells.active_spells[spell['name']] : true }
                    .select { |spell| spell['night'] ? UserVars.sun['night'] : true }
                    .select { |spell| spell['day'] ? UserVars.sun['day'] : true }
-                   .select { |spell| spell['slivers'] ? DRSpells.slivers : true }
                    .select { |spell| spell['starlight_threshold'] ? enough_starlight?(game_state, spell) : true }
     echo "Ready Spells: #{ready_spells.to_yaml}" if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1801,7 +1801,7 @@ class SpellProcess
                    .select { |spell| spell['cyclic'] ? !DRSpells.active_spells[spell['name']] : true }
                    .select { |spell| spell['night'] ? UserVars.sun['night'] : true }
                    .select { |spell| spell['day'] ? UserVars.sun['day'] : true }
-                   .select { |spell| spell['slivers'] ? DRSpells.slivers || @tk_ammo : true }
+                   .select { |spell| spell['slivers'] ? (DRSpells.slivers || @tk_ammo) : true }
                    .select { |spell| spell['starlight_threshold'] ? enough_starlight?(game_state, spell) : true }
     echo "Ready Spells: #{ready_spells.to_yaml}" if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1197,6 +1197,7 @@ class SpellProcess
     @perc_health_timer = Time.now
     @aura_timer = 0
     @avtalia_timer = Time.now - 290
+    @sliver_error = false
 
     @symbiosis_learning_threshold = settings.symbiosis_learning_threshold
     echo(" @symbiosis_learning_threshold: #{@symbiosis_learning_threshold}") if $debug_mode_ct
@@ -1308,7 +1309,15 @@ class SpellProcess
     return if game_state.casting
     return unless @tk_spell
     return if DRSpells.slivers
-    return if UserVars.moons['visible'].empty?
+    if UserVars.moons['visible'].empty? && !@sliver_error
+      if @tk_ammo
+        DRC.message "No moons visible, using #{@tk_ammo} for casting."
+      else
+        DRC.message "There are NO moons available and you have NO TK_AMMO set! You need to fix this!"
+      end
+      @sliver_error = true
+      return
+    end
     # With low skill you may fail to create the slivers
     # when breaking your moonblade. If so, keep retrying.
     retry_count = 0

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1306,7 +1306,6 @@ class SpellProcess
   def check_slivers(game_state)
     return unless DRStats.moon_mage?
     return if game_state.casting
-    #return if @tk_ammo
     return unless @tk_spell
     return if DRSpells.slivers
     return if UserVars.moons['visible'].empty?

--- a/validate.lic
+++ b/validate.lic
@@ -272,7 +272,7 @@ class DRYamlValidator
     return unless settings.offensive_spells.select { |spell_info| spell_info['slivers'] }.any?
     return if settings.tk_ammo
                                            
-    warn("You are using slivers for Telekenetic spells, but have no backup tk_ammo. If there are no moons, you will not cast the spell!")
+    warn("You are using slivers for Telekenetic spells but have no backup tk_ammo! If there are no moons, you will not cast the spell!")
   end
 
   def assert_that_summoned_weapons_are_skills(settings)

--- a/validate.lic
+++ b/validate.lic
@@ -268,6 +268,13 @@ class DRYamlValidator
             .each_key { |skill| error("Skill name in cycle_armors is not valid: #{skill}") }
   end
 
+  def assert_that_slivers_includes_tk_ammo(settings)
+    return unless settings.offensive_spells.select { |spell_info| spell_info['slivers'] }.any?
+    return if settings.tk_ammo
+                                           
+    warn("You are using slivers for Telekenetic spells, but have no backup tk_ammo. If there are no moons, you will not cast the spell!")
+  end
+
   def assert_that_summoned_weapons_are_skills(settings)
     return unless settings.summoned_weapons
 


### PR DESCRIPTION
It doesn't seem to be warranted, and is used as a fail-safe for no moons. If no moons, these spells never cast. I don't see the point iN not using slivers as well as tk_ammo, the latter being a failsafe if no moons are up. CT will always stow tk_ammo on cleanup, and it uses slivers first when casting the spell, don't see a problem with it using both.