### PR TITLE
Update combat-trainer.lic to fix tessera scoping

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2775,6 +2775,9 @@ class TrainerProcess
 
     @always_use_maneuvers = settings.always_use_maneuvers
     echo("  @always_use_maneuvers: #{@always_use_maneuvers}") if $debug_mode_ct
+
+    @tessera_mindstates = settings.tessera_mindstates
+    echo("  @tessera_mindstates: #{@tessera_mindstates}") if $debug_mode_ct
   end
 
   def execute(game_state)
@@ -3226,7 +3229,7 @@ class TrainerProcess
     return unless DRStats.trader?
     return if game_state.retreating?
     return if game_state.loaded || game_state.offhand?
-    return if DRSkill.getxp('Trading') > settings.tessera_mindstates
+    return if DRSkill.getxp('Trading') > @tessera_mindstates
 
     DRC.retreat
     return unless /inside your (.*)\./ =~ DRC.bput("get my tessera", 'You get a .+ tessera from inside your (.*).', 'What were you')


### PR DESCRIPTION
The previous tessera change used a bad variable scope, trying to access `settings` from invest_in_tessera, rather than defining the variable in TrainerProcess initialization