### PR TITLE
[scripts][dependency] Track warhorn/egg data in firebase (1 of 2)

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.6.1'
+$DEPENDENCY_VERSION = '1.6.2'
 $MIN_RUBY_VERSION = '2.5.5'
 
 no_pause_all
@@ -1444,11 +1444,64 @@ class MoonWatch
   end
 end
 
+class HornWatch
+  def initialize(debug)
+    @debug = debug
+    @firebase_url = 'https://dr-scripts.firebaseio.com/'
+  end
+
+  def debug
+    @debug = !@debug
+  end
+
+  def submit_horn_update(room, timestamp)
+    unless room && timestamp
+      echo('Nothing left to submit') if @debug
+      return
+    end
+
+    echo("submitting:#{room}:#{timestamp}") if @debug
+    uri = URI.parse("#{@firebase_url}/egg_warhorn/#{room}.json")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    request = Net::HTTP::Put.new(uri.request_uri)
+    request['Content-Type'] = 'application/json'
+    request.body = timestamp.to_i.to_json
+    response = http.request(request)
+    response.body.chomp
+  end
+
+  def get_horn_data(room)
+    echo("retrieving warhorn data for room:#{room}") if @debug
+    uri = URI.parse("#{@firebase_url}/egg_warhorn/#{room}.json")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request['Content-Type'] = 'application/json'
+    response = http.request(request)
+    return horn_data = Time.at(0) unless response.body
+
+    begin
+      return horn_data = Time.at(JSON.parse(response.body.chomp))
+    rescue
+      return horn_data = Time.at(0)
+    end
+    echo("warhorn data for room:#{room} is #{horn_data.inspect}") if @debug
+  rescue => e
+    echo("error in hornwatch #{e.inspect}")
+  end
+end
+
 $setupfiles = SetupFiles.new(debug)
 $manager = ScriptManager.new(debug)
 $bankbot = BankbotManager.new(debug)
 $reportbot = ReportbotManager.new(debug)
 $slackbot = SlackbotManager.new(debug)
+$hornwatch = HornWatch.new(debug)
 
 def enable_moon_connection
   $turn_on_moon_watch = true


### PR DESCRIPTION
Allows for submission of warhorn/egg data into firebase, and for us to check if a given room has a warhorn timer. 

In a subsequent PR, I'll submit the changes to combat-trainer that allow it to use this feature set.

To set a timer:
```
;eq $hornwatch.submit_horn_update(1900, Time.now)
```
then to query the timer by room
```
>;eq echo $hornwatch.get_horn_data(1900)                                                                                                                                                                                                      
[exec1: 2023-08-23 20:08:42 +1200] 
```

If there is no timer, we return epoch
```
>;eq echo $hornwatch.get_horn_data(190)                                                                                                                                                                                                       
[exec1: 1970-01-01 12:00:00 +1200]
```

This allows for time comparisons.