### PR TITLE
[script][inventory-manager]add vault book,storage book,pocket. adjust vault surface handling for container nesting data

### DIFF
--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -16,9 +16,10 @@ class InventoryManager
       ],
       [
         { name: 'save', regex: /save/i, description: "Save new or update current character's items to the database." },
-        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "DEPRECATED. Will call vault_standard." },
+        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "Uses vault book for inventory." },
         { name: 'vault_regular', regex: /vault_regular/i, optional: true, description: "Rummages your vault to save items NOTE: must be standing by your open vault." },
         { name: 'storage_box', regex: /storage_box/i, optional: true, description: "Rummages caravan storage box for items." },
+        { name: 'storage_book', regex: /storage_book/i, optional: true, description: "Uses storage book for caravan items instead of rummaging." },
         { name: 'family_vault', regex: /family_vault/i, optional: true, description: "Rummages your family vault to save items NOTE: must be standing by your open vault." },
         { name: 'register', regex: /register/i, optional: true, description: "Reads contents of deed register." },
         { name: 'eddy', regex: /eddy/i, optional: true, description: "Save the contents of an eddy (HE 436 Gift)." },
@@ -26,6 +27,7 @@ class InventoryManager
         { name: 'home', regex: /home/i, optional: true, description: "Save home inventory." },
         { name: 'servant', regex: /servant/i, optional: true, description: "Save shadow servant inventory." },
         { name: 'shop', regex: /shop/i, optional: true, description: "Save your Trader shop inventory." },
