### PR TITLE
fix: prevent dependency.lic self-update loop when cached tree is stale

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -2,7 +2,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#dependency
 =end
 
-$DEPENDENCY_VERSION = '2.2.0'
+$DEPENDENCY_VERSION = '2.2.1'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/f8ne99pVva'
 $MIN_LICH_VERSION = '5.15.0'
 
@@ -404,6 +404,14 @@ class ScriptManager
     echo("info:#{info}") if @debug
     content = download_raw_file(filename)
     return unless content
+
+    if filename == 'dependency.lic'
+      content_sha = Digest::SHA1.hexdigest('blob' + " #{content.bytesize}" + "\0" + content)
+      if content_sha == @versions[filename]
+        echo("dependency.lic content unchanged, skipping self-update") if @debug
+        return
+      end
+    end
 
     File.open(File.join(SCRIPT_DIR, "#{filename}"), 'w') { |file| file.print(content) }
 


### PR DESCRIPTION
## Summary
- Fixes infinite self-update restart loop when the cached GitHub tree API response (1-hour TTL) has a stale SHA for `dependency.lic` but the local file was already updated (e.g., by another character sharing the same `SCRIPT_DIR`)
- Before writing downloaded content, compares its git blob SHA against the existing file — if identical, skips the write and does not trigger a restart
- Bumps `$DEPENDENCY_VERSION` to `2.2.1`

## Root cause
After PR #7319 was merged, users with a stale cached tree (containing the pre-merge SHA) whose local `dependency.lic` was already the post-merge version hit an infinite loop:
1. Stale cache says SHA = `62a75a95` (old), local file SHA = `95cb16db` (new) → mismatch
2. Downloads from `raw.githubusercontent.com` → gets identical content already on disk
3. Writes same content, unconditionally sets `@self_updated = true`
4. Restarts → repeat until cache expires (up to 1 hour)

## Test plan
- [x] Verify loop stops when downloaded content matches existing file
- [x] Verify genuine dependency.lic updates still trigger self-update restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)