### PR TITLE
Updates to sigilharvest and common-items to fix some logic errors in the former and add compatibility to the latter

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -572,7 +572,8 @@ module DRCI
       /There's (?:only )?(.+) parts? left/,
       /The (?:.+) has (.+) uses remaining./,
       /There are enough left to create (.+) more/,
-      /You count out (.+) pieces? of material there/
+      /You count out (.+) pieces? of material there/,
+      /There (?:is|are) (.+) scrolls? left for use with crafting/
     ]
     count = 0
     $ORDINALS.each do |ordinal|

--- a/sigilharvest.lic
+++ b/sigilharvest.lic
@@ -338,7 +338,7 @@ class SigilHarvest
     # check our stock of scrolls since we just used some
     get_scrolls
 
-    #if roomcap was not specified, exit script once sigil-scrolls are harvested
+    # if roomcap was not specified, exit script once sigil-scrolls are harvested
     exit unless @args.roomcap
   end # scribe_sigils
 

--- a/sigilharvest.lic
+++ b/sigilharvest.lic
@@ -337,7 +337,9 @@ class SigilHarvest
 
     # check our stock of scrolls since we just used some
     get_scrolls
-    exit unless @args.roomcap #if roomcap was not specified, exit script once sigil-scrolls are harvested
+
+    #if roomcap was not specified, exit script once sigil-scrolls are harvested
+    exit unless @args.roomcap
   end # scribe_sigils
 
   # returns the current seasonw which determines what room list to pull from base-sigils
@@ -353,8 +355,8 @@ class SigilHarvest
 
     # Count scrolls and store number in a variable, set variable to 0 if scrolls are not found
     num_scrolls = DRCI.count_item_parts('blank scroll')
-    DRC.message("Scrolls Remaining: #{num_scrolls.to_s}") if @args.debug
-    DRC.message("Target Scrolls: #{target_scrolls.to_s}") if @args.debug
+    DRC.message("Scrolls Remaining: #{num_scrolls}") if @args.debug
+    DRC.message("Target Scrolls: #{target_scrolls}") if @args.debug
 
     # if we have enough scrolls exit the function
     return if num_scrolls >= target_scrolls
@@ -372,7 +374,7 @@ class SigilHarvest
       scroll_price = 90 # dokora
     end
 
-    DRC.message("Buying more scrolls from #{Room[scroll_room].title.to_s}") if @args.debug
+    DRC.message("Buying more scrolls from #{Room[scroll_room].title}") if @args.debug
 
     # ensure hands are clear
     DRCI.stow_hands
@@ -386,9 +388,9 @@ class SigilHarvest
     coppers_needed = num_to_order * scroll_price
 
     # go to bank if insufficient funds on hand
-    DRC.message("Getting #{coppers_needed.to_s} coppers to buy scrolls.") if @args.debug
+    DRC.message("Getting #{coppers_needed} coppers to buy scrolls.") if @args.debug
 
-    #get money if needed
+    # get money if needed
     DRCM.ensure_copper_on_hand(coppers_needed, @settings)
 
     # order repeatedly and combine

--- a/sigilharvest.lic
+++ b/sigilharvest.lic
@@ -56,7 +56,6 @@ class SigilHarvest
     @action_difficulty = { "trivial" => 1, "straightforward" => 2, "challenging" => 3, "difficult" => 4, "formidable" => 5 }
 
     @args = parse_args(arg_definitions)
-    @debug = @args.debug
 
     # sigil harvesting uses the same sorts of buffs that other gathering skills use i.e. outdoorsmanship and perception
     DRCA.do_buffs(@settings, 'outdoors')
@@ -338,6 +337,7 @@ class SigilHarvest
 
     # check our stock of scrolls since we just used some
     get_scrolls
+    exit unless @args.roomcap #if roomcap was not specified, exit script once sigil-scrolls are harvested
   end # scribe_sigils
 
   # returns the current seasonw which determines what room list to pull from base-sigils
@@ -352,11 +352,9 @@ class SigilHarvest
     @stock_scrolls ? target_scrolls = @stock_scrolls : target_scrolls = 25
 
     # Count scrolls and store number in a variable, set variable to 0 if scrolls are not found
-    if /^There (?:are|is) (.*) scrolls? left for use with crafting\.$/ =~ DRC.bput("count my blank scrolls", 'I could not find', /^There (?:is|are) .* scrolls? left for use with crafting\.$/)
-      num_scrolls = DRC.text2num($1)
-    else
-      num_scrolls = 0
-    end
+    num_scrolls = DRCI.count_item_parts('blank scroll')
+    DRC.message("Scrolls Remaining: #{num_scrolls.to_s}") if @args.debug
+    DRC.message("Target Scrolls: #{target_scrolls.to_s}") if @args.debug
 
     # if we have enough scrolls exit the function
     return if num_scrolls >= target_scrolls
@@ -374,19 +372,27 @@ class SigilHarvest
       scroll_price = 90 # dokora
     end
 
+    DRC.message("Buying more scrolls from #{Room[scroll_room].title.to_s}") if @args.debug
+
     # ensure hands are clear
     DRCI.stow_hands
 
-    # blank scrolls come in a stack of 25, divide the difference by 25 and ceil to determine the number of times we need to order to meet or exceed stock target
-    num_to_order = ((target_scrolls - num_scrolls) / 25).ceil()
+    # blank scrolls come in a stack of 25, divide the difference by 25 and round to determine the number of times we need to order. (Changed to ROUND instead of CEIL. No longer tries to always meet or exceed value but instead gets close to target quantity.)
+    num_to_order = target_scrolls - num_scrolls
+    num_to_order = num_to_order / 25
+    num_to_order = num_to_order.round
 
     # calculate the amount of money needed
     coppers_needed = num_to_order * scroll_price
 
     # go to bank if insufficient funds on hand
+    DRC.message("Getting #{coppers_needed.to_s} coppers to buy scrolls.") if @args.debug
+
+    #get money if needed
     DRCM.ensure_copper_on_hand(coppers_needed, @settings)
 
     # order repeatedly and combine
+    DRC.message("Ordering scrolls #{num_to_order} times.") if @args.debug
     (1..num_to_order).each do
       DRCT.order_item(scroll_room, 8)
       DRC.bput('combine', /^You combine|^You must/)


### PR DESCRIPTION
common-items: added another match string to make count_item_parts compatible with blank scrolls.

sigilharvest: fixed some logic errors that were preventing the script from buying scrolls when it otherwise should have been

NOTE: The changes to sigilharvest are dependent upon the match string added to common-items.