+        { name: 'pocket', regex: /pocket/i, optional: true, description: "Rummages your secret pocket container to save items." },
         { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." }
       ],
       [
@@ -45,12 +47,11 @@ class InventoryManager
     args = parse_args(arg_definitions)
     @settings = get_settings
     @inventory_ignores = @settings.inventory_manager_ignores
-
+    @vault_surfaces = @settings.inventory_manager_vault_surfaces
     setup
 
     if args.vault_book
-      DRC.message('Vault Book support has been removed in favor of VAULT STANDARD.')
-      add_vault_standard
+      add_vault_book
     elsif args.vault_standard
       add_vault_standard
     elsif args.vault_regular
@@ -64,6 +65,8 @@ class InventoryManager
       add_eddy_inv
     elsif args.storage_box
       add_storage_box_inv
+    elsif args.storage_book
+      add_storage_book
     elsif args.scrolls
       add_scrolls
     elsif args.home
@@ -72,6 +75,8 @@ class InventoryManager
       add_shadow_servant
     elsif args.shop
       add_trader_shop
+    elsif args.pocket
+        add_pocket_inv
     elsif args.save
       add_current_inv
     elsif args.count
@@ -124,7 +129,7 @@ class InventoryManager
   end
 
   def valid_data_row(item)
-    if item.include?('(vault)') || item.include?('(register)') || item.include?('(eddy)') || item.include?('(caravan_box)') || item.include?('(Family)')
+    if item.include?('(vault)') || item.include?('(register)') || item.include?('(eddy)') || item.include?('(caravan_box)') || item.include?('(Family)') || item.include?('(pocket)')
       true
     else
       false
@@ -185,7 +190,6 @@ class InventoryManager
     get_item_data(inventory_type)
 
     capture = Lich::Util.issue_command(command, end_pattern)
-
     lines = capture
     # when rummaging, this block splits the items, including the last two that are split by and instead of a comma
     if command.start_with?("rummage")
@@ -207,7 +211,10 @@ class InventoryManager
 
       next if item.empty?
       next if item.start_with?(*@inventory_ignores)
-
+      if item.start_with?(*@vault_surfaces)
+        container = item.to_s
+        next
+      end
       # if the item starts with a -, it's in a container
       if item[0].eql? '-'
         item[0] = ''
@@ -218,6 +225,20 @@ class InventoryManager
         item.concat(' (worn)')
       elsif inventory_type == 'shadow_servant'
         # items in a container are prefixed by 6 spaces
+        if line =~ /\s{6}(?:a|an|some) /
+          item.concat(" (in container - #{container})")
+        else
+          container = item.to_s
+        end
+      elsif /vault book/.match(command)
+        # items in vault book output are prefixed by 6 spaces
+        if line =~ /\s{6}(?:a|an|some) /
+          item.concat(" (in container - #{container})")
+        else
+          container = item.to_s
+        end
+      elsif /storage book/.match(command)
+        # items in a storage book are prefixed by 6 spaces
         if line =~ /\s{6}(?:a|an|some) /
           item.concat(" (in container - #{container})")
         else
@@ -242,6 +263,7 @@ class InventoryManager
 
       item.concat(" (#{inventory_type})")
 
+      next if item.start_with?(*@inventory_ignores)
       @item_data[@active_character] << item
     end
 
@@ -260,6 +282,15 @@ class InventoryManager
 
   def add_vault_standard
     check_inventory("vault standard", /^Vault Inventory:/, 'vault')
+  end
+
+  def add_vault_book
+    unless DRCI.get_item_if_not_held?("vault book")
+      DRC.message("Unable to find your vault book, exiting!")
+      exit
+    end
+    check_inventory("read my vault book", /^Vault Inventory/, 'vault')
+    DRCI.stow_item?("book")
   end
 
   def add_current_inv
@@ -284,7 +315,16 @@ class InventoryManager
   end
 
   def add_storage_box_inv
-    check_inventory("rummage storage boc", /^You rummage through a storage box/, 'caravan_box', 41)
+    check_inventory("rummage storage box", /^You rummage through a storage box/, 'caravan_box', 41)
+  end
+
+  def add_storage_book
+    unless DRCI.get_item_if_not_held?("storage book")
+      DRC.message("Unable to find your storage book, exiting!")
+      exit
+    end
+    check_inventory("read my storage book", /^\W+in the known realms since 402/, 'caravan_box')
+    DRCI.stow_item?("book")
   end
 
   def add_family_vault
@@ -293,6 +333,10 @@ class InventoryManager
 
   def add_vault_regular_inv
     check_inventory("rummage vault", /^You rummage through a secure vault/, 'vault', 42)
+  end
+
+  def add_pocket_inv
+    check_inventory("rummage my pocket", /^You rummage through a pocket/, 'pocket', 36)
   end
 
   def add_scrolls

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -291,9 +291,9 @@ class InventoryManager
       DRC.message("Unable to find your vault book, exiting!")
       exit
     end
-    
+
     check_inventory("read my vault book", /^Vault Inventory/, 'vault')
-    
+
     DRCI.stow_item?("book")
   end
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -16,10 +16,10 @@ class InventoryManager
       ],
       [
         { name: 'save', regex: /save/i, description: "Save new or update current character's items to the database." },
-        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "Uses vault book to get a list of items from your vault." },
+        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "Uses vault book for inventory." },
         { name: 'vault_regular', regex: /vault_regular/i, optional: true, description: "Rummages your vault to save items NOTE: must be standing by your open vault." },
         { name: 'storage_box', regex: /storage_box/i, optional: true, description: "Rummages caravan storage box for items." },
-        { name: 'storage_book', regex: /storage_book/i, optional: true, description: "Uses storage book to get a list of items from your caravan storage box." },
+        { name: 'storage_book', regex: /storage_book/i, optional: true, description: "Uses storage book for caravan items instead of rummaging." },
         { name: 'family_vault', regex: /family_vault/i, optional: true, description: "Rummages your family vault to save items NOTE: must be standing by your open vault." },
         { name: 'register', regex: /register/i, optional: true, description: "Reads contents of deed register." },
         { name: 'eddy', regex: /eddy/i, optional: true, description: "Save the contents of an eddy (HE 436 Gift)." },
@@ -27,7 +27,7 @@ class InventoryManager
         { name: 'home', regex: /home/i, optional: true, description: "Save home inventory." },
         { name: 'servant', regex: /servant/i, optional: true, description: "Save shadow servant inventory." },
         { name: 'shop', regex: /shop/i, optional: true, description: "Save your Trader shop inventory." },
