### PR TITLE
[scripts][validate] Mention the existence of favor_town

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -215,7 +215,7 @@ class DRYamlValidator
     valid_hometown_altars = get_data('theurgy')[settings.hometown]['favor_altars'].keys
     return if valid_hometown_altars.include?(settings.favor_god.capitalize)
 
-    warn("The favor_god: #{settings.favor_god} you have set does not have a favor altar in your hometown: #{settings.hometown}.  You will not be able to get favors if you fall below your favor_goal.")
+    warn("The favor_god: #{settings.favor_god} you have set does not have a favor altar in your hometown: #{settings.hometown}.  You will not be able to get favors if you fall below your favor_goal. Consider setting a favor_town where #{settings.favor_god} does have an altar.")
   end
 
   def assert_that_water_holder_is_set_when_using_altars(settings)


### PR DESCRIPTION
Resolves https://github.com/elanthia-online/dr-scripts/issues/7051
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update warning in `assert_that_hometown_has_altar_if_using_altars` to suggest setting a `favor_town` if `favor_god` lacks an altar in `hometown`.
> 
>   - **Behavior**:
>     - Update warning message in `assert_that_hometown_has_altar_if_using_altars` in `validate.lic` to suggest setting a `favor_town` if `favor_god` lacks an altar in `hometown`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 2fb1fb2f056def7382d4668712443022f94254c8. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->