### PR TITLE
Updates bundle tying/adjustment logic

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -597,9 +597,17 @@ class LootProcess
     # catch that game state thinks you need a bundle, but you've successfully skinned something this means that likely you have a marked bundle already made
     if game_state.need_bundle && Flags['ct-successful-skin']
       if @tie_bundle
-        DRC.bput('tie my bundle', 'TIE the bundle again')
-        if DRC.bput('tie my bundle', 'you tie the bundle', 'You don\'t seem to be able to do that right now') == 'you tie the bundle'
+        DRC.bput('tie my bundle', 'TIE the bundle again', 'But this bundle has already been tied off')
+        if DRC.bput('tie my bundle', 'you tie the bundle', 'But this bundle has already been tied off', 'You don\'t seem to be able to do that right now') =~ /you tie the bundle|already been tied off/
           until /You adjust your .* bundle so that you can more easily/ =~ DRC.bput('adjust my bundle', /^You adjust your .*/)
+            if DRC.right_hand && DRC.left_hand
+              DRCI.lower_item?(DRC.left_hand)
+              until /You adjust your .* bundle so that you can more easily/ =~ DRC.bput('adjust my bundle', /^You adjust your .*/)
+              end
+              fput 'lift'
+              fput 'bundle'
+              break
+            end
           end
           game_state.need_bundle = false
         end
@@ -1089,9 +1097,17 @@ class LootProcess
       case DRC.bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
       when /lumpy/
         if @tie_bundle
-          DRC.bput('tie my bundle', 'TIE the bundle again')
-          if DRC.bput('tie my bundle', 'you tie the bundle', 'You don\'t seem to be able to do that right now') == 'you tie the bundle'
-            until /You adjust your .* bundle so that you can more easily/ =~ DRC.bput('adjust my bundle', /^You adjust your .*/)
+          DRC.bput('tie my bundle', 'TIE the bundle again', 'But this bundle has already been tied off')
+          if DRC.bput('tie my bundle', 'you tie the bundle', 'But this bundle has already been tied off', 'You don\'t seem to be able to do that right now') =~ /you tie the bundle|already been tied off/
+            until /You adjust your .* bundle so that you can more easily/ =~ DRC.bput('adjust my bundle', /^You adjust your .*/, /You'll need a free hand for that/)
+              if DRC.right_hand && DRC.left_hand
+                DRCI.lower_item?(DRC.left_hand)
+                until /You adjust your .* bundle so that you can more easily/ =~ DRC.bput('adjust my bundle', /^You adjust your .*/)
+                end
+                fput 'lift'
+                fput 'bundle'
+                break
+              end
             end
             game_state.need_bundle = false
           end


### PR DESCRIPTION
- Should catch if you somehow enter combat with an already tied bundle
- Handles race condition on skinning that can happen if you have hands full on adjusting (usually caused by cyclic TM / Pulsing TM)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance bundle handling in `LootProcess` to manage already tied bundles and address race conditions during adjustments.
> 
>   - **Behavior**:
>     - In `LootProcess`, update `tie my bundle` logic to handle already tied bundles and adjust accordingly.
>     - Handle race condition during `adjust my bundle` when hands are full, ensuring proper adjustment.
>   - **Functions**:
>     - Modify `execute()` and `check_skinning()` in `LootProcess` to include new bundle handling logic.
>     - Update `tie my bundle` and `adjust my bundle` commands to check for tied state and free hands.
>   - **Misc**:
>     - Add additional checks for `right_hand` and `left_hand` in `LootProcess` to manage item handling during bundle adjustment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for ffa6a531af1c36e7debc75b329c1bddd9c5c43e3. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->