### PR TITLE
[script] base-spells - added cast messaging

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -149,6 +149,7 @@ prep_messages:
 # You tried to target a spell but there is nothing left to face
 - There is nothing else to face
 - With a chirurgeon's care, you press your fingertips against the side of your neck
+- Sutures of reddish-black energy delve deep to further thread your body with synthetic reinforcement
 
 cast_messages:
 - Converging in midair, angular ripples assemble a slender hexagonal rod whorled with faintly shifting fractals


### PR DESCRIPTION
Added `Sutures of reddish-black energy delve deep to further thread your body with synthetic reinforcement.` to the cast messaging list to match when PHP is recast on top of itself rather than a fresh cast.