### PR TITLE
[scripts][dependency]Add gate for initial commands for drinfomon

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1573,7 +1573,6 @@ def format_yaml_name(name)
 end
 
 DR_OBSOLETE_SCRIPTS = %w[
-
   events slackbot spellmonitor
   common-travel common-validation common drinfomon equipmanager
   common-money common-moonmage common-summoning common-theurgy common-arcana


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `dependency.lic` to handle obsolete scripts, improve DRInfomon startup, and update minimum Lich version to `5.13.6`.
> 
>   - **Behavior**:
>     - Update minimum Lich version to `5.13.6` in `dependency.lic`.
>     - Add `warn_obsolete_scripts` function to notify users of obsolete scripts in `dependency.lic`.
>     - Modify DRInfomon startup process to wait for `startup_complete?` or issue commands if not completed in time.
>   - **Functions**:
>     - Rename `dr_blocked_script?` to `dr_obsolete_script?` and update logic to handle obsolete scripts.
>     - Add `warn_obsolete_scripts` to iterate over `DR_OBSOLETE_SCRIPTS` and notify users.
>   - **Misc**:
>     - Update `DEPENDENCY_VERSION` to `2.0.20` in `dependency.lic`.
>     - Remove deprecated Lich version check in `ScriptManager` initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 5a480775d275fff26be99f0d026f61126a2fa37f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->