### PR TITLE
[scripts] [script-watch] Initial commit of script-watch.lic

### DIFF
--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -128,3 +128,4 @@ empty_values:
   weapon_training: {}
   whirlwind_trainables: []
   zombie: {}
+  script_watch_ignored_scripts: []

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2618,3 +2618,38 @@ tome_settings:
   - crossing-repair
   - task-forage
   debug: false
+
+# script-watch.lic settings:
+# display scripts hidden by hide_me (if false, only scripts listed by `;list` will be shown) 
+# if true all scripts in `;listall` will be shown, except for those listed in in `script_watch_ignored_scripts``
+script_watch_display_hidden: false
+# show script arguments after the script name
+script_watch_display_arguments: true
+# enable click on script name to pause/unpause script
+script_watch_enable_links: true
+# list of scripts you never want shown
+script_watch_ignored_scripts:
+  - dependency
+  - drinfomon
+  - spellmonitor
+  - events
+  - skill-recorder
+  - moonwatch
+  - roomnumbers
+  - textsubs
+# lower number means faster updates, but could have performance impact
+script_watch_cycle_time: 5
+# All the next settings control output format in the window: 
+#   They also need to be properly escaped XML/strings
+#   the default settings would result in output that looks similar to this:
+#   [afk] | [jail-buddy] | [t2] | [burgle] - <start>, <lockpick>, <drop> | [go2] - <1234>
+# What the name of the script should be surounded by, and what should be between scripts
+script_watch_script_prefix: "["  
+script_watch_script_postfix: "]"
+script_watch_script_separator: " | "
+# if arguments are turned on, what should separate the script name and the argument list
+script_watch_script_argument_separator: " - "
+# if arguments are turned on, what should the arguments be surrounded by and what should be between each argument
+script_watch_argument_prefix: "&lt;"
+script_watch_argument_postfix: "&gt;"
+script_watch_argument_separator: ", "

--- a/script-watch.lic
+++ b/script-watch.lic
@@ -32,7 +32,6 @@ class ScriptWatch
     # hide myself
     @ignored_scripts.push(Script.current.name)
 
-    @script_list = []
     @script_output = ''
     _respond("<streamWindow id='LichScripts' title='LichScripts' location='center' save='true' resident='true' />")
     _respond("<exposeStream id='LichScripts'/>")
@@ -45,8 +44,6 @@ class ScriptWatch
 
   def output_scripts()
     temp_list = @display_hidden ? Script.running + Script.hidden : Script.running
-
-    @script_list = temp_list
 
     temp_output = temp_list.select  { |s| !(@ignored_scripts.include?(s.name)) }
                            .collect { |s|
@@ -82,8 +79,8 @@ class ScriptWatch
                               end
 
                               output
-                                    }
-                                    .join(@script_separator)
+                           }
+                           .join(@script_separator)
 
     # attempt to short circuit to keep from sending unneeded xml, still update every 300s (5 min)
     return if @script_output == temp_output && ((Time.now - @last_update) < 300)

