### PR TITLE
[scripts][combat-trainer] Built-in autolooter support for gems

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -508,8 +508,9 @@ class LootProcess
         @autoloot_container,
         @full_pouch_container,
         @spare_gem_pouch_container,
-        @tie_pouch)
-        @autoloot_fill_gem_pouch_timer = Time.now
+        @tie_pouch
+      )
+      @autoloot_fill_gem_pouch_timer = Time.now
     end
 
     game_state.mob_died = false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -447,9 +447,22 @@ class LootProcess
     @gem_pouch_noun = settings.gem_pouch_noun
     echo("  @gem_pouch_noun: #{@gem_pouch_noun}") if $debug_mode_ct
 
+    @autoloot_container = settings.autoloot_container
+    echo("  @autoloot_container: #{@autoloot_container}") if $debug_mode_ct
+
+    @autoloot_gems = settings.autoloot_gems
+    echo("  @autoloot_gems: #{@autoloot_gems}") if $debug_mode_ct
+
+    @autoloot_fill_gem_pouch_delay = settings.autoloot_fill_gem_pouch_delay
+    echo("  @autoloot_fill_gem_pouch_delay: #{@autoloot_fill_gem_pouch_delay}") if $debug_mode_ct
+
+    @autoloot_fill_gem_pouch_timer = Time.now
+    echo("  @autoloot_fill_gem_pouch_timer: #{@autoloot_fill_gem_pouch_timer}") if $debug_mode_ct
+
     @loot_delay = settings.loot_delay
-    @loot_timer = Time.now - @loot_delay
     echo("  @loot_delay: #{@loot_delay}") if $debug_mode_ct
+
+    @loot_timer = Time.now - @loot_delay
     echo("  @loot_timer: #{@loot_timer}") if $debug_mode_ct
 
     @loot_bodies = settings.loot_bodies
@@ -488,6 +501,17 @@ class LootProcess
       fput 'DUMP JUNK'
       @dump_timer = Time.now
     end
+    if @autoloot_container && @autoloot_gems && (Time.now - @autoloot_fill_gem_pouch_timer > @autoloot_fill_gem_pouch_delay)
+      DRCI.fill_gem_pouch_with_container(
+        @gem_pouch_adjective,
+        @gem_pouch_noun,
+        @autoloot_container,
+        @full_pouch_container,
+        @spare_gem_pouch_container,
+        @tie_pouch)
+        @autoloot_fill_gem_pouch_timer = Time.now
+    end
+
     game_state.mob_died = false
     dispose_body(game_state)
     stow_lootables(game_state)

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -360,6 +360,12 @@ performance_monitor_weapons:
 retreat_threshold:
 # avoid damaging attacks in combat - useful when training against mobs that don't spawn well.  Doesn't work right with whirlwind.
 use_weak_attacks: false
+# Name of autoloot container for Combat Trainer
+autoloot_container:
+# Set to true if you have gems autolooted
+autoloot_gems: false
+# How frequently to fill your gem pouch with your autolooter in combat
+autoloot_fill_gem_pouch_delay: 120
 # loot bodies after killing them
 loot_bodies: true
 # Delay for looting bodies, in seconds


### PR DESCRIPTION
As per title.

To use set `autoloot_container` and toggle `autoloot_gems` to `true` in your yaml.

By default it'll fill your gem pouch with your autolooter every 2 minutes.
