### PR TITLE
[base-town] Added crossing npc healer room number

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -40,7 +40,8 @@ Crossing:
     id: 8266
     name: Falken
   npc_empath:
-    id: 6218
+    id: 6870 # This is the Crossing npc healer room.  Martyr Saedelthorp and Apprentice Kaiva.
+    # id: 6218 # This is dokt, commented out for the wild magic event.
   locksmithing:
     id: 19125
     name: Ragge


### PR DESCRIPTION
Added the room number for Kaiva/Martyr Saedelthorp and commented out the one for Dokt.