### PR TITLE
[scripts][combat-trainer] Tweak pounce to account for there being no NPCs in the room

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4440,7 +4440,6 @@ class GameState
     return false unless DRStats.barbarian? && DRStats.circle >= 100 # basic qualifications for use
     return false unless (@stomp_to_engage || @stomp_on_cooldown) && Flags['war-stomp-ready'] # ability is off cooldown and we've elected to use it
 
-    Flags.reset('war-stomp-ready')
     case DRC.bput("stomp",
                   /^As you feel your inner fire/,
                   /^With a heaving flex of masterfully controlled muscles/,
@@ -4465,6 +4464,7 @@ class GameState
     when /You are not ready to perform another War Stomp/, /You are too fatigued to perform a War Stomp/
       false
     else
+      Flags.reset('war-stomp-ready')
       true
     end
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4471,7 +4471,7 @@ class GameState
 
   def pounce
     return false unless DRStats.ranger? # Current basic qualifications for use
-    return false unless game_state.npcs.any? # We should have an NPC to pounce on
+    return false unless npcs.any? # We should have an NPC to pounce on
     return false unless (@pounce_on_cooldown || @pounce_to_engage) && Flags['pounce-ready'] # ability is off cooldown and we've elected to use
 
     Flags.reset('pounce-ready')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4438,6 +4438,7 @@ class GameState
 
   def stomp
     return false unless DRStats.barbarian? && DRStats.circle >= 100 # basic qualifications for use
+    return false unless npcs.any? # We should have an NPC to pounce on
     return false unless (@stomp_to_engage || @stomp_on_cooldown) && Flags['war-stomp-ready'] # ability is off cooldown and we've elected to use it
 
     case DRC.bput("stomp",

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4471,7 +4471,7 @@ class GameState
 
   def pounce
     return false unless DRStats.ranger? # Current basic qualifications for use
-    return false unless game_state.npcs
+    return false unless game_state.npcs.any? # We should have an NPC to pounce on
     return false unless (@pounce_on_cooldown || @pounce_to_engage) && Flags['pounce-ready'] # ability is off cooldown and we've elected to use
 
     Flags.reset('pounce-ready')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4474,7 +4474,6 @@ class GameState
     return false unless npcs.any? # We should have an NPC to pounce on
     return false unless (@pounce_on_cooldown || @pounce_to_engage) && Flags['pounce-ready'] # ability is off cooldown and we've elected to use
 
-    Flags.reset('pounce-ready')
     case DRC.bput("pounce",
                   /You angle yourself to knock .* to the ground/,
                   /^You spring towards .*, with the/,
@@ -4489,6 +4488,7 @@ class GameState
     when /What are you trying to attack/ # nothing to pounce on
       false
     else
+      Flags.reset('pounce-ready')
       true
     end
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4471,6 +4471,7 @@ class GameState
 
   def pounce
     return false unless DRStats.ranger? # Current basic qualifications for use
+    return false unless game_state.npcs
     return false unless (@pounce_on_cooldown || @pounce_to_engage) && Flags['pounce-ready'] # ability is off cooldown and we've elected to use
 
     Flags.reset('pounce-ready')
@@ -4484,6 +4485,8 @@ class GameState
       Flags.delete('pounce-ready')
       false
     when /You're too tired/ # ability not actually off cooldown
+      false
+    when /^What are you trying to attack/ # nothing to pounce on
       false
     else
       true

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4479,14 +4479,14 @@ class GameState
                   /You angle yourself to knock .* to the ground/,
                   /^You spring towards .*, with the/,
                   /^What are you trying to attack/,
-                  /Doing your best impression of a house cat, you pounce on absolutely nothing at all./,
-                  /You're too tired from the last time you pounced on some prey./)
+                  /Doing your best impression of a house cat, you pounce on absolutely nothing at all/,
+                  /You're too tired from the last time you pounced on some prey/)
     when /Doing your best impression/ # Not a ranger
       Flags.delete('pounce-ready')
       false
     when /You're too tired/ # ability not actually off cooldown
       false
-    when /^What are you trying to attack/ # nothing to pounce on
+    when /What are you trying to attack/ # nothing to pounce on
       false
     else
       true


### PR DESCRIPTION
As per discussion https://discord.com/channels/745675889622384681/745676478481432586/1141083619402719252

Adding two checks, one to not try if the room has no NPCs, and another in case by the time we do try, we just return false if there are no NPCs.