### PR TITLE
[scripts][attunement] Add magic disabled messaging

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -153,7 +153,7 @@ class Attunement
       end
       return true
     end
-    case DRC.bput(get_perceive_command, "You fail to sense", "You're not ready to do that again, yet", "You reach out", "You sense:", "Roundtime")
+    case DRC.bput(get_perceive_command, "You fail to sense", "You're not ready to do that again, yet", "You reach out", "You sense:", "Roundtime", "Something in the area is interfering")
     when "You reach out", "You sense:"
       true
     else


### PR DESCRIPTION
With wild magic, a specific room might have magic disabled temporarily. Adding this message will allow the script to continue smoothly.