### PR TITLE
feat(dr): Add cascading includes support to dependency.lic

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -1075,13 +1075,13 @@ class SetupFiles
            .uniq
            .select { |filepath| File.file?(filepath) } # ignore directories
            .each do |filepath|
-          filename = File.basename(filepath)
-          last_modified_date = File.mtime(filepath)
-          cached_file = cache_get_by_filename(filename)
-          echo "#{self.class}::#{__callee__} filepath=#{filepath}, last_modified_date=#{last_modified_date}, cached_file=#{cached_file.inspect}" if @debug
-          if cached_file.mtime != last_modified_date
-            cache_put_by_filepath(filepath)
-          end
+             filename = File.basename(filepath)
+             last_modified_date = File.mtime(filepath)
+             cached_file = cache_get_by_filename(filename)
+             echo "#{self.class}::#{__callee__} filepath=#{filepath}, last_modified_date=#{last_modified_date}, cached_file=#{cached_file.inspect}" if @debug
+             if cached_file.mtime != last_modified_date
+               cache_put_by_filepath(filepath)
+             end
         end
       end
     end


### PR DESCRIPTION
## Summary

Add support for **cascading includes** in YAML configuration files. Include files can now have their own `include:` property that references other include files, enabling modular and hierarchical configurations.

**Version:** `2.0.21` → `2.1.0`

## Changes

- Add `resolve_includes_recursively` method for depth-first include resolution
- Modify `get_settings` to use recursive include resolution
- Add circular dependency protection via `Set`-based visited tracking
- Handle diamond dependencies (shared includes loaded only once)
- Add debug output for resolved include order
- Add 18 comprehensive spec tests

## Problem

Previously, `include:` only worked at a single level. If `Mahtra-setup.yaml` included `include-hunting.yaml`, that hunting file could NOT itself include other files. Players had to list ALL dependencies in their character file.

## Solution

Include files can now nest includes:

```yaml
# Mahtra-setup.yaml
include:
  - hunting

# include-hunting.yaml
include:
  - combat       # NOW WORKS!
  - survival

# include-combat.yaml
include:
  - weapons      # Also works - any depth supported
```

## Merge Order (Depth-First)

```
1. base.yaml
2. base-empty.yaml
3. include-weapons.yaml      (deepest dependency)
4. include-combat.yaml       (depends on weapons)
5. include-survival.yaml     (sibling of combat)
6. include-hunting.yaml      (depends on combat, survival)
7. Mahtra-setup.yaml         (character file - always last)
```

## Edge Cases Handled

- **Circular dependencies**: `a -> b -> a` - Uses visited Set, no infinite loops
- **Diamond dependencies**: Shared includes loaded only once
- **Missing files**: Silently skipped
- **Self-references**: Handled gracefully

## Backwards Compatibility

**Fully backwards compatible** - existing configurations work unchanged.

## Test Plan

- [x] 18 new spec tests covering all edge cases
- [x] All specs pass locally
- [x] CI passes
- [x] Manual testing with nested include configurations

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds cascading includes support to YAML configuration files in `dependency.lic`, with depth-first resolution and circular dependency protection, and introduces 18 new spec tests.
> 
>   - **Behavior**:
>     - Adds cascading includes support in YAML configuration files in `dependency.lic`.
>     - New method `resolve_includes_recursively` for depth-first include resolution.
>     - Modifies `get_settings` to use recursive include resolution.
>     - Adds circular dependency protection using `Set`-based visited tracking.
>     - Handles diamond dependencies by loading shared includes only once.
>     - Adds debug output for resolved include order.
>   - **Tests**:
>     - Adds 18 spec tests in `dependency_cascading_includes_spec.rb` covering edge cases like circular dependencies, diamond dependencies, missing files, and self-references.
>   - **Misc**:
>     - Updates version from `2.0.21` to `2.1.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 4c79f71fa954fc4b13dfda18769551ff66b3e409. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->