### PR TITLE
Update restock.lic to add sigil book restocking and consolidated bank trip

### DIFF
--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -270,7 +270,7 @@ Riverhaven:
     id: 7792
     price: 115
   altar:
-    id: 438
+    id: 440
   favor_altars:
     Divyaush:
       id: 440

--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -254,7 +254,7 @@ Crossing:
     noun: basin
   primer_npc: shaman
 
-Haven:
+Riverhaven:
   wine_shop:
     id: 12048
     price: 300

--- a/restock.lic
+++ b/restock.lic
@@ -98,6 +98,8 @@
 #       stackable: false
 #       quantity: 30
 class Restock
+  SHARD_BRIBE_PADDING = 2502
+
   def initialize
     arg_definitions = [
       [
@@ -144,33 +146,12 @@ class Restock
   # @param town [String] town to use for banking
   # @return [void]
   def restock_default(item_list, town)
-    # Count regular items
-    items_to_restock = []
-    coin_needed = 0
+    items_to_restock, coin_needed = assess_restock_needs(item_list)
+    coin_needed += SHARD_BRIBE_PADDING * items_to_restock.length
 
-    item_list.each do |item|
-      remaining = if item['stackable']
-                    count_stackable_item(item)
-                  else
-                    count_nonstackable_item(item)
-                  end
-      if item['min_quantity']
-        next unless remaining < item['min_quantity']
-      end
-      next unless remaining < item['quantity']
-
-      num_needed = item['quantity'] - remaining
-      buy_num = (num_needed / item['size'].to_f).ceil
-      coin_needed += buy_num * item['price']
-      item['buy_num'] = buy_num
-      items_to_restock.push(item)
-    end
-    coin_needed += 2502 * items_to_restock.length
-
-    # Count sigil book scrolls
     sigil_purchases = collect_sigil_purchases
     coin_needed += sigil_purchases.sum { |p| p['needed'] * p['price'] }
-    coin_needed += 2502 * sigil_purchases.map { |p| p['room'] }.uniq.length
+    coin_needed += SHARD_BRIBE_PADDING * sigil_purchases.map { |p| p['room'] }.uniq.length
 
     return if items_to_restock.empty? && sigil_purchases.empty?
 
@@ -178,7 +159,6 @@ class Restock
     echo "Total coin needed: #{coin_needed}" if @debug
     DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
 
-    # Purchase regular items
     items_to_restock.each do |item|
       item['buy_num'].times do
         purchase_item(item)
@@ -187,16 +167,7 @@ class Restock
       end
     end
 
-    # Purchase sigil book scrolls grouped by shop room
-    sigil_purchases.group_by { |p| p['room'] }.each do |room, room_purchases|
-      DRCT.walk_to(room)
-      room_purchases.each do |purchase|
-        purchase['needed'].times do
-          purchase_via_order(purchase['order_number'])
-          DRC.bput("put my #{purchase['sigil_type']} sigil-scroll in my #{purchase['book']}", /You add/)
-        end
-      end
-    end
+    purchase_sigil_scrolls(sigil_purchases)
 
     DRCI.stow_hands
     DRCM.deposit_coins(@keep_copper, @settings, town)
@@ -209,35 +180,14 @@ class Restock
   # @param town [String] town to restock in
   # @return [void]
   def restock_items(item_list, town)
-    items_to_restock = []
-    coin_needed = 0
-
-    item_list.each do |item|
-      remaining = if item['stackable']
-                    count_stackable_item(item)
-                  else
-                    count_nonstackable_item(item)
-                  end
-      if item['min_quantity']
-        next unless remaining < item['min_quantity']
-      end
-      next unless remaining < item['quantity']
-
-      num_needed = item['quantity'] - remaining
-      buy_num = (num_needed / item['size'].to_f).ceil
-      coin_needed += buy_num * item['price']
-      item['buy_num'] = buy_num
-      items_to_restock.push(item)
-    end
+    items_to_restock, coin_needed = assess_restock_needs(item_list)
 
     return if items_to_restock.empty?
 
     DRCI.stow_hands
 
     if coin_needed > 0
-      # Pad for Shard night-bribe (2502 copper per shop visit).
-      # Over-estimates intentionally; excess deposited at end.
-      coin_needed += 2502 * items_to_restock.length
+      coin_needed += SHARD_BRIBE_PADDING * items_to_restock.length
       echo "Coin needed is #{coin_needed}" if @debug
       DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
     end
@@ -254,9 +204,8 @@ class Restock
 
   private
 
-  # Purchases a single item. Uses ask-for flow when item specifies a clerk,
-  # two-step order confirmation when item specifies an order_number,
-  # otherwise uses standard buy.
+  # Purchases a single item. Dispatches to ask-for, DRCT.order_item,
+  # or standard buy depending on item configuration.
   #
   # @param item [Hash] item configuration with 'name', 'room', optional 'clerk', optional 'order_number'
   # @return [void]
@@ -265,8 +214,7 @@ class Restock
       DRCT.walk_to(item['room'])
       fput("ask #{item['clerk']} for #{item['name']}")
     elsif item['order_number']
-      DRCT.walk_to(item['room'])
-      purchase_via_order(item['order_number'])
+      DRCT.order_item(item['room'], item['order_number'])
     else
       DRCT.buy_item(item['room'], item['name'])
     end
@@ -468,13 +416,43 @@ class Restock
     end
   end
 
-  # Purchases an item using the two-step order confirmation flow.
+  # Counts items, determines what needs restocking, and calculates coin cost.
   #
-  # @param order_number [Integer] catalog number from the shop's ORDER list
+  # @param item_list [Array<Hash>] items to evaluate
+  # @return [Array(Array<Hash>, Integer)] items needing restock and total coin cost
+  def assess_restock_needs(item_list)
+    items_to_restock = []
+    coin_needed = 0
+    item_list.each do |item|
+      remaining = item['stackable'] ? count_stackable_item(item) : count_nonstackable_item(item)
+      next if item['min_quantity'] && remaining >= item['min_quantity']
+      next unless remaining < item['quantity']
+      buy_num = ((item['quantity'] - remaining) / item['size'].to_f).ceil
+      coin_needed += buy_num * item['price']
+      item['buy_num'] = buy_num
+      items_to_restock << item
+    end
+    [items_to_restock, coin_needed]
+  end
+
+  # Purchases sigil scrolls and stows them into their books.
+  #
+  # @param sigil_purchases [Array<Hash>] purchase list from collect_sigil_purchases
   # @return [void]
-  def purchase_via_order(order_number)
-    DRC.bput("order #{order_number}", /Just order it again/)
-    DRC.bput("order #{order_number}", /hands you/)
+  def purchase_sigil_scrolls(sigil_purchases)
+    sigil_purchases.each do |purchase|
+      purchase['needed'].times do
+        DRCT.order_item(purchase['room'], purchase['order_number'])
+        if reget(3, 'Seeing that you are too encumbered')
+          fput('get sigil-scroll from counter')
+        end
+        unless DRCI.put_away_item?("#{purchase['sigil_type']} sigil-scroll", purchase['book'])
+          echo "Failed to add #{purchase['sigil_type']} scroll to #{purchase['book']}"
+          DRCI.stow_hands
+          return
+        end
+      end
+    end
   end
 end
 

--- a/restock.lic
+++ b/restock.lic
@@ -23,6 +23,7 @@
 #   - `min_quantity` [Integer] only restock when count drops below this threshold
 #   - `countable_name` [String] alternate noun for counting (when buy name differs)
 #   - `clerk` [String] NPC name; triggers "ask <clerk> for <item>" instead of buy
+#   - `order_number` [Integer] catalog number; triggers two-step ORDER confirmation flow
 #   - `container` [String] specific container to stow into
 #   - `hometown` [String] buy from this town instead of your hometown
 #
@@ -61,6 +62,31 @@
 #       quantity: 3
 #       clerk: shopkeeper
 #
+# @example Two-step order confirmation flow (society/catalog shops)
+#   restock:
+#     bone_totem:
+#       name: totem
+#       size: 1
+#       room: 14753
+#       order_number: 16
+#       price: 125
+#       stackable: false
+#       quantity: 20
+#       min_quantity: 5
+#       container: doeskin satchel
+#
+# @example Sigil books (nested under restock key)
+#   restock:
+#     sigil_books:
+#       platinum-hued book:
+#         container: doeskin satchel
+#         congruence:
+#           quantity: 20
+#           min_quantity: 5
+#           room: 14753
+#           order_number: 3
+#           price: 312
+#
 # @example Custom hometown override
 #   restock:
 #     arrow:
@@ -93,28 +119,91 @@ class Restock
     start_restock
   end
 
-  # Orchestrates the restock process by separating items into
-  # default-hometown and custom-hometown groups, then restocking
-  # each group in its respective town.
+  # Orchestrates the restock process. Default-hometown regular items and sigil
+  # books are handled together in one bank trip. Custom-hometown items each
+  # get their own separate trip.
   #
   # @return [void]
   def start_restock
-    # Parse data from user's yaml and base-consumables
     items = parse_restockable_items
-    # If user has specified a custom location to restock a specific item, grab that here
     custom_loc_items = items.select { |k| k['hometown'] }
-    # Remove those custom location items from the primary restock items list
-    items -= custom_loc_items
-    # Call the restock_items method on restock items that don't have custom location set
-    restock_items(items, @settings.hometown)
+    default_items = items - custom_loc_items
 
-    # Restock items that have a custom location set
+    # Default hometown: regular items + sigil books in one bank trip
+    restock_default(default_items, @settings.hometown)
+
+    # Custom hometown items each get their own trip (different bank)
     custom_loc_items.group_by { |v| v['hometown'] }
                     .each { |hometown, group| restock_items(group, hometown) }
   end
 
+  # Counts all default-hometown regular items and sigil book scrolls, makes a
+  # single bank withdrawal, purchases everything, then deposits.
+  #
+  # @param item_list [Array<Hash>] regular items to potentially restock
+  # @param town [String] town to use for banking
+  # @return [void]
+  def restock_default(item_list, town)
+    # Count regular items
+    items_to_restock = []
+    coin_needed = 0
+
+    item_list.each do |item|
+      remaining = if item['stackable']
+                    count_stackable_item(item)
+                  else
+                    count_nonstackable_item(item)
+                  end
+      if item['min_quantity']
+        next unless remaining < item['min_quantity']
+      end
+      next unless remaining < item['quantity']
+
+      num_needed = item['quantity'] - remaining
+      buy_num = (num_needed / item['size'].to_f).ceil
+      coin_needed += buy_num * item['price']
+      item['buy_num'] = buy_num
+      items_to_restock.push(item)
+    end
+    coin_needed += 2502 * items_to_restock.length
+
+    # Count sigil book scrolls
+    sigil_purchases = collect_sigil_purchases
+    coin_needed += sigil_purchases.sum { |p| p['needed'] * p['price'] }
+    coin_needed += 2502 * sigil_purchases.map { |p| p['room'] }.uniq.length
+
+    return if items_to_restock.empty? && sigil_purchases.empty?
+
+    DRCI.stow_hands
+    echo "Total coin needed: #{coin_needed}" if @debug
+    DRCM.ensure_copper_on_hand(coin_needed, @settings, town)
+
+    # Purchase regular items
+    items_to_restock.each do |item|
+      item['buy_num'].times do
+        purchase_item(item)
+        handle_encumbrance(item)
+        stow_item(item)
+      end
+    end
+
+    # Purchase sigil book scrolls grouped by shop room
+    sigil_purchases.group_by { |p| p['room'] }.each do |room, room_purchases|
+      DRCT.walk_to(room)
+      room_purchases.each do |purchase|
+        purchase['needed'].times do
+          purchase_via_order(purchase['order_number'])
+          DRC.bput("put my #{purchase['sigil_type']} sigil-scroll in my #{purchase['book']}", /You add/)
+        end
+      end
+    end
+
+    DRCI.stow_hands
+    DRCM.deposit_coins(@keep_copper, @settings, town)
+  end
+
   # Calculates quantities needed, withdraws coin, purchases, and stows
-  # items for a single town.
+  # items for a single town. Used only for custom-hometown items.
   #
   # @param item_list [Array<Hash>] items to potentially restock
   # @param town [String] town to restock in
@@ -165,15 +254,19 @@ class Restock
 
   private
 
-  # Purchases a single item. Uses ask-for flow when item specifies
-  # a clerk, otherwise uses standard buy.
+  # Purchases a single item. Uses ask-for flow when item specifies a clerk,
+  # two-step order confirmation when item specifies an order_number,
+  # otherwise uses standard buy.
   #
-  # @param item [Hash] item configuration with 'name', 'room', optional 'clerk'
+  # @param item [Hash] item configuration with 'name', 'room', optional 'clerk', optional 'order_number'
   # @return [void]
   def purchase_item(item)
     if item['clerk']
       DRCT.walk_to(item['room'])
       fput("ask #{item['clerk']} for #{item['name']}")
+    elsif item['order_number']
+      DRCT.walk_to(item['room'])
+      purchase_via_order(item['order_number'])
     else
       DRCT.buy_item(item['room'], item['name'])
     end
@@ -210,37 +303,24 @@ class Restock
   #
   # @return [Array<Hash>] fully populated restock item configurations
   def parse_restockable_items
-    # Get the yaml restock hash
     item_list = @restock
-    # Get the hometown consumables from base-consumables
     hometown_data = get_data('consumables')[@hometown]
     items = []
 
-    # Iterate through the yaml restock hash
     item_list.each do |key, value|
+      next if key == 'sigil_books'
       echo "Restock Item: #{key} - #{value}" if @debug
 
-      # If any restock key exists as a key in hometown consumables
-      # AND a custom town specification doesn't exist in this restock item,
-      # then we'll restock this item using the data in base-consumables for our hometown.
       if hometown_data.key?(key) && !value.key?('hometown')
-        # Get hash from base-consumables for the specific restock item (e.g. 'arrow')
         ht_data = hometown_data[key]
-
-        # Iterate through the base-consumables hash. Use consumable data from base-consumables
-        # _unless_ specific data is specified in user's yaml.
         ht_data.each_key { |k| value[k] = ht_data[k] unless value.key?(k) }
         items.push(value)
-      # Otherwise, the user has specified a custom restock. This custom set needs to specify
-      # ALL data for restocking, since we're not doing a base-consumables lookup.
       elsif valid_item_data?(value)
         items.push(value)
       else
         echo "No hometown of explicit data for '#{key}'"
       end
     end
-    # Return the full set of populated restock data, either full custom user-provided or from
-    # base-consumables or a combination thereof.
     echo "Items are: #{items}" if @debug
     items
   end
@@ -313,6 +393,88 @@ class Restock
     echo "Validating custom item data: #{item_data}" if @debug
 
     %w[name size room price stackable quantity].all? { |x| item_data.key?(x) }
+  end
+
+  # Checks all configured sigil books and returns a list of scrolls that need
+  # to be purchased, with quantity and shop info for each.
+  #
+  # @return [Array<Hash>] purchases needed across all books
+  def collect_sigil_purchases
+    return [] unless @restock['sigil_books']
+
+    purchases = []
+    @restock['sigil_books'].each do |book, book_config|
+      container = book_config['container']
+      book_config.each do |sigil_type, config|
+        next if sigil_type == 'container'
+        current = count_sigils_in_book(book, sigil_type, container)
+        next if current.nil?
+        next if config['min_quantity'] && current >= config['min_quantity']
+        needed = config['quantity'] - current
+        next if needed <= 0
+        echo "#{book} / #{sigil_type}: need #{needed} (have #{current} of #{config['quantity']})" if @debug
+        purchases << {
+          'book'         => book,
+          'sigil_type'   => sigil_type,
+          'order_number' => config['order_number'],
+          'price'        => config['price'],
+          'room'         => config['room'],
+          'needed'       => needed
+        }
+      end
+    end
+    purchases
+  end
+
+  # Turns the book to its contents page, reads it, and counts entries matching
+  # the given sigil type.
+  #
+  # @param book [String] identifying noun of the sigil book
+  # @param sigil_type [String] sigil type name to count
+  # @param container [String, nil] container the book lives in
+  # @return [Integer, nil] number of matching scrolls in the book, or nil if book not found
+  def count_sigils_in_book(book, sigil_type, container = nil)
+    DRCI.stow_hands
+    unless DRCI.get_item?(book, container)
+      echo "Sigil book '#{book}' not found in inventory."
+      return nil
+    end
+    DRC.bput("turn my #{book} to contents", /You turn|already/)
+    result = DRC.bput("read my #{book}", /no scrolls inside/, /Page -- Sigil Type/)
+    if result =~ /no scrolls inside/
+      stow_book(book, container)
+      return 0
+    end
+    lines = []
+    loop do
+      line = get
+      lines << line
+      break if line =~ /You can turn/
+    end
+    stow_book(book, container)
+    lines.count { |l| l =~ /\d+ -- #{Regexp.escape(sigil_type)}/i }
+  end
+
+  # Stows the sigil book into its configured container or default location.
+  #
+  # @param book [String] book noun
+  # @param container [String, nil] target container, or nil for default stow
+  # @return [void]
+  def stow_book(book, container)
+    if container
+      DRCI.put_away_item?(book, container)
+    else
+      DRCI.stow_hands
+    end
+  end
+
+  # Purchases an item using the two-step order confirmation flow.
+  #
+  # @param order_number [Integer] catalog number from the shop's ORDER list
+  # @return [void]
+  def purchase_via_order(order_number)
+    DRC.bput("order #{order_number}", /Just order it again/)
+    DRC.bput("order #{order_number}", /hands you/)
   end
 end
 

--- a/restock.lic
+++ b/restock.lic
@@ -440,16 +440,17 @@ class Restock
   # @param sigil_purchases [Array<Hash>] purchase list from collect_sigil_purchases
   # @return [void]
   def purchase_sigil_scrolls(sigil_purchases)
+    failed = false
     sigil_purchases.each do |purchase|
+      break if failed
       purchase['needed'].times do
         DRCT.order_item(purchase['room'], purchase['order_number'])
-        if reget(3, 'Seeing that you are too encumbered')
-          fput('get sigil-scroll from counter')
-        end
+        fput('get sigil-scroll from counter') if reget(3, 'Seeing that you are too encumbered')
         unless DRCI.put_away_item?("#{purchase['sigil_type']} sigil-scroll", purchase['book'])
           echo "Failed to add #{purchase['sigil_type']} scroll to #{purchase['book']}"
           DRCI.stow_hands
-          return
+          failed = true
+          break
         end
       end
     end

--- a/spec/restock_spec.rb
+++ b/spec/restock_spec.rb
@@ -44,6 +44,7 @@ module DRCT
   class << self
     def walk_to(*_args); end
     def buy_item(*_args); end
+    def order_item(*_args); end
   end
 end
 
@@ -52,6 +53,7 @@ module DRCI
     def open_container?(*_args); true; end
     def stow_hands; end
     def put_away_item?(*_args); true; end
+    def get_item?(*_args); true; end
     def count_items_in_container(*_args); 0; end
   end
 end
@@ -115,11 +117,11 @@ RSpec.describe Restock do
   end
 
   # ===========================================================================
-  # #start_restock -- duplicate purchase bug regression test
+  # #start_restock -- routing to restock_default vs restock_items
   # ===========================================================================
   describe '#start_restock' do
     context 'with items from multiple custom hometowns' do
-      it 'restocks each hometown group exactly once' do
+      it 'sends default items to restock_default and groups custom items by hometown' do
         crossing_item = make_item('hometown' => 'Crossing', 'name' => 'arrow')
         shard_item = make_item('hometown' => 'Shard', 'name' => 'bolt')
         instance = build_instance(
@@ -128,31 +130,34 @@ RSpec.describe Restock do
 
         allow(instance).to receive(:parse_restockable_items).and_return([crossing_item, shard_item])
 
-        call_log = []
+        default_calls = []
+        allow(instance).to receive(:restock_default) do |items, town|
+          default_calls << { town: town, items: items.map { |i| i['name'] } }
+        end
+
+        custom_calls = []
         allow(instance).to receive(:restock_items) do |items, town|
-          call_log << { town: town, items: items.map { |i| i['name'] } }
+          custom_calls << { town: town, items: items.map { |i| i['name'] } }
         end
 
         instance.send(:start_restock)
 
-        # Default hometown gets the non-custom items (empty in this case)
-        default_calls = call_log.select { |c| c[:town] == 'Riverhaven' }
+        # Default hometown gets non-custom items via restock_default (empty here)
         expect(default_calls.length).to eq(1)
+        expect(default_calls.first[:town]).to eq('Riverhaven')
         expect(default_calls.first[:items]).to be_empty
 
-        # Each custom hometown called exactly once -- not duplicated
-        crossing_calls = call_log.select { |c| c[:town] == 'Crossing' }
-        expect(crossing_calls.length).to eq(1)
-        expect(crossing_calls.first[:items]).to eq(['arrow'])
-
-        shard_calls = call_log.select { |c| c[:town] == 'Shard' }
-        expect(shard_calls.length).to eq(1)
-        expect(shard_calls.first[:items]).to eq(['bolt'])
+        # Each custom hometown called via restock_items exactly once
+        expect(custom_calls.length).to eq(2)
+        crossing = custom_calls.find { |c| c[:town] == 'Crossing' }
+        expect(crossing[:items]).to eq(['arrow'])
+        shard = custom_calls.find { |c| c[:town] == 'Shard' }
+        expect(shard[:items]).to eq(['bolt'])
       end
     end
 
     context 'with no custom hometown items' do
-      it 'only restocks the default hometown' do
+      it 'only calls restock_default for the default hometown' do
         item = make_item
         instance = build_instance(
           settings: OpenStruct.new(hometown: 'Crossing')
@@ -160,16 +165,18 @@ RSpec.describe Restock do
 
         allow(instance).to receive(:parse_restockable_items).and_return([item])
 
-        call_log = []
-        allow(instance).to receive(:restock_items) do |items, town|
-          call_log << { town: town, count: items.length }
+        default_calls = []
+        allow(instance).to receive(:restock_default) do |items, town|
+          default_calls << { town: town, count: items.length }
         end
+        allow(instance).to receive(:restock_items)
 
         instance.send(:start_restock)
 
-        expect(call_log.length).to eq(1)
-        expect(call_log.first[:town]).to eq('Crossing')
-        expect(call_log.first[:count]).to eq(1)
+        expect(default_calls.length).to eq(1)
+        expect(default_calls.first[:town]).to eq('Crossing')
+        expect(default_calls.first[:count]).to eq(1)
+        expect(instance).not_to have_received(:restock_items)
       end
     end
   end
@@ -567,6 +574,596 @@ RSpec.describe Restock do
       # Should use the user's custom values, not base-consumables
       expect(result.first['price']).to eq(150)
       expect(result.first['room']).to eq(5678)
+    end
+  end
+
+  # ===========================================================================
+  # #valid_item_data? -- required field validation
+  # ===========================================================================
+  describe '#valid_item_data?' do
+    it 'returns true when all required fields are present' do
+      instance = build_instance
+      expect(instance.send(:valid_item_data?, make_item)).to be true
+    end
+
+    %w[name size room price stackable quantity].each do |field|
+      it "returns false when '#{field}' is missing" do
+        item = make_item
+        item.delete(field)
+        instance = build_instance
+        expect(instance.send(:valid_item_data?, item)).to be false
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #assess_restock_needs -- extracted counting/filtering logic
+  # ===========================================================================
+  describe '#assess_restock_needs' do
+    it 'returns items needing restock with buy_num and total coin' do
+      item = make_item('quantity' => 30, 'size' => 10, 'price' => 100)
+      instance = build_instance
+
+      allow(instance).to receive(:count_nonstackable_item).and_return(5)
+
+      items, coin = instance.send(:assess_restock_needs, [item])
+
+      expect(items.length).to eq(1)
+      # (30 - 5) / 10.0 = 2.5, ceil = 3
+      expect(items.first['buy_num']).to eq(3)
+      expect(coin).to eq(300)
+    end
+
+    it 'skips items at or above min_quantity' do
+      item = make_item('min_quantity' => 10, 'quantity' => 30)
+      instance = build_instance
+
+      allow(instance).to receive(:count_nonstackable_item).and_return(15)
+
+      items, coin = instance.send(:assess_restock_needs, [item])
+
+      expect(items).to be_empty
+      expect(coin).to eq(0)
+    end
+
+    it 'includes items below min_quantity' do
+      item = make_item('min_quantity' => 10, 'quantity' => 30, 'size' => 10, 'price' => 100)
+      instance = build_instance
+
+      allow(instance).to receive(:count_nonstackable_item).and_return(5)
+
+      items, coin = instance.send(:assess_restock_needs, [item])
+
+      expect(items.length).to eq(1)
+      # (30 - 5) / 10.0 = 2.5, ceil = 3
+      expect(items.first['buy_num']).to eq(3)
+      expect(coin).to eq(300)
+    end
+
+    it 'skips items already at target quantity when no min_quantity set' do
+      item = make_item('quantity' => 10)
+      instance = build_instance
+
+      allow(instance).to receive(:count_nonstackable_item).and_return(10)
+
+      items, coin = instance.send(:assess_restock_needs, [item])
+
+      expect(items).to be_empty
+      expect(coin).to eq(0)
+    end
+
+    it 'uses count_stackable_item for stackable items' do
+      item = make_item('stackable' => true, 'quantity' => 30, 'size' => 10, 'price' => 50)
+      instance = build_instance
+
+      allow(instance).to receive(:count_stackable_item).and_return(10)
+
+      items, coin = instance.send(:assess_restock_needs, [item])
+
+      expect(items.length).to eq(1)
+      expect(instance).to have_received(:count_stackable_item).with(item)
+      expect(items.first['buy_num']).to eq(2)
+      expect(coin).to eq(100)
+    end
+
+    it 'handles multiple items independently' do
+      arrow = make_item('name' => 'arrow', 'quantity' => 20, 'size' => 10, 'price' => 100)
+      bolt = make_item('name' => 'bolt', 'quantity' => 10, 'size' => 5, 'price' => 200)
+      instance = build_instance
+
+      call_count = 0
+      allow(instance).to receive(:count_nonstackable_item) do
+        call_count += 1
+        call_count == 1 ? 0 : 0
+      end
+
+      items, coin = instance.send(:assess_restock_needs, [arrow, bolt])
+
+      expect(items.length).to eq(2)
+      # arrow: (20-0)/10 = 2 buys * 100 = 200
+      # bolt: (10-0)/5 = 2 buys * 200 = 400
+      expect(coin).to eq(600)
+    end
+  end
+
+  # ===========================================================================
+  # #purchase_item -- clerk, order_number, and standard buy flows
+  # ===========================================================================
+  describe '#purchase_item' do
+    it 'uses ask-for flow when item has a clerk' do
+      item = make_item('clerk' => 'shopkeeper', 'room' => 5678)
+      instance = build_instance
+
+      allow(DRCT).to receive(:walk_to)
+      allow(DRCT).to receive(:buy_item)
+
+      instance.send(:purchase_item, item)
+
+      expect(DRCT).to have_received(:walk_to).with(5678)
+      expect(DRCT).not_to have_received(:buy_item)
+    end
+
+    it 'uses DRCT.order_item when item has an order_number' do
+      item = make_item('order_number' => 16, 'room' => 14753)
+      instance = build_instance
+
+      allow(DRCT).to receive(:order_item)
+      allow(DRCT).to receive(:buy_item)
+
+      instance.send(:purchase_item, item)
+
+      expect(DRCT).to have_received(:order_item).with(14753, 16)
+      expect(DRCT).not_to have_received(:buy_item)
+    end
+
+    it 'prefers clerk over order_number when both are present' do
+      item = make_item('clerk' => 'shopkeeper', 'order_number' => 16, 'room' => 5678)
+      instance = build_instance
+
+      allow(DRCT).to receive(:walk_to)
+      allow(DRCT).to receive(:order_item)
+
+      instance.send(:purchase_item, item)
+
+      expect(DRCT).to have_received(:walk_to).with(5678)
+      expect(DRCT).not_to have_received(:order_item)
+    end
+
+    it 'uses standard buy_item when item has no clerk or order_number' do
+      item = make_item('room' => 5678)
+      instance = build_instance
+
+      allow(DRCT).to receive(:buy_item)
+      allow(DRCT).to receive(:walk_to)
+
+      instance.send(:purchase_item, item)
+
+      expect(DRCT).to have_received(:buy_item).with(5678, 'arrow')
+      expect(DRCT).not_to have_received(:walk_to)
+    end
+  end
+
+  # ===========================================================================
+  # #collect_sigil_purchases -- sigil book scroll counting
+  # ===========================================================================
+  describe '#collect_sigil_purchases' do
+    it 'returns empty array when no sigil_books config exists' do
+      instance = build_instance(restock: {})
+
+      result = instance.send(:collect_sigil_purchases)
+
+      expect(result).to eq([])
+    end
+
+    it 'returns empty array when sigil_books is nil' do
+      instance = build_instance(restock: { 'sigil_books' => nil })
+
+      result = instance.send(:collect_sigil_purchases)
+
+      expect(result).to eq([])
+    end
+
+    it 'calculates needed quantity and builds purchase hash' do
+      restock_config = {
+        'sigil_books' => {
+          'platinum-hued book' => {
+            'container' => 'satchel',
+            'congruence' => {
+              'quantity' => 20,
+              'min_quantity' => 5,
+              'room' => 14753,
+              'order_number' => 3,
+              'price' => 312
+            }
+          }
+        }
+      }
+      instance = build_instance(restock: restock_config)
+
+      allow(instance).to receive(:count_sigils_in_book)
+        .with('platinum-hued book', 'congruence', 'satchel')
+        .and_return(3)
+
+      result = instance.send(:collect_sigil_purchases)
+
+      expect(result.length).to eq(1)
+      purchase = result.first
+      expect(purchase['book']).to eq('platinum-hued book')
+      expect(purchase['sigil_type']).to eq('congruence')
+      expect(purchase['order_number']).to eq(3)
+      expect(purchase['price']).to eq(312)
+      expect(purchase['room']).to eq(14753)
+      expect(purchase['needed']).to eq(17)
+    end
+
+    it 'skips sigil types at or above min_quantity' do
+      restock_config = {
+        'sigil_books' => {
+          'platinum-hued book' => {
+            'container' => 'satchel',
+            'congruence' => {
+              'quantity' => 20,
+              'min_quantity' => 5,
+              'room' => 14753,
+              'order_number' => 3,
+              'price' => 312
+            }
+          }
+        }
+      }
+      instance = build_instance(restock: restock_config)
+
+      allow(instance).to receive(:count_sigils_in_book).and_return(10)
+
+      result = instance.send(:collect_sigil_purchases)
+
+      expect(result).to be_empty
+    end
+
+    it 'skips when book is not found (nil count)' do
+      restock_config = {
+        'sigil_books' => {
+          'missing book' => {
+            'congruence' => {
+              'quantity' => 20,
+              'room' => 14753,
+              'order_number' => 3,
+              'price' => 312
+            }
+          }
+        }
+      }
+      instance = build_instance(restock: restock_config)
+
+      allow(instance).to receive(:count_sigils_in_book).and_return(nil)
+
+      result = instance.send(:collect_sigil_purchases)
+
+      expect(result).to be_empty
+    end
+
+    it 'skips when already at target quantity' do
+      restock_config = {
+        'sigil_books' => {
+          'platinum-hued book' => {
+            'congruence' => {
+              'quantity' => 10,
+              'room' => 14753,
+              'order_number' => 3,
+              'price' => 312
+            }
+          }
+        }
+      }
+      instance = build_instance(restock: restock_config)
+
+      allow(instance).to receive(:count_sigils_in_book).and_return(10)
+
+      result = instance.send(:collect_sigil_purchases)
+
+      expect(result).to be_empty
+    end
+
+    it 'handles multiple sigil types in one book' do
+      restock_config = {
+        'sigil_books' => {
+          'platinum-hued book' => {
+            'container' => 'satchel',
+            'congruence' => {
+              'quantity' => 20,
+              'room' => 14753,
+              'order_number' => 3,
+              'price' => 312
+            },
+            'abolition' => {
+              'quantity' => 10,
+              'room' => 14753,
+              'order_number' => 5,
+              'price' => 250
+            }
+          }
+        }
+      }
+      instance = build_instance(restock: restock_config)
+
+      allow(instance).to receive(:count_sigils_in_book).and_return(0)
+
+      result = instance.send(:collect_sigil_purchases)
+
+      expect(result.length).to eq(2)
+      types = result.map { |p| p['sigil_type'] }
+      expect(types).to include('congruence')
+      expect(types).to include('abolition')
+    end
+  end
+
+  # ===========================================================================
+  # #purchase_sigil_scrolls -- purchasing and stowing scrolls into books
+  # ===========================================================================
+  describe '#purchase_sigil_scrolls' do
+    it 'orders from shop and stows scroll into book' do
+      purchases = [{
+        'book' => 'platinum-hued book',
+        'sigil_type' => 'congruence',
+        'order_number' => 3,
+        'price' => 312,
+        'room' => 14753,
+        'needed' => 2
+      }]
+      instance = build_instance
+
+      allow(DRCT).to receive(:order_item)
+      allow(instance).to receive(:reget).and_return(nil)
+      allow(DRCI).to receive(:put_away_item?).and_return(true)
+
+      instance.send(:purchase_sigil_scrolls, purchases)
+
+      expect(DRCT).to have_received(:order_item).with(14753, 3).exactly(2).times
+      expect(DRCI).to have_received(:put_away_item?)
+        .with('congruence sigil-scroll', 'platinum-hued book').exactly(2).times
+    end
+
+    it 'stops purchasing when put_away_item fails' do
+      purchases = [{
+        'book' => 'platinum-hued book',
+        'sigil_type' => 'congruence',
+        'order_number' => 3,
+        'price' => 312,
+        'room' => 14753,
+        'needed' => 5
+      }]
+      instance = build_instance
+
+      allow(DRCT).to receive(:order_item)
+      allow(instance).to receive(:reget).and_return(nil)
+      put_count = 0
+      allow(DRCI).to receive(:put_away_item?) do
+        put_count += 1
+        put_count <= 2
+      end
+      allow(DRCI).to receive(:stow_hands)
+
+      instance.send(:purchase_sigil_scrolls, purchases)
+
+      # Stopped after 3rd order (2 succeed, 3rd fails)
+      expect(DRCT).to have_received(:order_item).exactly(3).times
+      expect(DRCI).to have_received(:stow_hands)
+    end
+
+    it 'does nothing when purchase list is empty' do
+      instance = build_instance
+
+      allow(DRCT).to receive(:order_item)
+
+      instance.send(:purchase_sigil_scrolls, [])
+
+      expect(DRCT).not_to have_received(:order_item)
+    end
+  end
+
+  # ===========================================================================
+  # #restock_default -- consolidated bank trip
+  # ===========================================================================
+  describe '#restock_default' do
+    it 'combines regular item and sigil purchase costs in one withdrawal' do
+      item = make_item('quantity' => 20, 'size' => 10, 'price' => 100)
+      instance = build_instance
+
+      allow(instance).to receive(:count_nonstackable_item).and_return(0)
+      allow(instance).to receive(:collect_sigil_purchases).and_return([
+        { 'needed' => 5, 'price' => 200, 'room' => 14753 }
+      ])
+      allow(DRCI).to receive(:stow_hands)
+      allow(DRCM).to receive(:deposit_coins)
+      allow(instance).to receive(:purchase_item)
+      allow(instance).to receive(:handle_encumbrance)
+      allow(instance).to receive(:stow_item)
+      allow(instance).to receive(:purchase_sigil_scrolls)
+
+      # regular: 2 buys * 100 = 200; bribe: 2502 * 1 = 2502
+      # sigil: 5 * 200 = 1000; sigil bribe: 2502 * 1 = 2502
+      # total: 200 + 2502 + 1000 + 2502 = 7204
+      expected_coin = 200 + 2502 + 1000 + 2502
+      expect(DRCM).to receive(:ensure_copper_on_hand).with(expected_coin, anything, 'Crossing')
+
+      instance.send(:restock_default, [item], 'Crossing')
+    end
+
+    it 'returns early when nothing needs restocking and no sigil purchases' do
+      item = make_item('quantity' => 10)
+      instance = build_instance
+
+      allow(instance).to receive(:count_nonstackable_item).and_return(10)
+      allow(instance).to receive(:collect_sigil_purchases).and_return([])
+      allow(DRCI).to receive(:stow_hands)
+      allow(DRCM).to receive(:ensure_copper_on_hand)
+
+      instance.send(:restock_default, [item], 'Crossing')
+
+      expect(DRCI).not_to have_received(:stow_hands)
+      expect(DRCM).not_to have_received(:ensure_copper_on_hand)
+    end
+
+    it 'proceeds when only sigil purchases are needed' do
+      instance = build_instance
+
+      allow(instance).to receive(:collect_sigil_purchases).and_return([
+        { 'needed' => 3, 'price' => 100, 'room' => 14753 }
+      ])
+      allow(DRCI).to receive(:stow_hands)
+      allow(DRCM).to receive(:ensure_copper_on_hand)
+      allow(DRCM).to receive(:deposit_coins)
+      allow(instance).to receive(:purchase_sigil_scrolls)
+
+      # sigil: 3 * 100 = 300; bribe: 2502 * 1 room = 2502
+      expected_coin = 300 + 2502
+      expect(DRCM).to receive(:ensure_copper_on_hand).with(expected_coin, anything, 'Crossing')
+
+      instance.send(:restock_default, [], 'Crossing')
+    end
+
+    it 'pads bribe per unique sigil room, not per purchase' do
+      instance = build_instance
+
+      allow(instance).to receive(:collect_sigil_purchases).and_return([
+        { 'needed' => 2, 'price' => 100, 'room' => 14753 },
+        { 'needed' => 3, 'price' => 200, 'room' => 14753 },
+        { 'needed' => 1, 'price' => 50, 'room' => 9999 }
+      ])
+      allow(DRCI).to receive(:stow_hands)
+      allow(DRCM).to receive(:deposit_coins)
+      allow(instance).to receive(:purchase_sigil_scrolls)
+
+      # sigil cost: 2*100 + 3*200 + 1*50 = 850
+      # bribe: 2502 * 2 unique rooms = 5004
+      expected_coin = 850 + 5004
+      expect(DRCM).to receive(:ensure_copper_on_hand).with(expected_coin, anything, 'Crossing')
+
+      instance.send(:restock_default, [], 'Crossing')
+    end
+  end
+
+  # ===========================================================================
+  # #parse_restockable_items -- sigil_books key filtering
+  # ===========================================================================
+  describe '#parse_restockable_items' do
+    let(:consumables) do
+      {
+        'arrow' => {
+          'name'      => 'arrow',
+          'size'      => 10,
+          'price'     => 100,
+          'room'      => 1234,
+          'stackable' => false,
+          'quantity'  => 20
+        }
+      }
+    end
+
+    it 'merges base-consumables data for known items' do
+      restock_config = { 'arrow' => { 'quantity' => 30 } }
+      instance = build_instance(restock: restock_config, hometown: 'Crossing')
+
+      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
+
+      result = instance.send(:parse_restockable_items)
+
+      expect(result.length).to eq(1)
+      item = result.first
+      expect(item['quantity']).to eq(30)
+      expect(item['name']).to eq('arrow')
+      expect(item['size']).to eq(10)
+      expect(item['price']).to eq(100)
+    end
+
+    it 'preserves all user overrides over base-consumables defaults' do
+      restock_config = { 'arrow' => { 'quantity' => 50, 'price' => 200 } }
+      instance = build_instance(restock: restock_config, hometown: 'Crossing')
+
+      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
+
+      result = instance.send(:parse_restockable_items)
+      item = result.first
+
+      expect(item['quantity']).to eq(50)
+      expect(item['price']).to eq(200)
+    end
+
+    it 'accepts fully custom items with all required fields' do
+      restock_config = {
+        'custom_thing' => {
+          'name'      => 'widget',
+          'size'      => 1,
+          'room'      => 9999,
+          'price'     => 50,
+          'stackable' => false,
+          'quantity'  => 5
+        }
+      }
+      instance = build_instance(restock: restock_config, hometown: 'Crossing')
+
+      $test_data = OpenStruct.new(consumables: { 'Crossing' => {} })
+
+      result = instance.send(:parse_restockable_items)
+
+      expect(result.length).to eq(1)
+      expect(result.first['name']).to eq('widget')
+    end
+
+    it 'rejects custom items missing required fields' do
+      restock_config = {
+        'broken_thing' => { 'name' => 'widget' }
+      }
+      instance = build_instance(restock: restock_config, hometown: 'Crossing')
+
+      $test_data = OpenStruct.new(consumables: { 'Crossing' => {} })
+
+      result = instance.send(:parse_restockable_items)
+
+      expect(result).to be_empty
+    end
+
+    it 'skips base-consumables lookup when item specifies custom hometown' do
+      restock_config = {
+        'arrow' => {
+          'hometown'  => 'Shard',
+          'name'      => 'arrow',
+          'size'      => 10,
+          'room'      => 5678,
+          'price'     => 150,
+          'stackable' => false,
+          'quantity'  => 20
+        }
+      }
+      instance = build_instance(restock: restock_config, hometown: 'Crossing')
+
+      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
+
+      result = instance.send(:parse_restockable_items)
+
+      expect(result.length).to eq(1)
+      expect(result.first['price']).to eq(150)
+      expect(result.first['room']).to eq(5678)
+    end
+
+    it 'excludes the sigil_books key from regular item parsing' do
+      restock_config = {
+        'arrow' => { 'quantity' => 30 },
+        'sigil_books' => {
+          'platinum-hued book' => {
+            'container' => 'satchel',
+            'congruence' => { 'quantity' => 20, 'room' => 14753, 'order_number' => 3, 'price' => 312 }
+          }
+        }
+      }
+      instance = build_instance(restock: restock_config, hometown: 'Crossing')
+
+      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
+
+      result = instance.send(:parse_restockable_items)
+
+      expect(result.length).to eq(1)
+      expect(result.first['name']).to eq('arrow')
     end
   end
 

--- a/spec/restock_spec.rb
+++ b/spec/restock_spec.rb
@@ -575,6 +575,26 @@ RSpec.describe Restock do
       expect(result.first['price']).to eq(150)
       expect(result.first['room']).to eq(5678)
     end
+
+    it 'excludes the sigil_books key from regular item parsing' do
+      restock_config = {
+        'arrow'       => { 'quantity' => 30 },
+        'sigil_books' => {
+          'platinum-hued book' => {
+            'container'  => 'satchel',
+            'congruence' => { 'quantity' => 20, 'room' => 14753, 'order_number' => 3, 'price' => 312 }
+          }
+        }
+      }
+      instance = build_instance(restock: restock_config, hometown: 'Crossing')
+
+      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
+
+      result = instance.send(:parse_restockable_items)
+
+      expect(result.length).to eq(1)
+      expect(result.first['name']).to eq('arrow')
+    end
   end
 
   # ===========================================================================
@@ -1040,149 +1060,6 @@ RSpec.describe Restock do
       expect(DRCM).to receive(:ensure_copper_on_hand).with(expected_coin, anything, 'Crossing')
 
       instance.send(:restock_default, [], 'Crossing')
-    end
-  end
-
-  # ===========================================================================
-  # #parse_restockable_items -- sigil_books key filtering
-  # ===========================================================================
-  describe '#parse_restockable_items' do
-    let(:consumables) do
-      {
-        'arrow' => {
-          'name'      => 'arrow',
-          'size'      => 10,
-          'price'     => 100,
-          'room'      => 1234,
-          'stackable' => false,
-          'quantity'  => 20
-        }
-      }
-    end
-
-    it 'merges base-consumables data for known items' do
-      restock_config = { 'arrow' => { 'quantity' => 30 } }
-      instance = build_instance(restock: restock_config, hometown: 'Crossing')
-
-      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
-
-      result = instance.send(:parse_restockable_items)
-
-      expect(result.length).to eq(1)
-      item = result.first
-      expect(item['quantity']).to eq(30)
-      expect(item['name']).to eq('arrow')
-      expect(item['size']).to eq(10)
-      expect(item['price']).to eq(100)
-    end
-
-    it 'preserves all user overrides over base-consumables defaults' do
-      restock_config = { 'arrow' => { 'quantity' => 50, 'price' => 200 } }
-      instance = build_instance(restock: restock_config, hometown: 'Crossing')
-
-      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
-
-      result = instance.send(:parse_restockable_items)
-      item = result.first
-
-      expect(item['quantity']).to eq(50)
-      expect(item['price']).to eq(200)
-    end
-
-    it 'accepts fully custom items with all required fields' do
-      restock_config = {
-        'custom_thing' => {
-          'name'      => 'widget',
-          'size'      => 1,
-          'room'      => 9999,
-          'price'     => 50,
-          'stackable' => false,
-          'quantity'  => 5
-        }
-      }
-      instance = build_instance(restock: restock_config, hometown: 'Crossing')
-
-      $test_data = OpenStruct.new(consumables: { 'Crossing' => {} })
-
-      result = instance.send(:parse_restockable_items)
-
-      expect(result.length).to eq(1)
-      expect(result.first['name']).to eq('widget')
-    end
-
-    it 'rejects custom items missing required fields' do
-      restock_config = {
-        'broken_thing' => { 'name' => 'widget' }
-      }
-      instance = build_instance(restock: restock_config, hometown: 'Crossing')
-
-      $test_data = OpenStruct.new(consumables: { 'Crossing' => {} })
-
-      result = instance.send(:parse_restockable_items)
-
-      expect(result).to be_empty
-    end
-
-    it 'skips base-consumables lookup when item specifies custom hometown' do
-      restock_config = {
-        'arrow' => {
-          'hometown'  => 'Shard',
-          'name'      => 'arrow',
-          'size'      => 10,
-          'room'      => 5678,
-          'price'     => 150,
-          'stackable' => false,
-          'quantity'  => 20
-        }
-      }
-      instance = build_instance(restock: restock_config, hometown: 'Crossing')
-
-      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
-
-      result = instance.send(:parse_restockable_items)
-
-      expect(result.length).to eq(1)
-      expect(result.first['price']).to eq(150)
-      expect(result.first['room']).to eq(5678)
-    end
-
-    it 'excludes the sigil_books key from regular item parsing' do
-      restock_config = {
-        'arrow'       => { 'quantity' => 30 },
-        'sigil_books' => {
-          'platinum-hued book' => {
-            'container'  => 'satchel',
-            'congruence' => { 'quantity' => 20, 'room' => 14753, 'order_number' => 3, 'price' => 312 }
-          }
-        }
-      }
-      instance = build_instance(restock: restock_config, hometown: 'Crossing')
-
-      $test_data = OpenStruct.new(consumables: { 'Crossing' => consumables })
-
-      result = instance.send(:parse_restockable_items)
-
-      expect(result.length).to eq(1)
-      expect(result.first['name']).to eq('arrow')
-    end
-  end
-
-  # ===========================================================================
-  # #valid_item_data? -- required field validation
-  # ===========================================================================
-  describe '#valid_item_data?' do
-    it 'returns true when all required fields are present' do
-      instance = build_instance
-      expect(instance.send(:valid_item_data?, make_item)).to be true
-    end
-
-    %w[name size room price stackable quantity].each do |field|
-      it "returns false when '#{field}' is missing" do
-        item = make_item
-        item.delete(field)
-        instance = build_instance
-        expect(instance.send(:valid_item_data?, item)).to be false
-      end
     end
   end
 end

--- a/spec/restock_spec.rb
+++ b/spec/restock_spec.rb
@@ -767,13 +767,13 @@ RSpec.describe Restock do
       restock_config = {
         'sigil_books' => {
           'platinum-hued book' => {
-            'container' => 'satchel',
+            'container'  => 'satchel',
             'congruence' => {
-              'quantity' => 20,
+              'quantity'     => 20,
               'min_quantity' => 5,
-              'room' => 14753,
+              'room'         => 14753,
               'order_number' => 3,
-              'price' => 312
+              'price'        => 312
             }
           }
         }
@@ -800,13 +800,13 @@ RSpec.describe Restock do
       restock_config = {
         'sigil_books' => {
           'platinum-hued book' => {
-            'container' => 'satchel',
+            'container'  => 'satchel',
             'congruence' => {
-              'quantity' => 20,
+              'quantity'     => 20,
               'min_quantity' => 5,
-              'room' => 14753,
+              'room'         => 14753,
               'order_number' => 3,
-              'price' => 312
+              'price'        => 312
             }
           }
         }
@@ -825,10 +825,10 @@ RSpec.describe Restock do
         'sigil_books' => {
           'missing book' => {
             'congruence' => {
-              'quantity' => 20,
-              'room' => 14753,
+              'quantity'     => 20,
+              'room'         => 14753,
               'order_number' => 3,
-              'price' => 312
+              'price'        => 312
             }
           }
         }
@@ -847,10 +847,10 @@ RSpec.describe Restock do
         'sigil_books' => {
           'platinum-hued book' => {
             'congruence' => {
-              'quantity' => 10,
-              'room' => 14753,
+              'quantity'     => 10,
+              'room'         => 14753,
               'order_number' => 3,
-              'price' => 312
+              'price'        => 312
             }
           }
         }
@@ -868,18 +868,18 @@ RSpec.describe Restock do
       restock_config = {
         'sigil_books' => {
           'platinum-hued book' => {
-            'container' => 'satchel',
+            'container'  => 'satchel',
             'congruence' => {
-              'quantity' => 20,
-              'room' => 14753,
+              'quantity'     => 20,
+              'room'         => 14753,
               'order_number' => 3,
-              'price' => 312
+              'price'        => 312
             },
-            'abolition' => {
-              'quantity' => 10,
-              'room' => 14753,
+            'abolition'  => {
+              'quantity'     => 10,
+              'room'         => 14753,
               'order_number' => 5,
-              'price' => 250
+              'price'        => 250
             }
           }
         }
@@ -903,12 +903,12 @@ RSpec.describe Restock do
   describe '#purchase_sigil_scrolls' do
     it 'orders from shop and stows scroll into book' do
       purchases = [{
-        'book' => 'platinum-hued book',
-        'sigil_type' => 'congruence',
+        'book'         => 'platinum-hued book',
+        'sigil_type'   => 'congruence',
         'order_number' => 3,
-        'price' => 312,
-        'room' => 14753,
-        'needed' => 2
+        'price'        => 312,
+        'room'         => 14753,
+        'needed'       => 2
       }]
       instance = build_instance
 
@@ -925,12 +925,12 @@ RSpec.describe Restock do
 
     it 'stops purchasing when put_away_item fails' do
       purchases = [{
-        'book' => 'platinum-hued book',
-        'sigil_type' => 'congruence',
+        'book'         => 'platinum-hued book',
+        'sigil_type'   => 'congruence',
         'order_number' => 3,
-        'price' => 312,
-        'room' => 14753,
-        'needed' => 5
+        'price'        => 312,
+        'room'         => 14753,
+        'needed'       => 5
       }]
       instance = build_instance
 
@@ -971,8 +971,8 @@ RSpec.describe Restock do
 
       allow(instance).to receive(:count_nonstackable_item).and_return(0)
       allow(instance).to receive(:collect_sigil_purchases).and_return([
-        { 'needed' => 5, 'price' => 200, 'room' => 14753 }
-      ])
+                                                                        { 'needed' => 5, 'price' => 200, 'room' => 14753 }
+                                                                      ])
       allow(DRCI).to receive(:stow_hands)
       allow(DRCM).to receive(:deposit_coins)
       allow(instance).to receive(:purchase_item)
@@ -1008,8 +1008,8 @@ RSpec.describe Restock do
       instance = build_instance
 
       allow(instance).to receive(:collect_sigil_purchases).and_return([
-        { 'needed' => 3, 'price' => 100, 'room' => 14753 }
-      ])
+                                                                        { 'needed' => 3, 'price' => 100, 'room' => 14753 }
+                                                                      ])
       allow(DRCI).to receive(:stow_hands)
       allow(DRCM).to receive(:ensure_copper_on_hand)
       allow(DRCM).to receive(:deposit_coins)
@@ -1026,10 +1026,10 @@ RSpec.describe Restock do
       instance = build_instance
 
       allow(instance).to receive(:collect_sigil_purchases).and_return([
-        { 'needed' => 2, 'price' => 100, 'room' => 14753 },
-        { 'needed' => 3, 'price' => 200, 'room' => 14753 },
-        { 'needed' => 1, 'price' => 50, 'room' => 9999 }
-      ])
+                                                                        { 'needed' => 2, 'price' => 100, 'room' => 14753 },
+                                                                        { 'needed' => 3, 'price' => 200, 'room' => 14753 },
+                                                                        { 'needed' => 1, 'price' => 50, 'room' => 9999 }
+                                                                      ])
       allow(DRCI).to receive(:stow_hands)
       allow(DRCM).to receive(:deposit_coins)
       allow(instance).to receive(:purchase_sigil_scrolls)
@@ -1148,10 +1148,10 @@ RSpec.describe Restock do
 
     it 'excludes the sigil_books key from regular item parsing' do
       restock_config = {
-        'arrow' => { 'quantity' => 30 },
+        'arrow'       => { 'quantity' => 30 },
         'sigil_books' => {
           'platinum-hued book' => {
-            'container' => 'satchel',
+            'container'  => 'satchel',
             'congruence' => { 'quantity' => 20, 'room' => 14753, 'order_number' => 3, 'price' => 312 }
           }
         }


### PR DESCRIPTION
Introduces support for filling sigil books from catalog shops using the
two-step ORDER confirmation flow, and extends the purchase_item flow with
the same order_number mechanism for regular items (e.g. society shops).

All default-hometown items and sigil books now share a single count phase,
one bank withdrawal, and one deposit rather than making separate trips per
category. Custom-hometown items continue to use their own trips.

Sigil books support quantity, min_quantity, and container configuration,
nested under the existing restock key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alternative two-step order-number purchase flow for restocking.
  * Full sigil-book and sigil-scroll purchase and stow workflow during restocks.

* **Improvements**
  * Restocking split between default-hometown and custom-hometown handling for clearer routing.
  * Bribe padding and cost planning refined; consolidated coin withdrawal for combined purchases.
  * Purchase routing updated so clerk/ask flow takes precedence over order-number.

* **Tests**
  * Expanded coverage for routing, sigil behavior, purchase rounding, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/dr-scripts/pull/7392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->