### PR TITLE
[data][base.yaml] Add spin to list of no_play scripts.

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -297,6 +297,7 @@ pattern_hues_no_use_scripts:
   - steal
   - tinker
   - workorders
+  - spin
 
 pattern_hues_no_use_rooms:
   - 1900                                          # Crossing bank teller - included with regex below but shown for example


### PR DESCRIPTION
Adding Spin to the list of no_play scripts, because it hangs when using the spinner and you're playing on the zills/cowbell.