### PR TITLE
[script][spellmonitor] Track STC duration

### DIFF
--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -190,6 +190,12 @@ active_spells_hook = proc do |server_string|
       # Cyclic spell or Osrel Meraud cyclic spell
       spell = Regexp.last_match[:spell]
       duration = UNKNOWN_DURATION
+    when /Stellar Collector\s+\(\d+%,\s*(?<duration>\d+)\s*(?<unit>(?:roisae?n|anlaen))/
+      # Stellar Collector
+      spell = "Stellar Collector"
+      duration = Regexp.last_match[:duration].to_i
+      unit = Regexp.last_match[:unit]
+      duration = unit == 'anlaen' ? duration*30 : duration
     when /(?<spell>[^<>]+?)\s+\(.+\)/i
       # Spells with inexact duration verbiage, such as with
       # Barbarians without knowledge of Power Monger mastery

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -199,22 +199,15 @@ active_spells_hook = proc do |server_string|
       # Cyclic spell or Osrel Meraud cyclic spell
       spell = Regexp.last_match[:spell]
       duration = UNKNOWN_DURATION
-    when /(?<spell>Stellar Collector)\s+\((?<percentage>\d+)%,\s*(?<duration>\d+)\s*(?<unit>(?:roisae?n|anlaen))/
+    when /(?<spell>Stellar Collector)\s+\((?<percentage>\d+)%,\s*(?<duration>\d+)?\s*(?<unit>(?:roisae?n|anlaen|fading))/
       # Stellar collector special case
       # XML looks like:
       # Stellar Collector  (0%, 4 anlaen)
       spell = Regexp.last_match[:spell]
-      duration = Regexp.last_match[:duration].to_i
+      duration = duration.nil? ? 0 : Regexp.last_match[:duration].to_i
       DRSpells.stellar_percentage = Regexp.last_match[:percentage].to_i
       unit = Regexp.last_match[:unit]
       duration = unit == 'anlaen' ? duration*30 : duration
-    when /(?<spell>[^<>]+?)\s+\(fading\)/i, /(?<spell>[^<>]+?)\s+\(\d+%, fading\)/
-      # Spell fading away
-      # special case for Stellar Collector
-      # XML looks like:
-      # Stellar Collector  (0%, fading)
-      spell = Regexp.last_match[:spell]
-      duration = 0
     when /(?<spell>[^<>]+?)\s+\(.+\)/i
       # Spells with inexact duration verbiage, such as with
       # Barbarians without knowledge of Power Monger mastery

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -203,7 +203,7 @@ active_spells_hook = proc do |server_string|
       # Stellar collector special case
       # XML looks like:
       # Stellar Collector  (0%, 4 anlaen)
-      spell = "Stellar Collector"
+      spell = Regexp.last_match[:spell]
       duration = Regexp.last_match[:duration].to_i
       DRSpells.stellar_percentage = Regexp.last_match[:percentage].to_i
       unit = Regexp.last_match[:unit]

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -17,6 +17,7 @@ class DRSpells
   @@known_spells = {}
   @@known_feats = {}
   @@refresh_data = {}
+  @@stellar_percentage = 0
   @@slivers = false
   @@spellbook_format = nil # 'column-formatted' or 'non-column'
 
@@ -49,6 +50,14 @@ class DRSpells
 
   def self.slivers=(val)
     @@slivers = val
+  end
+  
+  def self.stellar_percentage
+    @@stellar_percentage
+  end
+  
+  def self.stellar_percentage=(val)
+    @@stellar_percentage = val
   end
 
   def self.grabbing_active_spells
@@ -190,12 +199,22 @@ active_spells_hook = proc do |server_string|
       # Cyclic spell or Osrel Meraud cyclic spell
       spell = Regexp.last_match[:spell]
       duration = UNKNOWN_DURATION
-    when /Stellar Collector\s+\(\d+%,\s*(?<duration>\d+)\s*(?<unit>(?:roisae?n|anlaen))/
-      # Stellar Collector
+    when /(?<spell>Stellar Collector)\s+\((?<percentage>\d+)%,\s*(?<duration>\d+)\s*(?<unit>(?:roisae?n|anlaen))/
+      # Stellar collector special case
+      # XML looks like:
+      # Stellar Collector  (0%, 4 anlaen)
       spell = "Stellar Collector"
       duration = Regexp.last_match[:duration].to_i
+      DRSpells.stellar_percentage = Regexp.last_match[:percentage].to_i
       unit = Regexp.last_match[:unit]
       duration = unit == 'anlaen' ? duration*30 : duration
+    when /(?<spell>[^<>]+?)\s+\(fading\)/i, /(?<spell>[^<>]+?)\s+\(\d+%, fading\)/
+      # Spell fading away
+      # special case for Stellar Collector
+      # XML looks like:
+      # Stellar Collector  (0%, fading)
+      spell = Regexp.last_match[:spell]
+      duration = 0
     when /(?<spell>[^<>]+?)\s+\(.+\)/i
       # Spells with inexact duration verbiage, such as with
       # Barbarians without knowledge of Power Monger mastery

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -204,7 +204,7 @@ active_spells_hook = proc do |server_string|
       # XML looks like:
       # Stellar Collector  (0%, 4 anlaen)
       spell = Regexp.last_match[:spell]
-      duration = duration.nil? ? 0 : Regexp.last_match[:duration].to_i
+      duration = Regexp.last_match[:duration].to_i
       DRSpells.stellar_percentage = Regexp.last_match[:percentage].to_i
       unit = Regexp.last_match[:unit]
       duration = unit == 'anlaen' ? duration*30 : duration

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -203,6 +203,7 @@ active_spells_hook = proc do |server_string|
       # Stellar collector special case
       # XML looks like:
       # Stellar Collector  (0%, 4 anlaen)
+      # Stellar Collector  (0%, fading)
       spell = Regexp.last_match[:spell]
       duration = Regexp.last_match[:duration].to_i
       DRSpells.stellar_percentage = Regexp.last_match[:percentage].to_i

--- a/spellmonitor.lic
+++ b/spellmonitor.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#spellmonitor
 =end
 
-$SPELLMONITOR_VERSION = '2.0.0'
+$SPELLMONITOR_VERSION = '2.0.1'
 
 custom_require.call(%w[drinfomon])
 


### PR DESCRIPTION
Stellar Collector can last a long time, but we didn't have any way of checking the remaining duration, since the unit of measurement could be anlaen, and the xml was different from normal spells:
```
Finesse  (9 roisaen)

Noumena  (8 roisaen)

Iridius Rod  (intact, fading)

Stellar Collector  (0%, 4 anlaen)
```
I added a regex specifically for this spell, since afaik, this is the only type of spell that operates like this.  Before this PR, checking your stellar collector with active_spells was either nil or 1000. After:
```
Stellar Collector  (100%, 3 anlaen)

>;e echo DRSpells.active_spells['Stellar Collector']
--- Lich: exec1 active.
[exec1: 90]
--- Lich: exec1 has exited.
```
Assuming here my math was correct, that an anlaen is 30 Roisaen. In truth, it's largely irrelevant, because by ~60 it reverts to Roisaen, at which point we just get the duration in Roisaen. Might need to make anlan an option, though like I said, I think it reverts to roisaen before then.

The purpose of this change was to allow folks to drop a collector and keep it up with buff-watcher (say recast: 20) which can be done anywhere. 