### PR TITLE
[scripts][inventory-manager]search case insensitive pattern

### DIFF
--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -359,7 +359,7 @@ class InventoryManager
       total_found = 0
       DRC.message "Checking #{k}:"
       v.each { |data|
-        if data.downcase.match?(item)
+        if data.downcase.include?(item)
           total_found += 1
           DRC.message "Match #{total_found}): #{data}"
         end

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -359,7 +359,7 @@ class InventoryManager
       total_found = 0
       DRC.message "Checking #{k}:"
       v.each { |data|
-        if data.include?(item)
+        if data.downcase.match?(item)
           total_found += 1
           DRC.message "Match #{total_found}): #{data}"
         end


### PR DESCRIPTION
Currently you are unable to use an item with capitalization to search as args.item comes through lowercase.  by downcasing the yaml value we can search the provided item pattern for keywords that are capitalized.