### PR TITLE
[script] [clerk-tools] add support for custom toolsets

### DIFF
--- a/clerk-tools.lic
+++ b/clerk-tools.lic
@@ -4,12 +4,18 @@ class Clerk
   def initialize
     arg_definitions = [
       [
-        { name: 'toolset', options: %w[forging outfitting engineering alchemy enchanting], description: 'What set of tools to use' },
+        { name: 'toolset', regex: /forging|outfitting|engineering|alchemy|enchanting|custom=\w+/, description: 'What set <forging outfitting engineering alchemy enchanting custom={set}> of tools to use.' },
         { name: 'action', options: %w[get store], description: 'Whether to get tools, or store them with the clerk' }
       ]
     ]
     args = parse_args(arg_definitions)
     action = args.action
+
+    if args.toolset.include?('=')
+      custom_toolset = args.toolset.split('=')[1].to_s
+    else
+      custom_toolset = nil
+    end
 
     settings = get_settings
     hometown = settings.force_crafting_town || settings.hometown
@@ -18,31 +24,32 @@ class Clerk
 
     crafting_data = get_data('crafting')
 
-    if args.toolset == 'engineering'
+    if !custom_toolset.nil?
+      if !settings.custom_clerk_tools.include?(custom_toolset)
+        echo "Could not find custom toolset labeled #{custom_toolset}"
+        exit
+      end
+
+      tools = settings.custom_clerk_tools[custom_toolset][:tool_list]
+      area = settings.custom_clerk_tools[custom_toolset][:area]
+      @belt = nil
+    elsif args.toolset == 'engineering'
       tools = settings.shaping_tools
       area = 'shaping'
       @belt = settings.engineering_belt
-    end
-
-    if args.toolset == 'outfitting'
+    elsif args.toolset == 'outfitting'
       tools = settings.outfitting_tools
       area = 'tailoring'
       @belt = settings.outfitting_belt
-    end
-
-    if args.toolset == 'forging'
+    elsif args.toolset == 'forging'
       tools = settings.forging_tools
       area = 'blacksmithing'
       @belt = settings.forging_belt
-    end
-
-    if args.toolset == 'alchemy'
+    elsif args.toolset == 'alchemy'
       tools = settings.alchemy_tools
       area = 'remedies'
       @belt = settings.alchemy_belt
-    end
-
-    if args.toolset == 'enchanting'
+    elsif args.toolset == 'enchanting'
       tools = settings.enchanting_tools
       area = 'artificing'
       @belt = settings.enchanting_belt

--- a/profiles/base-empty.yaml
+++ b/profiles/base-empty.yaml
@@ -129,3 +129,4 @@ empty_values:
   whirlwind_trainables: []
   zombie: {}
   script_watch_ignored_scripts: []
+  custom_clerk_tools: {}

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -931,11 +931,12 @@ enchanting_tools:
 # setup custom toolsets to get from clerk-tools.  example of format listed below
 custom_clerk_tools:
   # mining:                   # name of the toolset to use custom=mining in this case
+  #   :area: blacksmithing    # which local society to pick these up from 
   #   :tool_list:             # list of the tools in this toolset
   #     - slender pickaxe
   #     - tapered shovel
-  #   :area: blacksmithing    # which local society to pick these up from 
-  # repair:                   # ***IF*** the society lets you pick up all tools you could create a single repair list to pickup before runnign repair
+  # repair:                   # ***IF*** the society lets you pick up all tools you could create a single repair list to pickup before/dropoff after running repair
+  #   :area: blacksmithing
   #   :tool_list:             
   #     - bellow
   #     - diagonal-peen hammer
@@ -945,8 +946,6 @@ custom_clerk_tools:
   #     - chisels
   #     - rasp
   #     - rifflers
-  # :area: blacksmithing
-
 
 forging_belt:
 engineering_belt:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -928,6 +928,26 @@ enchanting_tools:
   - brazier
   - burin
 
+# setup custom toolsets to get from clerk-tools.  example of format listed below
+custom_clerk_tools:
+  # mining:                   # name of the toolset to use custom=mining in this case
+  #   :tool_list:             # list of the tools in this toolset
+  #     - slender pickaxe
+  #     - tapered shovel
+  #   :area: blacksmithing    # which local society to pick these up from 
+  # repair:                   # ***IF*** the society lets you pick up all tools you could create a single repair list to pickup before runnign repair
+  #   :tool_list:             
+  #     - bellow
+  #     - diagonal-peen hammer
+  #     - slender pickaxe
+  #     - tapered shovel
+  #     - tong
+  #     - chisels
+  #     - rasp
+  #     - rifflers
+  # :area: blacksmithing
+
+
 forging_belt:
 engineering_belt:
 outfitting_belt:


### PR DESCRIPTION
Allows for custom defined toolsets to be picked up from the society clerks.  Does NOT support toolbelts currently:

Yaml examples
```yaml
# setup custom toolsets to get from clerk-tools.  example of format listed below
custom_clerk_tools:
  mining:                   # name of the toolset to use custom=mining in this case
    :area: blacksmithing    # which local society to pick these up from 
    :tool_list:             # list of the tools in this toolset
      - slender pickaxe
      - tapered shovel
  repair:                   # ***IF*** the society lets you pick up all tools you could create a single repair list to pickup before runnign repair
    :area: blacksmithing
    :tool_list:             
      - bellow
      - diagonal-peen hammer
      - slender pickaxe
      - tapered shovel
      - tong
      - chisels
      - rasp
      - rifflers
