### PR TITLE
[script][bescort] Fix room ID for Crystal Cavern of Eluned check

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -2176,7 +2176,7 @@ class Bescort
   end
 
   def crystal_cavern_of_eluned
-    unless [1192, 51789].include?(Room.current.id)
+    unless [1192, 51798].include?(Room.current.id)
       echo 'You are not at the Crystal Cavern of Eluned entrance'
       return
     end


### PR DESCRIPTION
Needed to be updated since mapdb changes never went through, and new map changes happened since.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update room ID in `crystal_cavern_of_eluned` function to reflect new map changes.
> 
>   - **Behavior**:
>     - Update room ID in `crystal_cavern_of_eluned` function in `bescort.lic` from `51789` to `51798` to reflect new map changes.
>     - Ensures correct identification of Crystal Cavern of Eluned entrance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 789339be10a04b5af950d6a979723d63c4110f0a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->