### PR TITLE
[script][combat-trainer] Add custom spell prep arg to DRCA.prepare call

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2364,7 +2364,7 @@ class SpellProcess
     game_state.casting_regalia = data['abbrev'].casecmp('REGAL').zero?
 
     Flags.reset('ct-shock-warning')
-    DRCA.prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
+    DRCA.prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'], @settings['custom_spell_prep'])
 
     if Flags['ct-shock-warning'] && !game_state.is_permashocked?
       DRC.message('Dropping spell: Got shock warning.')


### PR DESCRIPTION
Top level profile yaml setting `custom_spell_prep` for preparing spells in combat with customized/altered prep messages needs to be passed in on the DRCA.prepare call, as it is expected by the function.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `@settings['custom_spell_prep']` argument to `DRCA.prepare?` call in `SpellProcess` class to support custom spell preparation messages.
> 
>   - **Behavior**:
>     - Add `@settings['custom_spell_prep']` argument to `DRCA.prepare?` call in `SpellProcess` class in `combat-trainer.lic` to support custom spell preparation messages.
>   - **Misc**:
>     - No other changes or files affected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 42c4e91397a6d7f7d6d8f582edc53d10c853a8b5. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->