### PR TITLE
[script][inventory-manager] Rewrite

### DIFF
--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -197,7 +197,7 @@ class InventoryManager
   def add_register_inv
     return unless DRCI.get_item?('register')
 
-    remove_previous_entries('register')
+    remove_previous_entries('Deed Register')
 
     DRC.bput("turn my register to contents", 'You flip your deed register', 'already at the table of contents')
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -8,7 +8,6 @@ class InventoryManager
   def initialize
     @active_character = Char.name.to_sym
     @item_db_path = "data/inventory.yaml"
-    @pg_prep_time = get_settings.pg_prep_time || 3
 
     arg_definitions = [
       [
@@ -235,35 +234,19 @@ class InventoryManager
 
     remove_previous_entries('(Shadow Servant)')
 
-    # Default behavior is a full prep, which can be modified with yaml setting pg_prep_time.
-    # This can be an integer representing prep time in seconds, nil for default, or anything else for snapcast
-    # DRCA.safe_release # This would be an appropriate place for setting a release block
-    DRCA.prepare?('pg', 5)
-    sleep @pg_prep_time
+    pg_pause = [300 / DRSkill.getrank("Utility") + 1, 5].min
 
-    case DRC.bput('cast servant', 'Within the belly', 'The center of your vision', 'backfires')
-    when 'The center of your vision'
-      DRC.message "Your servant is not present. Summon it and retry."
-    when 'backfires'
-      if @pg_prep_time < 5
-        DRC.message "Your prep time is too low, trying with 5 seconds."
-        @pg_prep_time = 5
-        add_servant_inv
-      else
-        DRC.message("Something is preventing your Piercing Gaze cast, exiting.")
-      end
-    when 'Within the belly'
-      while (line = get)
-        break if line =~ /Your servant/i
+    DRCA.cast_spell?({'abbrev'=>'pg', 'mana'=>5, 'prep_time'=>pg_pause, 'cast'=>'cast servant'}, get_settings)
+    while (line = get)
+      break if line =~ /Your servant/i
 
-        item = line.lstrip.concat(' (Shadow Servant)')
-        @item_data[@active_character] << item
-      end
-
-      DRC.message "Saving shadow servant data for #{@active_character}!"
-      UserVars.servant_last_updated = Time.now
-      File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
+      item = line.lstrip.concat(' (Shadow Servant)')
+      @item_data[@active_character] << item
     end
+
+    DRC.message "Saving shadow servant data for #{@active_character}!"
+    UserVars.servant_last_updated = Time.now
+    File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
   end
 
   def add_container_inventory(proper_name, interact_name, preposition = nil)

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -236,7 +236,7 @@ class InventoryManager
 
     pg_pause = [300 / DRSkill.getrank("Utility") + 1, 5].min
 
-    DRCA.cast_spell?({'abbrev'=>'pg', 'mana'=>5, 'prep_time'=>pg_pause, 'cast'=>'cast servant'}, get_settings)
+    DRCA.cast_spell?({ 'abbrev' => 'pg', 'mana' => 5, 'prep_time' => pg_pause, 'cast' => 'cast servant' }, get_settings)
     while (line = get)
       break if line =~ /Your servant/i
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -226,11 +226,16 @@ class InventoryManager
     return DRC.message "You do not know the spell Piercing Gaze. Do you even moonie?" unless DRSpells.known_spells['Piercing Gaze']
 
     remove_previous_entries('(Shadow Servant)')
-
-    pg_pause = [300 / DRSkill.getrank("Utility") + 1, 5].min
-
-    DRCA.prepare?('pg', 5)
-    sleep pg_pause
+    pg_prep = get_settings.waggle_sets['inventorypg']
+    
+    if pg_prep
+      DRCA.prepare?(pg_prep['abbrev'], pg_prep['mana'])
+      sleep pg_prep['prep_time'] || 15
+    else
+      pg_pause = [300 / DRSkill.getrank("Utility") + 1, 5].min
+      DRCA.prepare?('pg', 5)
+      sleep pg_pause
+    end
 
     case DRC.bput('cast servant', 'Within the belly', 'The center of your vision', 'backfires')
     when 'The center of your vision'

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -89,7 +89,7 @@ class InventoryManager
 
     @item_data = OpenStruct.new(YAML.load_file(@item_db_path)).to_h
   end
-
+  
   def remove_previous_entries(location_tag)
     if @item_data[@active_character]
       @item_data[@active_character].reject! { |line| line.include? location_tag }
@@ -110,7 +110,6 @@ class InventoryManager
       return nil
     when *container_is_closed_patterns
       return nil unless DRCI.open_container?(container)
-
       get_contents_of(container, preposition)
     else
       # Get string of just the comma separated item list
@@ -125,7 +124,7 @@ class InventoryManager
       sub_contents = contents.pop.split(/ and (?:a|an|some) /)
 
       # Tack those last two items back onto our item list array
-      contents << sub_contents
+      contents = contents.concat(sub_contents)
     end
   end
 
@@ -179,7 +178,7 @@ class InventoryManager
 
     DRC.bput('inv list', 'You have:')
     while (line = get)
-      break if line =~ /Roundtime/i
+      break if line =~ /\[Use INVENTORY HELP/i
 
       item = line.lstrip
       if item[0].eql? '-'
@@ -209,7 +208,7 @@ class InventoryManager
       while (line = get)
         break if line =~ /Currently stored/i
 
-        item = line.lstrip.concat(' (register)')
+        item = line.lstrip.concat(' (Deed Register)')
         @item_data[@active_character] << item
       end
     end
@@ -226,14 +225,15 @@ class InventoryManager
       exit
     end
 
-    remove_previous_entries('servant')
 
-    # Default behavior is a 3 second prep, which can be modified with yaml setting pg_prep_time.
+    remove_previous_entries('Shadow Servant')
+
+    # Default behavior is a full prep, which can be modified with yaml setting pg_prep_time.
     # This can be an integer representing prep time in seconds, nil for default, or anything else for snapcast
     # DRCA.safe_release # This would be an appropriate place for setting a release block
     DRCA.prepare?('pg', 5)
     sleep @pg_prep_time
-
+    
     case DRC.bput('cast servant', 'Within the belly', 'The center of your vision', 'backfires')
     when 'The center of your vision'
       DRC.message "Your servant is not present. Summon it and retry."
@@ -249,7 +249,7 @@ class InventoryManager
       while (line = get)
         break if line =~ /Your servant/i
 
-        item = line.lstrip.concat(' (servant)')
+        item = line.lstrip.concat(' (Shadow Servant)')
         @item_data[@active_character] << item
       end
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -113,11 +113,11 @@ class InventoryManager
       return nil
     when *container_is_closed_patterns
       return nil unless DRCI.open_container?(container)
-      
+
       get_contents_of(container, preposition)
     else
       # Get string of just the comma separated item list
-      contents = contents.match(/You rummage (around on|through) .* and see (?:a|an|some) (?<items>.*)\./)[:items]
+      contents = contents.match(/You rummage (around on|through) .* and see (?<items>.*)\./)[:items]
 
       # Split at a, an, or some, but only when it follows a comma
       # The last two items in the rummage list are never comma delimited, handle shortly
@@ -128,7 +128,7 @@ class InventoryManager
       sub_contents = contents.pop.split(/ and (?:a|an|some) /)
 
       # Tack those last two items back onto our item list array
-      contents = contents.concat(sub_contents)
+      contents << sub_contents
     end
   end
 
@@ -229,7 +229,6 @@ class InventoryManager
       exit
     end
 
-
     remove_previous_entries('Shadow Servant')
 
     # Default behavior is a full prep, which can be modified with yaml setting pg_prep_time.
@@ -237,7 +236,7 @@ class InventoryManager
     # DRCA.safe_release # This would be an appropriate place for setting a release block
     DRCA.prepare?('pg', 5)
     sleep @pg_prep_time
-    
+
     case DRC.bput('cast servant', 'Within the belly', 'The center of your vision', 'backfires')
     when 'The center of your vision'
       DRC.message "Your servant is not present. Summon it and retry."

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -12,7 +12,8 @@ class InventoryManager
     arg_definitions = [
       [
         { name: 'count', regex: /(check|count)/i, description: "Counts inventory items. Doesn't check inside closed containers." },
-        { name: 'desc', regex: /\w+/i, optional: true, description: "Optional specific count by description. Use quotes for multiple word strings, i.e., \"purple pouch\"." }
+        { name: 'desc', regex: /\w+/i, optional: true, description: "Optional specific count by description. Use quotes for multiple word strings, i.e., \"purple pouch\"." },
+        { name: 'player', regex: /\w+/, optional: true, description: 'Optional character name from which to source inventory information' }
       ],
       [
         { name: 'save', regex: /save/i, description: "Save new or update current character's items to the database." },
@@ -65,7 +66,7 @@ class InventoryManager
     elsif args.save
       add_current_inv
     elsif args.count
-      get_inv_count(args.desc)
+      get_inv_count(args.desc, args.player)
     elsif args.remove
       remove_character_data(args.name)
     elsif args.player
@@ -147,15 +148,10 @@ class InventoryManager
         closed += 1 if line.match?(/(closed)/)
       end
       DRC.message "You have #{count} items, #{closed} of which are (closed) containers."
+    elsif player
+      search_person_for_item(desc, player)
     else
-      # Counting items matching the description, i.e., inv count pouch
-      DRC.bput("inv search #{desc}", 'You rummage')
-      while (line = get)
-        break if line =~ /INVENTORY HELP/i
-
-        count += 1
-      end
-      DRC.message "You have #{count} items matching \"#{desc}\"."
+      search_for_item(desc)
     end
   end
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -227,7 +227,7 @@ class InventoryManager
 
     remove_previous_entries('(Shadow Servant)')
     pg_prep = get_settings.waggle_sets['inventorypg']
-    
+
     if pg_prep
       DRCA.prepare?(pg_prep['abbrev'], pg_prep['mana'])
       sleep pg_prep['prep_time'] || 15

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -2,12 +2,13 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#inventory-manager
 =end
 
-custom_require.call(%w[common])
+custom_require.call(%w[common common-arcana common-items])
 
 class InventoryManager
   def initialize
     @active_character = Char.name.to_sym
     @item_db_path = "data/inventory.yaml"
+    @pg_prep_time = get_settings.pg_prep_time
 
     arg_definitions = [
       [
@@ -15,7 +16,6 @@ class InventoryManager
         { name: 'desc', regex: /\w+/i, optional: true, description: "Optional specific count by description. Use quotes for multiple word strings, i.e., \"purple pouch\"." }
       ],
       [
-
         { name: 'save', regex: /save/i, description: "Save new or update current character's items to the database." },
         { name: 'vault_book', regex: /vault_book/i, optional: true, description: "Retrieves, reads, and save from vault book." },
         { name: 'vault_regular', regex: /vault_regular/i, optional: true, description: "Rummages your vault to save items NOTE: must be standing by your open vault." },
@@ -45,15 +45,17 @@ class InventoryManager
     if args.vault_book
       add_vault_book_inv
     elsif args.vault_regular
-      add_vault_regular_inv
+      add_container_inventory('Personal Vault', 'vault')
     elsif args.family_vault
-      add_family_vault
+      add_container_inventory('Family Vault', 'vault')
     elsif args.register
       add_register_inv
     elsif args.eddy
-      add_eddy_inv
+      add_container_inventory('Eddy Portal', 'watery portal', 'my ')
     elsif args.storage_box
-      add_storage_box_inv
+      add_container_inventory('Caravan Box', 'storage box')
+    elsif args.servant
+      add_servant_inv
     elsif args.save
       add_current_inv
     elsif args.count
@@ -85,6 +87,44 @@ class InventoryManager
 
     @item_data = OpenStruct.new(YAML.load_file(@item_db_path)).to_h
   end
+  
+  def remove_previous_entries(location_tag)
+    if @item_data[@active_character]
+      @item_data[@active_character].reject! { |line| line.include? location_tag }
+    else
+      @item_data[@active_character] = []
+    end
+  end
+
+  def get_contents_of(container, preposition = nil)
+    rummage_success_patterns = DRCI.class_variable_get(:@@rummage_success_patterns) << /^You rummage around on .* and see (.*)\./
+    rummage_failure_patterns = DRCI.class_variable_get(:@@rummage_failure_patterns)
+    container_is_closed_patterns = DRCI.class_variable_get(:@@container_is_closed_patterns)
+
+    # so this is a special problem as a result of how common-items handles rummaging.
+    contents = DRC.bput("rummage #{preposition}#{container}", container_is_closed_patterns, rummage_success_patterns, rummage_failure_patterns)
+    case contents
+    when *rummage_failure_patterns
+      return nil
+    when *container_is_closed_patterns
+      return nil unless DRCI.open_container?(container)
+      get_contents_of(container, preposition)
+    else
+      # Get string of just the comma separated item list
+      contents = contents.match(/You rummage (around on|through) .* and see (?:a|an|some) (?<items>.*)\./)[:items]
+
+      # Split at a, an, or some, but only when it follows a comma
+      # The last two items in the rummage list are never comma delimited, handle shortly
+      contents = contents.split(/, (?:a|an|some) /)
+
+      # Grab the last array element which is the final two items that are never comma
+      # delimited in game output, split them into their item descriptions
+      sub_contents = contents.pop.split(/ and (?:a|an|some) /)
+
+      # Tack those last two items back onto our item list array
+      contents = contents.concat(sub_contents)
+    end
+  end
 
   def get_inv_count(desc)
     count, closed = 0, 0
@@ -111,23 +151,15 @@ class InventoryManager
   end
 
   def add_vault_book_inv
-    if @item_data[@active_character]
-      @item_data[@active_character] = @item_data[@active_character].select { |line| !line.include? 'vault' }
-    else
-      @item_data[@active_character] = []
-    end
+    return unless DRCI.get_item?('vault book')
 
-    case DRC.bput('get my vault book', 'You get', 'What were')
-    when 'What were'
-      DRC.message "Unable to find your vault book, exiting!"
-      exit
-    end
+    remove_previous_entries('Personal Vault')
 
     DRC.bput('read my vault book', 'Vault Inventory:')
     while (line = get)
       break if line =~ /The last note/i
 
-      item = line.lstrip.concat(' (vault)')
+      item = line.lstrip.concat(' (Personal Vault)')
       @item_data[@active_character] << item
     end
 
@@ -138,11 +170,9 @@ class InventoryManager
   end
 
   def add_current_inv
-    if @item_data[@active_character]
-      @item_data[@active_character] = @item_data[@active_character].select { |line| (line.include?('vault') || line.include?('eddy')) }
-    else
-      @item_data[@active_character] = []
-    end
+    remove_previous_entries('worn')
+    remove_previous_entries('in container')
+    remove_previous_entries('Eddy Portal')
 
     DRC.bput('inv list', 'You have:')
     while (line = get)
@@ -163,17 +193,9 @@ class InventoryManager
   end
 
   def add_register_inv
-    if @item_data[@active_character]
-      @item_data[@active_character] = @item_data[@active_character].select { |line| !line.include? 'register' }
-    else
-      @item_data[@active_character] = []
-    end
+    return unless DRCI.get_item?('register')
 
-    case DRC.bput("get my register", 'You get', 'What were', 'You are already holding that')
-    when 'What were'
-      DRC.message "Unable to find your register, exiting!"
-      exit
-    end
+    remove_previous_entries('register')
 
     DRC.bput("turn my register to contents", 'You flip your deed register', 'already at the table of contents')
 
@@ -189,52 +211,54 @@ class InventoryManager
       end
     end
 
-    DRC.bput('stow my register', 'You put')
+    DRCI.stow_item?('register')
 
     DRC.message "Saving register data for #{@active_character}!"
     File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
   end
 
-  def add_eddy_inv
-    if @item_data[@active_character]
-      @item_data[@active_character] = @item_data[@active_character].select { |line| !line.include? 'eddy' }
-    else
-      @item_data[@active_character] = []
+  def add_servant_inv
+    unless DRStats.moon_mage?
+      DRC.message "You're not a Moon Mage! Try again."
+      exit
     end
 
-    using_sorter = false
-    if Script.running?('sorter')
-      stop_script('sorter')
-      using_sorter = true
+    remove_previous_entries('servant')
+
+    # Default behavior is a full prep, which can be modified with yaml setting pg_prep_time.
+    # This can be an integer representing prep time in seconds, nil for default, or anything else for snapcast
+    # DRCA.safe_release # This would be an appropriate place for setting a release block
+    DRCA.prepare?('pg', 5)
+    if @pg_prep_time.is_a? Integer
+      echo "Pausing #{@pg_prep_time} seconds"
+      sleep @pg_prep_time
+    elsif @pg_prep_time.nil?
+      waitcastrt?
     end
 
-    item_list = DRC.bput('look in my watery portal', /In the swirling eddy .*/i, 'What were')
-                   .slice!("In the swirling eddy you see")
-                   .split(",")
-    item_list.each_with_index do |item, itr|
-      if itr < item_list.length - 1
-        @item_data[@active_character] << item.lstrip.concat(' (eddy)')
-      else
-        item.split("and")
-            .each do |item2|
-          @item_data[@active_character] << item2.strip.concat(" (eddy)").tr('.', '')
-        end
+    case DRC.bput('cast servant', 'Within the belly', 'The center of your vision', 'backfires')
+    when 'The center of your vision'
+      DRC.message "Your servant is not present. Summon it and retry."
+    when 'backfires'
+      DRC.message "Your prep time is too low, set pg_prep_time a little higher or remove the setting for default long cast behavior"
+      @pg_prep_time = nil
+      add_servant_inv
+    when 'Within the belly'
+      while (line = get)
+        break if line =~ /Your servant/i
+
+        item = line.lstrip.concat(' (servant)')
+        @item_data[@active_character] << item
       end
-    end
 
-    DRC.message "Saving eddy data for #{@active_character}!"
-    File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
-    if using_sorter
-      start_script('sorter') unless Script.running?('sorter')
+      DRC.message "Saving shadow servant data for #{@active_character}!"
+      UserVars.servant_last_updated = Time.now
+      File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
     end
   end
 
-  def add_storage_box_inv
-    if @item_data[@active_character]
-      @item_data[@active_character] = @item_data[@active_character].select { |line| !line.include? 'caravan_box' }
-    else
-      @item_data[@active_character] = []
-    end
+  def add_container_inventory(proper_name, interact_name, preposition = nil)
+    remove_previous_entries(proper_name)
 
     using_sorter = false
     if Script.running?('sorter')
@@ -242,89 +266,13 @@ class InventoryManager
       using_sorter = true
     end
 
-    item_list = DRC.bput('rummage storage box', /through a storage box and see .*/i, 'What were')
-                   .slice!("You rummage through a storage box and see")
-                   .split(",")
-    item_list.each_with_index do |item, itr|
-      if itr < item_list.length - 1
-        @item_data[@active_character] << item.lstrip.concat(' (caravan_box)')
-      else
-        item.split("and")
-            .each do |item2|
-          @item_data[@active_character] << item2.strip.concat(" (caravan_box)").tr('.', '')
-        end
-      end
+    contents = get_contents_of(interact_name, preposition)
+
+    contents.each do |item|
+      @item_data[@active_character] << item.strip.concat(" (#{proper_name})").tr('.', '')
     end
 
-    DRC.message("Saving caravan box data for #{@active_character}!")
-    File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
-    if using_sorter
-      start_script('sorter') unless Script.running?('sorter')
-    end
-  end
-
-  def add_family_vault
-    if @item_data['Family']
-      @item_data['Family'] = @item_data['Family'].select { |line| !line.include? 'Family' }
-    else
-      @item_data['Family'] = []
-    end
-
-    using_sorter = false
-    if Script.running?('sorter')
-      stop_script('sorter')
-      using_sorter = true
-    end
-
-    item_list = DRC.bput('rummage vault', /through a vault and see .*/i, 'What were')
-                   .slice!("You rummage through a vault and see")
-                   .split(",")
-    item_list.each_with_index do |item, itr|
-      if itr < item_list.length - 1
-        @item_data['Family'] << item.lstrip.concat(' (Family)')
-      else
-        item.split("and")
-            .each do |item2|
-          @item_data['Family'] << item2.strip.concat(" (Family)").tr('.', '')
-        end
-      end
-    end
-
-    DRC.message("Saving family vault data!")
-    File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
-    if using_sorter
-      start_script('sorter') unless Script.running?('sorter')
-    end
-  end
-
-  def add_vault_regular_inv
-    if @item_data[@active_character]
-      @item_data[@active_character] = @item_data[@active_character].select { |line| !line.include? 'vault' }
-    else
-      @item_data[@active_character] = []
-    end
-
-    using_sorter = false
-    if Script.running?('sorter')
-      stop_script('sorter')
-      using_sorter = true
-    end
-
-    item_list = DRC.bput('rummage vault', /through a secure vault and see .*/i, 'What were')
-                   .slice!("You rummage through a secure vault and see")
-                   .split(",")
-    item_list.each_with_index do |item, itr|
-      if itr < item_list.length - 1
-        @item_data[@active_character] << item.lstrip.concat(' (vault)')
-      else
-        item.split("and")
-            .each do |item2|
-          @item_data[@active_character] << item2.strip.concat(" (vault)").tr('.', '')
-        end
-      end
-    end
-
-    DRC.message("Saving vault data for #{@active_character}!")
+    DRC.message "Saving #{proper_name} data for #{@active_character}!"
     File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
     if using_sorter
       start_script('sorter') unless Script.running?('sorter')

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -117,7 +117,7 @@ class InventoryManager
       get_contents_of(container, preposition)
     else
       # Get string of just the comma separated item list
-      contents = contents.match(/You rummage (around on|through) .* and see (?<items>.*)\./)[:items]
+      contents = contents.match(/You rummage (?:around on|through) .* and see (?<items>.*)\./)[:items]
 
       # Split at a, an, or some, but only when it follows a comma
       # The last two items in the rummage list are never comma delimited, handle shortly

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -22,6 +22,7 @@ class InventoryManager
         { name: 'storage_box', regex: /storage_box/i, optional: true, description: "Rummages caravan storage box for items." },
         { name: 'family_vault', regex: /family_vault/i, optional: true, description: "Rummages your family vault to save items NOTE: must be standing by your open vault." },
         { name: 'register', regex: /register/i, optional: true, description: "Reads contents of deed register." },
+        { name: 'servant', regex: /servant/i, optional: true, description: "Casts PG to read contents of your shadow servant." },
         { name: 'eddy', regex: /eddy/i, optional: true, description: "Save the contents of an eddy (HE 436 Gift)." }
       ],
       [

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -43,6 +43,10 @@ class InventoryManager
     args = parse_args(arg_definitions)
 
     setup
+    # Using this to clean up old data that might remain from before this version
+    ['(eddy)', '(register)', '(vault)', '(caravan_box)', '(Family)'].each do |entry_name|
+      remove_previous_entries(entry_name)
+    end
 
     if args.vault_book
       add_vault_book_inv
@@ -159,7 +163,7 @@ class InventoryManager
   def add_vault_book_inv
     return unless DRCI.get_item?('vault book')
 
-    remove_previous_entries('Personal Vault')
+    remove_previous_entries('(Personal Vault)')
 
     DRC.bput('read my vault book', 'Vault Inventory:')
     while (line = get)
@@ -176,9 +180,9 @@ class InventoryManager
   end
 
   def add_current_inv
-    remove_previous_entries('worn')
-    remove_previous_entries('in container')
-    remove_previous_entries('Eddy Portal')
+    remove_previous_entries('(worn)')
+    remove_previous_entries('(in container)')
+    remove_previous_entries('(Eddy Portal)')
 
     DRC.bput('inv list', 'You have:')
     while (line = get)
@@ -201,7 +205,7 @@ class InventoryManager
   def add_register_inv
     return unless DRCI.get_item?('register')
 
-    remove_previous_entries('Deed Register')
+    remove_previous_entries('(Deed Register)')
 
     DRC.bput("turn my register to contents", 'You flip your deed register', 'already at the table of contents')
 
@@ -229,7 +233,7 @@ class InventoryManager
       exit
     end
 
-    remove_previous_entries('Shadow Servant')
+    remove_previous_entries('(Shadow Servant)')
 
     # Default behavior is a full prep, which can be modified with yaml setting pg_prep_time.
     # This can be an integer representing prep time in seconds, nil for default, or anything else for snapcast
@@ -263,7 +267,7 @@ class InventoryManager
   end
 
   def add_container_inventory(proper_name, interact_name, preposition = nil)
-    remove_previous_entries(proper_name)
+    remove_previous_entries("(#{proper_name})")
 
     using_sorter = false
     if Script.running?('sorter')

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -144,7 +144,7 @@ class InventoryManager
         break if line =~ /INVENTORY HELP/i
 
         count += 1
-        closed += 1 if item.match?(/(closed)/)
+        closed += 1 if line.match?(/(closed)/)
       end
       DRC.message "You have #{count} items, #{closed} of which are (closed) containers."
     else

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -229,7 +229,7 @@ class InventoryManager
     pg_prep = get_settings.waggle_sets['inventorypg']
 
     if pg_prep
-      DRCA.prepare?(pg_prep['abbrev'], pg_prep['mana'])
+      DRCA.prepare?('pg', pg_prep['mana'])
       sleep pg_prep['prep_time'] || 15
     else
       pg_pause = [300 / DRSkill.getrank("Utility") + 1, 5].min

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -227,26 +227,32 @@ class InventoryManager
   end
 
   def add_servant_inv
-    unless DRSpells.known_spells['Piercing Gaze']
-      DRC.message "You do not know the spell Piercing Gaze. Do you even moonie?"
-      exit
-    end
+    return DRC.message "You do not know the spell Piercing Gaze. Do you even moonie?" unless DRSpells.known_spells['Piercing Gaze']
 
     remove_previous_entries('(Shadow Servant)')
 
     pg_pause = [300 / DRSkill.getrank("Utility") + 1, 5].min
 
-    DRCA.cast_spell?({ 'abbrev' => 'pg', 'mana' => 5, 'prep_time' => pg_pause, 'cast' => 'cast servant' }, get_settings)
-    while (line = get)
-      break if line =~ /Your servant/i
+    DRCA.prepare?('pg', 5)
+    sleep pg_pause
 
-      item = line.lstrip.concat(' (Shadow Servant)')
-      @item_data[@active_character] << item
+    case DRC.bput('cast servant', 'Within the belly', 'The center of your vision', 'backfires')
+    when 'The center of your vision'
+      DRC.message "Your servant is not present. Summon it and retry."
+    when 'backfires'
+      DRC.message "Something is preventing your Piercing Gaze cast, exiting."
+    when 'Within the belly'
+      while (line = get)
+        break if line =~ /Your servant/i
+
+        item = line.lstrip.concat(' (Shadow Servant)')
+        @item_data[@active_character] << item
+      end
+
+      DRC.message "Saving shadow servant data for #{@active_character}!"
+      UserVars.servant_last_updated = Time.now
+      File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
     end
-
-    DRC.message "Saving shadow servant data for #{@active_character}!"
-    UserVars.servant_last_updated = Time.now
-    File.open(@item_db_path, 'w') { |file| file.write(@item_data.to_yaml) }
   end
 
   def add_container_inventory(proper_name, interact_name, preposition = nil)

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -46,6 +46,7 @@ class InventoryManager
       add_vault_book_inv
     elsif args.vault_regular
       add_container_inventory('Personal Vault', 'vault')
+      add_container_inventory('Vault Shelf', 'shelf', 'on ')
     elsif args.family_vault
       add_container_inventory('Family Vault', 'vault')
     elsif args.register

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -136,7 +136,7 @@ class InventoryManager
     end
   end
 
-  def get_inv_count(desc)
+  def get_inv_count(desc, player)
     count, closed = 0, 0
     # Counting all items in inventory
     if desc.nil?

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -87,7 +87,7 @@ class InventoryManager
 
     @item_data = OpenStruct.new(YAML.load_file(@item_db_path)).to_h
   end
-  
+
   def remove_previous_entries(location_tag)
     if @item_data[@active_character]
       @item_data[@active_character].reject! { |line| line.include? location_tag }
@@ -108,6 +108,7 @@ class InventoryManager
       return nil
     when *container_is_closed_patterns
       return nil unless DRCI.open_container?(container)
+
       get_contents_of(container, preposition)
     else
       # Get string of just the comma separated item list
@@ -122,7 +123,7 @@ class InventoryManager
       sub_contents = contents.pop.split(/ and (?:a|an|some) /)
 
       # Tack those last two items back onto our item list array
-      contents = contents.concat(sub_contents)
+      contents << sub_contents
     end
   end
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -92,7 +92,7 @@ class InventoryManager
 
     @item_data = OpenStruct.new(YAML.load_file(@item_db_path)).to_h
   end
-  
+
   def remove_previous_entries(location_tag)
     if @item_data[@active_character]
       @item_data[@active_character].reject! { |line| line.include? location_tag }
@@ -113,6 +113,7 @@ class InventoryManager
       return nil
     when *container_is_closed_patterns
       return nil unless DRCI.open_container?(container)
+      
       get_contents_of(container, preposition)
     else
       # Get string of just the comma separated item list

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -27,7 +27,8 @@ class InventoryManager
       ],
       [
         { name: 'search', regex: /search/i, description: 'Start a search across all characters for specified item.' },
-        { name: 'item', regex: /\w+/i, optional: false, description: 'Item to find.' }
+        { name: 'item', regex: /\w+/i, optional: false, description: 'Item to find.' },
+        { name: 'player', regex: /\w+/, optional: true, description: 'Optional character name from which to source inventory information' }
       ],
       [
         { name: 'list', regex: /list/i, description: "Print out a list of names in the database." },
@@ -64,6 +65,8 @@ class InventoryManager
       get_inv_count(args.desc)
     elsif args.remove
       remove_character_data(args.name)
+    elsif args.player
+      search_person_for_item(args.item, args.player)
     elsif args.search
       search_for_item(args.item)
     elsif args.list
@@ -294,13 +297,23 @@ class InventoryManager
       return
     end
 
-    name_sym = name.capitalize.to_sym
-    if @item_data.has_key?(name_sym)
-      DRC.message "Inventory for #{name.capitalize}"
-      @item_data[name_sym].each { |item| DRC.message "   - #{item}" }
-    else
-      DRC.message "No data found for the character #{name.capitalize}!"
+    return DRC.message("No data found for #{name.capitalize}") unless @item_data[name.capitalize.to_sym]
+
+    DRC.message "Inventory for #{name.capitalize}"
+    @item_data[name.capitalize.to_sym].each { |item| DRC.message "   - #{item}" }
+  end
+
+  def search_person_for_item(item, player)
+    return DRC.message("No data found for #{player.capitalize}") unless @item_data[player.capitalize.to_sym]
+
+    total_found = 0
+    @item_data[player.capitalize.to_sym].each do |data|
+      if data =~ /#{item}/i
+        total_found += 1
+        DRC.message "Match: #{data}"
+      end
     end
+    DRC.message "Found #{total_found} matches on #{player.capitalize}"
   end
 
   def search_for_item(item)

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -226,10 +226,10 @@ class InventoryManager
     return DRC.message "You do not know the spell Piercing Gaze. Do you even moonie?" unless DRSpells.known_spells['Piercing Gaze']
 
     remove_previous_entries('(Shadow Servant)')
-    pg_prep = get_settings.waggle_sets['inventorypg']
+    pg_prep = get_settings.waggle_sets['inventorypg']['Piercing Gaze']
 
     if pg_prep
-      DRCA.prepare?('pg', pg_prep['mana'])
+      DRCA.prepare?(pg_prep['abbrev'], pg_prep['mana'])
       sleep pg_prep['prep_time'] || 15
     else
       pg_pause = [300 / DRSkill.getrank("Utility") + 1, 5].min

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -128,7 +128,7 @@ class InventoryManager
       sub_contents = contents.pop.split(/ and (?:a|an|some) /)
 
       # Tack those last two items back onto our item list array
-      contents << sub_contents
+      contents + sub_contents
     end
   end
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -8,7 +8,7 @@ class InventoryManager
   def initialize
     @active_character = Char.name.to_sym
     @item_db_path = "data/inventory.yaml"
-    @pg_prep_time = get_settings.pg_prep_time
+    @pg_prep_time = get_settings.pg_prep_time || 3
 
     arg_definitions = [
       [
@@ -221,31 +221,30 @@ class InventoryManager
   end
 
   def add_servant_inv
-    unless DRStats.moon_mage?
-      DRC.message "You're not a Moon Mage! Try again."
+    unless DRSpells.known_spells['Piercing Gaze']
+      DRC.message "You do not know the spell Piercing Gaze. Do you even moonie?"
       exit
     end
 
     remove_previous_entries('servant')
 
-    # Default behavior is a full prep, which can be modified with yaml setting pg_prep_time.
+    # Default behavior is a 3 second prep, which can be modified with yaml setting pg_prep_time.
     # This can be an integer representing prep time in seconds, nil for default, or anything else for snapcast
     # DRCA.safe_release # This would be an appropriate place for setting a release block
     DRCA.prepare?('pg', 5)
-    if @pg_prep_time.is_a? Integer
-      echo "Pausing #{@pg_prep_time} seconds"
-      sleep @pg_prep_time
-    elsif @pg_prep_time.nil?
-      waitcastrt?
-    end
+    sleep @pg_prep_time
 
     case DRC.bput('cast servant', 'Within the belly', 'The center of your vision', 'backfires')
     when 'The center of your vision'
       DRC.message "Your servant is not present. Summon it and retry."
     when 'backfires'
-      DRC.message "Your prep time is too low, set pg_prep_time a little higher or remove the setting for default long cast behavior"
-      @pg_prep_time = nil
-      add_servant_inv
+      if @pg_prep_time < 5
+        DRC.message "Your prep time is too low, trying with 5 seconds."
+        @pg_prep_time = 5
+        add_servant_inv
+      else
+        DRC.message("Something is preventing your Piercing Gaze cast, exiting.")
+      end
     when 'Within the belly'
       while (line = get)
         break if line =~ /Your servant/i


### PR DESCRIPTION
So, playing with inventory manager I noticed some redundant code, a few other small issues. Changes:
1. Use common-items for get/stow
2. collect container searching into one method
3. brought in rummage from common-items to allow rummaging vaults
4. collect removal of previous entries into one method
5. renamed a few entries using proper names eg 'vault' to 'Personal Vault', 'portal' to 'Eddy Portal' mostly for visual
6. since personal inventory catches portal, add a removal for portal entries prior to doing personal inventory

This includes the changes from #6554, so we'll leave it in draft until that's sorted.