### PR TITLE
Add lengthy grass eels in shard to base-hunting.yaml.

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1415,7 +1415,7 @@ hunting_zones:
 ##########                           ILITHI                           ##########
 ##########                                                            ##########
 ################################################################################
-  # https://elanthipedia.play.net/Kobold                                   35-50
+  # https://elanthipedia.play.net/Kobold                                  35-50
   shard_kobolds:
   - 2739
   - 2744
@@ -1423,6 +1423,15 @@ hunting_zones:
   - 2763
   - 2764
   - 2740
+  # https://elanthipedia.play.net/Lengthy_grass_eel                       45-60
+  lengthy_grass_eels:
+  - 51789
+  - 51790
+  - 51791
+  - 51792
+  - 51793
+  - 51794
+  - 51795
   # https://elanthipedia.play.net/Snippet                                 70-100
   # Construct
   snippets:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'Lengthy grass eels' hunting zone to `base-hunting.yaml` with rank range 45-60.
> 
>   - **Behavior**:
>     - Adds a new hunting zone `lengthy_grass_eels` for 'Lengthy grass eels' in `base-hunting.yaml`.
>     - Includes room IDs 51789 to 51795.
>     - Sets rank range to 45-60.
>   - **Misc**:
>     - Fixes minor alignment issue in comment for `shard_kobolds`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for ae33986412ac379059b4c1f09873d83dc34833a2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->