### PR TITLE
[scripts][hunting-buddy]Add buddy priority and avoidance

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -2,9 +2,10 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#hunting-buddy
 =end
 
-custom_require.call(%w[common common-arcana common-items common-travel drinfomon equipmanager events spellmonitor])
+custom_require.call(%w[common common-arcana common-items common-travel equipmanager events spellmonitor])
 
 class HuntingBuddy
+
   def initialize
     arg_definitions = [[]]
     args = parse_args(arg_definitions, true)
@@ -29,11 +30,11 @@ class HuntingBuddy
     echo("  @stop_on_high_threshold: #{@stop_on_high_threshold}") if $debug_mode_hunting
 
     @skillset_exp_thresholds = {
-      'Armor'    => @settings.armor_exp_training_max_threshold,
-      'Weapon'   => @settings.weapon_exp_training_max_threshold,
-      'Magic'    => @settings.magic_exp_training_max_threshold,
+      'Armor' => @settings.armor_exp_training_max_threshold,
+      'Weapon' => @settings.weapon_exp_training_max_threshold,
+      'Magic' => @settings.magic_exp_training_max_threshold,
       'Survival' => @settings.survival_exp_training_max_threshold,
-      'Lore'     => @settings.lore_exp_training_max_threshold
+      'Lore' => @settings.lore_exp_training_max_threshold
     }
     echo("  @skillset_exp_thresholds: #{@skillset_exp_thresholds}") if $debug_mode_hunting
 
@@ -76,6 +77,7 @@ class HuntingBuddy
     DRC.wait_for_script_to_complete('restock') unless @settings.sell_loot_skip_bank
 
     @hunting_info.each_with_index do |info, index|
+
       args = info['args'] # list of args to pass to combat-trainer
       before_actions = info['before'] # list of script names
       after_actions = info['after'] # list of script names
@@ -89,6 +91,8 @@ class HuntingBuddy
       stop_on_burgle_cooldown = info['stop_on_burgle_cooldown'] # boolean
       hunting_zones = [info[:zone]].flatten.compact # string or list of hunting zones
       waiting_room = info['full_waiting_room'] || @settings.safe_room # room id
+      prefer_buddies = info['prefer_buddies'] # boolean
+      avoid_buddies = info['avoid_buddies'] # boolean
 
       if $debug_mode_hunting
         echo("Processing hunting info number #{index + 1}")
@@ -105,6 +109,8 @@ class HuntingBuddy
         echo("  stop_on_burgle_cooldown: #{stop_on_burgle_cooldown}")
         echo("  hunting_zones: #{hunting_zones}")
         echo("  waiting_room: #{waiting_room}")
+        echo("  prefer_buddies: #{prefer_buddies}")
+        echo("  avoid_buddies: #{avoid_buddies}")
       end
 
       if @stop_hunting
@@ -168,7 +174,7 @@ class HuntingBuddy
       # that next hunt wants to be. These checks help reduce moving
       # around if it's be fine for us to start the next hunt in same spot.
       if index == 0 || !hunting_zones.include?(current_hunting_zone)
-        next unless find_hunting_room?(hunting_zones, waiting_room)
+        next unless find_hunting_room?(hunting_zones, waiting_room, prefer_buddies, avoid_buddies)
       end
 
       if @stopped_for_bleeding
@@ -273,7 +279,7 @@ class HuntingBuddy
     @hunting_zones.find { |_name, rooms| rooms.include?(room_id) }.first
   end
 
-  def find_hunting_room?(zones_to_search, waiting_room)
+  def find_hunting_room?(zones_to_search, waiting_room, prefer_buddies = false, avoid_buddies = false)
     UserVars.friends = @settings.hunting_buddies || []
     UserVars.hunting_nemesis = @settings.hunting_nemesis || []
 
