### PR TITLE
[scripts][dependency] Tweaks to downloading updated/missing files

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.7.1'
+$DEPENDENCY_VERSION = '1.7.2'
 $MIN_RUBY_VERSION = '3.2.2'
 
 no_pause_all
@@ -395,11 +395,14 @@ class ScriptManager
   def setup_profiles
     verify_or_make_dir File.join(SCRIPT_DIR, 'profiles')
     profile_tree_url = get_status['tree'].find { |element| element['path'] == 'profiles' }['url']
-    make_request(profile_tree_url)['tree'].each do |setup_file|
-      echo("downloading #{setup_file}") if @debug
-      blob = make_request(setup_file['url'])
-      File.open(File.join(SCRIPT_DIR, "profiles/#{setup_file['path']}"), 'w') { |file| file.print(Base64.decode64(blob['content'])) }
-    end
+    make_request(profile_tree_url)['tree']
+      # Select only base.yaml and base-empty.yaml
+      .select { |data| /^base(?:-empty)?\.yaml/ =~ data['path'] }
+      .each do |setup_file|
+        echo("downloading #{setup_file}") if @debug
+        blob = make_request(setup_file['url'])
+        File.open(File.join(SCRIPT_DIR, "profiles/#{setup_file['path']}"), 'w') { |file| file.print(Base64.decode64(blob['content'])) }
+      end
   end
 
   def setup_data
@@ -434,8 +437,10 @@ class ScriptManager
     verify_or_make_dir File.join(SCRIPT_DIR, 'profiles')
     profile_tree_url = get_status['tree'].find { |element| element['path'] == 'profiles' }['url']
     make_request(profile_tree_url)['tree']
-      .select { |data| /^base.+yaml/ =~ data['path'] }
-      .reject { |setup_file| setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
+      # Select only base.yaml and base-empty.yaml
+      .select { |data| /^base(?:-empty)?\.yaml/ =~ data['path'] }
+      # Reject files that exist, and have the same shasum as those on the repo.
+      .reject { |setup_file| File.exists?("profiles/#{setup_file['path']}") && setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
       .each do |setup_file|
         echo("downloading #{setup_file}") if @debug
         blob = make_request(setup_file['url'])
@@ -449,7 +454,8 @@ class ScriptManager
     profile_tree_url = get_status['tree'].find { |element| element['path'] == 'data' }['url']
     make_request(profile_tree_url)['tree']
       .select { |data| /^base.+yaml/ =~ data['path'] }
-      .reject { |setup_file| setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
+      # Reject files that exist, and have the same shasum as those on the repo.
+      .reject { |setup_file| File.exists?("data/#{setup_file['path']}") && setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
       .each do |setup_file|
         echo("downloading #{setup_file}") if @debug
         blob = make_request(setup_file['url'])

--- a/dependency.lic
+++ b/dependency.lic
@@ -440,7 +440,7 @@ class ScriptManager
       # Select only base.yaml and base-empty.yaml
       .select { |data| /^base(?:-empty)?\.yaml/ =~ data['path'] }
       # Reject files that exist, and have the same shasum as those on the repo.
-      .reject { |setup_file| File.exists?("profiles/#{setup_file['path']}") && setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
+      .reject { |setup_file| File.exist?("profiles/#{setup_file['path']}") && setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
       .each do |setup_file|
         echo("downloading #{setup_file}") if @debug
         blob = make_request(setup_file['url'])
@@ -455,7 +455,7 @@ class ScriptManager
     make_request(profile_tree_url)['tree']
       .select { |data| /^base.+yaml/ =~ data['path'] }
       # Reject files that exist, and have the same shasum as those on the repo.
-      .reject { |setup_file| File.exists?("data/#{setup_file['path']}") && setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
+      .reject { |setup_file| File.exist?("data/#{setup_file['path']}") && setup_file['sha'] == Settings['base_versions'][setup_file['path']] }
       .each do |setup_file|
         echo("downloading #{setup_file}") if @debug
         blob = make_request(setup_file['url'])


### PR DESCRIPTION
Two changes.

1. Checks that files exist, in addition to the existing hash comparison for versions in the database. This should remediate the case where folks accidentally delete a base file.

2. Fixes the missing `Samples` folder issue and resolves https://github.com/rpherbig/dr-scripts/issues/5392

We only download base.yaml and base-empty.yaml now explicitly.