### PR TITLE
[scripts][common] Adding line for new instrument - txistu

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -655,7 +655,7 @@ module DRC
       play_command = play_command + " on my #{instrument}"
     end
     fput('release ecry') if DRSpells.active_spells["Eillie's Cry"].to_i > 0
-    result = bput(play_command, 'too damaged to play', 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'Are you sure that\'s the right instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing')
+    result = bput(play_command, 'too damaged to play', 'dirtiness may affect your performance', 'slightest hint of difficulty', 'fumble slightly', /Your .+ is submerged in the water/, 'You begin a', 'You struggle to begin', 'You\'re already playing a song', 'You effortlessly begin', 'You begin some', 'You cannot play', 'Play on what instrument', 'Are you sure that\'s the right instrument', 'now isn\'t the best time to be playing', 'Perhaps you should find somewhere drier before trying to play', 'You should stop practicing', /^You really need to drain/)
     case result
     when 'Play on what instrument', 'Are you sure that\'s the right instrument'
       snapshot = "#{right_hand}#{left_hand}"
@@ -671,7 +671,7 @@ module DRC
       play_song?(settings, song_list, worn, skip_clean, climbing)
     when 'You cannot play'
       wait_for_script_to_complete('safe-room')
-    when 'dirtiness may affect your performance'
+    when 'dirtiness may affect your performance', /^You really need to drain/
       return true if DRSkill.getrank('Performance') < 20
       return true if skip_clean
       return true unless clean_instrument(settings, worn)


### PR DESCRIPTION
Before
```
2023-06-04 20:53:37 NZST: [performance]>play scales halt on my glaes txistu
2023-06-04 20:53:37 NZST: The armor on your head makes playing your glaes txistu more difficult.
2023-06-04 20:53:37 NZST: You really need to drain your glaes txistu first.
2023-06-04 20:53:37 NZST: You struggle to begin some halting scales on your glaes txistu.
```
After
```
2023-06-04 21:03:18 NZST: [performance]>tap my glaes txistu 
2023-06-04 21:03:18 NZST: You tap a slender goldenglow glaes txistu embellished with a dragon-shaped mouthpiece that you are wearing.
2023-06-04 21:03:18 NZST: [performance]>play scales halt on my glaes txistu
2023-06-04 21:03:19 NZST: The armor on your head makes playing your glaes txistu more difficult.
2023-06-04 21:03:19 NZST: You really need to drain your glaes txistu first.
2023-06-04 21:03:19 NZST: You struggle to begin some halting scales on your glaes txistu.
2023-06-04 21:03:19 NZST: [performance]>get my chamois cloth 
2023-06-04 21:03:19 NZST: You get a blood red chamois cloth from inside your traveler's pack.
2023-06-04 21:03:19 NZST: [performance]>stop play
2023-06-04 21:03:20 NZST: You stop playing your song.
2023-06-04 21:03:20 NZST: [performance]>remove my glaes txistu
2023-06-04 21:03:20 NZST: You remove a slender goldenglow glaes txistu embellished with a dragon-shaped mouthpiece from your hair.
2023-06-04 21:03:20 NZST: [performance]>wipe my glaes txistu with my chamois cloth
2023-06-04 21:03:21 NZST: A slender goldenglow glaes txistu embellished with a dragon-shaped mouthpiece is not in need of drying.
2023-06-04 21:03:21 NZST: [performance]>clean my glaes txistu with my chamois cloth
2023-06-04 21:03:21 NZST: With an expert's care, you carefully drain and clean your glaes txistu until you're satisfied that you've removed a very large amount of dust and residue from it.
...snip
```