### PR TITLE
[scripts][dependency] Move wayto_overrides to dependency.

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,8 +10,8 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.6.4'
-$MIN_RUBY_VERSION = '2.5.5'
+$DEPENDENCY_VERSION = '1.6.5'
+$MIN_RUBY_VERSION = '3.2.2'
 
 no_pause_all
 no_kill_all
@@ -680,6 +680,39 @@ class ScriptManager
       JSON.parse(response.body.chomp)
     rescue
       return nil
+    end
+  end
+  def make_map_edits
+    echo("Applying personal map overrides")
+    # Get base and personal wayto overrides
+    base_wayto_overrides = get_settings.base_wayto_overrides
+    personal_wayto_overrides = get_settings.personal_wayto_overrides
+    # Merge the two hashes into a single hash, favoring personal overrides for duplicate keys.
+    wayto_overrides = base_wayto_overrides.merge(personal_wayto_overrides)
+    # Iterate through the aggregated map wayto overrides from above and set new stringprocs
+    wayto_overrides.each do |_key, values|
+      start_room_id = values['start_room'].to_i
+      end_room_id = values['end_room'].to_i
+      start_room = Map.list[start_room_id]
+      old_wayto = start_room.wayto["#{end_room_id}"]
+      old_timeto = start_room.timeto["#{end_room_id}"]
+      new_wayto = old_wayto
+      new_timeto = old_timeto
+      if values['str_proc']
+        new_wayto = StringProc.new("#{values['str_proc']}")
+      end
+      if values['travel_time']
+        new_timeto = values['travel_time'].to_f
+      end
+      start_room.wayto["#{end_room_id}"] = new_wayto
+      start_room.timeto["#{end_room_id}"] = new_timeto
+    end
+    # Pull personal map custom targets, if any
+    personal_map_targets = get_settings.personal_map_targets
+    if personal_map_targets
+      custom_targets = (GameSettings['custom targets'] || Hash.new)
+      custom_targets.merge!(personal_map_targets)
+      GameSettings['custom targets'] = custom_targets
     end
   end
 end
@@ -1865,6 +1898,7 @@ echo("DRinfomon ready.")
 $manager.check_base_files
 $manager.check_data_files
 $manager.start_scripts
+$manager.make_map_edits
 
 if LICH_VERSION.match?(/^4/)
   _respond("<pushBold/>*****************************************************************************<popBold/>")

--- a/dependency.lic
+++ b/dependency.lic
@@ -682,6 +682,7 @@ class ScriptManager
       return nil
     end
   end
+
   def make_map_edits
     echo("Applying personal map overrides")
     # Get base and personal wayto overrides


### PR DESCRIPTION
To counter the excessive lag when having many local edits and using go2 applying (and re-applying) local map edits at every invocation, I'm moving them to dependency so they get called once per session instead.

Also updated $MIN_RUBY_VERSION to 3.2.2 to bring dependency into modern times.