### PR TITLE
[scripts][transfer-items] Update coin handling

### DIFF
--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -38,6 +38,11 @@ class ItemTransfer
       end
       # Attempt to get the item from the source container.
       if DRCI.get_item(item, source)
+        # Coins are automatically picked up and added to coin purse.
+        # Skip trying to transfer them to destination container.
+        if item =~ /coins?/i
+          next
+        end
         if destination == 'trash'
           trash_item(item)
         else


### PR DESCRIPTION
Summary - The script now properly handles coins when transferring items between containers.  Currently when the script attempts to transfer coins from the source container, it gives some messaging that says "What are your referring to?".  This happens because grabbing coins automatically puts the on your person.  So added a check to see if coins were grabbed, and skips trying to stow them.  Now the error message doesn't show up.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a check in `transfer_items` to skip transferring coins, preventing an error message.
> 
>   - **Behavior**:
>     - In `transfer_items` method of `ItemTransfer`, added check to skip transferring coins, which are automatically added to the coin purse.
>     - Prevents error message "What are you referring to?" when attempting to transfer coins.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 10f78418dc8f27de2cc32eafc2e83879c334eda0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->