### PR TITLE
Update sew.lic

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -312,7 +312,7 @@ class Sew
       DRCC.stow_crafting_item('stamp', @bag, @belt)
     end
 
-    DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
+    DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) unless DRC.right_hand =~ @noun
     case @finish
     when /log/
       DRCC.logbook_item('outfitting', @noun, @bag)


### PR DESCRIPTION
Added unless DRC.right_hand =~ @noun to line 315 to ensure finish does not prematurely stow the @noun, unintentionally bypassing the @finish.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds condition to prevent premature stowing of `@noun` in `finish` method of `sew.lic`.
> 
>   - **Behavior**:
>     - Adds condition `unless DRC.right_hand =~ @noun` to `DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)` in `finish` method to prevent premature stowing of `@noun`.
>   - **Misc**:
>     - Ensures `@finish` process is not bypassed unintentionally.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for b24899d66c0466dde969f0d9b685faf23bbf486d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->