### PR TITLE
[scripts][T2] Add startup delay.

### DIFF
--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -1056,6 +1056,13 @@ t2_skip_awaken:
   specific_descriptions:
     t2: Enable this to have T2 skip issuing "awaken" on startup
 
+t2_startup_delay:
+  description: T2 startup delay from drinfomon startup
+  referenced_by:
+    - t2
+  specific_descriptions:
+    t2: Timer to delay execution of T2 training blocks. Note this delay is timed from when drinfomon starts. Allows one to auto-start t2 safely.
+
 telescope_name:
   description: Noun of your telescope.
   example: telescope

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -41,6 +41,10 @@ t2_burgle_every_block: false
 # Toggle to tell T2 not to "awaken" on start up
 t2_skip_awaken: false
 
+# Timer to delay execution of T2 training blocks. Note this delay is timed from when drinfomon starts
+# This allows one to auto-start t2 safely.
+t2_startup_delay: 0
+
 # Combat settings
 # https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 aim_fillers:

--- a/t2.lic
+++ b/t2.lic
@@ -34,7 +34,7 @@ class T2
       end
     end
 
-    unless (Time.now - DRSkill.start_time > @settings.t2_startup_delay.to_i) || @args.nodelay
+    if !@args.nodelay && @settings.t2_startup_delay.to_i > 0
       pause until Time.now - DRSkill.start_time > @settings.t2_startup_delay
     end
   end

--- a/t2.lic
+++ b/t2.lic
@@ -9,7 +9,12 @@ custom_require.call(%w[common common-arcana equipmanager])
 
 class T2
   def initialize
-    arg_definitions = [[]]
+    arg_definitions = [
+      [
+      { name: 'nodelay', regex: /nodelay/i, optional: true, description: 'Skip settings.t2_startup_delay' }
+      ]
+    ]
+
     @args = parse_args(arg_definitions, true)
 
     @settings = get_settings(@args.flex)
@@ -28,6 +33,11 @@ class T2
         fput("avoid #{avoid['type']}")
       end
     end
+
+    unless (Time.now - DRSkill.start_time > @settings.t2_startup_delay.to_i) || @args.nodelay
+      pause until Time.now - DRSkill.start_time > @settings.t2_startup_delay
+    end
+
   end
 
   def run

--- a/t2.lic
+++ b/t2.lic
@@ -11,7 +11,7 @@ class T2
   def initialize
     arg_definitions = [
       [
-      { name: 'nodelay', regex: /nodelay/i, optional: true, description: 'Skip settings.t2_startup_delay' }
+        { name: 'nodelay', regex: /nodelay/i, optional: true, description: 'Skip settings.t2_startup_delay' }
       ]
     ]
 
@@ -37,7 +37,6 @@ class T2
     unless (Time.now - DRSkill.start_time > @settings.t2_startup_delay.to_i) || @args.nodelay
       pause until Time.now - DRSkill.start_time > @settings.t2_startup_delay
     end
-
   end
 
   def run


### PR DESCRIPTION
Delays startup of t2 until drinfomon has settled a bit.

This allows one to auto-autostart T2.

It also allows one to start T2 within a close amount of time after logging in. In my case, being on high latency (300ms+) distances from the server, if I start T2 too soon, the game chokes, specially go2. This resolves the issue by just waiting a bit before executing training blocks. I use 120s as a delay, for ereference, and it works wonderfully.

Note: This delta is from drinfomon starting, since that's the best way I could think of to find a delta from when we logged in (it's also the same method used in learned.lic to track "time since login" and it made sense to me.