### PR TITLE
[common-arcana.lic] Fix use_auto_mana with rituals

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -723,7 +723,7 @@ module DRCA
         discern_data['cambrinth'] = nil
       else
         discern =~ /minimum (\d+) mana streams and you think you can reinforce it with (\d+) more/i
-        calculate_mana(Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, discern_data, data['cyclic'], settings)
+        calculate_mana(Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, discern_data, data['cyclic'] || data['ritual'], settings)
       end
     end
     pause 1
@@ -734,7 +734,7 @@ module DRCA
     data
   end
 
-  def calculate_mana(min, more, discern_data, cyclic, settings)
+  def calculate_mana(min, more, discern_data, cyclic_or_ritual, settings)
     total = min + more
     total = (total * settings.prep_scaling_factor).floor
     discern_data['mana'] = [(total / 5.0).ceil, min].max
@@ -759,7 +759,7 @@ module DRCA
       discern_data['mana'] = discern_data['mana'] + (remaining - total_cambrinth_cap)
       remaining = total - discern_data['mana']
     end
-    if cyclic || total_cambrinth_charges == 0
+    if cyclic_or_ritual || total_cambrinth_charges == 0
       discern_data['cambrinth'] = nil
       discern_data['mana'] = discern_data['mana'] + remaining
     elsif remaining > 0


### PR DESCRIPTION
Rituals don't use camb, but use_auto_mana was still including camb in it's calculations when the spell was a ritual