### PR TITLE
[script][combat-trainer] Implement almanac usage via exposed method from [alamanc.lic] in combat-trainer

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3283,6 +3283,14 @@ class TrainerProcess
     game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
     DRC.retreat
     game_state.engage_slow
+
+    if Script.running?('almanac') && !$ALMANAC.nil?
+      echo "Almanac process is already running as script, using it's exposed method to invoke almanac usage." if $debug_mode_ct
+      $ALMANAC.use_almanac
+      game_state.wield_whirlwind_offhand if game_state.currently_whirlwinding
+      return
+    end
+
     DRC.bput("get my #{@almanac}", 'You get', 'What were')
     if training_skill
       DRC.bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')


### PR DESCRIPTION
This is part 2 of an update to combat-trainer so that it can more cleanly handle almanac usage 'internally' and so that when almanac is used it's used ideally by the same code blocks, instead of in multiple different locations.

Added check for running almanac process and invoked its method if active.  If not, falls back to old method of using the almanac.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Integrates almanac usage in `combat-trainer.lic` by using the `almanac` script's method if running, with a fallback to the previous method.
> 
>   - **Behavior**:
>     - In `TrainerProcess`, checks if `almanac` script is running and uses `$ALMANAC.use_almanac` if available.
>     - Falls back to previous almanac usage method if `almanac` script is not running.
>   - **Misc**:
>     - Adds debug message when using almanac method from `almanac` script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for d2b08009aadf2f4ee3c7993b056ba07787fae743. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->