### PR TITLE
feat(dr): refactor forge.lic with finish option, rental renewal, and robust patterns

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -289,6 +289,14 @@ class Forge
 
   # @!endgroup
 
+  # @!group Grindstone Constants
+
+  # Maximum retry attempts for spinning grindstone
+  # @return [Integer]
+  SPIN_MAX_RETRIES = 10
+
+  # @!endgroup
+
   # @!group Private Forge Constants
 
   # Default cost for private forge rental in copper
@@ -539,12 +547,22 @@ class Forge
     Lich::Messaging.msg('plain', "Forge: #{message}") if @debug
   end
 
-  # Log an error message (always displayed).
+  # Log an error message (always displayed, bold).
   #
   # @param message [String] the message to log
   # @return [void]
   def error_log(message)
     Lich::Messaging.msg('bold', "Forge: #{message}")
+  end
+
+  # Log an informational message (always displayed, plain).
+  #
+  # Use for success confirmations and status updates that aren't errors.
+  #
+  # @param message [String] the message to log
+  # @return [void]
+  def info_log(message)
+    Lich::Messaging.msg('plain', "Forge: #{message}")
   end
 
   # Stow whatever is in both hands.
@@ -616,15 +634,16 @@ class Forge
   # If item is in right hand, swaps it to left. If item is not found
   # in either hand, logs error and exits.
   #
+  # @param item [String] the item to check for (defaults to @item)
   # @return [void]
   # @raise [SystemExit] if item cannot be found
-  def ensure_item_in_left_hand
-    return if DRCI.in_left_hand?(@item)
+  def ensure_item_in_left_hand(item = @item)
+    return if DRCI.in_left_hand?(item)
 
-    if DRCI.in_right_hand?(@item)
+    if DRCI.in_right_hand?(item)
       DRC.bput('swap', *SWAP_PATTERNS)
     else
-      cleanup_and_exit("MISSING #{@item}. Please find it and restart.")
+      cleanup_and_exit("MISSING #{item}. Please find it and restart.")
     end
   end
 
@@ -675,7 +694,7 @@ class Forge
     DRCT.walk_to(private_forge_room)
 
     if Room.current.id == private_forge_room
-      error_log('Arrived at private forge.')
+      info_log('Arrived at private forge.')
       return
     end
 
@@ -702,7 +721,7 @@ class Forge
       error_log('No door found to enter private forge. Check room setup.')
       error_log('Falling back to current location.')
     else
-      error_log('Entered private forge.')
+      info_log('Entered private forge.')
     end
   end
 
@@ -731,8 +750,8 @@ class Forge
   # @return [void]
   def process_rental_expiration(expire_str)
     # Parse format: "Sun Dec 28 23:39:15 ET 2025"
-    # Convert ET to a timezone offset for parsing
-    expire_str_normalized = expire_str.sub(' ET ', ' -0500 ')
+    # Game always uses US Eastern Time — determine EST (-0500) vs EDT (-0400)
+    expire_str_normalized = expire_str.sub(' ET ', " #{eastern_utc_offset} ")
     expire_time = Time.parse(expire_str_normalized)
     minutes_remaining = ((expire_time - Time.now) / 60).to_i
 
@@ -742,10 +761,31 @@ class Forge
       error_log("RENTAL LOW (#{minutes_remaining} min) - PRE-EMPTIVELY RENEWING")
       renew_forge_rental
     elsif minutes_remaining < 20
-      error_log("Rental has #{minutes_remaining} minutes remaining")
+      info_log("Rental has #{minutes_remaining} minutes remaining")
     end
   rescue ArgumentError => e
-    debug_log("Could not parse rental time: #{expire_str} - #{e.message}")
+    error_log("Could not parse rental time: #{expire_str} - #{e.message}")
+  end
+
+  # Determine the current US Eastern timezone UTC offset.
+  #
+  # DragonRealms always uses US Eastern Time (ET). This method
+  # determines whether EST (-0500) or EDT (-0400) is currently
+  # in effect based on US DST rules (second Sunday of March
+  # to first Sunday of November).
+  #
+  # @return [String] UTC offset string ('-0500' or '-0400')
+  def eastern_utc_offset
+    now = Time.now.utc
+    year = now.year
+
+    march_day = (8..14).find { |d| Time.utc(year, 3, d).sunday? }
+    november_day = (1..7).find { |d| Time.utc(year, 11, d).sunday? }
+
+    dst_start = Time.utc(year, 3, march_day, 7) # 2am EST = 7:00 UTC
+    dst_end = Time.utc(year, 11, november_day, 6) # 2am EDT = 6:00 UTC
+
+    (now >= dst_start && now < dst_end) ? '-0400' : '-0500'
   end
 
   # Renew the private forge rental.
