### PR TITLE
[script][inventory-manager]update regex strip_nesting

### DIFF
--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -523,7 +523,7 @@ class InventoryManager
   end
 
   def strip_nesting(item)
-    if (match = /^(?<tap>[a-z "':!-]*(?<closed>\(closed\))?)\s\((?<nest1>(?<nest2>nested container[A-Za-z "':!-]*)\s\()?(?<main>in container[a-z '-]*)\)?\)\s(?<origin>\(.*\))$/i.match(item))
+    if (match = /^(?<tap>[a-z "':!-]*(?<closed>\(closed\))?)\s\((?<nest1>(?<nest2>nested container[a-z "':!-]*)\s\()?(?<main>in container[a-z "':!-]*)\)?\)\s(?<origin>\(.*\))$/i.match(item))
       return "#{match["tap"]} #{match["origin"]}"
     else
       return item


### PR DESCRIPTION
double quote in tap for primary container in the nesting output fails existing pattern.  Updated regex to match same character ranges in all 3 spots.