### PR TITLE
[script][smoke] Add new images, mastery mid-loop

### DIFF
--- a/smoke.lic
+++ b/smoke.lic
@@ -114,7 +114,7 @@ class Smoker
       @smoker = @pipe
     elsif args.smoke =~ /cigar/ && Flags['new-cig']
       quick_light(args.smoke)
-      @smoker = @pipe
+      @smoker = 'cigar'
     end
     send(args.teach + '_loop', images, args.player)
   end

--- a/smoke.lic
+++ b/smoke.lic
@@ -207,7 +207,7 @@ class Smoker
         return light_tobacco(target)
       end
       DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
-      return if @smoke_settings.lighter_tied_to && DRCI.tie_item?(@lighter, @smoke_settings.lighter_tied_to)
+      return if @smoke_settings[lighter_tied_to] && DRCI.tie_item?(@lighter, @smoke_settings[lighter_tied_to])
 
       DRCI.put_away_item?(@lighter, @bag)
     else # flint

--- a/smoke.lic
+++ b/smoke.lic
@@ -16,7 +16,7 @@ custom_require.call(%w[common common-items common-travel equipmanager events])
 class Smoker
   def initialize
     Flags.add('new-cig', 'That was the last of your', 'goes out and crumbles away'); Flags['new-cig'] = true
-    @full_image_list = ['deer', 'dragon', 'rabbit', 'pixie', 'kitten', 'troll', 'horse', 'paladin', 'whip', 'cloak', 'stump', 'fleas', 'daisies', 'unicorn', 'rams', 'bandit', 'ship', 'grave', 'fish', 'web', 'phoenix', 'bracelet', 'skeleton', 'tart', 'almanac', 'dartboard']
+    @full_image_list = ['deer', 'dragon', 'rabbit', 'pixie', 'kitten', 'troll', 'horse', 'paladin', 'whip', 'cloak', 'stump', 'fleas', 'daisies', 'unicorn', 'rams', 'bandit', 'ship', 'grave', 'fish', 'web', 'phoenix', 'bracelet', 'skeleton', 'tart', 'almanac', 'dartboard', 'wolf', 'vine', 'forge', 'moongate', 'mage', 'violin', 'altar', 'trader']
     UserVars.smoke_images_known ||= @full_image_list
     UserVars.smoke_images_mastered ||= []
     arg_definitions = [
@@ -269,6 +269,8 @@ class Smoker
   end
 
   def check_images(images)
+    # If we master everything during our loop, this variable will be empty, so we'll revert to just broad sampling.
+    return UserVars.smoke_images_known unless images
     # Here we're returning IF the provided list of images is identical to our known image size, and the follow-on comparison suggests we've mastered everything we know.
     return images if images.size == UserVars.smoke_images_known.size && UserVars.smoke_images_known.size == UserVars.smoke_images_mastered.size
 

--- a/smoke.lic
+++ b/smoke.lic
@@ -208,6 +208,7 @@ class Smoker
       end
       DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
       return if @smoke_settings.lighter_tied_to && DRCI.tie_item?(@lighter, @smoke_settings.lighter_tied_to)
+
       DRCI.put_away_item?(@lighter, @bag)
     else # flint
       unless DRCI.get_item?("flint")

--- a/smoke.lic
+++ b/smoke.lic
@@ -207,7 +207,7 @@ class Smoker
         return light_tobacco(target)
       end
       DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
-      return if @smoke_settings[lighter_tied_to] && DRCI.tie_item?(@lighter, @smoke_settings[lighter_tied_to])
+      return if @smoke_settings['lighter_tied_to'] && DRCI.tie_item?(@lighter, @smoke_settings['lighter_tied_to'])
 
       DRCI.put_away_item?(@lighter, @bag)
     else # flint

--- a/smoke.lic
+++ b/smoke.lic
@@ -207,6 +207,7 @@ class Smoker
         return light_tobacco(target)
       end
       DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
+      return if @smoke_settings.lighter_tied_to && DRCI.tie_item?(@lighter, @smoke_settings.lighter_tied_to)
       DRCI.put_away_item?(@lighter, @bag)
     else # flint
       unless DRCI.get_item?("flint")

--- a/smoke.lic
+++ b/smoke.lic
@@ -282,7 +282,7 @@ class Smoker
       break if line =~ /You don't know any smoke images/ # last line of empty smoke list
       next if line.include?('IMAGE - SKILL') # topline that would normally match
 
-      smoke_list << line.scan(/\w+\s-\s\w+\*?|\w+\s-\s\s\s\s\s\s\s\s\s/) # grabbing lines: "<image> - <mastery level>       <image> - <mastery level>        <image> - <mastery level>"
+      smoke_list << line.scan(/\w+\s-\s\w+\*?/) # grabbing lines: "<image> - <mastery level>       <image> - <mastery level>        <image> - <mastery level>"
     end
     smoke_list.flatten!
     # This draws off our array of known images, creating a new array of images found on our smoke list.
@@ -301,7 +301,7 @@ class Smoker
 
     # Here we're using the originally generated list like a hash
     images_mastered = smoke_list
-                      .select { |image_and_mastery| image_and_mastery.include?('master*') || image_and_mastery.include?('        ') } # selecting only those images we've fully mastered. non-olvi mastery is represented by a blank field after the image name.
+                      .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered.
                       .join(' ') # making a string of image names, dashes, and 'master*'
                       .split # creating a new array with all of those items as elements
                       .reject { |item| item =~ /-|master*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered

--- a/smoke.lic
+++ b/smoke.lic
@@ -207,8 +207,6 @@ class Smoker
         return light_tobacco(target)
       end
       DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
-      return if @smoke_settings['lighter_tied_to'] && DRCI.tie_item?(@lighter, @smoke_settings['lighter_tied_to'])
-
       DRCI.put_away_item?(@lighter, @bag)
     else # flint
       unless DRCI.get_item?("flint")


### PR DESCRIPTION
Adds the names of the new images from GF2023 (tentative) and sorts(hopefully) an issue where you've begun a loop and mastered everything mid-loop. Normally this would lead to just exhaling a line and a missed match. Instead, we'll just load the full list and sample for the duration of our loop.