### PR TITLE
Update base-spells.yaml - added anti-magic room checks for invoke/charge/perc

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2784,7 +2784,7 @@ class TrainerProcess
     when /^PercMana$/i
       moon_mage_perc(game_state)
     when /^Perc$/i
-      DRC.bput('perc', 'You reach out', 'Strangely, you can sense absolutely nothing.') unless game_state.retreating?
+      DRC.bput('perc', 'You reach out', 'Strangely, you can sense absolutely nothing.', 'Something in the area is interfering with your ability to perceive power.') unless game_state.retreating?
     when /^Perc Health$/i
       DRC.bput('perc heal', 'You close your eyes')
     when /^Astro$/i

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -144,6 +144,8 @@ prep_messages:
 - Please don't do that here
 - You cannot use the tattoo while maintaining the effort to stay hidden
 - As you attempt to prepare the spell, a sense of overwhelming peace washes over you
+# Tattoo failed to invoke due to anti-magic room
+- Something in the area is interfering with the magical device.
 # You tried to target a spell but there is nothing left to face
 - There is nothing else to face
 

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -10,6 +10,7 @@ charge_messages:
 - You fail to channel
 - you find it too clumsy to charge
 - How much do you want to charge
+- Something in the area is interfering with your magical senses.
 
 invoke_messages:
 - Images of streaking stars falling from the heavens flash
@@ -31,6 +32,7 @@ invoke_messages:
 - you find it too clumsy to invoke
 - You raise the (\w+) up, and a (\w+) glow surrounds it
 - You prick your finger with the tip of your athame
+- Something in the area is interfering with the magical device.
 
 prep_messages:
 - With rigid movements you prepare your body for the Embed the Cycle spell


### PR DESCRIPTION
Added matches for when invoking or charging cambrinth, perc, or invoking a tattoo fails due to wild magic anti-magic room