### PR TITLE
[script][setupaliases] correct due to syntax

### DIFF
--- a/setupaliases.lic
+++ b/setupaliases.lic
@@ -68,6 +68,5 @@ elsif Script.exists?('xnarost')
 end
 
 aliases_to_add.each do |trigger, target|
-  # UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
-  Script.run('alias', "add --global #{trigger} = #{target}")
+  UpstreamHook.run("<c>#{$clean_lich_char}alias add --global #{trigger} = #{target}")
 end


### PR DESCRIPTION
Due to how alias.lic works for adding/removing aliases, must be sent as an upstream command or a do_client as just running via Script.run is not compatible.

Fixes the client from seeing this:
```
--- Lich: setupaliases active.
--- Lich: alias active.
--- Lich: alias service started
--- Lich: alias has exited.
--- Lich: alias active.
--- Lich: alias service started
--- Lich: alias has exited.
--- Lich: alias active.
--- Lich: alias service started
--- Lich: alias has exited.
```
to
```
--- Lich: setupaliases active.
--- Alias saved
--- Alias saved
--- Alias saved
--- Alias saved
--- Alias saved
--- Alias saved
--- Alias saved
--- Alias saved
```