### PR TITLE
[script][sew] Reconciliation, Bug Fixes, and Robustness Improvements

### DIFF
--- a/sew.lic
+++ b/sew.lic
@@ -2,6 +2,8 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#sew
 =end
 
+require 'time'
+
 class Sew
   def initialize
     @settings = get_settings
@@ -16,7 +18,7 @@ class Sew
     arg_definitions = [
       [
         { name: 'finish', options: %w[hold log stow trash], description: 'What to do with the finished item.' },
-        { name: 'type', options: %w[knitting sewing leather], description: 'What tailoring type is this item.' }, # no longer in use, being removed next edit. Have to change the calls from other scripts.
+        { name: 'type', options: %w[knitting sewing leather], description: 'What tailoring type is this item.' },
         { name: 'chapter', regex: /\d+/i, variable: true, description: 'Chapter containing the item.' },
         { name: 'recipe_name', display: 'recipe name', regex: /^[A-z\s\-']+$/i, variable: true, description: 'Name of the recipe, wrap in double quotes if this is multiple words.' },
         { name: 'material', regex: /\w+/i, variable: true, description: 'Type of material to use.' },
@@ -43,7 +45,7 @@ class Sew
 
     args = parse_args(arg_definitions)
 
-    @finish = args.finish
+    @finish = args.finish || 'hold'
     args.recipe_name.sub!('lighten', 'tailored armor lightening')
     args.recipe_name.sub!('seal', 'tailored armor sealing')
     args.recipe_name.sub!('reinforce', 'tailored armor reinforcing')
@@ -52,7 +54,7 @@ class Sew
     @noun = args.noun
     @knit = args.knit
     @mat_type = args.material
-    @chapter = args.chapter.nil? ? 1 : args.chapter.to_i # chapter 5 for enhancements
+    @chapter = args.chapter.nil? ? 1 : args.chapter.to_i
     @info = get_data('crafting')['tailoring'][@hometown]
     @instructions = args.instructions
     @cloth = %w[silk wool burlap cotton felt linen electroweave steelsilk arzumodine bourde dergatine dragonar faeweave farandine imperial jaspe khaddar ruazin titanese zenganne]
@@ -61,8 +63,10 @@ class Sew
 
     Flags.add('sew-assembly', 'ready to be .* with some (small|large) cloth (padding)', 'another finished \S+ shield (handle)', 'another finished wooden (hilt|haft)', 'another finished (long|short|small|large) leather (cord|backing)', 'another finished (small|large) cloth (padding)', 'another finished (long|short) wooden (pole)')
     Flags.add('sew-done', 'The .* shows improved', 'Applying the final touches', 'The .* shows a slightly reduced weight', /^You realize that cannot be repaired, and stop/)
+    Flags.add('sew-rental-warning', 'Your rental time is almost up')
 
     if args.resume
+      Lich::Messaging.msg('plain', "Resuming work on #{@noun} (finish mode: #{@finish}).")
       if DRCI.in_hands?('knitting needles')
         @home_command = 'knit my needles'
         command = 'analyze my knitting needles'
@@ -80,6 +84,7 @@ class Sew
       DRCC.check_consumables('thread', @info['stock-room'], 6, @bag, @bag_items, @belt) unless args.skip
     end
 
+    check_rental_status
     work(prep)
   end
 
@@ -87,10 +92,15 @@ class Sew
     if DRCI.in_right_hand?(item)
       DRC.bput('swap', 'You move', 'You have nothing')
     else
-      DRC.message('***Please hold the item or material you wish to work on.***')
+      Lich::Messaging.msg('bold', "Please hold the item or material you wish to work on. Expected '#{item}' in right hand.")
       magic_cleanup
       exit
     end
+  end
+
+  def list_at_feet
+    atfeet = Lich::Util.issue_command('inv atfeet', /All of your items lying at your feet/, /Use INVENTORY HELP for more options/, usexml: false)
+    Lich::Messaging.msg('plain', "Items at feet: #{atfeet.join(', ')}") if atfeet&.any?
   end
 
   def prep
@@ -104,12 +114,12 @@ class Sew
       DRCC.find_recipe2(@chapter, @recipe_name, @settings.master_crafting_book, 'tailoring')
     else
       DRCC.get_crafting_item('tailoring book', @bag, @bag_items, @belt)
-      echo('*** You will need to upgrade to a journeyman or master book before 176 ranks! ***') if DRSkill.getrank('Outfitting') == 175
+      Lich::Messaging.msg('bold', 'You will need to upgrade to a journeyman or master book before 176 ranks!') if DRSkill.getrank('Outfitting') == 175
       DRCC.find_recipe2(@chapter, @recipe_name)
       DRCC.stow_crafting_item('tailoring book', @bag, @belt)
     end
 
-    if @chapter == 5 || @knit # knitting
+    if @knit || @chapter == 5 # knitting
       DRCC.get_crafting_item('yarn', @bag, @bag_items, @belt)
       check_hand('yarn') unless DRCI.in_left_hand?('yarn')
       swap_tool('knitting needles')
@@ -150,28 +160,31 @@ class Sew
   def assemble_part
     while Flags['sew-assembly']
       tool = DRC.right_hand
-      DRCC.stow_crafting_item(tool, @bag, @belt)
+      DRCC.stow_crafting_item(tool, @bag, @belt) if tool
       part = Flags['sew-assembly'].to_a[1..-1].join(' ')
       Flags.reset('sew-assembly')
       DRCC.get_crafting_item(part, @bag, @bag_items, @belt)
       DRC.bput("assemble my #{@noun} with my #{part}", 'affix it securely in place', 'and tighten the pommel to secure it', 'carefully mark where it will attach when you continue crafting')
-      swap_tool(tool)
+      swap_tool(tool) if tool
     end
   end
 
   def lift_or_stow_feet
     if DRCI.lift?
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand && !DRC.right_hand.include?(@noun.tr('.', ' '))
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if DRC.left_hand && !DRC.left_hand.include?(@noun.tr('.', ' '))
+      right = DRC.right_hand
+      left = DRC.left_hand
+      DRCC.stow_crafting_item(right, @bag, @belt) if right && !right.include?(@noun.tr('.', ' '))
+      DRCC.stow_crafting_item(left, @bag, @belt) if left && !left.include?(@noun.tr('.', ' '))
     else
       DRC.bput('stow feet', 'You put', 'Stow what')
     end
   end
 
   def work(command)
-    DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/) if @cube
+    DRC.bput("touch my #{@cube}", /^Warm vapor swirls around your head in a misty halo/, /^A thin cloud of vapor manifests with no particular effect./, /^Touch what/, /^You reach out and touch/) if @cube
     loop do
       DRCA.crafting_magic_routine(@settings)
+      renew_rental if Flags['sew-rental-warning']
       assemble_part
       result = DRC.bput(command,
                         'a slip knot in your yarn',
@@ -212,9 +225,15 @@ class Sew
                         'You need another',
                         'You untie and discard',
                         /^The .* needles must be cast to finish binding the knit yarn\.$/,
+                        /You need a larger amount of material to continue crafting/,
                         /^Roundtime/,
+                        /^You need a free hand to do that/,
                         /^You realize that cannot be repaired, and stop/)
       case result
+      when /You need a larger amount of material to continue crafting/
+        Lich::Messaging.msg('bold', "Not enough material to continue crafting #{@noun}. Exiting.")
+        magic_cleanup
+        exit
       when 'dimensions appear to have shifted and could benefit from some remeasuring', 'dimensions changed while working on it'
         swap_tool('yardstick')
         @home_tool = 'sewing needles'
@@ -236,6 +255,7 @@ class Sew
         swap_tool('sewing needles')
         command = "push my #{@noun} with my sewing needles"
       when 'What were you referring', 'I could not find what you were'
+        list_at_feet
         lift_or_stow_feet
         if command.include?('wax')
           DRCC.check_consumables('wax', @info['tool-room'], 10, @bag, @bag_items, @belt)
@@ -289,7 +309,7 @@ class Sew
         command = 'pull my needles'
       when 'You untie and discard'
         command = 'knit my yarn with my knitting needles'
-      when /^Roundtime/, /^You realize that cannot be repaired, and stop/
+      when /^Roundtime/, /^You realize that cannot be repaired, and stop/, /^You need a free hand to do that/
         waitrt?
         finish if Flags['sew-done']
         swap_tool(@home_tool) unless @home_tool.nil?
@@ -299,7 +319,7 @@ class Sew
   end
 
   def swap_tool(next_tool, skip = false)
-    return if DRC.right_hand.include?(next_tool)
+    return if next_tool.nil? || DRC.right_hand&.include?(next_tool)
 
     DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
     DRCC.get_crafting_item(next_tool, @bag, @bag_items, @belt, skip)
@@ -312,8 +332,10 @@ class Sew
       DRCC.stow_crafting_item('stamp', @bag, @belt)
     end
 
-    DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) unless DRC.right_hand&.include?(@noun.tr('.', ' '))
-    DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) unless DRC.left_hand&.include?(@noun.tr('.', ' '))
+    right = DRC.right_hand
+    left = DRC.left_hand
+    DRCC.stow_crafting_item(right, @bag, @belt) if right && !right.include?(@noun.tr('.', ' '))
+    DRCC.stow_crafting_item(left, @bag, @belt) if left && !left.include?(@noun.tr('.', ' '))
 
     case @finish
     when /log/
@@ -323,27 +345,69 @@ class Sew
     when /trash/
       DRCI.dispose_trash(@noun, @worn_trashcan, @worn_trashcan_verb)
     when /hold/
-      DRC.message("#{@noun} Complete")
+      Lich::Messaging.msg('bold', "#{@noun} complete — holding in hand.")
     end
 
     lift_or_stow_feet
     magic_cleanup
 
+    Lich::Messaging.msg('plain', "Sew script finished (#{@noun}, finish: #{@finish}).")
     exit
   end
-end
 
-def magic_cleanup
-  return if @settings.crafting_training_spells.empty?
+  def magic_cleanup
+    return if @settings.crafting_training_spells.empty?
 
-  DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-  DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
-  DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+    DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+    DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+    DRC.bput('release symb', "But you haven't", 'You release', 'Repeat this command')
+  end
+
+  def check_rental_status
+    result = DRC.bput('read notice',
+                      /It will expire (.+)\./,
+                      'I could not find',
+                      'What were you referring to')
+    return unless result =~ /It will expire (.+)\./
+
+    expire_str = Regexp.last_match(1)
+    expire_str_normalized = expire_str.sub(' ET ', ' -0500 ')
+    expire_time = Time.parse(expire_str_normalized)
+    minutes_remaining = ((expire_time - Time.now) / 60).to_i
+
+    if minutes_remaining < 10
+      Lich::Messaging.msg('bold', "*** RENTAL LOW (#{minutes_remaining} min) — AUTO-RENEWING ***")
+      renew_rental
+    elsif minutes_remaining < 20
+      Lich::Messaging.msg('bold', "*** Rental has #{minutes_remaining} minutes remaining ***")
+    end
+  rescue ArgumentError
+    Lich::Messaging.msg('bold', "Could not parse rental expiry time: #{expire_str}")
+  end
+
+  def renew_rental
+    Lich::Messaging.msg('bold', '*** RENTAL EXPIRING — AUTO-RENEWING ***')
+    Flags.reset('sew-rental-warning')
+    case DRC.bput('mark notice',
+                  'You mark the notice',
+                  'renewed your rental',
+                  'extends your rental',
+                  "You don't have enough",
+                  'I could not find')
+    when "You don't have enough"
+      Lich::Messaging.msg('bold', '*** INSUFFICIENT FUNDS TO RENEW RENTAL ***')
+    when 'I could not find'
+      Lich::Messaging.msg('bold', '*** COULD NOT FIND NOTICE — CHECK LOCATION ***')
+    else
+      Lich::Messaging.msg('bold', '*** RENTAL RENEWED ***')
+    end
+  end
 end
 
 before_dying do
   Flags.delete('sew-assembly')
-  Flags.delete('sealing-done')
+  Flags.delete('sew-done')
+  Flags.delete('sew-rental-warning')
 end
 
 Sew.new

--- a/spec/sew_spec.rb
+++ b/spec/sew_spec.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require 'time'
 
 # Load test harness which provides mock game objects
 load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
@@ -56,6 +57,8 @@ module DRCC
   def self.logbook_item(*_args); end
 
   def self.get_crafting_item(*_args); end
+
+  def self.check_consumables(*_args); end
 end
 
 module DRCI
@@ -72,17 +75,36 @@ module DRCI
   def self.in_right_hand?(*_args)
     false
   end
+
+  def self.in_hands?(*_args)
+    false
+  end
 end
 
 module DRCA
   def self.crafting_magic_routine(*_args); end
 end
 
+module DRSkill
+  def self.getrank(*_args)
+    0
+  end
+end
+
+module Lich
+  module Messaging
+    def self.msg(*_args); end
+  end
+
+  module Util
+    def self.issue_command(*_args)
+      []
+    end
+  end
+end
+
 # Load Sew class definition (without executing top-level code)
 load_lic_class('sew.lic', 'Sew')
-
-# Define magic_cleanup (top-level method called by Sew#finish)
-def magic_cleanup; end
 
 RSpec.configure do |config|
   config.before(:each) do
@@ -99,22 +121,120 @@ RSpec.describe Sew do
     sew.instance_variable_set(:@noun, 'rucksack')
     sew.instance_variable_set(:@bag, 'duffel bag')
     sew.instance_variable_set(:@belt, nil)
+    sew.instance_variable_set(:@bag_items, [])
     sew.instance_variable_set(:@stamp, false)
     sew.instance_variable_set(:@finish, 'log')
     sew.instance_variable_set(:@worn_trashcan, nil)
     sew.instance_variable_set(:@worn_trashcan_verb, nil)
     sew.instance_variable_set(:@settings, OpenStruct.new(crafting_training_spells: []))
+    sew.instance_variable_set(:@info, { 'tool-room' => 1, 'stock-room' => 2 })
 
     # Prevent actual exit and stub helper methods
     allow(sew).to receive(:exit)
-    allow(sew).to receive(:magic_cleanup)
-    allow(sew).to receive(:lift_or_stow_feet)
+    allow(sew).to receive(:waitrt?)
   end
 
   # ===========================================================================
-  # #finish — stow guards and logbook bundling
+  # #swap_tool — nil guards and tool swapping
+  # ===========================================================================
+  describe '#swap_tool' do
+    context 'when right hand is nil (empty)' do
+      before { $right_hand = nil }
+
+      it 'does not crash and stows/gets the new tool' do
+        expect(DRCC).to receive(:stow_crafting_item).with(nil, 'duffel bag', nil)
+        expect(DRCC).to receive(:get_crafting_item).with('scissors', 'duffel bag', [], nil, false)
+
+        sew.send(:swap_tool, 'scissors')
+      end
+    end
+
+    context 'when next_tool is nil' do
+      before { $right_hand = 'sewing needles' }
+
+      it 'returns early without stowing or getting' do
+        expect(DRCC).not_to receive(:stow_crafting_item)
+        expect(DRCC).not_to receive(:get_crafting_item)
+
+        sew.send(:swap_tool, nil)
+      end
+    end
+
+    context 'when the desired tool is already in right hand' do
+      before { $right_hand = 'sewing needles' }
+
+      it 'returns early without stowing or getting' do
+        expect(DRCC).not_to receive(:stow_crafting_item)
+        expect(DRCC).not_to receive(:get_crafting_item)
+
+        sew.send(:swap_tool, 'sewing needles')
+      end
+    end
+
+    context 'when right hand holds a partial match' do
+      before { $right_hand = 'steel sewing needles' }
+
+      it 'returns early because right_hand includes the tool name' do
+        expect(DRCC).not_to receive(:stow_crafting_item)
+        expect(DRCC).not_to receive(:get_crafting_item)
+
+        sew.send(:swap_tool, 'sewing needles')
+      end
+    end
+
+    context 'when right hand holds a different tool' do
+      before { $right_hand = 'scissors' }
+
+      it 'stows the current tool and gets the new one' do
+        expect(DRCC).to receive(:stow_crafting_item).with('scissors', 'duffel bag', nil)
+        expect(DRCC).to receive(:get_crafting_item).with('sewing needles', 'duffel bag', [], nil, false)
+
+        sew.send(:swap_tool, 'sewing needles')
+      end
+    end
+
+    context 'with skip parameter' do
+      before { $right_hand = 'scissors' }
+
+      it 'passes skip flag through to get_crafting_item' do
+        expect(DRCC).to receive(:stow_crafting_item)
+        expect(DRCC).to receive(:get_crafting_item).with('pins', 'duffel bag', [], nil, true)
+
+        sew.send(:swap_tool, 'pins', true)
+      end
+    end
+
+    context 'with belt configured' do
+      before do
+        sew.instance_variable_set(:@belt, 'leather belt')
+        $right_hand = 'scissors'
+      end
+
+      it 'passes belt to stow_crafting_item' do
+        expect(DRCC).to receive(:stow_crafting_item).with('scissors', 'duffel bag', 'leather belt')
+        allow(DRCC).to receive(:get_crafting_item)
+
+        sew.send(:swap_tool, 'sewing needles')
+      end
+
+      it 'passes belt to get_crafting_item' do
+        allow(DRCC).to receive(:stow_crafting_item)
+        expect(DRCC).to receive(:get_crafting_item).with('sewing needles', 'duffel bag', [], 'leather belt', false)
+
+        sew.send(:swap_tool, 'sewing needles')
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #finish — stow guards, logbook bundling, messaging
   # ===========================================================================
   describe '#finish' do
+    before(:each) do
+      allow(sew).to receive(:lift_or_stow_feet)
+      allow(sew).to receive(:magic_cleanup)
+    end
+
     context 'with a simple noun (no dot notation)' do
       before do
         sew.instance_variable_set(:@noun, 'rucksack')
@@ -191,6 +311,14 @@ RSpec.describe Sew do
 
         sew.send(:finish)
       end
+
+      it 'does not attempt to stow nil hands' do
+        allow(DRCC).to receive(:logbook_item)
+
+        expect(DRCC).not_to receive(:stow_crafting_item).with(nil, anything, anything)
+
+        sew.send(:finish)
+      end
     end
 
     context 'with hold finish' do
@@ -203,7 +331,6 @@ RSpec.describe Sew do
 
       it 'does not call logbook_item' do
         allow(DRCC).to receive(:stow_crafting_item)
-        allow(DRC).to receive(:message)
 
         expect(DRCC).not_to receive(:logbook_item)
 
@@ -212,11 +339,299 @@ RSpec.describe Sew do
 
       it 'keeps the crafted item in hand' do
         allow(DRCC).to receive(:stow_crafting_item)
-        allow(DRC).to receive(:message)
 
         expect(DRCC).not_to receive(:stow_crafting_item).with('small rucksack', anything, anything)
 
         sew.send(:finish)
+      end
+
+      it 'sends a hold completion message' do
+        allow(DRCC).to receive(:stow_crafting_item)
+        expect(Lich::Messaging).to receive(:msg).with('bold', 'small.rucksack complete — holding in hand.')
+        allow(Lich::Messaging).to receive(:msg).with('plain', anything)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'with stow finish' do
+      before do
+        sew.instance_variable_set(:@finish, 'stow')
+        $right_hand = 'sewing needles'
+        $left_hand = nil
+      end
+
+      it 'calls stow_crafting_item with the noun' do
+        allow(DRCC).to receive(:stow_crafting_item)
+        expect(DRCC).to receive(:stow_crafting_item).with('rucksack', 'duffel bag', nil)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'with trash finish' do
+      before do
+        sew.instance_variable_set(:@finish, 'trash')
+        sew.instance_variable_set(:@worn_trashcan, 'bucket')
+        sew.instance_variable_set(:@worn_trashcan_verb, 'put')
+        $right_hand = 'sewing needles'
+        $left_hand = nil
+      end
+
+      it 'calls dispose_trash with the noun' do
+        allow(DRCC).to receive(:stow_crafting_item)
+        expect(DRCI).to receive(:dispose_trash).with('rucksack', 'bucket', 'put')
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'with stamp enabled' do
+      before do
+        sew.instance_variable_set(:@stamp, true)
+        $right_hand = 'sewing needles'
+        $left_hand = nil
+      end
+
+      it 'swaps to stamp, marks, stows stamp, then finishes' do
+        # swap_tool will stow right hand and get stamp
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:get_crafting_item)
+        allow(DRCC).to receive(:logbook_item)
+        expect(DRC).to receive(:bput).with('mark my rucksack with my stamp', 'Roundtime')
+
+        sew.send(:finish)
+      end
+    end
+
+    it 'calls lift_or_stow_feet after finishing' do
+      $right_hand = nil
+      $left_hand = nil
+      allow(DRCC).to receive(:stow_crafting_item)
+      allow(DRCC).to receive(:logbook_item)
+      expect(sew).to receive(:lift_or_stow_feet)
+
+      sew.send(:finish)
+    end
+
+    it 'calls magic_cleanup before exit' do
+      $right_hand = nil
+      $left_hand = nil
+      allow(DRCC).to receive(:stow_crafting_item)
+      allow(DRCC).to receive(:logbook_item)
+      expect(sew).to receive(:magic_cleanup)
+
+      sew.send(:finish)
+    end
+
+    it 'prints a verbose finish message before exit' do
+      $right_hand = nil
+      $left_hand = nil
+      allow(DRCC).to receive(:stow_crafting_item)
+      allow(DRCC).to receive(:logbook_item)
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'Sew script finished (rucksack, finish: log).')
+
+      sew.send(:finish)
+    end
+
+    it 'calls exit at the end' do
+      $right_hand = nil
+      $left_hand = nil
+      allow(DRCC).to receive(:stow_crafting_item)
+      allow(DRCC).to receive(:logbook_item)
+      expect(sew).to receive(:exit)
+
+      sew.send(:finish)
+    end
+
+    context 'when right hand holds the crafted noun' do
+      before do
+        sew.instance_variable_set(:@noun, 'rucksack')
+        $right_hand = 'small burlap rucksack'
+        $left_hand = 'sewing needles'
+      end
+
+      it 'does not stow the crafted item from right hand' do
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:logbook_item)
+
+        expect(DRCC).not_to receive(:stow_crafting_item).with('small burlap rucksack', anything, anything)
+
+        sew.send(:finish)
+      end
+
+      it 'stows the tool from left hand' do
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:logbook_item)
+
+        expect(DRCC).to receive(:stow_crafting_item).with('sewing needles', 'duffel bag', nil)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'when both hands hold the crafted noun' do
+      before do
+        sew.instance_variable_set(:@noun, 'rucksack')
+        $right_hand = 'small burlap rucksack'
+        $left_hand = 'small burlap rucksack'
+      end
+
+      it 'does not stow either hand' do
+        allow(DRCC).to receive(:logbook_item)
+
+        expect(DRCC).not_to receive(:stow_crafting_item)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'with belt configured' do
+      before do
+        sew.instance_variable_set(:@belt, 'leather belt')
+        $right_hand = 'sewing needles'
+        $left_hand = nil
+      end
+
+      it 'passes belt to stow_crafting_item' do
+        expect(DRCC).to receive(:stow_crafting_item).with('sewing needles', 'duffel bag', 'leather belt')
+        allow(DRCC).to receive(:logbook_item)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'stow finish with dotted noun' do
+      before do
+        sew.instance_variable_set(:@finish, 'stow')
+        sew.instance_variable_set(:@noun, 'small.rucksack')
+        $right_hand = nil
+        $left_hand = nil
+      end
+
+      it 'passes the dotted noun to stow_crafting_item' do
+        expect(DRCC).to receive(:stow_crafting_item).with('small.rucksack', 'duffel bag', nil)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'trash finish with nil worn_trashcan' do
+      before do
+        sew.instance_variable_set(:@finish, 'trash')
+        sew.instance_variable_set(:@worn_trashcan, nil)
+        sew.instance_variable_set(:@worn_trashcan_verb, nil)
+        $right_hand = nil
+        $left_hand = nil
+      end
+
+      it 'calls dispose_trash with nil trashcan args' do
+        expect(DRCI).to receive(:dispose_trash).with('rucksack', nil, nil)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'noun substring boundary' do
+      before do
+        sew.instance_variable_set(:@noun, 'pack')
+        $right_hand = 'backpack'
+        $left_hand = nil
+      end
+
+      it 'does not stow right hand when item name contains noun as substring' do
+        # 'backpack'.include?('pack') is true, so it's treated as the crafted item
+        allow(DRCC).to receive(:logbook_item)
+        expect(DRCC).not_to receive(:stow_crafting_item).with('backpack', anything, anything)
+
+        sew.send(:finish)
+      end
+    end
+
+    context 'finish operation ordering' do
+      before do
+        sew.instance_variable_set(:@stamp, false)
+        $right_hand = 'sewing needles'
+        $left_hand = nil
+      end
+
+      it 'stows hands before logbook' do
+        order = []
+        allow(DRCC).to receive(:stow_crafting_item) { order << :stow }
+        allow(DRCC).to receive(:logbook_item) { order << :logbook }
+
+        sew.send(:finish)
+
+        expect(order.index(:stow)).to be < order.index(:logbook)
+      end
+
+      it 'calls lift_or_stow_feet after logbook' do
+        order = []
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:logbook_item) { order << :logbook }
+        allow(sew).to receive(:lift_or_stow_feet) { order << :lift }
+
+        sew.send(:finish)
+
+        expect(order.index(:logbook)).to be < order.index(:lift)
+      end
+
+      it 'calls magic_cleanup after lift_or_stow_feet' do
+        order = []
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:logbook_item)
+        allow(sew).to receive(:lift_or_stow_feet) { order << :lift }
+        allow(sew).to receive(:magic_cleanup) { order << :cleanup }
+
+        sew.send(:finish)
+
+        expect(order.index(:lift)).to be < order.index(:cleanup)
+      end
+
+      it 'prints finish message after magic_cleanup' do
+        order = []
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:logbook_item)
+        allow(sew).to receive(:magic_cleanup) { order << :cleanup }
+        allow(Lich::Messaging).to receive(:msg) { order << :msg }
+
+        sew.send(:finish)
+
+        expect(order.index(:cleanup)).to be < order.index(:msg)
+      end
+
+      it 'calls exit after the finish message' do
+        order = []
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:logbook_item)
+        allow(Lich::Messaging).to receive(:msg) { order << :msg }
+        allow(sew).to receive(:exit) { order << :exit }
+
+        sew.send(:finish)
+
+        expect(order.index(:msg)).to be < order.index(:exit)
+      end
+    end
+
+    context 'stamp operation ordering' do
+      before do
+        sew.instance_variable_set(:@stamp, true)
+        $right_hand = nil
+        $left_hand = nil
+      end
+
+      it 'stamps before stowing stamp, then proceeds to logbook' do
+        order = []
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:get_crafting_item)
+        allow(DRC).to receive(:bput).with('mark my rucksack with my stamp', 'Roundtime') { order << :mark }
+        allow(DRCC).to receive(:stow_crafting_item).with('stamp', 'duffel bag', nil) { order << :stow_stamp }
+        allow(DRCC).to receive(:logbook_item) { order << :logbook }
+
+        sew.send(:finish)
+
+        expect(order.index(:mark)).to be < order.index(:stow_stamp)
+        expect(order.index(:stow_stamp)).to be < order.index(:logbook)
       end
     end
   end
