### PR TITLE
Update base-healingherbs.yaml

### DIFF
--- a/data/base-healingherbs.yaml
+++ b/data/base-healingherbs.yaml
@@ -1,4 +1,4 @@
-### Added Riverhaven(uses Lang shop as primary) ###
+### Added Riverhaven(uses Lang shop as primary) ### 10/27/24
 ### Added Ratha (Thanks to Sharkbait!) ###
 
 herb_stocks:
@@ -397,6 +397,34 @@ herb_stocks:
       room: 8666
       price: 500
       quantity: 7
+    - name: hulij elixir
+      location: Langenfirth
+      size: 6
+      stackable: true
+      room: 8666
+      price: 500
+      quantity: 7
+    - name: hisan salve
+      location: Langenfirth
+      size: 6
+      stackable: true
+      room: 8666
+      price: 600
+      quantity: 7
+    - name: jadice pollen
+      location: Langenfirth
+      size: 6
+      stackable: true
+      room: 8666
+      price: 500
+      quantity: 19
+    - name: ojhenik potion
+      location: Langenfirth
+      size: 6
+      stackable: true
+      room: 8666
+      price: 500
+      quantity: 19 
   Ratha:
     - name: jadice flower
       size: 6


### PR DESCRIPTION
Restored 4 herbs at the end of the Riverhaven section that were deleted during previous editing.