### PR TITLE
feat(data): add wire-brush-number to blacksmithing config

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -411,6 +411,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 8776
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 8776
     repair-npc: clerk
     stock-volume: 5
@@ -459,6 +460,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 19246
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 19246
     repair-npc: clerk
     stock-volume: 5
@@ -497,6 +499,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 11263
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 11267
     repair-npc: Rokumru
     stock-volume: 5
@@ -541,6 +544,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 8784
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 8783
     repair-npc: clerk
     stock-volume: 5
@@ -580,6 +584,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 4436
     finisher-number: 6
+    wire-brush-number: 10
     crucibles:
       - 9611
       - 9613
@@ -637,6 +642,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 16409
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 16409
     repair-npc: clerk
     stock-room: 16405
@@ -681,6 +687,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 10755
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 10755
     repair-npc: clerk
     stock-room: 10758
@@ -715,6 +722,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 17692
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 17692
     repair-npc: clerk
     stock-room: 17694
@@ -758,6 +766,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 8892
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 8887
     repair-npc: clerk
     stock-room: 8894
@@ -796,6 +805,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 14793
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 9143
     repair-npc: clerk
     stock-room: 9132
@@ -836,6 +846,7 @@ blacksmithing:
     finisher-full: flask of oil
     finisher-room: 8810
     finisher-number: 6
+    wire-brush-number: 10
     repair-room: 11807
     repair-npc: Diwitt
     stock-room: 8811


### PR DESCRIPTION
## Summary
- Add `wire-brush-number: 10` to all 11 blacksmithing towns in base-crafting.yaml
- Centralizes the wire brush order number that was previously hardcoded in multiple scripts

## Motivation
The wire brush order number (10) is currently hardcoded in three locations:
- `repair.lic` line 137
- `common-crafting.rb` line 438 (in `DRCC.repair_own_tools`)
- Various custom forge scripts

This PR adds the value to the YAML data file so scripts can reference `info['wire-brush-number']` instead of hardcoding. Follow-up PRs will update the scripts to use this new field.

## Changes
Added to all 11 blacksmithing towns:
- Crossing, Leth Deriel, Volcano, Boar Clan, Riverhaven, Shard, Fang Cove, Ratha, Aesry, Hibarnhvidar, Therenborough, Muspar'i

## Test plan
- [ ] Verify YAML parses correctly
- [ ] Test scripts that use `get_data('crafting')['blacksmithing'][town]` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `wire-brush-number: 10` to blacksmithing config for 11 towns in `base-crafting.yaml`, centralizing a previously hardcoded value.
> 
>   - **Behavior**:
>     - Adds `wire-brush-number: 10` to blacksmithing config for 11 towns in `base-crafting.yaml`.
>     - Centralizes wire brush order number previously hardcoded in `repair.lic`, `common-crafting.rb`, and custom forge scripts.
>   - **Test Plan**:
>     - Verify YAML parses correctly.
>     - Test scripts using `get_data('crafting')['blacksmithing'][town]` still function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for d806ace426e6096db28d040aca8ea43de8ec0cf9. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->