@@ -763,7 +803,7 @@ class Forge
     when 'I could not find'
       error_log('COULD NOT FIND NOTICE - CHECK LOCATION')
     else
-      error_log('RENTAL RENEWED')
+      info_log('RENTAL RENEWED')
     end
   end
 
@@ -799,7 +839,7 @@ class Forge
     @home_command = "turn #{@item} on forge with my tongs"
     @stamp = false
     swap_tool('tongs')
-    ensure_item_in_left_hand unless DRCI.in_left_hand?('tongs')
+    ensure_item_in_left_hand('tongs') unless DRCI.in_left_hand?('tongs')
     @location = 'on forge'
     @command ||= "put my #{@item} on the forge"
   end
@@ -1021,7 +1061,7 @@ class Forge
 
     percent_str = progress[:percent] ? "#{progress[:percent]}%" : 'unknown'
     quality_str = progress[:quality] || 'unknown'
-    error_log("[#{phase}] Progress: #{percent_str} | Quality: #{quality_str}")
+    info_log("[#{phase}] Progress: #{percent_str} | Quality: #{quality_str}")
   end
 
   # Analyze item to determine crafting progress and quality.
@@ -1030,7 +1070,7 @@ class Forge
   # and quality assessment.
   #
   # @return [Hash, nil] progress info or nil if unavailable
-  #   - :percent [Integer, nil] completion percentage (0-100), nil if "final stage"
+  #   - :percent [Integer] completion percentage (0-100), 99 for "final stage"
   #   - :quality [String, nil] current quality assessment
   def analyze_progress
     location = DRCI.in_hands?(@item) ? "my #{@item}" : "#{@item} #{@location}"
@@ -1065,21 +1105,17 @@ class Forge
 
   # @!group Grindstone Management
 
-  # Maximum retry attempts for spinning grindstone
-  # @return [Integer]
-  SPIN_MAX_RETRIES = 10
-
   # Spin the grindstone to maintain speed.
   #
   # Uses a 20-second cooldown timer to avoid excessive spinning.
   # Retries if spin fails, with a maximum retry limit to prevent
   # unbounded recursion.
   #
-  # @param retries [Integer] current retry count (default: 0)
+  # @param retries [Integer] remaining retry attempts (countdown)
   # @return [void]
   # @raise [SystemExit] if max retries exceeded
-  def spin_grindstone(retries = 0)
-    if retries >= SPIN_MAX_RETRIES
+  def spin_grindstone(retries: SPIN_MAX_RETRIES)
+    if retries <= 0
       cleanup_and_exit("Failed to spin grindstone after #{SPIN_MAX_RETRIES} attempts.")
     end
 
@@ -1089,10 +1125,10 @@ class Forge
     result = DRC.bput('turn grind', *SPIN_SUCCESS_PATTERNS, *SPIN_FAILURE_PATTERNS, SPIN_MISSING_PATTERN)
     case result
     when *SPIN_FAILURE_PATTERNS
-      spin_grindstone(retries + 1)
+      spin_grindstone(retries: retries - 1)
     when SPIN_MISSING_PATTERN
       DRCC.find_grindstone(@hometown)
-      spin_grindstone(retries + 1)
+      spin_grindstone(retries: retries - 1)
     else
       @next_spin = Time.now + 20
     end
@@ -1366,10 +1402,7 @@ class Forge
   # @raise [SystemExit] exits since no work needed
   def handle_temper_already_done
     error_log("#{@item} has already been tempered. Further heating would damage it.")
-    error_log('Nothing to do.')
-    DRCC.stow_crafting_item('tongs', @bag, @forging_belt)
-    magic_cleanup
-    exit
+    cleanup_and_exit('Nothing to do.')
   end
 
   # Handle forge needs fuel.
@@ -1550,18 +1583,18 @@ class Forge
     case @finish
     when /log/
       DRCC.logbook_item('engineering', @item, @bag)
-      error_log("#{@item} logged to engineering logbook.")
+      info_log("#{@item} logged to engineering logbook.")
     when /stow/
       if DRCC.stow_crafting_item(@item, @bag, @forging_belt)
-        error_log("#{@item} stowed in #{@bag}.")
+        info_log("#{@item} stowed in #{@bag}.")
       else
         error_log("Failed to stow #{@item}. Item may still be in hand.")
       end
     when /trash/
       DRCI.dispose_trash(@item)
-      error_log("#{@item} disposed.")
+      info_log("#{@item} disposed.")
     else
-      error_log("#{@item} complete. Holding in hand.")
+      info_log("#{@item} complete. Holding in hand.")
     end
   end
 

--- a/spec/forge_spec.rb
+++ b/spec/forge_spec.rb
@@ -394,6 +394,77 @@ RSpec.describe Forge do
       end
     end
 
