### PR TITLE
Update capture-critter.lic to handle RT

### DIFF
--- a/capture-critter.lic
+++ b/capture-critter.lic
@@ -67,6 +67,7 @@ class CaptureCritter
 
     DRCT.walk_to(@event_info["return_room"])
     fput("put my #{held_item} on #{@event_info["return_surface"]}")
+    pause 1
     waitrt?
 
     handle_item(DRC.right_hand || DRC.left_hand)


### PR DESCRIPTION
Adding a pause after an fput to better handle RT.

A bput would be preferable, but there are a bunch of different variations on the games and I'm not sure about different messaging.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a 1-second pause after `fput` in `capture_and_return` method of `CaptureCritter` class to handle RT.
> 
>   - **Behavior**:
>     - Adds a 1-second pause after `fput("put my \\#{held_item} on \\#{@event_info[\"return_surface\"]}")` in `capture_and_return` method of `CaptureCritter` class to handle RT.
>   - **Misc**:
>     - A `bput` is not used due to uncertainty about different game messaging variations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 83bd0deb9e506fb2df2247ce7b3be920eb9a0199. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->