### PR TITLE
[script][burgle] Burgle bag noun interaction

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -476,7 +476,7 @@ class Burgle
 
   # ripped out of steal.lic
   def put_item?(item)
-    case DRC.bput("put my #{item} in my #{@loot_container}", 'What were you', 'You put', "You can't do that", 'no matter how you arrange it', 'even after stuffing', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again', 'That\'s too heavy to go in there', "^Weirdly, you can't manage", "^There's no room")
+    case DRC.bput("put my #{item} in my #{@loot_container}", 'What were you', 'You put', "You can't do that", "You can't put that there", 'no matter how you arrange it', 'even after stuffing', 'The .* is *.* too \w+ to fit in', 'There isn\'t any more room', 'perhaps try doing that again', 'That\'s too heavy to go in there', "^Weirdly, you can't manage", "^There's no room")
     when 'perhaps try doing that again'
       return put_item?(item)
     when 'You put'


### PR DESCRIPTION
If you loot a thing with the same noun as your burgle loot bag, you're essentially trying to put it in itself, resulting in the message seen below:
```
[burgle]>search counter
You rummage around the long counter, until you find a lengthy sluagh-hide cylinder emblazoned with a small fleece orchid.  It looks valuable, so you decide to take it.
Roundtime: 8 sec.
>
Gained: Thievery(+8), Stealth(+9)
Footsteps nearby make you wonder if you're pushing your luck.
>
[burgle]>put my lengthy cylinder in my cylinder
You come out of hiding.
You can't put that there!
>
A scream shocks you, as the owner discovers you ransacking their home.  You flee, the owner's calls for help following you outside.
```

Handling in burgle for failed stow already exists, adding this match just adds it to the 'drop' routine.