@@ -225,11 +640,6 @@ RSpec.describe Sew do
   # #lift_or_stow_feet — handling items at feet with dot notation
   # ===========================================================================
   describe '#lift_or_stow_feet' do
-    before do
-      # Unstub so we test the real method
-      allow(sew).to receive(:lift_or_stow_feet).and_call_original
-    end
-
     context 'when items at feet and lift succeeds' do
       before do
         allow(DRCI).to receive(:lift?).and_return(true)
@@ -264,6 +674,76 @@ RSpec.describe Sew do
 
         sew.send(:lift_or_stow_feet)
       end
+
+      it 'handles nil hands after lift' do
+        $right_hand = nil
+        $left_hand = nil
+
+        expect(DRCC).not_to receive(:stow_crafting_item)
+
+        sew.send(:lift_or_stow_feet)
+      end
+
+      it 'stows both hands if neither contains the noun' do
+        sew.instance_variable_set(:@noun, 'rucksack')
+        $right_hand = 'scissors'
+        $left_hand = 'burlap cloth'
+
+        expect(DRCC).to receive(:stow_crafting_item).with('scissors', 'duffel bag', nil)
+        expect(DRCC).to receive(:stow_crafting_item).with('burlap cloth', 'duffel bag', nil)
+
+        sew.send(:lift_or_stow_feet)
+      end
+
+      it 'caches hand values to avoid race conditions' do
+        sew.instance_variable_set(:@noun, 'rucksack')
+        $right_hand = 'scissors'
+        $left_hand = nil
+
+        # DRC.right_hand should only be called once (cached in local)
+        call_count = 0
+        allow(DRC).to receive(:right_hand) do
+          call_count += 1
+          call_count == 1 ? 'scissors' : nil
+        end
+        allow(DRC).to receive(:left_hand).and_return(nil)
+        allow(DRCC).to receive(:stow_crafting_item)
+
+        sew.send(:lift_or_stow_feet)
+
+        # right_hand should be called exactly once (cached)
+        expect(call_count).to eq(1)
+      end
+    end
+
+    context 'with dotted noun in left hand only' do
+      before do
+        allow(DRCI).to receive(:lift?).and_return(true)
+        sew.instance_variable_set(:@noun, 'small.rucksack')
+        $right_hand = nil
+        $left_hand = 'small rucksack'
+      end
+
+      it 'does not stow the crafted item from left hand' do
+        expect(DRCC).not_to receive(:stow_crafting_item)
+
+        sew.send(:lift_or_stow_feet)
+      end
+    end
+
+    context 'with belt configured' do
+      before do
+        allow(DRCI).to receive(:lift?).and_return(true)
+        sew.instance_variable_set(:@belt, 'leather belt')
+        $right_hand = 'scissors'
+        $left_hand = nil
+      end
+
+      it 'passes belt to stow_crafting_item' do
+        expect(DRCC).to receive(:stow_crafting_item).with('scissors', 'duffel bag', 'leather belt')
+
+        sew.send(:lift_or_stow_feet)
+      end
     end
 
     context 'when no items at feet' do
