### PR TITLE
Create repair.lic

### DIFF
--- a/repair.lic
+++ b/repair.lic
@@ -52,6 +52,11 @@ class Repair
       @toolset_list   << @settings.send(name + '_tools')
     end
 
+    if @town == 'Fang Cove' && fang_closed?
+      DRC.message("Fang Cove repair personnel are sleeping off their latest hangover, and aren't available for repairs at this hour. Try back later")
+      exit
+    end
+
     unless (repair_info = get_data('town')[@town]['metal_repair']) || args.self_repair
       DRC.message("No repair info found for #{@town}, exiting")
       reset_town
@@ -216,6 +221,11 @@ class Repair
 
     Flags.reset('proper-repair')
     UserVars.immune_list.store(gear_item, Time.now + 7000)
+  end
+
+  def fang_closed?    
+    tod = DRC.bput('time', /^It is currently .* and it is .*./)
+    ['evening', 'night', 'sunrise', 'dawn', 'early morning'].any? { |closed| tod.include?(closed) }
   end
 
   def pickup_repaired_items(repair_info)

--- a/repair.lic
+++ b/repair.lic
@@ -128,7 +128,7 @@ class Repair
 
   def repair_gear(gear, info, repair_own = false)
     verify_funds(gear, repair_own)
-    DRCT.walk_to(repair_info['id']) unless repair_own
+    DRCT.walk_to(info['id']) unless repair_own
 
     gear.each do |gear_item|
       unless smart_get_gear(gear_item)

--- a/repair.lic
+++ b/repair.lic
@@ -43,11 +43,11 @@ class Repair
     @repair_timer   = @settings.repair_timer
     @sort_head      = @settings.sort_auto_head
     @disciplines    = ['forging', 'tinkering', 'carving', 'shaping', 'outfitting', 'alchemy', 'enchanting', 'engineering']
-    @toolbelts_list = []
-    @toolset_list   = []
-    @craft_data     = get_data('crafting')['blacksmithing'][@town.capitalize]
+    @craft_data     = get_data('crafting')['blacksmithing'][@town]
     @equipmanager   = EquipmentManager.new
 
+    @toolbelts_list = []
+    @toolset_list   = []
     @disciplines.each do |name|
       @toolbelts_list << @settings.send(name + '_belt')
       @toolset_list   << @settings.send(name + '_tools')
@@ -177,7 +177,7 @@ class Repair
   end
 
   def self_repair(gear_item)
-    repeat = true
+    repeat = true # do we toggle this?
     while repeat
       ['wire brush', 'oil'].each do |tool|
         DRCI.get_item(tool, @bag)
@@ -208,8 +208,8 @@ class Repair
           break
         end
       end
-      set_immune(gear_item)
     end
+    set_immune(gear_item)
     smart_stow_gear(gear_item)
   end
 

--- a/repair.lic
+++ b/repair.lic
@@ -11,7 +11,6 @@
                                      # runs to shard, drops off your shield, bracer, pilum, and forging tools for pickup at a later time.
   (probably works)
 =end
-  
 
 custom_require.call(%w[common common-crafting common-items common-money common-travel equipmanager])
 
@@ -85,7 +84,7 @@ class Repair
     gear = []
     @equipmanager.items.each do |item|
       next if item.skip_repair
-      # add each item to our list of gear to repair
+
       gear << [item.adjective, item.name].join(' ').strip
     end
     gear
@@ -125,7 +124,7 @@ class Repair
         DRC.beep
         next
       end
-      self ? self_repair(gear_item) : shop_repair(gear_item)
+      self ? self_repair(gear_item) : shop_repair(gear_item, info)
     end
   end
 
@@ -144,8 +143,8 @@ class Repair
       DRCI.get_item(tool, @bag)
       command = tool == 'wire brush' ? "rub my #{gear_item} with my wire brush" : "pour my oil on my #{gear_item}"
       case DRC.bput(command, 'Roundtime', 'not damaged enough',
-                      'You cannot do that while engaged!',
-                      'cannot figure out how', 'Pour what')
+                    'You cannot do that while engaged!',
+                    'cannot figure out how', 'Pour what')
       when 'Roundtime'
         DRCI.put_away_item?(tool, @bag)
         next

