### PR TITLE
carve.lic - @ missing in front of variable

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -210,7 +210,7 @@ class Carve
     DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
     if @stamp
       DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
-      DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+      DRC.bput("mark my #{@noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
       DRCC.stow_crafting_item('stamp', @bag, @belt)
     end
     waitrt?


### PR DESCRIPTION
Line 213 was missing the @ in front of `noun`