### PR TITLE
[scripts][almanac] Expand pick-a-nack functionality

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -39,7 +39,6 @@ class Almanac
            .map { |skill| [skill.name, skill.exp] }
            .select { |element| element[1] }
            .reject { |skill, _exp| skill == "Mechanical Lore" }
-          #  .reject { |_skill, exp| exp.to_i > 18 }
            .select { |skill, exp| list.append [skill, exp] }
     skill = list.sort_by(&:last).first[0].sub(/(Lunar|Life|Arcane|Holy|Elemental)\s/, '')
     return skill

--- a/almanac.lic
+++ b/almanac.lic
@@ -33,9 +33,21 @@ class Almanac
       .min_by { |skill| [DRSkill.getxp(skill), DRSkill.getrank(skill)] }
   end
 
+  def skill_with_lowest_mindstate
+    list = []
+    DRSkill.list
+           .map { |skill| [skill.name, skill.exp] }
+           .select { |element| element[1] }
+           .reject { |skill, _exp| skill == "Mechanical Lore" }
+          #  .reject { |_skill, exp| exp.to_i > 18 }
+           .select { |skill, exp| list.append [skill, exp] }
+    skill = list.sort_by(&:last).first[0].sub(/(Lunar|Life|Arcane|Holy|Elemental)\s/, '')
+    return skill
+  end
+
   def use_almanac
     unless @almanac_skills.empty?
-      training_skill = almanac_sort_by_rate_then_rank(@priority_skills) || almanac_sort_by_rate_then_rank(@almanac_skills)
+      training_skill = almanac_sort_by_rate_then_rank(@priority_skills) || almanac_sort_by_rate_then_rank(@almanac_skills) || skill_with_lowest_mindstate
       echo("training skill is #{training_skill}")
       return unless training_skill
     end


### PR DESCRIPTION
Introduces a feature whereby if neither priority, nor almanac skills are under 18 mindstates, it'll train lowest mindstate skill overall. Takes into account the various magic types too.