### PR TITLE
[script] [combat-trainer] Added Call from Within functionality to combat-trainer. 

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -435,6 +435,9 @@ class LootProcess
     @make_zombie = settings.zombie['make']
     echo("  @make_zombie: #{@make_zombie}") if $debug_mode_ct
 
+    @make_bonebug = settings.bonebug['make']
+    echo("  @make_bonebug: #{@make_bonebug}") if $debug_mode_ct
+
     @wound_level_threshold = settings.necromancer_healing['wound_level_threshold'] || 1
     echo("  @wound_level_threshold: #{@wound_level_threshold}") if $debug_mode_ct
 
@@ -719,6 +722,11 @@ class LootProcess
         do_necro_ritual(mob_noun, 'arise', game_state)
         return false
       end
+      if @make_bonebug && !game_state.necro_casting? && !game_state.cfw_active?
+        echo 'Making bone bug' if $debug_mode_ct
+        do_necro_ritual(mob_noun, 'arise', game_state)
+        return false
+      end
 
       ritual = if @redeemed
                  'dissect'
@@ -760,7 +768,8 @@ class LootProcess
     case result
     when @rituals['arise']
       echo 'Detected arise messaging' if $debug_mode_ct
-      game_state.prepare_cfb = true if @make_zombie
+      game_state.prepare_cfb = true if @make_zombie && !game_state.cfb_active?
+      game_state.prepare_cfw = true if @make_bonebug && !game_state.cfw_active?
       @last_ritual = ritual
     when @rituals['preserve'], @rituals['dissect']
       echo 'Detected preserve or dissect messaging' if $debug_mode_ct
@@ -1228,6 +1237,9 @@ class SpellProcess
     @necromancer_zombie = settings.waggle_sets['zombie']
     echo("  @necromancer_zombie: #{@necromancer_zombie}") if $debug_mode_ct
 
+    @necromancer_bonebug = settings.waggle_sets['bonebug']
+    echo("  @necromancer_bonebug: #{@necromancer_bonebug}") if $debug_mode_ct
+
     @empath_spells = settings.empath_healing
     echo("  @empath_spells: #{@empath_spells}") if $debug_mode_ct
 
@@ -1413,6 +1425,7 @@ class SpellProcess
     check_slivers(game_state)
     check_regalia(game_state)
     check_consume(game_state)
+    check_cfw(game_state)
     check_cfb(game_state)
     check_bless(game_state)
     check_ignite(game_state)
@@ -1671,6 +1684,7 @@ class SpellProcess
     game_state.casting_weapon_buff = false
     game_state.casting_consume = false
     game_state.casting_cfb = false
+    game_state.casting_cfw = false
     game_state.casting_cyclic = false
     if game_state.casting_sorcery
       game_state.casting_sorcery = false
@@ -1918,6 +1932,18 @@ class SpellProcess
     prepare_spell(data, game_state, true)
   end
 
+  def check_cfw(game_state)
+    return unless DRStats.necromancer?
+    return unless @necromancer_bonebug['Call from Within']
+    return if game_state.casting
+    return unless game_state.prepare_cfw
+
+    game_state.casting_cfw = true
+    game_state.prepare_cfw = false
+    data = @necromancer_bonebug['Call from Within']
+    prepare_spell(data, game_state, true)
+  end
+
   def check_consume(game_state)
     return unless DRStats.necromancer?
     return unless @necromancer_healing
@@ -2125,6 +2151,8 @@ class PetProcess
 
     @zombie = settings.zombie
     echo("  @zombie: #{@zombie}") if $debug_mode_ct
+    @bonebug = settings.bonebug
+    echo("  @bonebug: #{@bonebug}") if $debug_mode_ct
 
     @is_present = false
     @current_stance = nil
@@ -2135,6 +2163,7 @@ class PetProcess
     check_zombie(game_state)
     if game_state.dismiss_pet?
       dismiss_zombie(game_state)
+      dismiss_bonebug(game_state)
       game_state.next_clean_up_step
       return true
     end
@@ -2154,6 +2183,13 @@ class PetProcess
     return unless game_state.cfb_active?
 
     command_zombie('leave', game_state)
+  end
+
+  def dismiss_bonebug(game_state)
+    return unless @is_present
+    return unless game_state.cfw_active?
+
+    DRCA.release_cyclics
   end
 
   def update_behavior(game_state)
@@ -4080,12 +4116,12 @@ class GameState
   $tactics_actions = ['bob', 'weave', 'circle']
 
   attr_accessor :action_count, :aim_queue, :analyze_combo_array, :blessed_room, :cast_timer,
-                :casting, :casting_cfb, :casting_consume, :casting_cyclic, :casting_moonblade,
+                :casting, :casting_cfb, :casting_cfw, :casting_consume, :casting_cyclic, :casting_moonblade,
                 :casting_regalia, :casting_sorcery, :casting_weapon_buff, :charges, :charges_total,
                 :clean_up_step, :constructs, :cooldown_timers, :current_weapon_skill,
                 :currently_whirlwinding, :dance_queue, :dancing, :danger, :hide_on_cast,
                 :last_regalia_type, :last_weapon_skill, :loaded, :mob_died, :need_bundle,
-                :no_loot, :no_skins, :no_stab_current_mob, :no_stab_mobs, :parrying, :prepare_cfb,
+                :no_loot, :no_skins, :no_stab_current_mob, :no_stab_mobs, :parrying, :prepare_cfb, :prepare_cfw,
                 :prepare_consume, :regalia_cancel, :reset_stance, :retreating, :starlight_values,
                 :swap_regalia_type, :target_weapon_skill, :use_charged_maneuvers,
                 :whirlwind_trainables, :wounds
@@ -4125,6 +4161,8 @@ class GameState
     @prepare_consume = false
     @prepare_cfb = false
     @casting_cfb = false
+    @prepare_cfw = false
+    @casting_cfw = false
     @use_charged_maneuvers = false
     @wounds = {}
     @blessed_room = false
@@ -4927,6 +4965,8 @@ class GameState
     return false unless DRStats.necromancer?
     return true if @prepare_cfb
     return true if @casting_cfb
+    return true if @prepare_cfw
+    return true if @casting_cfw
     return true if @prepare_consume
     return true if @casting_consume
 
@@ -5148,6 +5188,10 @@ class GameState
 
   def cfb_active?
     DRSpells.active_spells.include?('Call from Beyond')
+  end
+
+  def cfw_active?
+    DRSpells.active_spells.include?('Call from Within')
   end
 
   def construct_mode?


### PR DESCRIPTION
Added combat-trainer logic for CFW. This is essentially a cut and paste of the CFB code with tweaks made to handle the differences between the spells.

Works independently of CFB and they can both be utilized together using the settings below. The script will prioritize summoning a dormant CFB > creating a CFW > creating a CFB in order of least to most complicated to create in order to get your pets going as quickly as possible.
```
# zombie settings. Making a zombie in combat requires a waggle set called 'zombie' with CFB in it.
zombie:
  make: true
  summon: false
  stance: offense
  behavior: aggressive

# bonebug settings. Making a bonebug in combat requires a waggle set called 'bonebug' with CFW in it.
bonebug:
  make: true
```
Example waggles:
```
  cfb: &cfb
    Call from Beyond:
      mana: 30
  cfw: &cfw
    Call from Within:
      mana: 6

  zombie:
    << : *cfb
  bonebug:
    << : *cfw 
```
