### PR TITLE
[script] [wand-watcher.lic] Add optional DRSpells.active_spells check

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2231,6 +2231,9 @@ wands:
   #   container: backpack           # Container where the wand(s) are stored   [Mandatory]
   #   cooldown: 32                  # minutes between activation attempts      [Optional - defaults to 30]
   #   count: 2                      # number of wands you have                 [Optional - defaults to 2]
+  #   spell:                        # Name of the spell the wand casts         [Optional - leave blank/do not use to disable this check]
+  #   min duration: 1               # minimum duration left of spell to rebuff [Optional - defatuls to 1]
+
 
 # Don't try to grab any wands while these scripts are running.
 wand_watcher_no_use_scripts:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2232,7 +2232,7 @@ wands:
   #   cooldown: 32                  # minutes between activation attempts      [Optional - defaults to 30]
   #   count: 2                      # number of wands you have                 [Optional - defaults to 2]
   #   spell:                        # Name of the spell the wand casts         [Optional - leave blank/do not use to disable this check]
-  #   min duration: 1               # minimum duration left of spell to rebuff [Optional - defatuls to 1]
+  #   min duration: 1               # minimum duration left of spell to rebuff [Optional - defaults to 1]
 
 
 # Don't try to grab any wands while these scripts are running.

--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -140,6 +140,16 @@ class WandWatcher
       cooldown = @wand_list[wand]['cooldown'] || 30
       count = @wand_list[wand]['count'] || 2
       luck_item = @wand_list[wand]['luck_item'] || false
+      spell = @wand_list[wand]['spell'] 
+      min_duration = @wand_list[wand]['min duration'] || 1
+
+      # check if the wand has a visible spell set, and if the duration of that spell is above min duration, if so, delay activation
+      #   not all wand spells are visible, so leaving this value empty should bypass this check
+      if !spell.nil? && spell != '' && DRSpells.active_spells.has_key?(spell) && DRSpells.active_spells[spell] > min_duration
+        DRC.message "Spell duration above min duration to rebuff."
+        UserVars.wand_watcher_timers[wand] = Time.now + (DRSpells.active_spells[spell] - min_duration) * 60
+        next
+      end
 
       # cooldown is stored in minutes, but used in seconds
       cooldown *= 60

--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -140,7 +140,7 @@ class WandWatcher
       cooldown = @wand_list[wand]['cooldown'] || 30
       count = @wand_list[wand]['count'] || 2
       luck_item = @wand_list[wand]['luck_item'] || false
-      spell = @wand_list[wand]['spell'] 
+      spell = @wand_list[wand]['spell']
       min_duration = @wand_list[wand]['min duration'] || 1
 
       # check if the wand has a visible spell set, and if the duration of that spell is above min duration, if so, delay activation


### PR DESCRIPTION
In situations where the buff is still active with significant time on it but the nextuse timer check is in in the past, you can end up with wands on cooldown for extended periods of time  (usually due to login/logout).

This change lets you have wand-watcher _also_ look at the buff duration, and delay activation if the remaining time is above a user set threshold. 