### PR TITLE
[scripts][bescort] fix segoltha shortcut usage

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1528,7 +1528,7 @@ class Bescort
       if XMLData.room_exits.length == 2 || XMLData.room_exits.length == 1
         move 'west'
         move_count -= 1
-      elsif dir_of_travel == 'north' && move_count == 16 && UserVars.segoltha_shortcut == 'true'
+      elsif dir_of_travel == 'north' && move_count == 16
         move 'east'
         break if Room.current.id == 15888
       elsif XMLData.room_exits.include?(dir_of_travel)


### PR DESCRIPTION
Removed the segoltha_shortcut check.

This along with map updates I made fix the issue with the Segoltha River.

I snipped the timeto on room 1447 going to room 1879 (the tiger clan gate) so that way won't even try to path and it's an easy fix later.