### PR TITLE
Update base-hunting.yaml to match Elanthipedia

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -74,7 +74,7 @@ escort_zones:
     base: 7958
     area: wilds
     enter: leucro2
-  # https://elanthipedia.play.net/Seordhevor_kartais                     180-250
+  # https://elanthipedia.play.net/Seordhevor_kartais                     180-230
   # Undead, great swarm, corporeal
   # Zoluren
   kartais:
@@ -102,13 +102,6 @@ escort_zones:
     base: 247
     area: velaka
     enter: slavers
-  # https://elanthipedia.play.net/Red-Gold_scaled_atik%27et_(2)          250-350
-  # https://elanthipedia.play.net/Mottled_westanuryn
-  # Zoluren
-  red-gold_atiket:
-    base: 1784
-    area: gate_of_souls
-    enter: temple
   # https://elanthipedia.play.net/Forest_geni                            250-350
   # Good spawn but spread out, you may need to move around
   # Requires very high perception, known to get stuck with 250-300+
@@ -117,7 +110,14 @@ escort_zones:
     base: 7958
     area: wilds
     enter: geni
-  # https://elanthipedia.play.net/Supple_firecat                         310-450
+  # https://elanthipedia.play.net/Red-Gold_scaled_atik%27et_(2)          280-430
+  # https://elanthipedia.play.net/Mottled_westanuryn
+  # Zoluren
+  red-gold_atiket:
+    base: 1784
+    area: gate_of_souls
+    enter: temple
+  # https://elanthipedia.play.net/Supple_firecat                         300-430
   # https://elanthipedia.play.net/Muscular_firecat
   # The weaker Muscular firecats are mixed in with Supple firecats
   # Zoluren
@@ -155,8 +155,8 @@ escort_zones:
 hunting_areas_by_town:
   Theren:
   # https://elanthipedia.play.net/Wild_boar                                18-42
+  # https://elanthipedia.play.net/Cougar                                   30-49
   # https://elanthipedia.play.net/Kelpie                                   35-50
-  # https://elanthipedia.play.net/Cougar                                   30-51
   # https://elanthipedia.play.net/Wood_Troll_(1)                           36-53
     - wood_trolls_theren
   # https://elanthipedia.play.net/Blood_wolf_(2)                           75-90
@@ -174,11 +174,11 @@ hunting_areas_by_town:
   # https://elanthipedia.play.net/Elder_red_brocket_deer                 200-260
   # high swarm
     - brocket_elder
-  # https://elanthipedia.play.net/Sky_giant                              500-700
+  # https://elanthipedia.play.net/Sky_giant                              550-700
   # Good for boxes, lightning/wind magic
     - sky_giants
   Langenfirth:
-  # https://elanthipedia.play.net/Grey_clay_soldier                      175-250
+  # https://elanthipedia.play.net/Grey_clay_soldier                      150-240
     - clay_soldier
   # https://elanthipedia.play.net/Grey_clay_mage                         175-250
     - clay_mage
@@ -209,9 +209,9 @@ hunting_areas_by_town:
   # needs a quick remap, nothing crazy.
     - ashu_hhinvi
   Riverhaven:
-  # https://elanthipedia.play.net/Heggarangi_frog                          00-26
+  # https://elanthipedia.play.net/Heggarangi_frog                           0-26
     - heggarangi_frog_riverhaven
-  # https://elanthipedia.play.net/Zombie_goblin                            05-35
+  # https://elanthipedia.play.net/Zombie_goblin                             0-35
     - zombie_goblin_riverhaven
   # https://elanthipedia.play.net/Scarlet_crayfish                         15-38
   # On the map, but didn't see any spawn.
@@ -233,14 +233,14 @@ hunting_areas_by_town:
     - dusk_ogres
   # https://elanthipedia.play.net/Young_Ogre                              80-120
     - young_ogres_riverhaven
-  # https://elanthipedia.play.net/Giant_thicket_viper                     125-165
-  # https://elanthipedia.play.net/Piruati_serpent                          80-150
+  # https://elanthipedia.play.net/Giant_thicket_viper                     25-165
+  # https://elanthipedia.play.net/Piruati_serpent                        100-150
   #Vipers spit poison, so you need a shield. Both critters in area.
     - vipers_and_serpents
   # https://elanthipedia.play.net/Lesser_sluagh_(2)                      100-160
   # https://elanthipedia.play.net/Swamp_troll_(1)                        120-160
     - swamp_troll_riverhaven
-  # https://elanthipedia.play.net/Orc_scout                              160-220?
+  # https://elanthipedia.play.net/Orc_scout                              180-230
   # https://elanthipedia.play.net/Vicious_Warcat
   # warcats calm, need 35 disc
   # 19097 - Unmappable room
@@ -268,7 +268,7 @@ hunting_areas_by_town:
   # warcats calm, need 35 disc
   # Great swarm, boxes and skins
     - orc_reivers
-  # https://elanthipedia.play.net/Bristle-backed_peccary                 280-405
+  # https://elanthipedia.play.net/Bristle-backed_peccary                 280-400
   # Great swarm, in town with justice
     - bristle_peccs
   # https://elanthipedia.play.net/Greater_sluagh                         280-?
@@ -278,7 +278,9 @@ hunting_areas_by_town:
     - greater_sluagh
   # https://elanthipedia.play.net/Maelshyvean_shadow_beast               320-650
     - shadow_beasts
-  # https://elanthipedia.play.net/Orc_raider                             365-450
+  # https://elanthipedia.play.net/Maelshyvean_cinder_beast               350-570
+    - cinder_beasts
+  # https://elanthipedia.play.net/Orc_raider                             380-450
   # lower end raiders downstairs mixed with reivers
     - orc_raiders
   # higher end raiders upstairs raiders, highly rare chief
