### PR TITLE
[scripts][healer] Make Link Unity not a hard requirement to run this script

### DIFF
--- a/healer.lic
+++ b/healer.lic
@@ -177,8 +177,10 @@ class Healer
   # ============================================================
 
   # Validates that the empath has Link Unity by checking `link` command output.
-  # Uses silent issue_command to avoid polluting the game window.
-  # Exits immediately if not an empath or Unity not available.
+  # Checks whether the character can use Link Unity for wound transfers.
+  # Sets @unity_available accordingly. Exits only if the character
+  # is not an empath at all.
+  #
   # @return [void]
   def validate_link_unity
     waitrt?
@@ -205,13 +207,15 @@ class Healer
       exit
     end
 
-    unless output.include?('UNITY')
-      Lich::Messaging.msg('bold', 'Healer: ERROR - Link Unity not available. Cannot transfer wounds.')
-      Lich::Messaging.msg('bold', 'Healer: You need to learn the Unity manifestation of Empathic Link.')
-      exit
-    end
+    @unity_available = output.include?('UNITY')
 
-    Lich::Messaging.msg('bold', 'Healer: Link Unity verified')
+    if @unity_available
+      Lich::Messaging.msg('bold', 'Healer: Link Unity verified')
+    else
+      Lich::Messaging.msg('bold', 'Healer: WARNING - Link Unity not available. Wound transfers disabled.')
+      Lich::Messaging.msg('bold', 'Healer: You need to learn the Unity manifestation of Empathic Link.')
+      Lich::Messaging.msg('bold', 'Healer: Can still cure poison, disease, parasites, and heal vitality.')
+    end
   end
 
   # Checks if character knows Heal + Adaptive Curing for passive healing.
@@ -766,12 +770,13 @@ class Healer
       update_patient(victim, touched: true, timer: Time.now, dead: true) unless patient_data[:touched]
     end
 
-    # First encounter (living patients): upgrade to Unity link if patient has healable wounds
-    # Unity is for wound transfer only -- not for poison/disease/vitality (those use basic empathic link from touch)
+    # First encounter (living patients): establish Unity link if available and patient has healable wounds.
+    # Unity is an instant transfer-as-is method -- all wounds move immediately, and the empath's
+    # vitality is set to the patient's pre-unity value (lethal on dead patients).
     unless patient_data[:touched] || victim_health.dead
       if victim_health.score > 0 || victim_health.poisoned || victim_health.diseased
         DRC.log_window("Healer: New patient: #{victim}", "familiar")
-        if has_healable_wounds?(victim_health)
+        if @unity_available && has_healable_wounds?(victim_health)
           log("Upgrading to Unity link with #{victim} for wound transfer")
           link_result = DRC.bput("link #{victim} unity", *LINK_RESPONSES)
           if link_result =~ LINK_NOT_FOUND_PATTERN

--- a/healer.lic
+++ b/healer.lic
@@ -209,11 +209,7 @@ class Healer
 
     @unity_available = output.include?('UNITY')
 
-    if @unity_available
-      Lich::Messaging.msg('bold', 'Healer: Link Unity verified -- instant wound transfer available')
-    else
-      Lich::Messaging.msg('bold', 'Healer: Link Unity not available -- wounds will transfer via touch instead')
-    end
+    Lich::Messaging.msg('bold', 'Healer: Link Unity available') if @unity_available
   end
 
   # Checks if character knows Heal + Adaptive Curing for passive healing.
@@ -781,9 +777,7 @@ class Healer
             remove_patient(victim, reason: :not_found)
             return
           end
-        elsif !@unity_available
-          log("#{victim} will use touch transfer (Unity not available)")
-        else
+        elsif !has_healable_wounds?(victim_health)
           log("#{victim} only has hands/legs wounds, skipping Unity link")
         end
       end

--- a/healer.lic
+++ b/healer.lic
@@ -196,8 +196,9 @@ class Healer
     )
 
     unless lines
-      Lich::Messaging.msg('bold', 'Healer: ERROR - Could not check link abilities (timeout).')
-      exit
+      @unity_available = false
+      Lich::Messaging.msg('bold', 'Healer: Could not verify link abilities (timeout)')
+      return
     end
 
     output = lines.map { |l| l.gsub(/<[^>]*>/, '') }.join("\n")

--- a/healer.lic
+++ b/healer.lic
@@ -177,9 +177,9 @@ class Healer
   # ============================================================
 
   # Validates that the empath has Link Unity by checking `link` command output.
