### PR TITLE
[scripts][almanac][combat-trainer] Reject 0-rank skills from almanac …

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -38,7 +38,7 @@ class Almanac
     DRSkill.list
            .map { |skill| [skill.name, skill.exp, skill.rank] }
            .select { |element| element[1] }
-           .reject { |_skill, _exp, rank| rank.to_i == 1750 }
+           .reject { |_skill, _exp, rank| (rank.to_i == 1750 || rank.to_i == 0) }
            .reject { |skill, _exp| skill == "Mechanical Lore" }
            .select { |skill, exp| list.append [skill, exp] }
     skill = list.sort_by(&:last).first[0].sub(/(Lunar|Life|Arcane|Holy|Elemental)\s/, '')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2919,7 +2919,7 @@ class TrainerProcess
     DRSkill.list
            .map { |skill| [skill.name, skill.exp, skill.rank] }
            .select { |element| element[1] }
-           .reject { |_skill, _exp, rank| rank.to_i == 1750 }
+           .reject { |_skill, _exp, rank| (rank.to_i == 1750 || rank.to_i == 0) }
            .reject { |skill, _exp| skill == "Mechanical Lore" }
            .select { |skill, exp| list.append [skill, exp] }
     skill = list.sort_by(&:last).first[0].sub(/(Lunar|Life|Arcane|Holy|Elemental)\s/, '')


### PR DESCRIPTION
…list

We already rejected capped skills (1750) we now additionally reject zero-rank skills, since non-magic users have magic skills at zero ranks we can't train...