### PR TITLE
[scripts][hunting-buddy] Add combat_trainer_gear_set setting

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -214,7 +214,8 @@ class HuntingBuddy
 
     DRC.message("***STATUS*** Returning to safe room: #{@settings.safe_room}")
     DRCT.walk_to(@settings.safe_room)
-    EquipmentManager.new(@settings).wear_equipment_set?('standard')
+    worngear = @settings.combat_trainer_gear_set || "standard"
+    EquipmentManager.new(@settings).wear_equipment_set?(worngear)
   end
 
   def execute_actions(actions)


### PR DESCRIPTION
Added support for `combat_trainer_gear_set:` for use with combat-trainer.lic.  

When hunting-buddy.lic returns to your safe room from a combat-trainer.lic session that uses the `combat_trainer_gear_set:` gearset override, it now keeps you in that gearset rather than trying to swap you to the standard gearset. There is no behavior change if not using `combat_trainer_gear_set:`