+    describe '#info_log' do
+      it 'calls Lich::Messaging.msg with plain styling' do
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: info message')
+        forge_instance.send(:info_log, 'info message')
+      end
+    end
+
+    describe '#eastern_utc_offset' do
+      it 'returns -0500 for EST dates (January)' do
+        allow(Time).to receive(:now).and_return(Time.utc(2026, 1, 15, 12, 0, 0))
+        expect(forge_instance.send(:eastern_utc_offset)).to eq('-0500')
+      end
+
+      it 'returns -0400 for EDT dates (July)' do
+        allow(Time).to receive(:now).and_return(Time.utc(2026, 7, 15, 12, 0, 0))
+        expect(forge_instance.send(:eastern_utc_offset)).to eq('-0400')
+      end
+
+      it 'returns -0500 for December (EST)' do
+        allow(Time).to receive(:now).and_return(Time.utc(2026, 12, 1, 12, 0, 0))
+        expect(forge_instance.send(:eastern_utc_offset)).to eq('-0500')
+      end
+    end
+
+    describe '#validate_free_hand' do
+      it 'passes when both hands are empty' do
+        allow(DRC).to receive(:right_hand).and_return(nil)
+        allow(DRC).to receive(:left_hand).and_return(nil)
+        expect { forge_instance.send(:validate_free_hand) }.not_to raise_error
+      end
+
+      it 'passes when one hand has item and the other is free' do
+        allow(DRC).to receive(:right_hand).and_return('sword')
+        allow(DRC).to receive(:left_hand).and_return(nil)
+        expect { forge_instance.send(:validate_free_hand) }.not_to raise_error
+      end
+
+      it 'exits when both hands hold non-target items' do
+        allow(DRC).to receive(:right_hand).and_return('hammer')
+        allow(DRC).to receive(:left_hand).and_return('shield')
+        expect(Lich::Messaging).to receive(:msg).with('bold', /Need a free hand/)
+        expect(Lich::Messaging).to receive(:msg).with('bold', /Please stow extra items/)
+        expect { forge_instance.send(:validate_free_hand) }.to raise_error(SystemExit)
+      end
+    end
+
+    describe '#prepare_item_in_left_hand' do
+      it 'returns true immediately when item already in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(true)
+        expect(DRC).not_to receive(:bput)
+        expect(forge_instance.send(:prepare_item_in_left_hand)).to eq(true)
+      end
+
+      it 'gets item from anvil and ensures in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(false, true)
+        allow(DRCI).to receive(:in_hands?).and_return(false)
+        allow(DRCC).to receive(:stow_crafting_item)
+        expect(DRC).to receive(:bput).with('get sword on anvil', 'You get', 'What were you referring to?').and_return('You get')
+        expect(forge_instance.send(:prepare_item_in_left_hand)).to eq(true)
+      end
+
+      it 'logs error when get fails' do
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(false, true)
+        allow(DRCI).to receive(:in_hands?).and_return(false)
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(DRC).to receive(:bput).and_return('What were you referring to?')
+        expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to get sword/)
+        forge_instance.send(:prepare_item_in_left_hand, 'on anvil', 'grindstone work')
+      end
+    end
+
     describe '#check_rental_status' do
       before { stub_flags_class }
 
@@ -429,13 +500,12 @@ RSpec.describe Forge do
         allow(Time).to receive(:parse).and_call_original
         allow(Lich::Messaging).to receive(:msg)
         forge_instance.send(:check_rental_status)
-        expect(Lich::Messaging).to have_received(:msg).with('bold', /Forge: Rental has \d+ minutes remaining/)
+        expect(Lich::Messaging).to have_received(:msg).with('plain', /Forge: Rental has \d+ minutes remaining/)
       end
 
       it 'handles ArgumentError from time parsing' do
-        forge_instance.instance_variable_set(:@debug, true)
         allow(DRC).to receive(:bput).and_return('It will expire invalid time format.')
-        expect(Lich::Messaging).to receive(:msg).with('plain', /Could not parse rental time/)
+        expect(Lich::Messaging).to receive(:msg).with('bold', /Could not parse rental time/)
         forge_instance.send(:check_rental_status)
       end
     end
@@ -456,7 +526,7 @@ RSpec.describe Forge do
       it 'logs success message on renewal' do
         allow(DRC).to receive(:bput).and_return('You mark the notice')
         expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: FORGE RENTAL EXPIRING - AUTO-RENEWING')
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: RENTAL RENEWED')
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: RENTAL RENEWED')
         forge_instance.send(:renew_forge_rental)
       end
 
