### PR TITLE
Urgent fix to Corn Maze

### DIFF
--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -720,10 +720,8 @@ class CornMaze
   def stow_thing(thing)
     if @settings.cornmaze_containers.any?
       @settings.cornmaze_containers.each do |container|
-        return if DRCI.put_away_item?(thing, container)
-
-        return if DRCI.stow_item?(thing)
-
+        break if DRCI.put_away_item?(thing, container)
+        break if DRCI.stow_item?(thing)
         DRC.message("#{thing} didn't fit anywhere. Dropping it.")
         DRCI.dispose_trash(thing)
       end

--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -721,7 +721,9 @@ class CornMaze
     if @settings.cornmaze_containers.any?
       @settings.cornmaze_containers.each do |container|
         return if DRCI.put_away_item?(thing, container)
+
         return if DRCI.stow_item?(thing)
+
         DRC.message("#{thing} didn't fit anywhere. Dropping it.")
         DRCI.dispose_trash(thing)
       end

--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -720,12 +720,11 @@ class CornMaze
   def stow_thing(thing)
     if @settings.cornmaze_containers.any?
       @settings.cornmaze_containers.each do |container|
-        unless DRCI.put_away_item?(thing, container)
-          unless DRCI.stow_item?(thing)
-            DRC.message("#{thing} didn't fit anywhere. Dropping it.")
-            DRCI.dispose_trash(thing, @worn_trashcan, @worn_trashcan_verb)
-          end
-        end
+        return if DRCI.put_away_item?(thing, container)
+        return if DRCI.stow_item?(thing)
+        DRC.message("#{thing} didn't fit anywhere. Dropping it.")
+        DRCI.dispose_trash(thing)
+        return
       end
     else
       unless DRCI.stow_item?(thing)

--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -722,6 +722,7 @@ class CornMaze
       @settings.cornmaze_containers.each do |container|
         break if DRCI.put_away_item?(thing, container)
         break if DRCI.stow_item?(thing)
+
         DRC.message("#{thing} didn't fit anywhere. Dropping it.")
         DRCI.dispose_trash(thing)
       end

--- a/corn-maze.lic
+++ b/corn-maze.lic
@@ -724,7 +724,6 @@ class CornMaze
         return if DRCI.stow_item?(thing)
         DRC.message("#{thing} didn't fit anywhere. Dropping it.")
         DRCI.dispose_trash(thing)
-        return
       end
     else
       unless DRCI.stow_item?(thing)


### PR DESCRIPTION
Current stow logic isn't ever catching a true and returning.  This simplifies the check on if the stow was successful or not.  @MahtraDR may have a more elegant solution but we need to get something posted ASAP, folks are losing money.