### PR TITLE
Update base-recipes.yaml

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -8728,6 +8728,7 @@ crafting_recipes:
   herb1: dioica
   herb1_stock:
   liquid: alcohol
+  # Remedies Chapter 6 recipes
 - name: a body draught
   noun: draught
   volume: 1
@@ -8738,7 +8739,6 @@ crafting_recipes:
   herb1: ojhenik
   herb1_stock: 12
   liquid: alcohol
-# Remedies Chapter 6 recipes
 - name: a face draught
   noun: draught
   volume: 1


### PR DESCRIPTION
Moved header for Remedies Chapter 6 up one recipe to include body draught, which was listed under Chapter 5, but is a chapter 6 recipe.  Should be no functional benefit, but it corrects the titling.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reordered comments in `base-recipes.yaml` to correctly categorize `a body draught` under Remedies Chapter 6.
> 
>   - **Reordering**:
>     - Moved the comment `# Remedies Chapter 6 recipes` above the `a body draught` recipe in `base-recipes.yaml` to correctly categorize it under Chapter 6 instead of Chapter 5.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 5d3c062f5ea35690f13e36ac4bb55b42edf0c00a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->