### PR TITLE
[script] [combat-trainer] Option for Bard cyclic to segue to on combat end instead of releasing

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1392,6 +1392,9 @@ class SpellProcess
     if game_state.finish_spell_casting?
       echo('SpellProcess::clean_up') if $debug_mode_ct
       game_state.next_clean_up_step
+      if DRStats.guild == "Bard" && @settings.segue_spell_on_stop
+        DRCA.segue?(@settings.segue_spell_on_stop,@settings.segue_prep_on_stop)
+      end
       DRCA.release_cyclics(@settings.cyclic_no_release)
       if checkprep != 'None'
         DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1393,7 +1393,7 @@ class SpellProcess
       echo('SpellProcess::clean_up') if $debug_mode_ct
       game_state.next_clean_up_step
       if DRStats.guild == "Bard" && @settings.segue_spell_on_stop
-        DRCA.segue?(@settings.segue_spell_on_stop,@settings.segue_prep_on_stop)
+        DRCA.segue?(@settings.segue_spell_on_stop, @settings.segue_prep_on_stop)
       end
       DRCA.release_cyclics(@settings.cyclic_no_release)
       if checkprep != 'None'


### PR DESCRIPTION
Adds an option for Bards to segue to a chosen cyclic spell when combat ends instead of releasing their cyclic. If the segue fails it will still release the original cyclic if it's not on the cyclic_no_release list. 

These are the settings needed in your character yaml:
```
# Set a cyclic spell to segue to instead of releasing a cyclic when combat-trainer ends. 
# Bard only setting. Must know how to segue. 
# Strongly recommended to use a justice safe spell. Works best when using a spell from cyclic_no_release: 
# Use the cyclic spell abbrevation. E.g. botf. The segue parser doesn't like full spell names.
segue_spell_on_stop: botf
segue_prep_on_stop: 25
```