@@ -287,10 +289,8 @@ hunting_areas_by_town:
   # further upstairs, raiders with high spawn of clan chiefs
   # Barb warhorn = tons of chiefs
     - orc_chiefs
-  # https://elanthipedia.play.net/Maelshyvean_cinder_beast               450-600
-    - cinder_beasts
   Throne_City:
-  # https://elanthipedia.play.net/River_caiman                            75-125
+  # https://elanthipedia.play.net/River_caiman                             60-90
     - river_caiman
   # https://elanthipedia.play.net/Blue-belly_crocodile                   100-140
     - throne_bluebelly_crocs
@@ -308,7 +308,7 @@ hunting_areas_by_town:
   # https://elanthipedia.play.net/Sand_sprite                              50-73
   # Decent boxes
     - sandsprites
-  # https://elanthipedia.play.net/Silver_leucro                           95-110
+  # https://elanthipedia.play.net/Silver_leucro                           85-101
     - silver_leucros_ratha
   # https://elanthipedia.play.net/Adult_razortusk_boar                   100-130
     - razortuzk_boars
@@ -316,9 +316,9 @@ hunting_areas_by_town:
     - crimson_merrows
   # https://elanthipedia.play.net/Bawdy_swain                            120-150
     - bawdy_swain
-  # https://elanthipedia.play.net/Kra%27hei_hatchling                    130-210
+  # https://elanthipedia.play.net/Kra%27hei_hatchling                    130-190
     - kra_hei_hatchlings
-  # https://elanthipedia.play.net/Ochre_la%27heke                        150-240
+  # https://elanthipedia.play.net/Ochre_la%27heke                        180-240
     - ochre_la_heke
   # https://elanthipedia.play.net/Gaunt_shadow_master                      220-?
   # Good safe room: 9994
@@ -646,7 +646,7 @@ hunting_zones:
   - 8459
   # new mob - critter level 23-27                                          120-160
   # You'll need to remove gerbil's from the ignored_npcs: list otherwise it
-  # just sit there not hunting.  
+  # just sit there not hunting.
   undead_gerbils:
   - 8439
   - 8440
@@ -672,7 +672,7 @@ hunting_zones:
   - 8448
   - 8449
   - 8450
-  # https://elanthipedia.play.net/Revenant_conscript                       40-60
+  # https://elanthipedia.play.net/Revenant_conscript                       25-50
   revenant_conscripts:
   - 706
   - 707
@@ -698,7 +698,7 @@ hunting_zones:
   - 7237
   - 7238
   # https://elanthipedia.play.net/Wind_Hound                               45-73
-  # https://elanthipedia.play.net/Faenrae_reaver                           35-55
+  # https://elanthipedia.play.net/Faenrae_reaver                           35-52
   # Caution: hounds are live and reavers are undead
   reavers:
   - 1850
@@ -707,7 +707,7 @@ hunting_zones:
   - 1856
   - 1848
   - 1849
-  # https://elanthipedia.play.net/Bone_wolf                                45-73
+  # https://elanthipedia.play.net/Bone_wolf                                55-73
   # https://elanthipedia.play.net/Revenant_zombie                          45-59
   bone_wolves:
   - 2109
@@ -716,7 +716,7 @@ hunting_zones:
   - 2106
   - 2105
   - 2104
-  # https://elanthipedia.play.net/Beisswurm                                50-63
+  # https://elanthipedia.play.net/Beisswurm                                50-65
   beisswurms:
   - 7263
   - 7264
@@ -731,7 +731,16 @@ hunting_zones:
   - 19215
   - 19219
   - 19220
-  # https://elanthipedia.play.net/Endrus_serpent                           50-90
+  # https://elanthipedia.play.net/Copperhead_viper                         55-70
+  # 19228 is a Safe room, don't include in the hunting section
+  copperheads:
+  - 19221
+  - 19222
+  - 19231
+  - 14123
+  - 19225
+  - 14124
+  # https://elanthipedia.play.net/Endrus_serpent                          70-100
   endrus_serpents:
   - 9527
   - 9528
@@ -742,15 +751,6 @@ hunting_zones:
   - 9533
   - 9534
   - 9535
-  # https://elanthipedia.play.net/Copperhead_viper                         55-70
-  # 19228 is a Safe room, don't include in the hunting section
-  copperheads:
-  - 19221
-  - 19222
-  - 19231
-  - 14123
-  - 19225
-  - 14124
   # https://elanthipedia.play.net/Blood_wolf_(1)                           60-75
   crossing_blood_wolves:
   - 1580
@@ -788,18 +788,7 @@ hunting_zones:
   - 9060
   - 9061
   - 9062
-  # https://elanthipedia.play.net/Fire_Sprite                             80-100
-  fire_sprites:
-  - 1770
-  - 1771
-  - 1772
-  - 1773
-  - 1774
-  - 1775
-  - 1776
-  - 1777
-  - 1778
-  # https://elanthipedia.play.net/Snowbeast                               80-105
+  # https://elanthipedia.play.net/Snowbeast                               75-105
   # 2264 causes a loop, do not use
   # 2256 frequently has issues with day/night descriptions
   snowbeasts:
@@ -816,6 +805,17 @@ hunting_zones:
   - 2269
   - 2270
   - 2261
+  # https://elanthipedia.play.net/Fire_Sprite                             80-100
+  fire_sprites:
+  - 1770
+  - 1771
+  - 1772
+  - 1773
+  - 1774
+  - 1775
+  - 1776
+  - 1777
+  - 1778
   # https://elanthipedia.play.net/Young_Ogre                              80-120
   # 1593 is a Safe room, don't include in the hunting section
   young_ogres:
@@ -846,7 +846,7 @@ hunting_zones:
   - 12991
   - 12992
   - 12996
-  # https://elanthipedia.play.net/Granite_gargoyle                        95 to 125
+  # https://elanthipedia.play.net/Granite_gargoyle                        95-125
   # premie only rooms - outside Crossing North Gate
   # Newly separated gargoyles - no skunks or spirits
   granite_gargoyles_monastary:
