### PR TITLE
[scripts][sell-loot] Fix trying to sell empty marked bundles

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -113,14 +113,14 @@ class SellLoot
   end
 
   def sell_bundle
-    return unless DRCI.exists?('bundle')
+    return unless DRC.bput('count my bundle', /^You flip through .* bundle and find \d+ skins? in it/, /^I could not find/).scan(/\d+/).first.to_i.positive?
 
     return unless DRCT.walk_to(@hometown['tannery']['id'])
 
     return if DRC.bput('remove my bundle', 'You remove', 'You sling', 'Remove what', 'You take') == 'Remove what'
 
     DRC.release_invisibility
-    DRC.bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle')
+    DRC.bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle', 'I don\'t think I can give you anything for that worthless thing')
     case DRC.left_hand + " " + DRC.right_hand
     when /rope/
       DRCI.put_away_item?('rope')


### PR DESCRIPTION
First, check if the bundle is empty before trying to sell, second add match to if you try to sell an empty bundle so it doesn't hang.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue in `sell-loot.lic` where selling empty bundles caused script to hang by checking bundle contents and handling empty cases.
> 
>   - **Behavior**:
>     - In `sell_bundle`, check if the bundle is empty using `DRC.bput('count my bundle', ...)` before selling.
>     - Add match for 'I don\'t think I can give you anything for that worthless thing' in `DRC.bput('sell my bundle', ...)` to handle empty bundles.
>   - **Misc**:
>     - Minor logic adjustment in `sell_bundle` to prevent hanging when selling empty bundles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 12e0b483b2f2f647d8f6b3529789f11733679b7d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->