### PR TITLE
Update base-spells.yaml

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -142,6 +142,8 @@ prep_messages:
 - Please don't do that here
 - You cannot use the tattoo while maintaining the effort to stay hidden
 - As you attempt to prepare the spell, a sense of overwhelming peace washes over you
+# You tried to target a spell but there is nothing left to face
+- There is nothing else to face
 
 cast_messages:
 - Converging in midair, angular ripples assemble a slender hexagonal rod whorled with faintly shifting fractals


### PR DESCRIPTION
Added catch for case when using tattoo_tm: to target a tm spell after invoking it from a tattoo fails due to lack of target.