### PR TITLE
[script][favors] retry cleaning altar after refilling chalice

### DIFF
--- a/favor.lic
+++ b/favor.lic
@@ -114,7 +114,6 @@ class CrossingFavor
       when /^Wash the altar with what?/
         get_water
         DRCT.walk_to(@room)
-        break
       when /^But the altar is perfectly clean/
         break
       end


### PR DESCRIPTION
during the case when chalice is empty, after filling chalice, it returns to the altar but the `break` causes you to proceed like altar was successfully cleaned.  Had this happen twice.
```
--- Lich: go2 has exited.
[favor]>stow right
You put your chalice in your black haversack.
[favor]>get my shrew primer
You get a parchment shrew primer from inside your black haversack.
[favor]>put my shrew primer on lacquered altar
You reverently place a parchment shrew primer on the lacquered altar.
[favor]>pray
You begin to pray, kneeling before the altar.  A sense of peace and tranquility fills you as you murmur softly.
You feel a sense of shame as your offering is thrown violently from the dusty surface of the altar.
```