### PR TITLE
[scripts][drinfomon] make the capped skill mapping universal

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#drinfomon
 =end
 
-$DRINFOMON_VERSION = '2.0.34'
+$DRINFOMON_VERSION = '2.0.35'
 
 no_kill_all
 no_pause_all
@@ -312,7 +312,9 @@ class DRSkill
   def initialize(name, rank, exp, percent)
     @name = name # skill name like 'Evasion'
     @rank = rank.to_i # earned ranks in the skill
-    @exp = exp.to_i # learning rate in the skill from 0 to 34
+    # Skill mindstate x/34
+    # Hardcode caped skills to 34/34
+    @exp = rank.to_i >= 1750 ? 34 : exp.to_i
     @percent = percent.to_i # percent to next rank from 0 to 100
     @baseline = rank.to_i + (percent.to_i / 100.0)
     @current = rank.to_i + (percent.to_i / 100.0)
@@ -373,7 +375,7 @@ class DRSkill
     skill = self.find_skill(name)
     if skill
       skill.rank = rank.to_i
-      skill.exp = exp.to_i
+      skill.exp = skill.rank.to_i >= 1750 ? 34 : exp.to_i
       skill.percent = percent.to_i
       skill.current = rank.to_i + (percent.to_i / 100.0)
     else
@@ -408,7 +410,7 @@ class DRSkill
 
   def self.getxp(val)
     skill = self.find_skill(val)
-    skill.rank.to_i >= 1750 ? 34 : skill.exp.to_i
+    skill.exp.to_i
   end
 
   def self.getpercent(val)


### PR DESCRIPTION
Previously only DRSkill.getxp got the mapping from 1750 ranks to 34/34 mindstates. This change makes that mapping universal.