### PR TITLE
[data][spells] Add 'new' spells 'Starry Waters' and 'Visage'

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1275,6 +1275,14 @@ spell_data:
     mana_type: holy
     prep: prepare
     guild: Cleric
+  Starry Waters:
+    skill: Augmentation
+    abbrev: STAW
+    mana: 5
+    recast: 1
+    mana_type: holy
+    prep: prepare
+    guild: Cleric
   Malediction:
     skill: Debilitation
     mana: 5
@@ -1302,6 +1310,14 @@ spell_data:
   Minor Physical Protection:
     skill: Warding
     abbrev: MPP
+    mana: 1
+    recast: 1
+    mana_type: holy
+    prep: prepare
+    guild: Cleric
+  Visage:
+    skill: Warding
+    abbrev: VISAGE
     mana: 1
     recast: 1
     mana_type: holy


### PR DESCRIPTION
In relation to #7256 - allows for seamless transition in player yamls once the change is rolled into the game, without breaking if not rolled into all instances at the same time


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds new Cleric spells 'Starry Waters' and 'Visage' to `base-spells.yaml` for seamless player YAML transition.
> 
>   - **New Spells**:
>     - Adds `Starry Waters` spell for Clerics with skill `Augmentation`, mana `5`, recast `1`, and mana type `holy`.
>     - Adds `Visage` spell for Clerics with skill `Warding`, mana `1`, recast `1`, and mana type `holy`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 42a920ba9c2b1f36230b9132b4d500f201507902. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->