@@ -275,6 +755,990 @@ RSpec.describe Sew do
         expect(DRC).to receive(:bput).with('stow feet', 'You put', 'Stow what')
 
         sew.send(:lift_or_stow_feet)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #check_hand — item position verification
+  # ===========================================================================
+  describe '#check_hand' do
+    before do
+      allow(sew).to receive(:magic_cleanup)
+    end
+
+    context 'when item is in right hand' do
+      before do
+        allow(DRCI).to receive(:in_right_hand?).with('leather').and_return(true)
+      end
+
+      it 'swaps hands' do
+        expect(DRC).to receive(:bput).with('swap', 'You move', 'You have nothing')
+
+        sew.send(:check_hand, 'leather')
+      end
+
+      it 'does not exit' do
+        allow(DRC).to receive(:bput)
+        expect(sew).not_to receive(:exit)
+
+        sew.send(:check_hand, 'leather')
+      end
+    end
+
+    context 'when item has a dotted noun' do
+      before do
+        allow(DRCI).to receive(:in_right_hand?).with('small.rucksack').and_return(true)
+      end
+
+      it 'passes the dotted noun directly to in_right_hand?' do
+        allow(DRC).to receive(:bput)
+
+        expect(DRCI).to receive(:in_right_hand?).with('small.rucksack')
+
+        sew.send(:check_hand, 'small.rucksack')
+      end
+
+      it 'swaps hands when dotted noun is in right hand' do
+        expect(DRC).to receive(:bput).with('swap', 'You move', 'You have nothing')
+
+        sew.send(:check_hand, 'small.rucksack')
+      end
+    end
+
+    context 'when item is not in right hand' do
+      before do
+        allow(DRCI).to receive(:in_right_hand?).with('leather').and_return(false)
+      end
+
+      it 'sends a verbose error message' do
+        expect(Lich::Messaging).to receive(:msg).with('bold', "Please hold the item or material you wish to work on. Expected 'leather' in right hand.")
+
+        sew.send(:check_hand, 'leather')
+      end
+
+      it 'calls magic_cleanup before exiting' do
+        expect(sew).to receive(:magic_cleanup).ordered
+        expect(sew).to receive(:exit).ordered
+
+        sew.send(:check_hand, 'leather')
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #magic_cleanup — spell release (now instance method)
+  # ===========================================================================
+  describe '#magic_cleanup' do
+    context 'with no training spells configured' do
+      before do
+        sew.instance_variable_set(:@settings, OpenStruct.new(crafting_training_spells: []))
+      end
+
+      it 'returns early without releasing anything' do
+        expect(DRC).not_to receive(:bput)
+
+        sew.send(:magic_cleanup)
+      end
+    end
+
+    context 'with training spells configured' do
+      before do
+        sew.instance_variable_set(:@settings, OpenStruct.new(crafting_training_spells: [{ 'Symbiosis' => { 'abbrev' => 'symb' } }]))
+      end
+
+      it 'releases spell, mana, and symbiosis' do
+        expect(DRC).to receive(:bput).with('release spell', 'You let your concentration lapse', "You aren't preparing a spell").ordered
+        expect(DRC).to receive(:bput).with('release mana', 'You release all', "You aren't harnessing any mana").ordered
+        expect(DRC).to receive(:bput).with('release symb', "But you haven't", 'You release', 'Repeat this command').ordered
+
+        sew.send(:magic_cleanup)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #list_at_feet — diagnostic output
+  # ===========================================================================
+  describe '#list_at_feet' do
+    context 'when items are at feet' do
+      it 'outputs item list via Lich::Messaging' do
+        allow(Lich::Util).to receive(:issue_command).and_return(['a small rock', 'some burlap cloth'])
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Items at feet: a small rock, some burlap cloth')
+
+        sew.send(:list_at_feet)
+      end
+    end
+
+    context 'when no items at feet' do
+      it 'does not output anything for empty result' do
+        allow(Lich::Util).to receive(:issue_command).and_return([])
+        expect(Lich::Messaging).not_to receive(:msg)
+
+        sew.send(:list_at_feet)
+      end
+    end
+
+    context 'when issue_command returns nil' do
+      it 'does not crash' do
+        allow(Lich::Util).to receive(:issue_command).and_return(nil)
+        expect(Lich::Messaging).not_to receive(:msg)
+
+        expect { sew.send(:list_at_feet) }.not_to raise_error
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #check_rental_status — private rental expiry detection
+  # ===========================================================================
+  describe '#check_rental_status' do
+    # Helper: format a future time as the game would display it (ET timezone)
+    def rental_expiry_string(minutes_from_now)
+      future = Time.now + (minutes_from_now * 60)
+      est = future.getlocal('-05:00')
+      est.strftime('%a %b %d %H:%M:%S ET %Y')
+    end
+
+    context 'when notice is found with valid expiry' do
+      it 'renews if less than 10 minutes remaining' do
+        result = "It will expire #{rental_expiry_string(5)}."
+        allow(DRC).to receive(:bput).and_return(result)
+        allow(sew).to receive(:renew_rental)
+
+        expect(sew).to receive(:renew_rental)
+        expect(Lich::Messaging).to receive(:msg).with('bold', /RENTAL LOW.*AUTO-RENEWING/)
+
+        sew.send(:check_rental_status)
+      end
+
+      it 'warns if less than 20 minutes remaining' do
+        result = "It will expire #{rental_expiry_string(15)}."
+        allow(DRC).to receive(:bput).and_return(result)
+
+        expect(sew).not_to receive(:renew_rental)
+        expect(Lich::Messaging).to receive(:msg).with('bold', /Rental has \d+ minutes remaining/)
+
+        sew.send(:check_rental_status)
+      end
+
+      it 'does nothing if more than 20 minutes remaining' do
+        result = "It will expire #{rental_expiry_string(30)}."
+        allow(DRC).to receive(:bput).and_return(result)
+
+        expect(sew).not_to receive(:renew_rental)
+        expect(Lich::Messaging).not_to receive(:msg)
+
+        sew.send(:check_rental_status)
+      end
+    end
+
+    context 'when no notice is found' do
+      it 'returns early without error' do
+        allow(DRC).to receive(:bput).and_return('I could not find')
+
+        expect(sew).not_to receive(:renew_rental)
+        expect(Lich::Messaging).not_to receive(:msg)
+
+        expect { sew.send(:check_rental_status) }.not_to raise_error
+      end
+    end
+
+    context 'when time parsing fails' do
+      it 'catches ArgumentError and warns' do
+        allow(DRC).to receive(:bput).and_return('It will expire garbage time string.')
+
+        expect(Lich::Messaging).to receive(:msg).with('bold', /Could not parse rental expiry time/)
+
+        expect { sew.send(:check_rental_status) }.not_to raise_error
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #renew_rental — auto-renewal of private crafting room
+  # ===========================================================================
+  describe '#renew_rental' do
+    before do
+      stub_const('Flags', Class.new do
+        @data = {}
+
+        def self.[]=(key, val)
+          @data[key] = val
+        end
+
+        def self.[](key)
+          @data[key]
+        end
+
+        def self.reset(key)
+          @data[key] = nil
+        end
+      end)
+    end
+
+    context 'successful renewal' do
+      it 'marks the notice and reports success' do
+        allow(DRC).to receive(:bput).and_return('renewed your rental')
+
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** RENTAL EXPIRING — AUTO-RENEWING ***')
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** RENTAL RENEWED ***')
+
+        sew.send(:renew_rental)
+      end
+
+      it 'resets the rental warning flag' do
+        Flags['sew-rental-warning'] = true
+        allow(DRC).to receive(:bput).and_return('renewed your rental')
+        allow(Lich::Messaging).to receive(:msg)
+
+        sew.send(:renew_rental)
+
+        expect(Flags['sew-rental-warning']).to be_nil
+      end
+    end
+
+    context 'insufficient funds' do
+      it 'warns about insufficient funds' do
+        allow(DRC).to receive(:bput).and_return("You don't have enough")
+
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** RENTAL EXPIRING — AUTO-RENEWING ***')
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** INSUFFICIENT FUNDS TO RENEW RENTAL ***')
+
+        sew.send(:renew_rental)
+      end
+    end
+
+    context 'notice not found' do
+      it 'warns about missing notice' do
+        allow(DRC).to receive(:bput).and_return('I could not find')
+
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** RENTAL EXPIRING — AUTO-RENEWING ***')
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** COULD NOT FIND NOTICE — CHECK LOCATION ***')
+
+        sew.send(:renew_rental)
+      end
+    end
+
+    context 'extends rental response' do
+      it 'treats extends as success' do
+        allow(DRC).to receive(:bput).and_return('extends your rental')
+
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** RENTAL EXPIRING — AUTO-RENEWING ***')
+        expect(Lich::Messaging).to receive(:msg).with('bold', '*** RENTAL RENEWED ***')
+
+        sew.send(:renew_rental)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #assemble_part — nil hand safety
+  # ===========================================================================
+  describe '#assemble_part' do
+    # Stub Flags as a hash-like object for testing
+    before do
+      stub_const('Flags', Class.new do
+        @data = {}
+
+        def self.[]=(key, val)
+          @data[key] = val
+        end
+
+        def self.[](key)
+          @data[key]
+        end
+
+        def self.reset(key)
+          @data[key] = nil
+        end
+      end)
+    end
+
+    context 'when flag is not set' do
+      before { Flags['sew-assembly'] = nil }
+
+      it 'does nothing' do
+        expect(DRCC).not_to receive(:stow_crafting_item)
+        expect(DRCC).not_to receive(:get_crafting_item)
+
+        sew.send(:assemble_part)
+      end
+    end
+
+    context 'when right hand is nil during assembly' do
+      before do
+        Flags['sew-assembly'] = [true, 'small', 'cloth', 'padding']
+        $right_hand = nil
+      end
+
+      it 'does not attempt to stow nil' do
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+        allow(DRCC).to receive(:get_crafting_item)
+
+        expect(DRCC).not_to receive(:stow_crafting_item)
+
+        sew.send(:assemble_part)
+      end
+
+      it 'does not attempt to swap back to nil tool' do
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+        allow(DRCC).to receive(:get_crafting_item)
+
+        # swap_tool should not be called since tool is nil
+        expect(sew).not_to receive(:swap_tool)
+
+        sew.send(:assemble_part)
+      end
+    end
+
+    context 'when right hand has a tool during assembly' do
+      before do
+        Flags['sew-assembly'] = [true, 'large', 'cloth', 'padding']
+        $right_hand = 'scissors'
+      end
+
+      it 'stows the current tool, assembles, and swaps back' do
+        allow(DRCC).to receive(:get_crafting_item)
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+
+        expect(DRCC).to receive(:stow_crafting_item).with('scissors', 'duffel bag', nil).ordered
+        expect(DRCC).to receive(:get_crafting_item).with('large cloth padding', 'duffel bag', [], nil).ordered
+
+        sew.send(:assemble_part)
+      end
+
+      it 'swaps back to the original tool after assembly' do
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRCC).to receive(:get_crafting_item)
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+
+        expect(sew).to receive(:swap_tool).with('scissors')
+
+        sew.send(:assemble_part)
+      end
+    end
+
+    context 'part name construction from Flags' do
+      before { $right_hand = 'scissors' }
+
+      it 'joins three-word part names' do
+        Flags['sew-assembly'] = [true, 'small', 'cloth', 'padding']
+
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+
+        expect(DRCC).to receive(:get_crafting_item).with('small cloth padding', 'duffel bag', [], nil)
+
+        sew.send(:assemble_part)
+      end
+
+      it 'joins two-word part names' do
+        Flags['sew-assembly'] = [true, 'leather', 'cord']
+
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+
+        expect(DRCC).to receive(:get_crafting_item).with('leather cord', 'duffel bag', [], nil)
+
+        sew.send(:assemble_part)
+      end
+
+      it 'handles single-word part names' do
+        Flags['sew-assembly'] = [true, 'hilt']
+
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+
+        expect(DRCC).to receive(:get_crafting_item).with('hilt', 'duffel bag', [], nil)
+
+        sew.send(:assemble_part)
+      end
+    end
+
+    context 'with belt configured' do
+      before do
+        sew.instance_variable_set(:@belt, 'leather belt')
+        Flags['sew-assembly'] = [true, 'large', 'cloth', 'padding']
+        $right_hand = 'scissors'
+      end
+
+      it 'passes belt to stow and get' do
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+
+        expect(DRCC).to receive(:stow_crafting_item).with('scissors', 'duffel bag', 'leather belt')
+        expect(DRCC).to receive(:get_crafting_item).with('large cloth padding', 'duffel bag', [], 'leather belt')
+
+        sew.send(:assemble_part)
+      end
+    end
+
+    context 'Flags.reset clears the assembly flag' do
+      before do
+        Flags['sew-assembly'] = [true, 'small', 'cloth', 'padding']
+        $right_hand = nil
+      end
+
+      it 'resets the flag so the loop terminates after one iteration' do
+        allow(DRC).to receive(:bput).and_return('affix it securely in place')
+        allow(DRCC).to receive(:get_crafting_item)
+
+        sew.send(:assemble_part)
+
+        expect(Flags['sew-assembly']).to be_nil
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #prep — recipe/instruction lookup and material setup
+  # ===========================================================================
+  describe '#prep' do
+    before(:each) do
+      allow(DRCA).to receive(:crafting_magic_routine)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRCC).to receive(:stow_crafting_item)
+      allow(DRCC).to receive(:find_recipe2)
+      allow(DRC).to receive(:bput).and_return('Roundtime')
+      allow(DRCI).to receive(:in_left_hand?).and_return(true)
+      allow(sew).to receive(:check_hand)
+      allow(sew).to receive(:swap_tool)
+      allow(DRSkill).to receive(:getrank).and_return(100)
+
+      sew.instance_variable_set(:@instructions, nil)
+      sew.instance_variable_set(:@recipe_name, 'small rucksack')
+      sew.instance_variable_set(:@mat_type, 'burlap')
+      sew.instance_variable_set(:@knit, nil)
+      sew.instance_variable_set(:@chapter, 1)
+      sew.instance_variable_set(:@cloth, %w[silk wool burlap cotton felt linen electroweave steelsilk arzumodine bourde dergatine dragonar faeweave farandine imperial jaspe khaddar ruazin titanese zenganne])
+      sew.instance_variable_set(:@cube, nil)
+    end
+
+    it 'always calls crafting_magic_routine first' do
+      expect(DRCA).to receive(:crafting_magic_routine).with(sew.instance_variable_get(:@settings))
+
+      sew.send(:prep)
+    end
+
+    context 'instructions path' do
+      before do
+        sew.instance_variable_set(:@instructions, true)
+      end
+
+      it 'gets the instructions from bag' do
+        expect(DRCC).to receive(:get_crafting_item).with('rucksack instructions', 'duffel bag', [], nil)
+
+        sew.send(:prep)
+      end
+
+      it 'studies instructions twice if prompted to study again' do
+        allow(DRC).to receive(:bput).with('study my instructions', 'Roundtime', 'Study them again')
+                    .and_return('Study them again', 'Roundtime')
+        expect(DRC).to receive(:bput).with('study my instructions', 'Roundtime', 'Study them again').twice
+
+        sew.send(:prep)
+      end
+
+      it 'studies instructions only once if no re-study prompt' do
+        allow(DRC).to receive(:bput).with('study my instructions', 'Roundtime', 'Study them again')
+                    .and_return('Roundtime')
+        expect(DRC).to receive(:bput).with('study my instructions', 'Roundtime', 'Study them again').once
+
+        sew.send(:prep)
+      end
+
+      it 'does not use any recipe book' do
+        expect(DRCC).not_to receive(:find_recipe2)
+        expect(DRCC).not_to receive(:get_crafting_item).with('tailoring book', anything, anything, anything)
+
+        sew.send(:prep)
+      end
+    end
+
+    context 'master crafting book path' do
+      before do
+        sew.instance_variable_set(:@settings, OpenStruct.new(
+          crafting_training_spells: [],
+          master_crafting_book: 'master tailoring book'
+        ))
+      end
+
+      it 'calls find_recipe2 with master book and tailoring discipline' do
+        expect(DRCC).to receive(:find_recipe2).with(1, 'small rucksack', 'master tailoring book', 'tailoring')
+
+        sew.send(:prep)
+      end
+
+      it 'does not get or stow a basic book' do
+        expect(DRCC).not_to receive(:get_crafting_item).with('tailoring book', anything, anything, anything)
+        expect(DRCC).not_to receive(:stow_crafting_item).with('tailoring book', anything, anything)
+
+        sew.send(:prep)
+      end
+    end
+
+    context 'basic tailoring book path' do
+      before do
+        sew.instance_variable_set(:@settings, OpenStruct.new(
+          crafting_training_spells: [],
+          master_crafting_book: nil
+        ))
+      end
+
+      it 'gets the tailoring book from bag' do
+        expect(DRCC).to receive(:get_crafting_item).with('tailoring book', 'duffel bag', [], nil)
+        allow(DRCC).to receive(:get_crafting_item)
+
+        sew.send(:prep)
+      end
+
+      it 'calls find_recipe2 without master book argument' do
+        expect(DRCC).to receive(:find_recipe2).with(1, 'small rucksack')
+
+        sew.send(:prep)
+      end
+
+      it 'stows the tailoring book after finding recipe' do
+        expect(DRCC).to receive(:stow_crafting_item).with('tailoring book', 'duffel bag', nil)
+        allow(DRCC).to receive(:stow_crafting_item)
+
+        sew.send(:prep)
+      end
+
+      it 'warns at exactly rank 175' do
+        allow(DRSkill).to receive(:getrank).with('Outfitting').and_return(175)
+        expect(Lich::Messaging).to receive(:msg).with('bold', 'You will need to upgrade to a journeyman or master book before 176 ranks!')
+
+        sew.send(:prep)
+      end
+
+      it 'does not warn at rank 174' do
+        allow(DRSkill).to receive(:getrank).with('Outfitting').and_return(174)
+        expect(Lich::Messaging).not_to receive(:msg).with('bold', anything)
+
+        sew.send(:prep)
+      end
+
+      it 'does not warn at rank 176' do
+        allow(DRSkill).to receive(:getrank).with('Outfitting').and_return(176)
+        expect(Lich::Messaging).not_to receive(:msg).with('bold', anything)
+
+        sew.send(:prep)
+      end
+    end
+
+    context 'knitting via @knit flag' do
+      before { sew.instance_variable_set(:@knit, true) }
+
+      it 'gets yarn from bag' do
+        expect(DRCC).to receive(:get_crafting_item).with('yarn', 'duffel bag', [], nil)
+        allow(DRCC).to receive(:get_crafting_item)
+
+        sew.send(:prep)
+      end
+
+      it 'checks hand for yarn when not in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('yarn').and_return(false)
+        expect(sew).to receive(:check_hand).with('yarn')
+
+        sew.send(:prep)
+      end
+
+      it 'skips check_hand when yarn is in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('yarn').and_return(true)
+        expect(sew).not_to receive(:check_hand)
+
+        sew.send(:prep)
+      end
+
+      it 'swaps to knitting needles' do
+        expect(sew).to receive(:swap_tool).with('knitting needles')
+
+        sew.send(:prep)
+      end
+
+      it 'returns the knit command' do
+        result = sew.send(:prep)
+
+        expect(result).to eq('knit my yarn with my knitting needles')
+      end
+
+      it 'sets @home_tool to knitting needles' do
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@home_tool)).to eq('knitting needles')
+      end
+
+      it 'sets @home_command to knit my needles' do
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@home_command)).to eq('knit my needles')
+      end
+    end
+
+    context 'knitting via chapter 5' do
+      before do
+        sew.instance_variable_set(:@knit, nil)
+        sew.instance_variable_set(:@chapter, 5)
+      end
+
+      it 'triggers the knitting path without @knit flag' do
+        result = sew.send(:prep)
+
+        expect(result).to eq('knit my yarn with my knitting needles')
+      end
+    end
+
+    context 'enhancement — seal' do
+      before do
+        sew.instance_variable_set(:@recipe_name, 'tailored armor sealing')
+        sew.instance_variable_set(:@noun, 'shirt')
+      end
+
+      it 'disables stamp' do
+        sew.instance_variable_set(:@stamp, true)
+
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@stamp)).to eq(false)
+      end
+
+      it 'checks hand for noun when not in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('shirt').and_return(false)
+        expect(sew).to receive(:check_hand).with('shirt')
+
+        sew.send(:prep)
+      end
+
+      it 'skips check_hand when noun in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('shirt').and_return(true)
+        expect(sew).not_to receive(:check_hand)
+
+        sew.send(:prep)
+      end
+
+      it 'swaps to sealing wax' do
+        expect(sew).to receive(:swap_tool).with('sealing wax')
+
+        sew.send(:prep)
+      end
+
+      it 'returns the apply wax command' do
+        result = sew.send(:prep)
+
+        expect(result).to eq('apply my wax to my shirt')
+      end
+
+      it 'sets @home_tool and @home_command for sealing' do
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@home_tool)).to eq('sealing wax')
+        expect(sew.instance_variable_get(:@home_command)).to eq('apply my wax to my shirt')
+      end
+    end
+
+    context 'enhancement — reinforce' do
+      before do
+        sew.instance_variable_set(:@recipe_name, 'tailored armor reinforcing')
+        sew.instance_variable_set(:@noun, 'shirt')
+      end
+
+      it 'swaps to scissors' do
+        expect(sew).to receive(:swap_tool).with('scissors')
+
+        sew.send(:prep)
+      end
+
+      it 'returns the cut command' do
+        result = sew.send(:prep)
+
+        expect(result).to eq('cut my shirt with my scissors')
+      end
+
+      it 'sets @home_tool to scissors' do
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@home_tool)).to eq('scissors')
+      end
+    end
+
+    context 'cloth products' do
+      before do
+        sew.instance_variable_set(:@mat_type, 'burlap')
+        sew.instance_variable_set(:@recipe_name, 'small rucksack')
+      end
+
+      it 'gets the cloth material from bag' do
+        expect(DRCC).to receive(:get_crafting_item).with('burlap cloth', 'duffel bag', [], nil)
+        allow(DRCC).to receive(:get_crafting_item)
+
+        sew.send(:prep)
+      end
+
+      it 'checks hand for cloth when not in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('cloth').and_return(false)
+        expect(sew).to receive(:check_hand).with('cloth')
+
+        sew.send(:prep)
+      end
+
+      it 'swaps to scissors' do
+        expect(sew).to receive(:swap_tool).with('scissors')
+
+        sew.send(:prep)
+      end
+
+      it 'returns the cut command with material type' do
+        result = sew.send(:prep)
+
+        expect(result).to eq('cut my burlap cloth with my scissors')
+      end
+
+      it 'sets @home_tool to sewing needles' do
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@home_tool)).to eq('sewing needles')
+      end
+
+      it 'sets @home_command to push with noun' do
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@home_command)).to eq('push my rucksack with my needles')
+      end
+    end
+
+    context 'leather products' do
+      before do
+        sew.instance_variable_set(:@mat_type, 'deer')
+        sew.instance_variable_set(:@recipe_name, 'small rucksack')
+      end
+
+      it 'gets the leather material from bag' do
+        expect(DRCC).to receive(:get_crafting_item).with('deer leather', 'duffel bag', [], nil)
+        allow(DRCC).to receive(:get_crafting_item)
+
+        sew.send(:prep)
+      end
+
+      it 'checks hand for leather when not in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('leather').and_return(false)
+        expect(sew).to receive(:check_hand).with('leather')
+
+        sew.send(:prep)
+      end
+
+      it 'returns the cut command with material type' do
+        result = sew.send(:prep)
+
+        expect(result).to eq('cut my deer leather with my scissors')
+      end
+
+      it 'sets @home_tool to sewing needles for leather' do
+        sew.send(:prep)
+
+        expect(sew.instance_variable_get(:@home_tool)).to eq('sewing needles')
+      end
+    end
+
+    context 'cloth material detection' do
+      it 'recognizes all standard cloth types' do
+        %w[silk wool burlap cotton felt linen].each do |mat|
+          sew.instance_variable_set(:@mat_type, mat)
+          sew.instance_variable_set(:@recipe_name, 'small rucksack')
+
+          result = sew.send(:prep)
+
+          expect(result).to eq("cut my #{mat} cloth with my scissors"), "Failed for material: #{mat}"
+        end
+      end
+
+      it 'recognizes exotic cloth types' do
+        %w[electroweave steelsilk arzumodine bourde dergatine dragonar faeweave farandine].each do |mat|
+          sew.instance_variable_set(:@mat_type, mat)
+          sew.instance_variable_set(:@recipe_name, 'small rucksack')
+
+          result = sew.send(:prep)
+
+          expect(result).to eq("cut my #{mat} cloth with my scissors"), "Failed for material: #{mat}"
+        end
+      end
+
+      it 'falls through to leather for non-cloth materials' do
+        sew.instance_variable_set(:@mat_type, 'deer')
+        sew.instance_variable_set(:@recipe_name, 'small rucksack')
+
+        result = sew.send(:prep)
+
+        expect(result).to eq('cut my deer leather with my scissors')
+      end
+    end
+  end
+
+  # ===========================================================================
+  # Edge cases and integration-level scenarios
+  # ===========================================================================
+  describe 'finish default for resume' do
+    it 'defaults @finish to hold when args.finish is nil' do
+      # The @finish default is set in initialize, but we can verify the
+      # pattern: args.finish || 'hold' means nil args.finish → 'hold'
+      sew.instance_variable_set(:@finish, nil || 'hold')
+      expect(sew.instance_variable_get(:@finish)).to eq('hold')
+    end
+  end
+
+  describe 'double game-state read prevention in #finish' do
+    before do
+      allow(sew).to receive(:lift_or_stow_feet)
+      allow(sew).to receive(:magic_cleanup)
+      allow(DRCC).to receive(:logbook_item)
+    end
+
+    it 'reads right_hand and left_hand exactly once each' do
+      right_calls = 0
+      left_calls = 0
+
+      allow(DRC).to receive(:right_hand) do
+        right_calls += 1
+        'sewing needles'
+      end
+      allow(DRC).to receive(:left_hand) do
+        left_calls += 1
+        'small rucksack'
+      end
+      allow(DRCC).to receive(:stow_crafting_item)
+
+      sew.send(:finish)
+
+      expect(right_calls).to eq(1)
+      expect(left_calls).to eq(1)
+    end
+  end
+
+  describe 'verbose messaging on exit paths' do
+    before do
+      allow(sew).to receive(:lift_or_stow_feet)
+      allow(sew).to receive(:magic_cleanup)
+      $right_hand = nil
+      $left_hand = nil
+    end
+
+    it '#finish always prints a finish message' do
+      allow(DRCC).to receive(:stow_crafting_item)
+      allow(DRCC).to receive(:logbook_item)
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'Sew script finished (rucksack, finish: log).')
+
+      sew.send(:finish)
+    end
+
+    it '#check_hand prints a descriptive error on failure' do
+      allow(DRCI).to receive(:in_right_hand?).and_return(false)
+      allow(sew).to receive(:magic_cleanup)
+      expect(Lich::Messaging).to receive(:msg).with('bold', "Please hold the item or material you wish to work on. Expected 'rucksack' in right hand.")
+
+      sew.send(:check_hand, 'rucksack')
+    end
+  end
+
+  describe 'Flags cleanup' do
+    it 'sew.lic before_dying block deletes sew-done not sealing-done' do
+      # Verify the source code has the correct flag name
+      source = File.read(File.join(File.dirname(__FILE__), '..', 'sew.lic'))
+      expect(source).to include("Flags.delete('sew-done')")
+      expect(source).not_to include("Flags.delete('sealing-done')")
+    end
+
+    it 'cleans up the sew-rental-warning flag in before_dying' do
+      source = File.read(File.join(File.dirname(__FILE__), '..', 'sew.lic'))
+      expect(source).to include("Flags.delete('sew-rental-warning')")
+    end
+  end
+
+  describe 'magic_cleanup is an instance method' do
+    it 'is defined on the Sew class, not at top level' do
+      expect(Sew.instance_methods(false)).to include(:magic_cleanup)
+    end
+  end
+
+  describe 'bold vs plain messaging convention' do
+    before do
+      allow(sew).to receive(:lift_or_stow_feet)
+      allow(sew).to receive(:magic_cleanup)
+    end
+
+    it 'uses bold for hold completion (DRC.message replacement)' do
+      sew.instance_variable_set(:@finish, 'hold')
+      $right_hand = nil
+      $left_hand = nil
+
+      expect(Lich::Messaging).to receive(:msg).with('bold', 'rucksack complete — holding in hand.')
+      allow(Lich::Messaging).to receive(:msg).with('plain', anything)
+
+      sew.send(:finish)
+    end
+
+    it 'uses plain for the finish summary' do
+      sew.instance_variable_set(:@finish, 'log')
+      $right_hand = nil
+      $left_hand = nil
+      allow(DRCC).to receive(:logbook_item)
+
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'Sew script finished (rucksack, finish: log).')
+
+      sew.send(:finish)
+    end
+
+    it 'uses bold for check_hand failure' do
+      allow(DRCI).to receive(:in_right_hand?).with('leather').and_return(false)
+      allow(sew).to receive(:magic_cleanup)
+
+      expect(Lich::Messaging).to receive(:msg).with('bold', "Please hold the item or material you wish to work on. Expected 'leather' in right hand.")
+
+      sew.send(:check_hand, 'leather')
+    end
+  end
+
+  describe 'source code invariants' do
+    let(:source) { File.read(File.join(File.dirname(__FILE__), '..', 'sew.lic')) }
+
+    it 'uses Lich::Messaging.msg, never DRC.message' do
+      # Ignore comments (lines starting with #)
+      code_lines = source.lines.reject { |l| l.strip.start_with?('#') }
+      expect(code_lines.join).not_to match(/DRC\.message/)
+    end
+
+    it 'uses Lich::Messaging.msg, never bare echo' do
+      code_lines = source.lines.reject { |l| l.strip.start_with?('#') }
+      # Match bare echo calls but not 'echo' as part of a string or variable
+      expect(code_lines.join).not_to match(/^\s+echo\s/)
+    end
+
+    it 'has magic_cleanup as an instance method, not top-level' do
+      # The def magic_cleanup should be indented (inside the class)
+      expect(source).to match(/^  def magic_cleanup/)
+      expect(source).not_to match(/^def magic_cleanup/)
+    end
+
+    it 'deletes sew-done flag, not sealing-done' do
+      expect(source).to include("Flags.delete('sew-done')")
+      expect(source).not_to include("Flags.delete('sealing-done')")
+    end
+
+    it 'uses .tr for dot-notation normalization in finish' do
+      expect(source).to include("@noun.tr('.', ' ')")
+    end
+
+    it 'uses safe navigation or explicit nil checks for hand access' do
+      # All .include? calls on right_hand/left_hand should be guarded
+      # The pattern should be: `right && !right.include?` or `hand&.include?`
+      source.lines.each_with_index do |line, idx|
+        next if line.strip.start_with?('#')
+        next unless line.include?('.include?') && (line.include?('right') || line.include?('left'))
+
+        # Ensure it's guarded: either `&.include?` or `var && !var.include?` or `if var`
+        expect(line).to(
+          satisfy { |l| l.include?('&.include?') || l.match?(/\w+ && !\w+\.include\?/) },
+          "Unguarded .include? on hand at line #{idx + 1}: #{line.strip}"
+        )
       end
     end
   end


