### PR TITLE
[scripts][stack-scrolls] Add new turn syntax, and keep_scrolls

### DIFF
--- a/stack-scrolls.lic
+++ b/stack-scrolls.lic
@@ -9,6 +9,7 @@ class ScrollStack
     settings = get_settings
     scroll_stackers = settings.scroll_stackers
     @discard_scrolls = settings.discard_scrolls
+    @keep_scrolls = settings.keep_scrolls
     stacker_container = settings.stacker_container
     @worn_trashcan = settings.worn_trashcan
     @worn_trashcan_verb = settings.worn_trashcan_verb
@@ -82,9 +83,7 @@ class ScrollStack
 
     slot = target['contents'].find_index { |data| data.first =~ /#{query}/i }
 
-    slot.times do
-      DRC.bput("turn my #{target['name']}", 'You turn to a new')
-    end
+    DRC.bput("turn #{DRC.get_noun(target['name'])} to #{query}", /^You turn/)
 
     case DRC.bput("pull my #{target['name']}", 'This was the last copy', 'Carefully')
     when /This was the last/i
@@ -166,7 +165,9 @@ class ScrollStack
     end
     waitrt?
 
-    if @discard_scrolls.find { |discard| spell_name == discard }
+    if @discard_scrolls.find { |discard| spell_name == discard } || !@keep_scrolls.any?(/#{spell_name}/i)
+      DRC.message("Scroll in discards, or not in keep list.")
+      DRC.message("Scroll is #{spell_name}")
       DRCI.dispose_trash(scroll, @worn_trashcan, @worn_trashcan_verb)
     elsif (target = UserVars.stackers.find { |stacker| stacker['contents'].find { |data| data.first == spell_name } })
       stack_existing_scroll(target, scroll, spell_name, stacker_container)


### PR DESCRIPTION
This fixes the script to use the new syntax for turning to a specific spell.

It also adds a new settings, `keep_scrolls` which inverts the discard setting (and or works with it) so you can instead state which scrolls you want to keep.