### PR TITLE
[scripts][workorders] Fix for find_recipes being weird

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -590,7 +590,7 @@ class WorkOrders
   end
 
   def forge_items(info, materials_info, item, quantity)
-    recipe = find_recipe(materials_info, item, quantity)
+    recipe = find_recipe(materials_info, item, quantity).first
     remaining_volume = 0
 
     info['trash-room'] = nil if @worn_trashcan && @worn_trashcan_verb


### PR DESCRIPTION
For some reason, `find_recipes` returns an array, the first element of which is the actual recipe...