### PR TITLE
Update textsubs.lic -  regex fix for large plat values

### DIFF
--- a/textsubs.lic
+++ b/textsubs.lic
@@ -823,7 +823,7 @@ end
 
 # Commas when dealing with coins
 if settings.textsubs_use_plat_grouping
-  TextSubs.add('(?!.*>)\d{1,3}(?=(\d{4})+(?!\d)(?! platinum).*(Kronar|Dokora|Lirum))', '\&,')
+  TextSubs.add('(?!.*>)\d{1,3}(?=((\d{3})+|)(\d{4})(?!\d)(?! platinum).*(Kronar|Dokora|Lirum))', '\&,')
   TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d) platinum.*(Kronar|Dokora|Lirum))', '\&,')
 else
   TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')

--- a/textsubs.lic
+++ b/textsubs.lic
@@ -823,7 +823,7 @@ end
 
 # Commas when dealing with coins
 if settings.textsubs_use_plat_grouping
-  TextSubs.add('(?!.*>)\d{1,3}(?=((\d{3})+|)(\d{4})(?!\d)(?! platinum).*(Kronar|Dokora|Lirum))', '\&,')
+  TextSubs.add('(?!.*>)\d{1,3}(?=((\d{3})*(\d{4}))(?!\d)(?! platinum).*(Kronar|Dokora|Lirum))', '\&,')
   TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d) platinum.*(Kronar|Dokora|Lirum))', '\&,')
 else
   TextSubs.add('(?!.*>)\d{1,3}(?=(\d{3})+(?!\d).*(Kronar|Dokora|Lirum))', '\&,')


### PR DESCRIPTION
When `textsubs_use_plat_grouping: true` is set the output of currency amounts >=1000 plat was not displaying correctly. Namely, it continued digit groupings in sets of 4 which should only apply to the first plat grouping. Fixed the regex to properly sub in such cases.

Before:
 You are certain that the icesteel mask is worth exactly 1156,2500 Kronars.
 You think it is likely that the icesteel hauberk is worth around 1,8749,9987 Kronars.

After:
 You think it is likely that the icesteel mask is worth exactly 1,156,2500 Kronars.
 You estimate that the icesteel hauberk is worth about 18,749,9993 Kronars.