### PR TITLE
[script] [theurgy] Add hometown parameter to ensure_copper_on_hand

### DIFF
--- a/theurgy.lic
+++ b/theurgy.lic
@@ -251,7 +251,7 @@ class TheurgyActions
     items_to_buy.sort_by! { |item| item[:shop]['id'] }
 
     total_cost = items_to_buy.map { |i| i[:shop]['price'] }.reduce(:+)
-    DRCM.ensure_copper_on_hand(total_cost + 300, @settings) unless items_to_buy.empty?
+    DRCM.ensure_copper_on_hand(total_cost + 300, @settings, @hometown) unless items_to_buy.empty?
 
     unless holy_water?
       DRCT.walk_to(@data['holy_water']['id'])


### PR DESCRIPTION
ensure the expanded hometown options are respected so you check the correct money type.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `@hometown` parameter to `ensure_copper_on_hand` in `buy_supplies` to respect hometown settings for money type.
> 
>   - **Behavior**:
>     - Adds `@hometown` parameter to `DRCM.ensure_copper_on_hand` in `buy_supplies` method of `TheurgyActions` class to ensure correct money type is checked based on hometown settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 205e77b5e3bba77919700c7501baf2f6fbfa5173. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->