### PR TITLE
Updated base.yaml to include refill_town setting

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1232,6 +1232,8 @@ skeleton_key: skeleton key
 use_skeleton_key: false
 use_lockpick_ring: true
 skip_lockpick_ring_refill: false
+# If skip_lockpick_ring_refill is false and your hometown doesn't have a locksmith shop, add the nearest town with a shop here.
+refill_town: Shard
 # If you set 'use_lockpick_ring: false' then specify
 # the container that holds your loose lockpicks.
 # If you set 'use_lockpick_ring: true' then specify


### PR DESCRIPTION
Updated the base.yaml file to include the "refill_town" variable, which is used in the pick.lic update to specify a town other than your hometown to refill lockpicks.