### PR TITLE
Crafting updates

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -37,9 +37,9 @@ class Carve
     @training_spells = @settings.crafting_training_spells
 
     @main_tool = if @type == 'stack' || @type == 'bone'
-                   'saw'
+                   @settings.carving_tools.find { |item| /\bsaw/i =~ item }
                  else
-                   'chisel'
+                   @settings.carving_tools.find { |item| /\bchisel/i =~ item }
                  end
 
     DRC.wait_for_script_to_complete('buff', ['carve'])
@@ -64,12 +64,15 @@ class Carve
 
   def carve_item
     DRCA.crafting_magic_routine(@settings)
-    DRCC.get_crafting_item('carving book', @bag, @bag_items, @belt)
-    echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
-    turn_to("chapter #{@chapter}")
-    turn_to("page #{DRCC.find_recipe(@chapter, @recipe_name)}")
-    DRC.bput('study my book', 'Roundtime')
-    DRCC.stow_crafting_item('book', @bag, @belt)
+
+    if @settings.master_crafting_book
+      DRCC.find_recipe2(@chapter, @recipe_name, @settings.master_crafting_book, 'carving')
+    else
+      DRCC.get_crafting_item('carving book', @bag, @bag_items, @belt)
+      echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
+      DRCC.find_recipe2(@chapter, @recipe_name)
+      DRCC.stow_crafting_item('book', @bag, @belt)
+    end
     DRCC.get_crafting_item(@main_tool, @bag, @bag_items, @belt)
     if @type != 'boulder'
       case DRC.bput("get my #{@material} #{@type}", '^You get', '^You are already', '^What do you', '^What were you', 'You pick up', "can't quite lift it")

--- a/enchant.lic
+++ b/enchant.lic
@@ -22,6 +22,10 @@ class Enchant
         { name: 'noun', regex: /\w+/i, variable: true, description: 'Required: Noun of finished product, can wrap in double quotes if this is multiple words. Example: "small brazier"' },
         { name: 'base_noun', regex: /\w+/i, variable: true, optional: true, description: 'Optional: Noun of base item that will change once started.  Example: short pole turns into a loop once placed on brazier.' }
 
+      ],
+      [
+        { name: 'resume', regex:/resume/i },
+        { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item to resume.' },
       ]
     ]
 
@@ -54,41 +58,66 @@ class Enchant
     @item = args.noun
     @chapter = args.chapter
     @recipe = args.recipe
+    @resume = args.resume
     @primary_sigils = []
     @secondary_sigils = []
 
     @equipment_manager = EquipmentManager.new
     @equipment_manager.empty_hands
     DRC.wait_for_script_to_complete('buff', ['enchant'])
-    study_recipe
-    @item = 'fount' if @item == 'small sphere'
+    if @resume
+      DRCC.get_crafting_item(@brazier, @bag, @bag_items, @belt)
+      case DRC.bput("analyze #{@item} on my brazier", /scribing additional sigils onto the fount./, /ready for additional scribing./, /application of an imbue spell to advance the enchanting process./)
+      when /scribing additional sigils onto the fount./, /ready for additional scribing./
+        DRCC.get_crafting_item(@burin, @bag, @bag_items, @belt)
+        scribe
+      when /application of an imbue spell to advance the enchanting process./
+        case DRC.bput("look on my #{@brazier}", /On the.*brazier you see.*and a.*/)
+        when /On the.*brazier you see.*and a.*/
+          imbue
+        else
+          DRCC.get_crafting_item(@fount, @bag, @bag_items, @belt)
+          case DRC.bput("wave my #{@fount} at #{@item} on #{@brazier}", /^You slowly wave/, 'The fragile mana fount is not required')
+          when 'The fragile mana fount is not required'
+            DRCC.stow_crafting_item(@fount, @bag, @belt)
+          end
+          imbue
+        end
+      end
+    else
+      study_recipe
+      @item = 'fount' if @item == 'small sphere'
 
-    unless @item == "fount"
+      unless @item == "fount"
 
