### PR TITLE
[script] [combat-trainer] Added Necrotic Reconstruction functionality to CFB zombie creation 

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -768,6 +768,7 @@ class LootProcess
     case result
     when @rituals['arise']
       echo 'Detected arise messaging' if $debug_mode_ct
+      game_state.prepare_nr = true if @make_zombie && !game_state.cfb_active?
       game_state.prepare_cfb = true if @make_zombie && !game_state.cfb_active?
       game_state.prepare_cfw = true if @make_bonebug && !game_state.cfw_active?
       @last_ritual = ritual
@@ -1234,6 +1235,9 @@ class SpellProcess
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 
+    @corpse_healing = settings.waggle_sets['corpse_healing']
+    echo("  @corpse_healing: #{@corpse_healing}") if $debug_mode_ct
+
     @necromancer_zombie = settings.waggle_sets['zombie']
     echo("  @necromancer_zombie: #{@necromancer_zombie}") if $debug_mode_ct
 
@@ -1425,6 +1429,7 @@ class SpellProcess
     check_slivers(game_state)
     check_regalia(game_state)
     check_consume(game_state)
+    heal_corpse(game_state)
     check_cfw(game_state)
     check_cfb(game_state)
     check_bless(game_state)
@@ -1683,6 +1688,7 @@ class SpellProcess
 
     game_state.casting_weapon_buff = false
     game_state.casting_consume = false
+    game_state.casting_nr = false
     game_state.casting_cfb = false
     game_state.casting_cfw = false
     game_state.casting_cyclic = false
@@ -1941,6 +1947,18 @@ class SpellProcess
     game_state.casting_cfw = true
     game_state.prepare_cfw = false
     data = @necromancer_bonebug['Call from Within']
+    prepare_spell(data, game_state, true)
+  end
+
+  def heal_corpse(game_state)
+    return unless DRStats.necromancer?
+    return unless @corpse_healing['Necrotic Reconstruction']
+    return if game_state.casting
+    return unless game_state.prepare_nr
+
+    game_state.casting_nr = true
+    game_state.prepare_nr = false
+    data = @corpse_healing['Necrotic Reconstruction']
     prepare_spell(data, game_state, true)
   end
 
@@ -4117,12 +4135,12 @@ class GameState
   $tactics_actions = ['bob', 'weave', 'circle']
 
   attr_accessor :action_count, :aim_queue, :analyze_combo_array, :blessed_room, :cast_timer,
-                :casting, :casting_cfb, :casting_cfw, :casting_consume, :casting_cyclic, :casting_moonblade,
+                :casting, :casting_cfb, :casting_cfw, :casting_nr, :casting_consume, :casting_cyclic, :casting_moonblade,
                 :casting_regalia, :casting_sorcery, :casting_weapon_buff, :charges, :charges_total,
                 :clean_up_step, :constructs, :cooldown_timers, :current_weapon_skill,
                 :currently_whirlwinding, :dance_queue, :dancing, :danger, :hide_on_cast,
                 :last_regalia_type, :last_weapon_skill, :loaded, :mob_died, :need_bundle,
-                :no_loot, :no_skins, :no_stab_current_mob, :no_stab_mobs, :parrying, :prepare_cfb, :prepare_cfw,
+                :no_loot, :no_skins, :no_stab_current_mob, :no_stab_mobs, :parrying, :prepare_cfb, :prepare_cfw, :prepare_nr,
                 :prepare_consume, :regalia_cancel, :reset_stance, :retreating, :starlight_values,
                 :swap_regalia_type, :target_weapon_skill, :use_charged_maneuvers,
                 :whirlwind_trainables, :wounds
@@ -4160,6 +4178,8 @@ class GameState
     @casting_weapon_buff = false
     @casting_consume = false
     @prepare_consume = false
+    @prepare_nr = false
+    @casting_nr = false
     @prepare_cfb = false
     @casting_cfb = false
     @prepare_cfw = false
@@ -4964,6 +4984,8 @@ class GameState
 
   def necro_casting?
     return false unless DRStats.necromancer?
+    return true if @prepare_nr
+    return true if @casting_nr
     return true if @prepare_cfb
     return true if @casting_cfb
     return true if @prepare_cfw


### PR DESCRIPTION
Added a setting to enable Necrotic Reconstruction to be cast once before raising a CFB zombie. Add NR and corpse_healing settings to your waggles. Also requires CFB and zombie waggles to be set up. Example waggles:
```
waggle_sets:
  cfb: &cfb
    Call from Beyond:
      use_auto_mana: true
  nr: &nr
    Necrotic Reconstruction:
      use_auto_mana: true
  zombie:
    << : *cfb
  corpse_healing:
    << : *nr
```