### PR TITLE
[script] [bescort] Added more flying mount functionality

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -332,7 +332,7 @@ class Bescort
     case mode
     when 'mount'
       case type
-      when /broom|dirigible/i  #### This section is for broom type flying mounts that are just mounted
+      when /broom|dirigible/i # This section is for broom type flying mounts that are just mounted
         DRCI.get_item?(type)
         case DRC.bput("mount my #{type}", /You mount your/, /You are already mounted/, /What were you referring/)
         when /What were you referring/
@@ -340,7 +340,7 @@ class Bescort
           exit
         end
         DRC.bput("command #{type} to #{speed}", /You command your/)
-      when /carpet|rug/i  #### This section is for carpet style flying mounts that are lowered/unrolled before mounting
+      when /carpet|rug/i # This section is for carpet style flying mounts that are lowered/unrolled before mounting
         DRCI.get_item?(type)
         DRC.bput(DRC.right_hand == type ? "lower ground right" : "lower ground left", /You lower/, /But you aren't holding/)
         DRC.bput("unroll #{type}", /You carefully unroll/, /You can't unroll/, /What were you referring/)
@@ -350,7 +350,7 @@ class Bescort
           exit
         end
         DRC.bput("command #{type} to #{speed}", /You command your/)
-      when /cloud/i  #### This section is for mounts with different nouns than their activating item. May need to add more activation matches.
+      when /cloud/i # This section is for mounts with different nouns than their activating item. May need to add more activation matches.
         DRCI.remove_item?(@flying_mount_item)
         DRCI.get_item_if_not_held?(@flying_mount_item)
         case DRC.bput("#{@flying_mount_activate} my #{@flying_mount_item}", /You gently buff/, /Rub what/)
@@ -1139,7 +1139,7 @@ class Bescort
         use_flying_mount(@flying_mount, 'mount', 'drift')
       else
         DRC.message("#{@flying_mount} is not a valid type of flying mount.")
-        exit      
+        exit
       end
       path = mode == 'shard' ? %w[se se sw sw se] : %w[nw ne ne nw sw]
     else
@@ -1534,7 +1534,7 @@ class Bescort
         use_flying_mount(@flying_mount, 'mount', 'hover')
       else
         DRC.message("#{@flying_mount} is not a valid type of flying mount.")
-        exit      
+        exit
       end
       if dir_of_travel == 'south'
         move 'go bank'

--- a/bescort.lic
+++ b/bescort.lic
@@ -1223,9 +1223,9 @@ class Bescort
     start = north ? 1375 : 473
     manual_go2(start)
     moveset = north ? %w[north northwest northeast] : %w[south southwest southeast]
-    move 'dive river'
     if @flying_mount
       use_flying_mount(@flying_mount, 'mount')
+      move 'go river'
       if north
         move n
         move nw
@@ -1236,6 +1236,7 @@ class Bescort
       move 'go bridge'
       use_flying_mount(@flying_mount, 'dismount')
     else
+      move 'dive river'
       swim(moveset[0]) while XMLData.room_exits.include?(moveset[0])
       swim(moveset[1]) while XMLData.room_exits.include?('east')
       swim(moveset[2]) while XMLData.room_exits.include?(moveset[0])

--- a/bescort.lic
+++ b/bescort.lic
@@ -238,6 +238,13 @@ class Bescort
     @settings = get_settings
     @equipment_manager = EquipmentManager.new(@settings)
     @flying_mount = @settings.flying_mount
+    if @settings.mountable_item
+      @flying_mount_item = @settings.mountable_item
+    else
+      @flying_mount_item = @settings.flying_mount
+    end
+    @flying_mount_activate = @settings.mountable_verb
+    @flying_mount_dismount = @settings.mountable_dismount
 
     pause
 
@@ -324,16 +331,17 @@ class Bescort
     mode = mode.downcase
     case mode
     when 'mount'
-      DRCI.get_item?(type)
       case type
-      when /broom|dirigible/i
+      when /broom|dirigible/i  #### This section is for broom type flying mounts that are just mounted
+        DRCI.get_item?(type)
         case DRC.bput("mount my #{type}", /You mount your/, /You are already mounted/, /What were you referring/)
         when /What were you referring/
           DRC.message("Can't mount your #{type}, where is it?")
           exit
         end
         DRC.bput("command #{type} to #{speed}", /You command your/)
-      when /carpet|rug/i
+      when /carpet|rug/i  #### This section is for carpet style flying mounts that are lowered/unrolled before mounting
+        DRCI.get_item?(type)
         DRC.bput(DRC.right_hand == type ? "lower ground right" : "lower ground left", /You lower/, /But you aren't holding/)
         DRC.bput("unroll #{type}", /You carefully unroll/, /You can't unroll/, /What were you referring/)
         case DRC.bput("mount #{type}", /You step onto your .* which comes to life and slowly raises up off of the ground/, /You are already mounted/, /What were you referring/)
@@ -342,22 +350,34 @@ class Bescort
           exit
         end
         DRC.bput("command #{type} to #{speed}", /You command your/)
-      else
-        DRC.message("#{type} is not a valid type of flying mount.")
-        exit
+      when /cloud/i  #### This section is for mounts with different nouns than their activating item. May need to add more activation matches.
+        DRCI.remove_item?(@flying_mount_item)
+        DRCI.get_item_if_not_held?(@flying_mount_item)
+        case DRC.bput("#{@flying_mount_activate} my #{@flying_mount_item}", /You gently buff/, /Rub what/)
+        when /What were you referring/
+          DRC.message("Can't mount your #{type}, where is it?")
+          exit
+        end
+        DRC.bput("command #{type} to #{speed}", /You command your/, /You signal the/)
       end
     when 'dismount'
       case type
       when /broom|dirigible/i
         DRC.bput('dismount', /Your .* floats down to the ground/, /You climb off/)
+        DRCI.put_away_item?(type)
       when /carpet|rug/i
         DRC.bput('dismount', /Your .* floats down to the ground/, /You climb off/)
         DRC.bput("roll #{type}", /You roll up/, /You can't roll/)
+        DRCI.put_away_item?(type)
+      when /cloud/i
+        DRC.bput("#{@flying_mount_dismount} #{type}", /With a gesture,/)
+        DRCI.wear_item?(@flying_mount_item)
+        DRCI.put_away_item?(@flying_mount_item) if checkright
+        DRCI.put_away_item?(@flying_mount_item) if checkleft
       else
         DRC.message("#{type} is not a valid type of flying mount.")
         exit
       end
-      DRCI.put_away_item?(type)
     end
   end
 
@@ -1112,7 +1132,15 @@ class Bescort
 
     if @flying_mount
       move_fast = true
-      use_flying_mount(@flying_mount, 'mount', 'glide')
+      case @flying_mount
+      when /broom|dirigible|carpet|rug/i
+        use_flying_mount(@flying_mount, 'mount', 'glide')
+      when /cloud/i
+        use_flying_mount(@flying_mount, 'mount', 'drift')
+      else
+        DRC.message("#{@flying_mount} is not a valid type of flying mount.")
+        exit      
+      end
       path = mode == 'shard' ? %w[se se sw sw se] : %w[nw ne ne nw sw]
     else
       # If the footwear setting has been defined then respect that
@@ -1499,7 +1527,15 @@ class Bescort
     end
 
     if @flying_mount
-      use_flying_mount(@flying_mount, 'mount', 'skim')
+      case @flying_mount
+      when /broom|dirigible|carpet|rug/i
+        use_flying_mount(@flying_mount, 'mount', 'skim')
+      when /cloud/i
+        use_flying_mount(@flying_mount, 'mount', 'hover')
+      else
+        DRC.message("#{@flying_mount} is not a valid type of flying mount.")
+        exit      
+      end
       if dir_of_travel == 'south'
         move 'go bank'
         move 'west'

--- a/bescort.lic
+++ b/bescort.lic
@@ -359,6 +359,9 @@ class Bescort
           exit
         end
         DRC.bput("command #{type} to #{speed}", /You command your/, /You signal the/)
+      else
+        DRC.message("#{type} is not a valid type of flying mount.")
+        exit
       end
     when 'dismount'
       case type


### PR DESCRIPTION
Added support for flying mounts that use different nouns for the activation item and the mount. Flying mounts of the carpet, rug, broom and dirigible type that don't change nouns retain the same functionality they had previous to this update.

Related yaml settings:
```
# Flying mount setting
# Currently only used by bescort for the Faldesu, Segoltha and the Hib ice road.
# Example: flying_mount: silk carpet
flying_mount: 
# carpets, rugs, brooms and dirigibles are supported with just the above setting.
# If the item you use to summon your mount is different than the mount include it here as well as the activation/dismount verbs, otherwise leave all blank.
mountable_item: 
mountable_verb: 
mountable_dismount:
```

Possible missing things:
- activation/dimount text matches for all mounts
- additional speed options. Currently supports items with slow|glide|skim|fly and slow|drift|hover|fly

If your mount doesn't work, please tag me in the Lich discord with the following information:
```
Mount's noun:
Activated item's noun:
Mount verb(s):
Mount message(s):
Dismount verb(s):
Dismount message(s):
Speed options (slow to fast):
```