### PR TITLE
[setupaliases.lic] support for new map.lic for map alias

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#setupaliases
 =end
 
-[
+aliases_to_add = [
   # These will list the Ruby and Lich versions
   ['rubyver', "#{$clean_lich_char}e echo RUBY_VERSION"],
   ['lichver', "#{$clean_lich_char}e echo LICH_VERSION"],
@@ -51,7 +51,6 @@
   ['dm', "#{$clean_lich_char}repos download-mapdb"],
   ['rm', "#{$clean_lich_char}e Map.reload"],
 
-  ['map', "#{$clean_lich_char}xnarost"],
   # List all hunting zones from base-hunting alphabetically by name
   ['hz', "#{$clean_lich_char}e get_data('hunting').hunting_zones.sort.each{ |x| echo x }"],
   # List all escort zones from base-hunting alphabetically by name.
@@ -60,6 +59,15 @@
   ['fz', "#{$clean_lich_char}e get_data('hunting').hunting_zones.find_all { |k, v| k =~ /\\?/i}.each { |zone| respond \"\#\{zone[0]\}:  \#\{zone[1].join(', ')\}\" }"],
   # Calculate your unofficial trader bonus according to elanthipedia
   ['traderbonus', "#{$clean_lich_char}e x = DRStats.charisma*(DRSkill.getrank('Trading') + DRSkill.getrank('Appraisal')).to_f; echo case x when 0..2100 then (x/210).floor when 2101..8400 then ((x/350)+1).floor when 8401..Float::INFINITY then (((x+444)/2211)+21).floor end"]
-].each do |trigger, target|
-  UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
+]
+
+if Script.exists?('map')
+  aliases_to_add.push(['map', "#{$clean_lich_char}map"])
+elsif Script.exists?('xnarost')
+  aliases_to_add.push(['map', "#{$clean_lich_char}xnarost"])
+end
+
+aliases_to_add.each do |trigger, target|
+  # UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
+  Script.run('alias', "add --global #{trigger} = #{target}")
 end


### PR DESCRIPTION
Use `map.lic` if found, otherwise fallback to `xnarost.lic` for the `map` alias. Also switch from using an `Upstreamhook.run` to `Script.run` instead.