@@ -950,18 +950,6 @@ hunting_zones:
   - 6865
   - 6866
   - 6857
-  # https://elanthipedia.play.net/Forest_bandit                         160-200
-  # rank range is estimate based on critter range - Strong Magic
-  forest_bandits:
-  - 2434
-  - 2435
-  - 2436
-  - 2437
-  - 2438
-  - 2439
-  - 2440
-  - 2441
-  - 2442
   # https://elanthipedia.play.net/Scavenger_Troll                        170-220
   # Caution: may steal your weapons
   scavenger_trolls:
@@ -1056,13 +1044,18 @@ hunting_zones:
   - 19413
   - 9096
   - 9097
-  # https://elanthipedia.play.net/Cave_troll                             220-375
-  cave_trolls:
-  - 19194
-  - 19195
-  - 19196
-  - 19204
-  # - 19193 # First room, not a spawn room. Confirmed by GMs.
+  # https://elanthipedia.play.net/Forest_bandit                          210-240
+  # rank range is estimate based on critter range - Strong Magic
+  forest_bandits:
+  - 2434
+  - 2435
+  - 2436
+  - 2437
+  - 2438
+  - 2439
+  - 2440
+  - 2441
+  - 2442
   # https://elanthipedia.play.net/Giant_bear                             210-290
   # Super high spawn
   # You'll need to remove bear's from the ignored_npcs: list otherwise it
@@ -1078,6 +1071,13 @@ hunting_zones:
   giant_bears_cave:
   - 16536
   - 16537
+  # https://elanthipedia.play.net/Cave_troll                             240-375
+  cave_trolls:
+  - 19194
+  - 19195
+  - 19196
+  - 19204
+  # - 19193 # First room, not a spawn room. Confirmed by GMs.
   # https://elanthipedia.play.net/Onyx_gargoyle                          320-400
   # EMPATH SAFE - can be skinned and drops boxes, several rooms with good life mana
   onyx_gargoyles:
@@ -1099,8 +1099,8 @@ hunting_zones:
   toads:
   - 50266
   - 50267
-  # https://elanthipedia.play.net/Ember_bull                             280-400
-  # range is a guestimate based on criter level 67-69 
+  # https://elanthipedia.play.net/Ember_bull                             300-400
+  # range is a guestimate based on criter level 67-69
   ember_bulls:
   - 51072
   - 51073
@@ -1108,7 +1108,7 @@ hunting_zones:
   - 51075
   - 51076
   - 51077
-  # https://elanthipedia.play.net/Ember_bull_(2)                         325-500                    
+  # https://elanthipedia.play.net/Ember_bull_(2)                         325-500
   # range is a guestimate based on criter level 70-74
   # Estate Holder Only
   ember_bulls_hillside:
@@ -1143,18 +1143,6 @@ hunting_zones:
   - 16882
   - 16883
   - 16884
-  # https://elanthipedia.play.net/Snaer_hafwa                            350-500
-  # undead, incorp
-  snaer_hafwa_crossing:
-  - 13043
-  - 13042
-  - 13044
-  - 13045
-  - 13046
-  - 13047
-  - 13039
-  - 13037
-  - 13036
   # https://elanthipedia.play.net/Wir_dinego                             360-450
   # Coporeal undead, night time only
   wir_dinego_crossing:
@@ -1185,8 +1173,20 @@ hunting_zones:
   - 16886
   - 16887
   - 16888
+  # https://elanthipedia.play.net/Snaer_hafwa                            380-600
+  # undead, incorp
+  snaer_hafwa_crossing:
+  - 13043
+  - 13042
+  - 13044
+  - 13045
+  - 13046
+  - 13047
+  - 13039
+  - 13037
+  - 13036
+  # https://elanthipedia.play.net/Warklin_mauler                         400-500
   # https://elanthipedia.play.net/Armored_warklin                        400-600
-  # https://elanthipedia.play.net/Warklin_mauler                         400-600
   # Incredible swarm, usually packed
   # Slice damage immune
   warklin:
@@ -1252,8 +1252,8 @@ hunting_zones:
   - 11468
   - 11469
   - 11474
-  # https://elanthipedia.play.net/Xala%27shar_vanquisher                900-1100
-  # https://elanthipedia.play.net/Xala%27shar_conjurer                  900-1100
+  # https://elanthipedia.play.net/Xala%27shar_vanquisher                800-1100
+  # https://elanthipedia.play.net/Xala%27shar_conjurer                  800-1100
   xalas_2:
   - 12196
   - 12201
@@ -1312,7 +1312,7 @@ hunting_zones:
   - 12039
   - 12040
   - 12042
-  # https://elanthipedia.play.net/Arthelun_cabalist                    1100-1400
+  # https://elanthipedia.play.net/Arthelun_cabalist                    1100-1600
   # Magic casters, tons of boxes
   cabalist:
   - 12708
@@ -1326,7 +1326,7 @@ hunting_zones:
   cabalist-outdoors:
   - 12708
   - 12704
-  # https://elanthipedia.play.net/Arthelun_cabalist                    1100-1400
+  # https://elanthipedia.play.net/Arthelun_cabalist                    1100-1600
   # same cabalists, premie only rooms
   cabalist_crevice:
   - 15689
@@ -1362,9 +1362,9 @@ hunting_zones:
   - 1729
   - 1728
   - 1721
-  # critter level 184 +/- 1                                            1450 to 1750
+  # critter level 184 +/- 1                                            1450-1750
   # GM Notes: this creature requires you be an Empath, or be supported by one.
-  avtalia_scuttlers:                                                      
+  avtalia_scuttlers:
   - 50992
   - 50993
   - 50994
