### PR TITLE
[script][common-money] Incorrectly checking currency

### DIFF
--- a/common-money.lic
+++ b/common-money.lic
@@ -176,7 +176,7 @@ module DRCM
       if DRRoom.pcs.include?(settings.bankbot_name)
         amount_convert, type = amount_as_string.split
         amount = convert_to_copper(amount_convert, type)
-        currency = hometown_currency(settings.hometown)
+        currency = hometown_currency(hometown)
         case DRC.bput("whisper #{settings.bankbot_name} withdraw #{amount} #{currency}", 'offers you', 'Whisper what to who?')
         when 'offers you'
           DRC.bput('accept tip', 'Your current balance is')


### PR DESCRIPTION
So this has been bugging me for awhile, finally tracked down the problem. When passing a hometown that isn't your yaml hometown to this script's method ensure_copper_on_hand, it's supposed to use the hometown arg if provided:
```ruby
  def withdraw_exact_amount?(amount_as_string, settings, hometown = nil)
    hometown = settings.hometown if hometown == nil
```
 Problem is, in this particular spot:
```ruby
        currency = hometown_currency(settings.hometown)
```
it was getting the currency type from your yaml setting, rather than the hometown arg. Changing this to use the local variable instead of getting your hometown from settings sorts the issue.