### PR TITLE
[scripts][learned] Display skills with zero exp at the bottom

### DIFF
--- a/learned.lic
+++ b/learned.lic
@@ -22,10 +22,12 @@ class LearnedData
       [{ name: 'lore', regex: /lore/, description: 'Show exp gained in lore skills.' }],
       [{ name: 'guild', regex: /guild/, description: 'Show exp gained in your guild skill.' }],
       [{ name: 'reset', regex: /reset/, description: 'Reset learned experience' }],
+      [{ name: 'zero', regex: /zero/, description: 'Show only skills with nothing learned' }],
       []
     ]
 
     args = parse_args(arg_definitions)
+    @zero = args.zero ? true : false
 
     survival_skills = ['Evasion', 'Athletics', 'Perception', 'Stealth', 'Locksmithing', 'Thievery', 'First Aid', 'Outdoorsmanship', 'Skinning']
     lore_skills = ['Alchemy', 'Appraisal', 'Enchanting', 'Forging', 'Mechanical Lore', 'Performance', 'Scholarship', 'Tactics', 'Outfitting', 'Engineering']
@@ -76,13 +78,25 @@ class LearnedData
     learning_time = ((Time.now - DRSkill.start_time) / 60.0 / 60)
     columns = get_settings.learned_column_count
 
-    DRSkill.list
-           .select { |item| @skills_to_show.include?(item.name) }
-           .select { |item| item.current - item.baseline > 0 }
-           .sort_by { |item| item.current - item.baseline }
-           .reverse.each_slice(columns) do |skills|
-      output = skills.map { |skill| format_skill_data(skill, learning_time) }.join
-      respond(output)
+    if @zero
+      DRSkill.list
+             .select { |item| @skills_to_show.include?(item.name) }
+             .select { |item| item.current - item.baseline == 0 }
+             .sort_by { |item| item.current - item.baseline }
+             .reverse.each_slice(columns) do |skills|
+        output = skills.map { |skill| format_skill_data(skill, learning_time) }.join
+        respond(output)
+      end
+      exit
+    else
+      DRSkill.list
+             .select { |item| @skills_to_show.include?(item.name) }
+             .select { |item| item.current - item.baseline > 0 }
+             .sort_by { |item| item.current - item.baseline }
+             .reverse.each_slice(columns) do |skills|
+        output = skills.map { |skill| format_skill_data(skill, learning_time) }.join
+        respond(output)
+      end
     end
 
     total = DRSkill.list

--- a/learned.lic
+++ b/learned.lic
@@ -22,12 +22,10 @@ class LearnedData
       [{ name: 'lore', regex: /lore/, description: 'Show exp gained in lore skills.' }],
       [{ name: 'guild', regex: /guild/, description: 'Show exp gained in your guild skill.' }],
       [{ name: 'reset', regex: /reset/, description: 'Reset learned experience' }],
-      [{ name: 'zero', regex: /zero/, description: 'Show only skills with nothing learned' }],
       []
     ]
 
     args = parse_args(arg_definitions)
-    @zero = args.zero ? true : false
 
     survival_skills = ['Evasion', 'Athletics', 'Perception', 'Stealth', 'Locksmithing', 'Thievery', 'First Aid', 'Outdoorsmanship', 'Skinning']
     lore_skills = ['Alchemy', 'Appraisal', 'Enchanting', 'Forging', 'Mechanical Lore', 'Performance', 'Scholarship', 'Tactics', 'Outfitting', 'Engineering']
@@ -78,25 +76,12 @@ class LearnedData
     learning_time = ((Time.now - DRSkill.start_time) / 60.0 / 60)
     columns = get_settings.learned_column_count
 
-    if @zero
-      DRSkill.list
-             .select { |item| @skills_to_show.include?(item.name) }
-             .select { |item| item.current - item.baseline == 0 }
-             .sort_by { |item| item.current - item.baseline }
-             .reverse.each_slice(columns) do |skills|
-        output = skills.map { |skill| format_skill_data(skill, learning_time) }.join
-        respond(output)
-      end
-      exit
-    else
-      DRSkill.list
-             .select { |item| @skills_to_show.include?(item.name) }
-             .select { |item| item.current - item.baseline > 0 }
-             .sort_by { |item| item.current - item.baseline }
-             .reverse.each_slice(columns) do |skills|
-        output = skills.map { |skill| format_skill_data(skill, learning_time) }.join
-        respond(output)
-      end
+    DRSkill.list
+           .select { |item| @skills_to_show.include?(item.name) }
+           .sort_by { |item| item.current - item.baseline }
+           .reverse.each_slice(columns) do |skills|
+      output = skills.map { |skill| format_skill_data(skill, learning_time) }.join
+      respond(output)
     end
 
     total = DRSkill.list


### PR DESCRIPTION
Added a new 'zero' argument to the learned script that I've found useful primarily when working with newer characters to ensure that all of the skills are moving. If set, it will find only skills that have not had any experience gains in the session and list them.

Example output:

--- Lich: learned active.
    Enchanting     0.00 (0.00/hr, 0.00/day)     Alchemy       0.00 (0.00/hr, 0.00/day)
    Outfitting     0.00 (0.00/hr, 0.00/day)     Forging       0.00 (0.00/hr, 0.00/day)
    First Aid      0.00 (0.00/hr, 0.00/day)
--- Lich: learned has exited.