### PR TITLE
[scripts][dependency] Add repository fallback functionality

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '1.7.4'
+$DEPENDENCY_VERSION = '1.7.5'
 $MIN_RUBY_VERSION = '3.2.2'
 DRINFOMON_IN_CORE_LICH ||= false
 
@@ -205,8 +205,8 @@ class ScriptManager
     @paste_bin_token = 'dca351a27a8af501a8d3123e29af7981'
     @paste_bin_url = 'https://pastebin.com/api/api_post.php'
     @firebase_url = 'https://dr-scripts.firebaseio.com/'
-    @status_repo = Settings['status_repo'] || 'rpherbig/dr-scripts'
-    @status_branch = Settings['status_branch'] || 'master'
+    @status_repo = 'rpherbig/dr-scripts'
+    @status_branch = 'master'
     update_status_url
     # Gating setting lich_url on lich version
 
@@ -241,25 +241,31 @@ class ScriptManager
     @autostarts = (UserVars.autostart_scripts + Settings['autostart']).uniq
   end
 
+  def url_exist?(url_string)
+    url = URI.parse(url_string)
+    req = Net::HTTP.new(url.host, url.port)
+    req.use_ssl = (url.scheme == 'https')
+    path = url.path
+    res = req.request_head(path || '/')
+    res.code != "404" # false if returns 404 - not found
+  rescue Errno::ENOENT
+    false # false if can't find the server
+  end
+
   def update_status_url
-    @status_url = 'https://api.github.com/repos/' + @status_repo + '/git/trees/' + @status_branch
-  end
-
-  def set_custom_status_repo(repo, branch)
-    @status_repo = repo
-    @status_branch = branch
-    update_status_url
-  end
-
-  def set_custom_status_branch(branch)
-    @status_branch = branch
-    update_status_url
-  end
-
-  def unset_custom_status
-    @status_repo = 'rpherbig/dr-scripts'
-    @status_branch = 'master'
-    update_status_url
+    masterurl = 'https://api.github.com/repos/' + @status_repo + '/git/trees/' + @status_branch
+    # _respond Lich::Messaging.monsterbold("Master URL is #{masterurl.inspect}")
+    mainurl   = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/main'
+    # eo_drscripts = 'https://api.github.com/repos/elanthia-online/dr-scripts/git/trees/main'
+    if url_exist?(masterurl)
+      @status_url = masterurl
+      _respond Lich::Messaging.monsterbold("Using main Status URL.")
+    elsif url_exist?(mainurl)
+      _respond Lich::Messaging.monsterbold("Using alternate Status URL.")
+      @status_url = mainurl
+    else
+      _respond Lich::Messaging.monsterbold("Could not set Status URL. Please seek help on Discord.")
+    end
   end
 
   def check_custom_status
@@ -305,8 +311,6 @@ class ScriptManager
 
   def run_queue
     validate_supported_ruby_version
-    Settings['status_repo'] = @status_repo
-    Settings['status_branch'] = @status_branch
     update = false
 
     unless @add_autos.empty?
@@ -1672,22 +1676,6 @@ def stop_autostart(script_names)
       $manager.remove_global_auto(script)
     end
   end
-end
-
-def set_custom_status_repo(repo, branch = 'master')
-  $manager.set_custom_status_repo(repo, branch)
-end
-
-def set_custom_status_branch(branch)
-  $manager.set_custom_status_branch(branch)
-end
-
-def unset_custom_status
-  $manager.unset_custom_status
-end
-
-def check_custom_status
-  echo $manager.check_custom_status
 end
 
 def setup_profiles

--- a/dependency.lic
+++ b/dependency.lic
@@ -205,8 +205,8 @@ class ScriptManager
     @paste_bin_token = 'dca351a27a8af501a8d3123e29af7981'
     @paste_bin_url = 'https://pastebin.com/api/api_post.php'
     @firebase_url = 'https://dr-scripts.firebaseio.com/'
-    @status_repo = 'rpherbig/dr-scripts'
-    @status_branch = 'master'
+    @status_repo = Settings['status_repo'] || 'rpherbig/dr-scripts'
+    @status_branch = Settings['status_branch'] || 'master'
     update_status_url
     # Gating setting lich_url on lich version
 
@@ -241,6 +241,36 @@ class ScriptManager
     @autostarts = (UserVars.autostart_scripts + Settings['autostart']).uniq
   end
 
