### PR TITLE
[script][combat-trainer] New bound retrieval messaging

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3398,7 +3398,7 @@ class AttackProcess
     end
 
     retrieve_action = game_state.thrown_retrieve_verb
-    case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke")
+    case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke", "reuniting you with your lost belonging")
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work


### PR DESCRIPTION
Looks like they stealth edited the messaging to make room for the new bond retrieval messaging items. New:
```
A spiritwood and indurium military fork covered in spiraling demon gaze agates suddenly leaps toward you!  The fork slides to your right hand, reuniting you with your lost belonging.
```
likely have to test the others, see if we can find a common message, but this should be the new default messaging until said testing occurs.