### PR TITLE
refactor(repair): use yaml wire-brush-number config

### DIFF
--- a/repair.lic
+++ b/repair.lic
@@ -134,7 +134,7 @@ class Repair
     if repair_own
       DRCT.walk_to(current)
       DRCC.check_consumables('oil', @craft_data['finisher-room'], @craft_data['finisher-number'], @bag, @bag_items, nil, gear.size)
-      DRCC.check_consumables('wire brush', @craft_data['finisher-room'], 10, @bag, @bag_items, nil, gear.size)
+      DRCC.check_consumables('wire brush', @craft_data['finisher-room'], @craft_data['wire-brush-number'] || 10, @bag, @bag_items, nil, gear.size)
     end
   end
 


### PR DESCRIPTION
## Summary
- Replace hardcoded wire brush order number (10) with YAML config lookup
- Falls back to 10 for backwards compatibility

## Related PR
- Depends on #7312 for the YAML field to exist, but works without it due to fallback

## Changes
```ruby
# Before
DRCC.check_consumables('wire brush', @craft_data['finisher-room'], 10, ...)

# After
DRCC.check_consumables('wire brush', @craft_data['finisher-room'], @craft_data['wire-brush-number'] || 10, ...)
```

## Test plan
- [ ] Run `repair forging self_repair` and verify wire brush is purchased when needed
- [ ] Works before PR #7312 is merged (uses fallback value of 10)
- [ ] Works after PR #7312 is merged (uses YAML value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `repair.lic` to use YAML config for wire brush order number with fallback to hardcoded value.
> 
>   - **Behavior**:
>     - Refactor `verify_funds` in `repair.lic` to use `@craft_data['wire-brush-number']` from YAML config for wire brush order number.
>     - Falls back to hardcoded value `10` if YAML config is unavailable.
>   - **Dependencies**:
>     - Depends on PR #7312 for YAML field existence but maintains backward compatibility with fallback.
>   - **Testing**:
>     - Verify wire brush purchase in `repair forging self_repair`.
>     - Ensure functionality before and after PR #7312 merge.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 67137abba3377d329b977dad1d028bf2b6c84713. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->