### PR TITLE
fix(pick): handle Array-format waggle_sets in stop_khris/release_spells

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -267,12 +267,19 @@ class Pick
 
   # TODO - Move to DRCA
   def stop_khris(spells)
-    spells.each_key { |name| DRC.bput("khri stop #{name}", "You attempt to relax your mind from some of its meditative states") }
+    # Handle both Array format (legacy) and Hash format (standard waggle_sets)
+    names = spells.is_a?(Hash) ? spells.keys : Array(spells)
+    names.each { |name| DRC.bput("khri stop #{name}", "You attempt to relax your mind from some of its meditative states") }
   end
 
   # TODO - Move to DRCA
   def release_spells(spells)
-    spells.each_value { |spell_data| DRC.bput("release #{spell_data['abbrev']}") if spell_data['abbrev'] }
+    # Handle both Array format (legacy) and Hash format (standard waggle_sets)
+    if spells.is_a?(Hash)
+      spells.each_value { |spell_data| DRC.bput("release #{spell_data['abbrev']}") if spell_data['abbrev'] }
+    else
+      Array(spells).each { |spell| DRC.bput("release #{spell.abbrev}") if spell.respond_to?(:abbrev) && spell.abbrev }
+    end
   end
 
   def refill_ring


### PR DESCRIPTION
## Summary
- Fixes regression from PR #7303 where `stop_khris` and `release_spells` crash with `undefined method 'each_key' for an instance of Array`
- PR #7303 changed from `.each` to `.each_key`/`.each_value`, assuming Hash format
- Some users have Array-format waggle_sets, which is a valid legacy format

## Changes
- `stop_khris`: Check if spells is Hash (use `.keys`) or Array (iterate directly)
- `release_spells`: Check if spells is Hash (use `.each_value`) or Array (iterate with `.abbrev`)

## Test plan
- [ ] User with Array-format waggle_sets confirms `stop_khris` no longer crashes
- [ ] User with Hash-format waggle_sets confirms behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes regression in `pick.lic` by handling both Hash and Array formats for `waggle_sets` in `stop_khris` and `release_spells`.
> 
>   - **Behavior**:
>     - Fixes regression causing crashes in `stop_khris` and `release_spells` due to incorrect handling of `waggle_sets` format.
>     - `stop_khris`: Checks if `spells` is a Hash (uses `.keys`) or Array (iterates directly).
>     - `release_spells`: Checks if `spells` is a Hash (uses `.each_value`) or Array (iterates with `.abbrev`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 68b89a73b440023c8b409dfe88b53df3ca963608. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->