### PR TITLE
[scripts][dependency] Reconcile local and remote copies

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1516,7 +1516,7 @@ class HornWatch
       echo("No response body for some reason. Returning nil.")
       return nil
     else
-    response.body.chomp
+      response.body.chomp
     end
   end
 
@@ -1541,7 +1541,7 @@ class HornWatch
   rescue => e
     echo("error in hornwatch #{e.inspect}")
     echo("Returning time.at(0)")
-    return horn_data = Time.at(0)
+    return Time.at(0)
   end
 end
 

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,12 +10,16 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.6.5'
+$DEPENDENCY_VERSION = '1.6.6'
 $MIN_RUBY_VERSION = '3.2.2'
 
 no_pause_all
 no_kill_all
 
+while Script.running?('repository')
+  echo("Repository is running, pausing for 10 seconds.")
+  pause 10
+end
 class Object
   # IMPORT FUTURE LAWLZ
   def itself
@@ -1508,7 +1512,12 @@ class HornWatch
     request['Content-Type'] = 'application/json'
     request.body = timestamp.to_i.to_json
     response = http.request(request)
+    unless response.body
+      echo("No response body for some reason. Returning nil.")
+      return nil
+    else
     response.body.chomp
+    end
   end
 
   def get_horn_data(room)
@@ -1531,6 +1540,8 @@ class HornWatch
     echo("warhorn data for room:#{room} is #{horn_data.inspect}") if @debug
   rescue => e
     echo("error in hornwatch #{e.inspect}")
+    echo("Returning time.at(0)")
+    return horn_data = Time.at(0)
   end
 end
 


### PR DESCRIPTION
Adds a pause whilst repository is running. The two should never run at the same time anyway, but sometimes repository hasn't finished running when dependency is autostarted.

Added more meaningful rescues for hotnwatch.