### PR TITLE
[data] Update for Shadewing Harpies

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1259,6 +1259,13 @@ hunting_zones:
   - 13035
   - 11284
   - 11281
+  # https://elanthipedia.play.net/Shadewing_harpy                        700-900
+  shadewing_harpy:
+  - 51762
+  - 51763
+  - 51764
+  - 51765
+  - 51766
   # https://elanthipedia.play.net/Xala%27shar_magus                     750-1000
   # https://elanthipedia.play.net/Xala%27shar_thrall                    750-1000
   xalas_1:


### PR DESCRIPTION
New P1 hunting zone added in TT.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a new hunting zone for Shadewing Harpies in `base-hunting.yaml` with specified room IDs and rank range.
> 
>   - **Behavior**:
>     - Adds a new hunting zone `shadewing_harpy` to `base-hunting.yaml` with room IDs 51762, 51763, 51764, 51765, and 51766.
>     - The rank range for Shadewing Harpies is 700-900.
>   - **Misc**:
>     - Adds a comment with a link to the Elanthipedia page for Shadewing Harpies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for bd6bcd352c0d0a1405b06b3af238e06f02f5d23d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->