### PR TITLE
[scripts][common]Make song data clean up a tad more verbose

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -640,6 +640,9 @@ module DRC
     instrument = worn ? settings.worn_instrument : settings.instrument
 
     if UserVars.instrument.nil?
+      message("No previous instrument setting detected. Cleaning stored song data.")
+      UserVars.song = nil
+      UserVars.climbing_song = nil
       UserVars.instrument = instrument
     elsif UserVars.instrument != instrument
       message("New instrument #{instrument} detected; old instrument: #{UserVars.instrument}. Resetting stored song data.")


### PR DESCRIPTION
Ran into a case of a user deleting their `instrument` variable, but not their `song`, and `climbing_song` variables. 

This makes things a bit more user-proof.