### PR TITLE
enchant - Added messaging to stamp bput

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -225,7 +225,7 @@ class Enchant
 
   def stamp_item(noun)
     DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
-    DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+    DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged', /You lazily wave the stamp over the freshly enchanted/)
     DRCC.stow_crafting_item('stamp', @bag, @belt)
   end
 


### PR DESCRIPTION
When stamping an enchanted item (at least the one I'm making currently), it looks like this: `You lazily wave the stamp over the freshly enchanted totem.  The imbue spell's expiring magic latches onto the engraved image and permanently imprint it within the sigil lines.`

I added a match to the bput for the first part of that.