### PR TITLE
[script][bescort] Implement entry to Crystal Cavern of Eluned

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -232,6 +232,9 @@ class Bescort
       ],
       [
         { name: 'coffin', regex: /coffin/i, description: "Enter the abyss via coffin for lanky grey lachs, et al." }
+      ],
+      [
+        { name: 'eluned', regex: /eluned/i, description: "Enter the Crystal Cavern of Eluned." }
       ]
     ]
 
@@ -326,6 +329,8 @@ class Bescort
       asketis_mount(args.mode)
     elsif args.coffin
       coffin
+    elsif args.eluned
+      crystal_cavern_of_eluned
     end
   end
 
@@ -2166,6 +2171,15 @@ class Bescort
       DRC.release_invisibility
       DRC.bput('knock gate', 'You knock')
     end
+  end
+
+  def crystal_cavern_of_eluned
+    unless [1192, 51789].include?(Room.current.id)
+      echo 'You are not at the Crystal Cavern of Eluned entrance'
+      return
+    end
+    fput 'meditate'
+    waitfor 'Your simple world explodes into a torrent of color'
   end
 
   def get_fare?(amount, town, room)


### PR DESCRIPTION
Added functionality to enter the Crystal Cavern of Eluned.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to enter the Crystal Cavern of Eluned in `bescort.lic` by introducing a new argument and implementing the `crystal_cavern_of_eluned` method.
> 
>   - **Behavior**:
>     - Adds entry functionality for the Crystal Cavern of Eluned in `bescort.lic`.
>     - New argument `eluned` added to `arg_definitions` for entering the cavern.
>     - Implements `crystal_cavern_of_eluned` method to handle entry by checking room ID and executing `meditate` command.
>   - **Misc**:
>     - Updates `initialize` method to handle `eluned` argument and call `crystal_cavern_of_eluned` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 2271cfae2604b15a847f6b6cd32a4e456b06643b. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->