@@ -316,59 +322,62 @@ class HuntingBuddy
         end
 
         return DRCT.find_empty_room(rooms_to_search, waiting_room,
-                                    lambda do |_search_attempt|
-                                      # Skip room if has more people than your max limit
-                                      return false if DRRoom.pcs.size > @hunting_buddies_max
-                                      # Skip if one of your nemesis is in the room
-                                      return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
-                                      # Continue if one of your friends is in the room
-                                      return true if (DRRoom.pcs & UserVars.friends).any?
-                                      # Skip if anyone not in your group is in the room
-                                      return false if (DRRoom.pcs - DRRoom.group_members).any?
-
-                                      # No visible friends in the room and no visible people
-                                      UserVars.friends.each { |friend| Flags.add("hunting-buddy-room-check-#{friend}", friend) }
-                                      Flags.add('hunting-buddy-room-check',
-                                                # someone speaks
-                                                /says?, /,
-                                                /You hear/,
-                                                # someone attacks from the shadows
-                                                /Someone snipes a/,
-                                                /leaps from hiding and ambushes/,
-                                                # someone is already hunting here
-                                                /[A-Z][a-z]+ begins to advance/,
-                                                /[A-Z][a-z]+ (jabs|slices|draws|chops|sweeps|lunges|thrusts|claws|gouges|elbows|kicks|punches|knees|shoves|lobs|throws|hurls|fires|shoots|feints) (a|an|some|his|her|their)/)
-                                      case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
-                                      when /roundtime/i
-                                        data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
-                                        if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
-                                          pause
-                                          waitrt?
-                                          return UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
-                                        end
-                                        fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
-                                        room_is_empty = true
-                                        20.times do |_|
-                                          pause 0.5
-                                          return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
-                                          return false if Flags['hunting-buddy-room-check']
-
-                                          room_is_empty = (DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
-                                        end
-                                        room_is_empty
-                                      when /You're not in any condition to be searching around/i
-                                        DRC.message("***STATUS*** You're too injured to hunt!")
-                                        @stop_hunting = true
-                                        @stopped_for_bleeding = bleeding?
-                                        # Ironically, return true so the search for a suitable hunting room
-                                        # stops and then the hunting buddy loop will detect that you need help
-                                        # sooner rather than later.
-                                        true
-                                      end
-                                    end,
-                                    @settings.hunting_room_min_mana,
-                                    @settings.hunting_room_strict_mana,
-                                    @settings.hunting_room_max_searches)
+          lambda do |search_attempt|
+            # Skip room if has more people than your max limit
+            return false if DRRoom.pcs.size > @hunting_buddies_max
+            # Skip if one of your nemesis is in the room
+            return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
+            unless avoid_buddies
+              # Continue if one of your friends is in the room
+              return true if (DRRoom.pcs & UserVars.friends).any?
+            end
+            # Skip if anyone not in your group is in the room
+            return false if (DRRoom.pcs - DRRoom.group_members).any?
+            # No visible friends in the room and no visible people
+            UserVars.friends.each { |friend| Flags.add("hunting-buddy-room-check-#{friend}", friend) }
+            Flags.add('hunting-buddy-room-check',
+              # someone speaks
+              /says?, /,
+              /You hear/,
+              # someone attacks from the shadows
+              /Someone snipes a/,
+              /leaps from hiding and ambushes/,
+              # someone is already hunting here
+              /[A-Z][a-z]+ begins to advance/,
+              /[A-Z][a-z]+ (jabs|slices|draws|chops|sweeps|lunges|thrusts|claws|gouges|elbows|kicks|punches|knees|shoves|lobs|throws|hurls|fires|shoots|feints) (a|an|some|his|her|their)/
+            )
+            case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
+            when /roundtime/i
+              data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
+              if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
+                pause
+                waitrt?
+                return UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
+              end
+              fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
+              room_is_empty = true
+              20.times do |_|
+                pause 0.5
+                return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
+                return false if Flags['hunting-buddy-room-check']
+                room_is_empty = (DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+              end
+              room_is_empty
+            when /You're not in any condition to be searching around/i
+              DRC.message("***STATUS*** You're too injured to hunt!")
+              @stop_hunting = true
+              @stopped_for_bleeding = bleeding?
+              # Ironically, return true so the search for a suitable hunting room
+              # stops and then the hunting buddy loop will detect that you need help
+              # sooner rather than later.
+              true
+            end
+          end,
+          @settings.hunting_room_min_mana,
+          @settings.hunting_room_strict_mana,
+          @settings.hunting_room_max_searches,
+          prefer_buddies
+        )
       end
     end
   end
@@ -421,7 +430,7 @@ class HuntingBuddy
 
   # What is the learning rate high threshold at which point we should stop hunting?
   def get_skillset_exp_high_threshold(skillset)
-    @skillset_exp_thresholds[skillset] || @stop_on_high_threshold
+    @stop_on_high_threshold || @skillset_exp_thresholds[skillset]
   end
 
   # ------------------------------------------------------------
@@ -432,7 +441,7 @@ class HuntingBuddy
   end
 
   # What is the learning rate low threshold at which point we should stop hunting?
-  def get_skillset_exp_low_threshold(_skillset)
+  def get_skillset_exp_low_threshold(skillset)
     @stop_on_low_threshold
   end
 
@@ -442,7 +451,6 @@ class HuntingBuddy
   # Threshold is a number from 0 (None) to 11 (It's amazing you aren't squashed!)
   def encumbered?(threshold)
     return false unless threshold
-
     threshold = [[0, threshold.to_i].max, 11].min # ensure in range
     return DRC.check_encumbrance >= threshold
   end
@@ -454,7 +462,6 @@ class HuntingBuddy
   # as a way to avoid hunting if you already have enough boxes.
   def need_boxes?
     return false unless @settings.box_hunt_minimum
-
     DRCI.count_all_boxes(@settings) <= @settings.box_hunt_minimum
   end
 
@@ -582,8 +589,8 @@ before_dying do
   end
   DRCA.release_cyclics(get_settings.cyclic_no_release)
   Flags.flags.keys
-       .select { |flag_name| flag_name.start_with?('hunting-buddy-') }
-       .each   { |flag_name| Flags.delete(flag_name) }
+    .select { |flag_name| flag_name.start_with?('hunting-buddy-') }
+    .each   { |flag_name| Flags.delete(flag_name) }
 end
 
 $HUNTING_BUDDY = HuntingBuddy.new

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -5,7 +5,6 @@
 custom_require.call(%w[common common-arcana common-items common-travel equipmanager events spellmonitor])
 
 class HuntingBuddy
-
   def initialize
     arg_definitions = [[]]
     args = parse_args(arg_definitions, true)
@@ -30,11 +29,11 @@ class HuntingBuddy
     echo("  @stop_on_high_threshold: #{@stop_on_high_threshold}") if $debug_mode_hunting
 
     @skillset_exp_thresholds = {
-      'Armor' => @settings.armor_exp_training_max_threshold,
-      'Weapon' => @settings.weapon_exp_training_max_threshold,
-      'Magic' => @settings.magic_exp_training_max_threshold,
+      'Armor'    => @settings.armor_exp_training_max_threshold,
+      'Weapon'   => @settings.weapon_exp_training_max_threshold,
+      'Magic'    => @settings.magic_exp_training_max_threshold,
       'Survival' => @settings.survival_exp_training_max_threshold,
-      'Lore' => @settings.lore_exp_training_max_threshold
+      'Lore'     => @settings.lore_exp_training_max_threshold
     }
     echo("  @skillset_exp_thresholds: #{@skillset_exp_thresholds}") if $debug_mode_hunting
 
@@ -77,7 +76,6 @@ class HuntingBuddy
     DRC.wait_for_script_to_complete('restock') unless @settings.sell_loot_skip_bank
 
     @hunting_info.each_with_index do |info, index|
-
       args = info['args'] # list of args to pass to combat-trainer
       before_actions = info['before'] # list of script names
       after_actions = info['after'] # list of script names
@@ -322,62 +320,63 @@ class HuntingBuddy
         end
 
         return DRCT.find_empty_room(rooms_to_search, waiting_room,
-          lambda do |search_attempt|
-            # Skip room if has more people than your max limit
-            return false if DRRoom.pcs.size > @hunting_buddies_max
-            # Skip if one of your nemesis is in the room
-            return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
-            unless avoid_buddies
-              # Continue if one of your friends is in the room
-              return true if (DRRoom.pcs & UserVars.friends).any?
-            end
-            # Skip if anyone not in your group is in the room
-            return false if (DRRoom.pcs - DRRoom.group_members).any?
-            # No visible friends in the room and no visible people
-            UserVars.friends.each { |friend| Flags.add("hunting-buddy-room-check-#{friend}", friend) }
-            Flags.add('hunting-buddy-room-check',
-              # someone speaks
-              /says?, /,
-              /You hear/,
-              # someone attacks from the shadows
-              /Someone snipes a/,
-              /leaps from hiding and ambushes/,
-              # someone is already hunting here
-              /[A-Z][a-z]+ begins to advance/,
-              /[A-Z][a-z]+ (jabs|slices|draws|chops|sweeps|lunges|thrusts|claws|gouges|elbows|kicks|punches|knees|shoves|lobs|throws|hurls|fires|shoots|feints) (a|an|some|his|her|their)/
-            )
-            case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
-            when /roundtime/i
-              data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
-              if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
-                pause
-                waitrt?
-                return UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
-              end
-              fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
-              room_is_empty = true
-              20.times do |_|
-                pause 0.5
-                return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
-                return false if Flags['hunting-buddy-room-check']
-                room_is_empty = (DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
-              end
-              room_is_empty
-            when /You're not in any condition to be searching around/i
-              DRC.message("***STATUS*** You're too injured to hunt!")
-              @stop_hunting = true
-              @stopped_for_bleeding = bleeding?
-              # Ironically, return true so the search for a suitable hunting room
-              # stops and then the hunting buddy loop will detect that you need help
-              # sooner rather than later.
-              true
-            end
-          end,
-          @settings.hunting_room_min_mana,
-          @settings.hunting_room_strict_mana,
-          @settings.hunting_room_max_searches,
-          prefer_buddies
-        )
+                                    lambda do |_search_attempt|
+                                      # Skip room if has more people than your max limit
+                                      return false if DRRoom.pcs.size > @hunting_buddies_max
+                                      # Skip if one of your nemesis is in the room
+                                      return false if (DRRoom.pcs & UserVars.hunting_nemesis).any?
+
+                                      unless avoid_buddies
+                                        # Continue if one of your friends is in the room
+                                        return true if (DRRoom.pcs & UserVars.friends).any?
+                                      end
+                                      # Skip if anyone not in your group is in the room
+                                      return false if (DRRoom.pcs - DRRoom.group_members).any?
+
+                                      # No visible friends in the room and no visible people
+                                      UserVars.friends.each { |friend| Flags.add("hunting-buddy-room-check-#{friend}", friend) }
+                                      Flags.add('hunting-buddy-room-check',
+                                                # someone speaks
+                                                /says?, /,
+                                                /You hear/,
+                                                # someone attacks from the shadows
+                                                /Someone snipes a/,
+                                                /leaps from hiding and ambushes/,
+                                                # someone is already hunting here
+                                                /[A-Z][a-z]+ begins to advance/,
+                                                /[A-Z][a-z]+ (jabs|slices|draws|chops|sweeps|lunges|thrusts|claws|gouges|elbows|kicks|punches|knees|shoves|lobs|throws|hurls|fires|shoots|feints) (a|an|some|his|her|their)/)
+                                      case DRC.bput('search', 'roundtime', "You're not in any condition to be searching around")
+                                      when /roundtime/i
+                                        data = reget(40).reverse.take_while { |x| x !~ /You search around/ }
+                                        if data.grep(/vague silhouette|You notice \w+, who is|see signs that/).any?
+                                          pause
+                                          waitrt?
+                                          return UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
+                                        end
+                                        fput("say #{@settings.empty_hunting_room_messages.sample}") unless @settings.empty_hunting_room_messages.empty?
+                                        room_is_empty = true
+                                        20.times do |_|
+                                          pause 0.5
+                                          return true if UserVars.friends.find { |friend| Flags["hunting-buddy-room-check-#{friend}"] }
+                                          return false if Flags['hunting-buddy-room-check']
+
+                                          room_is_empty = (DRRoom.pcs - DRRoom.group_members - UserVars.friends).empty?
+                                        end
+                                        room_is_empty
+                                      when /You're not in any condition to be searching around/i
+                                        DRC.message("***STATUS*** You're too injured to hunt!")
+                                        @stop_hunting = true
+                                        @stopped_for_bleeding = bleeding?
+                                        # Ironically, return true so the search for a suitable hunting room
+                                        # stops and then the hunting buddy loop will detect that you need help
+                                        # sooner rather than later.
+                                        true
+                                      end
+                                    end,
+                                    @settings.hunting_room_min_mana,
+                                    @settings.hunting_room_strict_mana,
+                                    @settings.hunting_room_max_searches,
+                                    prefer_buddies)
       end
     end
   end
@@ -441,7 +440,7 @@ class HuntingBuddy
   end
 
   # What is the learning rate low threshold at which point we should stop hunting?
-  def get_skillset_exp_low_threshold(skillset)
+  def get_skillset_exp_low_threshold(_skillset)
     @stop_on_low_threshold
   end
 
@@ -451,6 +450,7 @@ class HuntingBuddy
   # Threshold is a number from 0 (None) to 11 (It's amazing you aren't squashed!)
   def encumbered?(threshold)
     return false unless threshold
+
     threshold = [[0, threshold.to_i].max, 11].min # ensure in range
     return DRC.check_encumbrance >= threshold
   end
@@ -462,6 +462,7 @@ class HuntingBuddy
   # as a way to avoid hunting if you already have enough boxes.
   def need_boxes?
     return false unless @settings.box_hunt_minimum
+
     DRCI.count_all_boxes(@settings) <= @settings.box_hunt_minimum
   end
 
@@ -589,8 +590,8 @@ before_dying do
   end
   DRCA.release_cyclics(get_settings.cyclic_no_release)
   Flags.flags.keys
-    .select { |flag_name| flag_name.start_with?('hunting-buddy-') }
-    .each   { |flag_name| Flags.delete(flag_name) }
+       .select { |flag_name| flag_name.start_with?('hunting-buddy-') }
+       .each   { |flag_name| Flags.delete(flag_name) }
 end
 
 $HUNTING_BUDDY = HuntingBuddy.new


### PR DESCRIPTION
Adds two toggles that go in `hunting_info:`

`prefer_buddies` and `avoid_buddies`

`prefer_buddies` Will run through all rooms in your defined hunting zone looking for a room with a buddy. It doesn't care about mana, it doesn't care about spawn, etc etc, it only cares whether there is already a buddy in the room or not. If there is a buddy, it'll plonk down in that room. If it runs the whole zone and finds no buddy, it'll start over from the beginning, and look for an empty room matching all the rest of the criteria we ignored earlier whilst looking for a buddy.

`avoid_buddies` Does what it says. It will treat as occupied a room that has a buddy in it.