@@ -505,7 +575,9 @@ RSpec.describe Forge do
         allow(DRCI).to receive(:in_hands?).and_return(false)
         allow(DRC).to receive(:bput).with('look on anvil', anything, anything).and_return('clean and ready')
         allow(DRC).to receive(:bput).with('look on forge', anything, anything).and_return('There is nothing')
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: sword not found on anvil, forge, or in hands. Exiting.')
+        allow(DRC).to receive(:bput) # Allow magic_cleanup bput calls
+        allow(DRCC).to receive(:stow_crafting_item)
+        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: sword not found on anvil, forge, or in hands.')
         expect { forge_instance.send(:find_item) }.to raise_error(SystemExit)
       end
     end
@@ -580,23 +652,20 @@ RSpec.describe Forge do
     end
 
     describe '#handle_grindstone' do
-      it 'gets item from anvil when not in left hand' do
+      before do
+        forge_instance.instance_variable_set(:@show_progress, false)
+      end
+
+      it 'prepares item in left hand when not already there' do
         forge_instance.instance_variable_set(:@resume, false)
         allow(DRCI).to receive(:in_left_hand?).and_return(false)
         allow(DRCI).to receive(:in_hands?).and_return(false)
-        expect(DRC).to receive(:bput).with('get sword from anvil', 'You get', 'What were you referring to?').and_return('You get')
-        expect(forge_instance).to receive(:check_hand).with('sword')
+        allow(DRCI).to receive(:in_right_hand?).and_return(false)
+        allow(DRC).to receive(:bput).and_return('You get')
+        allow(DRCC).to receive(:stow_crafting_item)
+        allow(forge_instance).to receive(:ensure_item_in_left_hand)
         forge_instance.send(:handle_grindstone)
         expect(forge_instance.instance_variable_get(:@command)).to eq('push grindstone with my sword')
-      end
-
-      it 'logs error when get fails' do
-        allow(DRCI).to receive(:in_left_hand?).and_return(false)
-        allow(DRCI).to receive(:in_hands?).and_return(false)
-        expect(DRC).to receive(:bput).and_return('What were you referring to?')
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Failed to get sword from anvil for grindstone work.')
-        expect(forge_instance).to receive(:check_hand).with('sword')
-        forge_instance.send(:handle_grindstone)
       end
 
       it 'sets home_tool to wire brush when resuming' do
@@ -608,11 +677,12 @@ RSpec.describe Forge do
     end
 
     describe '#handle_pliers' do
-      it 'gets item from anvil when not in left hand' do
-        allow(DRCI).to receive(:in_left_hand?).and_return(false)
-        allow(DRCI).to receive(:in_hands?).and_return(false)
-        expect(DRC).to receive(:bput).with('get sword from anvil', 'You get', 'What were you referring to?').and_return('You get')
-        expect(forge_instance).to receive(:check_hand).with('sword')
+      before do
+        forge_instance.instance_variable_set(:@show_progress, false)
+      end
+
+      it 'prepares item in left hand and swaps to pliers' do
+        allow(DRCI).to receive(:in_left_hand?).and_return(true)
         expect(forge_instance).to receive(:swap_tool).with('pliers')
         forge_instance.send(:handle_pliers)
         expect(forge_instance.instance_variable_get(:@command)).to eq('pull my sword with my pliers')
@@ -623,13 +693,14 @@ RSpec.describe Forge do
       before do
         forge_instance.instance_variable_set(:@location, 'on anvil')
         forge_instance.instance_variable_set(:@home_tool, 'hammer')
+        forge_instance.instance_variable_set(:@show_progress, false)
       end
 
       it 'gets item when not in left hand' do
-        allow(DRCI).to receive(:in_left_hand?).and_return(false)
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(false, true)
+        allow(DRCI).to receive(:in_right_hand?).and_return(false)
         expect(DRCC).to receive(:stow_crafting_item)
         expect(DRC).to receive(:bput).with('get sword on anvil', 'You get', 'What were you referring to?').and_return('You get')
-        expect(forge_instance).to receive(:check_hand).with('sword')
         expect(forge_instance).to receive(:swap_tool).with('oil', true)
         forge_instance.send(:handle_oiling)
         expect(forge_instance.instance_variable_get(:@command)).to eq('pour my oil on my sword')
@@ -638,9 +709,7 @@ RSpec.describe Forge do
       it 'always gets item when home_tool is tongs (temper)' do
         forge_instance.instance_variable_set(:@home_tool, 'tongs')
         forge_instance.instance_variable_set(:@location, 'on forge')
-        # When home_tool is tongs, it always enters the get block
-        # After getting item, it should be in left hand
-        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(true) # Item is in left hand after get
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(true)
         allow(DRCC).to receive(:stow_crafting_item)
         allow(DRC).to receive(:bput).with('get sword on forge', anything, anything).and_return('You get')
         allow(forge_instance).to receive(:swap_tool)
@@ -652,8 +721,8 @@ RSpec.describe Forge do
 
     describe '#handle_handle_assembly' do
       it 'gets item, assembles, puts back, and sets up pounding' do
