### PR TITLE
[scripts][combat-trainer] Add combat_trainer_gear_set setting

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3974,7 +3974,8 @@ class CombatTrainer
     @equipment_manager.empty_hands
     setup(settings)
     settings.storage_containers.each { |container| fput("open my #{container}") }
-    @equipment_manager.wear_equipment_set?('standard') if settings.cycle_armors_regalia.nil? || DRCA.parse_regalia.empty?
+    worngear = settings.combat_trainer_gear_set || "standard"
+    @equipment_manager.wear_equipment_set?(worngear) if settings.cycle_armors_regalia.nil? || DRCA.parse_regalia.empty?
   end
 
   def set_dance(message, settings)


### PR DESCRIPTION
Allows one to specify a gear set to be worn for the current combat-trainer configuration.

I use this to set a light armor-only set for my thief when uphunting, for example.