### PR TITLE
Eddy swap script

### DIFF
--- a/eddy-swap.lic
+++ b/eddy-swap.lic
@@ -15,14 +15,14 @@
   - bowl
   - mixing stick
   - sieve
-  
+
   portal_store:
     weapons:
       items:
       - broadsword
       - bar mace
       - javelin
-  
+
     alchemy_tools:
       items: *alchemy_tools
 
@@ -88,6 +88,7 @@ class Eddy
 
   def portal_check
     return if DRCI.exists?("eddy")
+
     DRC.message("You need to be wearing a portal to use this script!")
     exit
   end
@@ -109,6 +110,7 @@ class Eddy
     item_swap.each do |item|
       if !portal_container.nil?
         return unless DRCI.inside?("#{item}", "#{portal_container} in my portal")
+        
         DRCI.get_item?("#{item}", "#{portal_container} in my portal")
         DRCI.put_away_item?("#{item}", container)
       elsif DRCI.exists?("#{item}", "portal")

--- a/eddy-swap.lic
+++ b/eddy-swap.lic
@@ -1,0 +1,142 @@
+=begin
+
+  Modification of the tool-clerk script. Designed to get/put specified sets of items from/into your portal.
+
+  Yaml will need to have a portal_store: section added with specified sets and items you want to get and put. You can also link existing sets (like crafting tools) if desired.
+
+  You can also designate a container in your portal to get items from/put items into using the portal_container setting.
+
+  Example configuration:
+
+  <in your crafting section>
+  alchemy_tools: &alchemy_tools
+  - mortar
+  - pestle
+  - bowl
+  - mixing stick
+  - sieve
+  
+  portal_store:
+    weapons:
+      items:
+      - broadsword
+      - bar mace
+      - javelin
+  
+    alchemy_tools:
+      items: *alchemy_tools
+
+    forging_tools:
+      items: *forging_tools
+      portal_container: forging apron
+
+  You can then run the script with weapons, alchemy_tools, or forging_tools as the "set" argument and it'll leverage those items.
+
+  If any of the containers require adjective and noun, wrap the words in double quotes. Example: "leather pack"
+
+  TODO:
+  - Test with multiple bags of the same type in the portal (e.g., first backpack, second backpack)
+  - Error handling for full bags
+
+=end
+custom_require.call(%w[common common-items equipmanager])
+
+class Eddy
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'set', regex: /\w+/i, optional: false, description: 'REQUIRED: Set of items you want to transfer. Build in portal_store section of yaml.' },
+        { name: 'action', regex: /get|put/i, optional: false, description: 'REQUIRED: Designate whether you want to get items from portal/put items into portal. Must be get or put.' },
+        { name: 'container', regex: /\w+/i, optional: false, description: 'REQUIRED: Worn container you want to put your items into/get items from. Wrap multiple words in double quotes, ex: "leather pack"' }
+      ]
+    ]
+
+    portal_container = nil
+
+    settings = get_settings
+
+    args                    = parse_args(arg_definitions)
+    action                  = args.action
+    set                     = args.set
+    store_data              = settings.portal_store[set]
+    item_swap               = store_data['items']
+    portal_container        = store_data['portal_container']
+    container               = args.container
+
+    if action.nil? || set.nil? || container.nil?
+      DRC.message("Missing a required argument!")
+      exit
+    end
+
+    portal_check
+
+    if item_swap.nil?
+      DRC.message("Portal_store setting #{set} is empty or doesn't exist!")
+      exit
+    end
+
+    container_check(container, portal_container)
+
+    if action == 'get'
+      get_items(item_swap, container, portal_container)
+    elsif action == 'put'
+      put_items(item_swap, container, portal_container)
+    else
+      echo 'Unknown action'
+    end
+  end
+
+  def portal_check
+    return if DRCI.exists?("eddy")
+    DRC.message("You need to be wearing a portal to use this script!")
+    exit
+  end
+
+  def container_check(container, portal_container = nil)
+    if !portal_container.nil?
+      return if DRCI.inside?(portal_container, "portal")
+      DRC.message("Couldn't find the specified container in your portal!")
+      exit
+    elsif DRCI.exists?(container)
+      return
+    else
+      DRC.message("Couldn't find the specified container!")
+      exit
+    end
+  end
+
+  def get_items(item_swap, container, portal_container = nil)
+    item_swap.each do |item|
+      if !portal_container.nil?
+        return unless DRCI.inside?("#{item}", "#{portal_container} in my portal")
+        DRCI.get_item?("#{item}", "#{portal_container} in my portal")
+        DRCI.put_away_item?("#{item}", container)
+      elsif DRCI.exists?("#{item}", "portal")
+        DRCI.get_item?("#{item}", "portal")
+        DRCI.put_away_item?("#{item}", container)
+      else
+        DRC.message("Couldn't find #{item} in your portal! Exiting script!")
+        exit
+      end
+    end
+  end
+
+  def put_items(item_swap, container, portal_container = nil)
+    item_swap.each do |item|
+      if DRCI.exists?("#{item}", container)
+        DRCI.get_item?("#{item}", container)
+        if !portal_container.nil?
+          fput("put my #{item} in #{portal_container} in my portal")
+          fput("put my #{item} in #{portal_container} in my portal")
+        else
+          DRCI.put_away_item?("#{item}", "portal")
+        end
+      else
+        DRC.message("Coudln't find #{item} in your #{container}! Exiting script!")
+        exit
+      end
+    end
+  end
+end
+
+Eddy.new

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2571,14 +2571,9 @@ tome_settings:
 portal_store:
   # Create a set name for your items. This set will be called as a argument when running the script.
   example:
-    # Items you'd like to move into/out of the portal. 
+    # Items you'd like to move into/out of the portal. Items that are already in a list, such as workorder tools, can be linked.
     items:
     - godkiller blade
     - bagof holding
-  
-  # Multiple sets can be created and called as needed.
-  example_tools:
-    # Items that are already in a list, such as workorder tools, can be linked.
-    items: *example_tools
     # If you want to use containers within your portal for organization, set the portal_container value. This is an optional setting.
-    portal_container: example apron
+    portal_container: example baldric

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2566,3 +2566,19 @@ tome_settings:
   - crossing-repair
   - task-forage
   debug: false
+
+# Settings for the eddy-swap script, which is designed to take items out of/put items into a Corn Maze portal.
+portal_store:
+  # Create a set name for your items. This set will be called as a argument when running the script.
+  example:
+    # Items you'd like to move into/out of the portal. 
+    items:
+    - godkiller blade
+    - bagof holding
+  
+  # Multiple sets can be created and called as needed.
+  example_tools:
+    # Items that are already in a list, such as workorder tools, can be linked.
+    items: *example_tools
+    # If you want to use containers within your portal for organization, set the portal_container value. This is an optional setting.
+    portal_container: example apron


### PR DESCRIPTION
Adding a newly created eddy-swap script. This script is intended get items from/put items into the portal. The script supports using containers in the portal for organization as an optional setting.

There are a number of checks in the script to prevent loss of items. Containers are validated before actions are taken, items are tapped prior to being move in either direction, the the existence of the portal itself is also checked.

The base.yaml updates include placeholder examples to demonstrate the configuration settings. Placeholders were used in the event someone correctly ran the script accidently and moved items without warning.