+  def update_status_url
+    defaulturl = 'https://api.github.com/repos/' + @status_repo + '/git/trees/' + @status_branch
+    mainurl   = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/main'
+    fallbackurl = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/master'
+    eo_drscripts = 'https://api.github.com/repos/elanthia-online/dr-scripts/git/trees/main'
+
+    unless url_exist?(defaulturl)
+      _respond Lich::Messaging.monsterbold("Default URL #{defaulturl} not working. Using an alternate repo+branch combindation.")
+      _respond Lich::Messaging.monsterbold("Unsetting custom repo settings, if any.")
+      Settings['status_repo'] = nil if Settings['status_repo']
+      Settings['status_branch'] = nil if Settings['status_branch']
+    end
+
+    if url_exist?(defaulturl)
+      @status_url = defaulturl
+      _respond Lich::Messaging.monsterbold("Using set Status URL. #{defaulturl}")
+    elsif url_exist?(mainurl)
+      _respond Lich::Messaging.monsterbold("Using alternate Status URL. #{mainurl}")
+      @status_url = mainurl
+    elsif url_exist?(fallbackurl)
+      _respond Lich::Messaging.monsterbold("Using fallback Status URL. #{fallbackurl}")
+      @status_url = fallbackurl
+    elsif url_exist?(eo_drscripts)
+      _respond Lich::Messaging.monsterbold("Using Elanthia Online Status URL. #{eo_drscripts}")
+      @status_url = eo_drscripts
+    else
+      _respond Lich::Messaging.monsterbold("Could not set Status URL. Please seek help on Discord.")
+    end
+  end
+
   def url_exist?(url_string)
     url = URI.parse(url_string)
     req = Net::HTTP.new(url.host, url.port)
@@ -252,20 +282,21 @@ class ScriptManager
     false # false if can't find the server
   end
 
-  def update_status_url
-    masterurl = 'https://api.github.com/repos/' + @status_repo + '/git/trees/' + @status_branch
-    # _respond Lich::Messaging.monsterbold("Master URL is #{masterurl.inspect}")
-    mainurl   = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/main'
-    # eo_drscripts = 'https://api.github.com/repos/elanthia-online/dr-scripts/git/trees/main'
-    if url_exist?(masterurl)
-      @status_url = masterurl
-      _respond Lich::Messaging.monsterbold("Using main Status URL.")
-    elsif url_exist?(mainurl)
-      _respond Lich::Messaging.monsterbold("Using alternate Status URL.")
-      @status_url = mainurl
-    else
-      _respond Lich::Messaging.monsterbold("Could not set Status URL. Please seek help on Discord.")
-    end
+  def set_custom_status_repo(repo, branch)
+    @status_repo = repo
+    @status_branch = branch
+    update_status_url
+  end
+
+  def set_custom_status_branch(branch)
+    @status_branch = branch
+    update_status_url
+  end
+
+  def unset_custom_status
+    @status_repo = 'rpherbig/dr-scripts'
+    @status_branch = 'master'
+    update_status_url
   end
 
   def check_custom_status
@@ -311,6 +342,8 @@ class ScriptManager
 
   def run_queue
     validate_supported_ruby_version
+    Settings['status_repo'] = @status_repo
+    Settings['status_branch'] = @status_branch
     update = false
 
     unless @add_autos.empty?
@@ -1676,6 +1709,22 @@ def stop_autostart(script_names)
       $manager.remove_global_auto(script)
     end
   end
+end
+
+def set_custom_status_repo(repo, branch = 'master')
+  $manager.set_custom_status_repo(repo, branch)
+end
+
+def set_custom_status_branch(branch)
+  $manager.set_custom_status_branch(branch)
+end
+
+def unset_custom_status
+  $manager.unset_custom_status
+end
+
+def check_custom_status
+  echo $manager.check_custom_status
 end
 
 def setup_profiles

--- a/dependency.lic
+++ b/dependency.lic
@@ -248,7 +248,7 @@ class ScriptManager
     eo_drscripts = 'https://api.github.com/repos/elanthia-online/dr-scripts/git/trees/main'
 
     unless url_exist?(defaulturl)
-      _respond Lich::Messaging.monsterbold("Default URL #{defaulturl} not working. Using an alternate repo+branch combindation.")
+      _respond Lich::Messaging.monsterbold("Default URL #{defaulturl} not responding. Using an alternate repo+branch combindation.")
       _respond Lich::Messaging.monsterbold("Unsetting custom repo settings, if any.")
       Settings['status_repo'] = nil if Settings['status_repo']
       Settings['status_branch'] = nil if Settings['status_branch']

--- a/dependency.lic
+++ b/dependency.lic
@@ -243,7 +243,7 @@ class ScriptManager
 
   def update_status_url
     defaulturl = 'https://api.github.com/repos/' + @status_repo + '/git/trees/' + @status_branch
-    mainurl   = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/main'
+    mainurl = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/main'
     fallbackurl = 'https://api.github.com/repos/rpherbig/dr-scripts/git/trees/master'
     eo_drscripts = 'https://api.github.com/repos/elanthia-online/dr-scripts/git/trees/main'
 


### PR DESCRIPTION
Removing the concept of custom status URLs, and adding fallback functionality so we can rename the master branch, and as a prelude to moving this repo to the Elanthia Online GIthub organization.