### PR TITLE
Add Recall Match in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3159,7 +3159,7 @@ class TrainerProcess
     when /^PrayerMat$/i
       pray_mat(game_state)
     when /^Recall$/i
-      DRC.bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied') unless game_state.npcs.empty?
+      DRC.bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied', 'You search your mind') unless game_state.npcs.empty?
     when /^Barb Research Augmentation$/i
       DRC.bput('meditate research monkey', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Barb Research Warding$/i


### PR DESCRIPTION
Adds a match for game feedback from the "recall" command for when NPCs are in stealth or otherwise not present when the command is input. The game output in such cases returns, "You search your mind but nothing seems notable about the area."
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a match for the `recall` command in `combat-trainer.lic` to handle specific game output when NPCs are not present.
> 
>   - **Behavior**:
>     - Adds a match for the `recall` command in `TrainerProcess` in `combat-trainer.lic` to handle the game output "You search your mind but nothing seems notable about the area."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for a137f58a0c7c72245a2e8432dde7b57f4def7496. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->