### PR TITLE
[script][combat-trainer] Fix bundle tap regex for bundling rope

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1153,7 +1153,7 @@ class LootProcess
     return unless game_state.skinnable?(mob_noun)
 
     if game_state.need_bundle
-      case DRC.bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
+      case DRC.bput('tap my bundle', 'You tap a \w+ bundle\b.*that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
       when /lumpy/
         if @tie_bundle
           lowered_item = nil

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -403,6 +403,38 @@ RSpec.describe LootProcess do
       end
     end
 
+    context 'when need_bundle is true, bundle is lumpy with bundling rope, and both hands are full' do
+      let(:game_state) { build_game_state(need_bundle: true) }
+
+      before(:each) do
+        $right_hand = 'bastard sword'
+        $left_hand = 'javelin'
+
+        # tap: lumpy bundle with extra description from bundling rope
+        allow(DRC).to receive(:bput)
+          .with('tap my bundle', anything, anything, anything)
+          .and_return('You tap a lumpy bundle bound by a braided bundling rope that you are wearing')
+        allow(DRC).to receive(:bput)
+          .with('tie my bundle', 'TIE the bundle again', 'But this bundle has already been tied off')
+          .and_return('TIE the bundle again')
+        allow(DRC).to receive(:bput)
+          .with('tie my bundle', 'you tie the bundle', 'But this bundle has already been tied off', "You don't seem to be able to do that right now")
+          .and_return('you tie the bundle')
+        allow(DRC).to receive(:bput)
+          .with('adjust my bundle', /^You adjust your .*/, /You'll need a free hand for that/)
+          .and_return('You adjust your lumpy bundle so that you can more easily')
+        allow(DRC).to receive(:bput)
+          .with('skin', anything, anything, anything, anything, anything, anything, anything)
+          .and_return('roundtime')
+
+        instance = build_loot_process(tie_bundle: true, skin: true)
+        instance.send(:check_skinning, 'kobold', game_state)
+      end
+
+      include_examples 'frees a hand before tying the bundle'
+      include_examples 'clears need_bundle on game_state'
+    end
+
     context 'when need_bundle is true and bundle is tight (already tied)' do
       let(:game_state) { build_game_state(need_bundle: true) }
 


### PR DESCRIPTION
## Summary
- The `tap my bundle` regex `You tap a \w+ bundle that you are wearing` failed to match bundles using a braided bundling rope, which produce output like `You tap a lumpy bundle bound by a braided bundling rope that you are wearing`
- Loosened the regex to `You tap a \w+ bundle\b.*that you are wearing` to bridge any descriptive clause between the adjective and "that you are wearing"
- Added spec coverage for the bundling rope variant

## Test plan
- [x] Existing `#check_skinning` specs pass (new bundling rope context + all prior contexts)
- [ ] In-game verification with a braided bundling rope bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)