@@ -1375,7 +1375,7 @@ hunting_zones:
 ##########                           ILITHI                           ##########
 ##########                                                            ##########
 ################################################################################
-  # https://elanthipedia.play.net/Kobold                                   35-50
+  # https://elanthipedia.play.net/Kobold                                   36-49
   shard_kobolds:
   - 2739
   - 2744
@@ -1392,7 +1392,7 @@ hunting_zones:
   - 16906
   - 16907
   - 16908
-  # https://elanthipedia.play.net/Snowbeast                               80-105
+  # https://elanthipedia.play.net/Snowbeast                               75-105
   # Separated from granite gargoyles on Tuesday Tidings 82
   snowbeasts_dragonspine:
   - 2912
@@ -1404,7 +1404,7 @@ hunting_zones:
   - 2923
   - 2924
   - 2925
-  # https://elanthipedia.play.net/Snowbeast                               80-105
+  # https://elanthipedia.play.net/Snowbeast                               75-105
   # Estate Holder Only
   snowbeasts_grove:
   - 9621
@@ -1508,8 +1508,8 @@ hunting_zones:
   young_prereni_stones:
   - 12276
   - 12277
-  # https://elanthipedia.play.net/Windbag_(1)                            150-250
   # https://elanthipedia.play.net/Sylph_(2)                              150-250
+  # https://elanthipedia.play.net/Windbag_(1)                            200-300
   # Estate Holder Only - Construct
   windbags_sylphs:
   - 16923
@@ -1526,7 +1526,7 @@ hunting_zones:
   - 9631
   - 9632
   - 9633
-  # https://elanthipedia.play.net/Frostcrone                             200-300
+  # https://elanthipedia.play.net/Frostcrone                             180-340
   # undead
   frostcrones:
   - 16842
@@ -1537,13 +1537,13 @@ hunting_zones:
   - 16847
   - 16848
   - 16849
-  # https://elanthipedia.play.net/Blue-dappled_prereni_(1)               180-225
+  # https://elanthipedia.play.net/Blue-dappled_prereni_(1)               200-250
   # Crazy swarm, packed
   blue_dappled_prereni:
   - 10148
   - 10149
   - 10151
-  # https://elanthipedia.play.net/Blue-dappled_prereni_(2)               190-250
+  # https://elanthipedia.play.net/Blue-dappled_prereni_(2)               180-250
   # premie only rooms, slightly higher level than the standard ones
   blue_prereni_stones:
   - 12278
@@ -1588,8 +1588,8 @@ hunting_zones:
   - 16570
   - 6982
   # https://elanthipedia.play.net/Baby_forest_gryphon                    250-350
+  # https://elanthipedia.play.net/Fledgling_forest_gryphon_(1)           250-380
   # https://elanthipedia.play.net/Young_forest_gryphon                   300-420
-  # https://elanthipedia.play.net/Fledgling_forest_gryphon_(1)           300-400
   # Good swarm, few rooms usually full
   shard_gryphons: #baby/fledgling
   - 6244
@@ -1619,7 +1619,7 @@ hunting_zones:
   - 9512
   - 9511
   - 9510
-  # https://elanthipedia.play.net/Red-bristled_gremlin                   280-410
+  # https://elanthipedia.play.net/Red-bristled_gremlin                   250-400
   # premie only rooms
   red_gremlins:
   - 11445
@@ -1633,22 +1633,6 @@ hunting_zones:
   - 11508
   - 11507
   - 11503
-  # https://elanthipedia.play.net/Cloud_rat                              325-425
-  # Ranks estimate based on Creature Level 63-67.
-  # Room 16538 is either no spawn/low spawn, but critters still wander in
-  cloud_rats:
-  - 16540
-  - 16541
-  - 16542
-  - 16543
-  - 16539
-  - 16538
-  # https://elanthipedia.play.net/Cloud_rat                              325-425
-  # same rats - Estate Holder Only
-  cloud_rats_hollow:
-  - 16545
-  - 16546
-  - 16547
   # https://elanthipedia.play.net/Robed_Dragon_Priest(ess)               350-500
   dragon_priests:
   - 6379
@@ -1658,7 +1642,23 @@ hunting_zones:
   - 6383
   - 6384
   - 6385
-  # https://elanthipedia.play.net/Adan%27f_spirit_dancer                 380-600
+  # https://elanthipedia.play.net/Cloud_rat                              380-480
+  # Ranks estimate based on Creature Level 63-67.
+  # Room 16538 is either no spawn/low spawn, but critters still wander in
+  cloud_rats:
+  - 16540
+  - 16541
+  - 16542
+  - 16543
+  - 16539
+  - 16538
+  # https://elanthipedia.play.net/Cloud_rat                              380-480
+  # same rats - Estate Holder Only
+  cloud_rats_hollow:
+  - 16545
+  - 16546
+  - 16547
+  # https://elanthipedia.play.net/Adan%27f_spirit_dancer                 425-600
   adanf_spirit_dancers:
   - 10771
   - 10102
@@ -1669,7 +1669,7 @@ hunting_zones:
   - 10113
   - 10111
   - 10112
-  # https://elanthipedia.play.net/Vile_plague_wraith                     450-630
+  # https://elanthipedia.play.net/Vile_plague_wraith                     450-650
   # Need good stats/skills to defend against magics
   plague_wraiths:
   - 11349
@@ -1713,7 +1713,7 @@ hunting_zones:
   - 16347
   - 16348
   - 16349
-  # https://elanthipedia.play.net/Storm_bull_(3)                         600-750
+  # https://elanthipedia.play.net/Storm_bull_(3)                         550-800
   # Strongest of the Storm Bulls - creature level 111 - 115
   # Estate Holder only BUT Can bring non-esate holder hunting buddies in a group!!
   bulls_vale:
@@ -1777,7 +1777,7 @@ hunting_zones:
   - 12576
   - 12577
   - 12578
