### PR TITLE
Update drinfomon.lic luck regex

### DIFF
--- a/drinfomon.lic
+++ b/drinfomon.lic
@@ -1012,7 +1012,7 @@ regex_info_gender_age_circle = /^Gender:\s+\b(?<gender>.+)\b\s+Age:\s+\b(?<age>.
 # but what our scripts operate on is the percentage which comes through as an xml tag parsed by the `status_hook`.
 regex_info_stat_value = /(?<stat>Strength|Agility|Discipline|Intelligence|Reflex|Charisma|Wisdom|Stamina|Favors|TDPs)\s+:\s+(?<value>\d+)/
 regex_info_encumbrance = /^\s*Encumbrance\s+:\s+(?<encumbrance>[\w\s'?!]+)$/
-regex_info_luck = /^\s*Luck\s+:\s+.*\((?<luck>\d)\/3\)/
+regex_info_luck = /^\s*Luck\s+:\s+.*\((?<luck>[-\d]+)\/3\)/
 regex_info_balance = /^(?:You are|\[You're) (?<balance>#{Regexp.union(balance_values)}) balanced?/
 # ---
 info_hook = proc do |server_string|


### PR DESCRIPTION
The previous luck regex wasn't capturing negative luck rebounds (because of the negative sign):
   Luck : Unlucky (-1/3)
   Luck : Very Unlucky (-2/3)
   Luck : Abysmal (-3/3)