### PR TITLE
[scripts][gpouch] Added counter for multiple pouches

### DIFF
--- a/gpouch.lic
+++ b/gpouch.lic
@@ -10,17 +10,29 @@ class GivePouches
       [
         { name: 'container', regex: /\w+/i, variable: true, description: 'Name of the container to get pouches from' },
         { name: 'player', regex: /\w+/i, variable: true, description: 'Name of the player to give pouches to' },
-        { name: 'sell', regex: /sell/i, variable: true, optional: true, description: 'Sell the pouches to the trader instead' }
+        { name: 'sell', regex: /sell/i, variable: true, optional: true, description: 'Sell the pouches to the trader instead' },
+        { name: 'number', regex: /\d+/i, variable: true, optional: true, description: 'Number of pouches to give/sell to the trader. Defaults to 1 pouch.'}
       ]
     ]
 
-    args = parse_args(arg_definitions)
+    @args = parse_args(arg_definitions)
 
     @settings = get_settings
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
 
-    @sell = args.sell
+    @gem_pouch_adjective = @settings.gem_pouch_adjective
+    @gem_pouch_noun = @settings.gem_pouch_noun
+
+    @sell = @args.sell
+
+    if @number == 0
+      @sell_count = 1
+    elsif
+      @sell_count = @args.number = @args.number.to_i
+    end
+
+    @cycle = 0
 
     Flags.add('give-accepted', '.* has accepted your offer and is now holding .*')
     Flags.add('give-declined', '.* has declined the offer')
@@ -29,13 +41,27 @@ class GivePouches
 
     EquipmentManager.new.empty_hands
 
-    loop do
-      case DRC.bput("get pouch from #{args.container}", 'You get', 'What were you referring to')
-      when 'You get'
-        hand_over(args.player)
-      when 'What were you referring to'
-        break
+    if @sell_count > 1
+      loop do
+        if @cycle >= @sell_count
+          DRC.message('Finished selling pouches!')
+          exit
+        else
+          get_pouch
+        end
       end
+    else
+      get_pouch
+    end
+  end
+
+  def get_pouch
+    case DRC.bput("get #{@gem_pouch_adjective} #{@gem_pouch_noun} from #{@args.container}", 'You get', 'What were you referring to')
+    when 'You get'
+      hand_over(@args.player)
+      @cycle += 1
+    when 'What were you referring to'
+      exit
     end
   end
 

--- a/gpouch.lic
+++ b/gpouch.lic
@@ -11,7 +11,7 @@ class GivePouches
         { name: 'container', regex: /\w+/i, variable: true, description: 'Name of the container to get pouches from' },
         { name: 'player', regex: /\w+/i, variable: true, description: 'Name of the player to give pouches to' },
         { name: 'sell', regex: /sell/i, variable: true, optional: true, description: 'Sell the pouches to the trader instead' },
-        { name: 'number', regex: /\d+/i, variable: true, optional: true, description: 'Number of pouches to give/sell to the trader. Defaults to 1 pouch.'}
+        { name: 'number', regex: /\d+/i, variable: true, optional: true, description: 'Number of pouches to give/sell to the trader. Defaults to 1 pouch.' }
       ]
     ]
 
@@ -28,7 +28,7 @@ class GivePouches
 
     if @number == 0
       @sell_count = 1
-    elsif
+    else
       @sell_count = @args.number = @args.number.to_i
     end
 


### PR DESCRIPTION
Added a "number" option to the gpouch.lic script. This optional argument allows the sale of multiple pouches in a single execution without having to restart the script. Without this argument, the default value is one.