### PR TITLE
[data][base-recipes] Wrong part for Celestial Beacon

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -8864,10 +8864,10 @@ crafting_recipes:
   part:
   - bobcat rod
 - name: a celestial beacon
-  noun: heron bead
+  noun: gem
   type: artificing
   chapter: 2
-  work_order: true
+  work_order: false
   enchant_stock1_name: abolition
   enchant_stock1: 2
   enchant_stock2_name:
@@ -8878,7 +8878,7 @@ crafting_recipes:
   enchant_stock4:
   item:
   part:
-  - heron bead
+  - gem
 - name: a wind trinket
   noun: bone totem
   type: artificing


### PR DESCRIPTION
Incorrectly states celestial beacon uses a bead, when it requires a gem, and shouldn't be eligible for workorders.