### PR TITLE
Update combat-trainer.lic - added match for wild magic 1s prep proc

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3995,7 +3995,7 @@ class CombatTrainer
   end
 
   def setup(settings)
-    Flags.add('ct-spellcast', '^Your formation of a targeting pattern around .+ has completed\.', 'Your target pattern has finished forming around the area', '^You feel fully prepared to cast your spell\.')
+    Flags.add('ct-spellcast', '^Your formation of a targeting pattern around .+ has completed\.', 'Your target pattern has finished forming around the area', '^You feel fully prepared to cast your spell\.', '^Your spell pattern snaps into shape with little preparation!')
 
     Flags.add('last-stance', 'Setting your Evasion stance to \d+%, your Parry stance to \d+%, and your Shield stance to \d+%.  You have \d+ stance points left')
 


### PR DESCRIPTION
Added match to prevent combat-trainer from not recognizing a spell was fully prepared if the wild magic 1s preparation time proc occurred.