### PR TITLE
[scripts][sew] Use lift instead of stow feet

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -228,7 +228,13 @@ class Sew
         swap_tool('sewing needles')
         command = "push my #{@noun} with my sewing needles"
       when 'What were you referring', 'I could not find what you were'
-        DRC.bput('stow feet', 'You put', 'Stow what')
+        if DRCI.lift?
+          DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
+          DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if  DRC.left_hand
+        else
+          DRC.bput('stow feet', 'You put', 'Stow what')
+        end
+
         if command.include?('wax')
           DRCC.check_consumables('wax', @info['tool-room'], 10, @bag, @bag_items, @belt)
           swap_tool('wax')
@@ -314,8 +320,16 @@ class Sew
     when /hold/
       DRC.message("#{@noun} Complete")
     end
-    DRC.bput('stow feet', 'You put', 'Stow what')
+
+    if DRCI.lift?
+      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
+      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if  DRC.left_hand
+    else
+      DRC.bput('stow feet', 'You put', 'Stow what')
+    end
+
     magic_cleanup
+
     exit
   end
 end

--- a/sew.lic
+++ b/sew.lic
@@ -161,6 +161,15 @@ class Sew
     end
   end
 
+  def lift_or_stow_feet
+    if DRCI.lift?
+      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
+      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if  DRC.left_hand
+    else
+      DRC.bput('stow feet', 'You put', 'Stow what')
+    end
+  end
+
   def work(command)
     DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/) if @cube
     loop do
@@ -228,13 +237,7 @@ class Sew
         swap_tool('sewing needles')
         command = "push my #{@noun} with my sewing needles"
       when 'What were you referring', 'I could not find what you were'
-        if DRCI.lift?
-          DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
-          DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if  DRC.left_hand
-        else
-          DRC.bput('stow feet', 'You put', 'Stow what')
-        end
-
+        lift_or_stow_feet
         if command.include?('wax')
           DRCC.check_consumables('wax', @info['tool-room'], 10, @bag, @bag_items, @belt)
           swap_tool('wax')
@@ -321,13 +324,7 @@ class Sew
       DRC.message("#{@noun} Complete")
     end
 
-    if DRCI.lift?
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if  DRC.left_hand
-    else
-      DRC.bput('stow feet', 'You put', 'Stow what')
-    end
-
+    lift_or_stow_feet
     magic_cleanup
 
     exit


### PR DESCRIPTION
Instead of doing a blanket `stow feet` we will now `lift` and see what we have, then put it away using the crafting stow functions, which should put things back into the crafting container, and not the default stow container.