### PR TITLE
Adding ephemeron option to sanowret-crystal

### DIFF
--- a/sanowret-crystal.lic
+++ b/sanowret-crystal.lic
@@ -19,6 +19,9 @@ class SanowretCrystal
     @no_use_scripts = settings.sanowret_no_use_scripts
     @no_use_rooms = settings.sanowret_no_use_rooms
     @force_exhale = args.exhale || settings.sanowret_force_exhale
+    @ephemeron = settings.ephemeron
+    UserVars.ephemera_last_use = Time.now() - 7200 if UserVars.ephemera_last_use.nil? && @ephemeron
+    check_ephemera if args.run
     check_crystal if args.run
     passive unless args.run
   end
@@ -74,8 +77,27 @@ class SanowretCrystal
     end
   end
 
+  def check_ephemera
+    return unless @ephemeron
+    return if Time.now() - UserVars.ephemera_last_use <= 7200
+    return if DRSkill.getxp('Arcana') >= 25
+    return if @no_use_scripts.any? { |name| Script.running?(name) }
+
+    case DRC.bput("ephemeron manifest #{@ephemeron}", /^You raise a hand to your neck, calling through your crystalline fibril/, /^That is not an ephemeron currently in your collection/, /^That is not a known ephemeron/, /^Try as you might, your imagination alone cannot conjure such mental figments/, /^You should stop practicing /)
+    when /^You raise a hand to your neck, calling through your crystalline fibril/
+      UserVars.ephemera_last_use = Time.now()
+      pause 5 # Make sure there's enough time for EXP to pulse before considering whether to use a sanowret crystal
+    when /^That is not an ephemeron currently in your collection/, /^That is not a known ephemeron/, /^Try as you might, your imagination alone cannot conjure such mental figments/
+      DRC.message("Could not manifest your specified ephemeron: #{@ephemeron}. Please check your YAML setting for 'ephemeron:'.")
+      @ephemeron = false
+    when /^You should stop practicing/
+      UserVars.ephemera_last_use = Time.now() - 7200 + 120
+    end
+  end
+
   def passive
     loop do
+      check_ephemera
       check_crystal
       pause 10
     end


### PR DESCRIPTION
Manifesting an ephemeron gives 10-12 mindstates of arcana on a 2 hour cooldown. 

Unlike sanowrets themselves, there are no resource costs and basically no limitations (e.g., can be done in no-magic rooms and while remaining hiding/invisible).

To take advantage, you need to have an implanted crystalline fibril, at least 1 captured ephemeron, and an ephemeron specified in the "ephemeron: " YAML setting.

It's not a game-changer, but it can help train arcana while preserving concentration.

There's no benefit (short of personal preference, as they do usually show up in your LOOK) to using a particular rarity or ephemera type. Switching between types of ephemera doesn't change the cooldown.

It might seem a little counterintuitive to include ephemeron usage in sanowret-crystal, but I think it's the best way to do it. Manifesting an ephemeron right before the crystal check means you can occasionally skip needing to actually use the sanowret, saving some concentration.