### PR TITLE
add SMH cast messaging

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -157,6 +157,7 @@ cast_messages:
 - ^Your spell .*backfires
 - You strain, but are too mentally fatigued
 - ^You gesture
+- As you bow your head and chant
 - A soft silver glow envelops
 - You blend smoothly into your surroundings
 - You listen intently to the air


### PR DESCRIPTION
- Smite Horde no longer uses "You gesture" after a cast
- Added "As you bow your head and chant" to the cast_messages in base-spells.yaml