### PR TITLE
Add Charge elemental charge script to charge elemental charge for Warrior Mages

### DIFF
--- a/charge-elemental-charge.lic
+++ b/charge-elemental-charge.lic
@@ -1,5 +1,5 @@
 =begin
-  Documentation: 
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#charge-elemental-charge
 =end
 
 class Summoning
@@ -26,3 +26,4 @@ class Summoning
 end
 
 Summoning.new
+

--- a/charge-elemental-charge.lic
+++ b/charge-elemental-charge.lic
@@ -25,5 +25,3 @@ class Summoning
 end
 
 Summoning.new
-
-

--- a/charge-elemental-charge.lic
+++ b/charge-elemental-charge.lic
@@ -1,0 +1,28 @@
+=begin
+  Documentation: 
+=end
+
+class Summoning
+  def initialize
+    @settings = get_settings
+    @ec_minimum_level = @settings.elemental_charge_minimum_level || 6
+    @charging_room = @settings.elemental_charge_room
+    DRCT.walk_to(@charging_room)
+    charge_elemental_charge
+  end
+
+  def done_charging?
+    DRCA.check_elemental_charge >= @ec_minimum_level
+  end
+
+  def charge_elemental_charge
+    until done_charging?
+      #current_charge = DRCA.check_elemental_charge
+      fput('summon admittance')
+      waitrt?
+    end
+    fput('stand')
+  end
+end
+
+Summoning.new

--- a/charge-elemental-charge.lic
+++ b/charge-elemental-charge.lic
@@ -17,7 +17,6 @@ class Summoning
 
   def charge_elemental_charge
     until done_charging?
-      #current_charge = DRCA.check_elemental_charge
       fput('summon admittance')
       waitrt?
     end
@@ -26,4 +25,5 @@ class Summoning
 end
 
 Summoning.new
+
 

--- a/charge-elemental-charge.lic
+++ b/charge-elemental-charge.lic
@@ -2,11 +2,17 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#charge-elemental-charge
 =end
 
-class Summoning
+class ChargeElementalCharge
   def initialize
     @settings = get_settings
     @ec_minimum_level = @settings.elemental_charge_minimum_level || 6
     @charging_room = @settings.elemental_charge_room
+
+    unless @charging_room
+      DRC.message('charge-elemental-charge: elemental_charge_room is not set in your YAML profile.')
+      return
+    end
+
     DRCT.walk_to(@charging_room)
     charge_elemental_charge
   end
@@ -17,11 +23,9 @@ class Summoning
 
   def charge_elemental_charge
     until done_charging?
-      fput('summon admittance')
-      waitrt?
+      DRCS.summon_admittance
     end
-    fput('stand')
   end
 end
 
-Summoning.new
+ChargeElementalCharge.new

--- a/spec/charge_elemental_charge_spec.rb
+++ b/spec/charge_elemental_charge_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+
+load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
+include Harness
+
+def load_lic_class(filename, class_name)
+  return if Object.const_defined?(class_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
+  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
+
+  end_idx = nil
+  (start_idx + 1...lines.size).each do |i|
+    if lines[i] =~ /^end\s*$/
+      end_idx = i
+      break
+    end
+  end
+  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
+
+  class_source = lines[start_idx..end_idx].join
+  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
+module DRC
+  class << self
+    def bput(*_args)
+      'default'
+    end
+
+    def message(*_args); end
+  end
+end
+
+module DRCT
+  class << self
+    def walk_to(*_args); end
+  end
+end
+
+module DRCA
+  class << self
+    def check_elemental_charge
+      0
+    end
+  end
+end
+
+module DRCS
+  class << self
+    def summon_admittance; end
+  end
+end
+
+load_lic_class('charge-elemental-charge.lic', 'ChargeElementalCharge')
+
+RSpec.configure do |config|
+  config.before(:each) do
+    reset_data
+  end
+end
+
+RSpec.describe ChargeElementalCharge do
+  def build_instance(**overrides)
+    instance = described_class.allocate
+    defaults = {
+      settings: OpenStruct.new(
+        elemental_charge_minimum_level: 6,
+        elemental_charge_room: 1234
+      ),
+      ec_minimum_level: 6,
+      charging_room: 1234
+    }
+    defaults.merge(overrides).each do |k, v|
+      instance.instance_variable_set(:"@#{k}", v)
+    end
+    instance
+  end
+
+  describe '#done_charging?' do
+    it 'returns false when charge is below minimum level' do
+      instance = build_instance(ec_minimum_level: 6)
+      allow(DRCA).to receive(:check_elemental_charge).and_return(3)
+
+      expect(instance.done_charging?).to be false
+    end
+
+    it 'returns true when charge meets minimum level' do
+      instance = build_instance(ec_minimum_level: 6)
+      allow(DRCA).to receive(:check_elemental_charge).and_return(6)
+
+      expect(instance.done_charging?).to be true
+    end
+
+    it 'returns true when charge exceeds minimum level' do
+      instance = build_instance(ec_minimum_level: 6)
+      allow(DRCA).to receive(:check_elemental_charge).and_return(11)
+
+      expect(instance.done_charging?).to be true
+    end
+  end
+
+  describe '#charge_elemental_charge' do
+    it 'calls DRCS.summon_admittance until done charging' do
+      instance = build_instance
+      call_count = 0
+      allow(DRCA).to receive(:check_elemental_charge) { (call_count += 1) >= 3 ? 6 : 2 }
+      allow(DRCS).to receive(:summon_admittance)
+
+      instance.charge_elemental_charge
+
+      expect(DRCS).to have_received(:summon_admittance).exactly(2).times
+    end
+
+    it 'does not call summon_admittance when already charged' do
+      instance = build_instance
+      allow(DRCA).to receive(:check_elemental_charge).and_return(8)
+      allow(DRCS).to receive(:summon_admittance)
+
+      instance.charge_elemental_charge
+
+      expect(DRCS).not_to have_received(:summon_admittance)
+    end
+  end
+
+  describe 'class naming' do
+    it 'does not collide with the Summoning class from summoning.lic' do
+      expect(described_class.name).to eq('ChargeElementalCharge')
+      expect(described_class.name).not_to eq('Summoning')
+    end
+  end
+
+  describe 'nil room guard' do
+    it 'returns early with a message when charging_room is not set' do
+      allow(DRC).to receive(:message)
+      allow(DRCT).to receive(:walk_to)
+      allow(self).to receive(:get_settings).and_return(
+        OpenStruct.new(elemental_charge_minimum_level: nil, elemental_charge_room: nil)
+      )
+
+      described_class.new
+
+      expect(DRC).to have_received(:message).with(/elemental_charge_room is not set/)
+      expect(DRCT).not_to have_received(:walk_to)
+    end
+  end
+end


### PR DESCRIPTION
Script allows a warrior mage to charge their elemental charge to a specific level in a specific room.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `charge-elemental-charge.lic` script for Warrior Mages to automate charging elemental charge to a specified level in a specified room.
> 
>   - **Behavior**:
>     - New script `charge-elemental-charge.lic` for Warrior Mages to charge elemental charge to a specified level in a specified room.
>     - Uses `Summoning` class to automate charging process.
>   - **Classes & Methods**:
>     - `Summoning` class initializes with settings for `elemental_charge_minimum_level` and `elemental_charge_room`.
>     - `initialize` method walks to the charging room and starts charging.
>     - `done_charging?` method checks if the elemental charge is at or above the minimum level.
>     - `charge_elemental_charge` method performs the charging loop until the desired level is reached.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for e047e141c05b3a8799d7b8167f38818dc08122a2. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->