### PR TITLE
[scripts][bescort] gondola information

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1804,7 +1804,7 @@ class Bescort
   def ride_gondola(mode)
     case DRC.bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
     when /no wooden gondola here/i
-      DRC.bput('look gondola','The wooden gondola')
+      DRC.bput('look gondola', 'The wooden gondola')
       hide?
       waitfor 'The gondola stops on the platform and the door silently swings open'
       ride_gondola(mode)

--- a/bescort.lic
+++ b/bescort.lic
@@ -1804,6 +1804,7 @@ class Bescort
   def ride_gondola(mode)
     case DRC.bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
     when /no wooden gondola here/i
+      DRC.bput('look gondola','The wooden gondola')
       hide?
       waitfor 'The gondola stops on the platform and the door silently swings open'
       ride_gondola(mode)


### PR DESCRIPTION
Added a simple `look gondola` command if the gondola is not there for informational purposes so you don't have to manually type it to know where the gondola is. No change to the movement functionality of the script. This is simply to facilitate laziness in the event the user wants information on the gondola's location.