### PR TITLE
[scripts][several] Remove #quiet from several active-run scripts

### DIFF
--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -1,4 +1,3 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#find-darkbox
 =end

--- a/heal-remedy.lic
+++ b/heal-remedy.lic
@@ -1,4 +1,3 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#heal-remedy
 =end

--- a/smith.lic
+++ b/smith.lic
@@ -1,4 +1,3 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#smith
 =end

--- a/tendother.lic
+++ b/tendother.lic
@@ -1,4 +1,3 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#tendother
 =end

--- a/workorders.lic
+++ b/workorders.lic
@@ -1,4 +1,3 @@
-# quiet
 =begin
   Documentation: https://elanthipedia.play.net/Lich_script_repository#workorders
 =end


### PR DESCRIPTION
I don't know why they were set to quiet, they aren't anymore.

Remove `# quiet` from find-darkbox, heal-remedy, smith, tendother, and workorders.