### PR TITLE
[scripts][forge] Prevent race condition once item is finished

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -420,7 +420,7 @@ class Forge
       when 'Ingredients can be added' # backup catch for assembly
         assemble_part
       when 'Roundtime' # The follow-on for most sub actions, eg shovel/bellows. When no next-step text is received, we revert to the "home" process.
-        waitrt?    # prevent race condition
+        waitrt? # prevent race condition in processing flags
         echo("Work done?                                   :: #{Flags['work-done']}") if @debug
         finish if Flags['work-done']
         swap_tool(@home_tool)


### PR DESCRIPTION
Added waitrt? to prevent race condition during roundtime.

Resolves #7247 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `waitrt?` in `work` method of `Forge` class in `forge.lic` to prevent race condition during roundtime, resolving issue #7247.
> 
>   - **Behavior**:
>     - Adds `waitrt?` in `work` method of `Forge` class in `forge.lic` to prevent race condition during roundtime.
>     - Ensures script waits for roundtime to complete before proceeding with crafting steps.
>   - **Misc**:
>     - Resolves issue #7247 related to race condition during crafting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 43d944639588d3d2cfac4c4721390b8d822e867e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->