### PR TITLE
[scripts][moonwatch] Move get_settings call out of loop.

### DIFF
--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -61,7 +61,7 @@ Settings['set']['xibar'] = 174 * 60
 Settings['set']['katamba'] = 177 * 60
 
 if CharSettings['moon_window']
-  if $frontend == 'genie'   # fix genie bullshit
+  if $frontend == 'genie' # fix genie bullshit
     _respond("<streamWindow id='moonWindow' title='moonWindow' location='center' save='true' />")
     echo('Be sure to open the moonWindow window if not already open.')
   else

--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -26,6 +26,8 @@ args = parse_args(arg_definitions)
 
 $debug_mode_mm = UserVars.moon_debug || args.debug
 
+correct = args.correct || UserVars.moonwatch_correct || get_settings.moonwatch_correct
+
 enable_moon_connection
 
 RISE = 1
@@ -175,6 +177,6 @@ loop do
   update_moon_info(get_all_moon_data)
   update_sun_info(get_all_moon_data)
   update_moon_window if CharSettings['moon_window']
-  check_for_new_moons if args.correct || UserVars.moonwatch_correct || get_settings.moonwatch_correct
+  check_for_new_moons if correct
   pause 0.1 unless line
 end


### PR DESCRIPTION
Having this call inside the loop causes a lot of disk IO, and at least one user has reported it being very noticeable on a WSL install. There is no good reason to have this inside the loop in any case, as it's a static value in a yaml...