### PR TITLE
[scripts][knackstone] Introducing knackstone script

### DIFF
--- a/knackstone.lic
+++ b/knackstone.lic
@@ -132,7 +132,7 @@ class Knackstone
 
   # Issues a whisper command and returns true if confirmation is needed.
   def whisper_command(cmd)
-    Lich::Util.issue_command(cmd, /You whisper the fate/, /Roundtime|You have cast your lot to fate/,usexml: false).any?(CONFIRMATION_REGEX)
+    Lich::Util.issue_command(cmd, /You whisper the fate/, /Roundtime|You have cast your lot to fate/, usexml: false).any?(CONFIRMATION_REGEX)
   end
 end
 


### PR DESCRIPTION
Managed knackstone voting day by day based on a priority list. Will vote for the highest ranked option available from your list.
```
>;knacks
[custom/knackstone]>get my knackstone from my watery portal
[Assuming you mean an effervescent eddy of honey-hued light captured by a sungold frame.]
You get a blackened heraldic knackstone pierced through a tomiek lump from inside an effervescent eddy of honey-hued light captured by a sungold frame.
[custom/knackstone]>rub my knackstone
As you rub the surface of the heraldic knackstone, you are nearly overwhelmed by a tenuous connection to something vast, infinitely branching and impossible to navigate.  Without the slig
htest understanding of how, you feel that a period of bountiful blessings approaches, but you are unable to decipher the exact boon.
As best you can tell, it could be bonus to treasure map drop chance, bonus item drop chance, or bonus crafting experience.  The connection is severed just as quickly as it was forged, lea
ving you momentarily off balance.
[If you haven't already, you may WHISPER MY KNACKSTONE {1, 2 or 3} to attempt to influence that particular future boon becoming a reality.  You may only do this once per cycle, so choose carefully!]
Roundtime: 4 sec.
[custom/knackstone: Available options: ["bonus to treasure map drop chance", "bonus item drop chance", "bonus crafting experience"]]
[custom/knackstone: Sorting by preferences: ["bonus gem value from creatures", "bonus creature swarm activity", "bonus coins dropped from creatures", "bonus REXP value", "bonus experience", "bank fee removal", "bonus crafting experience", "bonus work order payouts", "bonus item drop chance", "bonus crafting prestige", "bonus to treasure map drop chance"]]
[custom/knackstone: Chosen option: bonus crafting experience]
[custom/knackstone]>WHISPER MY knackstone 3
You whisper the fate you wish to influence to the heraldic knackstone.  With all you can muster, you try to will bonus crafting experience into being.  You feel a questioning connection reaching out from the knackstone.
[To confirm your alignment with bonus crafting experience, repeat the command within 15 seconds.  You may only do this ONCE per cycle!]
Roundtime: 4 sec.
[custom/knackstone]>WHISPER MY knackstone 3
You whisper the fate you wish to influence to the heraldic knackstone.  You again hurl your will at the heraldic knackstone and sense an acknowledgment towards bonus crafting experience.  You have cast your lot to fate.
[custom/knackstone]>put my knackstone in my watery portal
[Assuming you mean an effervescent eddy of honey-hued light captured by a sungold frame.]
[Assuming you mean an effervescent eddy of honey-hued light captured by a sungold frame.]
You put your knackstone in the effervescent eddy.
--- Lich: custom/knackstone has exited.
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `knackstone.lic` script to manage knackstone voting based on user-defined preferences and handles various usage conditions.
> 
>   - **Behavior**:
>     - Introduces `knackstone.lic` to manage knackstone voting based on priority list.
>     - Votes for highest ranked available option from `DEFAULT_PREFERENCES`.
>     - Handles states where knackstone cannot be used (e.g., hidden or invisible).
>   - **Functions**:
>     - `Knackstone#run`: Main method to execute voting process.
>     - `Knackstone#use_knackstone`: Rubs knackstone, determines options, and votes.
>     - `Knackstone#find_best_option`: Selects best option based on preferences.
>     - `Knackstone#vote_for`: Casts vote for selected option.
>   - **Misc**:
>     - Uses regex to parse options and detect usage state.
>     - Debug mode available for detailed logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 60b227cdeae9fd844358572cb319186ef041e84a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->