--- a/script-watch.lic
+++ b/script-watch.lic
@@ -47,38 +47,38 @@ class ScriptWatch
 
     temp_output = temp_list.select  { |s| !(@ignored_scripts.include?(s.name)) }
                            .collect { |s|
-                              output = ""
-                              output.concat @script_prefix
-                              if @enable_links
-                                case $frontend
-                                when 'genie'
-                                  # use alternate link syntax for genie, so end users don't need to enable it globally
-                                  #   enabling links generally in genie can cause issus with .NET UI.  This link syntax
-                                  #   bypasses the global setting, which *shouldn't* cause the kind of problems enabling
-                                  #   links globally in genie can cause
-                                  # genie alternate link syntax:  {<text to display>:<link command>}
-                                  output.concat "{#{s.name}:#{$clean_lich_char}#{s.paused? ? 'unpause' : 'pause'} #{s.name}}"
-                                else
-                                  # standard link syntax for Wrayth (and maybe others?)
-                                  # in theory frostbite should use this, but there is a bug with multiple links in one
-                                  #   line with current version at this time - (DD: 2023-08-22)
-                                  #   v1.16.0-beta was released 2023-02-05
-                                  output.concat "<d cmd='#{$clean_lich_char}#{s.paused? ? 'unpause' : 'pause'} #{s.name}'>#{s.name}</d>"
-                                end
-                              else
-                                output.concat s.name
-                              end
-                              output.concat @script_postfix
-                              output.concat " (paused)" if s.paused?
+                             output = ""
+                             output.concat @script_prefix
+                             if @enable_links
+                               case $frontend
+                               when 'genie'
+                                 # use alternate link syntax for genie, so end users don't need to enable it globally
+                                 #   enabling links generally in genie can cause issus with .NET UI.  This link syntax
+                                 #   bypasses the global setting, which *shouldn't* cause the kind of problems enabling
+                                 #   links globally in genie can cause
+                                 # genie alternate link syntax:  {<text to display>:<link command>}
+                                 output.concat "{#{s.name}:#{$clean_lich_char}#{s.paused? ? 'unpause' : 'pause'} #{s.name}}"
+                               else
+                                 # standard link syntax for Wrayth (and maybe others?)
+                                 # in theory frostbite should use this, but there is a bug with multiple links in one
+                                 #   line with current version at this time - (DD: 2023-08-22)
+                                 #   v1.16.0-beta was released 2023-02-05
+                                 output.concat "<d cmd='#{$clean_lich_char}#{s.paused? ? 'unpause' : 'pause'} #{s.name}'>#{s.name}</d>"
+                               end
+                             else
+                               output.concat s.name
+                             end
+                             output.concat @script_postfix
+                             output.concat " (paused)" if s.paused?
 
-                              if @display_arguments && !(s.vars.empty?)
-                                output.concat @script_argument_separator
-                                output.concat @argument_prefix
-                                output.concat s.vars.drop(1).join("#{@argument_postfix}#{@argument_separator}#{@argument_prefix}")
-                                output.concat @argument_postfix
-                              end
+                             if @display_arguments && !(s.vars.empty?)
+                               output.concat @script_argument_separator
+                               output.concat @argument_prefix
+                               output.concat s.vars.drop(1).join("#{@argument_postfix}#{@argument_separator}#{@argument_prefix}")
+                               output.concat @argument_postfix
+                             end
 
-                              output
+                             output
                            }
                            .join(@script_separator)
 

--- a/script-watch.lic
+++ b/script-watch.lic
@@ -1,0 +1,103 @@
+=begin
+  Creates a script window and keeps list of scripts in it
+  It can be clickable to pause/unpause scripts as well\
+=end
+
+# custom_require
+
+no_pause_all
+no_kill_all
+hide_me
+
+class ScriptWatch
+  def initialize()
+    settings = get_settings
+    @display_hidden = settings.script_watch_display_hidden
+    @display_arguments = settings.script_watch_display_arguments
+    @enable_links = settings.script_watch_enable_links
+    @ignored_scripts = settings.script_watch_ignored_scripts
+    @passive_timer = settings.script_watch_cycle_time
+    
+    @script_prefix = settings.script_watch_script_prefix
+    @script_postfix = settings.script_watch_script_postfix
+    @script_separator = settings.script_watch_script_separator
+    
+    @script_argument_separator = settings.script_watch_script_argument_separator
+
+    @argument_prefix = settings.script_watch_argument_prefix
+    @argument_postfix = settings.script_watch_argument_postfix
+    @argument_separator = settings.script_watch_argument_separator
+    @last_update = Time.now
+
+    # hide myself
+    @ignored_scripts.push(Script.current.name)
+
+    @script_list = []
+    @script_output = ''
+    _respond("<streamWindow id='LichScripts' title='LichScripts' location='center' save='true' resident='true' />")
+    _respond("<exposeStream id='LichScripts'/>")
+
+    loop do
+      output_scripts()
+      pause @passive_timer
+    end
+  end
+
+  def output_scripts()
+    temp_list = @display_hidden ? Script.running + Script.hidden : Script.running 
+
+    @script_list = temp_list
+
+    temp_output = temp_list.select  { |s| !(@ignored_scripts.include?(s.name)) }
+                           .collect { |s| 
+                              output = ""
+                              output.concat @script_prefix
+                              if @enable_links
+                                case $frontend
+                                when 'genie'
+                                  # use alternate link syntax for genie, so end users don't need to enable it globally
+                                  #   enabling links generally in genie can cause issus with .NET UI.  This link syntax 
+                                  #   bypasses the global setting, which *shouldn't* cause the kind of problems enabling
+                                  #   links globally in genie can cause
+                                  # genie alternate link syntax:  {<text to display>:<link command>}
+                                  output.concat "{#{s.name}:#{$clean_lich_char}#{s.paused? ? 'unpause' : 'pause'} #{s.name}}"
+                                else
+                                  # standard link syntax for Wrayth (and maybe others?)
+                                  # in theory frostbite should use this, but there is a bug with multiple links in one
+                                  #   line with current version at this time - (DD: 2023-08-22)
+                                  #   v1.16.0-beta was released 2023-02-05
+                                  output.concat "<d cmd='#{$clean_lich_char}#{s.paused? ? 'unpause' : 'pause'} #{s.name}'>#{s.name}</d>"
+                                end
+                              else
+                                output.concat s.name
+                              end
+                              output.concat @script_postfix
+                              output.concat " (paused)" if s.paused?
+
+                              if @display_arguments && !(s.vars.empty?)
+                                output.concat @script_argument_separator
+                                output.concat @argument_prefix
+                                output.concat s.vars.drop(1).join("#{@argument_postfix}#{@argument_separator}#{@argument_prefix}")
+                                output.concat @argument_postfix
+                              end
+
+                              output
+                            }
+                            .join(@script_separator)
+
+    # attempt to short circuit to keep from sending unneeded xml, still update every 300s (5 min)
+    return if @script_output == temp_output && ( (Time.now - @last_update) < 300 )
+    @script_output = temp_output
+
+    _respond("<clearStream id=\"LichScripts\"/>\r\n")
+    _respond("<pushStream id=\"LichScripts\"/>#{@script_output}\r\n<popStream/>\r\n")
+    @last_update = Time.now
+  end
+end
+
+before_dying do
+  # clear window
+  _respond("<clearStream id=\"LichScripts\"/>\r\n")
+end
+
+ScriptWatch.new