### PR DESCRIPTION
# PR: sew.lic — Reconciliation, Bug Fixes, and Robustness Improvements

## Summary

Reconciles the `sew_bugfix` branch (dot-notation `.tr('.', ' ')` fixes from PR #7284) with custom improvements, while fixing 5 bugs, adding private rental auto-renewal, and applying robustness hardening across the script.

## Bug Fixes

### P0 — Crash Bugs
- **`swap_tool` nil crash**: `DRC.right_hand.include?(next_tool)` crashes with `NoMethodError` when hands are empty (`nil`). Fixed with `DRC.right_hand&.include?(next_tool)` and a `next_tool.nil?` early return.
- **`Flags.delete('sealing-done')` — wrong flag name**: The `before_dying` block deleted a flag that was never created (`sealing-done`), while the actual `sew-done` flag was leaked. Fixed to `Flags.delete('sew-done')`.

### P1 — Logic Bugs
- **`assemble_part` nil tool**: When right hand is empty during assembly, `tool` is `nil` and `swap_tool(nil)` would crash. Added `if tool` guards around stow and swap_tool calls.
- **`resume` silently drops finished items**: The resume arg definition has no `finish` parameter, so `@finish` was `nil`. When the item completed, the `case @finish` matched nothing and the item was silently abandoned. Fixed with `@finish = args.finish || 'hold'` default.

### P2 — Structural Issues
- **`magic_cleanup` was a top-level method**: Every other crafting script (forge.lic, shape.lic, remedy.lic, carve.lic) defines `magic_cleanup` as a class instance method. sew.lic was the only outlier with it at top-level, making it fragile and harder to test. Moved inside the `Sew` class.

## New Feature: Private Rental Auto-Renewal

When crafting in a private rental room, the sentry warns before the rental expires. Without renewal, the player is evicted and loses crafting progress.

- **`check_rental_status`**: Called at script start — reads the rental notice, parses the expiry time, and pre-emptively renews if <10 minutes remain (warns if <20 minutes).
- **`renew_rental`**: Called mid-craft when the sentry warning fires — runs `mark notice` to renew, with result handling for success, insufficient funds, and missing notice.
- **Work loop integration**: `renew_rental if Flags['sew-rental-warning']` runs every loop iteration.
- **Flag**: `Flags.add('sew-rental-warning', 'Your rental time is almost up')` with cleanup in `before_dying`.

Ported from forge.lic with messaging convention updates (`Lich::Messaging.msg('bold', ...)` instead of `DRC.message`/`echo`).

## Robustness Improvements

- **Double game-state reads eliminated**: `finish` and `lift_or_stow_feet` previously called `DRC.right_hand`/`DRC.left_hand` twice per line (once for the guard, once for the argument). Since these read live game state, the value could change between calls. Now cached in local variables.
- **`list_at_feet` wired into "not found" handler**: Previously dead code — now called as diagnostic output when the work loop encounters `'What were you referring'` / `'I could not find what you were'`, helping debug consumable loss.
- **Additional bput match patterns**: Added `/^You reach out and touch/` for cube touch, `/You need a larger amount of material/` with defensive exit, and `/^You need a free hand to do that/` with recovery handling.

## Verbose Messaging

Applied the convention that every exit/error path must explain itself:
- `check_hand` exit: `"Please hold the item or material you wish to work on. Expected '{item}' in right hand."` (bold)
- Material shortage exit: `"Not enough material to continue crafting {noun}. Exiting."` (bold)
- Material shortage calls `magic_cleanup` before exit (was missing)
- `finish` hold mode: `"{noun} complete — holding in hand."` (bold — `DRC.message` replacement)
- `finish` exit: `"Sew script finished ({noun}, finish: {mode})."` (plain — new informational)
- Resume start: `"Resuming work on {noun} (finish mode: {mode})."` (plain — new informational)
- Convention: `DRC.message` replacements use `Lich::Messaging.msg('bold', ...)`, new informational messages use `Lich::Messaging.msg('plain', ...)`.

## Style / Cleanup

- Removed stale comment `# no longer in use, being removed next edit` from `type` arg
- Kept `DRSkill.getrank('Outfitting') == 175` (one-time warning at exact rank threshold)
- Used `Lich::Messaging.msg('bold', ...)` for the rank warning instead of `echo`
- Reordered `@knit || @chapter == 5` (knitting check first for clarity)
- Added `require 'time'` for `Time.parse` in rental status parsing

## Test Coverage

138 RSpec examples covering:
- **`#swap_tool`** (8 tests): nil right hand, nil next_tool, tool already in hand, partial match, different tool, skip parameter, belt configured (stow/get)
- **`#finish`** (27 tests): simple nouns, dotted nouns, nil hands, hold/stow/trash/log modes, stamp marking, lift_or_stow_feet call, magic_cleanup call, verbose messaging, exit call, right hand holds noun, both hands hold noun, belt configured, dotted noun stow, trash with nil trashcan, noun substring boundary, operation ordering (stow→logbook→lift→cleanup→msg→exit), stamp ordering
- **`#lift_or_stow_feet`** (9 tests): stow non-noun items, dot-notation protection, simple nouns, nil hands, both-hand stow, game-state caching, dotted noun in left hand only, belt configured, stow feet fallback
- **`#check_hand`** (6 tests): item in right hand, item not in hand, verbose error, magic_cleanup ordering, dotted noun passthrough, dotted noun swap
- **`#magic_cleanup`** (2 tests): no spells configured, full release sequence
- **`#list_at_feet`** (3 tests): items present, empty result, nil result
- **`#check_rental_status`** (5 tests): <10 min auto-renew, <20 min warning, >20 min silent, no notice, parse failure
- **`#renew_rental`** (5 tests): successful renewal, flag reset, insufficient funds, missing notice, extends response
- **`#assemble_part`** (9 tests): no flag, nil right hand (no stow, no swap), tool present, swap back to tool, three/two/one-word part names, belt configured, Flags.reset
- **`#prep`** (40 tests): instructions path (get/study once/study twice/no book), master book (find_recipe2/no basic book), basic book (get/find/stow/rank 175 warning/no warn 174/176), knitting via @knit (yarn/check_hand/swap/command/home_tool/home_command), knitting via chapter 5, seal enhancement (disable stamp/check_hand/swap wax/command/home vars), reinforce enhancement (scissors/command/home_tool), cloth products (get material/check_hand/scissors/command/home vars), leather products (get material/check_hand/command/home_tool), cloth material detection (standard/exotic/fallback)
- **Edge cases** (10 tests): finish default for resume, double game-state read prevention, verbose messaging on all exit paths, Flags cleanup correctness, magic_cleanup is instance method
- **Convention enforcement** (14 tests): bold vs plain messaging (hold=bold, finish=plain, check_hand=bold), source code invariants (no DRC.message, no bare echo, magic_cleanup indented, correct flag names, .tr normalization, nil-guarded .include? calls, sew-rental-warning in before_dying)

## Files Changed

- `sew.lic` — all fixes, rental feature, and improvements
- `spec/sew_spec.rb` — comprehensive test suite (138 examples)