### PR TITLE
Update trade.lic crafting routines with better type checking

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -1874,7 +1874,7 @@ class Trade
       outfitting_type = should_knit? ? 'knitting' : 'sewing'
       outfitting_mat = should_knit? ? 'wool' : 'burlap'
       @current_materials[@outfitting_material_type] -= recipe['volume']
-      start_script('sew', ['stow', outfitting_type, recipe['chapter'], recipe['name'], outfitting_mat].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg }, recipe['noun'])
+      start_script('sew', ['stow', outfitting_type, recipe['chapter'].to_s, recipe['name'], outfitting_mat].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg }, recipe['noun'])
     end
   end
 
@@ -1974,7 +1974,7 @@ class Trade
       magic_cleanup
       @current_materials['balsa lumber'] -= recipe['volume']
       echo "recipe is #{recipe}" if debugging?
-      start_script('shape', ['stow', recipe['chapter'], recipe['name'], 'balsa', recipe['noun']].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg })
+      start_script('shape', ['stow', recipe['chapter'].to_s, recipe['name'], 'balsa', recipe['noun']].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg })
     end
   end
 


### PR DESCRIPTION
It looks like Ruby 3.0.1+ is stricter about type checking. A pattern match was being called on an integer (recipe['chapter']) and causing issues for people using modern versions of Ruby.