### PR TITLE
Update task-forage.lic

### DIFF
--- a/task-forage.lic
+++ b/task-forage.lic
@@ -623,6 +623,7 @@ class TaskForage
             @tasks_failed += 1
             determine_task_necessary
             get_task
+            DRCT.walk_to(@item_location)
           end
         end
       end


### PR DESCRIPTION
The gather_items subroutine wouldn't walk to the next foraging destination if there was a previous task failure