### PR TITLE
[scripts][common] rename ironwood boxes into iron boxes

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -329,7 +329,11 @@ module DRC
   # Take a game formated list of boxes "a reinforced wooden strongbox and a plain ironwood crate"
   # And return an array ["wooden strongbox", "ironwood crate"]
   def box_list_to_adj_and_noun(list)
-    list.strip.split($box_regex).reject(&:empty?).select { |item| item =~ $box_regex }
+    list.strip
+        .split($box_regex)
+        .reject(&:empty?)
+        .select { |item| item =~ $box_regex }
+        .map { |box| box.gsub('ironwood', 'iron') } # make all ironwood into iron because "the parser"
   end
 
   def scroll_list_to_adj_and_noun(list)


### PR DESCRIPTION
Renames `ironwood` into `iron` for parser edification purposes.

If I have an `ironwood coffer` and an `iron coffer` in the same container, the order can change, and if I `get iron coffer` and take the `ironwood coffer` before the iron coffer, a subsequent attempt to get the `ironwood coffer` will then fail, and the `iron coffer` will remain behind. This very simply renamed `ironwood` to `iron` in box adjectives, and keeps life simple for the parser.

![image](https://user-images.githubusercontent.com/93822896/226227050-997de2d6-bfa2-459c-84a8-23a3a04d0f25.png)
