### PR TITLE
[script][heal-remedy] Trash remedy if it won't stow

### DIFF
--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -109,7 +109,7 @@ def remedy_apply_wounds(body_part)
       when /potion/, /tonic/, /elixir/, /draught/
         drink_remedy?(remedy)
       end
-      stow_remedy
+      stow_remedy(remedy)
       @wounds_applied = TRUE
     else
       DRC.message("*** No more #{remedy}! ***")
@@ -129,7 +129,7 @@ def remedy_apply_scars(body_part)
       when /potion/, /tonic/, /elixir/, /draught/
         drink_remedy?(remedy)
       end
-      stow_remedy
+      stow_remedy(remedy)
       @wounds_applied = TRUE
     else
       DRC.message("*** No more #{remedy}! ***")
@@ -140,7 +140,7 @@ def remedy_apply_scars(body_part)
 end
 
 def remedy_apply_general_scar(body_part)
-  DRC.message("In apply_gerneral_scar function for remedies and wounded area is #{body_part}") if $debug_mode_hr
+  DRC.message("In apply_general_scar function for remedies and wounded area is #{body_part}") if $debug_mode_hr
   rem_scars_general = $remedies['remedies']['scars'][body_part]
   DRC.message("rem_scars_general: #{rem_scars_general}") if $debug_mode_hr
   rem_scars_general.each do |remedy|
@@ -151,7 +151,7 @@ def remedy_apply_general_scar(body_part)
       when /potion/, /tonic/, /elixir/, /draught/
         drink_remedy?(remedy)
       end
-      stow_remedy
+      stow_remedy(remedy)
       @wounds_applied = TRUE
     else
       DRC.message("*** No more #{remedy}! ***")
@@ -168,12 +168,12 @@ def herb_apply_wounds(body_part)
     when /salve/, /sap/
       DRCI.get_item?(remedy, @remedy_container) unless $nohands_mode
       DRC.bput("rub my #{remedy}", 'You', 'Rub what?') unless $nohands_mode
-      stow_remedy unless $nohands_mode
+      stow_remedy(remedy) unless $nohands_mode
       @wounds_applied = TRUE
     when /ungent/, /poultices/, /ointment/
       DRCI.get_item?(remedy, @remedy_container) unless $nohands_mode
       DRC.bput("rub my #{remedy}", 'You', 'Rub what?')
-      stow_remedy unless $nohands_mode
+      stow_remedy(remedy) unless $nohands_mode
       @wounds_applied = TRUE
     when /potion/, /tonic/, /elixir/, /draught/
       drink_remedy?(remedy)
@@ -195,7 +195,7 @@ def herb_apply_scars(body_part)
       DRC.bput("rub my #{remedy}", 'You', 'Rub what?')
     when /tonic/, /draught/, /qun/
       drink_remedy?(remedy)
-    when /genich/, /flower/, /root/, /leaf/, /grass/, /potion/, /nuloe/, /elixir/, /jadice/, /potion/, /pollen/
+    when /genich/, /flower/, /root/, /leaf/, /grass/, /potion/, /nuloe/, /elixir/, /jadice/, /pollen/
       eat_remedy?(remedy)
     end
   end
@@ -235,7 +235,7 @@ end
 
 def inhale_remedy?(remedy)
   DRC.message("In inhale_remedy function and remedy is #{remedy}") if $debug_mode_hr
-  #return false if $nohands_mode #working around this
+  # return false if $nohands_mode #working around this
   inhaled = false
   if DRC.left_hand && DRC.right_hand
     temp_left_item = DRC.left_hand
@@ -243,7 +243,7 @@ def inhale_remedy?(remedy)
   end
   if DRCI.get_item?(remedy, @remedy_container)
     inhaled = DRC.bput("inhale my #{remedy}", /You inhale/, /You might/) =~ /You inhale/
-    stow_remedy
+    stow_remedy(remedy)
   end
   DRCI.get_item?(temp_left_item) if temp_left_item
   inhaled

--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -109,7 +109,7 @@ def remedy_apply_wounds(body_part)
       when /potion/, /tonic/, /elixir/, /draught/
         drink_remedy?(remedy)
       end
-      DRCI.put_away_item?(remedy, @remedy_container)
+      stow_remedy
       @wounds_applied = TRUE
     else
       DRC.message("*** No more #{remedy}! ***")
@@ -129,7 +129,7 @@ def remedy_apply_scars(body_part)
       when /potion/, /tonic/, /elixir/, /draught/
         drink_remedy?(remedy)
       end
-      DRCI.put_away_item?(remedy, @remedy_container)
+      stow_remedy
       @wounds_applied = TRUE
     else
       DRC.message("*** No more #{remedy}! ***")
@@ -140,7 +140,7 @@ def remedy_apply_scars(body_part)
 end
 
 def remedy_apply_general_scar(body_part)
-  DRC.message("In apply_general_scar function for remedies and wounded area is #{body_part}") if $debug_mode_hr
+  DRC.message("In apply_gerneral_scar function for remedies and wounded area is #{body_part}") if $debug_mode_hr
   rem_scars_general = $remedies['remedies']['scars'][body_part]
   DRC.message("rem_scars_general: #{rem_scars_general}") if $debug_mode_hr
   rem_scars_general.each do |remedy|
@@ -151,7 +151,7 @@ def remedy_apply_general_scar(body_part)
       when /potion/, /tonic/, /elixir/, /draught/
         drink_remedy?(remedy)
       end
