### PR TITLE
[script][smoke] Rewrite, expand

### DIFF
--- a/smoke.lic
+++ b/smoke.lic
@@ -43,7 +43,7 @@ class Smoker
         { name: 'teach', regex: /teach/i, description: 'teach a particular image to player' },
         { name: 'smoke', regex: /cigar|pipe/i, description: 'smoke implement to use' },
         { name: 'player', options: DRRoom.pcs, description: 'Player to teach the image(s) to' },
-        { name: 'image', options: @full_image_list, optional: true, description: 'image to teach them (optional, can use smoke list)'}
+        { name: 'image', options: @full_image_list, optional: true, description: 'image to teach them (optional, can use smoke list)' }
       ],
       [
         { name: 'learn', regex: /learn/i, description: 'learn a smoke image from another player' },
@@ -90,7 +90,7 @@ class Smoker
     end
   end
 
-  def smoke_loop(images, number)    
+  def smoke_loop(images, number)
     DRCT.walk_to(@smoke_settings['smoke_room'])
     number.times do
       if @cigar && Flags['new-cig']
@@ -129,6 +129,7 @@ class Smoker
     @time_between = 0
     images.each do |image|
       next unless offer_lesson(image, player)
+
       until Flags['smoke-image-learned']
         quick_light(@smoker) if Flags['new-cig']
         smoke(image)
@@ -154,6 +155,7 @@ class Smoker
         pause 1 until Flags['teacher-smoked'] || Flags['smoke-image-learned']
         Flags.reset('teacher-smoked')
         break if Flags['smoke-image-learned']
+
         pause 1
         quick_light(@smoker) if Flags['new-cig']
         smoke(image)
@@ -297,16 +299,16 @@ class Smoker
       images -= (images - images_you_know) # creates an array of images we don't know, and removes them from our list of images we were hoping to smoke
     end
     # Here we might want to just smoke a curated list of images, regardless of whether we've mastered one or more
-    # TODO: support for non-halfling mastery? 
+    # TODO: support for non-halfling mastery?
     return images unless @smoke_settings['clean_list_of_mastered'] && DRStats.race == 'Halfling'
 
     # Here we're using the originally generated list like a hash
     images_mastered = smoke_list
-              .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
-              .join(' ') # making a string of image names, dashes, and 'master*'
-              .split # creating a new array with all of those items as elements
-              .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
-              .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
+                      .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
+                      .join(' ') # making a string of image names, dashes, and 'master*'
+                      .split # creating a new array with all of those items as elements
+                      .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
+                      .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
     DRC.message("Removing already mastered images: #{images_mastered.join(' ')}") unless images_mastered.empty? # images_mastered here means images from our variable 'images' that we sent this method
     UserVars.smoke_images_mastered |= images_mastered # here we're adding any mastered images we found on our list of mastered to our uservar, but only if they're not already present.
     images - UserVars.smoke_images_mastered # Finally, we return our original list minus any images we've mastered.

--- a/smoke.lic
+++ b/smoke.lic
@@ -11,9 +11,9 @@
     - tart
 =end
 
-custom_require.call(%w[common common-items events])
+custom_require.call(%w[common common-items common-travel equipmanager events])
 
-class Smoke
+class Smoker
   def initialize
     Flags.add('new-cig', 'That was the last of your', 'goes out and crumbles away'); Flags['new-cig'] = true
     @full_image_list = ['deer', 'dragon', 'rabbit', 'pixie', 'kitten', 'troll', 'horse', 'paladin', 'whip', 'cloak', 'stump', 'fleas', 'daisies', 'unicorn', 'rams', 'bandit', 'ship', 'grave', 'fish', 'web', 'phoenix', 'bracelet', 'skeleton', 'tart', 'almanac', 'dartboard']
@@ -33,24 +33,29 @@ class Smoke
         { name: 'until_out', regex: /until_out/i, optional: true, description: 'Smoke until out of tobacco' }
       ],
       [
-        { name: 'image', regex: /\w+/i, variable: true, description: 'Smoke image to learn, can be an ARRAY, will random one.' },
-        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun.' },
-        { name: 'container', regex: /\w+/i, variable: true, description: "Cigar's container." },
-        { name: 'lighter', regex: /\w+/i, variable: true, description: "Lighter's noun." }
-      ],
-      [
         { name: 'smoke', regex: /cigar|pipe/i, description: 'smoke utensil to light' },
         { name: 'light_only', regex: /light_only/i, description: 'lights the provided smoke utensil' }
       ],
       [
         { name: 'reset_known', regex: /reset_known/i, description: 'Reset list of known smoke images, used after learning one or more new images' }
+      ],
+      [
+        { name: 'teach', regex: /teach/i, description: 'teach a particular image to player' },
+        { name: 'smoke', regex: /cigar|pipe/i, description: 'smoke implement to use' },
+        { name: 'player', options: DRRoom.pcs, description: 'Player to teach the image(s) to' },
+        { name: 'image', options: @full_image_list, optional: true, description: 'image to teach them (optional, can use smoke list)'}
+      ],
+      [
+        { name: 'learn', regex: /learn/i, description: 'learn a smoke image from another player' },
+        { name: 'smoke', regex: /cigar|pipe/i, description: 'smoke implement to use' },
+        { name: 'player', options: DRRoom.pcs, description: 'Player to teach the image(s) to' }
       ]
     ]
 
     args            = parse_args(arg_definitions)
     @smoke_settings = get_settings.smoke
     @equipmanager   = EquipmentManager.new