--- a/script-watch.lic
+++ b/script-watch.lic
@@ -17,11 +17,11 @@ class ScriptWatch
     @enable_links = settings.script_watch_enable_links
     @ignored_scripts = settings.script_watch_ignored_scripts
     @passive_timer = settings.script_watch_cycle_time
-    
+
     @script_prefix = settings.script_watch_script_prefix
     @script_postfix = settings.script_watch_script_postfix
     @script_separator = settings.script_watch_script_separator
-    
+
     @script_argument_separator = settings.script_watch_script_argument_separator
 
     @argument_prefix = settings.script_watch_argument_prefix
@@ -44,19 +44,19 @@ class ScriptWatch
   end
 
   def output_scripts()
-    temp_list = @display_hidden ? Script.running + Script.hidden : Script.running 
+    temp_list = @display_hidden ? Script.running + Script.hidden : Script.running
 
     @script_list = temp_list
 
     temp_output = temp_list.select  { |s| !(@ignored_scripts.include?(s.name)) }
-                           .collect { |s| 
+                           .collect { |s|
                               output = ""
                               output.concat @script_prefix
                               if @enable_links
                                 case $frontend
                                 when 'genie'
                                   # use alternate link syntax for genie, so end users don't need to enable it globally
-                                  #   enabling links generally in genie can cause issus with .NET UI.  This link syntax 
+                                  #   enabling links generally in genie can cause issus with .NET UI.  This link syntax
                                   #   bypasses the global setting, which *shouldn't* cause the kind of problems enabling
                                   #   links globally in genie can cause
                                   # genie alternate link syntax:  {<text to display>:<link command>}
@@ -82,11 +82,12 @@ class ScriptWatch
                               end
 
                               output
-                            }
-                            .join(@script_separator)
+                                    }
+                                    .join(@script_separator)
 
     # attempt to short circuit to keep from sending unneeded xml, still update every 300s (5 min)
-    return if @script_output == temp_output && ( (Time.now - @last_update) < 300 )
+    return if @script_output == temp_output && ((Time.now - @last_update) < 300)
+
     @script_output = temp_output
 
     _respond("<clearStream id=\"LichScripts\"/>\r\n")


### PR DESCRIPTION
Provides a new script `script-watch.lic` that gives you a window that shows which scripts are running and their state (if paused), options to show script arguments, customize the format/which scripts are hidden from the window, and make the names clickable to pause/unpause.

The idea is to emulate the genie script bar as much as possible, for lich scripts.