### PR TITLE
[script][inventory-manager] add support for vault standard

### DIFF
--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -202,7 +202,7 @@ class InventoryManager
 
     container = ""
     lines.each do |line|
-      line.sub!(/\(\d+\)/,'') if command == 'vault standard'
+      line.sub!(/\(\d+\)/, '') if command == 'vault standard'
       item = line.lstrip
 
       next if item.empty?

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -16,7 +16,7 @@ class InventoryManager
       ],
       [
         { name: 'save', regex: /save/i, description: "Save new or update current character's items to the database." },
-        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "Retrieves, reads, and save from vault book." },
+        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "DEPRECATED. Will call vault_standard." },
         { name: 'vault_regular', regex: /vault_regular/i, optional: true, description: "Rummages your vault to save items NOTE: must be standing by your open vault." },
         { name: 'storage_box', regex: /storage_box/i, optional: true, description: "Rummages caravan storage box for items." },
         { name: 'family_vault', regex: /family_vault/i, optional: true, description: "Rummages your family vault to save items NOTE: must be standing by your open vault." },
@@ -25,7 +25,8 @@ class InventoryManager
         { name: 'scrolls', regex: /scrolls/i, optional: true, description: "Save spell scrolls tracked with sort-scrolls or stack-scrolls." },
         { name: 'home', regex: /home/i, optional: true, description: "Save home inventory." },
         { name: 'servant', regex: /servant/i, optional: true, description: "Save shadow servant inventory." },
-        { name: 'shop', regex: /shop/i, optional: true, description: "Save your Trader shop inventory." }
+        { name: 'shop', regex: /shop/i, optional: true, description: "Save your Trader shop inventory." },
+        { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." }
       ],
       [
         { name: 'search', regex: /search/i, description: 'Start a search across all characters for specified item.' },
@@ -48,7 +49,10 @@ class InventoryManager
     setup
 
     if args.vault_book
-      add_vault_book_inv
+      DRC.message('Vault Book support has been removed in favor of VAULT STANDARD.')
+      add_vault_standard
+    elsif args.vault_standard
+      add_vault_standard
     elsif args.vault_regular
       add_vault_regular_inv
     elsif args.family_vault
@@ -198,6 +202,7 @@ class InventoryManager
 
     container = ""
     lines.each do |line|
+      line.sub!(/\(\d+\)/,'') if command == 'vault standard'
       item = line.lstrip
 
       next if item.empty?
@@ -211,9 +216,16 @@ class InventoryManager
         # We don't want the inventory_type here as it's extra noise, so we do a .to_s so container doesn't get updated by changing item later
         container = (item.include?("eddy") ? "eddy" : item).to_s
         item.concat(' (worn)')
-      elsif (command == 'read my vault book' || inventory_type == 'shadow_servant')
-        # When reading the vault book, items in a container are prefixed by 6 spaces
+      elsif inventory_type == 'shadow_servant'
+        # items in a container are prefixed by 6 spaces
         if line =~ /\s{6}(?:a|an|some) /
+          item.concat(" (in container - #{container})")
+        else
+          container = item.to_s
+        end
+      elsif command == 'vault standard'
+        # items in a container are prefixed by 11 spaces once the item count is removed
+        if line =~ /\s{11}(?:a|an|some) /
           item.concat(" (in container - #{container})")
         else
           container = item.to_s
@@ -246,15 +258,8 @@ class InventoryManager
     string[colon..-2]
   end
 
-  def add_vault_book_inv
-    unless DRCI.get_item_if_not_held?("vault book")
-      DRC.message("Unable to find your vault book, exiting!")
-      exit
-    end
-
-    check_inventory("read my vault book", /^Vault Inventory:/, 'vault')
-
-    DRCI.stow_item?("vault book")
+  def add_vault_standard
+    check_inventory("vault standard", /^Vault Inventory:/, 'vault')
   end
 
   def add_current_inv


### PR DESCRIPTION
Adding the arg vault_standard, which calls the command VAULT STANDARD to list vault inventory. Removes support for vault books, which instead will call this command.