### PR TITLE
 [scripts][combat-trainer] Fix possible issues with not tying bundles with marked bundles

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -594,7 +594,7 @@ class LootProcess
       game_state.next_clean_up_step
     end
 
-    # catch that game state thinks you need a bundle, but you've succesfully skinned something this means that likely you have a marked bundle already made
+    # catch that game state thinks you need a bundle, but you've successfully skinned something this means that likely you have a marked bundle already made
     if game_state.need_bundle && Flags['ct-successful-skin']
       if @tie_bundle
         DRC.bput('tie my bundle', 'TIE the bundle again')


### PR DESCRIPTION
With marked bundles it's possible that they would never get tied (if using SkinKills/LootKills or would error out when attempted to be tied the first time, as empty bundles can't be tied.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bundle tying issues with marked bundles in `combat-trainer.lic` by adding checks for successful skinning and adjusting bundle handling logic.
> 
>   - **Behavior**:
>     - Fixes issue where marked bundles were not being tied in `LootProcess` class, specifically in `execute()` and `check_skinning()` methods.
>     - Adds check for `Flags['ct-successful-skin']` to handle cases where a bundle is successfully skinned but not tied.
>   - **Flags**:
>     - Adds `ct-successful-skin` flag to detect successful skinning and adjust bundle handling accordingly.
>     - Deletes `ct-successful-skin` flag in `before_dying` block to reset state.
>   - **Misc**:
>     - Adjusts logic in `execute()` and `check_skinning()` to ensure bundles are tied when necessary, handling both `lumpy` and `tight` bundle states.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for cbae66c1f36afeebe23c5cfad415964b13c6664a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->