### PR TITLE
[script][tessera] Add Trading mindstate threshold

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2058,6 +2058,9 @@ tessera_noun: tessera
 # How often you want to retry your tessera
 tessera_retry_interval: 375
 
+# The Trading mindstate threshold below which (or equal to) you will use your tessera.
+tessera_mindstates: 3
+
 # Tessera Pause time before pausing scripts and starting up
 tessera_startup_delay: 15
 

--- a/tessera.lic
+++ b/tessera.lic
@@ -15,6 +15,7 @@ class Tessera
     @no_use_scripts = settings.tessera_no_use_scripts
     @no_use_rooms = settings.tessera_no_use_rooms
     @tessera = settings.tessera_noun
+    @tessera_mindstates = settings.tessera_mindstates
 
     pause @startup_delay
     passive_loop
@@ -67,7 +68,7 @@ class Tessera
 
   # def to make sure when to use the tessera. The following conditions must NOT be true: hidden, invisible, cooldown active, hands full, not allowed scripts running and not standing in rooms that are not allowed.
   def should_use_tessera?
-    !(hidden? || invisible? || tessera_on_cooldown? || hands_full? || running_no_use_scripts? || inside_no_use_room?)
+    !(hidden? || invisible? || tessera_on_cooldown? || hands_full? || running_no_use_scripts? || inside_no_use_room? || DRSkill.getxp('Trading') >= @tessera_mindstates)
   end
 
   # def for checking if no_use_scripts (from yaml) are running. Used in should_use_tessera?.


### PR DESCRIPTION
Add a `tessera_mindstates` YAML setting. If your trading mindstates are above or equal to this threshold, the tessera will not be used. 
The purpose is to minimize constantly consuming all SLA, and give players the opportunity to use the tessera as a last resort.