### PR TITLE
Update combat-trainer.lic to add match for using egg while hidden

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2344,7 +2344,7 @@ class AbilityProcess
   def use_egg?
     use_egg = DRC.bput('invoke my egg', 'light envelops the area briefly',
                        'The red light within the egg is dim and moves about sluggishly',
-                       'Something about the area inhibits', 'Invoke what?')
+                       'Something about the area inhibits', 'Invoke what?', 'You cannot stay hidden while using the egg.')
 
     case use_egg
     when /The red light within the egg is dim and moves about sluggishly/


### PR DESCRIPTION
Add a match for using the war horn ability of the divine egg when hidden.

The match is for: "You cannot stay hidden while using the egg."