### PR TITLE
Pick updated to support towns other than hometown/fang cove settings

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -65,8 +65,6 @@ class Pick
 
     picking_data = get_data('picking').picking
 
-    #@lockpick_costs = picking_data['lockpick_costs'][@settings.fang_cove_override_town || @settings.hometown]
-
     @pick_identify_messages = picking_data['pick_messages_by_difficulty'];
     @pick_retry = picking_data['pick_retry']
     @pick_quick_threshold = @settings.pick['pick_quick_threshold'] || 2

--- a/pick.lic
+++ b/pick.lic
@@ -64,7 +64,8 @@ class Pick
     @has_pick_waggle = @settings.waggle_sets['pick']
 
     picking_data = get_data('picking').picking
-    @lockpick_costs = picking_data['lockpick_costs'][@settings.fang_cove_override_town || @settings.hometown]
+
+    #@lockpick_costs = picking_data['lockpick_costs'][@settings.fang_cove_override_town || @settings.hometown]
 
     @pick_identify_messages = picking_data['pick_messages_by_difficulty'];
     @pick_retry = picking_data['pick_retry']
@@ -103,6 +104,8 @@ class Pick
 
     @picking_room_id = Room.current.id
 
+    @refill_town = @settings.refill_town
+
     if @debug
       echo "Settings..."
       echo "- Sources: #{@sources}"
@@ -132,6 +135,12 @@ class Pick
       echo "- pick_careful: #{@pick_careful_threshold}"
       echo "- assumed_difficulty: #{@assumed_difficulty}"
     end
+
+    if @settings.refill_town
+      @lockpick_costs = picking_data['lockpick_costs'][@settings.refill_town]
+    else
+      @lockpick_costs = picking_data['lockpick_costs'][@settings.fang_cove_override_town || @settings.hometown]
+    end    
 
     if args.refill
       refill_ring
@@ -318,8 +327,17 @@ class Pick
       return
     end
 
-    DRCM.ensure_copper_on_hand(cost * lockpicks_needed, @settings)
-    DRCT.refill_lockpick_container(@settings.lockpick_type, @settings.fang_cove_override_town || @settings.hometown, @lockpick_container, lockpicks_needed)
+    if @refill_town
+      DRCM.ensure_copper_on_hand(cost * lockpicks_needed, @settings, @refill_town)
+    else
+      DRCM.ensure_copper_on_hand(cost * lockpicks_needed, @settings)
+    end
+
+    if @refill_town
+      DRCT.refill_lockpick_container(@settings.lockpick_type, @refill_town, @lockpick_container, lockpicks_needed)
+    else
+      DRCT.refill_lockpick_container(@settings.lockpick_type, @settings.fang_cove_override_town || @settings.hometown, @lockpick_container, lockpicks_needed)
+    end
   end
 
   def attempt_open(box_noun)

--- a/pick.lic
+++ b/pick.lic
@@ -138,7 +138,7 @@ class Pick
       @lockpick_costs = picking_data['lockpick_costs'][@settings.refill_town]
     else
       @lockpick_costs = picking_data['lockpick_costs'][@settings.fang_cove_override_town || @settings.hometown]
-    end    
+    end
 
     if args.refill
       refill_ring


### PR DESCRIPTION
The pick script has an option to automatically refill lockpicks in a lockpick ring once the number falls below 15. However, as only 5 towns have locksmith shops to purchase lockpicks, the script will fail to refill if your hometown isn't set to one of these towns.

This update creates a "refill_town" yaml setting. This setting allows players to manually specify a town (e.g., Hometown may be Hib, refill_town can be Shard) that will be used to refill the specified lockpick type in your lockpick ring. With this setting enabled, the script will not run to the refill_town specified, pull coins to purchase picks, buy the picks, then continue the script process.

The pick.lic script will default to using Hometown/Fang Cove overrides. If the refill_town setting is set, then it will use that instead. Players will need to ensure that if using the refill_town setting, that the town specified actually has the locksmith shop or the script will continue to fail.