-    images          = args.image || @smoke_settings['smoke_images'] || UserVars.smoke_images_known - UserVars.smoke_images_mastered
+    images          = args.image || @smoke_settings['smoke_images'] || UserVars.smoke_images_known
     @bag            = @smoke_settings['container']
     @pipe           = @smoke_settings['pipe']
     @lighter        = @smoke_settings['lighter']
@@ -58,17 +63,23 @@ class Smoke
     @cigar          = args.cigar
     @time_between   = @smoke_settings['time_between_exhales'] || 1
 
-    quick_light(args.smoke) if args.light_only
-    reset_known if args.reset_known
+    if args.light_only
+      quick_light(args.smoke)
+      exit
+    end
 
-    unless args.image || UserVars.smoke_images_known.size == UserVars.smoke_images_mastered.size
+    reset_known if args.reset_known
+    smoke_teach(args, images.to_a) if args.teach || args.learn
+
+    unless args.image
       images = check_images(images)
-      if images.empty?
+      if UserVars.smoke_images_known.size == UserVars.smoke_images_mastered.size
+        DRC.message("All known images mastered, sampling from your known list")
+      elsif images.empty?
         DRC.message("No valid images selected")
         exit
       end
     end
-    DRC.message("Images to train: #{images.to_a.join(' ')}")
 
     if args.until_out
       smoke_loop(images.to_a, 99)
@@ -79,31 +90,94 @@ class Smoke
     end
   end
 
-  def smoke_loop(images, number)
+  def smoke_loop(images, number)    
     DRCT.walk_to(@smoke_settings['smoke_room'])
     number.times do
       if @cigar && Flags['new-cig']
         Flags.reset('new-cig')
-        break unless DRCI.get_item_if_not_held?(@cigar, @bag)
-
-        light_tobacco(@cigar)
-        smoker = @cigar
+        quick_light(@cigar)
+        @smoker = @cigar
       elsif @pipe && Flags['new-cig']
         Flags.reset('new-cig')
-        break unless load_pipe
-
-        smoker = @pipe
+        quick_light(@pipe)
+        @smoker = @pipe
       end
-      smoke(images, smoker) until Flags['new-cig']
+      smoke(images) until Flags['new-cig']
       images = check_images(images) if @smoke_settings['clean_list_of_mastered']
     end
     DRCI.put_away_item?(@pipe, @bag) if DRCI.in_hands?(@pipe)
     DRC.message("Smoker Complete!")
   end
 
