### PR TITLE
[data][base-crafting] Add bingots info

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -5,16 +5,81 @@ stock:
     stock-number: 11
     stock-name: bronze
     stock-value: 562
+  bronze50:
+    stock-volume: 50
+    stock-number: 1
+    stock-name: bronze
+    stock-value: 6250
+  bronze100:
+    stock-volume: 100
+    stock-number: 2
+    stock-name: bronze
+    stock-value: 11875
+  bronze200:
+    stock-volume: 200
+    stock-number: 3
+    stock-name: bronze
+    stock-value: 23125
   steel:
     stock-volume: 10
     stock-number: 9
     stock-name: steel 
     stock-value: 2000
+  steel50:
+    stock-volume: 50
+    stock-number: 13
+    stock-name: steel
+    stock-value: 11875
+  steel100:
+    stock-volume: 100
+    stock-number: 14
+    stock-name: steel
+    stock-value: 23125
+  steel200:
+    stock-volume: 200
+    stock-number: 15
+    stock-name: steel
+    stock-value: 45625
+  iron50:
+    stock-volume: 50
+    stock-number: 7
+    stock-name: iron
+    stock-value: 7187
+  iron100:
+    stock-volume: 100
+    stock-number: 8
+    stock-name: iron
+    stock-value: 13750
+  iron200:
+    stock-volume: 200
+    stock-number: 9
+    stock-name: iron
+    stock-value: 26975
+  tin50:
+    stock-volume: 50
+    stock-number: 16
+    stock-name: tin
+    stock-value: 3125
+  tin100:
+    stock-volume: 100
+    stock-number: 17
+    stock-name: tin
+    stock-value: 5625
   coal:
     stock-volume: 10
     stock-number: 2
     stock-name: coal
     stock-value: 212
+  coal50:
+    stock-volume: 50
+    stock-number: 4
+    stock-name: coal
+    stock-value: 2187
+  coal100:
+    stock-volume: 100
+    stock-number: 5
+    stock-name: coal
+    stock-value: 3750
   linen:
     stock-volume: 10
     stock-number: 7
@@ -349,6 +414,7 @@ blacksmithing:
     repair-npc: clerk
     stock-volume: 5
     stock-room: 8775
+    bingots-room: 17118
     trash-room: 8773
     idle-room: 8775
   Leth Deriel:
@@ -396,6 +462,7 @@ blacksmithing:
     repair-npc: clerk
     stock-volume: 5
     stock-room: 19243
+    bingots-room: 17118 # crossing
     trash-room: 19264
     idle-room: 19246
   Muspar'i:
@@ -433,6 +500,7 @@ blacksmithing:
     repair-npc: Rokumru
     stock-volume: 5
     stock-room: 11264
+    bingots-room: # left intentionally blank until bingots are added here
     trash-room: 14350
     idle-room: 11260
     part-room: 11263
@@ -476,6 +544,7 @@ blacksmithing:
     repair-npc: clerk
     stock-volume: 5
     stock-room: 8785
+    bingots-room: # left intentionally blank until bingots are added here
     trash-room: 8787
     idle-room: 8785
   Langenfirth:
@@ -499,6 +568,7 @@ blacksmithing:
       - 17119
     stock-volume: 5
     stock-room: 4434
+    bingots-room: 17119
     trash-room: 9611
     repair-room: 8013
     repair-npc: clerk
@@ -568,6 +638,7 @@ blacksmithing:
     repair-room: 16409
     repair-npc: clerk
     stock-room: 16405
+    bingots-room: 17119 # shard
     trash-room: 16412
     idle-room: 16405
   Ratha:
@@ -610,6 +681,7 @@ blacksmithing:
     repair-room: 10755
     repair-npc: clerk
     stock-room: 10758
+    bingots-room: # left intentionally blank until bingots are added here
     trash-room: 10767
     idle-room: 10765
   Aesry:
@@ -643,6 +715,7 @@ blacksmithing:
     repair-room: 17692
     repair-npc: clerk
     stock-room: 17694
+    bingots-room: # left intentionally blank until bingots are added here
     trash-room: 17690
     idle-room: 17689      
   Hibarnhvidar: &forfedhdar_blacksmithing
@@ -684,6 +757,7 @@ blacksmithing:
     repair-room: 8887
     repair-npc: clerk
     stock-room: 8894
+    bingots-room: 17119 # shard
     trash-room: 8895
     idle-room: 8893
   Fang Cove:
@@ -721,6 +795,7 @@ blacksmithing:
     repair-room: 9143
     repair-npc: clerk
     stock-room: 9132
+    bingots-room: 17120
     trash-room: 14881
     idle-room: 9136
   Mer'Kresh:
@@ -759,6 +834,7 @@ blacksmithing:
     repair-room: 11807
     repair-npc: Diwitt
     stock-room: 8811
+    bingots-room: # left intentionally blank until bingots are added here
     trash-room: 8813
     idle-room: 8808
   Boar Clan:


### PR DESCRIPTION
Some additional information for the big ingots they're rolling out, for implementation into scripts like workorders, makesteel, or personal edits.  Haven't visited the islands, so not 100% on whether they're added there or not. 

Added tin and iron as options for future edits to workorders, since they're similar in workability to steel while being half or less the price. Tin in particular is notable here because of it's low weight and price, making it an attractive option if we ever roll out armorsmithing as an option. for weaponsmithing/blacksmithing, I could see stepping down to challenging and using tin as the new meta, since we'll likely never see a workorder over 100 volumes.