### PR TITLE
[scripts][safe-room] Add support for new empath spell healing plant

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -169,7 +169,7 @@ class SafeRoom
     Flags.reset('moved')
 
     if /.*vela.tohr (\w+)/ =~ DRRoom.room_objs.grep(/vela'tohr (plant|thicket)/).to_s
-      fput("touch #{Regexp.last_match(1).to_s}")
+      fput("touch #{Regexp.last_match(1)}")
     end
 
     if Room.current.id == 8393 # Fang Cove Healer fix
@@ -269,7 +269,7 @@ class SafeRoom
 
     unless DRRoom.pcs.include?(empath)
       if /.*vela.tohr (\w+)/ =~ DRRoom.room_objs.grep(/vela'tohr (plant|thicket)/).to_s
-        fput("touch #{Regexp.last_match(1).to_s}")
+        fput("touch #{Regexp.last_match(1)}")
       end
     end
 

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -41,6 +41,7 @@ class SafeRoom
       Flags.add('npc-idle', '^Dokt glances around the room')
       Flags.add('healthy',
                 'Dokt waves a large hand at you',
+                /^The last of your wounds knit shut/,
                 'Dokt gives you a quick glance',
                 'go have yourself a birthday party',
                 'you are well',
@@ -167,6 +168,10 @@ class SafeRoom
     Flags.reset('healthy')
     Flags.reset('moved')
 
+    if /.*vela.tohr (\w+)/ =~ DRRoom.room_objs.grep(/vela'tohr (plant|thicket)/).to_s
+      fput("touch #{Regexp.last_match(1).to_s}")
+    end
+
     if Room.current.id == 8393 # Fang Cove Healer fix
       fput "join list"
       until Flags['healthy'] || Flags['moved']
@@ -260,11 +265,19 @@ class SafeRoom
     return false unless empath
 
     DRCT.walk_to room_id
-    return false unless DRRoom.pcs.include?(empath)
+    return false unless DRRoom.pcs.include?(empath) || DRRoom.room_objs.grep(/vela'tohr (plant|thicket)/)
 
-    fput("whisper #{empath} heal")
-    fput("listen to #{empath}")
-    Flags.add('doneheal', '"Done!"', 'All set', 'not even injured', 'in good enough shape', 'All better')
+    unless DRRoom.pcs.include?(empath)
+      if /.*vela.tohr (\w+)/ =~ DRRoom.room_objs.grep(/vela'tohr (plant|thicket)/).to_s
+        fput("touch #{Regexp.last_match(1).to_s}")
+      end
+    end
+
+    if DRRoom.pcs.include?(empath)
+      fput("whisper #{empath} heal")
+      fput("listen to #{empath}")
+    end
+    Flags.add('doneheal', /^The last of your wounds knit shut/, '"Done!"', 'All set', 'not even injured', 'in good enough shape', 'All better')
     24.times do
       pause 5
       break if Flags['doneheal']


### PR DESCRIPTION
Adding support for the new empath spell `Embrace of the Vela'Tohr` creates a plant that one can touch to get healed (the plant is like a wound bank) the empath can then come around later and heal the plant.

This PR adds the plant as a healing option to safe-room. By default, I've made the plant take priority over NPC empaths, and player empaths take priority over the plant. 

I haven't decided if I want it opt-in, or opt-out, or not optional? 