### PR TITLE
[script][pick] Fix gem pouch tying -- tie at 70, swap at 500

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -72,7 +72,11 @@ class Pick
     @lockpick_container = @settings.lockpick_container
     @balance_lockpick_container = @settings.pick['balance_lockpick_container']
 
+    @gem_pouch_adjective = @settings.gem_pouch_adjective
+    @gem_pouch_noun = @settings.gem_pouch_noun
     @tie_gem_pouches = @settings.tie_gem_pouches
+    @full_pouch_container = @settings.full_pouch_container
+    @spare_gem_pouch_container = @settings.spare_gem_pouch_container
     @stop_pick_on_mindlock = args.all ? false : @settings.stop_pick_on_mindlock
 
     @loot_nouns = @settings.lootables
@@ -811,6 +815,13 @@ class Pick
     end
   end
 
+  # Opens a box and transfers its contents to the appropriate containers.
+  #
+  # Bulk-fills gems via {DRCI.fill_gem_pouch_with_container}, then
+  # individually loots remaining items (specials, trash, coins).
+  #
+  # @param box_noun [String] noun of the box to loot (must be in hand)
+  # @return [void]
   def loot(box_noun)
     echo "Looting #{box_noun}..." if @debug
     if DRC.bput("open my #{box_noun}", /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
@@ -820,9 +831,11 @@ class Pick
 
     loot_specials = @settings.loot_specials || []
     if @settings.fill_pouch_with_box || loot_specials.empty?
-      # Don't handle full pouches here, cause if we do, we can't tie them (when they're empty)
-      DRC.bput("fill my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun} with my #{box_noun}",
-               'You fill your', 'You open your', 'What were you referring to', /any gems/, /too full to fit/)
+      DRCI.fill_gem_pouch_with_container(
+        @gem_pouch_adjective, @gem_pouch_noun,
+        box_noun, @full_pouch_container,
+        @spare_gem_pouch_container, @tie_gem_pouches
+      )
     end
 
     # Loop to handle very full boxes that show "stuff" instead of all items
@@ -846,6 +859,40 @@ class Pick
     end
   end
 
+  # Stows a gem into the worn pouch, tying or swapping as needed.
+  #
+  # At 70 gems an untied pouch refuses more gems until tied. At 500
+  # gems a tied pouch is truly full and must be swapped for a spare.
+  #
+  # @param item [String] noun of the gem to stow
+  # @return [void]
+  def stow_gem(item)
+    case DRC.bput("stow my #{item}", /You put/, /You open/,
+                  /You'd better tie it up before putting/,
+                  /is too full to fit another gem/)
+    when /You put/, /You open/
+      return
+    when /You'd better tie it up/
+      DRCI.tie_gem_pouch?(@gem_pouch_adjective, @gem_pouch_noun)
+      DRCI.stow_item?(item)
+    when /is too full to fit another gem/
+      DRCI.lower_item?(item)
+      DRCI.swap_out_full_gempouch?(
+        @gem_pouch_adjective, @gem_pouch_noun,
+        @full_pouch_container, @spare_gem_pouch_container,
+        @tie_gem_pouches
+      )
+      DRCI.get_item?(item)
+      DRCI.stow_item?(item)
+    end
+  end
+
+  # Retrieves a single item from a box and routes it to the correct
+  # destination: loot_specials bag, gem pouch, trash, or dispose.
+  #
+  # @param item [String] noun of the item to retrieve
+  # @param box [String] noun of the box containing the item
+  # @return [void]
   def loot_item(item, box)
     # We don't touch glowing fragments, since we took off all our armor...
     return if item =~ /fragment/i
@@ -877,12 +924,7 @@ class Pick
 
     loot_nouns = @loot_nouns || []
     if loot_nouns.find { |thing| item_long.to_s.include?(thing) && !item_long.to_s.include?('sunstone runestone') }
-      case DRC.bput("stow my #{item}", /You put/, /You open/, /is too full to fit another gem/, /You'd better tie it up before putting/)
-      when /You put/, /You open/
-        return
-      when /You'd better tie it up/, /is too full to fit another gem/
-        swap_out_full_gempouch
-      end
+      stow_gem(item)
       return
     end
 
@@ -893,30 +935,6 @@ class Pick
       DRC.message("Pick: Unrecognized item '#{item_long}' - trashing it.")
       DRCI.dispose_trash(item, @worn_trashcan, @worn_trashcan_verb)
     end
-  end
-
-  def swap_out_full_gempouch
-    if @settings.spare_gem_pouch_container.nil?
-      DRC.message('Pick: spare_gem_pouch_container not set. Cannot swap out full gem pouch.')
-      pause 10
-      return
-    end
-
-    lowered_item = DRC.left_hand
-    DRCI.lower_item?(DRC.left_hand) if lowered_item
-
-    DRCI.remove_item?("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}")
-    if @settings.full_pouch_container
-      DRCI.put_away_item?("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}", @settings.full_pouch_container)
-    else
-      DRCI.stow_item?("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}")
-    end
-
-    DRCI.get_item?("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}", @settings.spare_gem_pouch_container)
-    DRCI.wear_item?("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}")
-    DRCI.get_item?(lowered_item) if lowered_item
-    DRCI.stow_item?(lowered_item) if lowered_item
-    DRC.bput("tie my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}", 'You tie', "it's empty?", 'has already been tied off') if @tie_gem_pouches
   end
 
   def find_lockpick

--- a/pick.lic
+++ b/pick.lic
@@ -75,6 +75,7 @@ class Pick
     @gem_pouch_adjective = @settings.gem_pouch_adjective
     @gem_pouch_noun = @settings.gem_pouch_noun
     @tie_gem_pouches = @settings.tie_gem_pouches
+    @first_fill = true
     @full_pouch_container = @settings.full_pouch_container
     @spare_gem_pouch_container = @settings.spare_gem_pouch_container
     @stop_pick_on_mindlock = args.all ? false : @settings.stop_pick_on_mindlock
@@ -831,10 +832,12 @@ class Pick
 
     loot_specials = @settings.loot_specials || []
     if @settings.fill_pouch_with_box || loot_specials.empty?
+      should_tie = @first_fill && @tie_gem_pouches
+      @first_fill = false
       DRCI.fill_gem_pouch_with_container(
         @gem_pouch_adjective, @gem_pouch_noun,
         box_noun, @full_pouch_container,
-        @spare_gem_pouch_container, @tie_gem_pouches
+        @spare_gem_pouch_container, should_tie
       )
     end
 

--- a/spec/pick_spec.rb
+++ b/spec/pick_spec.rb
@@ -234,6 +234,7 @@ RSpec.describe Pick do
     instance.instance_variable_set(:@gem_pouch_adjective, 'small')
     instance.instance_variable_set(:@gem_pouch_noun, 'pouch')
     instance.instance_variable_set(:@tie_gem_pouches, false)
+    instance.instance_variable_set(:@first_fill, true)
     instance.instance_variable_set(:@full_pouch_container, nil)
     instance.instance_variable_set(:@spare_gem_pouch_container, 'trunk')
     instance.instance_variable_set(:@tend_own_wounds, false)
@@ -884,8 +885,29 @@ RSpec.describe Pick do
       allow(DRCI).to receive(:get_item_list).and_return([])
     end
 
-    it 'delegates bulk gem fill to DRCI.fill_gem_pouch_with_container' do
-      instance = build_instance
+    it 'ties on first fill when tie_gem_pouches is true' do
+      instance = build_instance(tie_gem_pouches: true)
+
+      instance.send(:loot, 'chest')
+
+      expect(DRCI).to have_received(:fill_gem_pouch_with_container)
+        .with('small', 'pouch', 'chest', nil, 'trunk', true)
+    end
+
+    it 'does not tie on subsequent fills' do
+      instance = build_instance(tie_gem_pouches: true)
+
+      instance.send(:loot, 'chest')
+      instance.send(:loot, 'chest')
+
+      expect(DRCI).to have_received(:fill_gem_pouch_with_container)
+        .with('small', 'pouch', 'chest', nil, 'trunk', true).once
+      expect(DRCI).to have_received(:fill_gem_pouch_with_container)
+        .with('small', 'pouch', 'chest', nil, 'trunk', false).once
+    end
+
+    it 'never ties when tie_gem_pouches is false' do
+      instance = build_instance(tie_gem_pouches: false)
 
       instance.send(:loot, 'chest')
 

--- a/spec/pick_spec.rb
+++ b/spec/pick_spec.rb
@@ -65,6 +65,9 @@ module DRCI
     def lower_item?(_item); end
     def remove_item?(_item); end
     def wear_item?(_item); end
+    def tie_gem_pouch?(*_args); end
+    def swap_out_full_gempouch?(*_args); end
+    def fill_gem_pouch_with_container(*_args); end
   end
 end unless defined?(DRCI)
 
@@ -150,6 +153,9 @@ RSpec.describe Pick do
     allow(DRCI).to receive(:lower_item?).and_return(true)
     allow(DRCI).to receive(:remove_item?).and_return(true)
     allow(DRCI).to receive(:wear_item?).and_return(true)
+    allow(DRCI).to receive(:tie_gem_pouch?).and_return(true)
+    allow(DRCI).to receive(:swap_out_full_gempouch?).and_return(true)
+    allow(DRCI).to receive(:fill_gem_pouch_with_container)
 
     # Setup DRCH stubs
     allow(DRCH).to receive(:check_health).and_return({
@@ -225,6 +231,11 @@ RSpec.describe Pick do
     instance.instance_variable_set(:@trash_nouns, ['rock', 'pebble'])
     instance.instance_variable_set(:@trap_parts, ['wire', 'spring'])
     instance.instance_variable_set(:@picking_room_id, 1)
+    instance.instance_variable_set(:@gem_pouch_adjective, 'small')
+    instance.instance_variable_set(:@gem_pouch_noun, 'pouch')
+    instance.instance_variable_set(:@tie_gem_pouches, false)
+    instance.instance_variable_set(:@full_pouch_container, nil)
+    instance.instance_variable_set(:@spare_gem_pouch_container, 'trunk')
     instance.instance_variable_set(:@tend_own_wounds, false)
     instance.instance_variable_set(:@disarm_on_failed_identify, false)
     instance.instance_variable_set(:@failed_identify_container, nil)
@@ -766,21 +777,161 @@ RSpec.describe Pick do
   end
 
   # ---------------------------------------------------------------------------
-  # swap_out_full_gempouch
+  # stow_gem
   # ---------------------------------------------------------------------------
 
-  describe '#swap_out_full_gempouch' do
-    it 'shows message when spare_gem_pouch_container not set' do
+  describe '#stow_gem' do
+    it 'stows successfully on first attempt' do
+      instance = build_instance
+      allow(DRC).to receive(:bput)
+        .with('stow my gem', /You put/, /You open/,
+              /You'd better tie it up before putting/,
+              /is too full to fit another gem/)
+        .and_return('You put your gem in your pouch')
+
+      instance.send(:stow_gem, 'gem')
+
+      expect(DRCI).not_to have_received(:tie_gem_pouch?)
+      expect(DRCI).not_to have_received(:swap_out_full_gempouch?)
+    end
+
+    context 'when pouch needs tying (70 gems)' do
+      before(:each) do
+        allow(DRC).to receive(:bput)
+          .with('stow my gem', /You put/, /You open/,
+                /You'd better tie it up before putting/,
+                /is too full to fit another gem/)
+          .and_return("You'd better tie it up before putting more in")
+      end
+
+      it 'ties pouch then stows' do
+        instance = build_instance(tie_gem_pouches: true)
+
+        instance.send(:stow_gem, 'gem')
+
+        expect(DRCI).to have_received(:tie_gem_pouch?).with('small', 'pouch')
+        expect(DRCI).to have_received(:stow_item?).with('gem')
+      end
+
+      it 'does not swap the pouch' do
+        instance = build_instance
+
+        instance.send(:stow_gem, 'gem')
+
+        expect(DRCI).not_to have_received(:swap_out_full_gempouch?)
+      end
+    end
+
+    context 'when pouch is full (500 gems)' do
+      before(:each) do
+        allow(DRC).to receive(:bput)
+          .with('stow my gem', /You put/, /You open/,
+                /You'd better tie it up before putting/,
+                /is too full to fit another gem/)
+          .and_return('is too full to fit another gem')
+      end
+
+      it 'lowers gem, swaps pouch, retrieves and stows gem' do
+        instance = build_instance(
+          full_pouch_container: 'backpack',
+          spare_gem_pouch_container: 'trunk',
+          tie_gem_pouches: true
+        )
+
+        instance.send(:stow_gem, 'gem')
+
+        expect(DRCI).to have_received(:lower_item?).with('gem').ordered
+        expect(DRCI).to have_received(:swap_out_full_gempouch?)
+          .with('small', 'pouch', 'backpack', 'trunk', true).ordered
+        expect(DRCI).to have_received(:get_item?).with('gem').ordered
+        expect(DRCI).to have_received(:stow_item?).with('gem').ordered
+      end
+
+      it 'passes nil containers when not configured' do
+        instance = build_instance(
+          full_pouch_container: nil,
+          spare_gem_pouch_container: nil,
+          tie_gem_pouches: false
+        )
+
+        instance.send(:stow_gem, 'gem')
+
+        expect(DRCI).to have_received(:swap_out_full_gempouch?)
+          .with('small', 'pouch', nil, nil, false)
+      end
+
+      it 'still attempts to retrieve gem even when swap fails' do
+        allow(DRCI).to receive(:swap_out_full_gempouch?).and_return(false)
+        instance = build_instance
+
+        instance.send(:stow_gem, 'gem')
+
+        expect(DRCI).to have_received(:get_item?).with('gem')
+        expect(DRCI).to have_received(:stow_item?).with('gem')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # loot (fill delegation)
+  # ---------------------------------------------------------------------------
+
+  describe '#loot' do
+    before(:each) do
+      allow(DRC).to receive(:bput)
+        .with(/^open my/, anything, anything, anything)
+        .and_return('That is already open')
+      allow(DRCI).to receive(:get_item_list).and_return([])
+    end
+
+    it 'delegates bulk gem fill to DRCI.fill_gem_pouch_with_container' do
+      instance = build_instance
+
+      instance.send(:loot, 'chest')
+
+      expect(DRCI).to have_received(:fill_gem_pouch_with_container)
+        .with('small', 'pouch', 'chest', nil, 'trunk', false)
+    end
+
+    it 'passes pouch settings through to fill method' do
+      instance = build_instance(
+        gem_pouch_adjective: 'black',
+        gem_pouch_noun: 'sack',
+        full_pouch_container: 'backpack',
+        spare_gem_pouch_container: 'locker',
+        tie_gem_pouches: true
+      )
+
+      instance.send(:loot, 'strongbox')
+
+      expect(DRCI).to have_received(:fill_gem_pouch_with_container)
+        .with('black', 'sack', 'strongbox', 'backpack', 'locker', true)
+    end
+
+    it 'skips fill when fill_pouch_with_box is false and loot_specials exist' do
       settings = OpenStruct.new(
-        spare_gem_pouch_container: nil,
+        fill_pouch_with_box: false,
+        loot_specials: [{ 'name' => 'diamond', 'bag' => 'sack' }],
         gem_pouch_adjective: 'small',
         gem_pouch_noun: 'pouch'
       )
       instance = build_instance(settings: settings)
 
-      instance.send(:swap_out_full_gempouch)
+      instance.send(:loot, 'chest')
 
-      expect(messages.last).to include('spare_gem_pouch_container not set')
+      expect(DRCI).not_to have_received(:fill_gem_pouch_with_container)
+    end
+
+    it 'skips looting when box is locked' do
+      allow(DRC).to receive(:bput)
+        .with(/^open my/, anything, anything, anything)
+        .and_return('It is locked')
+      instance = build_instance
+
+      instance.send(:loot, 'chest')
+
+      expect(DRCI).not_to have_received(:fill_gem_pouch_with_container)
+      expect(messages.last).to include('Bug')
     end
   end
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `pick.lic` treated "You'd better tie it up" (pouch at 70 gems) and "too full to fit" (pouch at 500 gems) identically, always swapping the pouch out. This left untied pouches with only 70 gems stowed in containers instead of tying and continuing to fill to 500.
- **DRY**: Replaced the duplicate `swap_out_full_gempouch` method with calls to existing `DRCI` library methods (`fill_gem_pouch_with_container`, `swap_out_full_gempouch?`, `tie_gem_pouch?`) that already handle tying and swapping correctly.
- **Refactor**: Extracted `stow_gem` method with clear single responsibility -- handles the tie-at-70 and swap-at-500 gem pouch lifecycle. Extracted pouch settings to instance variables to eliminate repeated `@settings.gem_pouch_*` references.

## What changed

| Area | Before | After |
|------|--------|-------|
| 70-gem "tie it up" | Swapped pouch (wrong) | Ties pouch, retries stow |
| 500-gem "too full" | Swapped pouch | Swapped pouch (unchanged) |
| `fill` in `loot` | Raw `bput` with no tie/swap handling | `DRCI.fill_gem_pouch_with_container` |
| `swap_out_full_gempouch` | Custom 20-line method | Deleted, uses `DRCI.swap_out_full_gempouch?` |

## Test plan

- [x] All 62 existing specs pass
- [x] New specs for `stow_gem`: successful stow, tie-at-70, swap-at-500, nil containers, swap failure recovery
- [x] New specs for `loot`: fill delegation, settings passthrough, fill skip conditions, locked box guard
- [x] rubocop -A clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)