### PR TITLE
[data][base-sorting] Wholesale rejig

### DIFF
--- a/data/base-sorting.yaml
+++ b/data/base-sorting.yaml
@@ -1,147 +1,31 @@
-cambrinth:
-- .*cambrinth.*
-
-container:
-- arca
-- backpack
-- backtube
-- \bbags?\b
-- baldric
-- barrel
-- basket
-- bottle gourd
-- bowcase
-- bundle
-- carryall
-- carton
-- \bcase\b
-- cauldron
-- container
-- duffel
-- feedbag
-- game-bag
-- gearbag
-- harness
-- haversack
-- humidor
-- \bkit\b
-- knapsack
-- lockpick ring
-- lootsack
-- moneybelt
-- \bpack\b
-- pannier
-- pillowcase
-- pouch
-- purse
-- quiver
-- rucksack
-- rugursora
-- \bsack\b
-- satchel
-- scabbard
-- sheath
-- skillet
-- toolbag
-- toolbox
-- \btote\b
-- treasure chest
-- wallet
-- workbag
-
-jewelry:
-- amulet
-- anklet
-- badge
-- band
-- barrette
-- bracelet
-- brooch
-- carving
-- charm
-- choker
-- circlet
-- diadem
-- earcuff
-- earrings
-- globe
-- hip-chain
-- locket
-- medallion
-- necklace
-- pendant
-- pin
-- ring
-- /(?<!morning\s)star/
-
-crafting:
-- (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel(-faced)?|tomiek) (?:hammer|mallet)
-- (?:Aldamdin|curved|damite|Glaes-edged|Kertig|square|tapered|Tomiek|triple-fluted|Tyrium|wide).*shovel
-- (?:apprentice .*|journeyman .*|master .*) (?:book|instructions)
-- awl
-- ^book$
-- borax flux
-- brazier
-- burin
-- burlap cloth
-- carving knife
-- chisels
-- cleaning cloth
-- cotton thread
-- deed
-- deed register
-- drawknife
-- flask of oil
-- fount
-- grain alcohol
-- haft
-- imbue.* rod
-- imbue.*rod
-- ingot
-- sewing needles
-- knitting needles
-- large.*bowl
-- bellows
-- pliers
-- logbook
-- loop
-- metal clamp
-- metal clamps
-- mixing bowl
-- mixing stick
-- mortar
-- pestle
-- pins
-- rasp
-- rifflers
-- salts
-- scissors
-- sieve
-- sigil (?:book|volume)
-- sigil-.*
-- slickstone
-- stamp
-- stirring rod
-- surface polish
-- tanning lotion
-- tongs
-- tool catalog
-- totem
-- water
-- wood glue
-- wood shaper
-- wood stain
-- wool yarn
-- yardstick
-
-materials:
-- nugget
-- lumber
-- (?:Adder|Aesetani applewood|Aformosia|Albarco|Alder|Alerce|Apple|Ash|Aspen|Avodire|Azurelle|Balsa|Bamboo|Birch|Bloodwood|Bocote|Cedar|Cherry|Copperwood|Crabwood|Cypress|Darkspine|Diamondwood|Dragonwood|Durian|Ebony|E'erdream|Elm|Felwood|Finivire|Fir|Glitvire|Gloomwood|Goldwood|Greenheart|Hemlock|Hickory|Ilomba|Iroko|Ironwood|Kapok|Larch|Lelori|Lirisan|Macawood|Mahogany|Mangrove|Maple|Mistwood|Moabi|Oak|Osage|Pine|Ramin|Redwood|Rockwood|Rosewood|Sandalwood|Shadowbark|Silverwood|Smokewood|Spruce|Tamarak|Tamboti|Teak|Walnut|Willow|Yew|Zingana) (?:stick|branch|limb|log)
-- bone
-- (?:Alabaster|Andesite|Anjisis|Basalt|Belzune|Blackwater jet|Breccia|Diamondique|Dolomite|Felstone|Fulginode|Gabbro|Granite|Jade|Limestone|Marble|Obsidian|Onyx|Pumice|Quartzite|Sandstone|Schist|Senci|Serpentine|Soapstone|Travertine|Xenomite) (?:rocks|rock|stone|boulder|pebble)
-
-brawling:
+### 10/27/24 - New and Reorganized Categories. Regex condensed entries. New items added.
+### Note: The categories that have the '_nouns' suffix populate same-named categories without the suffix.
+### So “clothing” and “clothing_nouns” will overlap and both populate the “clothing" list.
+### The '_nouns' sections are the end of the file.
+###
+### Items not caught in the _nouns categories correctly can be added into their counterparts. 
+### The easiest way for sorter to catch it seems to be, for example:
+### Text 		a perfectly smooth sphere of blued moonsilver
+### Regex		(perfectly.)?smooth sphere(.of)?(.blued)?(.moonsilver)?
+appearance:
+- pair of slender silver bands
+- warped glass vial
+- peacock blue beard glitter
+- small ebony wardrobe(.carved with a whimsical design of dancing fae)?
+- small Seed(.of)?(.Entropy)?(.wrought)?(.from)?(.purple gold)?
+- trio of multihued moons
+music:
+- zills
+- cowbell
+- chamois cloth
+pilgrim badge:
+- pilgrim\'s badge
+### GEAR ###
+gear - armour:
+- contoured demonscale mask darkened
+- tapered demonscale helm(.darkened)?(. to a deep abyssal black)?
+- sleek shirt(.embroidered with writhing tel'athi vipers)?
+gear - brawling:
 - animite shackle
 - Dwarven iron bracer
 - handwraps
@@ -153,20 +37,428 @@ brawling:
 - knuckles
 - knuckleguards
 - stomping boots
+- reinforced leather armguard(.with blackened steel riveting)?
+gear - shield:
+- dented pot lid(.dappled with scorch marks)?
+gear - weapon:
+- farmer's hand sickle(.composed of iron)?
+- darkstone longsword(.trailing wraith-bone ringlets)?(.from the pommel)?
+### CLOTHING ###
+clothing:
+- cuffed oilcloth boots bound by wide ties
+- Katamba\-black dergatine odaj.*
+- scorched leather beard guard
+- fitted shirt(.of)?(.celadon)?(.Elven)?(.wool)?(.buttoned)?(.with)?(.silver)?
+clothing - hiders:
+- heavily stained alchemist's robe
+clothing - skates:
+- skates
+clothing - wings:
+- .*wings.*
+### CONTAINERS ###
+container:
+- .*dergatine backpack enmeshed
+- shimmery cloth-of-gold gamebag
+container - autolooter:
+- loot(?:sack|pouch|belt)
+- spidersilk clutch
+- pearlescent shagreen belt bag
+container - hold anything:
+- abyssal black thigh bag
+- spidersilk hip pouch
+- Elven wool thigh pouch
+container - vault storage:
+- (?:bottom|middle|top) drawer
+- brass hook
+- steel wire rack
+- (?:small|large) shelf
+### CONTAINER - STACKERS ###
+stacker - crafting:
+- torch cluster bundled
+- rough burlap pouch(.painted with a basalt runestone)?
+stacker - dirt:
+- (scruffy.)?jadeleaf(.arm)?.pouch(.with an acenite clasp)?
+- soft suede (?:pouch|pouch with knotted vine cords)
+- sleek moonsilk thigh bag(.with a tursa buckle)?
+- polished ebony pillbox(.with a fine silver chain)?
+- stained leather bag(.with fraying cord straps)?
+stacker - herbs:
+- (?:foraging|herb(al)?).(?:apron|case|pouch)
+stacker - lockpicks:
+- lockpick (?:ring|wristcuff)
+- wavy.*spiral
+stacker - scrolls:
+- abyssal-black codex
+- petite dark blue tome
+- poke .*
+- booklet
+- carmine codex
+- scroll case
+- papers
+- folio
+- folio graced
+- faceted crystal-bound tome boasting a rainbow sapphire dragon
+- yellow notebook
+- worn book
+- eventide-hued tome boldly
+- compact scroll folio shaded slate grey
+- (?:gold swirled|swirled|slim sluagh-hide) codex
+- stormy grey scroll case(.composed of matte thornweave)?
+- star-streaked midnight black sack fastened with an obsidian murder crow
+### CRAFTING ###
+crafting - general:
+- waist strap for a crafting instruction book
+- laborer's drab cotton odaj
+- forger's belt
+- toolbelt
+- packet of deed claim forms
+- instructions
+- arrow flights?
+- backer
+- backing
+- borax flux
+- bow string
+- cleaning cloth
+- cloth padding
+- cotton thread
+- deed register
+- flask of oil
+- grain alcohol
+- haft
+- leather cord
+- leather strips?
+- mechanisms
+- packet
+- salts
+- stamp
+- tanning lotion
+- tool catalog
+- totem
+- water
+- basic runestone
+- (?:burlap|cotton|linen|silk|wool) cloth
+- lumber
+- (?:Adder|Aesetani applewood|Aformosia|Albarco|Alder|Alerce|Apple|Ash|Aspen|Avodire|Azurelle|Balsa|Bamboo|Birch|Bloodwood|Bocote|Cedar|Cherry|Copperwood|Crabwood|Cypress|Darkspine|Diamondwood|Dragonwood|Durian|Ebony|E'erdream|Elm|Felwood|Finivire|Fir|Glitvire|Gloomwood|Goldwood|Greenheart|Hemlock|Hickory|Ilomba|Iroko|Ironwood|Kapok|Larch|Lelori|Lirisan|Macawood|Mahogany|Mangrove|Maple|Mistwood|Moabi|Oak|Osage|Pine|Ramin|Redwood|Rockwood|Rosewood|Sandalwood|Shadowbark|Silverwood|Smokewood|Spruce|Tamarak|Tamboti|Teak|Walnut|Willow|Yew|Zingana) (?:stick|branch|limb|log)
+- bone
+- (?:Alabaster|Andesite|Anjisis|Basalt|Belzune|Blackwater jet|Breccia|Diamondique|Dolomite|Felstone|Fulginode|Gabbro|Granite|Jade|Limestone|Marble|Obsidian|Onyx|Pumice|Quartzite|Sandstone|Schist|Senci|Serpentine|Soapstone|Travertine|Xenomite) (?:rocks|rock|stone|boulder|pebble)
+- ingot
+- yarn
+crafting - alchemy tools:
+- alchemy work order logbook
+- large.*bowl
+- mortar
+- pestle
+- mixing (?:bowl|stick)
+- sieve
+- heavy cauldron
+crafting - enchanting tools:
+- brazier
+- burin
+- enchanting work order logbook
+- fount
+- imbue.* rod
+- imbue.*rod
+- loop
+- sigil (?:tome|book|volume)
+- sigil-.*
+- large.*tome
+crafting - engineering tools:
+- bone saw
+- carving knife
+- chisels
+- clamps
+- drawknife
+- engineering work order logbook
+- metal clamps?
+- rasp
+- rifflers
+- tinker's tools
+- woodcutting saw
+- wood glue
+- wood shaper
+- wood stain
+crafting - forging tools:
+- (?:aldamdin|audrualm|ball-peen|Blacksmith's|cross-peen|damite|diagonal-peen|forging|straight-peen|Silversteel-faced|tomiek) (?:hammer|mallet)
+- (?:Aldamdin|curved|damite|Glaes-edged|Kertig|square|tapered|Tomiek|triple-fluted|Tyrium|wide).*shovel
+- bellows
+- forging work order logbook
+- pliers
+- stirring rod
+- tongs
+- wire brush
+crafting - outfitting tools:
+- awl
+- hide scraper
+- knitting needles
+- outfitting work order logbook
+- pins
+- sewing needles
+- scissors
+- slickstone
+- yardstick
+- distaff
+- small darkened blade
+### ESTATE HOLDER AND HOUSE ###
+estate holder:
+- (?:bank|vault|darkened leather).book
+- platinum sigil
+estate holder - home and furniture:
+- miniature hay bale
+- pair of iron sconces
+- furniture voucher
+- circle
+- decorative volcanic rocks
+- windchime
+- pile
+- pillow
+- pile of clay limbs
+- garland of gaethzen orbs
+- furniture voucher
+### MAGICAL ###
+magical:
+- glass egg
+- glass octahedron
+- glowing starstone
+- potency crystal
+- infuser stone
+- dark leather wallet
+- oily sea-green potion
+- .*wand.*
+- dried gourd rattle
+- rose-colored vial
+- golden bangle
+- worm charm
+- sanguine-stained verdant heart
+magical - cambrinth:
+- .*cambrinth.*
+- sturdy belt(.dangling thirty-nine cambrinth disks)?
+- ^armband(.displaying an array of cambrinth lotus flowers)?
+- dusty traveler's backpack
+- rugged fractalline hip pouch
+- plain homespun arm pouch
+- tattered aubergine robe(.covered in cambrinth\-beaded symbols)?
+magical - food generator:
+- ^yellow pouch(.embroidered with many ears of corn)?
+- ^red pouch(.embroidered with a pork chop)?
+- brightly painted box(.with many happy\-looking animals)?
+magical - gaethzen:
+- .*gaethzen.*
+- shielded gaethzen lantern
+magical - ritual focus:
+- tyrium Elemental Dragon(.with eyes of lightning amethyst)?
+- ka'hurst havri'negh emblem(.inlaid with an intricate geometric design)?
+- (flat)?(.rosewood)?.effigy pipe(.ornamented by a small plump animal)?
+- lifelike anatomical heart(.carved from bloodmist garnet)?
+- vela'tohr plant lifesculpted
+- wizened Life Dragon(.carved from verdant lirisan)?
+- platinum triquetra(.interlaced with a circle of blue gold)?
+- brooch.(of knotted brass)?(.accented with malachite and rose quartz)?
+- fine necklace(.of golden discs interspersed between lapis lazuli shapes)?
+- wooden toy soldier(.holding an abnormally large shield)?
+- (clockwork.)?armillary sphere(.with golden rings)?
+- howling wolf(.carved from eventide moonstone)?
+- nightfire opal charm inscribed with a simple moon
+- pallid ouroboros ring(.carved from dreamstone)?
+- obsidian-tipped arrow(.with a broken shaft)?
+- small bronze compass(.etched with a series of circular sigils)?
+- double ouroboros amulet(.carved from dreamstone)?
+### MATERIALS ###
+material:
+- (?:fibrous|tiny).*icon of.*(strands)?
+- chunk of.*
+material - alteration:
+- windsteel (?:boulder|clump)
+- spiritwood (?:branch|limb)
+- (?:short|long|massive) plank
+- perfectly smooth sphere
+- (perfectly.)?smooth sphere(.of)?(.blued)?(.moonsilver)?
+- (blued.)?moonsilver sphere
+material - cassava:
+- cassava root cradled
+- cassava
+material - chakrel:
+- .*chakrel.*
+material - soulstone:
+- soulstone
+- palladium war (?:belt|belt set with a central soulstone)
+- braided diamond-hide (?:baldric| baldric with a soulstone and animite buckle)
+### TOYS & FLUFF ###
+toy:
+- abacus
+- dark chocolate\-hued dream pillow
+- roly\-poly dragon doll(.wearing a fuzzy red hat)?
+- shiny green togball(.embellished with iridescent gold ink)?
+toy - collectibles:
+- cards?
+- dira
+toy - fire and smoke:
+- (?:black|dark piece of polished) flint
+- goatskin pouch
+- tobacco pouch
+toy - writing:
+- quill
+- (?:writing|companion).slate
+toy - pet:
+- assassin bug
+- beetle
+- birdeater
+- centipede
+- lizard
+- mantis
+- scorpion
+- spider
+- tarantula
+- wheel bug
+- woodlouse hunter
+- soft woven sack
+- glittery\s.*\sblob(.formed from fine silky sand)?
+### TRAINERS ###
+trainer:
+- (?:keepsake|training|jewelry) box
+- weave climbing rope
+- dark leather pouch
+- .*liquor cabinet
+- sanowret crystal
+trainer - textbooks:
+- textbook
+- gilded guidebook
+- battered field guide(.with a worn leather cover)?
+- glossy black leather textbook with gold script on the front
+- massive codex
+- black and gold swirled codex crafted from wood
+- carmine codex featuring a stitched cover
+- large square atlas
+- simple blue compendium
+### VALUABLE ###
+valuable:
+- bloodscrip
+- boarding pass
+- coins?
+- concise contract
+- dueling slip
+- map
+- memory orb
+- note
+- package
+- pass
+- permit
+- profile
+- sealed writ
+- Su Helmas contract
+- mirror-finish memory orb of polished telothian
+valuable - collection pieces:
+- (?:moonsilver|platinum) chain
+- unembellished ring
+- (?:ruby|onyx|sapphire) chunk
+- (?:heavy|long|curved|short) (?:blade|handle|pommel)
+- (?:large|medium|small) (?:cover|grip|rim)
+- star-streaked midnight black (?:sack|sack fastened with an obsidian murder crow)
+valuable - gem pouch:
+- gem pouch
+valuable - rare gems:
+- Amlothite
+- Cloudstone
+- Dawgolite
+- Durgauldite
+- Elanthite
+- Er'qutrite
+- Estrildite
+- Grazhite
+- Hav'roth's Ambrosia
+- Ismenite
+- Katambite
+- Merewaldite
+- Penhetite
+- Sphere of polished coral banded with sunrise hues
+- Syrin's heart
+- Szeldite
+- Verenite
+- Xibarite
+- Yavasite
+- Yoakenite
+- pure .* tarina
+- (?:Dragonvein|Fire|Inkdrop|Mountain|Plumed) agate
+- (?:Orchid|Viperscale) alexandrite
+- (?:Dragonfire|Dragon's blood|Drake's heart) amber
+- (?:Lightning|Violet's Heart) amethyst
+- Tiger lily carnelian
+- (?:Chaos|Mermaid's) chalcedony
+- Volcano's Heart citrine
+- Imperial coral
+- (?:Black assassin's|Black|Blue|Champagne|Dalterein|Fortune's Star|Huntress|Lilac|Midnight|Molten\-core|Night|Ocean's Heart|Pink|Red|Royal star|Scorpion|Sea|Smoky|White) diamond
+- (?:Absinthe|Bearclaw|Crimson|Glacier|Ilithi|Nature's Canopy|Ocean's Deep|Red|Scarlet|Shadow|Siato star|Spring|Taisidon|Winter) emerald
+- (?:Bloodmist|Demantoid|Forest's Heart|Nimbus|Plum|Taisidon sunset) garnet
+- Bleeding heart jade
+- (?:Autumn|Forest fire|Ocean|Spiderweb|Sunstar|Wild Horse) jasper
+- (?:Blackwater|Riverhaven) jet
+- Hekemhhg lazuli
+- Eventide moonstone
+- (?:Grazhir's|Midnight) onyx
+- (?:Aurora|Black|Cherry|Chocolate|Dendritic|Draconic|Dragon Fire|Firesilk|Flame|Frost Flare|Frost|Frostfire|Frostflare|Nightfire|Sky|Sunset|Water|Winter) opal
+- (?:Baroque|Dafora|Damaryn|Damilyo|Ebon Jackal's Heart|Fang|Fire|Frost|Geshi|Idopun|Moon|Pitch|Taisidonian|Talan) pearl
+- (?:Blood|Cloud|Conquerer's|Dragon's Blood|Dragon's Eye|Dragon's Heart|Gemfire|Grapefruit|Imperial|Merlot|Midnight|Moonspun|Serpent's Heart|Smoke|Star|Starlight|Teiro's Hate|Vengeance) ruby
+- (?:Crimson|Dalaeji black|Dragon's scale|Drogor's Wrath|Duskbloom|Elamiri|Eluned's tear|Haze|Ice|Idon's|Imperial|Lotus Flower|Mermaid's Tear|Musparan Gold|Phantom|Rainbow|Serpent's head|Shrike's Eye|Star|Summer's Heart|Tempest|Twilight|Viper's eye|Zoluren White) sapphire
+- (?:Dusk|Katamba|Unicorn|Zenith) spinel
+- (?:Fire Maiden topaz|Golden|Imperial|Lava|Lion's Heart|Mystic|Saffron|Smoky|Starfire|Stormfire|Stormheart|Xibar|Zoluren Royal) topaz
+- (?:Aurora|Reshalian|Seastar|Vela'tohr|Watermelon) tourmaline
+- (?:Jungle|Cloud) turquoise
 
-instruments:
-- zills
-- cowbell
-
-armor_nouns:
-- aegis
+### GENERAL ###
+herbs:
+- blocil berries
+- (?:blue|hisan|jadice|red) flower
+- (?:georin|hulnik|nilos) grass
+- (?:aevaes|aloe|hulij|plovik|riolur) leaves
+- (?:belradi|eghmok) moss
+- (?:jadice|qun) pollen
+- (?:cebi|ithor|lujeakave|nemoih|ojhenik|yelith) root
+- (?:dioica|muljin|sufil) sap
+- (?:genich|junliar|nuloe) stem
+- seolarn weed
+- (?:dried|crushed) aevaes
+- (?:dried|crushed) aloe
+- (?:dried|crushed) belradi
+- (?:dried|crushed) blocil
+- (?:dried|crushed) blue flowers?
+- (?:dried|crushed) cebi
+- (?:dried|crushed) dioica
+- (?:dried|crushed) eghmok
+- (?:dried|crushed) genich
+- (?:dried|crushed) georin
+- (?:dried|crushed) hisan
+- (?:dried|crushed) hulij
+- (?:dried|crushed) hulnik
+- (?:dried|crushed) ithor
+- (?:dried|crushed) jadice
+- (?:dried|crushed) junliar
+- (?:dried|crushed) lujeakave
+- (?:dried|crushed) muljin
+- (?:dried|crushed) nemoih
+- (?:dried|crushed) nilos
+- (?:dried|crushed) nuloe
+- (?:dried|crushed) ojhenik
+- (?:dried|crushed) plovik
+- (?:dried|crushed) qun
+- (?:dried|crushed) red flowers?
+- (?:dried|crushed) riolur
+- (?:dried|crushed) seolarn
+- (?:dried|crushed) sufil
+- (?:dried|crushed) yelith
+ammunition_nouns:
+- bolts?
+- arrows?
+- rocks?
+- (?:balanced|elongated|smooth) .* stones?
+- blowgun darts?
+- blunt(-tipped)?\s(stone|arrow|bolt)s?
+- frost-white shards?
+gear - armour_nouns:
 - armet
 - armor
 - aventail
 - balaclava
 - bascinet
 - breastplate
-- buckler
 - chain mail
 - chain shirt
 - cowl
@@ -178,7 +470,6 @@ armor_nouns:
 - gauntlets
 - gloves
 - greathelm
-- greatshield
 - greaves
 - half plate
 - hauberk
@@ -188,132 +479,26 @@ armor_nouns:
 - legguards
 - mantlet
 - mask
+- battle odaj
 - plate
 - robes
-- shield
-- sipar
 - tasset
-- targe
 - vambraces
-
-weapon_nouns:
-- adze
-- awl\-pike
-- axe
-- backsword
-- battlesword
-- blackjack
-- blade
-- bludgeon
-- bola
-- bow
-- broadsword
-- cestus
-- claidhmore
-- club
-- crook
-- crossbow
-- crowbill
-- cudgel
-- dagger
-- dagesse
-- dart
-- discus
-- epee
-- espadon
-- estoc
-- falchion
-- fist\-scythe
-- flail
-- flamberge
-- gauche
-- greataxe
-- greatsword
-- halberd
-- hammer
-- hammer\-of\-Kai
-- handaxe
-- harpoon
-- hatchet
-- hook\-knife
-- jackblade
-- javelin
-- jeddart\-axe
-- kaskara
-- katana
-- katar
-- khopesh
-- knife
-- knuckle\-blade
-- knuckle\-duster
-- kris
-- lance
-- langsax
-- longsword
-- mace
-- machete
-- mattock
-- maul
-- naginata
-- \bnet\b
-- paingrip
-- pilum
-- pitchfork
-- quarterstaff
-- short\-staff
-- quoit
-- rapier
-- razorpaw
-- runestaff
-- sabre
-- sai
-- scimitar
-- sledgehammer
-- spear
-- spikestar
-- staff
-- sword
-- tiger\-claw
-- trident
-- troll\-claw
-- voulge
-- wakizashi
-- waraxe
-- warblade
-- whip
-- whip\-blade
-- yierka\-spur
-- yumi
-- foil
-- bulawa
-- cleaver
-- yataghan
-- sapara
-- scramasax
-- warlance
-- sling
-- shriike
-- cinquedea
-- claymore
-- cane
-- pike
-- longbow
-- shortbow
-- cutlass
-- (morning|throwing) star
-- pasabas
-- hhr'ata
-- nightstick
-
-ammunition:
-- bolts?
-- arrows?
-- rocks?
-- blowgun darts?
-- blunt(-tipped)?\s(stone|arrow|bolt)s?
-- frost-white shards?
-
-clothing:
+appearance_nouns:
+- brush
+- comb
+- mirror
+box_nouns:
+- coffer
+- strongbox
+- chest
+- caddy
+- trunk
+- casket
+- skippet
+- crate
+- \bbox\b
+clothing_nouns:
 - alpargatas
 - alb
 - apron
@@ -353,6 +538,7 @@ clothing:
 - cloak
 - clogs
 - coat
+- walking coat finely
 - coinec
 - corsage
 - costume
@@ -376,6 +562,7 @@ clothing:
 - goggles
 - gown
 - greatcloak
+- greatcloak accented down
 - greatkilt
 - hat
 - headband
@@ -448,6 +635,7 @@ clothing:
 - trews
 - tricorn
 - trousers
+- heavy golden stitching
 - uaro's'sugi
 - uuzhal
 - veil
@@ -455,320 +643,207 @@ clothing:
 - waistcoat
 - wig
 - wings
-
-valuable:
-- copper coin
-- bronze coin
-- silver coin
-- gold coin
-- platinum coin
-- copper coins
-- bronze coins
-- silver coins
-- gold coins
-- platinum coins
-- map
-- pass
-- note
-- package
-- permit
-- profile
-
-pet:
-- assassin bug
-- beetle
-- birdeater
-- centipede
-- lizard
-- mantis
-- scorpion
-- spider
-- tarantula
-- wheel bug
-- woodlouse hunter
-
-consumable_locksmithing_trainers:
-- keepsake box
-- jewelry box
-
-box_nouns:
-- coffer
-- strongbox
+container_nouns:
+- arca
+- back(?:pack|tube)
+- \bbags?\b
+- baldric
+- barrel
+- basket
+- bottle gourd
+- bowcase
+- bundle
+- carryall
+- carton
+- \bcase\b
+- cauldron
 - chest
-- caddy
-- trunk
-- casket
-- skippet
-- crate
-- \bbox\b
-
-herbs:
-- aevaes leaves
-- aloe leaves
-- belradi moss
-- blocil berries
-- blue flower
-- cebi root
-- dioica sap
-- eghmok moss
-- genich stem
-- georin grass
-- hisan flower
-- hulij leaves
-- hulnik grass
-- ithor root
-- jadice flower
-- jadice pollen
-- junliar stem
-- lujeakave root
-- muljin sap
-- nemoih root
-- nilos grass
-- nuloe stem
-- ojhenik root
-- plovik leaves
-- qun pollen
-- red flower
-- riolur leaves
-- seolarn weed
-- sufil sap
-- yelith root
-- (?:dried|crushed) aevaes
-- (?:dried|crushed) aloe
-- (?:dried|crushed) belradi
-- (?:dried|crushed) blocil
-- (?:dried|crushed) blue flowers?
-- (?:dried|crushed) cebi
-- (?:dried|crushed) dioica
-- (?:dried|crushed) eghmok
-- (?:dried|crushed) genich
-- (?:dried|crushed) georin
-- (?:dried|crushed) hisan
-- (?:dried|crushed) hulij
-- (?:dried|crushed) hulnik
-- (?:dried|crushed) ithor
-- (?:dried|crushed) jadice
-- (?:dried|crushed) junliar
-- (?:dried|crushed) lujeakave
-- (?:dried|crushed) muljin
-- (?:dried|crushed) nemoih
-- (?:dried|crushed) nilos
-- (?:dried|crushed) nuloe
-- (?:dried|crushed) ojhenik
-- (?:dried|crushed) plovik
-- (?:dried|crushed) qun
-- (?:dried|crushed) red flowers?
-- (?:dried|crushed) riolur
-- (?:dried|crushed) seolarn
-- (?:dried|crushed) sufil
-- (?:dried|crushed) yelith
-
-remedies:
-- (?:salve|unguent|poultices|ointment|potion|tonic|elixir|draught)
-
-scroll_keepers:
-- poke .*
-- booklet
-- scroll case
-- papers
-- folio
-- tome
-- yellow notebook
-- worn book
-- codex
-
-collectibles:
-- card
-- dira
-
-runestones:
+- container
+- duffel
+- feedbag
+- game-bag
+- gearbag
+- harness
+- haversack
+- humidor
+- \bkit\b
+- knapsack
+- lootsack
+- moneybelt
+- \bpack\b
+- pannier
+- pillowcase
+- pouch
+- purse
+- quiver
+- rucksack
+- rugursora
+- \bsack\b
+- saddlebag
+- satchel
+- scabbard
+- sheath
+- sidebag
+- skillet
+- toolbag
+- toolbox
+- \btote\b
+- wallet
+- workbag
+jewelry_nouns:
+- amulet
+- anklet
+- badge
+- band
+- barrette
+- bracelet
+- brooch
+- carving
+- charm
+- choker
+- circlet
+- diadem
+- earcuff
+- earrings
+- globe
+- hip-chain
+- locket
+- medallion
+- necklace
+- pendant
+- pin
+- ring
+- /(?<!morning\s)star/
+material_nouns:
+- \bdeed\b
+- \bbar\b
+- \bfragment\b
+- \bnugget\b
+- \bstack\b
+magical - runestone_nouns:
 - runestone
-
-rare gems:
-- Absinthe emerald
-- Amlothite
-- Aurora opal
-- Aurora tourmaline
-- Autumn jasper
-- Baroque pearl
-- Bearclaw emerald
-- Black assassin's diamond
-- Black diamond
-- Black opal
-- Blackwater jet
-- Bleeding heart jade
-- Blood ruby
-- Bloodmist garnet
-- Blue diamond
-- Champagne diamond
-- Chaos chalcedony
-- Cherry opal
-- Chocolate opal
-- Cloud ruby
-- Cloud turquoise
-- Cloudstone
-- Conquerer's ruby
-- Crimson emerald
-- Crimson sapphire
-- Dafora pearl
-- Dalaeji black sapphire
-- Dalterein diamond
-- Damaryn pearl
-- Damilyo pearl
-- Dawgolite
-- Demantoid garnet
-- Dendritic opal
-- Draconic opal
-- Dragon Fire opal
-- Dragonfire amber
-- Dragon's blood amber
-- Dragon's Blood ruby
-- Dragon's Eye ruby
-- Dragon's Heart ruby
-- Dragon's scale sapphire
-- Dragonvein agate
-- Drake's heart amber
-- Drogor's Wrath sapphire
-- Durgauldite
-- Dusk spinel
-- Duskbloom sapphire
-- Ebon Jackal's Heart pearl
-- Elamiri sapphire
-- Elanthite
-- Eluned's tear sapphire
-- Er'qutrite
-- Estrildite
-- Eventide moonstone
-- Fang pearl
-- Fire agate
-- Fire Maiden topaz
-- Fire pearl
-- Firesilk opal
-- Flame opal
-- Forest fire jasper
-- Forest's Heart garnet
-- Fortune's Star diamond
-- Frost Flare opal
-- Frost opal
-- Frost pearl
-- Frostfire opal
-- Frostflare opal
-- Gemfire ruby
-- Geshi pearl
-- Glacier emerald
-- Golden topaz
-- Grapefruit ruby
-- Grazhir's onyx
-- Grazhite
-- Hav'roth's Ambrosia
-- Haze sapphire
-- Hekemhhg lazuli
-- Huntress diamond
-- Ice sapphire
-- Idon's sapphire
-- Idopun pearl
-- Ilithi emerald
-- Imperial coral
-- Imperial ruby
-- Imperial sapphire
-- Imperial topaz
-- Inkdrop agate
-- Ismenite
-- Jungle turquoise
-- Katamba spinel
-- Katambite
-- Lava topaz
-- Lightning amethyst
-- Lilac diamond
-- Lion's Heart topaz
-- Lotus Flower sapphire
-- Merewaldite
-- Merlot ruby
-- Mermaid's chalcedony
-- Mermaid's Tear sapphire
-- Midnight diamond
-- Midnight onyx
-- Midnight ruby
-- Molten-core diamond
-- Moon pearl
-- Moonspun ruby
-- Mountain agate
-- Musparan Gold sapphire
-- Mystic topaz
-- Nature's Canopy emerald
-- Night diamond
-- Nightfire opal
-- Nimbus garnet
-- Ocean jasper
-- Ocean's Deep emerald
-- Ocean's Heart diamond
-- Orchid alexandrite
-- Penhetite
-- Phantom sapphire
-- Pink diamond
-- Pitch pearl
-- Plum garnet
-- Plumed agate
-- Rainbow sapphire
-- Red diamond
-- Red emerald
-- Reshalian tourmaline
-- Riverhaven jet
-- Royal star diamond
-- Saffron topaz
-- Scarlet emerald
-- Scorpion diamond
-- Sea diamond
-- Seastar tourmaline
-- Serpent's head sapphire
-- Serpent's Heart ruby
-- Shadow emerald
-- Shrike's Eye sapphire
-- Siato star emerald
-- Sky opal
-- Smoke ruby
-- Smoky diamond
-- Smoky topaz
-- Sphere of polished coral banded with sunrise hues
-- Spiderweb jasper
-- Spring emerald
-- Star ruby
-- Star sapphire
-- Starfire topaz
-- Starlight ruby
-- Stormfire topaz
-- Stormheart topaz
-- Summer's Heart sapphire
-- Sunset opal
-- Sunstar jasper
-- Syrin's heart
-- Szeldite
-- Taisidon emerald
-- Taisidon sunset garnet
-- Taisidonian pearl
-- Talan pearl
-- Teiro's Hate ruby
-- Tempest sapphire
-- Tiger lily carnelian
-- Twilight sapphire
-- Unicorn spinel
-- Vela'tohr tourmaline
-- Vengeance ruby
-- Verenite
-- Violet's Heart amethyst
-- Viper's eye sapphire
-- Viperscale alexandrite
-- Volcano's Heart citrine
-- Water opal
-- Watermelon tourmaline
-- White diamond
-- Wild Horse jasper
-- Winter emerald
-- Winter opal
-- Xibar topaz
-- Xibarite
-- Yavasite
-- Yoakenite
-- Zenith spinel
-- Zoluren Royal topaz
-- Zoluren White sapphire
+remedies_nouns:
+- (?:salve|ungent|poultices|ointment|potion|tonic|elixir|draught)
+gear - shield_nouns:
+- aegis
+- bamarhliwa
+- buckler
+- greatshield
+- shield
+- sipar
+- targe
+gear - weapon_nouns:
+- military\sfork
+- riste
+- adze
+- axe
+- backsword
+- battlesword
+- blackjack
+- blade
+- bludgeon
+- bola
+- bow
+- broadsword
+- cestus
+- claidhmore
+- club
+- crook
+- crossbow
+- crowbill
+- cudgel
+- dagger
+- dart
+- discus
+- epee
+- espadon
+- estoc
+- falchion
+- fist\-scythe
+- flail
+- flamberge
+- gauche
+- gladius
+- greataxe
+- greatsword
+- ceremonial iron greatsword
+- ceremonial iron greatsword enriched
+- halberd
+- hammer
+- hammer\-of\-Kai
+- handaxe
+- harpoon
+- hatchet
+- hook\-knife
+- jackblade
+- javelin
+- jeddart\-axe
+- kaskara
+- katana
+- katar
+- khopesh
+- knife
+- knuckle\-blade
+- knuckle\-duster
+- kris
+- lance
+- langsax
+- longsword
+- mace
+- machete
+- mattock
+- maul
+- naginata
+- nodachi
+- \bnet\b
+- paingrip
+- pilum
+- pitchfork
+- quarterstaff
+- short\-staff
+- quoit
+- rapier
+- razorpaw
+- runestaff
+- sabre
+- sai
+- scimitar
+- skefne
+- sledgehammer
+- spear
+- spikestar
+- staff
+- sword
+- tachi
+- throwing blades
+- tiger\-claw
+- trident
+- troll\-claw
+- voulge
+- wakizashi
+- waraxe
+- warblade
+- whip
+- whip\-blade
+- yierka\-spur
+- yumi
+- foil
+- bulawa
+- cleaver
+- yataghan
+- sapara
+- scramasax
+- warlance
+- sling
+- shrike
+- cinquedea
+- claymore
+- cane
+- pike
+- longbow
+- shortbow
+- cutlass
+- (morning|throwing) star
+- pasabas
+- hhr\'ata
+- nightstick


### PR DESCRIPTION
base-sorting.lic – Update

-	The categories have been reorganized, with some subdivided and some new ones added.
-	Some of the items from the original categories have been condensed using regex.
-	Description added at the top of the file.

I believe most of the categories are straightforward.


NEW CATEGORIES

appearance	(Appearance altering items.)
music	(Musical instruments and related.)
pilgrim badge
gear	
-	armour
-	brawling
-	shield
-	weapon clothing
-	hiders	(Non-magical hiders.)
-	skates
-	wings container
-	autoloot
-	hold anything
-	vault storage	(Vault furniture. Useful for when looking or rummaging in vaults.) stacker	
-	crafting	(Crafting component stackers.)
-	dirt
-	herbs
-	lockpicks
-	scrolls crafting (crafting items and supplies)
-	alchemy tools
-	enchanting tools
-	engineering tools
-	forging tools
-	outfitting tools estate holder
-	home and furniture magical
-	cambrinth
-	food generator
-	gaethzen
-	ritual focus	
-	runestone	 material	Raw and processes materials in general.
-	alteration	 (Alteration fodder.)
-	cassava	
-	chakrel
-	soulstone toy	(Fluff and RP items.)
-	collectibles	(Cards, dira, etc.)
-	fire and smoke	(Things to light and burn with.)
-	writing	(Things to write and send with.)
-	pet trainer
-	textbooks valuable
-	collection pieces	(Collection items that combine.)
-	gem pouch
-	rare gems jewelry
remedies