-  # https://elanthipedia.play.net/Adult_wyvern                         1000-1300
+  # https://elanthipedia.play.net/Adult_wyvern                         1000-1350
   adult_wyverns:
   - 9038
   - 9039
@@ -1840,7 +1840,7 @@ hunting_zones:
   - 9495
   - 9496
   - 15351
-  # https://elanthipedia.play.net/Bone_wyvern                          1500-1750
+  # https://elanthipedia.play.net/Bone_wyvern                          1450-1750
   # Toughest critter in DR. These are absolutely no joke!
   # Very powerful necromantic magic, hunt here at your own risk
   #  - You will need extensive shield skill to avoid bloodburst
@@ -1861,13 +1861,13 @@ hunting_zones:
 ##########                          THERENGIA                         ##########
 ##########                                                            ##########
 ################################################################################
-  # https://elanthipedia.play.net/Heggarangi_frog                          00-26
+  # https://elanthipedia.play.net/Heggarangi_frog                           0-26
   heggarangi_frog_riverhaven:
   - 488
   - 487
   - 490
   - 489
-  # https://elanthipedia.play.net/Zombie_goblin                            05-35
+  # https://elanthipedia.play.net/Zombie_goblin                             0-35
   zombie_goblin_riverhaven:
   - 332
   - 333
@@ -1904,7 +1904,7 @@ hunting_zones:
   - 7828
   # https://elanthipedia.play.net/Wood_Troll_(1)                           36-53
   # https://elanthipedia.play.net/Kelpie                                   35-50
-  # https://elanthipedia.play.net/Cougar                                   30-51
+  # https://elanthipedia.play.net/Cougar                                   30-49
   # https://elanthipedia.play.net/Wild_boar                                18-42
   wood_trolls_theren:
   - 3316
@@ -1961,7 +1961,7 @@ hunting_zones:
   - 8584
   - 8577
   - 8576
-  # https://elanthipedia.play.net/Dark_fiend                               70-90
+  # https://elanthipedia.play.net/Dark_fiend                               60-75
   # incorp undead, not very swarmy
   dark_fiends:
   - 7830
@@ -1973,6 +1973,16 @@ hunting_zones:
   - 7836
   - 7837
   - 7838
+  # https://elanthipedia.play.net/River_caiman                             60-90
+  river_caiman:
+  - 3090
+  - 3091
+  - 3092
+  - 3094
+  - 3095
+  - 3096
+  - 3097
+  - 3098
   # https://elanthipedia.play.net/Giant_wolf_spider                        70-98
   # under Theren keep
   wolf_spider:
@@ -2013,16 +2023,6 @@ hunting_zones:
   - 8673
   - 8677
   - 8678
-  # https://elanthipedia.play.net/River_caiman                            75-125
-  river_caiman:
-  - 3090
-  - 3091
-  - 3092
-  - 3094
-  - 3095
-  - 3096
-  - 3097
-  - 3098
   # https://elanthipedia.play.net/Sand_spider                             80-100
   sand_spider:
   - 259
@@ -2107,8 +2107,8 @@ hunting_zones:
   - 3073
   - 3072
   - 3070
+  # https://elanthipedia.play.net/Piruati_serpent                        100-150
   # https://elanthipedia.play.net/Giant_thicket_viper                    125-165
-  # https://elanthipedia.play.net/Piruati_serpent                         80-150
   # Vipers spit poison, so you need a shield. Both critters in area.
   vipers_and_serpents:
   - 498
@@ -2122,7 +2122,7 @@ hunting_zones:
   - 12125
   - 3086
   - 3087
-  # https://elanthipedia.play.net/Grey_clay_soldier                      175-250
+  # https://elanthipedia.play.net/Grey_clay_soldier                      150-240
   clay_soldier:
   - 13902
   - 13903
@@ -2145,7 +2145,7 @@ hunting_zones:
   - 13916
   - 13917
   - 13918
-  # https://elanthipedia.play.net/Orc_scout                              160-220
+  # https://elanthipedia.play.net/Orc_scout                              180-230
   # https://elanthipedia.play.net/Vicious_Warcat
   # warcats calm, need 35 disc
   # 19097 - Unmappable room
@@ -2297,7 +2297,7 @@ hunting_zones:
   - 15059
   - 15060
   - 15061
-  # https://elanthipedia.play.net/Bristle-backed_peccary                 280-405
+  # https://elanthipedia.play.net/Bristle-backed_peccary                 280-400
   # Great swarm, in town with justice
   bristle_peccs:
   - 7707
@@ -2324,8 +2324,8 @@ hunting_zones:
   - 3057
   - 3061
   - 3064
-  # https://elanthipedia.play.net/Birdcatcher_Spider                     300-400
-  # https://elanthipedia.play.net/Tree_Snake                             300-400
+  # https://elanthipedia.play.net/Birdcatcher_Spider                     310-420
+  # https://elanthipedia.play.net/Tree_Snake                             300-420
   # Snakes by day, Spiders by night - good swarm, puncture resist, poisonous
   tree_snakes_spiders:
   - 9018
@@ -2356,47 +2356,7 @@ hunting_zones:
   - 10786
   - 10787
   - 10778
