### PR TITLE
[scripts][sort-scrolls] adjust handling of scrolls with > 2 words in the adjective segment

### DIFF
--- a/sort-scrolls.lic
+++ b/sort-scrolls.lic
@@ -130,11 +130,12 @@ class ScrollSorter
   def sort_scrolls
     scrolls = DRCI.get_scroll_list_in_container(@default_container)
     scrolls.each do |s|
-      next unless get_scroll(s)
+      s.split.count > 2 ? scroll = "#{s.split.first} #{s.split.last}" : scroll = s
+      next unless get_scroll(scroll)
 
-      guild = check_scroll(s)
+      guild = check_scroll(scroll)
       unknown(guild) if guild.nil?
-      stack_scroll(s, guild)
+      stack_scroll(scroll, guild)
     end
   end
 


### PR DESCRIPTION
three word scrolls were having parsing issues.  unable to get `sanguine paper scroll`.  scroll system puts it all into the 15 characters for adjective, so we can split and use the first + last to successfully grab.  tested with various paper colors.