### PR TITLE
[script][combat-trainer] Pass summoned_weapons_adjective to shape_summoned_weapon

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4646,6 +4646,9 @@ class GameState
     end
     echo("  @dual_load: #{@dual_load}") if $debug_mode_ct
 
+    @summoned_weapons_adjective = settings.summoned_weapons_adjective
+    echo("  @summoned_weapons_adjective: #{@summoned_weapons_adjective}") if $debug_mode_ct
+
     @summoned_weapons_element = settings.summoned_weapons_element
     echo("  @summoned_weapons_element: #{@summoned_weapons_element}") if $debug_mode_ct
 
@@ -5705,9 +5708,10 @@ class GameState
 
   def prepare_summoned_weapon(weapon_already_summoned)
     info = summoned_info(weapon_skill)
+    adj = OpenStruct.new(summoned_weapons_adjective: @summoned_weapons_adjective)
 
     DRCS.summon_weapon(UserVars.moons['visible'].first, @summoned_weapons_element, @summoned_weapons_ingot, weapon_skill) unless weapon_already_summoned
-    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot) if weapon_already_summoned || DRStats.moon_mage?
+    DRCS.shape_summoned_weapon(weapon_skill, @summoned_weapons_ingot, adj) if weapon_already_summoned || DRStats.moon_mage?
     DRCS.turn_summoned_weapon if info['turn']
     DRCS.push_summoned_weapon if info['push']
     DRCS.pull_summoned_weapon if info['pull']

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -91,6 +91,24 @@ end
 module DRCS
   class << self
     def break_summoned_weapon(*_args); end
+
+    def summon_weapon(*_args); end
+
+    def shape_summoned_weapon(*_args); end
+
+    def turn_summoned_weapon(*_args); end
+
+    def push_summoned_weapon(*_args); end
+
+    def pull_summoned_weapon(*_args); end
+  end
+end
+
+module UserVars
+  @moons = {}
+
+  class << self
+    attr_accessor :moons
   end
 end
 
@@ -646,6 +664,145 @@ RSpec.describe GameState do
           target_weapon_skill: 20
         )
         expect(gs.skill_done?).to be false
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #prepare_summoned_weapon specs
+  #
+  # Validates that summoned_weapons_adjective is passed to
+  # DRCS.shape_summoned_weapon via an OpenStruct, and that summon/shape/turn/
+  # push/pull are called according to flags and guild.
+  # ===========================================================================
+  describe '#prepare_summoned_weapon' do
+    def build_summoned_game_state(**overrides)
+      instance = GameState.allocate
+      defaults = {
+        summoned_weapons_adjective: nil,
+        summoned_weapons_element: 'fire',
+        summoned_weapons_ingot: 'animite',
+        summoned_weapons: [{ 'name' => 'Large Edged', 'turn' => false, 'push' => false, 'pull' => false }],
+        current_weapon_skill: 'Large Edged'
+      }
+      defaults.merge(overrides).each do |k, v|
+        instance.instance_variable_set(:"@#{k}", v)
+      end
+      instance
+    end
+
+    before(:each) do
+      allow(DRCS).to receive(:summon_weapon)
+      allow(DRCS).to receive(:shape_summoned_weapon)
+      allow(DRCS).to receive(:turn_summoned_weapon)
+      allow(DRCS).to receive(:push_summoned_weapon)
+      allow(DRCS).to receive(:pull_summoned_weapon)
+      UserVars.moons = { 'visible' => ['Katamba'] }
+    end
+
+    context 'when weapon is already summoned' do
+      it 'passes an OpenStruct with summoned_weapons_adjective to shape_summoned_weapon' do
+        gs = build_summoned_game_state(summoned_weapons_adjective: 'blazing')
+
+        gs.prepare_summoned_weapon(true)
+
+        expect(DRCS).to have_received(:shape_summoned_weapon) do |skill, ingot, adj|
+          expect(skill).to eq('Large Edged')
+          expect(ingot).to eq('animite')
+          expect(adj).to be_a(OpenStruct)
+          expect(adj.summoned_weapons_adjective).to eq('blazing')
+        end
+      end
+
+      it 'does not call summon_weapon' do
+        gs = build_summoned_game_state
+
+        gs.prepare_summoned_weapon(true)
+
+        expect(DRCS).not_to have_received(:summon_weapon)
+      end
+    end
+
+    context 'when weapon is not yet summoned' do
+      it 'calls summon_weapon before shaping' do
+        allow(DRStats).to receive(:moon_mage?).and_return(true)
+        gs = build_summoned_game_state
+
+        gs.prepare_summoned_weapon(false)
+
+        expect(DRCS).to have_received(:summon_weapon).with('Katamba', 'fire', 'animite', 'Large Edged')
+        expect(DRCS).to have_received(:shape_summoned_weapon)
+      end
+
+      it 'does not shape when not a moon mage' do
+        allow(DRStats).to receive(:moon_mage?).and_return(false)
+        gs = build_summoned_game_state
+
+        gs.prepare_summoned_weapon(false)
+
+        expect(DRCS).to have_received(:summon_weapon)
+        expect(DRCS).not_to have_received(:shape_summoned_weapon)
+      end
+    end
+
+    context 'with nil summoned_weapons_adjective' do
+      it 'passes OpenStruct with nil adjective' do
+        gs = build_summoned_game_state(summoned_weapons_adjective: nil)
+
+        gs.prepare_summoned_weapon(true)
+
+        expect(DRCS).to have_received(:shape_summoned_weapon) do |_skill, _ingot, adj|
+          expect(adj).to be_a(OpenStruct)
+          expect(adj.summoned_weapons_adjective).to be_nil
+        end
+      end
+    end
+
+    context 'with empty string summoned_weapons_adjective' do
+      it 'passes OpenStruct with empty adjective' do
+        gs = build_summoned_game_state(summoned_weapons_adjective: '')
+
+        gs.prepare_summoned_weapon(true)
+
+        expect(DRCS).to have_received(:shape_summoned_weapon) do |_skill, _ingot, adj|
+          expect(adj.summoned_weapons_adjective).to eq('')
+        end
+      end
+    end
+
+    context 'with turn/push/pull flags' do
+      it 'calls turn, push, and pull when all flags are set' do
+        gs = build_summoned_game_state(
+          summoned_weapons: [{ 'name' => 'Large Edged', 'turn' => true, 'push' => true, 'pull' => true }]
+        )
+
+        gs.prepare_summoned_weapon(true)
+
+        expect(DRCS).to have_received(:turn_summoned_weapon)
+        expect(DRCS).to have_received(:push_summoned_weapon)
+        expect(DRCS).to have_received(:pull_summoned_weapon)
+      end
+
+      it 'skips turn, push, and pull when flags are false' do
+        gs = build_summoned_game_state
+
+        gs.prepare_summoned_weapon(true)
+
+        expect(DRCS).not_to have_received(:turn_summoned_weapon)
+        expect(DRCS).not_to have_received(:push_summoned_weapon)
+        expect(DRCS).not_to have_received(:pull_summoned_weapon)
+      end
+    end
+
+    context 'OpenStruct compatibility with shape_summoned_weapon' do
+      it 'creates an object that responds to .summoned_weapons_adjective' do
+        gs = build_summoned_game_state(summoned_weapons_adjective: 'blazing')
+
+        gs.prepare_summoned_weapon(true)
+
+        expect(DRCS).to have_received(:shape_summoned_weapon) do |_skill, _ingot, adj|
+          expect(adj).to respond_to(:summoned_weapons_adjective)
+        end
       end
     end
   end

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -104,11 +104,9 @@ module DRCS
   end
 end
 
