### PR TITLE
[scripts][find-darkbox] Replace bput with dispose_trash

### DIFF
--- a/find-darkbox.lic
+++ b/find-darkbox.lic
@@ -15,6 +15,8 @@ trash_items = settings.hollow_eve_junk.map { |x| /\b#{x}\b/i }
 darkbox_stop_on_wounded = settings.darkbox_stop_on_wounded
 he_use_herbs_remedies = settings.he_use_herbs_remedies
 hollow_eve_loot_container = settings.hollow_eve_loot_container
+worn_trashcan = settings.worn_trashcan
+worn_trashcan_verb = settings.worn_trashcan_verb
 
 if Script.running?('roomnumbers')
   stop_script('roomnumbers')
@@ -97,7 +99,7 @@ loop do
       if in_hand
         case in_hand
         when *trash_items
-          DRC.bput("put my #{in_hand} in bucket", 'You put', 'You drop', 'What were', 'Stow what?')
+          DRCI.dispose_trash(in_hand, worn_trashcan, worn_trashcan_verb)
         else
           # Coil rope so we can store it
           if /\brope\b/ =~ in_hand


### PR DESCRIPTION
Allows for nuanced trash disposal.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `bput` with `dispose_trash` in `find-darkbox.lic` for nuanced trash disposal using `worn_trashcan` settings.
> 
>   - **Behavior**:
>     - Replaces `DRC.bput` with `DRCI.dispose_trash` for trash disposal in `find-darkbox.lic`.
>     - Utilizes `worn_trashcan` and `worn_trashcan_verb` settings for nuanced disposal.
>   - **Settings**:
>     - Adds `worn_trashcan` and `worn_trashcan_verb` to settings in `find-darkbox.lic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 7b285eb22259de2838c2eb11b1ee0e027f3c23f7. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->