### PR TITLE
[scripts] [safe-room] Force use of camb when using devour to deal with fried nerves situations

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -131,7 +131,8 @@ class SafeRoom
       break if result =~ /^What were you/
 
       unless DRSpells.active_spells['Devour']
-        DRCA.cast_spell(settings.necromancer_healing['Devour'], settings, true)  # we want to force camb because otherwise high nerve damage casts will always result in min prep due to lost held mana
+        # we want to force camb because otherwise high nerve damage casts will always result in min prep due to lost held mana
+        DRCA.cast_spell(settings.necromancer_healing['Devour'], settings, true)  
         devours -= 1 unless DRC.right_hand
       end
       pause 5

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -132,7 +132,7 @@ class SafeRoom
 
       unless DRSpells.active_spells['Devour']
         # we want to force camb because otherwise high nerve damage casts will always result in min prep due to lost held mana
-        DRCA.cast_spell(settings.necromancer_healing['Devour'], settings, true)  
+        DRCA.cast_spell(settings.necromancer_healing['Devour'], settings, true)
         devours -= 1 unless DRC.right_hand
       end
       pause 5

--- a/safe-room.lic
+++ b/safe-room.lic
@@ -131,7 +131,7 @@ class SafeRoom
       break if result =~ /^What were you/
 
       unless DRSpells.active_spells['Devour']
-        DRCA.cast_spell(settings.necromancer_healing['Devour'], settings)
+        DRCA.cast_spell(settings.necromancer_healing['Devour'], settings, true)  # we want to force camb because otherwise high nerve damage casts will always result in min prep due to lost held mana
         devours -= 1 unless DRC.right_hand
       end
       pause 5


### PR DESCRIPTION
If your nerves are fired, it's basically impossible to hold mana for anything longer then a second.  In that situation you end up casting a REALLY weak devour which will take forever to heal.