-  # https://elanthipedia.play.net/Orc_raider                             365-450
-  # lower end raiders downstairs mixed with reivers
-  orc_raiders:
-  - 8704
-  - 8705
-  - 8706
-  - 8707
-  - 8708
-  - 8709
-  # https://elanthipedia.play.net/Isundjen_conjurer                      360-500
-  isundjen_conjurers:
-  - 211
-  - 15063
-  - 15064
-  - 15065
-  - 15066
-  # https://elanthipedia.play.net/Orc_raider                             380-450
-  # higher end raiders upstairs raiders, highly rare chief
-  orc_raiders_upstairs:
-  - 8710
-  - 8711
-  - 8712
-  - 8713
-  - 8714
-  - 8715
-  # https://elanthipedia.play.net/Orc_clan-chief                         400-500
-  # further upstairs, raiders with high spawn of clan chiefs
-  # Barb warhorn = tons of chiefs
-  orc_chiefs:
-  - 8716
-  - 8717
-  - 8718
-  # https://elanthipedia.play.net/Lesser_voltaic_custodian               450-625
-  voltaic_custodian:
-  - 16451
-  - 16452
-  - 16453
-  - 16454
-  - 16455
-  - 16456
-  # https://elanthipedia.play.net/Maelshyvean_cinder_beast               450-600
+  # https://elanthipedia.play.net/Maelshyvean_cinder_beast               350-570
   cinder_beasts:
   - 19455
   - 10792
@@ -2420,8 +2380,48 @@ hunting_zones:
   - 10810
   - 10811
   - 10812
+  # https://elanthipedia.play.net/Isundjen_conjurer                      360-500
+  isundjen_conjurers:
+  - 211
+  - 15063
+  - 15064
+  - 15065
+  - 15066
+  # https://elanthipedia.play.net/Orc_raider                             380-450
+  # higher end raiders upstairs raiders, highly rare chief
+  orc_raiders_upstairs:
+  - 8710
+  - 8711
+  - 8712
+  - 8713
+  - 8714
+  - 8715
+  # https://elanthipedia.play.net/Orc_raider                             380-450
+  # lower end raiders downstairs mixed with reivers
+  orc_raiders:
+  - 8704
+  - 8705
+  - 8706
+  - 8707
+  - 8708
+  - 8709
+  # https://elanthipedia.play.net/Orc_clan-chief                         400-500
+  # further upstairs, raiders with high spawn of clan chiefs
+  # Barb warhorn = tons of chiefs
+  orc_chiefs:
+  - 8716
+  - 8717
+  - 8718
+  # https://elanthipedia.play.net/Lesser_voltaic_custodian               450-625
+  voltaic_custodian:
+  - 16451
+  - 16452
+  - 16453
+  - 16454
+  - 16455
+  - 16456
   # - 11006 Issue with day/night descriptions
-  # https://elanthipedia.play.net/Sky_giant                              500-700
+  # https://elanthipedia.play.net/Sky_giant                              550-700
   # Good for boxes, lightning/wind magic
   sky_giants:
   - 10072
@@ -2434,7 +2434,7 @@ hunting_zones:
   - 10066
   - 10065
   - 10064
-  # https://elanthipedia.play.net/Bronze_leucro                        575?-800?
+  # https://elanthipedia.play.net/Bronze_leucro                          600-800
   bronze_leucro:
   - 15946
   - 15947
@@ -2500,31 +2500,12 @@ hunting_zones:
 ##########                           FORFEDHDAR                       ##########
 ##########                                                            ##########
 ################################################################################
-  # https://elanthipedia.play.net/Writhing_maiden%27s_tress               125-210
-  # Spawn increased TT 127 - 7/26/22
-  maidens_tress:
-  - 4221
-  - 4222
-  - 4223
-  - 4224
-  - 4225
-  - 4226
-  - 4227
-  # https://elanthipedia.play.net/Matron%27s_tress                        175-250
-  matron_tress:
-  - 4228
-  - 4229
-  - 4230
-  - 4231
-  - 4232
-  - 4233
-  - 4234  
-  # https://elanthipedia.play.net/Young_cave_troll                        75-170
+  # https://elanthipedia.play.net/Young_cave_troll                        85-170
   # Skill range may be old - can confirm worked fantastic 100-135
   young_cave_trolls:
   - 10121
   - 10122
-  # https://elanthipedia.play.net/Vela%27tohr_bloodvine                  120-195
+  # https://elanthipedia.play.net/Vela%27tohr_bloodvine                  120-170
   bloodvines_hib:
   - 4212
   - 4213
@@ -2538,7 +2519,17 @@ hunting_zones:
   - 14441
   - 14442
   - 14443
-  # https://elanthipedia.play.net/Mutant_togball                         130-175
+  # https://elanthipedia.play.net/Writhing_maiden%27s_tress               125-210
+  # Spawn increased TT 127 - 7/26/22
+  maidens_tress:
+  - 4221
+  - 4222
+  - 4223
+  - 4224
+  - 4225
+  - 4226
+  - 4227
+  # https://elanthipedia.play.net/Mutant_togball                         130-165
   mutant_togball:
   - 7112
   - 7113
@@ -2548,7 +2539,27 @@ hunting_zones:
   - 7117
   - 7118
   - 7119
-  # https://elanthipedia.play.net/Sickly_blightwater_nyad                160-245
+  # https://elanthipedia.play.net/Stumpy_blight_ogre                     150-230
+  # Reasonable step up from young_blue_dappled_prereni
+  # Use shield shield/weapon so harder to hit at level
+  blight_ogre_stumpy:
+  - 4294
+  - 4290
+  - 4293
+  - 4291
+  # https://elanthipedia.play.net/Decaying_blightwater_nyad              150-250
+  decaying_blightwater_nyads:
+  - 4257
+  - 4250
+  - 4248
+  - 4249
+  - 4259
+  - 4260
+  - 4258
+  - 4261
+# - 4263 #no spawn seen
+
+  # https://elanthipedia.play.net/Sickly_blightwater_nyad                160-250
   sickly_blightwater_nyads:
   - 4240
   - 4241
@@ -2565,17 +2576,15 @@ hunting_zones:
   - 4252
   - 4253
   - 4254