-module UserVars
-  @moons = {}
-
+class UserVars
   class << self
-    attr_accessor :moons
+    attr_accessor :moons unless method_defined?(:moons)
   end
 end
 

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -984,7 +984,7 @@ RSpec.describe SetupProcess do
     # User-facing messaging
     # =========================================================================
     context 'messaging for 5a (all at 34, weapon equipped)' do
-      it 'warns the user once about continuing with current weapon' do
+      it 'warns the user once about all skills being mindlocked' do
         allow(DRC).to receive(:message)
         game_state = build_game_state_double(weapon_skill: 'Bow')
         setup = build_setup_process
@@ -992,7 +992,7 @@ RSpec.describe SetupProcess do
         setup.send(:determine_next_to_train, game_state, weapon_training, false)
         setup.send(:determine_next_to_train, game_state, weapon_training, false)
 
-        expect(DRC).to have_received(:message).with(/Continuing to attack with Bow/).once
+        expect(DRC).to have_received(:message).with(/All weapon_training skills mindlocked/).once
       end
     end
 


### PR DESCRIPTION
## Summary
- Reads `summoned_weapons_adjective` from profile settings and passes it through to `DRCS.shape_summoned_weapon` via an `OpenStruct`, which is what the method expects (it calls `settings&.summoned_weapons_adjective` with dot-access).
- Supersedes #7266, which used `JSON.parse` with string interpolation to build the OpenStruct -- that approach was fragile (breaks on special characters in the adjective) and unnecessarily complex.
- Fixes a stale spec assertion in `SetupProcess` messaging tests (production message changed from "Continuing to attack" to "All weapon_training skills mindlocked").

## What changed

| File | Change |
|------|--------|
| `combat-trainer.lic` | Read `summoned_weapons_adjective` from settings, pass via `OpenStruct.new(summoned_weapons_adjective: @summoned_weapons_adjective)` to `shape_summoned_weapon` |
| `spec/combat_trainer_spec.rb` | 9 new specs for `prepare_summoned_weapon` (custom adj, nil, empty string, summon/shape gating, turn/push/pull flags, OpenStruct compatibility). Fix stale `SetupProcess` 5a messaging assertion. Add DRCS stubs and UserVars mock. |

## YAML usage

```yaml
summoned_weapons_adjective: blazing
```

When set, the adjective is included in `shape` and `identify` commands for summoned weapons. When absent or nil, behavior is unchanged.

## Test plan
- [x] 66 specs pass (9 new + 57 existing, including the fixed stale assertion)
- [x] Rubocop clean
- [x] CI green
- [ ] Verify a Moon Mage or Warrior Mage with `summoned_weapons_adjective` set in their YAML gets the custom adjective applied when shaping summoned weapons
- [ ] Verify characters without `summoned_weapons_adjective` set continue to work (nil is handled gracefully by `shape_summoned_weapon`)