### PR TITLE
[script][common-items] common pyrotechnics

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -1240,7 +1240,7 @@ module DRCI
 
     DRCI.stow_item?('flint') if DRCI.in_hands?('flint')
     equipmanager.return_held_gear
-    DRCI.lift?(item.split.last, stow) # If we are successful, simply lifts the item. otherwise, stows it accordingly
+    DRCI.lift?(item, stow) # If we are successful, simply lifts the item. otherwise, stows it accordingly
     !stow # returns our result
   end
 

--- a/common-items.lic
+++ b/common-items.lic
@@ -382,6 +382,14 @@ module DRCI
     /^What is it you're trying to give/
   ]
 
+  @@light_success_patterns = [
+    /^You touch/,
+    /^That('s| is) already burning/,
+    /bursts into flames/,
+    /quickly catch fire/,
+    /^But .* is already lit/
+  ]
+
   #########################################
   # TRASH ITEM
   #########################################
@@ -1197,32 +1205,25 @@ module DRCI
   # fetched with EquipmentManager.new.item_by_desc(blade)
   # lighter is a hash from yaml setting:
   #   lighter_info:
-  #     name: lava drake
+  #     name: lava draked
   #     container: smoking jacket
   def light_item_on_fire?(item, blade, lighter, item_container = nil)
-    return false unless DRCI.get_item_if_not_held?(item)
-
     equipmanager = EquipmentManager.new
-    if DRStats.warrior_mage? && /prepared/ =~ DRC.bput("prep c b t", /^You are now prepared/)
-      DRC.bput("gesture #{item}", /^You touch/, /^That's already burning/, /bursts into flames/, /quickly catch fire/, /^But .* is already lit/)
+    if DRStats.warrior_mage? && /prepared/ =~ DRC.bput("prep c b t", /^You are now prepared/) && ready_set_light("gesture #{item}")
+      return true
+    elsif lighter['name'] && DRCI.get_item?(lighter['name'], lighter['container']) && ready_set_light("point my #{lighter['name']} at #{item}")
+      return DRCI.put_away_item?(lighter['name'], lighter['container'])
     elsif lighter['name']
-      unless DRCI.get_item?(lighter['name'], lighter['container'])
-        DRC.message("#{lighter['name']} appears to be awol, going to try flint and steel")
-        lighter['name'] = false
-        return light_item_on_fire(item, blade, lighter, item_container)
-      end
-      DRC.bput("point my #{lighter['name']} at my #{item}", /^That's already burning/, /bursts into flames/, /quickly catch fire/, /^But .* is already lit/)
-      DRCI.put_away_item?(lighter['name'], lighter['container'])
-    else # flint
-      return light_with_flint?(item, blade, equipmanager, item_container)
+      DRCI.put_away_item?(lighter['name'], lighter['container']) if DRCI.in_hands?(lighter['name'])
+      DRC.message("#{lighter['name']} appears to be awol or non-functional, going to try flint and steel")
     end
+    # Fall back to flint if the above fails
+    light_with_flint?(item, blade, equipmanager, item_container)
   end
 
   def light_with_flint?(item, blade, equipmanager, item_container = nil)
-    return false unless DRCI.get_item_if_not_held?(item)
-
     stow = item_container || true
-    DRCI.lower_item?(item)
+    DRCI.lower_item?(DRC.right_hand)
     if !DRCI.get_item?("flint")
       DRC.message("Missing flint, scoot to your local shop and pick some up!")
     elsif !equipmanager.get_item?(blade)
@@ -1231,7 +1232,7 @@ module DRCI
       else
         DRC.message("#{blade} needs to be defined in your gear setting in your yaml")
       end
-    elsif !DRC.bput("light #{item} with my flint", { 'timeout' => 5 }, /^That's already burning/, /^But .* is already lit/, /bursts into flames/, /quickly catch fire/)
+    elsif !ready_set_light("light #{item} with my flint")
       DRC.message("#{item} didn't light, reasons unknown, submit issue if you feel this is in error")
     else
       stow = false
@@ -1239,7 +1240,11 @@ module DRCI
 
     DRCI.stow_item?('flint') if DRCI.in_hands?('flint')
     equipmanager.return_held_gear
-    DRCI.lift?(item, stow) # If we are successful, simply lifts the item. otherwise, stows it accordingly
+    DRCI.lift?(item.split.last, stow) # If we are successful, simply lifts the item. otherwise, stows it accordingly
     !stow # returns our result
+  end
+
+  def ready_set_light(command)
+    Regexp.new(@@light_success_patterns.join('|')) =~ DRC.bput(command, { 'timeout' => 5, 'suppress_no_match' => true }, @@light_success_patterns)
   end
 end

--- a/common-items.lic
+++ b/common-items.lic
@@ -1245,6 +1245,6 @@ module DRCI
   end
 
   def ready_set_light(command)
-    Regexp.new(LIGHT_SUCCESS_PATTERNS.join('|')) =~ DRC.bput(command, { 'timeout' => 5, 'suppress_no_match' => true }, @@light_success_patterns)
+    Regexp.new(LIGHT_SUCCESS_PATTERNS.join('|')) =~ DRC.bput(command, { 'timeout' => 5, 'suppress_no_match' => true }, LIGHT_SUCCESS_PATTERNS)
   end
 end

--- a/common-items.lic
+++ b/common-items.lic
@@ -382,7 +382,7 @@ module DRCI
     /^What is it you're trying to give/
   ]
 
-  @@light_success_patterns = [
+  LIGHT_SUCCESS_PATTERNS = [
     /^You touch/,
     /^That('s| is) already burning/,
     /bursts into flames/,
@@ -1245,6 +1245,6 @@ module DRCI
   end
 
   def ready_set_light(command)
-    Regexp.new(@@light_success_patterns.join('|')) =~ DRC.bput(command, { 'timeout' => 5, 'suppress_no_match' => true }, @@light_success_patterns)
+    Regexp.new(LIGHT_SUCCESS_PATTERNS.join('|')) =~ DRC.bput(command, { 'timeout' => 5, 'suppress_no_match' => true }, @@light_success_patterns)
   end
 end

--- a/common-items.lic
+++ b/common-items.lic
@@ -1245,6 +1245,6 @@ module DRCI
   end
 
   def ready_set_light(command)
-    Regexp.new(LIGHT_SUCCESS_PATTERNS.join('|')) =~ DRC.bput(command, { 'timeout' => 5, 'suppress_no_match' => true }, LIGHT_SUCCESS_PATTERNS)
+    Regexp.union(LIGHT_SUCCESS_PATTERNS) =~ DRC.bput(command, { 'timeout' => 5, 'suppress_no_match' => true }, LIGHT_SUCCESS_PATTERNS)
   end
 end

--- a/common-items.lic
+++ b/common-items.lic
@@ -1217,7 +1217,7 @@ module DRCI
       DRCI.put_away_item?(lighter['name'], lighter['container']) if DRCI.in_hands?(lighter['name'])
       DRC.message("#{lighter['name']} appears to be awol or non-functional, going to try flint and steel")
     end
-    # Fall back to flint if the above fails
+
     light_with_flint?(item, blade, equipmanager, item_container)
   end
 

--- a/common-items.lic
+++ b/common-items.lic
@@ -1198,7 +1198,7 @@ module DRCI
   # LIGHTERS AND LIGHTING THINGS ON FIRE
   #########################################
 
-  # Method must be run with clean hands
+  # Method must be run with item in hand.
   # Method ends with clean hands, or lit item in your right hand.
   # Any script calling this method needs to call script 'equipmanager' to load it's methods and your settings
   # blade arg is the EquipmentManager formatted version of a weapon, as defined in gear

--- a/common-items.lic
+++ b/common-items.lic
@@ -1185,4 +1185,61 @@ module DRCI
       fill_gem_pouch_with_container(gem_pouch_adjective, gem_pouch_noun, source_container, full_pouch_container, spare_gem_pouch_container, should_tie_gem_pouches)
     end
   end
+
+  #########################################
+  # LIGHTERS AND LIGHTING THINGS ON FIRE
+  #########################################
+
+  # Method must be run with clean hands
+  # Method ends with clean hands, or lit item in your right hand.
+  # Any script calling this method needs to call script 'equipmanager' to load it's methods and your settings
+  # blade arg is the EquipmentManager formatted version of a weapon, as defined in gear
+  # fetched with EquipmentManager.new.item_by_desc(blade)
+  # lighter is a hash from yaml setting:
+  #   lighter_info:
+  #     name: lava drake
+  #     container: smoking jacket
+  def light_item_on_fire?(item, blade, lighter, item_container = nil)
+    return false unless DRCI.get_item_if_not_held?(item)
+
+    equipmanager = EquipmentManager.new
+    if DRStats.warrior_mage? && /prepared/ =~ DRC.bput("prep c b t", /^You are now prepared/)
+      DRC.bput("gesture #{item}", /^You touch/, /^That's already burning/, /bursts into flames/, /quickly catch fire/, /^But .* is already lit/)
+    elsif lighter['name']
+      unless DRCI.get_item?(lighter['name'], lighter['container'])
+        DRC.message("#{lighter['name']} appears to be awol, going to try flint and steel")
+        lighter['name'] = false
+        return light_item_on_fire(item, blade, lighter, item_container)
+      end
+      DRC.bput("point my #{lighter['name']} at my #{item}", /^That's already burning/, /bursts into flames/, /quickly catch fire/, /^But .* is already lit/)
+      DRCI.put_away_item?(lighter['name'], lighter['container'])
+    else # flint
+      return light_with_flint?(item, blade, equipmanager, item_container)
+    end
+  end
+
+  def light_with_flint?(item, blade, equipmanager, item_container = nil)
+    return false unless DRCI.get_item_if_not_held?(item)
+
+    stow = item_container || true
+    DRCI.lower_item?(item)
+    if !DRCI.get_item?("flint")
+      DRC.message("Missing flint, scoot to your local shop and pick some up!")
+    elsif !equipmanager.get_item?(blade)
+      if blade.name
+        DRC.message("Missing #{blade.name}, find it.")
+      else
+        DRC.message("#{blade} needs to be defined in your gear setting in your yaml")
+      end
+    elsif !DRC.bput("light #{item} with my flint", { 'timeout' => 5 }, /^That's already burning/, /^But .* is already lit/, /bursts into flames/, /quickly catch fire/)
+      DRC.message("#{item} didn't light, reasons unknown, submit issue if you feel this is in error")
+    else
+      stow = false
+    end
+
+    DRCI.stow_item?('flint') if DRCI.in_hands?('flint')
+    equipmanager.return_held_gear
+    DRCI.lift?(item, stow) # If we are successful, simply lifts the item. otherwise, stows it accordingly
+    !stow # returns our result
+  end
 end

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -599,6 +599,14 @@ firstaid_scholarship_modifier:
   specific_descriptions:
     first-aid: Adjusting the modifier to a smaller number would select higher ranked charts where a larger number would select lower ranked charts based on Elanthipedia Anatomy Chart data.
 
+flint_lighter:
+  description: Weapon or blade to use with flint to light objects on fire
+  example: steel cutlass
+  referenced_by:
+    - combat-trainer
+    - theurgy
+    - smoke
+
 flying_mount:
   description: Specify a flying mount.
   example: silk carpet
@@ -787,6 +795,17 @@ instrument:
     - first-aid
   specific_descriptions:
     first-aid: Used just as a Zills check. If you have this specified, first-aid won't try to pause playing.
+
+lighter_info:
+  description: adjective and noun of your special lighter for lighting fires
+  example: (see specific_descriptions below)
+  referenced_by:
+    - combat-trainer
+    - theurgy
+    - smoke
+  specific_descriptions:
+    name: lava drake
+    container: smoking jacket
 
 lootables:
   description: List of lootable items in base-items.yaml. Do not change. You can add lootables via loot_additions.

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -722,8 +722,12 @@ crossing_training:
 use_research: false
 research_skills:
 water_holder:
-# a metal weapon to light flint with, lighters dont work
+# a metal weapon to use with flint to light objects on fire
 flint_lighter:
+# lighter definition to use special lighter instead of flint and steel
+lighter_info:
+  name:
+  container:
 scouting_buffs:
 crossing_training_stationary_skills_only: false
 outdoor_room: 793


### PR DESCRIPTION
common method to empower your inner pyromaniac
1. If warmie, uses burning touch
2. if you have a lighter, and it's properly defined, use that
3. Otherwise, grabs flint and steel and lights your item with that

Lighter yaml setting:
```yaml
lighter_info:
  name: lava drake
  container: smoking jacket
```

Calling script needs to initialize equipmanager script, and pass appropriately formatted item information for the blade via:
```ruby
EquipmentManager.new.item_by_desc(blade)
```

IF successful, ends the method with the lit item in your right hand and a 'true' response. IF unsuccessful, stows your goodies ( or attempts to) and returns false.

Flint method can be called separately, but need to pass it an initialized equipmanager arg to handle weapon.