-  # https://elanthipedia.play.net/Decaying_blightwater_nyad              170-250
-  decaying_blightwater_nyads:
-  - 4257
-  - 4250
-  - 4248
-  - 4249
-  - 4259
-  - 4260
-  - 4258
-  - 4261
-# - 4263 #no spawn seen
+  # https://elanthipedia.play.net/Matron%27s_tress                        175-250
+  matron_tress:
+  - 4228
+  - 4229
+  - 4230
+  - 4231
+  - 4232
+  - 4233
+  - 4234
   # https://elanthipedia.play.net/Frostweyr_bear                         175-225
   # Knockback attack to prone, stunned, and another room
   # You'll need to remove bear's from the ignored_npcs: list otherwise it
@@ -2590,15 +2599,7 @@ hunting_zones:
   - 6990
   - 6989
   - 6988
-  # https://elanthipedia.play.net/Stumpy_blight_ogre                     170-240
-  # Reasonable step up from young_blue_dappled_prereni
-  # Use shield shield/weapon so harder to hit at level
-  blight_ogre_stumpy:
-  - 4294
-  - 4290
-  - 4293
-  - 4291
-  # https://elanthipedia.play.net/Giant_blight_ogre                      180-270
+  # https://elanthipedia.play.net/Giant_blight_ogre                      180-250
   blight_ogre_giant:
   - 4303
   - 4340
@@ -2611,6 +2612,13 @@ hunting_zones:
   - 50213
   - 50212
   - 50221
+  # https://elanthipedia.play.net/Frost_angiswaerd                       260-340
+  # Warning, area is icy, and you will slip and hurt yourself if you move too fast!
+  frost_angiswaerd:
+  - 11202
+  - 11199
+  - 11200
+  - 11201
   # https://elanthipedia.play.net/Icy_blue_ghast                         280-430
   # 4 tiers, each 'slightly' tougher than the first
   blue_ghasts_1:
@@ -2643,13 +2651,6 @@ hunting_zones:
   - 46887
   - 46885
   - 46884
-  # https://elanthipedia.play.net/Frost_angiswaerd
-  # Warning, area is icy, and you will slip and hurt yourself if you move too fast!
-  frost_angiswaerd:
-  - 11202
-  - 11199
-  - 11200
-  - 11201
   # https://elanthipedia.play.net/Armored_shalswar                       300-400
   # https://elanthipedia.play.net/Dragon_Priest_sentinel                 300-460
   # https://elanthipedia.play.net/Dragon_Priest_zealot                   400-520
@@ -2663,14 +2664,7 @@ hunting_zones:
   - 6229
   - 6224
   - 6223
-  # https://elanthipedia.play.net/Dragon_Priest_juggernaut               400-500
-  # Add disarm orb: 60 (or less) to buff_nonspells:
-  juggernauts:
-  - 4548
-  - 4550
-  - 4551
-  - 4552
-  # https://elanthipedia.play.net/Black_marble_gargoyle                  300-440
+  # https://elanthipedia.play.net/Black_marble_gargoyle                  330-540
   # Train some skills way higher than 440
   black_marble_gargoyles:
   - 31500
@@ -2684,6 +2678,13 @@ hunting_zones:
   - 31521
   - 31523
   - 31524
+  # https://elanthipedia.play.net/Dragon_Priest_juggernaut               400-500
+  # Add disarm orb: 60 (or less) to buff_nonspells:
+  juggernauts:
+  - 4548
+  - 4550
+  - 4551
+  - 4552
   # https://elanthipedia.play.net/Mountain_Giant                         375-550
   # Boxes and skins, decent swarm, often packed
   mountain_giants:
@@ -2717,16 +2718,6 @@ hunting_zones:
   - 7122
   - 9536
   - 7121
-  # https://elanthipedia.play.net/Black_goblin                           460-720
-  # Need 520+ shield & evasion to avoid thrown axes which lodge
-  black_goblins:
-  - 4167
-  - 4168
-  - 4170
-  - 4169
-  - 4157
-  - 4158
-  - 4143
   # https://elanthipedia.play.net/Black_ape                              490-750
   # Swarms well most of the time
   # Add 'tooth' to loot_additions, can be sold like gems
@@ -2759,7 +2750,17 @@ hunting_zones:
   - 9540
   - 9542
   - 9541
-  # https://elanthipedia.play.net/Enraged_tusky                          490-800
+  # https://elanthipedia.play.net/Black_goblin                           500-720
+  # Need 520+ shield & evasion to avoid thrown axes which lodge
+  black_goblins:
+  - 4167
+  - 4168
+  - 4170
+  - 4169
+  - 4157
+  - 4158
+  - 4143
+  # https://elanthipedia.play.net/Enraged_tusky                          500-750
   # Large critter range 104-114 - approach with care
   # Now spawn only in the new tusky pens - Undead
   tusky:
@@ -2781,7 +2782,7 @@ hunting_zones:
   - 4285
   - 4287
   - 4278
-  # https://elanthipedia.play.net/Zombie_head-splitter                   600-725
+  # https://elanthipedia.play.net/Zombie_head-splitter                   600-733
   # Crazy box droppers, crazy swarm
   zombie_headsplitters:
   - 9543
@@ -2794,7 +2795,7 @@ hunting_zones:
   - 9550
   - 9551
   # https://elanthipedia.play.net/Bony_wind_wretch                      700-1000?
-  # https://elanthipedia.play.net/Ragged_wind_hag                       700-1000?
+  # https://elanthipedia.play.net/Ragged_wind_hag                        700-950
   wretch_and_hag:
   - 34371
   - 34372
@@ -2869,7 +2870,7 @@ hunting_zones:
   - 17015
   - 17016
   - 17017
-  # https://elanthipedia.play.net/Jeol_moradu                           1400-1700
+  # https://elanthipedia.play.net/Jeol_moradu                          1200-1500
   jeol_moradu:
   - 15078
   - 15079
@@ -2936,14 +2937,7 @@ hunting_zones:
   - 5645
   - 5650
   - 5652
