### PR TITLE
[script][combat-trainer] Enable whirlwind with additional weapons

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3339,10 +3339,10 @@ class AttackProcess
 
       game_state.sheath_offhand_weapon(skill) if offhand_weapon_name
     end
-
-    # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
+    # If maneuver was successful, register an action taken and return
     return game_state.action_taken if maneuver_success
 
+    # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
     verb = game_state.melee_attack_verb
     command = game_state.offhand? ? "#{verb} left" : verb
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3340,24 +3340,23 @@ class AttackProcess
       game_state.sheath_offhand_weapon(skill) if offhand_weapon_name
     end
 
-    verb = game_state.melee_attack_verb
+    # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
+    return game_state.action_taken if maneuver_success
 
+    verb = game_state.melee_attack_verb
     command = game_state.offhand? ? "#{verb} left" : verb
 
-    # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
-    unless maneuver_success
-      if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush? || game_state.ambush_stun_training?
-        DRC.hide?(@hide_type)
-      end
+    if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush? || game_state.ambush_stun_training?
+      DRC.hide?(@hide_type)
+    end
 
-      if (game_state.backstab? || game_state.ambush? || game_state.ambush_stun_training?) && hiding?
-        if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
-          command += " #{@ambush_location}"
-        elsif (game_state.ambush_stun_training?)
-          command = command.sub(verb, 'ambush stun')
-        else
-          command = command.sub(verb, 'backstab')
-        end
+    if (game_state.backstab? || game_state.ambush? || game_state.ambush_stun_training?) && hiding?
+      if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
+        command += " #{@ambush_location}"
+      elsif (game_state.ambush_stun_training?)
+        command = command.sub(verb, 'ambush stun')
+      else
+        command = command.sub(verb, 'backstab')
       end
     end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4085,7 +4085,7 @@ class GameState
     @left_hand_free = settings.left_hand_free
     echo("  @left_hand_free: #{@left_hand_free}") if $debug_mode_ct
 
-    $twohanded_skills = $twohanded_skills | settings.twohanded_weapon_skills
+    $twohanded_skills |= settings.twohanded_weapon_skills
     echo("  $twohanded_skills: #{$twohanded_skills}") if $debug_mode_ct
 
     @dynamic_dance_skill = settings.dynamic_dance_skill

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3378,7 +3378,7 @@ class AttackProcess
     when /You must free up your left hand first/
       $twohanded_skills << game_state.weapon_skill
       game_state.sheath_whirlwind_offhand
-    when /You need two hands/      
+    when /You need two hands/
       fput('stow left') if DRC.left_hand && DRC.left_hand !~ /\b#{game_state.weapon_name}/i
       fput('stow right') if DRC.right_hand && DRC.right_hand !~ /\b#{game_state.weapon_name}/i
     else

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3340,15 +3340,15 @@ class AttackProcess
       game_state.sheath_offhand_weapon(skill) if offhand_weapon_name
     end
 
+    verb = game_state.melee_attack_verb
+
+    command = game_state.offhand? ? "#{verb} left" : verb
+
     # If we didn't try a maneuver, or we did but it wasn't successful, then fallback to normal attack.
     unless maneuver_success
       if game_state.backstab? || game_state.use_stealth_attack? || game_state.ambush? || game_state.ambush_stun_training?
         DRC.hide?(@hide_type)
       end
-
-      verb = game_state.melee_attack_verb
-
-      command = game_state.offhand? ? "#{verb} left" : verb
 
       if (game_state.backstab? || game_state.ambush? || game_state.ambush_stun_training?) && hiding?
         if (game_state.backstab? && game_state.no_stab_current_mob) || (game_state.ambush? && !game_state.backstab?)
@@ -3359,37 +3359,31 @@ class AttackProcess
           command = command.sub(verb, 'backstab')
         end
       end
