### PR TITLE
[scripts][combat-trainer] Remove unusable skills from skinning/dissect list

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -859,6 +859,8 @@ class LootProcess
         break
       when 'cannot be skinned'
         game_state.unskinnable(mob_noun)
+        @dissect_cycle_skills.delete("Skinning")
+        @skin = false
         break
       when 'That creature cannot'
         arranges = 0
@@ -933,6 +935,9 @@ class LootProcess
       return false
     when 'While likely a fascinating study', "That'd be a waste of time.", 'You do not yet possess the knowledge'
       game_state.undissectable(mob_noun)
+      @dissect_cycle_skills.delete("First Aid")
+      @dissect_cycle_skills.delete("Thanatology") if @dissect_for_thanatology
+      @dissect = false
       return false
     when 'would probably object', "should be left alone."
       dissected?('', game_state)
@@ -971,6 +976,8 @@ class LootProcess
       return
     when 'cannot be skinned', 'carrying far too many items'
       game_state.unskinnable(mob_noun)
+      @dissect_cycle_skills.delete("Skinning")
+      @skin = false
       return
     end
     pause 1


### PR DESCRIPTION
As per title. 

Prior to this, even if a mob wasn't skinnable, if we had skinning as the priority between skinning and dissecting, it'd try to skin anyway.