### PR TITLE
[scripts][combat-trainer] Honor stop_hunting_if_bleeding

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1061,12 +1061,13 @@ class SafetyProcess
     Flags.add('ct-parasite', 'blood mite on your (?<body_part>.*)\.')
     @equipment_manager = equipment_manager
     @health_threshold = settings.health_threshold
+    @stop_on_bleeding = settings.stop_hunting_if_bleeding
     echo("  @health_threshold: #{@health_threshold}") if $debug_mode_ct
     @untendable_counter = 0
   end
 
   def execute(game_state)
-    if @untendable_counter >= 3
+    if @untendable_counter >= 3 && @stop_on_bleeding
       echo('Skipping tendme check due to untendable backoff') if $debug_mode_ct
       echo("Couldn't tend bleeders after trying three times. Stopping hunt to heal.")
       $HUNTING_BUDDY.stop_hunting


### PR DESCRIPTION
We were defaulting to exiting combat with untendable bleeders. Now we honor the `stop_hunting_if_bleeding` setting, as with weird necros who want to heal in combat...