### PR TITLE
[script] [tome] bug fix in before_dying

### DIFF
--- a/tome.lic
+++ b/tome.lic
@@ -1,5 +1,12 @@
 custom_require.call(%w[common common-items drinfomon events])
+
 class Tome
+  @@tome = nil
+
+  def self.tome
+    @@tome
+  end
+
   def initialize
     arg_definitions = [
       [
@@ -13,7 +20,7 @@ class Tome
     @tome_settings = @settings.tome_settings
     @debug = args.debug
 
-    @tome = @tome_settings['tome_name']
+    @@tome = @tome_settings['tome_name']
     @quit_early = @tome_settings['quit_early']
     @scholarship_limit = @tome_settings['scholarship_limit'] || 34
     @passive_scripts = @tome_settings['passive_scripts']
@@ -21,9 +28,9 @@ class Tome
     @no_use_rooms = @settings.sanowret_no_use_rooms
 
     # check to ensure tome is defined in gear, and warn user if not
-    if @settings.gear.find { |item| @tome =~ /#{item[:adjective]}\s*#{item[:name]}/i }.nil?
+    if @settings.gear.find { |item| @@tome =~ /#{item[:adjective]}\s*#{item[:name]}/i }.nil?
       message = "To minimize the possibility that items that you hold in your hands could be lost they should be listed in your `gear:`. Your tome is not listed in your `gear:` settings:"
-      message += "\n  - #{@tome}"
+      message += "\n  - #{@@tome}"
       message += "\nIf you need assistance with this, please ask in the lich discord (listed in #{$clean_lich_char}links) for help."
       message += "\n\n---This check is *advisory* for now, but will become mandatory in the near future.---"
       DRC.message(message)
@@ -42,7 +49,7 @@ class Tome
     }
 
     if @quit_early
-      Flags.add('study-complete', Regexp.new(@penultimate_pages[@tome]))
+      Flags.add('study-complete', Regexp.new(@penultimate_pages[@@tome]))
     else
       Flags.add('study-complete', /^Having finished your studies,/)
     end
@@ -57,7 +64,7 @@ class Tome
     return false if DRSkill.getxp('Scholarship') >= @scholarship_limit
     return true unless @passive
     return false if hiding? || invisible?
-    return false if DRC.left_hand && DRC.right_hand && !DRCI.in_hands?(@tome)
+    return false if DRC.left_hand && DRC.right_hand && !DRCI.in_hands?(@@tome)
     return false if @no_use_rooms.any? { |name| /#{name}/ =~ DRRoom.title || name.to_s == Room.current.id.to_s }
     if @passive_scripts.any? { |name|
       echo "Passive script: #{name}" if Script.running?(name) && @debug
@@ -83,7 +90,7 @@ class Tome
     while Time.now < end_time
       if !should_train?
         pause_scripts if @passive
-        DRCI.stow_item?(@tome)
+        DRCI.stow_item?(@@tome)
         DRC.safe_unpause_list @scripts_to_unpause if @passive
         return false
       end
@@ -107,11 +114,11 @@ class Tome
       next unless should_train?
 
       pause_scripts if @passive
-      unless DRCI.get_item?(@tome)
+      unless DRCI.get_item?(@@tome)
         DRC.safe_unpause_list @scripts_to_unpause if @passive
         next
       end
-      result = DRC.bput("study my #{@tome}",
+      result = DRC.bput("study my #{@@tome}",
                         /^You immerse yourself in the wisdom of your/,
                         /^You are unable to focus on studying your/,
                         /^You must complete or cancel your current magical research project/,
@@ -124,7 +131,7 @@ class Tome
            /^Considering that you are in combat/,
            /^However, you find that you lack the concentration to focus on your studies/
         pause_scripts if @passive
-        DRCI.stow_item?(@tome)
+        DRCI.stow_item?(@@tome)
         DRC.safe_unpause_list @scripts_to_unpause if @passive
         pause 10
         next
@@ -135,7 +142,7 @@ class Tome
       # (which only will happen if we finished reading but somehow missed the completion flag - e.g., if another script stowed the book)
       pause 1 until Flags['study-complete'] or !should_train? or DRStats.concentration == 100
       pause_scripts if @passive
-      DRCI.stow_item?(@tome)
+      DRCI.stow_item?(@@tome)
       DRC.safe_unpause_list @scripts_to_unpause if @passive
     end
   end
@@ -144,7 +151,7 @@ end
 before_dying do
   Flags.delete('study-complete')
   DRC.fix_standing
-  DRCI.stow_item?(@tome) if DRCI.in_hands?(@tome)
+  DRCI.stow_item?(Tome.tome) if !Tome.tome.nil? && DRCI.in_hands?(Tome.tome)
 end
 
 Tome.new


### PR DESCRIPTION
If script is ended/killed while tome is still in your hands, the before dying can't access the name of the tome, as it's trying to use an instance variable outside the class.

This sets the tome name to be a class variable, and creates an accessor to access it outside the class itself.