### PR TITLE
[scripts][tinker]mechanism updates

### DIFF
--- a/tinker.lic
+++ b/tinker.lic
@@ -71,6 +71,11 @@ class Tinker
       work("analyze my #{@noun}")
     elsif args.mechanisms
       DRCC.get_adjust_tongs?('reset shovel', @bag, @bag_items, @belt, true) if @settings.adjustable_tongs
+      if @bag_items == nil
+        @bag_items = ["mechanisms"] 
+      else
+        @bag_items.push("mechanisms") unless @bag_items.any? { |item| /mechanism/.match(item) }
+      end
       mechanisms(args)
     else
       DRCC.check_consumables('stain', @info['tool-room'], @info['stain-number'], @bag, @bag_items, @belt) unless args.skip
@@ -237,6 +242,7 @@ class Tinker
         DRCI.stow_hands
         exit
       when /pulling on the gear press/
+        tool = 'pliers'
         command = "pull my #{@noun} with press"
       when /you are left with several complete mechanisms/
         DRCC.stow_crafting_item(DRC.right_hand, @bag, nil)

--- a/tinker.lic
+++ b/tinker.lic
@@ -72,7 +72,7 @@ class Tinker
     elsif args.mechanisms
       DRCC.get_adjust_tongs?('reset shovel', @bag, @bag_items, @belt, true) if @settings.adjustable_tongs
       if @bag_items == nil
-        @bag_items = ["mechanisms"] 
+        @bag_items = ["mechanisms"]
       else
         @bag_items.push("mechanisms") unless @bag_items.any? { |item| /mechanism/.match(item) }
       end


### PR DESCRIPTION
set tool for mechanism in proper case. otherwise, `swap_tool` goes to first entry in `tinkering_tools` (bellow in `base.yaml`)

if creating mechanisms, add mechanism to `bag_items` if not present. `get my mechanism` fails when holding one to combine multiples.

![image](https://github.com/user-attachments/assets/d73ba077-9102-425f-ad24-d9ba1c2b4670)
