### PR TITLE
[scripts] [safe-room] Add support for EV only places in safe_room_empaths

### DIFF
--- a/safe-room.lic
+++ b/safe-room.lic
@@ -270,7 +270,7 @@ class SafeRoom
         .map { |room| pc_empaths.select { |empath| empath['id'] == room } }
         .flatten
         .each do |empath|
-      next unless DRRoom.pcs.include?(empath['name'].capitalize!) || @validator.in_game?(empath['name'])
+      next unless empath['name'].upcase == 'EV' || DRRoom.pcs.include?(empath['name'].capitalize!) || @validator.in_game?(empath['name'])
       next unless use_pc_empath?(empath['id'], empath['name'])
 
       DRCM.ensure_copper_on_hand(settings.safe_room_tip_threshold || 0, settings)


### PR DESCRIPTION
Adds the ability to set rooms to be checked for EV (Embrace of the Vela'tohr) plants, instead of just PC empaths.

```yaml
safe_room_empaths:
  - name: EV 
    id: 1234
  - name: EV
    id: 4321
```