### PR TITLE
Forest of the Night additions - Cougars and Amalgams

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -528,6 +528,14 @@ hunting_zones:
   - 10053
   - 10052
   - 10051
+  # https://elanthipedia.play.net/Cougar                                   30-49
+  cougars_forest_of_night:
+  - 9352
+  - 9353
+  - 9354
+  - 9355
+  - 9356
+  - 9357
   # https://elanthipedia.play.net/Grass_eel                                25-50
   grass_eels:
   - 1492
@@ -637,6 +645,14 @@ hunting_zones:
   - 8475
   - 8476
   - 8477
+  # https://elanthipedia.play.net/Ichorous_ossein_amalgam			70-90
+  ossein_amalgams:
+  - 10041
+  - 10042
+  - 10043
+  - 10044
+  - 10045
+  - 10046
   # new mob - critter level 18-22                                          85-130
   greater_water_sprites:
   - 8465


### PR DESCRIPTION
Added rooms for cougars and the new amalgams. 10040 was left off for amalgams since that room would likely be problematic as is if someone was hunting cougars who couldn't handle amalgams.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds new hunting zones for cougars and ossein amalgams in `base-hunting.yaml`, excluding a problematic room for amalgams.
> 
>   - **Behavior**:
>     - Adds `cougars_forest_of_night` hunting zone with rooms 9352 to 9357 for cougars.
>     - Adds `ossein_amalgams` hunting zone with rooms 10041 to 10046 for ossein amalgams.
>     - Excludes room 10040 from `ossein_amalgams` to prevent issues with cougar hunters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 320adc12aa82b3180f5608724e1a5bda5ae86f67. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->