### PR TITLE
Revert "[script][combat-trainer] Add custom spell prep arg to DRCA.prepare call"

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2364,7 +2364,7 @@ class SpellProcess
     game_state.casting_regalia = data['abbrev'].casecmp('REGAL').zero?
 
     Flags.reset('ct-shock-warning')
-    DRCA.prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'], @settings['custom_spell_prep'])
+    DRCA.prepare?(data['abbrev'], data['mana'], data['symbiosis'], command, data['tattoo_tm'], data['runestone_name'], data['runestone_tm'])
 
     if Flags['ct-shock-warning'] && !game_state.is_permashocked?
       DRC.message('Dropping spell: Got shock warning.')


### PR DESCRIPTION
Reverts elanthia-online/dr-scripts#7267

We need to align this better with a required minimum lich version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts addition of custom spell preparation argument in `DRCA.prepare` call in `combat-trainer.lic` for Lich version compatibility.
> 
>   - **Revert Change**:
>     - Reverts addition of `@settings['custom_spell_prep']` argument in `DRCA.prepare?` call in `combat-trainer.lic`.
>   - **Reason**:
>     - Ensures compatibility with a minimum required Lich version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 116e37d1acdd2e6403fb142c16638594c284db05. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->