### PR TITLE
[scripts][exp-monitor] Preparing for moving to core-lich

### DIFF
--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -2,6 +2,13 @@ no_pause_all
 no_kill_all
 silence_me
 
+# Check if the new DRExpMonitor module is available (Lich 5 drinfomon)
+if defined?(DRExpMonitor)
+  respond "exp-monitor.lic is deprecated - use ';display expgains' command instead"
+  respond "The new DRExpMonitor module is built into drinfomon"
+  exit
+end
+
 UserVars.echo_exp = true
 UserVars.echo_exp_time ||= 1
 DRSkill.gained_skills.clear


### PR DESCRIPTION
As per title. Once https://github.com/elanthia-online/lich-5/pull/1154 is merged and we move to a required min-version that includes it, we'll delete this script.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a deprecation check in `exp-monitor.lic` to advise using `DRExpMonitor` if available, preparing for migration to `core-lich`.
> 
>   - **Behavior**:
>     - Adds a check in `exp-monitor.lic` to see if `DRExpMonitor` is defined.
>     - If `DRExpMonitor` is available, advises using `';display expgains'` and exits the script.
>   - **Deprecation**:
>     - Marks `exp-monitor.lic` as deprecated in favor of the `DRExpMonitor` module built into `drinfomon`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 620409259d8f297d10844fa32f87cca8ced03451. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->