### PR TITLE
[scripts][dependency] Remove the concept of min Ruby version requirement

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -261,7 +261,7 @@ class ScriptManager
     # Setting Settings['lich_fork_sha'] to nil if using lich5. This setting isn't used anymore.
 
     Settings['base_versions'] ||= {}
-    
+
     @add_autos = []
     @remove_autos = []
     update_autostarts


### PR DESCRIPTION
We don't need this as we have min-Lich version requirements, which themselves have min-Ruby requirements. 