### PR TITLE
Fixed Premature Finishing...

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -313,7 +313,7 @@ class Sew
     end
 
     DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) unless DRC.right_hand.include?(@noun)
-	  DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) unless DRC.left_hand.include?(@noun)
+    DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) unless DRC.left_hand.include?(@noun)
 
     case @finish
     when /log/


### PR DESCRIPTION
Issue: Script was overriding @finish = "hold", storing the item in the @bag by the end of the script, due to  the methods :finish and :lift_or_stow_feet. 

Corrected by adding/modifying  if/unless conditions.

Also the =~ was having issues as the validation condition.

Corrected by using the 'include?(@noun)'.

Also added a stow right hand to :finish to round things out. 

Script will also now correctly clean up after using enhancements on an object as a result.