### PR TITLE
[scripts][common] Move from local Time.now to server_time

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -879,7 +879,7 @@ module DRC
 
     _respond(
       "<pushStream id=\"#{window_name}\"/>" + (make_bold ? bold(text) : text),
-      "<popStream id=\"#{window_name}\" /><prompt time=\"#{Time.now.to_i}\">&gt;</prompt>"
+      "<popStream id=\"#{window_name}\" /><prompt time=\"#{XMLData.server_time.to_i}\">&gt;</prompt>"
     )
   end
 


### PR DESCRIPTION
This should bypass a condition where genie's RT calculations canbe affected when local system time isn't the same as server time.