### PR TITLE
[script][tendme] Catch new lodges and handle full hands

### DIFF
--- a/tendme.lic
+++ b/tendme.lic
@@ -41,7 +41,7 @@ class TendMe
       .map { |wound| wound.body_part }
       .uniq
       .each { |body_part| tended_wounds = DRCH.bind_wound(body_part) || tended_wounds }
-    DRC.bput('lift', /^You pick up/, /^There is nothing/) if lowered
+    DRCI.lift? if lowered
     DRC.safe_unpause_list(scripts_to_unpause)
     return tended_wounds
   end

--- a/tendme.lic
+++ b/tendme.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#tendme
 =end
 
-custom_require.call(%w[common common-healing events])
+custom_require.call(%w[common common-healing common-items events])
 
 class TendMe
   def initialize
@@ -23,6 +23,10 @@ class TendMe
       echo("Cannot pause, trying again in 30 seconds.")
       pause 30
     end
+    
+    if checkleft && checkright && DRCI.lower_item?(DRC.left_hand)          
+      lowered = true
+    end
 
     tended_wounds = false
     health_data = DRCH.check_health
@@ -36,12 +40,14 @@ class TendMe
       .map { |wound| wound.body_part }
       .uniq
       .each { |body_part| tended_wounds = DRCH.bind_wound(body_part) || tended_wounds }
+    DRC.bput('lift', /^You pick up/, /^There is nothing/) if lowered
     DRC.safe_unpause_list(scripts_to_unpause)
     return tended_wounds
   end
 
   # Monitor for wounds to begin bleeding again then tend them.
   def monitor_health(train)
+    Flags.add('tendme-new-lodge', /lodges .* in your .*!/)
     Flags.add('tendme-bind-lodged', /You feel a slight pain from the (?<item>.*) lodged in your (?<body_part>.*)\./)
     Flags.add('tendme-bind-wound', /The bandages (?:binding|compressing) your (?<body_part>.*) (?:become|come|soak)/)
     Flags.add('tendme-rewrap-wound', /You feel like now might be a good time to change the (?:bandages|bindings) on your (?<body_part>.*)\./)
@@ -64,9 +70,10 @@ class TendMe
         Flags.reset('tendme-bind-wound')
       end
       # Detected lodged ammo or parasites, tend them out.
-      if Flags['tendme-bind-lodged']
+      if Flags['tendme-bind-lodged'] || Flags['tendme-new-lodge']
         tend_wounds = true
         Flags.reset('tendme-bind-lodged')
+        Flags.reset('tendme-new-lodge')
       end
       if tend_wounds
         bind_open_wounds?
@@ -79,6 +86,7 @@ before_dying do
   Flags.delete('tendme-bind-wound')
   Flags.delete('tendme-rewrap-wound')
   Flags.delete('tendme-bind-lodged')
+  Flags.delete('tendme-new-lodge')
 end
 
 TendMe.new

--- a/tendme.lic
+++ b/tendme.lic
@@ -18,6 +18,7 @@ class TendMe
   end
 
   def bind_open_wounds?
+    lowered = false
     # Pause scripts to prevent interference
     until (scripts_to_unpause = DRC.safe_pause_list)
       echo("Cannot pause, trying again in 30 seconds.")

--- a/tendme.lic
+++ b/tendme.lic
@@ -24,8 +24,8 @@ class TendMe
       echo("Cannot pause, trying again in 30 seconds.")
       pause 30
     end
-    
-    if checkleft && checkright && DRCI.lower_item?(DRC.left_hand)          
+
+    if checkleft && checkright && DRCI.lower_item?(DRC.left_hand)
       lowered = true
     end
 


### PR DESCRIPTION
Noticed while using tendme monitor as a during, it waits until lodged items start tweaking before tending, and if your hands are full, it just skips the tend. This is no bueno.

This version uses lower if your hands are full, and catches a lodge when it happens, to forestall having to take more damage down the road.