### PR TITLE
[script] workorders - Add turnin option

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -9,15 +9,16 @@ class WorkOrders
     arg_definitions = [
       [
         { name: 'discipline', options: %w[blacksmithing weaponsmithing tailoring shaping carving remedies artificing], description: 'What type of workorder to do?' },
-        { name: 'repair', regex: /repair/i, optional: true, description: 'repair tools instead of crafting' }
+        { name: 'repair', regex: /repair/i, optional: true, description: 'repair tools instead of crafting' },
+        { name: 'turnin', regex: /turnin/i, optional: true, description: 'get work order and turn it in immediately with items already on hand' }
       ]
     ]
 
     args = parse_args(arg_definitions)
-    work_order(args.discipline, args.repair)
+    work_order(args.discipline, args.repair, args.turnin)
   end
 
-  def work_order(discipline, repair)
+  def work_order(discipline, repair, turnin)
     @settings = get_settings
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
@@ -144,7 +145,14 @@ class WorkOrders
       exit
     end
 
-    send(craft_method, info, materials_info, item, quantity)
+    if turnin
+      quantity.times do |count|
+        DRCI.get_item(item['noun'], @settings.default_container)
+        bundle_item(item['noun'], info['logbook'])
+      end
+    else
+      send(craft_method, info, materials_info, item, quantity)
+    end
 
     complete_work_order(info)
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -146,7 +146,7 @@ class WorkOrders
     end
 
     if turnin
-      quantity.times do |count|
+      quantity.times do
         DRCI.get_item(item['noun'], @settings.default_container)
         bundle_item(item['noun'], info['logbook'])
       end


### PR DESCRIPTION
Added `turnin` as one of the run options so that you have the items already made on hand, you can run `;workorders <discipline> turnin` and it will go to the society, get the workorders, then bundle your items and turn it in.