### PR TITLE
[burgle.lic] fix race condition on search

### DIFF
--- a/burgle.lic
+++ b/burgle.lic
@@ -435,6 +435,7 @@ class Burgle
     return if Flags['burgle-footsteps']
 
     result = DRC.bput("search #{target}", 'It looks valuable', 'Roundtime', 'I could not')
+    waitrt?
     @search_count += 1
     if result =~ /It looks valuable/
       store_loot if DRC.right_hand && DRC.left_hand


### PR DESCRIPTION
If you fail to find loot, and footsteps happen during the RT, the script will continue to search at least one more time.

Adding `waitrt?` after the search forces the script to wait before deciding what to do, including checking the burgle-footsteps flag
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in `burgle.lic` by adding `waitrt?` after search to ensure round time completion before proceeding.
> 
>   - **Behavior**:
>     - Fixes race condition in `search_for_loot()` in `burgle.lic` by adding `waitrt?` after `DRC.bput("search ")` to ensure round time is complete before proceeding.
>     - Prevents additional search attempts if footsteps are detected during round time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 5c5f25497d8301fb8146c9f284bc0dd0b50ff21f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->