### PR TITLE
[script] [combat-trainer] Devour functionality with necromancer_healing

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1930,6 +1930,7 @@ class SpellProcess
     end
 
     return unless game_state.prepare_consume
+    return if @necromancer_healing.key?('Devour') && DRSpells.active_spells['Devour']
 
     echo "@necromancer_healing.key?('Consume Flesh'): #{@necromancer_healing.key?('Consume Flesh')}" if $debug_mode_ct
     echo "@necromancer_healing.key?('Devour'): #{@necromancer_healing.key?('Devour')}" if $debug_mode_ct


### PR DESCRIPTION
Adds a fail-safe to not recast Devour if it is still active when using necromancer_healing settings.