### PR TITLE
[scripts] [safe-room] fix check for vela'tohr in use_pc_empath?

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -268,7 +268,7 @@ class SafeRoom
     return false unless empath
 
     DRCT.walk_to room_id
-    return false unless DRRoom.pcs.include?(empath) || DRRoom.room_objs.grep(@plant_regex)
+    return false unless DRRoom.pcs.include?(empath) || DRRoom.room_objs.grep(@plant_regex).size > 0
 
     unless DRRoom.pcs.include?(empath)
       if /.*vela.tohr (\w+)/ =~ DRRoom.room_objs.grep(@plant_regex).to_s


### PR DESCRIPTION
`DRRoom.room_objs.grep` returns an array of matches, so it will always evaluate to truthy.
Change the check to ensure that there was at least one match.