-      unless DRCI.exists?(@fount)
-        cleanup
-        exit
+        unless DRCI.exists?(@fount)
+          cleanup
+          exit
+        end
+
+        DRCC.get_crafting_item(@fount, @bag, @bag_items, @belt)
+        case DRC.bput("wave my #{@fount} at #{@item} on #{@brazier}", /^You slowly wave/, 'The fragile mana fount is not required')
+        when 'The fragile mana fount is not required'
+          DRCC.stow_crafting_item(@fount, @bag, @belt)
+        end
       end
 
-      DRCC.get_crafting_item(@fount, @bag, @bag_items, @belt)
-      case DRC.bput("wave my #{@fount} at #{@item} on #{@brazier}", /^You slowly wave/, 'The fragile mana fount is not required')
-      when 'The fragile mana fount is not required'
-        DRCC.stow_crafting_item(@fount, @bag, @belt)
-      end
+      DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/) if @cube
+      imbue
+
+      DRCC.get_crafting_item(@burin, @bag, @bag_items, @belt)
+      scribe
     end
-
-    DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/) if @cube
-    imbue
-
-    DRCC.get_crafting_item(@burin, @bag, @bag_items, @belt)
-    scribe
   end
 
   def study_recipe
-    DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @belt)
-    turn_to("page #{DRCC.find_recipe(@chapter, @recipe)}")
-    DRC.bput("study my #{@book_type} book", 'You scan', 'You review', 'You peruse')
-    DRCC.stow_crafting_item("#{@book_type} book", @bag, @belt)
+    if @settings.master_crafting_book
+      DRCC.find_recipe2(@chapter, @recipe, @settings.master_crafting_book, @book_type)
+    else
+      DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt)
+      DRCC.find_recipe2(@chapter, @recipe)
+      DRCC.stow_crafting_item("book", @bag, @forging_belt)
+    end
     DRCC.get_crafting_item(@brazier, @bag, @bag_items, @belt) if @use_own_brazier
 
     case DRC.bput("get my #{@baseitem} from my #{@bag}", 'You get a', 'That is far too dangerous')

--- a/enchant.lic
+++ b/enchant.lic
@@ -24,7 +24,7 @@ class Enchant
 
       ],
       [
-        { name: 'resume', regex:/resume/i },
+        { name: 'resume', regex: /resume/i },
         { name: 'noun', regex: /\w+/i, variable: true, description: 'Noun of item to resume.' },
       ]
     ]

--- a/forge.lic
+++ b/forge.lic
@@ -141,14 +141,11 @@ class Forge
       return if @recipe_name.include?('temper')
 
       if settings.master_crafting_book
-        DRC.bput("turn my #{settings.master_crafting_book} to discipline #{@book_type}", 'You turn the') if settings.master_crafting_book
-        DRC.bput("turn my #{settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, settings.master_crafting_book)}", 'You turn your', 'The .* is already')
-        DRC.bput("study my #{settings.master_crafting_book}", 'Roundtime')
+        DRCC.find_recipe2(@chapter, @recipe_name, settings.master_crafting_book, @book_type)
       else
         DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt)
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Forging') == 175
-        DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
-        DRC.bput('study my book', 'Roundtime')
+        DRCC.find_recipe2(@chapter, @recipe_name)
         DRCC.stow_crafting_item("book", @bag, @forging_belt)
       end
     end

--- a/remedy.lic
+++ b/remedy.lic
@@ -168,11 +168,14 @@ class Remedy
     stow_item(DRC.left_hand)
     stow_item(DRC.right_hand)
     pause 0.2 # to prevent issues with lag during the stow commands
-    DRC.bput('get remed book', 'What were', 'You get')
-    echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Alchemy') == 175
-    turn_to("page #{DRCC.find_recipe(@chapter, @recipe_name)}")
-    DRC.bput('study my book', 'Roundtime')
-    stow_item('book')
+    if @settings.master_crafting_book
+      DRCC.find_recipe2(@chapter, @recipe_name, @settings.master_crafting_book, @book_type)
+    else
+      DRCC.get_crafting_item("#{@book_type} book", @bag, @bag_items, @forging_belt)
+      echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Alchemy') == 175
+      DRCC.find_recipe2(@chapter, @recipe_name)
+      DRCC.stow_crafting_item("book", @bag, @forging_belt)
+    end
 
     if ('red flower').include?(@herb1)
       @herb1 = 'dried flower' unless DRCI.exists?('red flower')