+  def smoke_teach(args, images)
+    Flags.add('smoke-image-learned', /finally catches on to your instructions on how to make the .* smoke image/, /^You now know the basics of making the .* smoke image/)
+    Flags.add('teacher-smoked', /^#{args.player.capitalize} takes a long drag off of his/)
+    Flags.add('student-smoked', /^#{args.player.capitalize} tries to make the image/)
+    Flags.add('time-to-listen', /^#{args.player.capitalize} starts to tell you about (a|an|the) (?<image>\w+) smoke image/)
+    if args.smoke == 'pipe' && Flags['new-cig']
+      quick_light(@pipe)
+      @smoker = @pipe
+    elsif args.smoke =~ /cigar/ && Flags['new-cig']
+      quick_light(args.smoke)
+      @smoker = @pipe
+    end
+    teach_loop(images, args.player) if args.teach
+    learn_loop(args.player) if args.learn
+  end
+
+  def teach_loop(images, player)
+    @time_between = 0
+    images.each do |image|
+      next unless offer_lesson(image, player)
+      until Flags['smoke-image-learned']
+        quick_light(@smoker) if Flags['new-cig']
+        smoke(image)
+        pause 1 until Flags['student-smoked'] || Flags['smoke-image-learned']
+        Flags.reset('student-smoked')
+        pause 8 unless Flags['smoke-image-learned']
+      end
+      Flags.reset('smoke-image-learned')
+    end
+  end
+
+  def learn_loop(player)
+    @time_between = 0
+    loop do
+      if /make a (?<image>\w+) smoke image/ =~ DRC.bput("Listen #{player}", /You start paying attention to Scrounger's advice on how to make a (?<image>\w+) smoke image/, /^#{player.capitalize} isn't teaching a class/)
+        image = Regexp.last_match[:image]
+      else
+        pause 1 until Flags['time-to-listen']
+        image = Flags['time-to-listen'][:image]
+        DRC.bput("Listen #{player}", /You start paying attention to/)
+      end
+      until Flags['smoke-image-learned']
+        pause 1 until Flags['teacher-smoked'] || Flags['smoke-image-learned']
+        Flags.reset('teacher-smoked')
+        break if Flags['smoke-image-learned']
+        pause 1
+        quick_light(@smoker) if Flags['new-cig']
+        smoke(image)
+      end
+      Flags.reset('smoke-image-learned')
+      Flags.reset('time-to-listen')
+    end
+  end
+
+  def offer_lesson(image, player)
+    case DRC.bput("smoke teach #{image} #{player}", { 'timeout' => 35, 'suppress_no_match' => true }, /^#{player.capitalize} starts paying attention to your advice on how to make/, /^#{player.capitalize} nods to you/, /already knows how to make that smoke image/)
+    when /paying attention/, /nods to you/
+      true
+    when /already knows how/
+      false
+    else
+      DRC.message("Student Unresponsive")
+      exit
+    end
+  end
+
   def load_pipe
-    DRCI.get_item_if_not_held?(@pipe, @bag)
-    contents = DRC.bput("look in my #{@pipe}", /^In the .* you see some .*/, /^There is nothing in there/)
+    exit unless DRCI.get_item_if_not_held?(@pipe, @bag)
+    contents = DRC.bput("look in my #{@pipe}", /^In the .* you see (a|an|some) .*/, /^There is nothing in there/)
     case contents
     when /burning/
       return true
@@ -114,15 +188,14 @@ class Smoke
     light_tobacco("tobacco in pipe")
   end
 
-  def quick_light(smoke)
-    case smoke
+  def quick_light(smoker)
+    Flags.reset('new-cig')
+    case smoker
     when /pipe/
       load_pipe
-      exit
     when /cigar/
-      exit unless DRCI.get_item_if_not_held?(smoke, @bag)
-      light_tobacco(smoke)
-      exit
+      exit unless DRCI.get_item_if_not_held?(smoker, @bag)
+      light_tobacco(smoker)
     end
   end
 
@@ -141,35 +214,41 @@ class Smoke
     else # flint
       unless DRCI.get_item?("flint")
         DRC.message("Missing flint, scoot to your local shop and pick some up, every adventurer should have flint and steel")
-        DRCI.put_away_item(DRC.right_hand, @bag)
+        DRCI.put_away_item?(DRC.right_hand, @bag)
         exit
       end
       DRCI.lower_item?(target.split.last)
       @equipmanager.get_item?(@blade)
       DRC.bput("light #{target} with my flint", /^Roundtime/, /^That's already burning/)
-      DRCI.put_away_item?("flint", @bag)
+      DRCI.stow_item?("flint")
       @equipmanager.return_held_gear
       DRCI.lift?
     end
   end
 
   def exhale_smoke(image)
-    if /untrained/ =~ DRC.bput("exhale line #{image}", /^Roundtime/, /^You are untrained in the ways of making that image./)
+    case DRC.bput("exhale line #{image}", /^Roundtime/, /^You are untrained in the ways of making that image./, /^You now know the basics of making/)
+    when /untrained/
       fput 'exhale ring'
+    when /You need to observe your teacher performing/
+      DRC.message("Teaching borked, give it some time and try again")
+      exit
+    when /You now know/
+      DRC.message("Image learned, waiting for the next")
     end
   end
 
-  def inhale(image, smoker)
-    if /out of your lungs first/ =~ DRC.bput("inhale my #{smoker}", /^You take/, /out of your lungs first/)
+  def inhale(image)
+    if /out of your lungs first/ =~ DRC.bput("inhale my #{@smoker}", /^You take/, /out of your lungs first/)
       exhale_smoke(image, true)
-      return inhale(image, smoker)
+      return inhale(image)
     end
   end
 
-  def smoke(images, smoker)
+  def smoke(images)
     # pull a random image from our list of images
-    image = images.sample
-    inhale(image, smoker)
+    image = images.to_a.sample
+    inhale(image)
     pause 1
     exhale_smoke(image)
     waitrt?
@@ -183,7 +262,12 @@ class Smoke
     UserVars.smoke_images_mastered = []
     # Then cleaning out images we don't know, getting a list of images we've mastered
     # and providing a list of images to train
-    DRC.message("New Training List: #{check_images(@full_image_list).join(' ')}")
+    training_list = check_images(@full_image_list)
+    if training_list.empty?
+      DRC.message("All known images are mastered. Set a list under smoke_images in your yaml, or smoker will select from your known images at random")
+    else
+      DRC.message("New Training List: #{training_list.join(' ')}")
+    end
     exit
   end
 
@@ -213,16 +297,16 @@ class Smoke
       images -= (images - images_you_know) # creates an array of images we don't know, and removes them from our list of images we were hoping to smoke
     end
     # Here we might want to just smoke a curated list of images, regardless of whether we've mastered one or more
-    # TODO: support for non-halfling mastery?
+    # TODO: support for non-halfling mastery? 
     return images unless @smoke_settings['clean_list_of_mastered'] && DRStats.race == 'Halfling'
 
     # Here we're using the originally generated list like a hash
     images_mastered = smoke_list
-                      .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
-                      .join(' ') # making a string of image names, dashes, and 'master*'
-                      .split # creating a new array with all of those items as elements
-                      .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
-                      .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
+              .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
+              .join(' ') # making a string of image names, dashes, and 'master*'
+              .split # creating a new array with all of those items as elements
+              .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
+              .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
     DRC.message("Removing already mastered images: #{images_mastered.join(' ')}") unless images_mastered.empty? # images_mastered here means images from our variable 'images' that we sent this method
     UserVars.smoke_images_mastered |= images_mastered # here we're adding any mastered images we found on our list of mastered to our uservar, but only if they're not already present.
     images - UserVars.smoke_images_mastered # Finally, we return our original list minus any images we've mastered.
@@ -231,6 +315,10 @@ end
 
 before_dying do
   Flags.delete('new-cig')
+  Flags.delete('smoke-image-learned')
+  Flags.delete('teacher-smoked')
+  Flags.delete('student-smoked')
+  Flags.delete('time-to-listen')
 end
 
-Smoke.new
+Smoker.new

--- a/smoke.lic
+++ b/smoke.lic
@@ -79,7 +79,7 @@ class Smoke
     end
   end
 
-  def smoke_loop(images, number)    
+  def smoke_loop(images, number)
     DRCT.walk_to(@smoke_settings['smoke_room'])
     number.times do
       if @cigar && Flags['new-cig']
@@ -213,16 +213,16 @@ class Smoke
       images -= (images - images_you_know) # creates an array of images we don't know, and removes them from our list of images we were hoping to smoke
     end
     # Here we might want to just smoke a curated list of images, regardless of whether we've mastered one or more
-    # TODO: support for non-halfling mastery? 
+    # TODO: support for non-halfling mastery?
     return images unless @smoke_settings['clean_list_of_mastered'] && DRStats.race == 'Halfling'
 
     # Here we're using the originally generated list like a hash
     images_mastered = smoke_list
-              .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
-              .join(' ') # making a string of image names, dashes, and 'master*'
-              .split # creating a new array with all of those items as elements
-              .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
-              .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
+                      .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
+                      .join(' ') # making a string of image names, dashes, and 'master*'
+                      .split # creating a new array with all of those items as elements
+                      .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
+                      .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
     DRC.message("Removing already mastered images: #{images_mastered.join(' ')}") unless images_mastered.empty? # images_mastered here means images from our variable 'images' that we sent this method
     UserVars.smoke_images_mastered |= images_mastered # here we're adding any mastered images we found on our list of mastered to our uservar, but only if they're not already present.
     images - UserVars.smoke_images_mastered # Finally, we return our original list minus any images we've mastered.

--- a/smoke.lic
+++ b/smoke.lic
@@ -40,15 +40,10 @@ class Smoker
         { name: 'reset_known', regex: /reset_known/i, description: 'Reset list of known smoke images, used after learning one or more new images' }
       ],
       [
-        { name: 'teach', regex: /teach/i, description: 'teach a particular image to player' },
+        { name: 'teach', regex: /teach|learn/i, description: 'teach or learn smoke images' },
         { name: 'smoke', regex: /cigar|pipe/i, description: 'smoke implement to use' },
         { name: 'player', options: DRRoom.pcs, description: 'Player to teach the image(s) to' },
-        { name: 'image', options: @full_image_list, optional: true, description: 'image to teach them (optional, can use smoke list)' }
-      ],
-      [
-        { name: 'learn', regex: /learn/i, description: 'learn a smoke image from another player' },
-        { name: 'smoke', regex: /cigar|pipe/i, description: 'smoke implement to use' },
-        { name: 'player', options: DRRoom.pcs, description: 'Player to teach the image(s) to' }
+        { name: 'image', options: @full_image_list, optional: true, description: 'image to teach (optional, can use smoke list). Do not use if you are learning.' }
       ]
     ]
 
@@ -69,7 +64,7 @@ class Smoker
     end
 
     reset_known if args.reset_known
-    smoke_teach(args, images.to_a) if args.teach || args.learn
+    smoke_teach(args, images.to_a) if args.teach
 
     unless args.image
       images = check_images(images)
@@ -121,8 +116,7 @@ class Smoker
       quick_light(args.smoke)
       @smoker = @pipe
     end
-    teach_loop(images, args.player) if args.teach
-    learn_loop(args.player) if args.learn
+    send(args.teach + '_loop', images, args.player)
   end
 
   def teach_loop(images, player)
@@ -141,10 +135,10 @@ class Smoker
     end
   end
 
-  def learn_loop(player)
+  def learn_loop(_images, player)
     @time_between = 0
     loop do
-      if /make a (?<image>\w+) smoke image/ =~ DRC.bput("Listen #{player}", /You start paying attention to Scrounger's advice on how to make a (?<image>\w+) smoke image/, /^#{player.capitalize} isn't teaching a class/)
+      if /make a (?<image>\w+) smoke image/ =~ DRC.bput("Listen #{player}", /^You .* paying attention to Scrounger's advice on how to make a (?<image>\w+) smoke image/, /^#{player.capitalize} isn't teaching a class/)
         image = Regexp.last_match[:image]
       else
         pause 1 until Flags['time-to-listen']
@@ -166,7 +160,7 @@ class Smoker
   end
 
   def offer_lesson(image, player)
-    case DRC.bput("smoke teach #{image} #{player}", { 'timeout' => 35, 'suppress_no_match' => true }, /^#{player.capitalize} starts paying attention to your advice on how to make/, /^#{player.capitalize} nods to you/, /already knows how to make that smoke image/)
+    case DRC.bput("smoke teach #{image} #{player}", { 'timeout' => 45, 'suppress_no_match' => true }, /^#{player.capitalize} starts paying attention to your advice on how to make/, /^#{player.capitalize} nods to you/, /already knows how to make that smoke image/)
     when /paying attention/, /nods to you/
       true
     when /already knows how/
@@ -285,7 +279,7 @@ class Smoker
       break if line =~ /You don't know any smoke images/ # last line of empty smoke list
       next if line.include?('IMAGE - SKILL') # topline that would normally match
 
-      smoke_list << line.scan(/\w+\s-\s\w+\*?/) # grabbing lines: "<image> - <mastery level>       <image> - <mastery level>        <image> - <mastery level>"
+      smoke_list << line.scan(/\w+\s-\s\w+\*?|\w+\s-\s\s\s\s\s\s\s\s\s/) # grabbing lines: "<image> - <mastery level>       <image> - <mastery level>        <image> - <mastery level>"
     end
     smoke_list.flatten!
     # This draws off our array of known images, creating a new array of images found on our smoke list.
@@ -300,11 +294,11 @@ class Smoker
     end
     # Here we might want to just smoke a curated list of images, regardless of whether we've mastered one or more
     # TODO: support for non-halfling mastery?
-    return images unless @smoke_settings['clean_list_of_mastered'] && DRStats.race == 'Halfling'
+    return images unless @smoke_settings['clean_list_of_mastered']
 
     # Here we're using the originally generated list like a hash
     images_mastered = smoke_list
-                      .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
+                      .select { |image_and_mastery| image_and_mastery.include?('master*') || image_and_mastery.include?('        ') } # selecting only those images we've fully mastered. non-olvi mastery is represented by a blank field after the image name.
                       .join(' ') # making a string of image names, dashes, and 'master*'
                       .split # creating a new array with all of those items as elements
                       .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered

--- a/smoke.lic
+++ b/smoke.lic
@@ -1,142 +1,236 @@
 =begin
-  * If smoke_image is not included with YAML setting, it will just smoke/inhale/exhale.
-  * Can use flint or a lighter with YAML.
-  * Can random an image, supports array or single.
-  * Supports warrior mage cantrip Burning Touch.
-  Use YAML settings:
-    smoke:
-      cigar_container:
-      smoke_image:
-      lighter:
-        type:
-        container:
-        blade:
+  smoke:
+    container: smoking jacket
+    pipe: glitvire pipe
+    lighter: lava drake
+    blade: serrated parazonium
+    time_between_exhales: 3
+    clean_list_of_mastered: true
+    smoke_images:
+    - deer
+    - tart
 =end
 
 custom_require.call(%w[common common-items events])
 
-class Smoker
+class Smoke
   def initialize
+    Flags.add('new-cig', 'That was the last of your', 'goes out and crumbles away'); Flags['new-cig'] = true
+    @full_image_list = ['deer', 'dragon', 'rabbit', 'pixie', 'kitten', 'troll', 'horse', 'paladin', 'whip', 'cloak', 'stump', 'fleas', 'daisies', 'unicorn', 'rams', 'bandit', 'ship', 'grave', 'fish', 'web', 'phoenix', 'bracelet', 'skeleton', 'tart', 'almanac', 'dartboard']
+    UserVars.smoke_images_known ||= @full_image_list
+    UserVars.smoke_images_mastered ||= []
     arg_definitions = [
       [
-        { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun. (Only thing required if using YAML settings.)' }
+        { name: 'cigar', regex: /\w+?\s?cigar|cigar/i, variable: true, description: 'Cigar noun.' },
+        { name: 'image', options: UserVars.smoke_images_known, optional: true, description: 'Option to select a particular image out of your known images' },
+        { name: 'repeat', regex: /\d+/, optional: true, description: 'Smoke this many pieces of tobacco' },
+        { name: 'until_out', regex: /until_out/i, optional: true, description: 'Smoke until out of tobacco' }
+      ],
+      [
+        { name: 'pipe', regex: /pipe/i, description: 'Uses the pipe defined in your yaml settings' },
+        { name: 'image', options: UserVars.smoke_images_known, optional: true, description: 'Option to select a particular image out of your known images' },
+        { name: 'repeat', regex: /\d+/, optional: true, description: 'Smoke this many pieces of tobacco' },
+        { name: 'until_out', regex: /until_out/i, optional: true, description: 'Smoke until out of tobacco' }
       ],
       [
         { name: 'image', regex: /\w+/i, variable: true, description: 'Smoke image to learn, can be an ARRAY, will random one.' },
         { name: 'cigar', regex: /\w+/i, variable: true, description: 'Cigar noun.' },
         { name: 'container', regex: /\w+/i, variable: true, description: "Cigar's container." },
         { name: 'lighter', regex: /\w+/i, variable: true, description: "Lighter's noun." }
+      ],
+      [
+        { name: 'smoke', regex: /cigar|pipe/i, description: 'smoke utensil to light' },
+        { name: 'light_only', regex: /light_only/i, description: 'lights the provided smoke utensil' }
+      ],
+      [
+        { name: 'reset_known', regex: /reset_known/i, description: 'Reset list of known smoke images, used after learning one or more new images' }
       ]
     ]
 
-    args = parse_args(arg_definitions)
+    args            = parse_args(arg_definitions)
+    @smoke_settings = get_settings.smoke
+    @equipmanager   = EquipmentManager.new
+    images          = args.image || @smoke_settings['smoke_images'] || UserVars.smoke_images_known - UserVars.smoke_images_mastered
+    @bag            = @smoke_settings['container']
+    @pipe           = @smoke_settings['pipe']
+    @lighter        = @smoke_settings['lighter']
+    @blade          = @equipmanager.items.find { |gear| gear.short_regex =~ @smoke_settings['blade'] || gear.name =~ /\b#{@smoke_settings['blade']}\b/i }
+    @cigar          = args.cigar
+    @time_between   = @smoke_settings['time_between_exhales'] || 1
 
-    if args.image
-      @image = args.image
-      @cigar = args.cigar
-      @cigar_container = args.container
-      @lighter = args.lighter
-    else
-      smoke_settings = get_settings.smoke
+    quick_light(args.smoke) if args.light_only
+    reset_known if args.reset_known
 
-      @cigar = args.cigar
-      if smoke_settings['smoke_image']
-        @image = if smoke_settings['smoke_image'].is_a? Array
-                   smoke_settings['smoke_image'].sample
-                 else
-                   smoke_settings['smoke_image']
-                 end
-      end
-
-      @lighter_info = smoke_settings['lighter']
-      @cigar_container = smoke_settings['cigar_container']
-    end
-
-    Flags.add('new-cig', 'That was the last of your')
-
-    smoke_cig if cig? && light_cig?
-
-    Flags.delete('new-cig')
-  end
-
-  def cig?
-    unless DRCI.get_item?(@cigar, @cigar_container)
-      DRC.message 'Out of cigars, exiting.'
-      return false
-    end
-    true
-  end
-
-  def exhale_smoke
-    pause 3
-    output = 'exhale'
-    output = "exhale line #{@image}" if @image
-    DRC.bput(output.to_s, 'You (blow|breathe|exhale|loft|cast|need)')
-  end
-
-  def light_cig?
-    output = "get my #{@lighter}"
-    output = "get #{@lighter_info['type']} in my #{@lighter_info['container']}" unless @lighter_info.empty?
-    output = 'prep c b t' if @lighter_info['type'].eql? 'cantrip'
-
-    case DRC.bput(output.to_s, 'You get', 'What were', 'You are already', 'You are now prepared', 'You have no idea')
-    when 'You have no idea'
-      DRC.message "You don't know the cantrip you are trying to you! EXITING!"
-      exit
-    when 'You are now prepared'
-      case DRC.bput("gesture my #{@cigar}", 'You touch')
-      when 'You touch'
-        Flags.reset('new-cig')
-        return true
-      when 'What were'
-        DRC.message 'Cigar missing! Exiting!'
+    unless args.image || UserVars.smoke_images_known.size == UserVars.smoke_images_mastered.size
+      images = check_images(images)
+      if images.empty?
+        DRC.message("No valid images selected")
         exit
       end
-    when 'What were'
-      DRC.message 'No lighter found! Exiting.'
-      return false
     end
+    DRC.message("Images to train: #{images.to_a.join(' ')}")
 
-    if @lighter_info['type'].include?('flint')
-      DRCI.lower_item?(@cigar)
-      DRC.bput("wield my #{@lighter_info['blade']}", 'You get', 'What were', 'You are already', 'You draw')
-    end
-
-    if @lighter
-      fput("point my #{@lighter} at #{@cigar}")
-      waitrt?
+    if args.until_out
+      smoke_loop(images.to_a, 99)
+    elsif args.repeat
+      smoke_loop(images.to_a, args.repeat.to_i)
     else
-      fput("light #{@cigar} with my #{@lighter_info['type']}")
-      waitrt?
-      DRC.bput("sheath my #{@lighter_info['blade']}", /You (sheath|put)/)
-      DRC.bput('lift', 'You pick up')
+      smoke_loop(images.to_a, 1)
     end
-
-    DRC.bput("put my #{@lighter_info['type']} in my #{@lighter_info['container']}", 'You put')
-
-    Flags.reset('new-cig')
-    true
   end
 
-  def smoke_cig
-    inhale_counter = 0
-    until Flags['new-cig']
-      if @image
-        DRC.bput("inhale my #{@cigar}", 'You take', 'What were', 'out of your lungs first')
-        exhale_smoke
-        waitrt?
-      else
-        output = "smoke my #{@cigar}"
-        output = "inhale my #{@cigar}" if inhale_counter.zero?
-        DRC.bput(output.to_s, 'You puff', 'You take', 'What were')
-        exhale_smoke if inhale_counter.zero?
-        pause 15
-        inhale_counter += 1
-        inhale_counter = 0 if inhale_counter > 2
-        next
+  def smoke_loop(images, number)    
+    DRCT.walk_to(@smoke_settings['smoke_room'])
+    number.times do
+      if @cigar && Flags['new-cig']
+        Flags.reset('new-cig')
+        break unless DRCI.get_item_if_not_held?(@cigar, @bag)
+
+        light_tobacco(@cigar)
+        smoker = @cigar
+      elsif @pipe && Flags['new-cig']
+        Flags.reset('new-cig')
+        break unless load_pipe
+
+        smoker = @pipe
       end
+      smoke(images, smoker) until Flags['new-cig']
+      images = check_images(images) if @smoke_settings['clean_list_of_mastered']
     end
+    DRCI.put_away_item?(@pipe, @bag) if DRCI.in_hands?(@pipe)
+    DRC.message("Smoker Complete!")
+  end
+
+  def load_pipe
+    DRCI.get_item_if_not_held?(@pipe, @bag)
+    contents = DRC.bput("look in my #{@pipe}", /^In the .* you see some .*/, /^There is nothing in there/)
+    case contents
+    when /burning/
+      return true
+    when /There is nothing/
+      DRCI.get_item?('tobacco', @bag)
+      DRCI.put_away_item?('tobacco', @pipe)
+    end
+    light_tobacco("tobacco in pipe")
+  end
+
+  def quick_light(smoke)
+    case smoke
+    when /pipe/
+      load_pipe
+      exit
+    when /cigar/
+      exit unless DRCI.get_item_if_not_held?(smoke, @bag)
+      light_tobacco(smoke)
+      exit
+    end
+  end
+
+  def light_tobacco(target) # loaded pipe or cigar in hand, ends with either in hand, ready to rip
+    if DRStats.warrior_mage?
+      DRC.bput("prep c b t", /^You are now prepared/)
+      DRC.bput("gesture #{target}", /^You touch/, /^That's already burning/)
+    elsif @lighter
+      unless DRCI.get_item?(@lighter)
+        DRC.message("#{@lighter} appears to be awol, going to try flint and steel")
+        @lighter = false
+        return light_tobacco(target)
+      end
+      DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
+      DRCI.put_away_item?(@lighter, @bag)
+    else # flint
+      unless DRCI.get_item?("flint")
+        DRC.message("Missing flint, scoot to your local shop and pick some up, every adventurer should have flint and steel")
+        DRCI.put_away_item(DRC.right_hand, @bag)
+        exit
+      end
+      DRCI.lower_item?(target.split.last)
+      @equipmanager.get_item?(@blade)
+      DRC.bput("light #{target} with my flint", /^Roundtime/, /^That's already burning/)
+      DRCI.put_away_item?("flint", @bag)
+      @equipmanager.return_held_gear
+      DRCI.lift?
+    end
+  end
+
+  def exhale_smoke(image)
+    if /untrained/ =~ DRC.bput("exhale line #{image}", /^Roundtime/, /^You are untrained in the ways of making that image./)
+      fput 'exhale ring'
+    end
+  end
+
+  def inhale(image, smoker)
+    if /out of your lungs first/ =~ DRC.bput("inhale my #{smoker}", /^You take/, /out of your lungs first/)
+      exhale_smoke(image, true)
+      return inhale(image, smoker)
+    end
+  end
+
+  def smoke(images, smoker)
+    # pull a random image from our list of images
+    image = images.sample
+    inhale(image, smoker)
+    pause 1
+    exhale_smoke(image)
+    waitrt?
+    pause @time_between
+  end
+
+  def reset_known
+    # Resetting our known images to the master list
+    UserVars.smoke_images_known = @full_image_list
+    # and our mastered images to an empty list
+    UserVars.smoke_images_mastered = []
+    # Then cleaning out images we don't know, getting a list of images we've mastered
+    # and providing a list of images to train
+    DRC.message("New Training List: #{check_images(@full_image_list).join(' ')}")
+    exit
+  end
+
+  def check_images(images)
+    # Here we're returning IF the provided list of images is identical to our known image size, and the follow-on comparison suggests we've mastered everything we know.
+    return images if images.size == UserVars.smoke_images_known.size && UserVars.smoke_images_known.size == UserVars.smoke_images_mastered.size
+
+    smoke_list = []
+    fput 'smoke list'
+    loop do
+      line = get
+      break if line =~ /Total images known/ # last line after smoke list
+      break if line =~ /You don't know any smoke images/ # last line of empty smoke list
+      next if line.include?('IMAGE - SKILL') # topline that would normally match
+
+      smoke_list << line.scan(/\w+\s-\s\w+\*?/) # grabbing lines: "<image> - <mastery level>       <image> - <mastery level>        <image> - <mastery level>"
+    end
+    smoke_list.flatten!
+    # This draws off our array of known images, creating a new array of images found on our smoke list.
+    # effectively comparing the two, and removing images we don't know
+    # smoke_images_known, unless already defined, contains a list of all possible images, so this is important
+    images_you_know = UserVars.smoke_images_known.select { |image| smoke_list.any? { |image_and_mastery| image_and_mastery.include?(image) } }
+    # smoke_images_known, unless already defined, contains a list of all possible images, so this is important
+    UserVars.smoke_images_known = images_you_know
+    unless (images - images_you_know).empty? # skip if we haven't asked to smoke any images we don't know
+      DRC.message("Removing images you do not know: #{(images - images_you_know).join(' ')}") # prints out a string representing the difference between what images we know and what images we wanted to smoke
+      images -= (images - images_you_know) # creates an array of images we don't know, and removes them from our list of images we were hoping to smoke
+    end
+    # Here we might want to just smoke a curated list of images, regardless of whether we've mastered one or more
+    # TODO: support for non-halfling mastery? 
+    return images unless @smoke_settings['clean_list_of_mastered'] && DRStats.race == 'Halfling'
+
+    # Here we're using the originally generated list like a hash
+    images_mastered = smoke_list
+              .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered
+              .join(' ') # making a string of image names, dashes, and 'master*'
+              .split # creating a new array with all of those items as elements
+              .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
+              .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
+    DRC.message("Removing already mastered images: #{images_mastered.join(' ')}") unless images_mastered.empty? # images_mastered here means images from our variable 'images' that we sent this method
+    UserVars.smoke_images_mastered |= images_mastered # here we're adding any mastered images we found on our list of mastered to our uservar, but only if they're not already present.
+    images - UserVars.smoke_images_mastered # Finally, we return our original list minus any images we've mastered.
   end
 end
 
-Smoker.new
+before_dying do
+  Flags.delete('new-cig')
+end
+
+Smoke.new


### PR DESCRIPTION
Had some trouble using a lighter, then got a little creative.
1. simplified the yaml settings
2. option to just light your cigar/pipe to smoke manually
3. repeat arg allows you to smoke cigars or tobacco N times, practicing images (t2 integration)
4. first run loads a master list of images, then removes images you don't know, before setting a list of usables.
5. if you opt to clean your list of mastered (olvi only) it will run through your list of images randomly, smoking each until you've mastered them, then remove them from your list.
6. running reset_known will start you back to the full list, useful if you've learned a new smoke image and want it added to your routine.
7. You can pass it a single image, to use just that image
8. yaml setting smoke_images will set a defined list of images to practice (this is what you'd use for non-olvi image practice)

New Yaml Pattern:
```yaml
  smoke:
    container: smoking jacket
    pipe: glitvire pipe
    lighter: lava drake
    blade: serrated parazonium
    time_between_exhales: 3
    clean_list_of_mastered: true
    smoke_images:
    - deer
    - tart
```

Could do with some testing.

Working on adding smoke teach and smoke learn, to automate both sides of the process with ideal conditions.