-      DRCI.put_away_item?(remedy, @remedy_container)
+      stow_remedy
       @wounds_applied = TRUE
     else
       DRC.message("*** No more #{remedy}! ***")
@@ -168,12 +168,12 @@ def herb_apply_wounds(body_part)
     when /salve/, /sap/
       DRCI.get_item?(remedy, @remedy_container) unless $nohands_mode
       DRC.bput("rub my #{remedy}", 'You', 'Rub what?') unless $nohands_mode
-      DRCI.put_away_item?(remedy, @remedy_container) unless $nohands_mode
+      stow_remedy unless $nohands_mode
       @wounds_applied = TRUE
     when /ungent/, /poultices/, /ointment/
       DRCI.get_item?(remedy, @remedy_container) unless $nohands_mode
       DRC.bput("rub my #{remedy}", 'You', 'Rub what?')
-      DRCI.put_away_item?(remedy, @remedy_container) unless $nohands_mode
+      stow_remedy unless $nohands_mode
       @wounds_applied = TRUE
     when /potion/, /tonic/, /elixir/, /draught/
       drink_remedy?(remedy)
@@ -195,7 +195,7 @@ def herb_apply_scars(body_part)
       DRC.bput("rub my #{remedy}", 'You', 'Rub what?')
     when /tonic/, /draught/, /qun/
       drink_remedy?(remedy)
-    when /genich/, /flower/, /root/, /leaf/, /grass/, /potion/, /nuloe/, /elixir/, /jadice/, /pollen/
+    when /genich/, /flower/, /root/, /leaf/, /grass/, /potion/, /nuloe/, /elixir/, /jadice/, /potion/, /pollen/
       eat_remedy?(remedy)
     end
   end
@@ -235,7 +235,7 @@ end
 
 def inhale_remedy?(remedy)
   DRC.message("In inhale_remedy function and remedy is #{remedy}") if $debug_mode_hr
-  # return false if $nohands_mode #working around this
+  #return false if $nohands_mode #working around this
   inhaled = false
   if DRC.left_hand && DRC.right_hand
     temp_left_item = DRC.left_hand
@@ -243,10 +243,14 @@ def inhale_remedy?(remedy)
   end
   if DRCI.get_item?(remedy, @remedy_container)
     inhaled = DRC.bput("inhale my #{remedy}", /You inhale/, /You might/) =~ /You inhale/
-    DRCI.put_away_item?(remedy, @remedy_container)
+    stow_remedy
   end
   DRCI.get_item?(temp_left_item) if temp_left_item
   inhaled
+end
+
+def stow_remedy(remedy)
+  DRCI.dispose_trash(remedy, @settings.worn_trashcan, @settings.worn_trashcan_verb) unless DRCI.put_away_item?(remedy, @remedy_container)
 end
 
 wounds


### PR DESCRIPTION
Ran into this issue with CT (to be dealt with separately):
```
[heal-remedy]>get my georin salve 

You get some georin salve from inside your thigh bag.

[heal-remedy]>rub my georin salve

You rub a portion of some georin salve on yourself.


[heal-remedy]>stow my georin salve

The georin salve is too long to fit in the bag.

[heal-remedy]>eat my riolur leaf

What were you referring to?

[heal-remedy]>get my nilos salve 

You need a free hand to pick that up.

[heal-remedy]>rub my nilos salve

Rub what?

RUB (item|person|critter|self)
RUB (person|self) (bodypart)
Note: Some rub locations may not be available in certain cases.

[heal-remedy]>stow my nilos salve

Stow what?  Type 'STOW HELP' for details.

[heal-remedy]>get my muljin sap 

You need a free hand to pick that up.

[heal-remedy]>rub my muljin sap

Rub what?

RUB (item|person|critter|self)
RUB (person|self) (bodypart)
Note: Some rub locations may not be available in certain cases.

[heal-remedy]>stow my muljin sap

You feel somewhat less terrifying.
Stow what?  Type 'STOW HELP' for details.

[heal-remedy]>drink my qun pollen

Drink what?

[heal-remedy]>eat my hulij elixir

What were you referring to?

[heal-remedy]>eat my genich stem

What were you referring to?

[heal-remedy]>eat my ojhenik potion

What were you referring to?

[combat-trainer]>get my kertig.dagesse

You need a free hand to pick that up.
You struggle to maintain the quaking fury unleashed upon your enemies!
The quaking fury inside of you continues unabated.
The churning rage inside of you continues unabated.
You feel your inner fire cool as you finish practicing the Form of the Piranha.
The churning rage inside of you continues unabated.
***STATUS*** 8 minutes of hunting remaining or waiting on Tactics

[combat-trainer: *** No match was found after 15 seconds, dumping info]


[combat-trainer: checked against [/^You .*(?i-mx:\bkertig.*\bdagesse)/, /^You .*dagesse/i, /^The.* slides easily out/i, /^What were you referring/i, /But that is already/i, /You are already/i]]

[combat-trainer: for command get my kertig.dagesse]
```
got stuck with georin salve in my hand. Reason being, we stow without checking whether stow succeeded, and blithely continue as though it were stowed. 

This change would just trash whatever herb which, for whatever reason, won't return to the bag it was drawn from.

Other options include attempting to split it, which allowed me to put half back, or setting up a backup bag. In truth, I just need a larger herb bag, but I can't be the first one this has happened to, nor the last unless this is sorted.

Also, considering adding a hands check, which would either lower left if hands are full, or exit with a message about our hands. Leaning towards the former, similar to #6564 , open to suggestions.