### PR TITLE
[data][spells] Remove MAPP and MPP after renamed in all instances

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1267,14 +1267,6 @@ spell_data:
     harmless: true
     prep: prepare
     guild: Cleric
-  Major Physical Protection:
-    skill: Augmentation
-    abbrev: MAPP
-    mana: 5
-    recast: 1
-    mana_type: holy
-    prep: prepare
-    guild: Cleric
   Starry Waters:
     skill: Augmentation
     abbrev: STAW
@@ -1304,14 +1296,6 @@ spell_data:
     abbrev: MC
     mana: 10
     harmless: false
-    mana_type: holy
-    prep: prepare
-    guild: Cleric
-  Minor Physical Protection:
-    skill: Warding
-    abbrev: MPP
-    mana: 1
-    recast: 1
     mana_type: holy
     prep: prepare
     guild: Cleric


### PR DESCRIPTION
Closes #7256 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `Major Physical Protection` and `Minor Physical Protection` spells from `data/base-spells.yaml` after renaming.
> 
>   - **Spells Removed**:
>     - Remove `Major Physical Protection` and `Minor Physical Protection` from `data/base-spells.yaml`.
>     - These spells were previously renamed, and this PR finalizes their removal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 0554bcc83a12a070fb1b1c5150196f359b0dc045. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->