### PR TITLE
base-recipes - typo correction

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -9274,7 +9274,7 @@ crafting_recipes:
   type: artificing
   chapter: 3
   work_order: true
-  nchant_stock1_name: rarefaction
+  enchant_stock1_name: rarefaction
   enchant_stock1: 5
   enchant_stock2_name:
   enchant_stock2:


### PR DESCRIPTION
`enchant_stock1_name` was missing the first e.  Fixed