### PR TITLE
Add common-arcana to the obsolete script notification in dependency.lic

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1573,7 +1573,7 @@ def format_yaml_name(name)
 end
 
 DR_OBSOLETE_SCRIPTS = %w[
-  bootstrap common-crafting common-healing-data common-healing common-items
+  bootstrap common-arcana common-crafting common-healing-data common-healing common-items
   common-money common-moonmage common-summoning common-theurgy
   common-travel common-validation common drinfomon equipmanager
   events slackbot spellmonitor


### PR DESCRIPTION
Adding common-arcana to the obsolete scripts notification
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `common-arcana` to obsolete script notifications in `dependency.lic`.
> 
>   - **Behavior**:
>     - Adds `common-arcana` to `DR_OBSOLETE_SCRIPTS` array in `dependency.lic` for obsolete script notification.
>   - **Misc**:
>     - No other changes or additions in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 88ff8c53a76210cc6fd9a3d047346c8555d5dcbe. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->