### PR TITLE
[scripts][outdoorsmanship][data][base.yaml] Adds `skip_magic` toggle

### DIFF
--- a/outdoorsmanship.lic
+++ b/outdoorsmanship.lic
@@ -9,6 +9,7 @@ class Outdoorsmanship
     arg_definitions = [
       [
         { name: 'perception', regex: /perception/, optional: true, description: 'Check Perception skill in place of Outdoorsmanship' },
+        { name: 'skip_magic', regex: /skip_magic/, optional: true, description: 'Skips magic routines, including buffing' },
         { name: 'mindstates', regex: /^\d+/, optional: true, description: 'Number of mindstates or collection attempts to perform before exiting. Defaults to 3' },
         { name: 'room', regex: /(room=(\d+))/, optional: true, description: 'Specific room to forage in - primarily used to locate a trash bin. Syntax:  room=1234' },
         { name: 'collect_item', regex: /\w+/i, optional: true, description: 'Item to collect. Will use forage_item if not set. Wrap "multiple words" in double quotes.' }
@@ -18,10 +19,11 @@ class Outdoorsmanship
     @settings = get_settings
     @training_spells = @settings.crafting_training_spells
     @targetxp = 4
-    @targetxp = args.mindstates.to_i if args.mindstates
+    @targetxp = args.mindstates.to_i || @settings.outdoorsmanship_mindstate_goal
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
     @outdoors_room = @settings.outdoors_room
+    @skip_magic = args.skip_magic || @settings.outdoorsmanship_skip_magic
     if args.room
       room = args.room.split('=')[1]
       @outdoors_room = room
@@ -44,7 +46,7 @@ class Outdoorsmanship
     start_exp = DRSkill.getxp(@skill_name)
     @end_exp = [start_exp + @targetxp, 34].min
     DRCT.walk_to(@outdoors_room)
-    DRC.wait_for_script_to_complete('buff', ['outdoorsmanship'])
+    DRC.wait_for_script_to_complete('buff', ['outdoorsmanship']) unless @skip_magic
     train_outdoorsmanship
   end
 
@@ -52,21 +54,22 @@ class Outdoorsmanship
     attempt = 0 # Failsafe counter to prevent an infinite loop if item isn't collectable in the room
     while (DRSkill.getxp(@skill_name) < @end_exp) && (attempt < @targetxp)
       if @train_method == 'forage'
-        DRCA.crafting_magic_routine(@settings)
+        DRCA.crafting_magic_routine(@settings) unless @skip_magic
         DRC.forage?(@forage_item)
         DRCI.dispose_trash(@forage_item, @worn_trashcan, @worn_trashcan_verb)
         attempt += 1
       else
         item = @forage_item
-        DRCA.crafting_magic_routine(@settings)
+        DRCA.crafting_magic_routine(@settings) unless @skip_magic
         DRC.collect(item)
         waitrt?
       end
     end
-    magic_cleanup
+    magic_cleanup unless @skip_magic
   end
 
   def magic_cleanup
+    return if @skip_magic
     return if @training_spells.empty?
 
     DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -750,6 +750,10 @@ performance_pause: 3
 performance_mindstate_goal: 31
 # If you choose forage method, you'll want a room with a trash bin!  Leave blank to not set a default room.
 outdoors_room:
+# mindstate goal for outdoorsmanship.lic
+outdoorsmanship_mindstate_goal: 31
+# Whether or not to train magic whilst running outdoorsmanship.lic
+outdoorsmanship_skip_magic: false
 # If you choose forage method, you'll want to select a custom item for best learning rate.
 forage_item: rock
 # what item to braid in ;mech-lore


### PR DESCRIPTION
In addition to adding a `skip_magic` command line argument, also adds the possibility of adding a desired mindstate in yaml with `outdoorsmanship_mindstate_goal` (defaults to 31) and the option of adding a yaml setting for opting out of magic as well with `outdoorsmanship_skip_magic` (defaults to false)