### PR TITLE
[data] base-town.yaml - add leth repair shop

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -341,8 +341,10 @@ Leth Deriel:
     id: 19162
   vault:
     id: 4488
-  leather_repair: *catrox
-  metal_repair: *catrox
+  leather_repair: &verrys
+    id: 51797
+    name: Verrys
+  metal_repair: *verrys
   gemshop:
     id: 50268
     name: Ghendil


### PR DESCRIPTION
Add new repair shop for leth from TT313
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a new repair shop entry for Leth Deriel in `data/base-town.yaml`, introducing `Verrys` for leather and metal repair.
> 
>   - **Behavior**:
>     - Adds new `leather_repair` entry for Leth Deriel with id `51797` and name `Verrys` in `data/base-town.yaml`.
>     - Updates `metal_repair` entry for Leth Deriel to use the new `leather_repair` anchor `verrys`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 567218ef55af3df6050808acd9e8589f1e7280d6. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->