-  # Checks whether the character can use Link Unity for wound transfers.
-  # Sets @unity_available accordingly. Exits only if the character
-  # is not an empath at all.
+  # Checks whether the character can use Link Unity for instant wound transfers.
+  # Sets @unity_available accordingly. Without Unity, wounds still transfer
+  # via the normal touch flow. Exits only if the character is not an empath.
   #
   # @return [void]
   def validate_link_unity
@@ -210,11 +210,9 @@ class Healer
     @unity_available = output.include?('UNITY')
 
     if @unity_available
-      Lich::Messaging.msg('bold', 'Healer: Link Unity verified')
+      Lich::Messaging.msg('bold', 'Healer: Link Unity verified -- instant wound transfer available')
     else
-      Lich::Messaging.msg('bold', 'Healer: WARNING - Link Unity not available. Wound transfers disabled.')
-      Lich::Messaging.msg('bold', 'Healer: You need to learn the Unity manifestation of Empathic Link.')
-      Lich::Messaging.msg('bold', 'Healer: Can still cure poison, disease, parasites, and heal vitality.')
+      Lich::Messaging.msg('bold', 'Healer: Link Unity not available -- wounds will transfer via touch instead')
     end
   end
 
@@ -770,22 +768,23 @@ class Healer
       update_patient(victim, touched: true, timer: Time.now, dead: true) unless patient_data[:touched]
     end
 
-    # First encounter (living patients): establish Unity link if available and patient has healable wounds.
-    # Unity is an instant transfer-as-is method -- all wounds move immediately, and the empath's
-    # vitality is set to the patient's pre-unity value (lethal on dead patients).
+    # First encounter (living patients): use Unity for instant wound transfer if available.
+    # Without Unity, wounds transfer via the normal touch flow instead.
     unless patient_data[:touched] || victim_health.dead
       if victim_health.score > 0 || victim_health.poisoned || victim_health.diseased
         DRC.log_window("Healer: New patient: #{victim}", "familiar")
         if @unity_available && has_healable_wounds?(victim_health)
-          log("Upgrading to Unity link with #{victim} for wound transfer")
+          log("Using Unity link with #{victim} for instant wound transfer")
           link_result = DRC.bput("link #{victim} unity", *LINK_RESPONSES)
           if link_result =~ LINK_NOT_FOUND_PATTERN
             Lich::Messaging.msg("bold", "Healer: Could not link with #{victim}")
             remove_patient(victim, reason: :not_found)
             return
           end
+        elsif !@unity_available
+          log("#{victim} will use touch transfer (Unity not available)")
         else
-          log("#{victim} only has hands/legs wounds, skipping unity link")
+          log("#{victim} only has hands/legs wounds, skipping Unity link")
         end
       end
     end

--- a/spec/healer_spec.rb
+++ b/spec/healer_spec.rb
@@ -76,7 +76,12 @@ load_lic_class('healer.lic', 'Healer')
 
 # Helper to build a Healer instance bypassing startup validations.
 # Tests that exercise validation do so explicitly.
