### PR TITLE
[data] [base-recipes] Fix part for boarding axe

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -3801,7 +3801,7 @@ crafting_recipes:
   work_order: true
   chapter: 9
   part:
-  - hilt
+  - haft
 - name: a metal splitting maul
   noun: maul
   volume: 15


### PR DESCRIPTION
Change part from hilt to haft:

> read book
        -=   Chapter 9, Page 6: Instructions for crafting a metal boarding axe    =-

  A metal boarding axe is a craftable item in the Forging society under the Weaponsmithing crafting discipline.  This is considered to be a difficult piece to make, though knowledge of the Expert Swappable Weapon Design technique will be beneficial to the crafter.

  This item is listed as a "finished metal swappable bladed weapon" ingredient type and is created using a forging hammer, some tongs, some metalworking oil, a grindstone and a metal anvil with forge.  A crafter may also find it helpful to have a shovel and a bellows on hand.

 A list of ingredients is provided:

   (1) refined metal ingot (10 volume)
   (1) finished wooden haft