### PR TITLE
[scripts][forge] Resolve race condition when finishing item

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -315,6 +315,7 @@ class Forge
                         'I could not find what you were referring to',
                         'Ingredients can be added',
                         'Pour what',
+                        'Applying the final touches',
                         'Roundtime')
       echo("Match result                                 :: #{result}") if @debug
       echo("Assembly? Part string or false               :: #{Flags['forge-assembly']}") if @debug
@@ -419,7 +420,10 @@ class Forge
         exit
       when 'Ingredients can be added' # backup catch for assembly
         assemble_part
+      when 'Applying the final touches' # item completed - handle directly to avoid race condition
+        finish
       when 'Roundtime' # The follow-on for most sub actions, eg shovel/bellows. When no next-step text is received, we revert to the "home" process.
+        waitrt?
         echo("Work done?                                   :: #{Flags['work-done']}") if @debug
         finish if Flags['work-done']
         swap_tool(@home_tool)
@@ -452,13 +456,9 @@ class Forge
   end
 
   def magic_cleanup
-    if @training_spells.empty?
-      exit
-    else
-      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
-      DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
-    end
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
   end
 end
 


### PR DESCRIPTION
Resolves https://github.com/elanthia-online/dr-scripts/issues/7247
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in `forge.lic` by handling 'Applying the final touches' directly and simplifies `magic_cleanup` method.
> 
>   - **Behavior**:
>     - Adds 'Applying the final touches' to match conditions in `Forge` class to handle item completion directly, avoiding race condition.
>     - Calls `finish` method directly when 'Applying the final touches' is matched.
>   - **Misc**:
>     - Simplifies `magic_cleanup` method by removing unnecessary conditional check for `@training_spells`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 144510e1e3b5f357b30100237469cb984322f228. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->