### PR TITLE
[script] [tome] Add additional study failure message

### DIFF
--- a/tome.lic
+++ b/tome.lic
@@ -123,13 +123,15 @@ class Tome
                         /^You are unable to focus on studying your/,
                         /^You must complete or cancel your current magical research project/,
                         /^Considering that you are in combat/,
-                        /^However, you find that you lack the concentration to focus on your studies/)
+                        /^However, you find that you lack the concentration to focus on your studies/,
+                        /^This is not a good place for that/)
       DRC.safe_unpause_list @scripts_to_unpause if @passive
       case result
       when /^You are unable to focus on studying your/,
            /^You must complete or cancel your current magical research project/,
            /^Considering that you are in combat/,
-           /^However, you find that you lack the concentration to focus on your studies/
+           /^However, you find that you lack the concentration to focus on your studies/,
+           /^This is not a good place for that/
         pause_scripts if @passive
         DRCI.stow_item?(@@tome)
         DRC.safe_unpause_list @scripts_to_unpause if @passive


### PR DESCRIPTION
Add failure message for when you try to study your tome in a room where it is not allowed (such as the Crossing Bank Lobby). This allows the script to continue gracefully, without hanging due to no recognized response.