-
-      DRC.bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
-    pause
-    waitrt?
-
-    if reget(5, 'flying too high for you to attack')
+    case DRC.bput(command, /^Wouldn't it be better if you used a melee weapon?/, /^You must free up your left hand first/, /^You turn to face/, /^Face What?/, /Roundtime/, /^You aren't close enough to attack/, /^It would help if you were closer/, /^There is nothing else to face!/, /^You must be hidden/, /flying too high for you to attack/, /^You can't coldcock/, /while it is flying/, /Novel idea, but it's a ghost!/, /Bumbling, you slip/, /^You can not slam with that/, /^You must be hidden or invisible to ambush/, /^You don't have enough focus/, /^You don't think you have enough focus/, /is already out cold/)
+    when /flying too high for you to attack/, /while it is flying/
       case DRC.bput('face next', 'There is nothing', 'You turn to face', 'Face what')
-      when 'There is nothing'
+      when /There is nothing/
         pause 5
       end
-    end
-
-    if reget(5, 'You can\'t backstab that')
+    when /You can't backstab that/
       if game_state.npcs.uniq.length == 1
         game_state.unstabbable(game_state.npcs.first)
       else
         game_state.no_stab_current_mob = true
       end
-    end
-
-    if reget(5, 'You aren\'t close enough to attack', 'It would help if you were closer')
+    when /You aren't close enough to attack/, /It would help if you were closer/
       game_state.engage
+    when /You must free up your left hand first/
+      $twohanded_skills << game_state.weapon_skill
+      game_state.sheath_whirlwind_offhand
+    when /You need two hands/      
+      fput('stow left') if DRC.left_hand && DRC.left_hand !~ /\b#{game_state.weapon_name}/i
+      fput('stow right') if DRC.right_hand && DRC.right_hand !~ /\b#{game_state.weapon_name}/i
     else
       game_state.action_taken
     end
-    return unless reget(5, 'You need two hands')
-
-    fput('stow left') if DRC.left_hand && DRC.left_hand !~ /\b#{game_state.weapon_name}/i
-    fput('stow right') if DRC.right_hand && DRC.right_hand !~ /\b#{game_state.weapon_name}/i
   end
 
   def attack_thrown(game_state)
@@ -3814,6 +3808,9 @@ class AttackProcess
       # We optimistically assumed 45 seconds. If that wasn't enough then
       # we'll wait another 15 seconds and retry.
       game_state.cooldown_timers[action] += 15
+      return false
+    when /You must free up your left hand first/
+      $twohanded_skills << game_state.weapon_skill
       return false
     when *maneuver_failure_messages
       return false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4085,6 +4085,9 @@ class GameState
     @left_hand_free = settings.left_hand_free
     echo("  @left_hand_free: #{@left_hand_free}") if $debug_mode_ct
 
+    $twohanded_skills = $twohanded_skills | settings.twohanded_weapon_skills
+    echo("  $twohanded_skills: #{$twohanded_skills}") if $debug_mode_ct
+
     @dynamic_dance_skill = settings.dynamic_dance_skill
     echo("  @dynamic_dance_skill: #{@dynamic_dance_skill}") if $debug_mode_ct
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -333,6 +333,10 @@ zombie:
   behavior: defensive
 # a hash of weapon skills and the weapons used to train them. They must be defined in gear
 weapon_training:
+# Array of weapons to be treated as twohanded weapons eg staves, polearms
+twohanded_weapon_skills:
+- Twohanded Edged
+- Twohanded Blunt
 # Tells Ct to ignore mindstates, allowing one to farm whilst mindlocked, or with capped weapons
 combat_trainer_ignore_weapon_mindstate: false
 # how many mindstates to use a weapon for


### PR DESCRIPTION
Current CT on a barb, you're limited to one-handed staves and polearms for whirlwind. When you attempt to whirlwind with a twohander, you get a message saying you need to free up your left hand. What this change does is capture that, and add your current weapon skill to the list of twohanded weapon skills for the remainder of the hunt.

In particular with barbarians and maneuvers, CT wields a weapon from your whirlwind list in the offhand, as you can get an extra attack with your offhand on most maneuvers. However, if you're trying to maneuver with a twohander, you'll get the same message about freeing up your offhand, so we'll catch that and add the current weapon to our twohanded skills list. 

The obvious alternative would be a separate setting, with a list of weapon skills that are two-handed:
```yaml
twohanded_weapon_skills:
- Twohanded Edged
- Twohanded Blunt
- Staves
- Polearms
```
Actually, think I'll add this.