### PR TITLE
[data][base-crafting] Part rooms and lenses

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -1150,7 +1150,7 @@ shaping:
     clamps-number: 12
     glue-number: 13
     stain-number: 14
-    idle-room:
+    idle-room: 10737
   Shard:
     npc: Master
     npc_last_name: Master
@@ -1297,7 +1297,7 @@ carving:
     clamps-number: 12
     glue-number: 13
     stain-number: 14
-    idle-room:
+    idle-room: 10737
   Shard:
     npc: Master
     npc_last_name: Master

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -1291,7 +1291,7 @@ carving:
     repair-room: 10734
     repair-npc: Glarstan
     stock-room: 10738
-    pattern-book: shaping
+    pattern-book: carving
     part-room: 10737
     tool-room: 10737
     clamps-number: 12

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -341,9 +341,11 @@ stock:
     stock-value: 212
   bow string:
     stock-value: 150
+  lenses:
+    stock-value: 1250
   bone backer:
     stock-value: 100
-  leather strip:
+  leather strips:
     stock-value: 625
   arrow flights:
     stock-value: 62
@@ -1088,7 +1090,7 @@ shaping:
     - 9115
     shaping-rooms:
     - 9116
-    - 14878
+    # - 14878
     logbook: engineering
     repair-room: 9143
     repair-npc: clerk
@@ -1251,6 +1253,7 @@ carving:
     repair-room: 19209
     repair-npc: Rangu
     stock-room: 8864
+    part-room: 8864
     pattern-book: carving
   Leth Deriel:
     << : *zoluren_carving
@@ -1267,11 +1270,34 @@ carving:
     repair-room: 8856
     repair-npc: Valomenica
     stock-room: 9110
+    part-room: 8857
     pattern-book: carving
   Langenfirth:
     << : *theren_carving
   Therenborough:
     << : *theren_carving
+  Ratha:
+    npc: Master
+    npc_last_name: Master
+    npc-rooms:
+    - 10733
+    - 10734
+    - 10735
+    - 10736
+    - 10737
+    - 10738
+    - 10739
+    logbook: engineering
+    repair-room: 10734
+    repair-npc: Glarstan
+    stock-room: 10738
+    pattern-book: shaping
+    part-room: 10737
+    tool-room: 10737
+    clamps-number: 12
+    glue-number: 13
+    stain-number: 14
+    idle-room:
   Shard:
     npc: Master
     npc_last_name: Master
@@ -1340,6 +1366,7 @@ carving:
     repair-room: 17153
     repair-npc: clerk
     stock-room: 17152
+    part-room: 17152
     pattern-book: carving
   Boar Clan:
     << : *forfedhdar_carving
@@ -2310,6 +2337,40 @@ recipe_parts:
     Fang Cove:
       part-room: 9118
       part-number:
+  lenses:  
+    Crossing:
+      part-room: 8864
+      part-number:
+    Leth Deriel:
+      part-room: 8864
+      part-number:
+    Riverhaven:
+      part-room: 9110
+      part-number:
+    Langenfirth:
+      part-room: 9110
+      part-number:
+    Therenborough:
+      part-room: 9110
+      part-number:
+    Muspar'i:
+      part-room: 11272
+      part-number:
+    Ratha:
+      part-room: 10738
+      part-number:
+    Shard:
+      part-room: 4436
+      part-number:
+    Boar Clan:
+      part-room: 17152 # Hibarnhvidar
+      part-number:
+    Hibarnhvidar:
+      part-room: 17152
+      part-number:
+    Fang Cove:
+      part-room: 9118
+      part-number:
   bone backer:
     Crossing:
       part-room: 8864
@@ -2477,4 +2538,3 @@ recipe_parts:
     Fang Cove:
       part-room: 14784
       part-number:
- 

--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -2405,7 +2405,7 @@ recipe_parts:
     Fang Cove:
       part-room: 9118
       part-number:
-  leather strip:
+  leather strips:
     Crossing:
       part-room: 8864
       part-number:

--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -5761,7 +5761,7 @@ crafting_recipes:
   work_order: true
   chapter: 9
   part:
-  - leather strip
+  - leather strips
 - name: a wood quarterstaff
   noun: quarterstaff
   volume: 9
@@ -5787,7 +5787,7 @@ crafting_recipes:
   work_order: true
   chapter: 9
   part:
-  - leather strip
+  - leather strips
 - name: a weighted staff
   noun: staff
   volume: 9
@@ -5795,7 +5795,7 @@ crafting_recipes:
   work_order: true
   chapter: 9
   part:
-  - leather strip
+  - leather strips
 # Shaping Chapter 10 recipes
 - name: a rough wood table
   noun: table


### PR DESCRIPTION
We were missing a few part rooms in carving, including an entire entry for Ratha.
Add lenses information
leather strip to strips to match the actual item we're buying/using
14878 doesn't exist in FC, both shaping rooms are the same rm number (9116)