### PR TITLE
Added unhandled match string for dissect in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -953,14 +953,15 @@ class LootProcess
                   'This ritual may only be performed on a corpse',
                   /You learn something/i,
                   'A failed or completed ritual has rendered',
-                  'You realize after a few seconds')
+                  'You realize after a few seconds',
+				  'prevents a meaningful dissection')
     when /You succeed in dissecting the corpse/, /You learn something/i
       return true
     when /You'll gain no insights from this attempt/
       waitrt?
       fput("dissect")
       return false
-    when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered', 'You realize after a few seconds'
+    when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered', 'You realize after a few seconds', 'prevents a meaningful dissection'
       return false
     when 'While likely a fascinating study', "That'd be a waste of time.", 'You do not yet possess the knowledge'
       game_state.undissectable(mob_noun)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -954,7 +954,7 @@ class LootProcess
                   /You learn something/i,
                   'A failed or completed ritual has rendered',
                   'You realize after a few seconds',
-				  'prevents a meaningful dissection')
+                  'prevents a meaningful dissection')
     when /You succeed in dissecting the corpse/, /You learn something/i
       return true
     when /You'll gain no insights from this attempt/


### PR DESCRIPTION
The following messages were previously unhandled when a necromancer would attempt to dissect after performing other rituals on a corpse.

The preservation ritual that has been performed on this corpse prevents a meaningful dissection.
The harvesting ritual performed on this corpse prevents a meaningful dissection.