### PR TITLE
[scripts][common-items] Small tidying and error correction

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -63,7 +63,7 @@ module DRCI
   ]
 
   GET_ITEM_SUCCESS_PATTERNS = [
-    /you draw/i,
+    /you draw (?!\w+'s wounds)/i,
     /^You get/,
     /^You pick/,
     /^You pluck/,
@@ -1169,9 +1169,13 @@ module DRCI
                   /is too full to fit/,
                   /^You'd better tie it up before putting/,
                   /You'll need to tie it up before/,
+                  /Please rephrase that command/,
                   'What were you referring to',
                   "There aren't any gems",
                   'You fill your')
+    when /Please rephrase that command/
+      DRC.message("Container #{source_container} not found. Skipping fill")
+      return
     when /^You'd better tie it up before putting/, /You'll need to tie it up before/
       # This is equivalent to a full pouch, unless we should tie pouches, in which case we tie and retry
       unless should_tie_gem_pouches


### PR DESCRIPTION
Empath link unity triggered false positives on get item success, now it doesn't.

Skips filling pouch if you don't have the source to fill from.