-def build_healer(settings: {}, friends: [])
+#
+# @param settings [Hash] overrides merged into default test settings
+# @param friends [Array<String>] friend list for the healer
+# @param unity [Boolean] whether Unity link is available (default true)
+# @return [Healer] configured instance
+def build_healer(settings: {}, friends: [], unity: true)
   test_settings = OpenStruct.new({
     friends: friends,
     healer_waggle_set: 'healme',
@@ -90,7 +95,9 @@ def build_healer(settings: {}, friends: [])
   allow_any_instance_of(Healer).to receive(:validate_healing_spells).and_return(false)
   allow_any_instance_of(Healer).to receive(:validate_vh_spell).and_return(false)
 
-  Healer.new
+  healer = Healer.new
+  healer.instance_variable_set(:@unity_available, unity)
+  healer
 end
 
 # Builds a HealthResult-like object with sensible defaults
@@ -401,6 +408,123 @@ RSpec.describe Healer do
       healer.send(:heal_patient, healer.get_patient('Tenuk'))
 
       expect(healer.instance_variable_get(:@spell_task)).to be_nil
+    end
+  end
+
+  # ============================================================
+  # Unity Link Availability (Graceful Degradation)
+  # ============================================================
+
+  describe 'validate_link_unity' do
+    it 'sets @unity_available to true when UNITY appears in link output' do
+      $test_settings = OpenStruct.new(friends: [], healer_waggle_set: 'healme', cambrinth: nil, waggle_sets: nil)
+
+      allow_any_instance_of(Healer).to receive(:validate_healing_spells).and_return(false)
+      allow_any_instance_of(Healer).to receive(:validate_vh_spell).and_return(false)
+
+      link_output = ['<output>LINK options: TOUCH UNITY</output>']
+      allow(Lich::Util).to receive(:issue_command).and_return(link_output)
+
+      healer = Healer.new
+
+      expect(healer.instance_variable_get(:@unity_available)).to be true
+    end
+
+    it 'sets @unity_available to false when UNITY is absent from link output' do
+      $test_settings = OpenStruct.new(friends: [], healer_waggle_set: 'healme', cambrinth: nil, waggle_sets: nil)
+
+      allow_any_instance_of(Healer).to receive(:validate_healing_spells).and_return(false)
+      allow_any_instance_of(Healer).to receive(:validate_vh_spell).and_return(false)
+
+      link_output = ['<output>LINK options: TOUCH</output>']
+      allow(Lich::Util).to receive(:issue_command).and_return(link_output)
+
+      healer = Healer.new
+
+      expect(healer.instance_variable_get(:@unity_available)).to be false
+    end
+
+    it 'warns but continues when Unity is not available' do
+      $test_settings = OpenStruct.new(friends: [], healer_waggle_set: 'healme', cambrinth: nil, waggle_sets: nil)
+
+      allow_any_instance_of(Healer).to receive(:validate_healing_spells).and_return(false)
+      allow_any_instance_of(Healer).to receive(:validate_vh_spell).and_return(false)
+
+      link_output = ['<output>LINK options: TOUCH</output>']
+      allow(Lich::Util).to receive(:issue_command).and_return(link_output)
+
+      expect(Lich::Messaging).to receive(:msg)
+        .with('bold', /WARNING - Link Unity not available/)
+
+      Healer.new
+    end
+  end
+
+  # ============================================================
+  # Living Patient Unity Link Gating
+  # ============================================================
+
+  describe 'living patient healing with Unity gating' do
+    it 'attempts Unity link when @unity_available is true and patient has healable wounds' do
+      healer = build_healer(friends: ['Tenuk'], unity: true)
+      healer.add_patient('Tenuk')
+      DRRoom.pcs = ['Tenuk']
+
+      living_wounded = health_result(
+        score: 9,
+        wounds: { 2 => [wound(body_part: 'chest', severity: 2)] }
+      )
+      allow(DRCH).to receive(:perceive_health_other).with('Tenuk').and_return(living_wounded)
+
+      expect(DRC).to receive(:bput)
+        .with('link Tenuk unity', *Healer::LINK_RESPONSES)
+        .and_return('You feel a connection')
+
+      healer.send(:heal_patient, healer.get_patient('Tenuk'))
+    end
+
+    it 'skips Unity link when @unity_available is false' do
+      healer = build_healer(friends: ['Tenuk'], unity: false)
+      healer.add_patient('Tenuk')
+      DRRoom.pcs = ['Tenuk']
+
+      living_wounded = health_result(
+        score: 9,
+        wounds: { 2 => [wound(body_part: 'chest', severity: 2)] }
+      )
+      allow(DRCH).to receive(:perceive_health_other).with('Tenuk').and_return(living_wounded)
+
+      expect(DRC).not_to receive(:bput).with(/link.*unity/i, anything, anything)
+
+      healer.send(:heal_patient, healer.get_patient('Tenuk'))
+    end
+
+    it 'still queues poison patients when Unity is unavailable' do
+      healer = build_healer(friends: ['Tenuk'], unity: false)
+      healer.add_patient('Tenuk')
+      DRRoom.pcs = ['Tenuk']
+
+      poisoned_patient = health_result(poisoned: true, score: 0)
+      allow(DRCH).to receive(:perceive_health_other).with('Tenuk').and_return(poisoned_patient)
+
+      healer.send(:heal_patient, healer.get_patient('Tenuk'))
+
+      task = healer.instance_variable_get(:@spell_task)
+      expect(task).not_to be_nil
+      expect(task[:type]).to eq(:poison)
+    end
+
+    it 'still queues diseased patients when Unity is unavailable' do
+      healer = build_healer(friends: ['Tenuk'], unity: false)
+      healer.add_patient('Tenuk')
+      DRRoom.pcs = ['Tenuk']
+
+      diseased_patient = health_result(diseased: true, score: 0)
+      allow(DRCH).to receive(:perceive_health_other).with('Tenuk').and_return(diseased_patient)
+
+      healer.send(:heal_patient, healer.get_patient('Tenuk'))
+
+      expect(healer.get_patient('Tenuk')[:touched]).to be true
     end
   end
 

--- a/spec/healer_spec.rb
+++ b/spec/healer_spec.rb
@@ -444,7 +444,7 @@ RSpec.describe Healer do
       expect(healer.instance_variable_get(:@unity_available)).to be false
     end
 
-    it 'warns but continues when Unity is not available' do
+    it 'notes fallback to touch transfer when Unity is not available' do
       $test_settings = OpenStruct.new(friends: [], healer_waggle_set: 'healme', cambrinth: nil, waggle_sets: nil)
 
       allow_any_instance_of(Healer).to receive(:validate_healing_spells).and_return(false)
@@ -454,7 +454,7 @@ RSpec.describe Healer do
       allow(Lich::Util).to receive(:issue_command).and_return(link_output)
 
       expect(Lich::Messaging).to receive(:msg)
-        .with('bold', /WARNING - Link Unity not available/)
+        .with('bold', /Link Unity not available -- wounds will transfer via touch/)
 
       Healer.new
     end

--- a/spec/healer_spec.rb
+++ b/spec/healer_spec.rb
@@ -444,7 +444,7 @@ RSpec.describe Healer do
       expect(healer.instance_variable_get(:@unity_available)).to be false
     end
 
-    it 'notes fallback to touch transfer when Unity is not available' do
+    it 'does not message when Unity is not available' do
       $test_settings = OpenStruct.new(friends: [], healer_waggle_set: 'healme', cambrinth: nil, waggle_sets: nil)
 
       allow_any_instance_of(Healer).to receive(:validate_healing_spells).and_return(false)
@@ -453,8 +453,7 @@ RSpec.describe Healer do
       link_output = ['<output>LINK options: TOUCH</output>']
       allow(Lich::Util).to receive(:issue_command).and_return(link_output)
 
-      expect(Lich::Messaging).to receive(:msg)
-        .with('bold', /Link Unity not available -- wounds will transfer via touch/)
+      expect(Lich::Messaging).not_to receive(:msg).with('bold', /Unity/)
 
       Healer.new
     end

--- a/spec/healer_spec.rb
+++ b/spec/healer_spec.rb
@@ -392,7 +392,8 @@ RSpec.describe Healer do
       dead_clear = health_result(dead: true, score: 0)
       allow(DRCH).to receive(:perceive_health_other).with('Tenuk').and_return(dead_clear)
 
-      expect(DRC).not_to receive(:bput).with(/link.*unity/, anything, anything)
+      expect(DRC).not_to receive(:bput)
+        .with(a_string_matching(/link.*unity/), *Healer::LINK_RESPONSES)
 
       healer.send(:heal_patient, healer.get_patient('Tenuk'))
     end
@@ -493,7 +494,8 @@ RSpec.describe Healer do
       )
       allow(DRCH).to receive(:perceive_health_other).with('Tenuk').and_return(living_wounded)
 
-      expect(DRC).not_to receive(:bput).with(/link.*unity/i, anything, anything)
+      expect(DRC).not_to receive(:bput)
+        .with(a_string_matching(/link.*unity/i), *Healer::LINK_RESPONSES)
 
       healer.send(:heal_patient, healer.get_patient('Tenuk'))
     end


### PR DESCRIPTION
## Summary
- Healer no longer exits when Link Unity is unavailable
- Unity is an optional convenience for instant wound transfer -- the normal touch flow handles everything regardless
- Only logs Unity availability when it IS available; silence otherwise (nothing noteworthy)

## Changes
- `validate_link_unity`: sets `@unity_available` flag instead of exiting; only messages when Unity is present
- `heal_patient`: gates only the `link <patient> unity` command on `@unity_available`; separate log for hands/legs-only skip
- Updated YARD doc to reflect Unity as optional
- Added `unity` parameter to `build_healer` test helper (defaults to `true`)
- Added specs for `validate_link_unity` (Unity present, absent, no spurious messaging)
- Added specs for living patient Unity gating (with/without Unity, poison/disease unaffected)

## Test plan
- [x] `bundle exec rspec spec/healer_spec.rb` -- 75 examples, 0 failures
- [x] `rubocop -A healer.lic` -- no offenses
- [x] `rubocop -A spec/healer_spec.rb` -- no offenses
- [ ] In-game test with empath who knows Unity (should behave identically to before)
- [ ] In-game test with empath who does NOT know Unity (should start normally, heal everything via standard touch flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup validation no longer terminates unexpectedly when Link Unity is unavailable
  * Wound transfers now automatically use standard transfer methods as a fallback when Unity is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->