### PR TITLE
[scripts][dependency]Warn on custom_require.call obsolete scripts

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#dependency
 =end
 
-$DEPENDENCY_VERSION = '2.0.20'
+$DEPENDENCY_VERSION = '2.0.21'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/f8ne99pVva'
 $MIN_LICH_VERSION = '5.13.6'
 
@@ -1582,8 +1582,18 @@ DR_OBSOLETE_SCRIPTS = %w[
 def dr_obsolete_script?(name)
   script_name = name.to_s.sub(/\.lic$/, '')
   return false unless DR_OBSOLETE_SCRIPTS.include?(script_name)
-  path = File.exist?(File.join(SCRIPT_DIR, 'custom', "#{script_name}.lic")) ? 'scripts/custom' : 'scripts'
-  _respond Lich::Messaging.monsterbold("--- Lich: WARNING: '#{script_name}' (#{path}/#{script_name}.lic) is obsolete and not recommended. It may cause problems. If you don't know what to do here, please seek help in the DR Lich Discord.")
+
+  custom_path = File.join(SCRIPT_DIR, 'custom', "#{script_name}.lic")
+  scripts_path = File.join(SCRIPT_DIR, "#{script_name}.lic")
+
+  if File.exist?(custom_path)
+    _respond Lich::Messaging.monsterbold("--- Lich: WARNING: '#{script_name}.lic' is obsolete and should be deleted from scripts/custom. It is no longer needed and may cause problems.")
+  elsif File.exist?(scripts_path)
+    _respond Lich::Messaging.monsterbold("--- Lich: WARNING: '#{script_name}.lic' is obsolete and should be deleted from #{SCRIPT_DIR}. It is no longer needed and may cause problems.")
+  end
+
+  caller_name = Script.current.name rescue 'unknown'
+  _respond Lich::Messaging.monsterbold("--- Lich: WARNING: '#{caller_name}' references obsolete script '#{script_name}'. The calling script should be updated to remove this dependency.")
   false
 end
 


### PR DESCRIPTION
## Improve obsolete script warnings in dependency

### Summary
- `dr_obsolete_script?` now distinguishes between an obsolete file existing on disk vs. a script referencing an obsolete dependency by name
- When the file exists (in `scripts/` or `scripts/custom/`), warns the user to delete it
- Always warns which calling script holds the stale reference, so users know what to update
- When both conditions are true, both warnings are emitted
- Previously, the warning implied the file existed and should be deleted even when only a `custom_require.call` referenced it and no file was present

### Test plan
- [x] Verify a script calling `custom_require.call('common')` where `common.lic` exists in `scripts/` produces two warnings: one to delete the file, one identifying the calling script
- [x] Verify the same call where `common.lic` exists in `scripts/custom/` warns to delete from `scripts/custom` plus the calling script warning
- [x] Verify the same call where no `common.lic` file exists anywhere produces only the calling script warning
- [x] Run `rspec spec/dependency/warn_obsolete_blocked_scripts_spec.rb` — 42 examples, 0 failures

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves `dr_obsolete_script?` warnings in `dependency.lic` to distinguish between obsolete files on disk and scripts referencing obsolete dependencies by name, aiding users in script management.
> 
>   - **Behavior**:
>     - `dr_obsolete_script?` in `dependency.lic` now distinguishes between obsolete files on disk and scripts referencing obsolete dependencies by name.
>     - Warns users to delete obsolete files if they exist in `scripts/` or `scripts/custom/`.
>     - Always warns which calling script references the obsolete script, aiding users in updating dependencies.
>     - Emits both warnings if both conditions are met.
>   - **Misc**:
>     - Updates `$DEPENDENCY_VERSION` to '2.0.21'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for c48d6f841f344b05f0936e23cb2617766b6dde40. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->