### PR TITLE
fix(dr): include volume noun in deed name for workorders forging

### DIFF
--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -914,12 +914,12 @@ RSpec.describe WorkOrders do
     end
 
     context 'when ingot is not available but deed is' do
-      it 'uses correct deed name with volume noun (alabaster rock deed)' do
+      it 'uses volume noun only for deed retrieval (rock deed)' do
         # First call for ingot fails, then deed succeeds
         allow(DRCI).to receive(:get_item?).with('alabaster ingot').and_return(false, true)
 
-        # This is the bug fix - should use "alabaster rock deed" not "alabaster deed"
-        expect(DRCI).to receive(:get_item?).with('alabaster rock deed').and_return(true)
+        # Game only accepts "rock deed" not "alabaster rock deed"
+        expect(DRCI).to receive(:get_item?).with('rock deed').and_return(true)
         allow(workorders).to receive(:deed_ingot_volume).and_return(100)
         allow(DRCI).to receive(:get_item_if_not_held?)
 
@@ -928,13 +928,13 @@ RSpec.describe WorkOrders do
     end
 
     context 'when more volume is needed' do
-      it 'searches for deed with correct volume noun' do
+      it 'searches for deed with volume noun only' do
         # First ingot available but not enough volume, need to get more
         allow(DRCI).to receive(:get_item?).with('alabaster ingot').and_return(true, true)
         allow(workorders).to receive(:ingot_volume).and_return(5, 100)
 
-        # The key assertion: deed search uses volume noun "rock" not just "deed"
-        expect(DRCI).to receive(:get_item?).with('alabaster rock deed').and_return(true)
+        # Game only accepts "rock deed" not "alabaster rock deed"
+        expect(DRCI).to receive(:get_item?).with('rock deed').and_return(true)
         allow(workorders).to receive(:deed_ingot_volume).and_return(50)
         allow(DRCI).to receive(:get_item_if_not_held?)
 
@@ -947,7 +947,7 @@ RSpec.describe WorkOrders do
         workorders.instance_variable_set(:@deeds_noun, 'pebble')
         allow(DRCI).to receive(:get_item?).with('alabaster ingot').and_return(false)
 
-        expect(DRCI).to receive(:get_item?).with('alabaster pebble deed').and_return(true)
+        expect(DRCI).to receive(:get_item?).with('pebble deed').and_return(true)
         allow(workorders).to receive(:deed_ingot_volume).and_return(100)
         allow(DRCI).to receive(:get_item_if_not_held?)
 
@@ -958,7 +958,7 @@ RSpec.describe WorkOrders do
         workorders.instance_variable_set(:@deeds_noun, 'boulder')
         allow(DRCI).to receive(:get_item?).with('alabaster ingot').and_return(false)
 
-        expect(DRCI).to receive(:get_item?).with('alabaster boulder deed').and_return(true)
+        expect(DRCI).to receive(:get_item?).with('boulder deed').and_return(true)
         allow(workorders).to receive(:deed_ingot_volume).and_return(100)
         allow(DRCI).to receive(:get_item_if_not_held?)
 
@@ -966,23 +966,25 @@ RSpec.describe WorkOrders do
       end
     end
 
-    context 'with different material types' do
-      it 'uses correct material name in deed search' do
+    context 'deed retrieval is material-agnostic' do
+      it 'uses same deed noun regardless of material type (steel)' do
         workorders.instance_variable_set(:@use_own_ingot_type, 'steel')
         allow(DRCI).to receive(:get_item?).with('steel ingot').and_return(false)
 
-        expect(DRCI).to receive(:get_item?).with('steel rock deed').and_return(true)
+        # Still just "rock deed" - material type not used in deed retrieval
+        expect(DRCI).to receive(:get_item?).with('rock deed').and_return(true)
         allow(workorders).to receive(:deed_ingot_volume).and_return(100)
         allow(DRCI).to receive(:get_item_if_not_held?)
 
         workorders.send(:forge_items_with_own_ingot, info, materials_info, item, 1)
       end
 
-      it 'uses correct material name for bronze' do
+      it 'uses same deed noun regardless of material type (bronze)' do
         workorders.instance_variable_set(:@use_own_ingot_type, 'bronze')
         allow(DRCI).to receive(:get_item?).with('bronze ingot').and_return(false)
 
-        expect(DRCI).to receive(:get_item?).with('bronze rock deed').and_return(true)
+        # Still just "rock deed" - material type not used in deed retrieval
+        expect(DRCI).to receive(:get_item?).with('rock deed').and_return(true)
         allow(workorders).to receive(:deed_ingot_volume).and_return(100)
         allow(DRCI).to receive(:get_item_if_not_held?)
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -737,7 +737,7 @@ class WorkOrders
     recipe = find_recipe(materials_info, item, quantity).first
 
     unless DRCI.get_item?("#{@use_own_ingot_type} ingot")
-      unless DRCI.get_item?("#{@use_own_ingot_type} #{@deeds_noun} deed")
+      unless DRCI.get_item?("#{@deeds_noun} deed")
         Lich::Messaging.msg('bold', 'WorkOrders: Out of material/deeds for forging')
         exit
       end
@@ -754,7 +754,7 @@ class WorkOrders
 
     if volume < quantity * recipe['volume']
       smelt = true
-      unless DRCI.get_item?("#{@use_own_ingot_type} #{@deeds_noun} deed")
+      unless DRCI.get_item?("#{@deeds_noun} deed")
         Lich::Messaging.msg('bold', 'WorkOrders: Out of material/deeds for forging (need more volume)')
         DRCI.stow_hands
         exit


### PR DESCRIPTION
## Summary

- Fixes deed retrieval in `forge_items_with_own_ingot` when using own ingots with deeds
- When buying deeds from the Engineering society (e.g., "alabaster rock deed"), the script was trying to get "alabaster deed" instead of "alabaster rock deed", causing "What were you referring to?" errors
- Added `DEED_SIZE_NOUNS` constant to map deed sizes to their volume nouns (pebble/rock/boulder)
- Updated `get_item?` calls to include the volume noun in the deed search

## Test plan

- [x] Added specs for `DEED_SIZE_NOUNS` constant
- [x] Added specs for `forge_items_with_own_ingot` verifying deed name includes volume noun
- [x] Added specs for different deed sizes (pebble/rock/boulder)
- [x] Added specs for different material types (alabaster/steel/bronze)
- [x] All 92 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes deed retrieval in `forge_items_with_own_ingot` by including volume noun, adding `DEED_SIZE_NOUNS` constant, and updating tests.
> 
>   - **Behavior**:
>     - Fixes deed retrieval in `forge_items_with_own_ingot` to include volume noun, preventing errors when using own ingots with deeds.
>     - Updates `get_item?` calls to include volume noun in deed search.
>   - **Constants**:
>     - Adds `DEED_SIZE_NOUNS` constant to map deed sizes to volume nouns (pebble/rock/boulder).
>   - **Tests**:
>     - Adds specs for `DEED_SIZE_NOUNS` and `forge_items_with_own_ingot` verifying deed name includes volume noun.
>     - Adds specs for different deed sizes (pebble/rock/boulder) and material types (alabaster/steel/bronze).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for a76e4b0521ddd06895f33b19a52fc1e07f7ee03f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->