### PR TITLE
Update base-recipes.yaml

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -9753,7 +9753,7 @@ crafting_recipes:
   noun: small sphere
   type: artificing
   chapter: 4
-  work_order: faltuese
+  work_order: false
   enchant_stock1_name: congruence
   enchant_stock1: 3
   enchant_stock2_name: congruence


### PR DESCRIPTION
Misspelling causing issues with enchant when used with workorders since its buying the incorrect number of decay sigils.