### PR TITLE
Update base.yaml

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1442,6 +1442,7 @@ ignored_npcs:
   - piglet
   - raccoon
   - shadowling
+  - devourer
 
 favor_god: Hodierna
 # Offer primers on favor altars instead of doing the puzzle, allows more immortal choices and is faster at higher favor counts


### PR DESCRIPTION
Added `devourer` to the list of ignored_npcs for combat because of the multi-armed devourers being dropped all over the place.