### PR TITLE
[scripts][combat-trainer] end GS pause loop after 10 seconds

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1712,7 +1712,13 @@ class SpellProcess
 
     return unless @command
 
-    pause 0.5 until DRRoom.npcs.include?('warrior')
+    # escape valve in case spell immediately fails (due to anti magic?)
+    temp_count = 0
+    until DRRoom.npcs.include?('warrior') || temp_count > 20
+      pause 0.5
+      temp_count += 1
+    end
+
     fput("command #{@command}")
     @command = nil
   end


### PR DESCRIPTION
So far, two complaints on Discord about instances where after casting GS, combat-trainer "hangs" not doing anything. After casting GS, CT pauses until the warrior is found. If the warrior never appears, it'll pause indefinitely. Now, after 10 seconds, we'll move on.

Log of casting the spell and having it immediately fail. combat-trainer then hung for a couple minutes before I manually stopped it.

https://pastebin.com/aYpr1qRH