### PR TITLE
[scripts][safe-room] Moving the plant check earlier in the process

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -168,10 +168,6 @@ class SafeRoom
     Flags.reset('healthy')
     Flags.reset('moved')
 
-    if /.*vela.tohr (\w+)/ =~ DRRoom.room_objs.grep(/vela'tohr (plant|thicket)/).to_s
-      fput("touch #{Regexp.last_match(1)}")
-    end
-
     if Room.current.id == 8393 # Fang Cove Healer fix
       fput "join list"
       until Flags['healthy'] || Flags['moved']
@@ -203,6 +199,10 @@ class SafeRoom
     end
 
     DRC.release_invisibility
+
+    if /.*vela.tohr (\w+)/ =~ DRRoom.room_objs.grep(/vela'tohr (plant|thicket)/).to_s
+      fput("touch #{Regexp.last_match(1)}")
+    end
 
     if DRRoom.pcs.empty? || DRRoom.pcs_prone.empty? || Room.current.id == 8393
       wait_for_healing


### PR DESCRIPTION
Previously we would only touch the plant when it was our turn to get healed by the NPC empath. Now we touch the plant right when we enter the room.