### PR TITLE
[scripts][go2] Re-supporting the ability to use spaces in custom go2 locations

### DIFF
--- a/go2.lic
+++ b/go2.lic
@@ -14,7 +14,7 @@
 
    changelog:
       1.36 (2024-03-03)
-        Re-supporting the ability to use spaces in custom go2 locations. 
+        Re-supporting the ability to use spaces in custom go2 locations.
       1.35 (2023-02-04)
         Add support for custom named targets with an array of roomnumbers. Finds nearest.
       1.34 (2022-11-26)
@@ -357,7 +357,7 @@ elsif script.vars[1] =~ /^save/i
       echo "error: proper format examples - ;go2 save test=1234 OR ;go2 save test=[1234, 1432] etc."
       exit
    end
-   target_name = $1
+   target_name = $1.strip
    target = $2.split(',')
               .collect(&:strip)
 

--- a/go2.lic
+++ b/go2.lic
@@ -9,10 +9,12 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.35
+           version: 1.36
           required: Lich >= 4.6.14
 
    changelog:
+      1.36 (2024-03-03)
+        Re-supporting the ability to use spaces in custom go2 locations. 
       1.35 (2023-02-04)
         Add support for custom named targets with an array of roomnumbers. Finds nearest.
       1.34 (2022-11-26)
@@ -350,7 +352,7 @@ elsif script.vars[0] =~ /^list$/i
    respond output
    exit
 elsif script.vars[1] =~ /^save/i
-   unless script.vars[0] =~ /^save ([a-zA-Z0-9!@.#$%_-]+)\s?=\s?(current|\d+)$/ || script.vars[0] =~ /^save ([a-zA-Z0-9!@.#$%_-]+)\s?=\s?\[?([current\d,\s]+)\]?$/
+   unless script.vars[0] =~ /^save ([a-zA-Z0-9!@.#$%_\s-]+)\s?=\s?(current|\d+)$/ || script.vars[0] =~ /^save ([a-zA-Z0-9!@.#$%_\s-]+)\s?=\s?\[?([current\d,\s]+)\]?$/
       echo "error: format"
       echo "error: proper format examples - ;go2 save test=1234 OR ;go2 save test=[1234, 1432] etc."
       exit


### PR DESCRIPTION
An  earlier commit removed the ability to use spaces as part of custom locations. This adds back in that ability.