-        { name: 'pocket', regex: /pocket/i, optional: true, description: "Rummages your secret pocket container for list of items. NOTE: Must be wearing the container." },
+        { name: 'pocket', regex: /pocket/i, optional: true, description: "Rummages your secret pocket container to save items." },
         { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." }
       ],
       [
@@ -154,7 +154,10 @@ class InventoryManager
     count, closed = 0, 0
     if desc.nil?
       # Counting all items in inventory
-      capture = Lich::Util.issue_command('inv list', /^You have:/)
+      capture = []
+      until capture != []
+        capture = Lich::Util.issue_command('inv list', /^You have:/)
+      end
       capture.each do |line|
         item = line.lstrip
 
@@ -167,7 +170,10 @@ class InventoryManager
       DRC.message("You have #{count} items, #{closed} of which are (closed) containers.")
     else
       # Counting items matching the description, i.e., inv count pouch
-      capture = Lich::Util.issue_command("inv search #{desc}", /rummage about your person/)
+      capture = []
+      until capture != []
+        capture = Lich::Util.issue_command("inv search #{desc}", /rummage about your person/)
+      end
       capture.each do |line|
         item = line.lstrip
 
@@ -189,7 +195,10 @@ class InventoryManager
 
     get_item_data(inventory_type)
 
-    capture = Lich::Util.issue_command(command, end_pattern)
+    capture = []
+    until capture != []
+      capture = Lich::Util.issue_command(command, end_pattern)
+    end
     lines = capture
     # when rummaging, this block splits the items, including the last two that are split by and instead of a comma
     if command.start_with?("rummage")
@@ -382,7 +391,10 @@ class InventoryManager
 
   def check_scroll_stacker(stacker)
     spells = []
-    capture = Lich::Util.issue_command("flip my #{stacker.split.last}", /^You flip through the #{stacker.split.last}, checking each section before closing it.$/)
+    capture = []
+    until capture != []
+      capture = Lich::Util.issue_command("flip my #{stacker.split.last}", /^You flip through the #{stacker.split.last}, checking each section before closing it.$/)
+    end
     capture.each do |line|
       if line =~ /The (.+) section has (\d+)/
         spell = "#{Regexp.last_match(1)} (#{Regexp.last_match(2)})"
@@ -423,7 +435,10 @@ class InventoryManager
     get_item_data('trader_shop')
 
     surfaces = Hash.new
-    capture = Lich::Util.issue_command("shop customer", /^The following items contain goods for sale:/)
+    capture = []
+    until capture != []
+      capture = Lich::Util.issue_command("shop customer", /^The following items contain goods for sale:/)
+    end
     capture.each do |line|
       line = line.lstrip
 
@@ -436,7 +451,10 @@ class InventoryManager
     end
 
     surfaces.each do |surface|
-      capture = Lich::Util.issue_command(surface[1], /, you see:/)
+      capture = []
+      until capture != []
+        capture = Lich::Util.issue_command(surface[1], /, you see:/)
+      end
       capture.each do |line|
         line = line.lstrip
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -156,7 +156,7 @@ class InventoryManager
       # Counting all items in inventory
       capture = []
       until capture != []
-        capture = Lich::Util.issue_command('inv list', /^You have:/, timeout: 3)
+        capture = Lich::Util.issue_command('inv list', /^You have:/, timeout: 3) unless waitrt?
       end
       capture.each do |line|
         item = line.lstrip
@@ -172,7 +172,7 @@ class InventoryManager
       # Counting items matching the description, i.e., inv count pouch
       capture = []
       until capture != []
-        capture = Lich::Util.issue_command("inv search #{desc}", /rummage about your person/, timeout: 3)
+        capture = Lich::Util.issue_command("inv search #{desc}", /rummage about your person/, timeout: 3) unless waitrt?
       end
       capture.each do |line|
         item = line.lstrip
@@ -197,7 +197,7 @@ class InventoryManager
 
     capture = []
     until capture != []
-      capture = Lich::Util.issue_command(command, end_pattern, timeout: 3)
+      capture = Lich::Util.issue_command(command, end_pattern, timeout: 3) unless waitrt?
     end
     lines = capture
     # when rummaging, this block splits the items, including the last two that are split by and instead of a comma
@@ -229,7 +229,14 @@ class InventoryManager
       # if the item starts with a -, it's in a container
       if item[0].eql? '-'
         item[0] = ''
-        item.concat(" (in container - #{container})")
+        if line =~ /\s{8,}-(?:a|an|some) /
+            item.concat(" (nested container - #{sub_container})")
+        elsif line =~ /\s{5}-(?:a|an|some) /
+            item.concat(" (in container - #{container})")
+            sub_container = item.to_s
+        else
+            container = item.to_s
+        end
       elsif inventory_type == 'character'
         # We don't want the inventory_type here as it's extra noise, so we do a .to_s so container doesn't get updated by changing item later
         container = (item.include?("eddy") ? "eddy" : item).to_s
@@ -397,7 +404,7 @@ class InventoryManager
     spells = []
     capture = []
     until capture != []
-      capture = Lich::Util.issue_command("flip my #{stacker.split.last}", /^You flip through the #{stacker.split.last}, checking each section before closing it.$/, timeout: 3)
+      capture = Lich::Util.issue_command("flip my #{stacker.split.last}", /^You flip through the #{stacker.split.last}, checking each section before closing it.$/, timeout: 3) unless waitrt?
     end
     capture.each do |line|
       if line =~ /The (.+) section has (\d+)/
@@ -441,7 +448,7 @@ class InventoryManager
     surfaces = Hash.new
     capture = []
     until capture != []
-      capture = Lich::Util.issue_command("shop customer", /^The following items contain goods for sale:/, timeout: 3)
+      capture = Lich::Util.issue_command("shop customer", /^The following items contain goods for sale:/, timeout: 3) unless waitrt?
     end
     capture.each do |line|
       line = line.lstrip
@@ -457,7 +464,7 @@ class InventoryManager
     surfaces.each do |surface|
       capture = []
       until capture != []
-        capture = Lich::Util.issue_command(surface[1], /, you see:/, timeout: 3)
+        capture = Lich::Util.issue_command(surface[1], /, you see:/, timeout: 3) unless waitrt?
       end
       capture.each do |line|
         line = line.lstrip

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -230,12 +230,12 @@ class InventoryManager
       if item[0].eql? '-'
         item[0] = ''
         if line =~ /\s{8,}-(?:a|an|some) /
-            item.concat(" (nested container - #{sub_container})")
+          item.concat(" (nested container - #{sub_container})")
         elsif line =~ /\s{5}-(?:a|an|some) /
-            item.concat(" (in container - #{container})")
-            sub_container = item.to_s
+          item.concat(" (in container - #{container})")
+          sub_container = item.to_s
         else
-            container = item.to_s
+          container = item.to_s
         end
       elsif inventory_type == 'character'
         # We don't want the inventory_type here as it's extra noise, so we do a .to_s so container doesn't get updated by changing item later
@@ -251,23 +251,23 @@ class InventoryManager
       elsif command == "read my storage book" || command == "read my vault book"
         # items in vault/storage book output are prefixed by 6 spaces
         if line =~ /\s{8,}(?:a|an|some) /
-            item.concat(" (nested container - #{sub_container})")
-          elsif line =~ /\s{6}(?:a|an|some) /
-            item.concat(" (in container - #{container})")
-            sub_container = item.to_s
-          else
-            container = item.to_s
-          end
+          item.concat(" (nested container - #{sub_container})")
+        elsif line =~ /\s{6}(?:a|an|some) /
+          item.concat(" (in container - #{container})")
+          sub_container = item.to_s
+        else
+          container = item.to_s
+        end
       elsif command == 'vault standard'
         # items in a container are prefixed by 11 spaces once the item count is removed
         if line =~ /\s{16,}(?:a|an|some) /
-            item.concat(" (nested container - #{sub_container})")
-          elsif line =~ /\s{11}(?:a|an|some) /
-            item.concat(" (in container - #{container})")
-            sub_container = item.to_s
-          else
-            container = item.to_s
-          end
+          item.concat(" (nested container - #{sub_container})")
+        elsif line =~ /\s{11}(?:a|an|some) /
+          item.concat(" (in container - #{container})")
+          sub_container = item.to_s
+        else
+          container = item.to_s
+        end
       elsif inventory_type == 'home'
         if !item.start_with?("Attached:")
           item = clean_home_string(item)

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -16,10 +16,10 @@ class InventoryManager
       ],
       [
         { name: 'save', regex: /save/i, description: "Save new or update current character's items to the database." },
-        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "Uses vault book for inventory." },
+        { name: 'vault_book', regex: /vault_book/i, optional: true, description: "Uses vault book to get a list of items from your vault." },
         { name: 'vault_regular', regex: /vault_regular/i, optional: true, description: "Rummages your vault to save items NOTE: must be standing by your open vault." },
         { name: 'storage_box', regex: /storage_box/i, optional: true, description: "Rummages caravan storage box for items." },
-        { name: 'storage_book', regex: /storage_book/i, optional: true, description: "Uses storage book for caravan items instead of rummaging." },
+        { name: 'storage_book', regex: /storage_book/i, optional: true, description: "Uses storage book to get a list of items from your caravan storage box." },
         { name: 'family_vault', regex: /family_vault/i, optional: true, description: "Rummages your family vault to save items NOTE: must be standing by your open vault." },
         { name: 'register', regex: /register/i, optional: true, description: "Reads contents of deed register." },
         { name: 'eddy', regex: /eddy/i, optional: true, description: "Save the contents of an eddy (HE 436 Gift)." },
@@ -27,7 +27,7 @@ class InventoryManager
         { name: 'home', regex: /home/i, optional: true, description: "Save home inventory." },
         { name: 'servant', regex: /servant/i, optional: true, description: "Save shadow servant inventory." },
         { name: 'shop', regex: /shop/i, optional: true, description: "Save your Trader shop inventory." },
-        { name: 'pocket', regex: /pocket/i, optional: true, description: "Rummages your secret pocket container to save items." },
+        { name: 'pocket', regex: /pocket/i, optional: true, description: "Rummages your secret pocket container for list of items. NOTE: Must be wearing the container." },
         { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." }
       ],
       [

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -320,7 +320,7 @@ class InventoryManager
   end
 
   def add_eddy_inv
-    checkInventory("inv eddy", /^Inside a/, 'eddy')
+    check_inventory("inv eddy", /^Inside a/, 'eddy')
   end
 
   def add_storage_box_inv

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -314,7 +314,7 @@ class InventoryManager
 
     DRC.bput("turn my register to contents", 'You flip your deed register', 'already at the table of contents')
 
-    check_inventory("read my register", /^Stored Deeds:/, 'register')
+    check_inventory("read my register", /^Stored Deeds:|You haven't stored any deeds in this register/, 'register')
 
     DRCI.stow_item?("register")
   end

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -76,7 +76,7 @@ class InventoryManager
     elsif args.shop
       add_trader_shop
     elsif args.pocket
-        add_pocket_inv
+      add_pocket_inv
     elsif args.save
       add_current_inv
     elsif args.count
@@ -211,6 +211,7 @@ class InventoryManager
 
       next if item.empty?
       next if item.start_with?(*@inventory_ignores)
+
       if item.start_with?(*@vault_surfaces)
         container = item.to_s
         next
@@ -263,7 +264,6 @@ class InventoryManager
 
       item.concat(" (#{inventory_type})")
 
-      next if item.start_with?(*@inventory_ignores)
       @item_data[@active_character] << item
     end
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -240,15 +240,8 @@ class InventoryManager
         else
           container = item.to_s
         end
-      elsif /vault book/.match(command)
-        # items in vault book output are prefixed by 6 spaces
-        if line =~ /\s{6}(?:a|an|some) /
-          item.concat(" (in container - #{container})")
-        else
-          container = item.to_s
-        end
-      elsif /storage book/.match(command)
-        # items in a storage book are prefixed by 6 spaces
+      elsif command == "read my storage book" || command == "read my vault book"
+        # items in vault/storage book output are prefixed by 6 spaces
         if line =~ /\s{6}(?:a|an|some) /
           item.concat(" (in container - #{container})")
         else
@@ -298,7 +291,9 @@ class InventoryManager
       DRC.message("Unable to find your vault book, exiting!")
       exit
     end
+    
     check_inventory("read my vault book", /^Vault Inventory/, 'vault')
+    
     DRCI.stow_item?("book")
   end
 
@@ -332,7 +327,9 @@ class InventoryManager
       DRC.message("Unable to find your storage book, exiting!")
       exit
     end
+
     check_inventory("read my storage book", /^\W+in the known realms since 402/, 'caravan_box')
+
     DRCI.stow_item?("book")
   end
 

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -229,9 +229,9 @@ class InventoryManager
       # if the item starts with a -, it's in a container
       if item[0].eql? '-'
         item[0] = ''
-        if line =~ /\s{8,}-(?:a|an|some) /
+        if line =~ /\s{8,}-(?:a|an|some|the|several|clusters|one) /
           item.concat(" (nested container - #{sub_container})")
-        elsif line =~ /\s{5}-(?:a|an|some) /
+        elsif line =~ /\s{5}-(?:a|an|some|the|several|clusters|one) /
           item.concat(" (in container - #{container})")
           sub_container = item.to_s
         else
@@ -241,18 +241,11 @@ class InventoryManager
         # We don't want the inventory_type here as it's extra noise, so we do a .to_s so container doesn't get updated by changing item later
         container = (item.include?("eddy") ? "eddy" : item).to_s
         item.concat(' (worn)')
-      elsif inventory_type == 'shadow_servant'
-        # items in a container are prefixed by 6 spaces
-        if line =~ /\s{6}(?:a|an|some) /
-          item.concat(" (in container - #{container})")
-        else
-          container = item.to_s
-        end
-      elsif command == "read my storage book" || command == "read my vault book"
-        # items in vault/storage book output are prefixed by 6 spaces
-        if line =~ /\s{8,}(?:a|an|some) /
+      elsif command == "read my storage book" || command == "read my vault book" || inventory_type == "shadow_servant"
+        # Vault book, storage book and shadow servant via PG all have same output formatting
+        if line =~ /\s{8,}(?:a|an|some|the|several|clusters|one) /
           item.concat(" (nested container - #{sub_container})")
-        elsif line =~ /\s{6}(?:a|an|some) /
+        elsif line =~ /\s{6}(?:a|an|some|the|several|clusters|one) /
           item.concat(" (in container - #{container})")
           sub_container = item.to_s
         else
@@ -260,9 +253,9 @@ class InventoryManager
         end
       elsif command == 'vault standard'
         # items in a container are prefixed by 11 spaces once the item count is removed
-        if line =~ /\s{16,}(?:a|an|some) /
+        if line =~ /\s{16,}(?:a|an|some|the|several|clusters|one) /
           item.concat(" (nested container - #{sub_container})")
-        elsif line =~ /\s{11}(?:a|an|some) /
+        elsif line =~ /\s{11}(?:a|an|some|the|several|clusters|one) /
           item.concat(" (in container - #{container})")
           sub_container = item.to_s
         else

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -156,7 +156,7 @@ class InventoryManager
       # Counting all items in inventory
       capture = []
       until capture != []
-        capture = Lich::Util.issue_command('inv list', /^You have:/)
+        capture = Lich::Util.issue_command('inv list', /^You have:/, timeout: 3)
       end
       capture.each do |line|
         item = line.lstrip
@@ -172,7 +172,7 @@ class InventoryManager
       # Counting items matching the description, i.e., inv count pouch
       capture = []
       until capture != []
-        capture = Lich::Util.issue_command("inv search #{desc}", /rummage about your person/)
+        capture = Lich::Util.issue_command("inv search #{desc}", /rummage about your person/, timeout: 3)
       end
       capture.each do |line|
         item = line.lstrip
@@ -197,7 +197,7 @@ class InventoryManager
 
     capture = []
     until capture != []
-      capture = Lich::Util.issue_command(command, end_pattern)
+      capture = Lich::Util.issue_command(command, end_pattern, timeout: 3)
     end
     lines = capture
     # when rummaging, this block splits the items, including the last two that are split by and instead of a comma
@@ -214,6 +214,7 @@ class InventoryManager
     end
 
     container = ""
+    sub_container = ""
     lines.each do |line|
       line.sub!(/\(\d+\)/, '') if command == 'vault standard'
       item = line.lstrip
@@ -242,18 +243,24 @@ class InventoryManager
         end
       elsif command == "read my storage book" || command == "read my vault book"
         # items in vault/storage book output are prefixed by 6 spaces
-        if line =~ /\s{6}(?:a|an|some) /
-          item.concat(" (in container - #{container})")
-        else
-          container = item.to_s
-        end
+        if line =~ /\s{8,}(?:a|an|some) /
+            item.concat(" (nested container - #{sub_container})")
+          elsif line =~ /\s{6}(?:a|an|some) /
+            item.concat(" (in container - #{container})")
+            sub_container = item.to_s
+          else
+            container = item.to_s
+          end
       elsif command == 'vault standard'
         # items in a container are prefixed by 11 spaces once the item count is removed
-        if line =~ /\s{11}(?:a|an|some) /
-          item.concat(" (in container - #{container})")
-        else
-          container = item.to_s
-        end
+        if line =~ /\s{16,}(?:a|an|some) /
+            item.concat(" (nested container - #{sub_container})")
+          elsif line =~ /\s{11}(?:a|an|some) /
+            item.concat(" (in container - #{container})")
+            sub_container = item.to_s
+          else
+            container = item.to_s
+          end
       elsif inventory_type == 'home'
         if !item.start_with?("Attached:")
           item = clean_home_string(item)
@@ -390,7 +397,7 @@ class InventoryManager
     spells = []
     capture = []
     until capture != []
-      capture = Lich::Util.issue_command("flip my #{stacker.split.last}", /^You flip through the #{stacker.split.last}, checking each section before closing it.$/)
+      capture = Lich::Util.issue_command("flip my #{stacker.split.last}", /^You flip through the #{stacker.split.last}, checking each section before closing it.$/, timeout: 3)
     end
     capture.each do |line|
       if line =~ /The (.+) section has (\d+)/
@@ -434,7 +441,7 @@ class InventoryManager
     surfaces = Hash.new
     capture = []
     until capture != []
-      capture = Lich::Util.issue_command("shop customer", /^The following items contain goods for sale:/)
+      capture = Lich::Util.issue_command("shop customer", /^The following items contain goods for sale:/, timeout: 3)
     end
     capture.each do |line|
       line = line.lstrip
@@ -450,7 +457,7 @@ class InventoryManager
     surfaces.each do |surface|
       capture = []
       until capture != []
-        capture = Lich::Util.issue_command(surface[1], /, you see:/)
+        capture = Lich::Util.issue_command(surface[1], /, you see:/, timeout: 3)
       end
       capture.each do |line|
         line = line.lstrip

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2190,13 +2190,6 @@ inventory_manager_ignores:
   - 'Vault Inventory'
   - 'Done'
   - 'The last note'
-  - 'a brass hook'
-  - 'a steel wire rack'
-  - 'a small shelf'
-  - 'a top drawer'
-  - 'a middle drawer'
-  - 'a bottom drawer'
-  - 'a large shelf'
   - 'Inside a'
   - 'Page'
   - 'Stored Deeds'
@@ -2205,6 +2198,17 @@ inventory_manager_ignores:
   - 'The home contains'
   - 'Within the belly'
   - 'Your Servant is holding'
+  - 'in the known realms'
+  - 'A notation at'
+  
+inventory_manager_vault_surfaces:
+  - 'a brass hook'
+  - 'a steel wire rack'
+  - 'a small shelf'
+  - 'a top drawer'
+  - 'a middle drawer'
+  - 'a bottom drawer'
+  - 'a large shelf'
 
 stabbity:
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2200,6 +2200,7 @@ inventory_manager_ignores:
   - 'Your Servant is holding'
   - 'in the known realms'
   - 'A notation at'
+  - '...You have nothing currently stored'
   
 inventory_manager_vault_surfaces:
   - 'a brass hook'


### PR DESCRIPTION
**inventory-manager.lic:**
- Added storage book logic for new system
  - clean output for storage box like a vault book
- Added vault book logic for new system
  - vault standard fails if rent is past due
- Added logic for rummaging secret pocket containers
- Added logic to retry the `Lich::Util.issue_command` when timing out
- Update eddy method call
- Handle empty register and storage book contents

**base.yaml:**
- moved vault surfaces to separate key to handle tagging nested items
- added pattern for storage book ignores