### PR TITLE
[script][bescort] Enable TOGGLE DISEMBARK support for shard gondola

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1904,7 +1904,8 @@ class Bescort
       move mode
       hide?
       waitfor 'With a soft bump, the gondola comes to a stop at its destination'
-      move 'out'
+      pause .5
+      move 'out' unless [2249, 2904].include?(Room.current.id)
     end
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `bescort.lic`, updated `ride_gondola` to conditionally skip disembarking for specific room IDs, with a pause for timing consistency.
> 
>   - **Behavior**:
>     - In `ride_gondola` method of `bescort.lic`, added a condition to skip `move 'out'` if the current room ID is 2249 or 2904, indicating specific gondola platforms.
>   - **Misc**:
>     - Added a `pause .5` before the conditional `move 'out'` to ensure timing consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for e212d92c5139f1a07d492f19f3b1ba5699f44b90. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->