### PR TITLE
[scripts][wand-watcher] Wand-Watcher special handling of astrolabes

### DIFF
--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -139,11 +139,23 @@ class WandWatcher
       container = @wand_list[wand]['container']
       cooldown = @wand_list[wand]['cooldown'] || 30
       count = @wand_list[wand]['count'] || 2
+      luck_item = @wand_list[wand]['luck_item'] || false
 
       # cooldown is stored in minutes, but used in seconds
       cooldown *= 60
       # count is stored as number you own, but ordinals is based on 0 index
       count -= 1
+
+      if luck_item
+        fput("info")
+        pause 1
+      end
+
+      if luck_item && DRStats.luck.to_i > 0
+        DRC.message("SKipping luck item because luck greater than 0. Will recheck in 60 seconds.")
+        UserVars.wand_watcher_timers[wand] = Time.now + 60
+        next
+      end
 
       # If you fail getting the wand
       # - because you don't have the right number


### PR DESCRIPTION
If you have a group-based astrolabe, you might give the luck effect to someone else with a group based astrolabe.

This makes it so you can tell wand-watcher to treat astrolabes as special, and check luck state before invoking yours, deferring by 60 seconds (each time) until you have no luck.

Note there is no messaging about when luck ends, which is annoying... so we have to `info` before each check.