### PR TITLE
[scripts][workorders][data][base-recipes] fix for an issue with rod parts

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -8893,7 +8893,7 @@ crafting_recipes:
   enchant_stock4:
   item:
   part:
-  - bobcat rod
+  - basalt bobcat rod
 - name: a celestial beacon
   noun: gem
   type: artificing
@@ -9940,7 +9940,7 @@ crafting_recipes:
   enchant_stock4:
   item:
   part:
-  - rod
+  - basalt bobcat rod
 - name: an abstract burin
   noun: burin
   type: artificing
@@ -9987,7 +9987,7 @@ crafting_recipes:
   enchant_stock4:
   item:
   part:
-  - rod
+  - basalt bobcat rod
 - name: a precise burin
   noun: burin
   type: artificing
@@ -10032,7 +10032,7 @@ crafting_recipes:
   enchant_stock4:
   item:
   part:
-  - rod
+  - basalt bobcat rod
 - name: a compact enchanter's brazier
   noun: brazier
   type: artificing

--- a/workorders.lic
+++ b/workorders.lic
@@ -770,14 +770,16 @@ class WorkOrders
     if recipe['part']
       (recipe['part']).each do |p|
         p.to_s
-        tmp_part_count = DRCI.count_items_in_container(p.split.last, @bag)
+
+        tmp_part_count = DRCI.count_items_in_container(p, @bag)
         next unless tmp_part_count < quantity
 
         need_part = quantity - tmp_part_count
-        # Found a weird challenge that made the temp_part_count equal 1 even though no "part" was in container
-        need_part += 1 if reget(3, 'but there is nothing in there like that') && (need_part + tmp_part_count) != quantity
-        DRC.message("need_part with potiental plus 1 is #{need_part}.")
-        order_parts(recipe['part'], need_part)
+
+        DRC.message("need_part is #{need_part}.")
+        
+        # parts are listed by only their noun
+        order_parts([p.split.last], need_part)
       end
     end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -777,7 +777,7 @@ class WorkOrders
         need_part = quantity - tmp_part_count
 
         DRC.message("need_part is #{need_part}.")
-        
+
         # parts are listed by only their noun
         order_parts([p.split.last], need_part)
       end


### PR DESCRIPTION
Corrected an issue I (and others) have encountered since 2022 when logic to use existing materials for enchanting was added. After digging into it, the biggest source of the issue is that it was passing only the noun into DRCI.count_items_in_container, which prevented that method from checking for the full item name as it should. Additionally, rods were listed with only their partial name as parts in base-recipes. Finally, rods are listed with only their noun in base-crafting, but the script was passing the full name here.

I've tested with both a low and high level enchanter.

This fixes issue #6290 