### PR TITLE
[script][almanac.lic] Refactor almanac.lic to allow other scripts to invoke it

### DIFF
--- a/almanac.lic
+++ b/almanac.lic
@@ -169,4 +169,3 @@ before_dying do
 end
 $ALMANAC.run
 $ALMANAC = nil
-


### PR DESCRIPTION
This is part 1 of an update to combat-trainer so that it can more cleanly handle almanac usage 'internally' and so that when almanac is used it's used ideally by the same code blocks, instead of in multiple different locations.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `almanac.lic` to introduce `$ALMANAC` for external invocation and replace `passive_loop` with `run` method.
> 
>   - **Behavior**:
>     - Introduces global `$ALMANAC` variable in `almanac.lic` for external script invocation.
>     - Replaces `passive_loop` with `run` method, which is now explicitly called.
>   - **Encapsulation**:
>     - Moves `almanac_sort_by_rate_then_rank` and `skill_with_lowest_mindstate` to private scope.
>   - **Misc**:
>     - Sets `$ALMANAC` to `nil` before and after script execution to ensure clean state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 08cd6251b701d892d475cc571fb5b338199f06e1. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->