### PR TITLE
[script][combat-trainer] Pass summoned_weapons_adjective as settings argument to shape_summoned_weapon calls

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4568,6 +4568,9 @@ class GameState
     @summoned_weapons_ingot = settings.summoned_weapons_ingot
     echo("  @summoned_weapons_ingot: #{@summoned_weapons_ingot}") if $debug_mode_ct
 
+    @summoned_weapons_adjective = settings.summoned_weapon_adjective
+    echo("  @summoned_weapons_adjective: #{@summoned_weapons_adjective}") if $debug_mode_ct
+
     @stop_on_bleeding = settings.stop_hunting_if_bleeding
     echo("  @stop_on_bleeding: #{@stop_on_bleeding}") if $debug_mode_ct
 
@@ -5608,7 +5611,7 @@ class GameState
     info = summoned_info(weapon_skill)
 
     DRCS.summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
-    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot) if weapon_already_summoned || DRStats.moon_mage?
+    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, [summoned_weapons_adjective: @summoned_weapons_adjective]) if weapon_already_summoned || DRStats.moon_mage?
     DRCS.turn_summoned_weapon if info['turn']
     DRCS.push_summoned_weapon if info['push']
     DRCS.pull_summoned_weapon if info['pull']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4562,14 +4562,14 @@ class GameState
     end
     echo("  @dual_load: #{@dual_load}") if $debug_mode_ct
 
+    @summoned_weapons_adjective = settings.summoned_weapons_adjective
+    echo("  @summoned_weapons_adjective: #{@summoned_weapons_adjective}") if $debug_mode_ct
+
     @summoned_weapons_element = settings.summoned_weapons_element
     echo("  @summoned_weapons_element: #{@summoned_weapons_element}") if $debug_mode_ct
 
     @summoned_weapons_ingot = settings.summoned_weapons_ingot
     echo("  @summoned_weapons_ingot: #{@summoned_weapons_ingot}") if $debug_mode_ct
-
-    @summoned_weapons_adjective = settings.summoned_weapon_adjective
-    echo("  @summoned_weapons_adjective: #{@summoned_weapons_adjective}") if $debug_mode_ct
 
     @stop_on_bleeding = settings.stop_hunting_if_bleeding
     echo("  @stop_on_bleeding: #{@stop_on_bleeding}") if $debug_mode_ct
@@ -5609,9 +5609,10 @@ class GameState
 
   def prepare_summoned_weapon(weapon_already_summoned)
     info = summoned_info(weapon_skill)
+    adj = JSON.parse("{\"summoned_weapons_adjective\": \"#{@summoned_weapons_adjective}\"}", object_class: OpenStruct)
 
     DRCS.summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
-    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, {'summoned_weapons_adjective': @summoned_weapons_adjective}) if weapon_already_summoned || DRStats.moon_mage?
+    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, adj) if weapon_already_summoned || DRStats.moon_mage?
     DRCS.turn_summoned_weapon if info['turn']
     DRCS.push_summoned_weapon if info['push']
     DRCS.pull_summoned_weapon if info['pull']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -5611,7 +5611,7 @@ class GameState
     info = summoned_info(weapon_skill)
 
     DRCS.summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
-    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, [summoned_weapons_adjective: @summoned_weapons_adjective]) if weapon_already_summoned || DRStats.moon_mage?
+    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, {summoned_weapons_adjective: @summoned_weapons_adjective}) if weapon_already_summoned || DRStats.moon_mage?
     DRCS.turn_summoned_weapon if info['turn']
     DRCS.push_summoned_weapon if info['push']
     DRCS.pull_summoned_weapon if info['pull']

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -5611,7 +5611,7 @@ class GameState
     info = summoned_info(weapon_skill)
 
     DRCS.summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
-    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, {summoned_weapons_adjective: @summoned_weapons_adjective}) if weapon_already_summoned || DRStats.moon_mage?
+    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, {'summoned_weapons_adjective': @summoned_weapons_adjective}) if weapon_already_summoned || DRStats.moon_mage?
     DRCS.turn_summoned_weapon if info['turn']
     DRCS.push_summoned_weapon if info['push']
     DRCS.pull_summoned_weapon if info['pull']

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -348,7 +348,7 @@ class InventoryManager
   end
 
   def add_family_vault
-    check_inventory("rummage vault", /^You rummage through a secure vault/, 'Family', 42)
+    check_inventory("rummage vault", /^You rummage through a vault/, 'Family', 42)
   end
 
   def add_vault_regular_inv

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -26,7 +26,8 @@ class InventoryManager
         { name: 'servant', regex: /servant/i, optional: true, description: "Save shadow servant inventory." },
         { name: 'shop', regex: /shop/i, optional: true, description: "Save your Trader shop inventory." },
         { name: 'pocket', regex: /pocket/i, optional: true, description: "Rummages your secret pocket container for list of items. NOTE: Must be wearing the container." },
-        { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." }
+        { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." },
+        { name: 'vault_family', regex: /vault_family/i, optional: true, description: "Uses VAULT FAMILY to get a list of items." }
       ],
       [
         { name: 'search', regex: /search/i, description: 'Start a search across all characters for specified item.' },
@@ -54,6 +55,8 @@ class InventoryManager
       add_vault_book
     elsif args.vault_standard
       add_vault_standard
+    elsif args.vault_family
+      add_vault_family
     elsif args.vault_regular
       add_vault_regular_inv
     elsif args.family_vault
@@ -291,6 +294,10 @@ class InventoryManager
 
   def add_vault_standard
     check_inventory("vault standard", /^Vault Inventory:/, 'vault')
+  end
+
+  def add_vault_family
+    check_inventory("vault family", /^Vault Inventory:/, 'Family')
   end
 
   def add_vault_book


### PR DESCRIPTION
Top level profile yaml setting `summoned_weapons_adjective` for shaping summoned weapons with custom adjectives needs to be passed in on the shape_summoned_weapon call, as it is expected by the DRCS function. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pass `summoned_weapons_adjective` as a settings argument to `shape_summoned_weapon` in `GameState` to meet `DRCS` function expectations.
> 
>   - **Behavior**:
>     - Pass `summoned_weapons_adjective` as a settings argument to `shape_summoned_weapon` in `prepare_summoned_weapon()` in `GameState`.
>     - Initialize `@summoned_weapons_adjective` from settings and log it if `$debug_mode_ct` is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for f7b6d3235ae79fe6ab4805733fc73505362e7297. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->