### PR TITLE
burgle - update room to accept an array

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -110,6 +110,9 @@ class Burgle
       DRC.message("You have empty burgle_settings.  These must be set before running.")
       return false
     end
+    if @burgle_room.is_a?(Array)
+      @burgle_room = DRCT.sort_destinations(@burgle_room)[0]
+    end
     unless @burgle_room.is_a?(Integer)
       DRC.message("Invalid burgle_settings:room setting.  This must be room id of the room you want to burgle from.")
       return false


### PR DESCRIPTION
burgle room can now be an array and the script will go to the room that's closest to you.

If you don't want to use this, just having a single room as before will also work.

```
burgle_settings:
  room: 1234
```
OR
```
burgle_settings:
  room:
    - 1
    - 1001
    - 2001
    - 3001
    - 4001
    - 5001
```
OR
```
burgle_settings:
  room: [1, 1001, 2001, 3001, 4001, 5001]
```