### PR TITLE
[scripts][combat-trainer] Don't try to skin unskinnable mob

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -879,7 +879,11 @@ class LootProcess
         already_arranged = true
       end
 
-      skill_to_train = game_state.sort_by_rate_then_rank(@dissect_cycle_skills, @dissect_priority).first
+      if game_state.skinnable?(mob_noun)
+        skill_to_train = game_state.sort_by_rate_then_rank(@dissect_cycle_skills, @dissect_priority).first
+      else
+        skill_to_train = 'First Aid'
+      end
 
       if skill_to_train == 'First Aid' || skill_to_train == 'Thanatology'
         unless dissected?(mob_noun, game_state)


### PR DESCRIPTION
If a user had set `dissect_priority: Skinning` under certain conditions CT would keep on trying to skin an unskinnable mob until Skinning was ahead of FA, which would never happen...