+        allow(DRCI).to receive(:in_left_hand?).and_return(true)
         expect(DRC).to receive(:bput).with('get sword from anvil', 'You get', 'What were you referring to?').and_return('You get')
-        expect(forge_instance).to receive(:check_hand).with('sword')
         expect(forge_instance).to receive(:assemble_part)
         expect(DRC).to receive(:bput).with('put my sword on anvil', 'You put')
         expect(forge_instance).to receive(:swap_tool).with('forging hammer')
@@ -671,10 +740,10 @@ RSpec.describe Forge do
         forge_instance.instance_variable_set(:@home_command, 'pound sword on anvil with my forging hammer')
       end
 
-      it 'calls finish when work-done flag is set' do
+      it 'calls complete_crafting when work-done flag is set' do
         Flags['work-done'] = true
         expect(forge_instance).to receive(:waitrt?)
-        expect(forge_instance).to receive(:finish)
+        expect(forge_instance).to receive(:complete_crafting)
         expect(forge_instance).to receive(:swap_tool).with('forging hammer')
         forge_instance.send(:handle_roundtime)
       end
@@ -732,8 +801,7 @@ RSpec.describe Forge do
         Flags['forge-assembly'] = ['full match', 'wooden', 'hilt']
         $right_hand = nil
         allow(DRCI).to receive(:get_item?).with('wooden hilt').and_return(false)
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Missing wooden hilt. Cannot continue assembly. Exiting.')
-        expect(forge_instance).to receive(:magic_cleanup)
+        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Missing wooden hilt. Cannot continue assembly.')
         expect { forge_instance.send(:assemble_part) }.to raise_error(SystemExit)
       end
     end
@@ -798,22 +866,37 @@ RSpec.describe Forge do
       end
     end
 
-    describe '#check_hand' do
+    describe '#ensure_item_in_left_hand' do
+      it 'returns immediately when item is in left hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(true)
+        expect(DRC).not_to receive(:bput)
+        forge_instance.send(:ensure_item_in_left_hand)
+      end
+
       it 'swaps hands when item in right hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(false)
         allow(DRCI).to receive(:in_right_hand?).with('sword').and_return(true)
         expect(DRC).to receive(:bput).with('swap', 'You move', 'You have nothing')
-        forge_instance.send(:check_hand, 'sword')
+        forge_instance.send(:ensure_item_in_left_hand)
+      end
+
+      it 'accepts explicit item parameter' do
+        allow(DRCI).to receive(:in_left_hand?).with('tongs').and_return(false)
+        allow(DRCI).to receive(:in_right_hand?).with('tongs').and_return(true)
+        expect(DRC).to receive(:bput).with('swap', 'You move', 'You have nothing')
+        forge_instance.send(:ensure_item_in_left_hand, 'tongs')
       end
 
       it 'exits with error when item not in either hand' do
+        allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(false)
         allow(DRCI).to receive(:in_right_hand?).with('sword').and_return(false)
         expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: MISSING sword. Please find it and restart.')
         expect(forge_instance).to receive(:magic_cleanup)
-        expect { forge_instance.send(:check_hand, 'sword') }.to raise_error(SystemExit)
+        expect { forge_instance.send(:ensure_item_in_left_hand) }.to raise_error(SystemExit)
       end
     end
 
-    describe '#finish' do
+    describe '#complete_crafting' do
       before do
         $right_hand = 'hammer'
         allow(DRCC).to receive(:stow_crafting_item)
@@ -823,35 +906,35 @@ RSpec.describe Forge do
       it 'logs item to engineering logbook when finish is log' do
         forge_instance.instance_variable_set(:@finish, 'log')
         expect(DRCC).to receive(:logbook_item).with('engineering', 'sword', 'backpack')
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: sword logged to engineering logbook.')
-        expect { forge_instance.send(:finish) }.to raise_error(SystemExit)
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: sword logged to engineering logbook.')
+        expect { forge_instance.send(:complete_crafting) }.to raise_error(SystemExit)
       end
 
       it 'stows item when finish is stow' do
         forge_instance.instance_variable_set(:@finish, 'stow')
         expect(DRCC).to receive(:stow_crafting_item).with('sword', 'backpack', nil).and_return(true)
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: sword stowed in backpack.')
-        expect { forge_instance.send(:finish) }.to raise_error(SystemExit)
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: sword stowed in backpack.')
+        expect { forge_instance.send(:complete_crafting) }.to raise_error(SystemExit)
       end
 
       it 'logs failure when stow fails' do
         forge_instance.instance_variable_set(:@finish, 'stow')
         expect(DRCC).to receive(:stow_crafting_item).with('sword', 'backpack', nil).and_return(false)
         expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Failed to stow sword. Item may still be in hand.')