-  # https://elanthipedia.play.net/Moss_mey                                90-135
-  moss_meys:
-  - 5581
-  - 5583
-  - 5582
-  - 5584
-  - 5585
-  # https://elanthipedia.play.net/Silver_leucro                           95-110
+  # https://elanthipedia.play.net/Silver_leucro                           85-101
   silver_leucros_ratha:
   - 5182
   - 5183
@@ -2951,6 +2945,13 @@ hunting_zones:
   - 5174
   - 5175
   - 5176
+  # https://elanthipedia.play.net/Moss_mey                                90-135
+  moss_meys:
+  - 5581
+  - 5583
+  - 5582
+  - 5584
+  - 5585
   # https://elanthipedia.play.net/Adult_razortusk_boar                   100-130
   razortusk_boars:
   - 5139
@@ -3026,7 +3027,7 @@ hunting_zones:
   - 5520
   - 5521
   - 5522
-  # https://elanthipedia.play.net/Kra%27hei_hatchling                    130-210
+  # https://elanthipedia.play.net/Kra%27hei_hatchling                    130-190
   kra_hei_hatchlings:
   - 4890
   - 4892
@@ -3044,6 +3045,20 @@ hunting_zones:
   - 4920
   - 4922
   - 4921
+  # https://elanthipedia.play.net/nightreaver_unyn                       150-225
+  nightreaver_unyn:
+  - 12491
+  - 12503
+  - 12504
+  - 12505
+  - 12536
+  - 12522
+  - 12517
+  - 12514
+  - 12513
+  - 12512
+  - 12515
+  - 12516
   # https://elanthipedia.play.net/Yvhh_la%27tami                         160-200
   yvhh:
   - 12457
@@ -3060,21 +3075,7 @@ hunting_zones:
   - 12468
   - 12469
   - 12470
-  # https://elanthipedia.play.net/nightreaver_unyn                       180-225
-  nightreaver_unyn:
-  - 12491
-  - 12503
-  - 12504
-  - 12505
-  - 12536
-  - 12522
-  - 12517
-  - 12514
-  - 12513
-  - 12512
-  - 12515
-  - 12516
-  # https://elanthipedia.play.net/Ochre_la%27heke                        150-240
+  # https://elanthipedia.play.net/Ochre_la%27heke                        180-240
   ochre_la_heke:
   - 12952
   - 12956
@@ -3169,8 +3170,8 @@ hunting_zones:
   - 5311
   - 5312
   - 12662
-  # https://elanthipedia.play.net/graverobber_(2)                        270-380
-  # https://elanthipedia.play.net/ghoul_raven                            260-400
+  # https://elanthipedia.play.net/graverobber_(2)                        270-420
+  # https://elanthipedia.play.net/ghoul_raven                            280-380
   graverobbers_and_ghoul_ravens:
   - 5531
   - 5532
@@ -3179,7 +3180,7 @@ hunting_zones:
   - 5528
   - 5529
   - 5530
-  # https://elanthipedia.play.net/Bristle-backed_peccary                 280-405
+  # https://elanthipedia.play.net/Bristle-backed_peccary                 280-400
   bristle_back_peccary_mriss:
   - 6819
   - 6829
@@ -3189,16 +3190,7 @@ hunting_zones:
   - 6826
   - 6827
   - 6828
-  # https://elanthipedia.play.net/Wir_dinego                             300-400
-  wir_dinego:
-  - 5543
-  - 5537
-  - 5540
-  - 5541
-  - 5542
-  - 5544
-  - 5545
-  # https://elanthipedia.play.net/Dobek_moruryn                       300 to 450
+  # https://elanthipedia.play.net/Dobek_moruryn                          300-450
   # underground, long stun on entry (no danger), poison stingers, Ratha
   # many duplicate rooms and maze rooms - please do not add rooms or edit mapdb
   dobek:
@@ -3208,13 +3200,15 @@ hunting_zones:
   - 11111
   - 11112
   - 11113
-  # https://elanthipedia.play.net/snaer_hafwa                            350-500
-  snaer_hafwa:
-  - 12927
-  - 12928
-  - 12929
-  - 12926
-  - 12930
+  # https://elanthipedia.play.net/Wir_dinego                             360-450
+  wir_dinego:
+  - 5543
+  - 5537
+  - 5540
+  - 5541
+  - 5542
+  - 5544
+  - 5545
   # https://elanthipedia.play.net/Spiny_bloodfish_(1)                      360-?
   spiny_bloodfish:
   - 11844
@@ -3232,6 +3226,13 @@ hunting_zones:
   - 6813
   - 6811
   - 6810
+  # https://elanthipedia.play.net/snaer_hafwa                            380-600
+  snaer_hafwa:
+  - 12927
+  - 12928
+  - 12929
+  - 12926
+  - 12930
   # https://elanthipedia.play.net/Asaren_Celpeze                         400-620
   # add ambergris to loot_additions
   asaren_celpeze_1:
@@ -3256,7 +3257,7 @@ hunting_zones:
   - 6636
   - 6637
   - 6638
-  # https://elanthipedia.play.net/Asaren_celpeze_(3)                     550-800
+  # https://elanthipedia.play.net/Asaren_celpeze_(3)                     500-620
   # add ambergris to loot_additions
   asaren_celpeze_northern:
   - 6616
@@ -3302,7 +3303,7 @@ hunting_zones:
   - 15703
   - 15704
   - 15705
-  # https://elanthipedia.play.net/Gale_drake                            950-1300
+  # https://elanthipedia.play.net/Gale_drake                           1000-1300
   # strong elemental magic, outside Ratha
   gale_drakes:
   - 16855


### PR DESCRIPTION
Per the discussion in the Discord, this updated version of base-hunting has skill ranges scraped from Elanthipedia. Some hunting spots were also re-ordered to match their new positions relative to other hunting zones. The update is effectively semantically identical to the previous version, with the only changes being zone ordering and comments (per https://www.yamldiff.com/)