### PR TITLE
2 spaces after period dark aspect

### DIFF
--- a/truffenyi-commune-quest.lic
+++ b/truffenyi-commune-quest.lic
@@ -124,23 +124,23 @@ class TruffenyiCommuneQuest
                              'kerenhappuch'
                            when /a small desert village ravaged by a sand storm, the well in the center almost completely covered over/i
                              'dergati'
-                           when /a riotous party. Wine sloshes out of full cups held by people around the table, while other figures are slumped over in their chairs, dark pools around their feet/i
+                           when /a riotous party.  Wine sloshes out of full cups held by people around the table, while other figures are slumped over in their chairs, dark pools around their feet/i
                              'trothfang'
                            when /a tithe box sitting outside of a small chapel, the tail of a snake disappearing into the slot/i
                              'huldah'
                            when /a scene of wilted crops interspersed with livestock lying supine; a rough texture to the carving is noticeable above each animal/i
                              'ushnish'
-                           when /a simply dressed mage sleeping underneath an elm tree during a downpour. A spellbook sits open on a nearby picnic table/i
+                           when /a simply dressed mage sleeping underneath an elm tree during a downpour.  A spellbook sits open on a nearby picnic table/i
                              'drogor'
-                           when /a haggard looking Gnome lying on his side and clutching his knees in his arms. A crooked smile stretches across his face as he stares at a roach crawling in front of him/i
+                           when /a haggard looking Gnome lying on his side and clutching his knees in his arms.  A crooked smile stretches across his face as he stares at a roach crawling in front of him/i
                              "be'ort"
                            when /the outskirts of a small village; the trees skirting the border are fully engulfed in flames/i
                              'harawep'
                            when /young woman walking away from an orphanage/i
                              'idon'
-                           when /a man walking down the aisle of a courtroom. On either side of the man, a group of figures raise their fists toward him, while a woman sits near the front of the group weeping/i
+                           when /a man walking down the aisle of a courtroom.  On either side of the man, a group of figures raise their fists toward him, while a woman sits near the front of the group weeping/i
                              'botolf'
-                           when /a long beach after a horrific battle. A few figures seem to be crawling away from the tide/i
+                           when /a long beach after a horrific battle.  A few figures seem to be crawling away from the tide/i
                              'aldauth'
                            else
                              nil


### PR DESCRIPTION
The altar descriptions (at least mine) seem to have 2 spaces after periods, but the matches in the script only had one. I added a second space, but I think likely the better move would be to do it with regex to handle any number of spaces, or to shorten the matches to not include any periods while still being unique.