### PR TITLE
[scripts][combat-trainer] Added CFW functionality

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2189,7 +2189,7 @@ class PetProcess
     return unless @is_present
     return unless game_state.cfw_active?
 
-	DRCA.release_cyclics
+    DRCA.release_cyclics
   end
 
   def update_behavior(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2217,13 +2217,6 @@ class PetProcess
     update_stance(game_state)
   end
 
-  def check_bonebug(game_state)
-    return unless DRStats.necromancer?
-    return unless game_state.cfw_active?
-
-    summon_bonebug(game_state)
-  end
-
   def command_zombie(command, game_state)
     return unless game_state.cfb_active?
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -835,8 +835,9 @@ class LootProcess
       return
     end
 
-    result = DRC.bput("put material in my #{@necro_container}", 'You put')
+    result = DRC.bput("put material in my #{@necro_container}", 'You put', 'material doesn\'t seem to fit')
     @current_harvest_count += 1 if result =~ /^You put/
+    DRC.bput('drop material', 'you discard it') if result =~ /^material doesn't seem to fit/
   end
 
   def dispose_body(game_state)
@@ -1424,8 +1425,8 @@ class SpellProcess
     check_slivers(game_state)
     check_regalia(game_state)
     check_consume(game_state)
-    check_cfb(game_state)
     check_cfw(game_state)
+    check_cfb(game_state)
     check_bless(game_state)
     check_ignite(game_state)
     check_rutilors_edge(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -435,6 +435,9 @@ class LootProcess
     @make_zombie = settings.zombie['make']
     echo("  @make_zombie: #{@make_zombie}") if $debug_mode_ct
 
+    @make_bonebug = settings.bonebug['make']
+    echo("  @make_bonebug: #{@make_bonebug}") if $debug_mode_ct
+
     @wound_level_threshold = settings.necromancer_healing['wound_level_threshold'] || 1
     echo("  @wound_level_threshold: #{@wound_level_threshold}") if $debug_mode_ct
 
@@ -719,6 +722,11 @@ class LootProcess
         do_necro_ritual(mob_noun, 'arise', game_state)
         return false
       end
+      if @make_bonebug && !game_state.necro_casting? && !game_state.cfw_active?
+        echo 'Making bone bug' if $debug_mode_ct
+        do_necro_ritual(mob_noun, 'arise', game_state)
+        return false
+      end
 
       ritual = if @redeemed
                  'dissect'
@@ -760,7 +768,8 @@ class LootProcess
     case result
     when @rituals['arise']
       echo 'Detected arise messaging' if $debug_mode_ct
-      game_state.prepare_cfb = true if @make_zombie
+      game_state.prepare_cfb = true if @make_zombie && !game_state.cfb_active?
+      game_state.prepare_cfw = true if @make_bonebug && !game_state.cfw_active?
       @last_ritual = ritual
     when @rituals['preserve'], @rituals['dissect']
       echo 'Detected preserve or dissect messaging' if $debug_mode_ct
@@ -1227,6 +1236,9 @@ class SpellProcess
     @necromancer_zombie = settings.waggle_sets['zombie']
     echo("  @necromancer_zombie: #{@necromancer_zombie}") if $debug_mode_ct
 
+    @necromancer_bonebug = settings.waggle_sets['bonebug']
+    echo("  @necromancer_bonebug: #{@necromancer_bonebug}") if $debug_mode_ct
+
     @empath_spells = settings.empath_healing
     echo("  @empath_spells: #{@empath_spells}") if $debug_mode_ct
 
@@ -1413,6 +1425,7 @@ class SpellProcess
     check_regalia(game_state)
     check_consume(game_state)
     check_cfb(game_state)
+    check_cfw(game_state)
     check_bless(game_state)
     check_ignite(game_state)
     check_rutilors_edge(game_state)
@@ -1670,6 +1683,7 @@ class SpellProcess
     game_state.casting_weapon_buff = false
     game_state.casting_consume = false
     game_state.casting_cfb = false
+    game_state.casting_cfw = false
     game_state.casting_cyclic = false
     if game_state.casting_sorcery
       game_state.casting_sorcery = false
@@ -1917,6 +1931,18 @@ class SpellProcess
     prepare_spell(data, game_state, true)
   end
 
+  def check_cfw(game_state)
+    return unless DRStats.necromancer?
+    return unless @necromancer_bonebug['Call from Within']
+    return if game_state.casting
+    return unless game_state.prepare_cfw
+
+    game_state.casting_cfw = true
+    game_state.prepare_cfw = false
+    data = @necromancer_bonebug['Call from Within']
+    prepare_spell(data, game_state, true)
+  end
+
   def check_consume(game_state)
     return unless DRStats.necromancer?
     return unless @necromancer_healing
@@ -2124,6 +2150,8 @@ class PetProcess
 
     @zombie = settings.zombie
     echo("  @zombie: #{@zombie}") if $debug_mode_ct
+    @bonebug = settings.bonebug
+    echo("  @bonebug: #{@bonebug}") if $debug_mode_ct
 
     @is_present = false
     @current_stance = nil
@@ -2134,6 +2162,7 @@ class PetProcess
     check_zombie(game_state)
     if game_state.dismiss_pet?
       dismiss_zombie(game_state)
+      dismiss_bonebug(game_state)
       game_state.next_clean_up_step
       return true
     end
@@ -2153,6 +2182,13 @@ class PetProcess
     return unless game_state.cfb_active?
 
     command_zombie('leave', game_state)
+  end
+
+  def dismiss_bonebug(game_state)
+    return unless @is_present
+    return unless game_state.cfw_active?
+
+	DRCA.release_cyclics
   end
 
   def update_behavior(game_state)
@@ -2178,6 +2214,13 @@ class PetProcess
     summon_zombie(game_state)
     update_behavior(game_state)
     update_stance(game_state)
+  end
+
+  def check_bonebug(game_state)
+    return unless DRStats.necromancer?
+    return unless game_state.cfw_active?
+
+    summon_bonebug(game_state)
   end
 
   def command_zombie(command, game_state)
@@ -4079,12 +4122,12 @@ class GameState
   $tactics_actions = ['bob', 'weave', 'circle']
 
   attr_accessor :action_count, :aim_queue, :analyze_combo_array, :blessed_room, :cast_timer,
-                :casting, :casting_cfb, :casting_consume, :casting_cyclic, :casting_moonblade,
+                :casting, :casting_cfb, :casting_cfw, :casting_consume, :casting_cyclic, :casting_moonblade,
                 :casting_regalia, :casting_sorcery, :casting_weapon_buff, :charges, :charges_total,
                 :clean_up_step, :constructs, :cooldown_timers, :current_weapon_skill,
                 :currently_whirlwinding, :dance_queue, :dancing, :danger, :hide_on_cast,
                 :last_regalia_type, :last_weapon_skill, :loaded, :mob_died, :need_bundle,
-                :no_loot, :no_skins, :no_stab_current_mob, :no_stab_mobs, :parrying, :prepare_cfb,
+                :no_loot, :no_skins, :no_stab_current_mob, :no_stab_mobs, :parrying, :prepare_cfb, :prepare_cfw,
                 :prepare_consume, :regalia_cancel, :reset_stance, :retreating, :starlight_values,
                 :swap_regalia_type, :target_weapon_skill, :use_charged_maneuvers,
                 :whirlwind_trainables, :wounds
@@ -4124,6 +4167,8 @@ class GameState
     @prepare_consume = false
     @prepare_cfb = false
     @casting_cfb = false
+    @prepare_cfw = false
+    @casting_cfw = false
     @use_charged_maneuvers = false
     @wounds = {}
     @blessed_room = false
@@ -4926,6 +4971,8 @@ class GameState
     return false unless DRStats.necromancer?
     return true if @prepare_cfb
     return true if @casting_cfb
+    return true if @prepare_cfw
+    return true if @casting_cfw
     return true if @prepare_consume
     return true if @casting_consume
 
@@ -5147,6 +5194,10 @@ class GameState
 
   def cfb_active?
     DRSpells.active_spells.include?('Call from Beyond')
+  end
+
+  def cfw_active?
+    DRSpells.active_spells.include?('Call from Within')
   end
 
   def construct_mode?

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -68,6 +68,7 @@ module DRCA
     /^The Rite of Forbearance matrix loses cohesion, leaving you to wallow in temptation/, # Rite of Forbearance (ROF)
     /^The Rite of Grace matrix loses cohesion, leaving your body exposed/, # Rite of Grace (ROG)
     /^The greenish hues about you vanish as the Universal Solvent matrix loses its cohesion/ # Universal Solvent (USOL)
+    /^You sense your Call from Within spell weaken and disperse./ # Call from Within (CFW)
   ]
 
   def infuse_om(harness, amount)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -67,8 +67,8 @@ module DRCA
     /^The Rite of Contrition matrix loses cohesion, leaving your aura naked/, # Rite of Contrition (ROC)
     /^The Rite of Forbearance matrix loses cohesion, leaving you to wallow in temptation/, # Rite of Forbearance (ROF)
     /^The Rite of Grace matrix loses cohesion, leaving your body exposed/, # Rite of Grace (ROG)
-    /^The greenish hues about you vanish as the Universal Solvent matrix loses its cohesion/ # Universal Solvent (USOL)
-    /^You sense your Call from Within spell weaken and disperse/. # Call from Within (CFW)
+    /^The greenish hues about you vanish as the Universal Solvent matrix loses its cohesion/, # Universal Solvent (USOL)
+    /^You sense your Call from Within spell weaken and disperse/ # Call from Within (CFW)
   ]
 
   def infuse_om(harness, amount)

