### PR TITLE
[scripts][plantheal]Fixing two user-reported bugs

### DIFF
--- a/plantheal.lic
+++ b/plantheal.lic
@@ -392,31 +392,52 @@ class PlantHeal
     end
   end
 
+  MAX_BACKFIRE_RETRIES = 2
+
   def cast_ev_manual(mana)
-    # If we have a separate prep room, go there first
-    origin = nil
-    if @preproom.nonzero?
-      origin = @plantroom
-      DRCT.walk_to(@preproom)
+    attempts = 0
+
+    loop do
+      # If we have a separate prep room, go there first
+      origin = nil
+      if @preproom.nonzero?
+        origin = @plantroom
+        DRCT.walk_to(@preproom)
+      end
+
+      get_focus
+      DRCA.prepare?('EV', mana)
+      invoke_focus
+      waitrt?
+      sleep @ev_extra_wait
+      stow_focus
+
+      # If we prepped elsewhere, walk back to cast
+      DRCT.walk_to(origin) if origin
+
+      result = DRC.bput('cast',
+                        'You gesture',
+                        'You strain, but are too mentally fatigued',
+                        'You aren\'t harnessing any mana',
+                        'You lose your concentration',
+                        'backfires',
+                        'Roundtime')
+      waitrt?
+
+      if result =~ /backfires/i
+        attempts += 1
+        if attempts > MAX_BACKFIRE_RETRIES
+          DRC.message("**EV backfired #{attempts} times -- giving up.**")
+          return false
+        end
+        DRC.message("**EV backfired** (attempt #{attempts}/#{MAX_BACKFIRE_RETRIES + 1}). Re-preparing...")
+        pause 1
+        next
+      end
+
+      pause 3
+      return result =~ /You gesture|Roundtime/i ? true : false
     end
-
-    get_focus
-    DRCA.prepare?('EV', mana)
-    invoke_focus
-    waitrt?
-    sleep @ev_extra_wait
-    stow_focus
-
-    # If we prepped elsewhere, walk back to cast
-    DRCT.walk_to(origin) if origin
-
-    DRC.bput('cast',
-             'You gesture',
-             'You strain, but are too mentally fatigued',
-             'You aren\'t harnessing any mana',
-             'You lose your concentration',
-             'Roundtime')
-    pause 3
   end
 
   def cast_for_others
@@ -523,7 +544,10 @@ class PlantHeal
 
     # Pre-hug check: bleeding, threshold, hug_count, wounds, EV, healing spells, plant noun
     noun = pre_hug_check
-    return HugResult.new(0, :stopped_early) unless noun
+    unless noun
+      DRC.message("pre_hug_check state: bleeding=#{bleeding?} hugs=#{@total_hugs}/#{@hug_count} empathy=#{DRSkill.getxp('Empathy')}/#{@threshold} plant=#{plant_noun_in_room.inspect}")
+      return HugResult.new(0, :stopped_early)
+    end
 
     result = DRC.bput("hug #{noun}", *HUG_RESPONSES)
     case result


### PR DESCRIPTION
## Handle EV backfires in `cast_ev_manual` and improve `stopped_early` diagnostics

### Problem

`cast_ev_manual` matched its `DRC.bput('cast', ...)` against five patterns, none of
which covered backfire messages (`Your spell barely backfires.`). When a backfire
occurred, bput timed out after 15 seconds with no match, the script assumed no plant
was created, and exited — wasting all the prep/invoke/wait time with no retry.

Separately, when `pre_hug_check` returned false and the script exited with
`:stopped_early`, the exit message said "check logs above for details" but the
specific reason (threshold, hug_count, bleeding, plant gone) could scroll past or
be hard to find. This made it difficult to diagnose why the script stopped without
hugging.

### Changes

**Backfire detection and retry in `cast_ev_manual`** (`plantheal.lic:395-441`)

- Added `'backfires'` to the bput match patterns — eliminates the 15-second timeout.
- Wrapped the full prepare/invoke/cast cycle in a retry loop. On backfire, the method
  re-prepares and re-casts (up to `MAX_BACKFIRE_RETRIES = 2` retries, 3 total attempts).
- Returns `true`/`false` so callers can distinguish success from failure. Existing
  callers don't check the return value, which is fine — if all retries fail, the
  downstream "no plant in room" flow still handles it gracefully.

**Diagnostic dump on `stopped_early` exit** (`plantheal.lic:547-549`)

- When `pre_hug_check` returns false and `hug_plant_once` is about to return
  `:stopped_early`, a single diagnostic line is now logged with the current state:
  `bleeding`, `hugs` (current/max), `empathy` (current/threshold), and `plant`
  (noun or nil). This makes the exit reason visible right next to the exit message
  without needing to scroll back through the log.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes EV backfire handling and improves diagnostics for early exits in `plantheal.lic`.
> 
>   - **Backfire Handling in `cast_ev_manual`**:
>     - Added `'backfires'` to `DRC.bput` match patterns to prevent 15-second timeout.
>     - Implemented retry loop for backfires, allowing up to 2 retries (3 attempts total).
>     - Returns `true`/`false` to indicate success or failure, maintaining compatibility with existing callers.
>   - **Improved Diagnostics on `stopped_early`**:
>     - Logs diagnostic line with `bleeding`, `hugs`, `empathy`, and `plant` state when `pre_hug_check` fails.
>     - Provides immediate context for early exit without needing to scroll through logs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 343c05b2094c8270e7c66a73c85a43f83609c7c3. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->