### PR TITLE
 [script][bescort] Enable TOGGLE DISEMBARK support for shard gondola

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -1904,7 +1904,8 @@ class Bescort
       move mode
       hide?
       waitfor 'With a soft bump, the gondola comes to a stop at its destination'
-      move 'out'
+      pause 0.5
+      move 'out' unless [2249, 2904].include?(Room.current.id)
     end
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add conditional check in `ride_gondola` to prevent moving 'out' at gondola platforms in `bescort.lic`.
> 
>   - **Behavior**:
>     - In `ride_gondola` method, added a check to prevent moving 'out' if the current room ID is 2249 or 2904, ensuring proper handling at north and south platforms.
>   - **Misc**:
>     - Added a `pause 0.5` before moving 'out' in `ride_gondola` to ensure smooth transition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 46120a1f95a6f0fd0f15a6517718a771cab28862. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->