### PR TITLE
Adding a period to the save regex

### DIFF
--- a/go2.lic
+++ b/go2.lic
@@ -350,7 +350,7 @@ elsif script.vars[0] =~ /^list$/i
    respond output
    exit
 elsif script.vars[1] =~ /^save/i
-   unless script.vars[0] =~ /^save ([a-zA-Z0-9!@#$%_-]+)\s?=\s?(current|\d+)$/ || script.vars[0] =~ /^save ([a-zA-Z0-9!@#$%_-]+)\s?=\s?\[?([current\d,\s]+)\]?$/
+   unless script.vars[0] =~ /^save ([a-zA-Z0-9!@.#$%_-]+)\s?=\s?(current|\d+)$/ || script.vars[0] =~ /^save ([a-zA-Z0-9!@.#$%_-]+)\s?=\s?\[?([current\d,\s]+)\]?$/
       echo "error: format"
       echo "error: proper format examples - ;go2 save test=1234 OR ;go2 save test=[1234, 1432] etc."
       exit


### PR DESCRIPTION
When saving a new location, players should be able to use a '.' in their location names.