### PR TITLE
[scripts][combat-trainer] Don't try to switch pouches if left hand is full

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -501,21 +501,14 @@ class LootProcess
       fput 'DUMP JUNK'
       @dump_timer = Time.now
     end
-    if @autoloot_container && @autoloot_gems && (Time.now - @autoloot_fill_gem_pouch_timer > @autoloot_fill_gem_pouch_delay)
-      DRCI.fill_gem_pouch_with_container(
-        @gem_pouch_adjective,
-        @gem_pouch_noun,
-        @autoloot_container,
-        @full_pouch_container,
-        @spare_gem_pouch_container,
-        @tie_pouch
-      )
-      @autoloot_fill_gem_pouch_timer = Time.now
-    end
+    fill_pouch_with_autolooter if @autoloot_container && @autoloot_gems
 
     game_state.mob_died = false
+
     dispose_body(game_state)
+
     stow_lootables(game_state)
+
     if (game_state.mob_died || game_state.npcs.empty?) && game_state.finish_killing?
       15.times do
         break unless Flags['using-corpse']
@@ -527,9 +520,26 @@ class LootProcess
       echo('LootProcess::clean_up') if $debug_mode_ct
       game_state.next_clean_up_step
     end
+
     return true if game_state.finish_spell_casting? || game_state.stowing?
 
     false
+  end
+
+  def fill_pouch_with_autolooter
+    return unless (Time.now - @autoloot_fill_gem_pouch_timer > @autoloot_fill_gem_pouch_delay)
+    return unless DRC.left_hand.nil?
+
+    DRCI.fill_gem_pouch_with_container(
+      @gem_pouch_adjective,
+      @gem_pouch_noun,
+      @autoloot_container,
+      @full_pouch_container,
+      @spare_gem_pouch_container,
+      @tie_pouch
+    )
+
+    @autoloot_fill_gem_pouch_timer = Time.now
   end
 
   def stow_loot(item, game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -502,7 +502,7 @@ class LootProcess
       @dump_timer = Time.now
     end
 
-    fill_pouch_with_autolooter if @autoloot_container && @autoloot_gems
+    fill_pouch_with_autolooter(game_state) if @autoloot_container && @autoloot_gems
 
     game_state.mob_died = false
 
@@ -527,9 +527,11 @@ class LootProcess
     false
   end
 
-  def fill_pouch_with_autolooter
-    return unless (Time.now - @autoloot_fill_gem_pouch_timer > @autoloot_fill_gem_pouch_delay)
-    return unless DRC.left_hand.nil?
+  def fill_pouch_with_autolooter(game_state)
+    return unless (Time.now - @autoloot_fill_gem_pouch_timer) > @autoloot_fill_gem_pouch_delay
+    return unless (DRC.left_hand.nil? || game_state.currently_whirlwinding)
+
+    game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
 
     DRCI.fill_gem_pouch_with_container(
       @gem_pouch_adjective,
@@ -541,6 +543,8 @@ class LootProcess
     )
 
     @autoloot_fill_gem_pouch_timer = Time.now
+
+    game_state.wield_whirlwind_offhand if game_state.currently_whirlwinding
   end
 
   def stow_loot(item, game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -501,6 +501,7 @@ class LootProcess
       fput 'DUMP JUNK'
       @dump_timer = Time.now
     end
+
     fill_pouch_with_autolooter if @autoloot_container && @autoloot_gems
 
     game_state.mob_died = false


### PR DESCRIPTION
As per title. Refactored a bit into its own def, and now we just try later when the left hand is empty.

As is, in edge cases where the pouch is full, and the offhand is also full, this could mess up the CT routine by stowing the left hand, and getting it back, into the right hand later. 