-        expect { forge_instance.send(:finish) }.to raise_error(SystemExit)
+        expect { forge_instance.send(:complete_crafting) }.to raise_error(SystemExit)
       end
 
       it 'disposes item when finish is trash' do
         forge_instance.instance_variable_set(:@finish, 'trash')
         expect(DRCI).to receive(:dispose_trash).with('sword')
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: sword disposed.')
-        expect { forge_instance.send(:finish) }.to raise_error(SystemExit)
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: sword disposed.')
+        expect { forge_instance.send(:complete_crafting) }.to raise_error(SystemExit)
       end
 
       it 'holds item in hand when finish is hold' do
         forge_instance.instance_variable_set(:@finish, 'hold')
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: sword complete. Holding in hand.')
-        expect { forge_instance.send(:finish) }.to raise_error(SystemExit)
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: sword complete. Holding in hand.')
+        expect { forge_instance.send(:complete_crafting) }.to raise_error(SystemExit)
       end
 
       it 'stamps item when @stamp is true' do
@@ -860,7 +943,7 @@ RSpec.describe Forge do
         expect(forge_instance).to receive(:swap_tool).with('stamp')
         expect(DRC).to receive(:bput).with('mark my sword with my stamp', *Forge::STAMP_PATTERNS)
         expect(DRCC).to receive(:stow_crafting_item).with('stamp', 'backpack', nil)
-        expect { forge_instance.send(:finish) }.to raise_error(SystemExit)
+        expect { forge_instance.send(:complete_crafting) }.to raise_error(SystemExit)
       end
     end
 
@@ -874,43 +957,42 @@ RSpec.describe Forge do
     end
 
     describe '#go_to_private_forge' do
-      let(:settings) { OpenStruct.new(hometown: 'Crossing') }
-
       before do
         forge_instance.instance_variable_set(:@info, { 'private_forge' => 16_936 })
         forge_instance.instance_variable_set(:@private_forge_cost, 5000)
         forge_instance.instance_variable_set(:@hometown, 'Crossing')
+        forge_instance.instance_variable_set(:@settings, OpenStruct.new(hometown: 'Crossing'))
       end
 
       it 'returns early and logs when no private forge defined' do
         forge_instance.instance_variable_set(:@info, {})
         expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: No private forge defined for Crossing. Using public forge.')
         expect(DRCM).not_to receive(:ensure_copper_on_hand)
-        forge_instance.send(:go_to_private_forge, settings)
+        forge_instance.send(:go_to_private_forge)
       end
 
       it 'exits when unable to get money' do
         allow(DRCM).to receive(:ensure_copper_on_hand).and_return(false)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Unable to get 5000 copper/)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Check your bank balance/)
-        expect { forge_instance.send(:go_to_private_forge, settings) }.to raise_error(SystemExit)
+        expect { forge_instance.send(:go_to_private_forge) }.to raise_error(SystemExit)
       end
 
       it 'succeeds when already in private forge room after walk_to' do
         allow(DRCM).to receive(:ensure_copper_on_hand).and_return(true)
         allow(DRCT).to receive(:walk_to)
         allow(Room).to receive(:current).and_return(MockRoom.new(16_936))
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Arrived at private forge.')
-        forge_instance.send(:go_to_private_forge, settings)
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: Arrived at private forge.')
+        forge_instance.send(:go_to_private_forge)
       end
 
       it 'tries go door when not in private forge room' do
         allow(DRCM).to receive(:ensure_copper_on_hand).and_return(true)
         allow(DRCT).to receive(:walk_to)
-        allow(Room).to receive(:current).and_return(MockRoom.new(12_345)) # Different room
+        allow(Room).to receive(:current).and_return(MockRoom.new(12_345))
         expect(DRC).to receive(:bput).with('go door', *Forge::PRIVATE_FORGE_ENTRY_SUCCESS, *Forge::PRIVATE_FORGE_ENTRY_BLOCKED, 'What were you').and_return('You head through')
-        expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Entered private forge.')
-        forge_instance.send(:go_to_private_forge, settings)
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: Entered private forge.')
+        forge_instance.send(:go_to_private_forge)
       end
 
       it 'exits with verbose error when blocked by sentry' do
@@ -924,7 +1006,7 @@ RSpec.describe Forge do
         expect(Lich::Messaging).to receive(:msg).with('bold', /Forge is already rented/)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Other restriction/)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Exiting/)
-        expect { forge_instance.send(:go_to_private_forge, settings) }.to raise_error(SystemExit)
+        expect { forge_instance.send(:go_to_private_forge) }.to raise_error(SystemExit)
       end
 
       it 'falls back gracefully when no door found' do
@@ -934,17 +1016,11 @@ RSpec.describe Forge do
         expect(DRC).to receive(:bput).and_return('What were you')
         expect(Lich::Messaging).to receive(:msg).with('bold', /No door found/)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Falling back/)
