### PR TITLE
[scripts][pick] Handle khri safe dodged failures

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -540,11 +540,8 @@ class Pick
     when *@disarmed_trap_messages.values
       echo "Identified already disarmed trap: #{disarm_result}" if @debug
       trapped = false
-    when *@disarm_retry
+    when *@disarm_retry, 'Thanks to an instinct provided by your sense of security'
       echo 'Failed to disarm trap' if @debug
-      trapped = true
-    when 'Thanks to an instinct provided by your sense of security'
-      echo 'Dodged a trap with Safe...' if @debug
       trapped = true
     when *@disarm_succeeded
       echo 'Successfully disarmed trap' if @debug

--- a/pick.lic
+++ b/pick.lic
@@ -461,7 +461,7 @@ class Pick
 
     case disarm_identify_match
     when 'Thanks to an instinct provided by your sense of security'
-      echo 'Dodged a trap with Safe...' if @debug
+      echo 'Detected a trap with Safe...' if @debug
       trapped = true
     when *@disarm_lost_box_matches
       DRC.message('Lost your box somehow...')

--- a/pick.lic
+++ b/pick.lic
@@ -461,8 +461,8 @@ class Pick
 
     case disarm_identify_match
     when 'Thanks to an instinct provided by your sense of security'
-      echo 'Dodged a trap with Safe...'
-      trapped = false
+      echo 'Dodged a trap with Safe...' if @debug
+      trapped = true
     when *@disarm_lost_box_matches
       DRC.message('Lost your box somehow...')
       trapped = false # Flag the box as not trapped, so it will fall through and move on...
@@ -545,7 +545,7 @@ class Pick
       trapped = true
     when 'Thanks to an instinct provided by your sense of security'
       echo 'Dodged a trap with Safe...' if @debug
-      trapped = false
+      trapped = true
     when *@disarm_succeeded
       echo 'Successfully disarmed trap' if @debug
       trapped = false


### PR DESCRIPTION
The old logic assumes that dodging a blown trap with Khri Safe fully disarms the box, and that it's ok to proceed with picking. This doesn't seem to be the case - see the attached log: [khri_safe_dodge.txt](https://github.com/rpherbig/dr-scripts/files/14184625/khri_safe_dodge.txt)
From line 22 onward, all traps remain after dodging the failed disarm.