### PR TITLE
[script][combat-trainer] Custom invoke message matching

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3398,7 +3398,8 @@ class AttackProcess
     end
 
     retrieve_action = game_state.thrown_retrieve_verb
-    case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke", "reuniting you with your lost belonging")
+    case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke", "reuniting you with your lost belonging",
+                  /In its place, you are left with your .*./, /returning .* to your/, /depositing .* back to the rightful owner/, /Your .* appears within reach/, /you are reunited with your/, /A tiny ripplegate gurgles into being near your/)
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3403,7 +3403,8 @@ class AttackProcess
       /In its place, you are left with your/,
       /returning .* to your/,
       /depositing .* back to the rightful owner/,
-      /Your .* appears within reach/, /you are reunited with your/,
+      /Your .* appears within reach/,
+      /you are reunited with your/,
       /A tiny ripplegate gurgles into being near your/
     ]
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3400,7 +3400,7 @@ class AttackProcess
     retrieve_action = game_state.thrown_retrieve_verb
     bonded_invoke_success = [
       /reuniting you with your lost belonging/, # new standard invoke bond
-      /In its place, you are left with your .*./, # new custom invokes
+      /In its place, you are left with your/, # new custom invokes
       /returning .* to your/, # new custom invokes
       /depositing .* back to the rightful owner/, # new custom invokes
       /Your .* appears within reach/, /you are reunited with your/, # new custom invokes

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3399,14 +3399,14 @@ class AttackProcess
 
     retrieve_action = game_state.thrown_retrieve_verb
     bonded_invoke_success = [
-                  /reuniting you with your lost belonging/, # new standard invoke bond
-                  /In its place, you are left with your .*./, # new custom invokes
-                  /returning .* to your/, # new custom invokes
-                  /depositing .* back to the rightful owner/, # new custom invokes
-                  /Your .* appears within reach/, /you are reunited with your/, # new custom invokes
-                  /A tiny ripplegate gurgles into being near your/
+      /reuniting you with your lost belonging/, # new standard invoke bond
+      /In its place, you are left with your .*./, # new custom invokes
+      /returning .* to your/, # new custom invokes
+      /depositing .* back to the rightful owner/, # new custom invokes
+      /Your .* appears within reach/, /you are reunited with your/, # new custom invokes
+      /A tiny ripplegate gurgles into being near your/
     ]
-    
+
     case DRC.bput(retrieve_action,
                   /^You are already holding/,
                   /^You pick up/,

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3398,12 +3398,12 @@ class AttackProcess
     end
 
     retrieve_action = game_state.thrown_retrieve_verb
-    bonded_invoke_success = [
-      /reuniting you with your lost belonging/, # new standard invoke bond
-      /In its place, you are left with your/, # new custom invokes
-      /returning .* to your/, # new custom invokes
-      /depositing .* back to the rightful owner/, # new custom invokes
-      /Your .* appears within reach/, /you are reunited with your/, # new custom invokes
+    bonded_invoke_success = [ # standard and custom invoke messages
+      /reuniting you with your lost belonging/,
+      /In its place, you are left with your/,
+      /returning .* to your/,
+      /depositing .* back to the rightful owner/,
+      /Your .* appears within reach/, /you are reunited with your/,
       /A tiny ripplegate gurgles into being near your/
     ]
 
@@ -3411,15 +3411,14 @@ class AttackProcess
                   /^You are already holding/,
                   /^You pick up/,
                   /^You get/,
-                  /^You catch/, # old invoke bond message
                   /^What were you/,
                   /^You don't have any bonds to invoke/,
-                  bonded_invoke_success) # new custom invokes
+                  bonded_invoke_success)
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work
       DRC.bput("get #{game_state.weapon_name}", 'You pick up', 'You get')
-    when 'You catch', *bonded_invoke_success
+    when *bonded_invoke_success
       DRC.bput('swap', 'You move', 'You have nothing') if game_state.offhand?
     end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3414,7 +3414,7 @@ class AttackProcess
                   /^You get/,
                   /^What were you/,
                   /^You don't have any bonds to invoke/,
-                  bonded_invoke_success)
+                  *bonded_invoke_success)
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3398,8 +3398,19 @@ class AttackProcess
     end
 
     retrieve_action = game_state.thrown_retrieve_verb
-    case DRC.bput(retrieve_action, 'You are already holding', 'You pick up', 'You get', 'You catch', 'What were you', "You don't have any bonds to invoke", "reuniting you with your lost belonging",
-                  /In its place, you are left with your .*./, /returning .* to your/, /depositing .* back to the rightful owner/, /Your .* appears within reach/, /you are reunited with your/, /A tiny ripplegate gurgles into being near your/)
+    case DRC.bput(retrieve_action,
+                  /^You are already holding/,
+                  /^You pick up/,
+                  /^You get/,
+                  /^You catch/, # old invoke bond message
+                  /^What were you/,
+                  /^You don't have any bonds to invoke/,
+                  /reuniting you with your lost belonging/, # new standard invoke bond
+                  /In its place, you are left with your .*./, # new custom invokes
+                  /returning .* to your/, # new custom invokes
+                  /depositing .* back to the rightful owner/, # new custom invokes
+                  /Your .* appears within reach/, /you are reunited with your/, # new custom invokes
+                  /A tiny ripplegate gurgles into being near your/) # new custom invokes
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3398,6 +3398,15 @@ class AttackProcess
     end
 
     retrieve_action = game_state.thrown_retrieve_verb
+    bonded_invoke_success = [
+                  /reuniting you with your lost belonging/, # new standard invoke bond
+                  /In its place, you are left with your .*./, # new custom invokes
+                  /returning .* to your/, # new custom invokes
+                  /depositing .* back to the rightful owner/, # new custom invokes
+                  /Your .* appears within reach/, /you are reunited with your/, # new custom invokes
+                  /A tiny ripplegate gurgles into being near your/
+    ]
+    
     case DRC.bput(retrieve_action,
                   /^You are already holding/,
                   /^You pick up/,
@@ -3405,17 +3414,12 @@ class AttackProcess
                   /^You catch/, # old invoke bond message
                   /^What were you/,
                   /^You don't have any bonds to invoke/,
-                  /reuniting you with your lost belonging/, # new standard invoke bond
-                  /In its place, you are left with your .*./, # new custom invokes
-                  /returning .* to your/, # new custom invokes
-                  /depositing .* back to the rightful owner/, # new custom invokes
-                  /Your .* appears within reach/, /you are reunited with your/, # new custom invokes
-                  /A tiny ripplegate gurgles into being near your/) # new custom invokes
+                  bonded_invoke_success) # new custom invokes
     when 'What were you'
       # Workaround for a game bug when you lob an unblessed weapon at a noncorporeal mob
       # The weapon lands on the ground, not in the 'at feet' slot, and 'my' will not work
       DRC.bput("get #{game_state.weapon_name}", 'You pick up', 'You get')
-    when 'You catch'
+    when 'You catch', *bonded_invoke_success
       DRC.bput('swap', 'You move', 'You have nothing') if game_state.offhand?
     end
 


### PR DESCRIPTION
The new custom bond invokes have unique messaging for the retrieval. This will be an  issue if/when they allow truly custom messaging, but for now, this matches all 8 released at droughtmans.