### PR TITLE
base-crafting - Updated repair clerks in Hib

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -968,7 +968,7 @@ tailoring:
     - 17133
     - 17140
     logbook: outfitting
-    repair-room: 8887 #temporarily using forging society clerk because outfitting society has no clerk currently.
+    repair-room: 17136
     repair-npc: clerk
     stock-room: 17134
     tool-room: 17136
@@ -1450,7 +1450,7 @@ remedies:
     - 17148
     - 17149
     logbook: alchemy
-    repair-room: 17153 #temporarily using engineering society clerk because alchemy society has no clerk currently.
+    repair-room: 17143
     repair-npc: clerk
     stock-room: 17143
     stock-number: 1


### PR DESCRIPTION
Changed room numbers for the 2 new repair clerks in Hib, the outfitting and alchemy societies.