### PR TITLE
[scripts][outdoorsmanship] Add outdoorsmanship waggle

### DIFF
--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -45,6 +45,7 @@ class Outdoorsmanship
     start_exp = DRSkill.getxp(@skill_name)
     @end_exp = [start_exp + @targetxp, 34].min
     DRCT.walk_to(@outdoors_room)
+    DRC.wait_for_script_to_complete('buff', ['outdoorsmanship'])
     train_outdoorsmanship
   end
 


### PR DESCRIPTION
Since the addition of `collect <item> practice` buffing outdoorsmanship is crucial for lower roundtimes. This adds support for a outdoorsmanship waggle to be cast prior to training.