### PR TITLE
register.lic - Add compatibility for column formatted output

### DIFF
--- a/register.lic
+++ b/register.lic
@@ -147,10 +147,10 @@ class Register
   end
 
   def find_unlabeled
-    results = search('^\s{4}.*[A-z]+$')
+    results = search('^\s*.*([A-z]+|\|\s+\|)$')
     pages = Array.new
     results.each do |line|
-      if line =~ /^\s+(\d+)/
+      if line =~ /^\|?\s+(\d+)/
         pages.push(Regexp.last_match(1).to_i)
       end
     end
@@ -185,6 +185,7 @@ class Register
     loop do
       line = get
       contents.push(line) if line =~ /\W?#{query}\W?/i
+      break if line.match('Currently Stored: ')
       break if line.match('Maximum:  ')
     end
     return contents


### PR DESCRIPTION
Added compatibility with the column formatted output given with TOGGLE CRAFT. It will now work properly with that setting.