### PR TITLE
Update tome.lic

### DIFF
--- a/tome.lic
+++ b/tome.lic
@@ -22,6 +22,7 @@ class Tome
 
     @@tome = @tome_settings['tome_name']
     @quit_early = @tome_settings['quit_early']
+    @penultimate_page = @tome_settings['second_to_last_page']
     @scholarship_limit = @tome_settings['scholarship_limit'] || 34
     @passive_scripts = @tome_settings['passive_scripts']
     @passive = args.active ? false : @tome_settings['passive']
@@ -45,10 +46,14 @@ class Tome
       'brinewood book'          => "While Merelew observed the stars and the moons crown,",
       'kuwinite codex'          => "But, she is a great warrior with the fury of a mother",
       'smokewood codex'         => "Rumor also has it that the Empire had great powers of magic or technology",
-      'togball manual'          => "A team may not enter the opposing team's Blood Zone"
+      'togball manual'          => "A team may not enter the opposing team's Blood Zone",
+      'weathered book'          => "\"There he is!\" Grundgy turned to see half a dozen of the guards hacking through the briars and reed",
+      'worn book'               => "I was unsure a little of whether dragons drank wine,"
     }
 
-    if @quit_early
+    if @quit_early && @penultimate_page
+      Flags.add('study-complete', Regexp.new(@penultimate_page))
+    elsif @quit_early
       Flags.add('study-complete', Regexp.new(@penultimate_pages[@@tome]))
     else
       Flags.add('study-complete', /^Having finished your studies,/)


### PR DESCRIPTION
1. Added "penultimate page" definitions for the new MT tomes.
2. Added an optional "second_to_last_page" YAML setting, which will allow people to specify/override the page to stop studying on. Useful for books that don't get added to the script for whatever reason, alterations, etc.