--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -68,7 +68,7 @@ module DRCA
     /^The Rite of Forbearance matrix loses cohesion, leaving you to wallow in temptation/, # Rite of Forbearance (ROF)
     /^The Rite of Grace matrix loses cohesion, leaving your body exposed/, # Rite of Grace (ROG)
     /^The greenish hues about you vanish as the Universal Solvent matrix loses its cohesion/ # Universal Solvent (USOL)
-    /^You sense your Call from Within spell weaken and disperse./ # Call from Within (CFW)
+    /^You sense your Call from Within spell weaken and disperse/. # Call from Within (CFW)
   ]
 
   def infuse_om(harness, amount)

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -2120,6 +2120,15 @@ spell_data:
     mana_type: arcane
     prep: prepare
     guild: Necromancer
+  Call from Within:
+    skill: Utility #Also Targeted Magic
+    abbrev: CFW
+    mana: 6
+    recast: -1
+    mana_type: arcane
+    prep: prepare
+    cyclic: true
+    guild: Necromancer
   Chirurgia:
     abbrev: CHIR
     guild: Necromancer

--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -2123,7 +2123,7 @@ spell_data:
   Call from Within:
     skill: Utility #Also Targeted Magic
     abbrev: CFW
-    mana: 6
+    mana: 5
     recast: -1
     mana_type: arcane
     prep: prepare


### PR DESCRIPTION
1. Added combat-trainer logic for CFW
Basically copied all relevant CFB sections and tweaked them to work for CFW.

Works independently of CFB and can be utilized together using these settings:
```
# zombie settings. Making a zombie in combat requires a waggle set called 'zombie' with CFB in it.
zombie:
  make: true
  summon: false
  stance: offense
  behavior: aggressive

# bonebug settings. Making a bonebug in combat requires a waggle set called 'bonebug' with CFW in it.
bonebug:
  make: true
```
Example waggles:
```
  cfb: &cfb
    Call from Beyond:
      mana: 30
  cfw: &cfw
    Call from Within:
      mana: 6

  zombie:
    << : *cfb
  bonebug:
    << : *cfw 
```
The script will prioritize summoning a dormant CFB > creating a CFW > creating a CFB in order of least to most complicated to create in order to get your pets going as quickly as possible.

2. Added cyclic release message for CFW to common-arcana

3. Added CFW entry to base-spells