-        forge_instance.send(:go_to_private_forge, settings)
+        forge_instance.send(:go_to_private_forge)
       end
     end
 
     describe '#prep' do
-      let(:settings) do
-        OpenStruct.new(
-          master_crafting_book: false
-        )
-      end
-
       before do
         forge_instance.instance_variable_set(:@bag, 'backpack')
         forge_instance.instance_variable_set(:@bag_items, [])
@@ -955,6 +1031,7 @@ RSpec.describe Forge do
         forge_instance.instance_variable_set(:@book_type, 'weaponsmithing')
         forge_instance.instance_variable_set(:@home_tool, 'forging hammer')
         forge_instance.instance_variable_set(:@hammer, 'forging hammer')
+        forge_instance.instance_variable_set(:@settings, OpenStruct.new(master_crafting_book: false))
         allow(DRCA).to receive(:crafting_magic_routine)
         allow(DRSkill).to receive(:getrank).and_return(200)
       end
@@ -973,28 +1050,27 @@ RSpec.describe Forge do
           allow(DRC).to receive(:bput).with('put my ingot on anvil', Forge::PUT_SUCCESS_PATTERN).and_return('You put')
 
           expect(DRCC).to receive(:get_crafting_item).with('bronze ingot', 'backpack', [], nil, true)
-          forge_instance.send(:prep, settings)
+          forge_instance.send(:prep)
         end
 
         it 'exits when ingot not in hands after fetch attempt' do
           allow(DRCI).to receive(:in_hands?).with('ingot').and_return(false)
           allow(forge_instance).to receive(:magic_cleanup)
 
-          # error_log adds "Forge:" prefix
-          expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Failed to get bronze ingot. Exiting.')
-          expect { forge_instance.send(:prep, settings) }.to raise_error(SystemExit)
+          expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: Failed to get bronze ingot.')
+          expect { forge_instance.send(:prep) }.to raise_error(SystemExit)
         end
 
         it 'places ingot on anvil when successfully fetched' do
           allow(DRCI).to receive(:in_hands?).with('ingot').and_return(true)
           expect(DRC).to receive(:bput).with('put my ingot on anvil', Forge::PUT_SUCCESS_PATTERN)
-          forge_instance.send(:prep, settings)
+          forge_instance.send(:prep)
         end
 
         it 'sets up command for pounding after placing ingot' do
           allow(DRCI).to receive(:in_hands?).with('ingot').and_return(true)
           allow(DRC).to receive(:bput).with('put my ingot on anvil', Forge::PUT_SUCCESS_PATTERN)
-          forge_instance.send(:prep, settings)
+          forge_instance.send(:prep)
           expect(forge_instance.instance_variable_get(:@command)).to eq('pound ingot on anvil with my forging hammer')
         end
       end
@@ -1011,7 +1087,7 @@ RSpec.describe Forge do
 
         it 'does not attempt to fetch ingot' do
           expect(DRCC).not_to receive(:get_crafting_item).with(/ingot/, anything, anything, anything, anything)
-          forge_instance.send(:prep, settings)
+          forge_instance.send(:prep)
         end
       end
     end


### PR DESCRIPTION
## Summary

Comprehensive refactoring of `forge.lic` following the established dr-scripts/lich-5 refactoring patterns. This PR adds new features, fixes bugs, improves code maintainability, and adds comprehensive test coverage.

### New Features
- **`finish` argument** - Optional argument to specify what happens to completed items:
  - `hold` (default) - Leave item in hand
  - `log` - Log to engineering logbook
  - `stow` - Stow in crafting container
  - `trash` - Dispose of item
- **Automatic forge rental renewal** - Proactively checks rental status at startup and renews if <10 minutes remaining. Also monitors for low rental warning during crafting and auto-renews.
- **Progress reporting** - Optional `forge_show_progress` setting reports completion % and quality at milestones (cooling, grinding, pliers)

### Bug Fixes
- **`@debug` assignment order** - Fixed bug where `@debug` was used in echo statement before being assigned (line 69 in original)
- **`setup_temper_defaults` tongs bug** - `ensure_item_in_left_hand` was checking for `@item` (the forging target) instead of `'tongs'`; now accepts optional item parameter and temper setup passes `'tongs'` explicitly
- **Timezone handling** - Rental expiration parsing was hardcoded to EST (`-0500`); new `eastern_utc_offset` method dynamically detects EST vs EDT using US DST rules (2nd Sunday March → 1st Sunday November)
- **Silent error swallowing** - `process_rental_expiration` rescue block changed from `debug_log` to `error_log` so time parsing failures are always visible
- **`handle_temper_already_done`** - Was using inline stow/magic_cleanup/exit; now uses `cleanup_and_exit` for consistent cleanup