--- a/repair.lic
+++ b/repair.lic
@@ -250,7 +250,7 @@ class Repair
       DRCC.get_crafting_item(gear_item, @bag, @bag_items, toolbelt)
     elsif (tool_name = @toolset_list.find { |tools| tools.any? { |name| name =~ /\b#{gear_item}\b/i } }.select { |tool| tool =~ /\b#{gear_item}\b/i }.first)
       DRCI.get_item?(tool_name, @bag)
-    elsif (item_info = @equipmanager.item_by_desc(gear_item))
+    elsif (item_info = @equipmanager.items.find { |gear| gear.short_regex =~ gear_item || gear.name =~ /\b#{gear_item}\b/i })
       @equipmanager.get_item?(item_info)
     else
       DRCI.get_item?(gear_item)

--- a/repair.lic
+++ b/repair.lic
@@ -125,7 +125,7 @@ class Repair
   end
 
   def should_repair?
-    return true if @repair_timer.nil? || @force
+    return true if @repair_timer.nil? || @force_repair
 
     @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
   end

--- a/repair.lic
+++ b/repair.lic
@@ -53,7 +53,7 @@ class Repair
     end
 
     if @town == 'Fang Cove' && fang_closed?
-      DRC.message('Fang Cove repair personnel are sleeping off their latest hangover, and aren't available for repairs at this hour. Try back between mid-morning and sunset')
+      DRC.message('Fang Cove repair personnel are sleeping off their latest hangover, and are not available for repairs at this hour. Try back between mid-morning and sunset')
       exit
     end
 

--- a/repair.lic
+++ b/repair.lic
@@ -1,3 +1,17 @@
+=begin
+  All in one repair script. Can be run with the listed options or any combination of tools, gear, etc.
+    Only restricted in pickup, the pickup routine will go to the last repair location, or the location you designate,
+    if you have any tickets from that repair person.
+  EXAMPLES:
+  ;repair forging                    # runs to your hometown repair shop, drops off and picks up your forging tools
+  ;repair forging self_repair        # Uses wire brush and oil to repair your own forging tools as defined in yaml
+  ;repair forging crossing           # runs to crossing repair shop, drops off and picks up your forging tools
+  ;repair forging drop_off shard     # runs to shard, drops your forging tools at the repair shop for pickup at a later time.
+  ;repair shield "iron bracer" pilum forging shard drop_off
+                                     # runs to shard, drops off your shield, bracer, pilum, and forging tools for pickup at a later time.
+  (probably works)
+=end
+
 custom_require.call(%w[common common-crafting common-items common-money common-travel equipmanager])
 
 class Repair
@@ -69,7 +83,7 @@ class Repair
     gear = []
     @equipmanager.items.each do |item|
       next if item.skip_repair
-      # add each item to our list of gear to repair
+
       gear << [item.adjective, item.name].join(' ').strip
     end
     gear
@@ -140,8 +154,8 @@ class Repair
       DRCI.get_item(tool, @bag)
       command = tool == 'wire brush' ? "rub my #{gear_item} with my wire brush" : "pour my oil on my #{gear_item}"
       case DRC.bput(command, 'Roundtime', 'not damaged enough',
-                      'You cannot do that while engaged!',
-                      'cannot figure out how', 'Pour what')
+                    'You cannot do that while engaged!',
+                    'cannot figure out how', 'Pour what')
       when 'Roundtime'
         DRCI.put_away_item?(tool, @bag)
         next

--- a/repair.lic
+++ b/repair.lic
@@ -113,7 +113,7 @@ class Repair
   def should_repair?
     return true if @repair_timer.nil?
 
-    @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
+    @repair_timer >= (Time.now - UserVars.repair_timer_snap).to_i
   end
 
   def verify_funds(gear, repair_own)

--- a/repair.lic
+++ b/repair.lic
@@ -53,7 +53,7 @@ class Repair
     end
 
     if @town == 'Fang Cove' && fang_closed?
-      DRC.message("Fang Cove repair personnel are sleeping off their latest hangover, and aren't available for repairs at this hour. Try back between mid-morning and sunset")
+      DRC.message('Fang Cove repair personnel are sleeping off their latest hangover, and aren't available for repairs at this hour. Try back between mid-morning and sunset')
       exit
     end
 

--- a/repair.lic
+++ b/repair.lic
@@ -53,7 +53,7 @@ class Repair
     end
 
     if @town == 'Fang Cove' && fang_closed?
-      DRC.message("Fang Cove repair personnel are sleeping off their latest hangover, and aren't available for repairs at this hour. Try back later")
+      DRC.message("Fang Cove repair personnel are sleeping off their latest hangover, and aren't available for repairs at this hour. Try back between mid-morning and sunset")
       exit
     end
 

--- a/repair.lic
+++ b/repair.lic
@@ -101,7 +101,7 @@ class Repair
     (gear_list + selections).flatten
   end
 
-  def reset_town(leave: false)
+  def reset_town(leave = false)
     if UserVars.last_repair_town
       DRC.message("Last repair town was: #{UserVars.last_repair_town}. Resetting.") if leave
       UserVars.last_repair_town = nil
@@ -117,7 +117,7 @@ class Repair
     @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
   end
 
-  def repair_gear(gear, info, repair_own: false)
+  def repair_gear(gear, info, repair_own = false)
     gear.each do |gear_item|
       unless smart_get_gear(gear_item)
         DRC.message("Missing #{gear_item}, skipping")

--- a/repair.lic
+++ b/repair.lic
@@ -19,11 +19,12 @@ class Repair
     UserVars.repair_timer_snap ||= Time.now
     arg_definitions = [
       [
-        { name: 'drop', regex: /drop_off/i, optional: true, description: 'Drop off gear only, do not pick up' },
-        { name: 'pickup', regex: /pick_up/i, optional: true, description: 'Pick up items only' },
+        { name: 'drop_off', regex: /drop_off/i, optional: true, description: 'Drop off gear only, do not pick up' },
+        { name: 'pick_up', regex: /pick_up/i, optional: true, description: 'Pick up items only' },
         { name: 'self_repair', regex: /self_repair/i, optional: true, description: 'Use wire brush and oil to repair items yourself. WARNING: LOTS OF RT, even with techs.' },
         { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town to repair in' },
         { name: 'reset_town', regex: /reset_town/i, optional: true, description: 'Clears last town variable' },
+        { name: 'force_repair', regex: /force_repair/i, optional: true, description: 'Ignore repair_timer' },
         { name: 'script_summary', regex: /script_summary/i, optional: true, description: 'Repair script with option to split drop and pickup routines' }
       ]
     ]
@@ -36,7 +37,8 @@ class Repair
     @bag            = @settings.crafting_container
     @bag_items      = @settings.crafting_items_in_container
     @cash_on_hand   = @settings.repair_withdrawal_amount
-    @town           = args.town.capitalize || UserVars.last_repair_town || @settings.hometown
+    @town           = args.town.capitalize || UserVars.last_repair_town || @settings.repair_town || @settings.hometown
+    @force_repair   = args.force_repair
     @repair_timer   = @settings.repair_timer
     @sort_head      = @settings.sort_auto_head
     @disciplines    = ['forging', 'tinkering', 'carving', 'shaping', 'outfitting', 'alchemy', 'enchanting', 'engineering']
@@ -58,11 +60,11 @@ class Repair
 
     @equipmanager.empty_hands
 
-    if args.drop # dropping off based on remaining args
+    if args.drop_off # dropping off based on remaining args
       gear_list = args.flex.empty? ? prep_full_repair : build_list(args.flex)
       UserVars.last_repair_town = @town
       repair_gear(gear_list, repair_info)
-    elsif args.pickup # by default picks up everything at the last place you dropped off, or your hometown.
+    elsif args.pick_up # by default picks up everything at the last place you dropped off, or your hometown.
       pickup_repaired_items(repair_info)
       fput('sort auto head') if @sort_head
     elsif args.flex.empty? # This represents no flex args, so full repair routine.
@@ -80,7 +82,10 @@ class Repair
   end
 
   def prep_full_repair
-    exit unless should_repair?
+    unless should_repair?
+      DRC.message("Last repair was #{(Time.now - UserVars.repair_timer_snap).to_i / 60} minutes ago, which is less than your repair_timer settings\nCurrently set to repair only once every #{@repair_timer / 60} minutes. Run with arg force_repair to repair anyways.")
+      exit
+    end
 
     UserVars.repair_timer_snap = Time.now
     gear = []
@@ -114,7 +119,7 @@ class Repair
   end
 
   def should_repair?
-    return true if @repair_timer.nil?
+    return true if @repair_timer.nil? || @force
 
     @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
   end

--- a/repair.lic
+++ b/repair.lic
@@ -12,7 +12,7 @@
   (probably works)
 =end
 
-custom_require.call(%w[common common-crafting common-items common-money common-travel equipmanager])
+custom_require.call(%w[common common-crafting common-items common-money common-travel equipmanager events])
 
 class Repair
   def initialize

--- a/repair.lic
+++ b/repair.lic
@@ -1,0 +1,217 @@
+=begin
+  All in one repair script. Can be run with the listed options or any combination of tools, gear, etc.
+    Only restricted in pickup, the pickup routine will go to the last repair location, or the location you designate,
+    if you have any tickets from that repair person.
+  EXAMPLES:
+  ;repair forging                    # runs to your hometown repair shop, drops off and picks up your forging tools
+  ;repair forging self_repair        # Uses wire brush and oil to repair your own forging tools as defined in yaml
+  ;repair forging crossing           # runs to crossing repair shop, drops off and picks up your forging tools
+  ;repair forging drop_off shard     # runs to shard, drops your forging tools at the repair shop for pickup at a later time.
+  ;repair shield "iron bracer" pilum forging shard drop_off
+                                     # runs to shard, drops off your shield, bracer, pilum, and forging tools for pickup at a later time.
+  (probably works)
+=end
+  
+
+custom_require.call(%w[common common-crafting common-items common-money common-travel equipmanager])
+
+class Repair
+  def initialize
+    UserVars.repair_timer_snap ||= Time.now
+    arg_definitions = [
+      [
+        { name: 'drop', regex: /drop_off/i, optional: true, description: 'Drop off gear only, do not pick up' },
+        { name: 'pickup', regex: /pick_up/i, optional: true, description: 'Pick up items only' },
+        { name: 'self_repair', regex: /self_repair/i, optional: true, description: 'Use wire brush and oil to repair items yourself. WARNING: LOTS OF RT, even with techs.' },
+        { name: 'town', regex: $HOMETOWN_REGEX, optional: true, description: 'Town to repair in' },
+        { name: 'reset_town', regex: /reset_town/i, optional: true, description: 'Clears last town variable' },
+        { name: 'script_summary', regex: /script_summary/i, optional: true, description: 'Repair script with option to split drop and pickup routines' }
+      ]
+    ]
+
+    args = parse_args(arg_definitions, true)
+    reset_town(true) if args.reset_town
+
+    @settings       = get_settings
+    @bag            = @settings.crafting_container
+    @bag_items      = @settings.crafting_items_in_container
+    cash_on_hand    = @settings.repair_withdrawal_amount
+    town            = UserVars.last_repair_town || args.town.capitalize || @settings.hometown
+    @repair_timer   = @settings.repair_timer
+    @sort_head      = @settings.sort_auto_head
+    @disciplines    = ['forging', 'tinkering', 'carving', 'shaping', 'outfitting', 'alchemy', 'enchanting']
+    @toolbelts_list = []
+    @toolset_list   = []
+    @craft_data     = get_data('crafting')['blacksmithing'][town.capitalize]
+    @equipmanager   = EquipmentManager.new
+
+    @disciplines.each do |name|
+      @toolbelts_list << @settings.send(name + '_belt')
+      @toolset_list   << @settings.send(name + '_tools')
+    end
+
+    unless (repair_info = get_data('town')[town]['metal_repair']) || args.self_repair
+      DRC.message("No repair info found for #{town}, exiting")
+      reset_town
+      exit
+    end
+
+    @equipmanager.empty_hands
+
+    if args.drop # dropping off based on remaining args
+      gear_list = args.flex.empty? ? prep_full_repair : build_list(args.flex)
+      DRCM.ensure_copper_on_hand(cash_on_hand, @settings, town)
+      repair_gear(gear_list, repair_info)
+      UserVars.last_repair_town = town
+    elsif args.pickup # by default picks up everything at the last place you dropped off, or your hometown.
+      pickup_repaired_items(repair_info)
+      fput('sort auto head') if @sort_head
+    elsif args.flex.empty? # This represents no arguments whatsoever, so full repair routine.
+      gear_list = prep_full_repair
+      DRCM.ensure_copper_on_hand(cash_on_hand, @settings, town)
+      repair_gear(gear_list, repair_info, args.self_repair)
+      pickup_repaired_items(repair_info) unless args.self_repair
+      fput('sort auto head') if @sort_head
+    else # Here we have flex args, and no drop/pickup specified, so doing a full routine on the specific items from our flex args.
+      gear_list = build_list(args.flex)
+      DRCM.ensure_copper_on_hand(cash_on_hand, @settings, town)
+      repair_gear(gear_list, repair_info, args.self_repair)
+      pickup_repaired_items(repair_info) unless args.self_repair
+    end
+  end
+
+  def prep_full_repair
+    exit unless should_repair?
+    gear = []
+    @equipmanager.items.each do |item|
+      next if item.skip_repair
+      # add each item to our list of gear to repair
+      gear << [item.adjective, item.name].join(' ').strip
+    end
+    gear
+  end
+
+  def build_list(selections)
+    gear_list = []
+    @disciplines.each do |toolset|
+      if selections.include?(toolset)
+        gear_list << @settings.send(toolset + '_tools')
+        selections -= [toolset]
+      end
+    end
+    (gear_list + selections).flatten
+  end
+
+  def reset_town(leave: false)
+    if UserVars.last_repair_town
+      DRC.message("Last repair town was: #{UserVars.last_repair_town}. Resetting.") if leave
+      UserVars.last_repair_town = nil
+    else
+      DRC.message("Last repair town not defined.")
+    end
+    exit if leave
+  end
+
+  def should_repair?
+    return true if @repair_timer.nil?
+
+    @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
+  end
+
+  def repair_gear(gear, info, self: false)
+    gear.each do |gear_item|
+      unless smart_get_gear(gear_item)
+        DRC.message("Missing #{gear_item}, skipping")
+        DRC.beep
+        next
+      end
+      self ? self_repair(gear_item) : shop_repair(gear_item)
+    end
+  end
+
+  def shop_repair(gear_item, repair_info)
+    DRCT.walk_to(repair_info['id'])
+    DRC.release_invisibility
+    if DRCI.give_item?(repair_info['name'], gear_item)
+      DRCI.stow_item?("#{repair_info['name']} ticket")
+    else
+      smart_stow_gear(gear_item)
+    end
+  end
+
+  def self_repair(gear_item)
+    ['wire brush', 'oil'].each do |tool|
+      DRCI.get_item(tool, @bag)
+      command = tool == 'wire brush' ? "rub my #{gear_item} with my wire brush" : "pour my oil on my #{gear_item}"
+      case DRC.bput(command, 'Roundtime', 'not damaged enough',
+                      'You cannot do that while engaged!',
+                      'cannot figure out how', 'Pour what')
+      when 'Roundtime'
+        DRCI.put_away_item?(tool, @bag)
+        next
+      when 'not damaged enough'
+        DRCI.put_away_item?(tool, @bag)
+        break
+      when 'Pour what'
+        DRCC.check_consumables('oil', info['finisher-room'], info['finisher-number'], @bag, @bag_items, nil)
+        DRCI.get_item(tool, @bag)
+        DRC.bput("pour my oil on my #{gear_item}", 'Roundtime')
+        DRCI.put_away_item?(tool, @bag)
+        next
+      when 'You cannot do that while engaged!'
+        DRC.message("Cannot repair in combat")
+        smart_stow_gear(gear_item)
+        DRCI.put_away_item?(tool, @bag)
+        exit
+      when 'cannot figure out how'
+        DRC.message("Something has gone wrong, moving to next item")
+        DRCI.put_away_item?(tool, @bag)
+        break
+      end
+      smart_stow_gear(gear_item)
+    end
+  end
+
+  def pickup_repaired_items(repair_info)
+    reset_town # resets our last repair location for next run
+    exit unless DRCI.exists?("#{repair_info['name']} ticket") # no ticket, nothing to collect
+
+    DRCT.walk_to(repair_info['id'])
+    DRC.release_invisibility
+    while DRCI.get_item?("#{repair_info['name']} ticket")
+      pause 30 until DRC.bput('look at my ticket', /should be ready by now/, /^Looking at the/) == 'should be ready by now'
+      DRC.bput("give #{repair_info['name']}", /^You hand/, /takes your ticket/)
+      pause 0.01 until (item = [DRC.right_hand, DRC.left_hand].compact.first) # waits for repaired item to hit your hand
+      smart_stow_gear(item)
+    end
+    UserVars.repair_timer_snap = Time.now
+  end
+
+  def smart_get_gear(gear_item)
+    return false unless gear_item
+
+    if (toolbelt = @toolbelts_list.select { |belt| belt["items"].find { |name| name =~ /\b#{gear_item}\b/i } }.first)
+      DRCC.get_crafting_item(gear_item, @bag, @bag_items, toolbelt)
+    elsif (tool_name = @toolset_list.find { |tools| tools.any? { |name| name =~ /\b#{gear_item}\b/i } }.select { |tool| tool =~ /\b#{gear_item}\b/i }.first)
+      DRCI.get_item?(tool_name, @bag)
+    elsif (item_info = @equipmanager.items.find { |gear| gear.short_regex =~ gear_item || gear.name =~ /\b#{gear_item}\b/i })
+      @equipmanager.get_item?(item_info)
+    else
+      DRCI.get_item?(gear_item)
+    end
+  end
+
+  def smart_stow_gear(gear_item)
+    return true unless gear_item
+
+    if (toolbelt = @toolbelts_list.select { |belt| belt["items"].find { |name| name =~ /\b#{gear_item}\b/i } }.first)
+      DRCC.stow_crafting_item(gear_item, @bag, toolbelt)
+    elsif @toolset_list.any? { |tools| tools.find { |name| name =~ /\b#{gear_item}\b/i } }
+      DRCI.put_away_item?(gear_item, @bag)
+    else
+      @equipmanager.return_held_gear
+    end
+  end
+end
+
+Repair.new

--- a/repair.lic
+++ b/repair.lic
@@ -141,16 +141,23 @@ class Repair
       return
     end
 
+    missing = []
     verify_funds(gear, repair_own)
     DRCT.walk_to(info['id']) unless repair_own
 
     gear.each do |gear_item|
       unless smart_get_gear(gear_item)
         DRC.message("Missing #{gear_item}, skipping")
-        DRC.beep
+        missing << gear_item
         next
       end
       repair_own ? self_repair(gear_item) : shop_repair(gear_item, info)
+    end
+    unless missing.empty?
+      DRC.beep
+      missing.each do |item|
+        DRC.message("Missing listed gear item: #{item}")
+      end
     end
   end
 

--- a/repair.lic
+++ b/repair.lic
@@ -1,17 +1,3 @@
-=begin
-  All in one repair script. Can be run with the listed options or any combination of tools, gear, etc.
-    Only restricted in pickup, the pickup routine will go to the last repair location, or the location you designate,
-    if you have any tickets from that repair person.
-  EXAMPLES:
-  ;repair forging                    # runs to your hometown repair shop, drops off and picks up your forging tools
-  ;repair forging self_repair        # Uses wire brush and oil to repair your own forging tools as defined in yaml
-  ;repair forging crossing           # runs to crossing repair shop, drops off and picks up your forging tools
-  ;repair forging drop_off shard     # runs to shard, drops your forging tools at the repair shop for pickup at a later time.
-  ;repair shield "iron bracer" pilum forging shard drop_off
-                                     # runs to shard, drops off your shield, bracer, pilum, and forging tools for pickup at a later time.
-  (probably works)
-=end
-
 custom_require.call(%w[common common-crafting common-items common-money common-travel equipmanager])
 
 class Repair
@@ -34,14 +20,14 @@ class Repair
     @settings       = get_settings
     @bag            = @settings.crafting_container
     @bag_items      = @settings.crafting_items_in_container
-    cash_on_hand    = @settings.repair_withdrawal_amount
-    town            = UserVars.last_repair_town || args.town.capitalize || @settings.hometown
+    @cash_on_hand   = @settings.repair_withdrawal_amount
+    @town           = args.town.capitalize || UserVars.last_repair_town || @settings.hometown
     @repair_timer   = @settings.repair_timer
     @sort_head      = @settings.sort_auto_head
     @disciplines    = ['forging', 'tinkering', 'carving', 'shaping', 'outfitting', 'alchemy', 'enchanting']
     @toolbelts_list = []
     @toolset_list   = []
-    @craft_data     = get_data('crafting')['blacksmithing'][town.capitalize]
+    @craft_data     = get_data('crafting')['blacksmithing'][@town.capitalize]
     @equipmanager   = EquipmentManager.new
 
     @disciplines.each do |name|
@@ -49,8 +35,8 @@ class Repair
       @toolset_list   << @settings.send(name + '_tools')
     end
 
-    unless (repair_info = get_data('town')[town]['metal_repair']) || args.self_repair
-      DRC.message("No repair info found for #{town}, exiting")
+    unless (repair_info = get_data('town')[@town]['metal_repair']) || args.self_repair
+      DRC.message("No repair info found for #{@town}, exiting")
       reset_town
       exit
     end
@@ -59,21 +45,20 @@ class Repair
 
     if args.drop # dropping off based on remaining args
       gear_list = args.flex.empty? ? prep_full_repair : build_list(args.flex)
-      DRCM.ensure_copper_on_hand(cash_on_hand, @settings, town)
+      UserVars.last_repair_town = @town
       repair_gear(gear_list, repair_info)
-      UserVars.last_repair_town = town
     elsif args.pickup # by default picks up everything at the last place you dropped off, or your hometown.
       pickup_repaired_items(repair_info)
       fput('sort auto head') if @sort_head
-    elsif args.flex.empty? # This represents no arguments whatsoever, so full repair routine.
+    elsif args.flex.empty? # This represents no flex args, so full repair routine.
       gear_list = prep_full_repair
-      DRCM.ensure_copper_on_hand(cash_on_hand, @settings, town)
+      UserVars.last_repair_town = @town unless args.self_repair
       repair_gear(gear_list, repair_info, args.self_repair)
       pickup_repaired_items(repair_info) unless args.self_repair
       fput('sort auto head') if @sort_head
     else # Here we have flex args, and no drop/pickup specified, so doing a full routine on the specific items from our flex args.
       gear_list = build_list(args.flex)
-      DRCM.ensure_copper_on_hand(cash_on_hand, @settings, town)
+      UserVars.last_repair_town = @town unless args.self_repair
       repair_gear(gear_list, repair_info, args.self_repair)
       pickup_repaired_items(repair_info) unless args.self_repair
     end
@@ -84,7 +69,7 @@ class Repair
     gear = []
     @equipmanager.items.each do |item|
       next if item.skip_repair
-
+      # add each item to our list of gear to repair
       gear << [item.adjective, item.name].join(' ').strip
     end
     gear
@@ -117,7 +102,20 @@ class Repair
     @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
   end
 
+  def verify_funds(gear, repair_own)
+    current = Room.current.id
+    DRCM.ensure_copper_on_hand(@cash_on_hand, @settings, @town)
+    if repair_own
+      DRCT.walk_to(current)
+      DRCC.check_consumables('oil', @craft_data['finisher-room'], @craft_data['finisher-number'], @bag, @bag_items, nil, gear.size)
+      DRCC.check_consumables('wire brush', @craft_data['finisher-room'], 10, @bag, @bag_items, nil, gear.size)
+    end
+  end
+
   def repair_gear(gear, info, repair_own = false)
+    verify_funds(gear, repair_own)
+    DRCT.walk_to(repair_info['id']) unless repair_own
+
     gear.each do |gear_item|
       unless smart_get_gear(gear_item)
         DRC.message("Missing #{gear_item}, skipping")
@@ -129,7 +127,6 @@ class Repair
   end
 
   def shop_repair(gear_item, repair_info)
-    DRCT.walk_to(repair_info['id'])
     DRC.release_invisibility
     if DRCI.give_item?(repair_info['name'], gear_item)
       DRCI.stow_item?("#{repair_info['name']} ticket")
@@ -143,8 +140,8 @@ class Repair
       DRCI.get_item(tool, @bag)
       command = tool == 'wire brush' ? "rub my #{gear_item} with my wire brush" : "pour my oil on my #{gear_item}"
       case DRC.bput(command, 'Roundtime', 'not damaged enough',
-                    'You cannot do that while engaged!',
-                    'cannot figure out how', 'Pour what')
+                      'You cannot do that while engaged!',
+                      'cannot figure out how', 'Pour what')
       when 'Roundtime'
         DRCI.put_away_item?(tool, @bag)
         next
@@ -167,8 +164,8 @@ class Repair
         DRCI.put_away_item?(tool, @bag)
         break
       end
-      smart_stow_gear(gear_item)
     end
+    smart_stow_gear(gear_item)
   end
 
   def pickup_repaired_items(repair_info)

--- a/repair.lic
+++ b/repair.lic
@@ -37,7 +37,7 @@ class Repair
     @bag            = @settings.crafting_container
     @bag_items      = @settings.crafting_items_in_container
     @cash_on_hand   = @settings.repair_withdrawal_amount
-    @town           = args.town.capitalize || UserVars.last_repair_town || @settings.repair_town || @settings.hometown
+    @town           = args.town.split.map(&:capitalize).join(' ') || UserVars.last_repair_town || @settings.repair_town || @settings.hometown
     @force_repair   = args.force_repair
     @repair_timer   = @settings.repair_timer
     @sort_head      = @settings.sort_auto_head

--- a/repair.lic
+++ b/repair.lic
@@ -30,6 +30,7 @@ class Repair
 
     args = parse_args(arg_definitions, true)
     reset_town(true) if args.reset_town
+    Flags.add('proper-repair', 'Your excellent training in the ways of tool repair')
 
     @settings       = get_settings
     @bag            = @settings.crafting_container
@@ -127,6 +128,12 @@ class Repair
   end
 
   def repair_gear(gear, info, repair_own = false)
+    gear.reject! { |item| is_immune?(item) }
+    if gear.empty?
+      DRC.message("All items queued for repair remain immune to damage, exiting")
+      return
+    end
+
     verify_funds(gear, repair_own)
     DRCT.walk_to(info['id']) unless repair_own
 
@@ -179,8 +186,22 @@ class Repair
         break
       end
     end
-    self_repair(gear_item) if repeat
+    if repeat
+      set_immune(gear_item)
+      self_repair(gear_item)
+    end
     smart_stow_gear(gear_item)
+  end
+
+  def is_immune?(gear_item)
+    UserVars.immune_list[gear_item] >= Time.now
+  end
+
+  def set_immune(gear_item)
+    return unless Flags['proper-repair']
+
+    Flags.reset('proper-repair')
+    UserVars.immune_list.store(gear_item, Time.now + 7000)
   end
 
   def pickup_repaired_items(repair_info)
@@ -223,6 +244,10 @@ class Repair
       @equipmanager.return_held_gear
     end
   end
+end
+
+before_dying do
+  Flags.delete('proper-repair')
 end
 
 Repair.new

--- a/repair.lic
+++ b/repair.lic
@@ -37,7 +37,8 @@ class Repair
     @bag            = @settings.crafting_container
     @bag_items      = @settings.crafting_items_in_container
     @cash_on_hand   = @settings.repair_withdrawal_amount
-    @town           = args.town.split.map(&:capitalize).join(' ') || UserVars.last_repair_town || @settings.repair_town || @settings.hometown
+    _town           = args.town || UserVars.last_repair_town || @settings.repair_town || @settings.hometown
+    @town           = _town.split.map(&:capitalize).join(' ')
     @force_repair   = args.force_repair
     @repair_timer   = @settings.repair_timer
     @sort_head      = @settings.sort_auto_head

--- a/repair.lic
+++ b/repair.lic
@@ -250,7 +250,7 @@ class Repair
       DRCC.get_crafting_item(gear_item, @bag, @bag_items, toolbelt)
     elsif (tool_name = @toolset_list.find { |tools| tools.any? { |name| name =~ /\b#{gear_item}\b/i } }.select { |tool| tool =~ /\b#{gear_item}\b/i }.first)
       DRCI.get_item?(tool_name, @bag)
-    elsif (item_info = @equipmanager.items.find { |gear| gear.short_regex =~ gear_item || gear.name =~ /\b#{gear_item}\b/i })
+    elsif (item_info = @equipmanager.item_by_desc(gear_item))
       @equipmanager.get_item?(item_info)
     else
       DRCI.get_item?(gear_item)

--- a/repair.lic
+++ b/repair.lic
@@ -38,7 +38,7 @@ class Repair
     @town           = args.town.capitalize || UserVars.last_repair_town || @settings.hometown
     @repair_timer   = @settings.repair_timer
     @sort_head      = @settings.sort_auto_head
-    @disciplines    = ['forging', 'tinkering', 'carving', 'shaping', 'outfitting', 'alchemy', 'enchanting']
+    @disciplines    = ['forging', 'tinkering', 'carving', 'shaping', 'outfitting', 'alchemy', 'enchanting', 'engineering']
     @toolbelts_list = []
     @toolset_list   = []
     @craft_data     = get_data('crafting')['blacksmithing'][@town.capitalize]

--- a/repair.lic
+++ b/repair.lic
@@ -223,7 +223,7 @@ class Repair
     UserVars.immune_list.store(gear_item, Time.now + 7000)
   end
 
-  def fang_closed?    
+  def fang_closed?
     tod = DRC.bput('time', /^It is currently .* and it is .*./)
     ['evening', 'night', 'sunrise', 'dawn', 'early morning'].any? { |closed| tod.include?(closed) }
   end

--- a/repair.lic
+++ b/repair.lic
@@ -37,8 +37,8 @@ class Repair
     @bag            = @settings.crafting_container
     @bag_items      = @settings.crafting_items_in_container
     @cash_on_hand   = @settings.repair_withdrawal_amount
-    _town           = args.town || UserVars.last_repair_town || @settings.repair_town || @settings.hometown
-    @town           = _town.split.map(&:capitalize).join(' ')
+    low_town        = args.town || UserVars.last_repair_town || @settings.repair_town || @settings.hometown
+    @town           = low_town.split.map(&:capitalize).join(' ')
     @force_repair   = args.force_repair
     @repair_timer   = @settings.repair_timer
     @sort_head      = @settings.sort_auto_head

--- a/repair.lic
+++ b/repair.lic
@@ -117,14 +117,14 @@ class Repair
     @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
   end
 
-  def repair_gear(gear, info, self: false)
+  def repair_gear(gear, info, repair_own: false)
     gear.each do |gear_item|
       unless smart_get_gear(gear_item)
         DRC.message("Missing #{gear_item}, skipping")
         DRC.beep
         next
       end
-      self ? self_repair(gear_item) : shop_repair(gear_item, info)
+      repair_own ? self_repair(gear_item) : shop_repair(gear_item, info)
     end
   end
 

--- a/repair.lic
+++ b/repair.lic
@@ -81,6 +81,8 @@ class Repair
 
   def prep_full_repair
     exit unless should_repair?
+
+    UserVars.repair_timer_snap = Time.now
     gear = []
     @equipmanager.items.each do |item|
       next if item.skip_repair
@@ -216,7 +218,6 @@ class Repair
       pause 0.01 until (item = [DRC.right_hand, DRC.left_hand].compact.first) # waits for repaired item to hit your hand
       smart_stow_gear(item)
     end
-    UserVars.repair_timer_snap = Time.now
   end
 
   def smart_get_gear(gear_item)

--- a/repair.lic
+++ b/repair.lic
@@ -177,38 +177,38 @@ class Repair
   end
 
   def self_repair(gear_item)
-    repeat = false
-    ['wire brush', 'oil'].each do |tool|
-      DRCI.get_item(tool, @bag)
-      command = tool == 'wire brush' ? "rub my #{gear_item} with my wire brush" : "pour my oil on my #{gear_item}"
-      case DRC.bput(command, 'Roundtime', 'not damaged enough',
-                    'You cannot do that while engaged!',
-                    'cannot figure out how', 'Pour what')
-      when 'Roundtime'
-        DRCI.put_away_item?(tool, @bag)
-        repeat = true
-      when 'not damaged enough'
-        DRCI.put_away_item?(tool, @bag)
-        break
-      when 'Pour what'
-        DRCC.check_consumables('oil', info['finisher-room'], info['finisher-number'], @bag, @bag_items, nil)
+    repeat = true
+    while repeat
+      ['wire brush', 'oil'].each do |tool|
         DRCI.get_item(tool, @bag)
-        DRC.bput("pour my oil on my #{gear_item}", 'Roundtime')
-        DRCI.put_away_item?(tool, @bag)
-      when 'You cannot do that while engaged!'
-        DRC.message("Cannot repair in combat")
-        smart_stow_gear(gear_item)
-        DRCI.put_away_item?(tool, @bag)
-        exit
-      when 'cannot figure out how'
-        DRC.message("Something has gone wrong, moving to next item")
-        DRCI.put_away_item?(tool, @bag)
-        break
+        command = tool == 'wire brush' ? "rub my #{gear_item} with my wire brush" : "pour my oil on my #{gear_item}"
+        case DRC.bput(command, 'Roundtime', 'not damaged enough',
+                      'You cannot do that while engaged!',
+                      'cannot figure out how', 'Pour what')
+        when 'Roundtime'
+          DRCI.put_away_item?(tool, @bag)
+        when 'not damaged enough'
+          DRCI.put_away_item?(tool, @bag)
+          repeat = false
+          break
+        when 'Pour what'
+          DRCC.check_consumables('oil', info['finisher-room'], info['finisher-number'], @bag, @bag_items, nil)
+          DRCI.get_item(tool, @bag)
+          DRC.bput("pour my oil on my #{gear_item}", 'Roundtime')
+          DRCI.put_away_item?(tool, @bag)
+        when 'You cannot do that while engaged!'
+          DRC.message("Cannot repair in combat")
+          smart_stow_gear(gear_item)
+          DRCI.put_away_item?(tool, @bag)
+          exit
+        when 'cannot figure out how'
+          DRC.message("Something has gone wrong, moving to next item")
+          DRCI.put_away_item?(tool, @bag)
+          repeat = false
+          break
+        end
       end
-    end
-    if repeat
       set_immune(gear_item)
-      self_repair(gear_item)
     end
     smart_stow_gear(gear_item)
   end

--- a/repair.lic
+++ b/repair.lic
@@ -150,6 +150,7 @@ class Repair
   end
 
   def self_repair(gear_item)
+    repeat = false
     ['wire brush', 'oil'].each do |tool|
       DRCI.get_item(tool, @bag)
       command = tool == 'wire brush' ? "rub my #{gear_item} with my wire brush" : "pour my oil on my #{gear_item}"
@@ -158,7 +159,7 @@ class Repair
                     'cannot figure out how', 'Pour what')
       when 'Roundtime'
         DRCI.put_away_item?(tool, @bag)
-        next
+        repeat = true
       when 'not damaged enough'
         DRCI.put_away_item?(tool, @bag)
         break
@@ -167,7 +168,6 @@ class Repair
         DRCI.get_item(tool, @bag)
         DRC.bput("pour my oil on my #{gear_item}", 'Roundtime')
         DRCI.put_away_item?(tool, @bag)
-        next
       when 'You cannot do that while engaged!'
         DRC.message("Cannot repair in combat")
         smart_stow_gear(gear_item)
@@ -179,6 +179,7 @@ class Repair
         break
       end
     end
+    self_repair(gear_item) if repeat
     smart_stow_gear(gear_item)
   end
 

--- a/repair.lic
+++ b/repair.lic
@@ -113,7 +113,7 @@ class Repair
   def should_repair?
     return true if @repair_timer.nil?
 
-    @repair_timer >= (Time.now - UserVars.repair_timer_snap).to_i
+    @repair_timer <= (Time.now - UserVars.repair_timer_snap).to_i
   end
 
   def verify_funds(gear, repair_own)


### PR DESCRIPTION
  All in one repair script. Can be run with the listed options or any combination of tools, gear, etc.
    Only restricted in pickup, the pickup routine will go to the last repair location, or the location you designate,
    if you have any tickets from that repair person.

  EXAMPLES:
  ;repair forging                    # runs to your hometown repair shop, drops off and picks up your forging tools
  ;repair forging self_repair        # Uses wire brush and oil to repair your own forging tools as defined in yaml
  ;repair forging crossing           # runs to crossing repair shop, drops off and picks up your forging tools
  ;repair forging drop_off shard     # runs to shard, drops your forging tools at the repair shop for pickup at a later time.
  ;repair shield "iron bracer" pilum forging shard drop_off
                                     # runs to shard, drops off your shield, bracer, pilum, and forging tools for pickup at a later time.

  (probably works)