### PR TITLE
[scripts][common] Ball and chain is a ball

### DIFF
--- a/common.lic
+++ b/common.lic
@@ -545,6 +545,8 @@ module DRC
   def fix_dr_bullshit(string)
     return string if string.split.length <= 2
 
+    string.sub!(' and chain', '') if string =~ /ball and chain/
+
     string =~ /(\S+) .* (\S+)/
     "#{Regexp.last_match(1)} #{Regexp.last_match(2)}"
   end

--- a/common.lic
+++ b/common.lic
@@ -287,6 +287,7 @@ module DRC
   def kick_pile?(item = 'pile')
     fix_standing
     return unless DRRoom.room_objs.any? { |room_obj| room_obj.match?(/pile/) }
+
     bput("kick #{item}", 'I could not find', 'take a step back and run up to', 'Now what did the .* ever do to you', 'You lean back and kick your feet,') == 'take a step back and run up to'
   end
 


### PR DESCRIPTION
Before
```
>;eq echo DRC.right_hand                                                                                                                                                                                                                      
[exec1: spiked chain]
```
after
```
>;eq echo DRC.right_hand                                                                                                                                                                                                                      
[exec1: spiked ball]
```
The after is the correct one.

Resolves https://github.com/rpherbig/dr-scripts/issues/6123