--- a/sew.lic
+++ b/sew.lic
@@ -102,14 +102,11 @@ class Sew
         DRC.bput('study my instructions', 'Roundtime', 'Study them again')
       end
     elsif @settings.master_crafting_book
-      DRC.bput("turn my #{@settings.master_crafting_book} to discipline tailoring", 'You turn the')
-      DRC.bput("turn my #{@settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, @settings.master_crafting_book)}", 'You turn your', 'The .* is already')
-      DRC.bput("study my #{@settings.master_crafting_book}", 'Roundtime')
+      DRCC.find_recipe2(@chapter, @recipe_name, @settings.master_crafting_book, 'tailoring')
     else
       DRCC.get_crafting_item('tailoring book', @bag, @bag_items, @belt)
       echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
-      DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
-      DRC.bput('study my book', 'Roundtime')
+      DRCC.find_recipe2(@chapter, @recipe_name)
       DRCC.stow_crafting_item('tailoring book', @bag, @belt)
     end
 

--- a/shape.lic
+++ b/shape.lic
@@ -95,14 +95,11 @@ class Shape
       return 'scrape my lumber with my drawknife'
     else
       if @settings.master_crafting_book
-        DRC.bput("turn my #{@settings.master_crafting_book} to discipline shaping", 'You turn the')
-        DRC.bput("turn my #{@settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, @settings.master_crafting_book)}", 'You turn your', 'The .* is already')
-        DRC.bput("study my #{@settings.master_crafting_book}", 'Roundtime')
+        DRCC.find_recipe2(@chapter, @recipe_name, @settings.master_crafting_book, 'shaping')
       else
         DRCC.get_crafting_item("shaping book", @bag, @bag_items, @belt)
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
-        DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
-        DRC.bput('study my book', 'Roundtime')
+        DRCC.find_recipe2(@chapter, @recipe_name)
         DRCC.stow_crafting_item("shaping book", @bag, @belt)
       end
     end

--- a/tinker.lic
+++ b/tinker.lic
@@ -112,14 +112,12 @@ class Tinker
       end
     else
       if @settings.master_crafting_book
-        DRC.bput("turn my #{@settings.master_crafting_book} to discipline tinkering", 'You turn the')
-        DRC.bput("turn my #{@settings.master_crafting_book} to page #{DRCC.find_recipe(@chapter, @recipe_name, @settings.master_crafting_book)}", 'You turn your', 'The .* is already')
-        DRC.bput("study my #{@settings.master_crafting_book}", 'Roundtime')
+        DRCC.find_recipe2(@chapter, @recipe_name, @settings.master_crafting_book, "tinkering")
       else
         DRCC.get_crafting_item("tinkering book", @bag, @bag_items, @belt)
         echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Engineering') == 175
-        DRC.bput("turn my book to page #{DRCC.find_recipe(@chapter, @recipe_name)}", 'You turn your', 'The book is already')
-        DRC.bput('study my book', 'Roundtime')
+        DRCC.find_recipe2(@chapter, @recipe_name)
+        DRCC.stow_crafting_item("tinkering book", @bag, @belt)
       end
     end
     if @chapter == 8


### PR DESCRIPTION
Update to all crafting scripts to use the new common-crafting method `find_recipe2` which works with both normal crafting books and the master crafting book to find the recipe requested and it also studies it.

In enchant, I also added resume functionality.  I've done some testing but this could use more robust testing as I may not have found every scenario.

In carve, I updated the section that sets the main tool to match and use the full name listed in `carving_tools:`.  This helps the script get the correct saw if you have a both a bone saw and a wood saw on you, as long as they have different adjectives.

For the rest, I either updated the study sections to use the new method or added support for the master crafting books and updated the normal book method.