### PR TITLE
[t2] fix bug on reload_settings

### DIFF
--- a/t2.lic
+++ b/t2.lic
@@ -10,9 +10,9 @@ custom_require.call(%w[common common-arcana equipmanager])
 class T2
   def initialize
     arg_definitions = [[]]
-    args = parse_args(arg_definitions, true)
+    @args = parse_args(arg_definitions, true)
 
-    @settings = get_settings(args.flex)
+    @settings = get_settings(@args.flex)
 
     @shutdown = false
     fput('awaken')
@@ -112,7 +112,7 @@ class T2
   end
 
   def reload_settings(debug = false)
-    temp_settings = get_settings
+    temp_settings = get_settings(@args.flex)
 
     if temp_settings.training_list.nil? ||
        temp_settings.training_list.class != Array ||


### PR DESCRIPTION
when reloading, it'd always load from the main <char>-setup.yaml, instead of respecting command line arguments passed to load <char>-<extra>.yaml.