### PR TITLE
feat(pick): add max attempt limits and robustness improvements

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -320,9 +320,9 @@ class Pick
         while current_box['trap_difficulty'].nil?
           identify_attempts += 1
           if identify_attempts > @max_identify_attempts
-            DRC.message("Pick: Failed to identify trap after #{@max_identify_attempts} attempts. Stowing box.")
-            handle_trap_too_hard_or_blacklisted(current_box, @too_hard_container)
-            return
+            DRC.message("Pick: Failed to identify trap after #{@max_identify_attempts} attempts. Proceeding with careful disarm.")
+            current_box['trap_difficulty'] = @disarm_careful_threshold
+            break
           end
           glance(current_box) if @use_glance
           identify_trap(current_box)
@@ -370,9 +370,9 @@ class Pick
         while current_box['lock_difficulty'].nil?
           lock_identify_attempts += 1
           if lock_identify_attempts > @max_identify_attempts
-            DRC.message("Pick: Failed to identify lock after #{@max_identify_attempts} attempts. Stowing box.")
-            handle_trap_too_hard_or_blacklisted(current_box, @too_hard_container)
-            return
+            DRC.message("Pick: Failed to identify lock after #{@max_identify_attempts} attempts. Proceeding with careful pick.")
+            current_box['lock_difficulty'] = @pick_careful_threshold
+            break
           end
           glance(current_box) if @use_glance
           find_lockpick unless @use_lockpick_ring


### PR DESCRIPTION
## Summary

This PR adds configurable retry limits for trap/lock identification and disarm/pick operations, preventing infinite loops when these operations fail repeatedly. It also includes several bug fixes, robustness improvements, and a comprehensive test suite.

## User-Facing Changes

### New Settings

Add these to your yaml under `pick:`:

```yaml
pick:
  max_identify_attempts: 5    # default 5 - limits trap/lock identification retries
  max_disarm_attempts: 5      # default 5 - limits disarm/pick retries
```

### Smart Failure Handling

When max attempts are exceeded:

| Situation | Behavior |
|-----------|----------|
| Can't identify trap difficulty | **Proceeds with careful disarm** (you may still succeed!) |
| Can't identify lock difficulty | **Proceeds with careful pick** (you may still succeed!) |
| Can't disarm trap | Box stowed in `too_hard_container` or trashed |
| Can't pick lock | Box stowed in `too_hard_container` or trashed |

This approach gives you a chance to succeed even when you can't identify the difficulty level.

### Deprecated Settings Removed

The following deprecated settings warnings (from August 2021, 4.5 years ago) have been removed:

| Old Setting | Replacement |
|-------------|-------------|
| `picking_box_storage` | `pick.too_hard_container` and/or `pick.blacklist_container` |
| `always_pick_blind` | `pick.pick_quick_threshold: 16` |
| `never_pick_blind` | `pick.pick_quick_threshold: 0` |
| `lockpick_ignore_difficulty` | `pick.assumed_difficulty: "careful"` |
| `lockpick_force_disarm_careful` | `pick.disarm_careful_threshold: 0` |

If you're still using any of these old settings, please update to the new format.

## Bug Fixes

### 1. `@refill_town` Undefined Variable (Critical)
**Before:** The `refill_ring` method referenced `@refill_town` which was never assigned as an instance variable, causing the conditional logic to always take the wrong branch.

**After:** Now correctly uses `@settings.refill_town` and simplified the logic:
```ruby
refill_town = @settings.refill_town || @settings.fang_cove_override_town || @settings.hometown
DRCM.ensure_copper_on_hand(cost * lockpicks_needed, @settings, refill_town)
DRCT.refill_lockpick_container(@settings.lockpick_type, refill_town, @lockpick_container, lockpicks_needed)
```

### 2. Hash Iteration Bug in `stop_khris` / `release_spells`
**Before:** Used `.each` on a hash, which yields `[key, value]` pairs, not individual elements. Also `spell.abbrev` assumed spell objects instead of hash values.

**After:** 
- `stop_khris` now uses `.each_key` to iterate over spell names
- `release_spells` now uses `.each_value` and accesses `spell_data['abbrev']`

### 3. Nil Safety in `loot_item`
**Before:** If `item_long` was nil (case statement didn't match), or if `loot_specials` was nil, the code would crash with `NoMethodError`.

**After:** Added defensive guards:
- Added "What were you referring" to the bput match list
- Added explicit nil guard for `item_long`
- Added `|| []` fallbacks for `loot_specials`, `loot_nouns`, and `trash_nouns`

## Robustness Improvements

### Infinite Recursion Prevention

Converted all recursive methods to loops with max attempt limits:

| Method | Issue | Fix |
|--------|-------|-----|
| `dismantle` | Could recurse infinitely on "repeat this request" or "hands too full" | Loop with max 5 attempts |
| `analyze_and_harvest` | Could recurse infinitely on "unable to determine" | Loop with max 5 attempts |
| `harvest` | Could recurse infinitely on "fumble around" | Loop with max 5 attempts |
| `loot` | Could recurse infinitely on "stuff" overflow | Loop with max 10 rounds |

### Consistent Messaging

- All user-facing messages now use `Pick:` prefix for easy identification
- All exit points now have verbose messaging explaining why the script stopped
- Replaced `echo` with `DRC.message` for important notifications

## Test Plan

Added comprehensive RSpec test suite with 40 examples covering:

- [ ] Default settings validation
- [ ] `holding_box?` behavior
- [ ] `handle_trap_too_hard_or_blacklisted` - stow success/failure paths
- [ ] `dismantle` - retry loop and max attempts
- [ ] `analyze_and_harvest` - retry loop and success path
- [ ] `harvest` - retry loop and item handling
- [ ] `loot` - max rounds limit and normal exit
- [ ] `loot_item` - fragments, stuff, coins, failed gets, nil safety, unrecognized items
- [ ] `refill_ring` - town selection, skip conditions, unknown lockpick type
- [ ] `stop_khris` - correct hash key iteration
- [ ] `release_spells` - correct hash value iteration, abbrev access
- [ ] `handle_trap_sprung` - trap type display
- [ ] `dispose_empty_box` - trash vs dismantle paths
- [ ] `swap_out_full_gempouch` - missing container message
- [ ] Identification failure behavior - proceed vs dispose logic
- [ ] Messaging prefix consistency

```bash
$ rspec spec/pick_spec.rb
........................................
Finished in 0.03459 seconds
40 examples, 0 failures
```

## Files Changed

- `pick.lic` - Main script with all improvements
- `spec/pick_spec.rb` - New comprehensive test suite

---

🤖 Generated with [Claude Code](https://claude.ai/code)