### PR TITLE
[scripts][alchemy] Improve foraged ingredient handling

### DIFF
--- a/alchemy.lic
+++ b/alchemy.lic
@@ -80,8 +80,7 @@ class Alchemy
         waitrt?
       end
       quantity_needed -= 6 # Forage forages 6 units.
-      fput("put my #{ingredient['name']} in my #{@alchemy_herb_storage}")
-      pause 0.5
+      DRCI.put_away_item?(ingredient['name'], @alchemy_herb_storage)
       # Track the count down to make sure it stops when enough foraged.
       echo("quantity_needed = #{quantity_needed}") if @debug
     end

--- a/alchemy.lic
+++ b/alchemy.lic
@@ -109,7 +109,7 @@ class Alchemy
             if f_stack == 75
               DRCI.put_away_item?("first #{ingredient['output']}", @herb_container)
             elsif s_stack == 75
-              DRC.bput("put my second #{ingredient['output']} in my #{@herb_container}", "You put", "Stow what?")
+              DRCI.put_away_item?("second #{ingredient['output']}", @herb_container)
             end
           end
         end

--- a/alchemy.lic
+++ b/alchemy.lic
@@ -81,6 +81,7 @@ class Alchemy
       end
       quantity_needed -= 6 # Forage forages 6 units.
       fput("put my #{ingredient['name']} in my #{@alchemy_herb_storage}")
+   pause 0.5
       # Track the count down to make sure it stops when enough foraged.
       echo("quantity_needed = #{quantity_needed}") if @debug
     end
@@ -107,9 +108,9 @@ class Alchemy
             f_stack = DRC.bput("count my first #{ingredient['output']}", 'You count out \d+ pieces').scan(/\d+/).first.to_i
             s_stack = DRC.bput("count my second #{ingredient['output']}", 'I could not find', 'You count out \d+ pieces').scan(/\d+/).first.to_i
             if f_stack == 75
-              DRC.bput("stow my first #{ingredient['output']}", "You put")
+              DRC.bput("put my first #{ingredient['output']} in my #{@herb_container}", "You put")
             elsif s_stack == 75
-              DRC.bput("stow my second #{ingredient['output']}", "You put", "Stow what?")
+              DRC.bput("put my second #{ingredient['output']} in my #{@herb_container}", "You put", "Stow what?")
             end
           end
         end

--- a/alchemy.lic
+++ b/alchemy.lic
@@ -107,7 +107,7 @@ class Alchemy
             f_stack = DRC.bput("count my first #{ingredient['output']}", 'You count out \d+ pieces').scan(/\d+/).first.to_i
             s_stack = DRC.bput("count my second #{ingredient['output']}", 'I could not find', 'You count out \d+ pieces').scan(/\d+/).first.to_i
             if f_stack == 75
-              DRC.bput("put my first #{ingredient['output']} in my #{@herb_container}", "You put")
+              DRCI.put_away_item?("first #{ingredient['output']}", @herb_container)
             elsif s_stack == 75
               DRC.bput("put my second #{ingredient['output']} in my #{@herb_container}", "You put", "Stow what?")
             end

--- a/alchemy.lic
+++ b/alchemy.lic
@@ -81,7 +81,7 @@ class Alchemy
       end
       quantity_needed -= 6 # Forage forages 6 units.
       fput("put my #{ingredient['name']} in my #{@alchemy_herb_storage}")
-   pause 0.5
+      pause 0.5
       # Track the count down to make sure it stops when enough foraged.
       echo("quantity_needed = #{quantity_needed}") if @debug
     end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -956,9 +956,8 @@ class LootProcess
                   /You learn something/i,
                   'A failed or completed ritual has rendered',
                   'You realize after a few seconds',
-                  'prevents a meaningful dissection',
-                  "With less concern than you'd give a fresh corpse")
-    when /You succeed in dissecting the corpse/, /You learn something/i, /With less concern than you'd give a fresh corpse/
+                  'prevents a meaningful dissection')
+    when /You succeed in dissecting the corpse/, /You learn something/i
       return true
     when /You'll gain no insights from this attempt/
       waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -956,8 +956,9 @@ class LootProcess
                   /You learn something/i,
                   'A failed or completed ritual has rendered',
                   'You realize after a few seconds',
-                  'prevents a meaningful dissection')
-    when /You succeed in dissecting the corpse/, /You learn something/i
+                  'prevents a meaningful dissection',
+                  "With less concern than you'd give a fresh corpse")
+    when /You succeed in dissecting the corpse/, /You learn something/i, /With less concern than you'd give a fresh corpse/
       return true
     when /You'll gain no insights from this attempt/
       waitrt?


### PR DESCRIPTION
Add pause after putting foraged ingredient into herb storage container, to better prevent hitting RT.

Changed from using "stow" ingredient to putting the ingredient in the desired crafting container. Stow was putting ingredients into other containers, causing issues with getting ingredients out again (particularly crushed vs uncrushed versions).