### PR TITLE
[script][common-items] get/stow for clean-leather

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -70,7 +70,8 @@ module DRCI
     /^You deftly remove/,
     /^You are already holding/,
     /^You fade in for a moment as you/,
-    /^You carefully lift/
+    /^You carefully lift/,
+    /^You carefully remove .* from the bundle/
   ]
 
   @@get_item_failure_patterns = [
@@ -204,7 +205,8 @@ module DRCI
     # The following are success messages for putting an item in a container OFF your person.
     /^You drop/i,
     /^You set/i,
-    /^You put/i
+    /^You put/i,
+    /^You carefully fit .* into your bundle/
   ]
 
   @@put_away_item_failure_patterns = [


### PR DESCRIPTION
Special messaging for get_item and put_away_item to and from bundle to mesh with clean-leather's use of common methods #6611 .

Since most folks will be utilizing a pair of bundles for ease of storage, these matches are necessary for that to work properly:
```
[clean-leather]>put my hide in my bundle
You carefully fit a curing bull hide into your bundle.
>
[clean-leather]>get my bull hide from my second.bundle
You carefully remove a storm bull hide from the bundle.
```