### PR TITLE
[profile][base] Update note

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -830,7 +830,7 @@ crafting_container: backpack
 crafting_items_in_container:
 adjustable_tongs: false
 # If you have one, set this to the noun of the book eg book of master crafting instructions would be master_crafting_book: book
-master_crafting_book: false
+master_crafting_book:
 forging_tools:
 - diagonal-peen hammer
 - tong

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -829,6 +829,7 @@ crafting_container: backpack
 # list of items to only grab from crafting_container, aka - oil for forging
 crafting_items_in_container:
 adjustable_tongs: false
+# If you have one, set this to the noun of the book eg book of master crafting instructions would be master_crafting_book: book
 master_crafting_book: false
 forging_tools:
 - diagonal-peen hammer


### PR DESCRIPTION
Was brought up to me that missing a note, folks would set this to true, rather than the noun.  Hopefully this make it more explicit to match it's use:
```ruby
if settings.master_crafting_book
        DRC.bput("turn my #{settings.master_crafting_book} to discipline #{@book_type}", 'You turn the') if settings.master_crafting_book
        DRC.bput("turn my #{settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, settings.master_crafting_book)}", 'You turn your', 'The .* is already')
        DRC.bput("study my #{settings.master_crafting_book}", 'Roundtime')
```