### PR TITLE
[script][bescort] Enable TOGGLE DISEMBARK support for crossing-leth ferry

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1974,7 +1974,8 @@ class Bescort
     when 'You hand him', 'The Captain gives you a little nod'
       hide?
       waitfor 'reaches the dock and its crew ties the ferry off'
-      move 'go dock'
+      pause 0.5
+      move 'go dock' unless [1904, 957].include?(Room.current.id)
     when 'The ferry has just pulled away from the dock', 'There is no ferry here to go aboard'
       pause 1 while DRRoom.room_objs.find { |x| x =~ /the ferry/ }
       take_xing_ferry(mode)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a conditional pause in `take_xing_ferry` method of `bescort.lic` to handle specific room IDs before moving to the dock.
> 
>   - **Behavior**:
>     - In `bescort.lic`, `take_xing_ferry` method now includes a `pause 0.5` before `move 'go dock'` unless the current room ID is 1904 or 957.
>     - This change ensures the script waits briefly before moving to the dock, handling specific room ID cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 7b0a0fc95751ad637a0fedc268eae74ca4f38717. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->