### PR TITLE
[scripts][knackstone] Add worn knackstone functionality

### DIFF
--- a/knackstone.lic
+++ b/knackstone.lic
@@ -31,6 +31,7 @@ class Knackstone
     settings = get_settings
     @knackstone = settings.knackstone_noun || "knackstone"
     @knackstone_container = settings.knackstone_container || "watery portal"
+    @knackstone_worn = settings.knackstone_worn || false
     @knackstone_preferences = settings.knackstone_preferences || DEFAULT_PREFERENCES
     @debug = settings.knackstone_debug || false
   end
@@ -38,11 +39,16 @@ class Knackstone
   # Main execution method. Checks conditions, gets the knackstone, and uses it.
   def run
     return if unusable_state?
-    return unless ensure_knackstone_in_hand
 
-    use_knackstone
-
-    put_away_knackstone
+    if @knackstone_worn
+      return unless remove_worn_knackstone
+      use_knackstone
+      wear_knackstone
+    else
+      return unless ensure_knackstone_in_hand
+      use_knackstone
+      put_away_knackstone
+    end
   end
 
   private
@@ -59,6 +65,28 @@ class Knackstone
       return true
     end
     false
+  end
+
+  def remove_worn_knackstone
+    return true if DRCI.in_hands?(@knackstone)
+
+    if DRC.left_hand && DRC.right_hand
+      DRC.message('Hands full, cannot remove knackstone.')
+      return false
+    end
+
+    unless DRCI.remove_item?(@knackstone)
+      DRC.message("Could not remove knackstone. Something is wrong!")
+      exit
+    end
+    true
+  end
+
+  def wear_knackstone
+    unless DRCI.wear_item?(@knackstone)
+      DRC.message("Could not wear knackstone. Something is wrong!")
+      exit
+    end
   end
 
   def put_away_knackstone


### PR DESCRIPTION
Adds functionality to use a worn knackstone.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to handle using a worn knackstone in the `Knackstone` class, with new methods for removal and re-wearing.
> 
>   - **Behavior**:
>     - Adds support for using a worn knackstone in `run()` method of `Knackstone` class.
>     - If `@knackstone_worn` is true, removes knackstone using `remove_worn_knackstone()`, uses it, and re-wears it with `wear_knackstone()`.
>     - If not worn, ensures knackstone is in hand, uses it, and puts it away.
>   - **Functions**:
>     - Adds `remove_worn_knackstone()` to handle removal of worn knackstone, checking hand availability.
>     - Adds `wear_knackstone()` to re-wear the knackstone after use.
>   - **Settings**:
>     - Introduces `@knackstone_worn` setting to determine if knackstone is worn.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for f97190756da98cb5d53e36739f7db2c69e1a3e2c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->