### Code Quality Improvements
- **`frozen_string_literal: true`** pragma added
- **30+ pattern constants extracted** - All inline pattern arrays/strings moved to frozen class constants for clarity and reuse
- **`SPIN_MAX_RETRIES` relocated** - Moved from between methods to constants section at class top
- **`spin_grindstone` keyword param** - Changed from positional `retries = 0` count-up to keyword `retries: SPIN_MAX_RETRIES` countdown per project conventions
- **`Regexp.last_match` → named captures** - Rental time parsing now uses explicit named capture (`expire_time`) instead of global state
- **Three-tier logging** - `error_log` (bold, errors/warnings), `info_log` (plain, success/status), `debug_log` (plain, debug-only); 8 success messages moved from `error_log` to `info_log`
- **`Lich::Messaging.msg` with `Forge:` prefix** - All `echo`/`DRC.message` calls converted to proper messaging API with consistent module prefix
- **DRCI predicate conversions** - `get my ingot` → `DRCI.get_item?` with proper failure handling and messaging
- **Verbose failure messaging** - Every exit/failure path now logs a descriptive error message explaining what went wrong
- **Refactored `work()` method** - Large case statement split into focused handler methods (`handle_fuel_needed`, `handle_pounding`, `handle_grindstone`, `handle_pliers`, `handle_oiling`, `handle_handle_assembly`, `handle_roundtime`) for maintainability
- **Full YARD documentation** - Every method has `@param`, `@return`, `@raise`, `@example` tags as appropriate

### Constants Added (30+)
| Constant | Description |
|----------|-------------|
| `RENTAL_EXPIRE_PATTERN` | Named capture regex for rental expiration |
| `RENTAL_NOT_FOUND_PATTERNS` | Notice not found responses |
| `RENTAL_RENEW_SUCCESS/FAILURE_PATTERNS` | Rental renewal responses |
| `TONGS_ERROR_PATTERNS` | Tongs-related error messages |
| `FUEL_NEEDED_PATTERNS` | Forge fuel low messages |
| `BELLOWS_NEEDED_PATTERNS` | Bellows needed messages |
| `TONGS_TURN_PATTERNS` | Turn with tongs messages (6 patterns) |
| `COOLING_PATTERNS` | Slack tub/cooling messages |
| `POUND_PATTERNS` | Pounding needed messages (6 patterns) |
| `GRINDSTONE_PATTERNS` | Grindstone work messages (6 patterns) |
| `PLIERS_PATTERNS` | Pliers work messages (5 patterns) |
| `OIL_PATTERNS` | Oiling needed messages (4 patterns) |
| `SPIN_SUCCESS/FAILURE_PATTERNS` | Grindstone spinning results |
| `SPIN_MAX_RETRIES` | Bounded recursion limit for grindstone |
| `ASSEMBLE_SUCCESS_PATTERNS` | Assembly success messages |
| `STAMP_PATTERNS` | Stamping result messages |
| + 15 more single-value constants |

### New Files
- `spec/forge_spec.rb` - **78 comprehensive tests** covering:
  - All 30+ constants (frozen, correct values)
  - `resolve_recipe_name` conversion logic
  - `debug_log` / `error_log` / `info_log` messaging
  - `eastern_utc_offset` EST/EDT detection
  - `validate_free_hand` hand checking logic
  - `prepare_item_in_left_hand` item retrieval
  - `ensure_item_in_left_hand` with explicit item param
  - `check_rental_status` parsing and renewal logic
  - `renew_forge_rental` success/failure paths
  - `find_item` location detection
  - `restow_ingot` with failure handling
  - All handler methods (`handle_fuel_needed`, `handle_pounding`, etc.)
  - `assemble_part` with missing part handling
  - `spin_grindstone` success/failure/missing paths
  - `swap_tool` with adjustable tongs logic
  - `complete_crafting` with all finish options (hold/log/stow/trash)
  - `set_defaults` for all recipe types

## Test plan
- [x] Created 78 RSpec tests covering all functionality
- [x] All tests passing locally
- [x] Rubocop clean (no offenses)
- [x] Spec-to-code alignment verified (all method names and signatures match)
- [x] Manual in-game testing of:
  - [x] Normal forging workflow
  - [ ] `finish log` option
  - [ ] `finish stow` option
  - [x] `finish trash` option
  - [x] Rental renewal at <10 minutes
  - [x] Rental warning at 10-20 minutes
  - [ ] Resume functionality

## Migration Notes
- No breaking changes - all existing usage patterns continue to work
- New `finish` argument is optional, defaults to `hold` (existing behavior)
- Rental check is automatic and transparent
- New YAML settings: `forge_show_progress` (default: true), `forge_use_private_forge`, `forge_private_forge_cost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)