### PR TITLE
[script] [combat-trainer] Added necro_corpse_priority: setting

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -710,11 +710,11 @@ class LootProcess
     echo "  should_perform_ritual? #{should_perform_ritual?(game_state)}" if $debug_mode_ct
     if @last_ritual.nil?
       if @necro_corpse_priority == 'pet'
-        DRC.message("Prioritizing pet creation over healing")
+        echo ("Prioritizing pet creation over healing" if $debug_mode_ct
         check_necro_pet(mob_noun, game_state)
         check_necro_heal(mob_noun, game_state)
       elsif @necro_corpse_priority == 'heal' || !@necro_corpse_priority
-        DRC.message("Prioritizing healing over pet creation")
+        echo "Prioritizing healing over pet creation" if $debug_mode_ct
         check_necro_heal(mob_noun, game_state)
         check_necro_pet(mob_noun, game_state)
       end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -438,6 +438,9 @@ class LootProcess
     @make_bonebug = settings.bonebug['make']
     echo("  @make_bonebug: #{@make_bonebug}") if $debug_mode_ct
 
+    @necro_corpse_priority = settings.necro_corpse_priority
+    echo("  @necro_corpse_priority: #{@necro_corpse_priority}") if $debug_mode_ct
+	
     @wound_level_threshold = settings.necromancer_healing['wound_level_threshold'] || 1
     echo("  @wound_level_threshold: #{@wound_level_threshold}") if $debug_mode_ct
 
@@ -1428,10 +1431,17 @@ class SpellProcess
     end
     check_slivers(game_state)
     check_regalia(game_state)
-    check_consume(game_state)
-    heal_corpse(game_state)
-    check_cfw(game_state)
-    check_cfb(game_state)
+    if @settings.necro_corpse_priority == 'pet'
+      check_cfw(game_state)
+      heal_corpse(game_state)
+      check_cfb(game_state)
+      check_consume(game_state)
+    elsif @settings.necro_corpse_priority['heal'] || !@settings.necro_corpse_priority
+      check_consume(game_state)
+      check_cfw(game_state)
+      heal_corpse(game_state)
+      check_cfb(game_state)
+    end
     check_bless(game_state)
     check_ignite(game_state)
     check_rutilors_edge(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -709,28 +709,15 @@ class LootProcess
 
     echo "  should_perform_ritual? #{should_perform_ritual?(game_state)}" if $debug_mode_ct
     if @last_ritual.nil?
-      if @necro_heal && !game_state.necro_casting?
-        game_state.wounds = DRCH.check_health['wounds']
-        echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
-        echo "wound_level_threshold: #{@wound_level_threshold}" if $debug_mode_ct
-        unless game_state.wounds.empty?
-          if @wound_level_threshold <= game_state.wounds.keys.max
-            do_necro_ritual(mob_noun, 'consume', game_state)
-            return false
-          end
-        end
+      if @necro_corpse_priority == 'pet'
+        DRC.message("Prioritizing pet creation over healing")
+        check_necro_pet(mob_noun, game_state)
+        check_necro_heal(mob_noun, game_state)
+      elsif @necro_corpse_priority == 'heal' || !@necro_corpse_priority
+        DRC.message("Prioritizing healing over pet creation")
+        check_necro_heal(mob_noun, game_state)
+        check_necro_pet(mob_noun, game_state)
       end
-      if @make_zombie && !game_state.necro_casting? && !game_state.cfb_active?
-        echo 'Making zombie' if $debug_mode_ct
-        do_necro_ritual(mob_noun, 'arise', game_state)
-        return false
-      end
-      if @make_bonebug && !game_state.necro_casting? && !game_state.cfw_active?
-        echo 'Making bone bug' if $debug_mode_ct
-        do_necro_ritual(mob_noun, 'arise', game_state)
-        return false
-      end
-
       ritual = if @redeemed
                  'dissect'
                elsif @current_harvest_count < @necro_count
@@ -747,6 +734,33 @@ class LootProcess
     return false if %w[consume harvest dissect].include?(@last_ritual)
 
     true
+  end
+
+  def check_necro_heal(mob_noun, game_state)
+    if @necro_heal && !game_state.necro_casting?
+      game_state.wounds = DRCH.check_health['wounds']
+      echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
+      echo "wound_level_threshold: #{@wound_level_threshold}" if $debug_mode_ct
+      unless game_state.wounds.empty?
+        if @wound_level_threshold <= game_state.wounds.keys.max
+          do_necro_ritual(mob_noun, 'consume', game_state)
+          return false
+        end
+      end
+    end
+  end  
+  
+  def check_necro_pet(mob_noun, game_state)
+    if @make_zombie && !game_state.necro_casting? && !game_state.cfb_active?
+      echo 'Making zombie' if $debug_mode_ct
+      do_necro_ritual(mob_noun, 'arise', game_state)
+      return false
+    end
+    if @make_bonebug && !game_state.necro_casting? && !game_state.cfw_active?
+      echo 'Making bone bug' if $debug_mode_ct
+      do_necro_ritual(mob_noun, 'arise', game_state)
+      return false
+    end
   end
 
   def do_necro_ritual(mob_noun, ritual, game_state)
@@ -1431,17 +1445,10 @@ class SpellProcess
     end
     check_slivers(game_state)
     check_regalia(game_state)
-    if @settings.necro_corpse_priority == 'pet'
-      check_cfw(game_state)
-      heal_corpse(game_state)
-      check_cfb(game_state)
-      check_consume(game_state)
-    elsif @settings.necro_corpse_priority['heal'] || !@settings.necro_corpse_priority
-      check_consume(game_state)
-      check_cfw(game_state)
-      heal_corpse(game_state)
-      check_cfb(game_state)
-    end
+    check_consume(game_state)
+    check_cfw(game_state)
+    heal_corpse(game_state)
+    check_cfb(game_state)
     check_bless(game_state)
     check_ignite(game_state)
     check_rutilors_edge(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -710,7 +710,7 @@ class LootProcess
     echo "  should_perform_ritual? #{should_perform_ritual?(game_state)}" if $debug_mode_ct
     if @last_ritual.nil?
       if @necro_corpse_priority == 'pet'
-        echo ("Prioritizing pet creation over healing" if $debug_mode_ct
+        echo "Prioritizing pet creation over healing" if $debug_mode_ct
         check_necro_pet(mob_noun, game_state)
         check_necro_heal(mob_noun, game_state)
       elsif @necro_corpse_priority == 'heal' || !@necro_corpse_priority

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -440,7 +440,7 @@ class LootProcess
 
     @necro_corpse_priority = settings.necro_corpse_priority
     echo("  @necro_corpse_priority: #{@necro_corpse_priority}") if $debug_mode_ct
-	
+
     @wound_level_threshold = settings.necromancer_healing['wound_level_threshold'] || 1
     echo("  @wound_level_threshold: #{@wound_level_threshold}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -748,8 +748,8 @@ class LootProcess
         end
       end
     end
-  end  
-  
+  end
+
   def check_necro_pet(mob_noun, game_state)
     if @make_zombie && !game_state.necro_casting? && !game_state.cfb_active?
       echo 'Making zombie' if $debug_mode_ct


### PR DESCRIPTION
Added `necro_corpse_priority:` setting to allow for prioritization of using corpses for either healing or pet creation. This does not change any behavior unless the setting is added to a yaml.

Default behavior is to prioritze healing from corpses over pet creation, and this is the same behavior as before this update. To have it do this, exclude the setting, leave it blank or set it to `heal`. To have it prioritize pet creation from corpses set it to `pet`.

Rituals other than consume/arise also have not changed. They are handled separately in the rituals section and continue to be prioritized behind both pets and healing as before.