### PR TITLE
Update truffenyi-commune-quest.lic for dark aspect match

### DIFF
--- a/truffenyi-commune-quest.lic
+++ b/truffenyi-commune-quest.lic
@@ -116,7 +116,7 @@ class TruffenyiCommuneQuest
                             end
 
     dark_aspect_immortal = case altar_look_second
-                           when /an overloaded wagon travelling toward a wooden bridge. The supports look rotten and cracked/i
+                           when /an overloaded wagon travelling toward a wooden bridge.\s+The supports look rotten and cracked/i
                              'zachriedek'
                            when /a long row of dismembered bodies leading toward a broken altar/i
                              'asketi'


### PR DESCRIPTION
updated match for Zachriedek to support the multiple sentences
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update regex in `do_altar` method to match multiple sentences for Zachriedek in `dark_aspect_immortal`.
> 
>   - **Behavior**:
>     - Updated regex in `dark_aspect_immortal` case in `do_altar` method to match multiple sentences for Zachriedek.
>     - Allows whitespace between sentences in the pattern `/an overloaded wagon travelling toward a wooden bridge.\s+The supports look rotten and cracked/i`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 513001fb25371a3dcb895e676cdd728e9c1a33a9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->