### PR TITLE
[scripts][common-items]add wear/remove pattern for adventure set boots

### DIFF
--- a/common-items.lic
+++ b/common-items.lic
@@ -121,7 +121,8 @@ module DRCI
     /^You carefully arrange/,
     /^A brisk chill rushes through you as you wear/, # some hiro bearskin gloves interlaced with strips of ice-veined leather
     /^You drape/,
-    /You lean over and slip your feet into the boots./ # a pair of weathered barkcloth boots lined in flannel
+    /You lean over and slip your feet into the boots./, # a pair of weathered barkcloth boots lined in flannel,
+    /You reach down and step into/ # pair of enaada boots clasped by asharsh'dai
   ]
 
   WEAR_ITEM_FAILURE_PATTERNS = [
@@ -181,7 +182,8 @@ module DRCI
     /as you remove/,
     /slide themselves off of your/,
     /you manage to loosen/,
-    /you unlace/
+    /you unlace/,
+    /You slam the heels/
   ]
 
   REMOVE_ITEM_FAILURE_PATTERNS = [

--- a/common-items.lic
+++ b/common-items.lic
@@ -122,7 +122,7 @@ module DRCI
     /^A brisk chill rushes through you as you wear/, # some hiro bearskin gloves interlaced with strips of ice-veined leather
     /^You drape/,
     /You lean over and slip your feet into the boots./, # a pair of weathered barkcloth boots lined in flannel,
-    /You reach down and step into/ # pair of enaada boots clasped by asharsh'dai
+    /^You reach down and step into/ # pair of enaada boots clasped by asharsh'dai
   ]
 
   WEAR_ITEM_FAILURE_PATTERNS = [
@@ -183,7 +183,7 @@ module DRCI
     /slide themselves off of your/,
     /you manage to loosen/,
     /you unlace/,
-    /You slam the heels/
+    /^You slam the heels/
   ]
 
   REMOVE_ITEM_FAILURE_PATTERNS = [


### PR DESCRIPTION
```
>;e echo DRCI.remove_item?("boots")
--- Lich: exec1 active.
[exec1]>remove my boots
You slam the heels of your enaada boots down against the floor a few times to loosen them before kicking them off.  You quickly reach down to retrieve them, hitting them together a few times to clean off remaining dust and dirt.
>
[exec1: true]
--- Lich: exec1 has exited.
>;e echo DRCI.wear_item?("boots")
--- Lich: exec1 active.
[exec1]>wear my boots
You reach down and step into your enaada boots before tugging at the clasps, tightening the fit.
>
[exec1: true]
--- Lich: exec1 has exited.
```