### PR TITLE
Update base-crafting.yaml

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -2088,7 +2088,7 @@ recipe_parts:
     Langenfirth:
       << : *therengia_large_padding
     Therenborough:
-      << : *therengia_large_padding  
+      << : *therengia_large_padding
     Shard:
       part-room: 10939
       part-number: 12


### PR DESCRIPTION
Added &therengia_large_padding information from line 2085 to 2091
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `large padding` entry for Riverhaven, Langenfirth, and Therenborough in `base-crafting.yaml` using shared anchor `therengia_large_padding`.
> 
>   - **Behavior**:
>     - Adds `large padding` entry for `Riverhaven`, `Langenfirth`, and `Therenborough` in `base-crafting.yaml`.
>     - Uses anchor `therengia_large_padding` for shared `part-room` 9716 and `part-number` 12.
>   - **Misc**:
>     - No changes to existing entries or other parts of the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for df7f53a6c98a2adc3335764a120d800d23c7a25f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->