### PR TITLE
[scripts][stack-scrolls] Exact spell name matches for discards

### DIFF
--- a/stack-scrolls.lic
+++ b/stack-scrolls.lic
@@ -166,7 +166,7 @@ class ScrollStack
     end
     waitrt?
 
-    if @discard_scrolls.find { |discard| spell_name =~ /#{discard}/i }
+    if @discard_scrolls.find { |discard| spell_name == discard }
       DRCI.dispose_trash(scroll, @worn_trashcan, @worn_trashcan_verb)
     elsif (target = UserVars.stackers.find { |stacker| stacker['contents'].find { |data| data.first == spell_name } })
       stack_existing_scroll(target, scroll, spell_name, stacker_container)


### PR DESCRIPTION
Prior to this, listing `Shockwave` in my discards caused `Flame Shockwave` to also be discarded. This has the drawback of requiring exact spell names, but the benefit that exact spell names don't have fuzzy matching...