### PR TITLE
[script][sigilharvest]Updated stowing of sigils and blank scrolls

### DIFF
--- a/sigilharvest.lic
+++ b/sigilharvest.lic
@@ -45,7 +45,6 @@ class SigilHarvest
         { name: 'sigil', regex: /\w+/, description: "Type of sigil to harvest OR enter 'random' to target a random sigil." },
         { name: 'precision', regex: /\d+/, description: 'Precision target.' },
         { name: 'minutes', regex: /\d+/, optional: true, description: 'Session time limit in minutes (default: 30)' },
-        { name: 'one', regex: /one/i, optional: true, description: 'Override time and only harvest from one room.' },
         { name: 'debug', regex: /debug/i, optional: true, description: 'Provides extra debug information while the script runs' }
       ]
     ]
@@ -96,7 +95,6 @@ class SigilHarvest
     @sigil_results = []
     @start_time = Time.now
     @time_limit = (@args.minutes || 30).to_i
-    @one = @args.one || nil
     @rooms_visited = 0
 
     log_startup_banner
@@ -692,7 +690,6 @@ class SigilHarvest
   end
 
   def time_expired?
-    return true if (@one && @rooms_visited == 1)
     elapsed_minutes >= @time_limit
   end
 


### PR DESCRIPTION
Updated the script to use `DRCC.stow_crafting_item()` instead of `DRCI.stow_item?()` for the blank scrolls and the scribed sigil-scrolls.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `sigilharvest.lic` to use `DRCC.stow_crafting_item()` for scrolls and adds single-room harvesting option.
> 
>   - **Behavior**:
>     - Replaces `DRCI.stow_item?()` with `DRCC.stow_crafting_item()` for handling `sigil-scroll` and `blank scroll` in `scribe_sigils()` and `get_scrolls()`.
>     - Adds `@one` argument to limit harvesting to one room in `initialize()` and `time_expired()`.
>   - **Misc**:
>     - Adds `one` option to `arg_definitions` in `initialize()` for single-room harvesting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 208b1ec7bf935ac019fbbfa62ad8c1e732ba389d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->