### PR TITLE
[common] [moonmage] Add new methods covering burn/dazzle casting requirements

### DIFF
--- a/common-moonmage.lic
+++ b/common-moonmage.lic
@@ -348,6 +348,20 @@ module DRCMM
     data
   end
 
+  # returns true if at least one bright moon (yavash, xibar) or the sun are
+  #  above the horizon and won't set for at least another ~4 minutes.
+  def bright_celestial_object?
+    check_moonwatch
+    (UserVars.sun['day'] && UserVars.sun['timer'] >= 4) || visible_moons.include?('xibar') || visible_moons.include?('yavash')
+  end
+
+  # returns true if at least one moon (katamba, yavash, xibar) or the sun are
+  #  above the horizon and won't set for at least another ~4 minutes.
+  def any_celestial_object?
+    check_moonwatch
+    (UserVars.sun['day'] && UserVars.sun['timer'] >= 4) || moons_visible?
+  end
+
   # Returns true if at least one moon (e.g. katamba, yavash, xibar)
   # is above the horizon and won't set for at least another ~4 minutes.
   def moons_visible?


### PR DESCRIPTION
Burn requires any moon or sun to be up to cast
Dazzle requires bright moon or sun to be cast

This is a part 1 of 3 changes to enable combat-trainer to cast brun/dazzle when it can, and another spell when it can't.  Needs to be 3 changes due to how dr-scripts updates work.

Part 1 - new common methods (this change)
Part 2 - new data fields in base-spells on the two spells
Part 3 - update to combat-trainer.

