### PR TITLE
[scripts][combat-trainer] Include an optional health check for parasites

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1056,6 +1056,7 @@ class SafetyProcess
     Flags.add('ct-itemdropped', '^Your (?<item>.*) falls to your feet\.', '^You cannot maintain your grip on the (?<item>.*), and it falls to the ground!')
     Flags.add('ct-germshieldlost', 'It jerks the.* (?<shield>\w+) out of your hands')
     Flags.add('active-mitigation', 'You believe you could \b(?<action>\w+) out of the way of the \b(?<obstacle>\w+)')
+    Flags.add('ct-parasite', 'blood mite on your (?<body_part>.*)\.')
     @equipment_manager = equipment_manager
     @health_threshold = settings.health_threshold
     echo("  @health_threshold: #{@health_threshold}") if $debug_mode_ct
@@ -1080,6 +1081,7 @@ class SafetyProcess
     DRC.fix_standing
     check_item_recovery(game_state)
     tend_lodged
+    tend_parasite
     active_mitigation
     game_state.danger = in_danger?(game_state.danger)
     keep_away if !game_state.danger && game_state.retreating?
@@ -1145,6 +1147,13 @@ class SafetyProcess
 
     DRCH.bind_wound(Flags['ct-lodged'][:body_part])
     Flags.reset('ct-lodged')
+  end
+
+  def tend_parasite
+    return unless Flags['ct-parasite']
+
+    DRC.wait_for_script_to_complete('tendme')
+    Flags.reset('ct-parasite')
   end
 
   def keep_away
@@ -5322,6 +5331,7 @@ before_dying do
   Flags.delete('pouch-full')
   Flags.delete('container-full')
   Flags.delete('ct-lodged')
+  Flags.delete('ct-parasite')
   Flags.delete('ct-engaged')
   Flags.delete('active-mitigation')
   Flags.delete('ct-spelllost')


### PR DESCRIPTION
Added a ct-parasite flag to look for parasites (line 1059). Currently only looks for blood mites but can be expanded to include other parasites.

If the flag is set, will call the tendme script to tend the parasite (lines 1084 & 1152-1157).

User will have to add a buff_nonspells health command to their yaml to enable this function:
buff_nonspells:
  health: 300

Without a manual health check, this change will be transparent to users.