### PR TITLE
Update wand-watcher.lic activation_failure_messages

### DIFF
--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -35,7 +35,7 @@ class WandWatcher
     @no_use_rooms = settings.wand_watcher_no_use_rooms
     @startup_delay = args.delay || settings.wand_watcher_startup_delay
     @passive_delay = settings.wand_watcher_passive_delay
-    @activation_failure_messages = [/^The .* remains inert/]
+    @activation_failure_messages = [/^(The|An|A) .* remains inert/]
     @activation_blocked_messages = [/^Something in the area is interfering/,
                                     /^This is not a good place for that/,
                                     /^This is not the best place to be doing that/,


### PR DESCRIPTION
Expanded the ".* remains inert" @activation_failure_messages to account for astrolabes