### PR TITLE
[script][tome] Add new books and penultimate message

### DIFF
--- a/tome.lic
+++ b/tome.lic
@@ -47,7 +47,14 @@ class Tome
       'togball manual'          => "A team may not enter the opposing team's Blood Zone",
       'weathered book'          => "\"There he is!\" Grundgy turned to see half a dozen of the guards hacking through the briars and reed",
       'worn book'               => "I was unsure a little of whether dragons drank wine,",
-      'Dwarven codex'           => "The Rituals of Consignment"
+      'Dwarven codex'           => "The Rituals of Consignment",
+      'radiant treatise'        => "VIII. Vice and Error",
+      'ox-hide memoir'          => "Finally, I noticed that on my path to Truffenyi's side",
+      'songsilk memoir'         => "What I didn't account for was how drastic of an effect the influence of the Heralds had on my memory",
+      'modest-sized biography'  => "At a quiet vigil, Miraena spoke of remorse",
+      'research journal'        => "To address this imbalance, Liraxes asserted itself",
+      'demonbone grimoire'      => "Skairelden, the Forge",
+      'darkspine grimoire'      => "Gwulach, the Drinker of Minds"
     }
 
     if @quit_early && @penultimate_page


### PR DESCRIPTION
Used https://elanthipedia.play.net/Tomes_of_Lore_(2) for penultimate page output.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds new entries to `@penultimate_pages` in `tome.lic` for additional books based on external source.
> 
>   - **Behavior**:
>     - Adds new entries to `@penultimate_pages` in `tome.lic` for books: `radiant treatise`, `ox-hide memoir`, `songsilk memoir`, `modest-sized biography`, `research journal`, `demonbone grimoire`, `darkspine grimoire`.
>   - **Misc**:
>     - Uses external source for penultimate page output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 4c6ee4bca12f65222d3f6ae87e5620ecd056579a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->