### PR TITLE
Added Several Hunts in Shard

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1631,7 +1631,7 @@ hunting_zones:
   # - 6975 #has a trunk in the room that messes with looting
   # https://elanthipedia.play.net/Peccary                               225-300
   # horses & antelope sometimes also present
-  peccary_shard:
+  shard_peccary:
   - 6282
   - 6288
   - 6289
@@ -1642,7 +1642,7 @@ hunting_zones:
   - 6314
   - 8419
   - 11477
-  peccary_shard_plus:
+  shard_peccary_plus:
   #these appraise slightly higher
   - 11479
   - 14745

--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1642,8 +1642,9 @@ hunting_zones:
   - 6314
   - 8419
   - 11477
+  # https://elanthipedia.play.net/Peccary                               225-300
+  # these appraise slightly higher
   shard_peccary_plus:
-  #these appraise slightly higher
   - 11479
   - 14745
   - 6310
@@ -1659,6 +1660,28 @@ hunting_zones:
   - 16569
   - 16570
   - 6982
+  # https://elanthipedia.play.net/Clouded_arzumos                        230-340
+  # also antelopes
+  shard_clouded_arzumos:
+  - 6285
+  - 6286
+  - 6290
+  - 6291
+  - 6292
+  - 6293
+  - 6294
+  # https://elanthipedia.play.net/Clouded_arzumos                        230-340
+  # these appraise slightly higher
+  shard_clouded_arzumos_plus:
+  - 6295
+  - 6296
+  - 6297
+  - 6298
+  - 6299
+  - 6300
+  - 6301
+  - 6302
+  - 6303
   # https://elanthipedia.play.net/Baby_forest_gryphon                    250-350
   # https://elanthipedia.play.net/Young_forest_gryphon                   300-420
   # https://elanthipedia.play.net/Fledgling_forest_gryphon_(1)           300-400
@@ -1679,27 +1702,6 @@ hunting_zones:
   - 6237
   - 6238
   - 6239
-  # https://elanthipedia.play.net/Clouded_arzumos                        230-340
-  # also antelopes
-  shard_clouded_arzumos:
-  - 6285
-  - 6286
-  - 6290
-  - 6291
-  - 6292
-  - 6293
-  - 6294
-  shard_clouded_arzumos_plus:
-  # these appraise slightly higher
-  - 6295
-  - 6296
-  - 6297
-  - 6298
-  - 6299
-  - 6300
-  - 6301
-  - 6302
-  - 6303
   # https://elanthipedia.play.net/Adan%27f_shadow_mage                   250-370
   # https://elanthipedia.play.net/Adan%27f_blood_warrior                 250-325
   # Spawn is hit or miss

--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -1629,6 +1629,29 @@ hunting_zones:
   - 6974
   - 6973
   # - 6975 #has a trunk in the room that messes with looting
+  # https://elanthipedia.play.net/Peccary                               225-300
+  # horses & antelope sometimes also present
+  peccary_shard:
+  - 6282
+  - 6288
+  - 6289
+  - 6326
+  - 6325
+  - 6324
+  - 6315
+  - 6314
+  - 8419
+  - 11477
+  peccary_shard_plus:
+  #these appraise slightly higher
+  - 11479
+  - 14745
+  - 6310
+  - 11480
+  - 6312
+  - 6323
+  - 6320
+  - 6319
   # https://elanthipedia.play.net/Beltunumshi_(2)                        225-350
   # same beltunumshi construct, estate holder only
   beltunumshi_thicket:
@@ -1656,6 +1679,27 @@ hunting_zones:
   - 6237
   - 6238
   - 6239
+  # https://elanthipedia.play.net/Clouded_arzumos                        230-340
+  # also antelopes
+  shard_clouded_arzumos:
+  - 6285
+  - 6286
+  - 6290
+  - 6291
+  - 6292
+  - 6293
+  - 6294
+  shard_clouded_arzumos_plus:
+  # these appraise slightly higher
+  - 6295
+  - 6296
+  - 6297
+  - 6298
+  - 6299
+  - 6300
+  - 6301
+  - 6302
+  - 6303
   # https://elanthipedia.play.net/Adan%27f_shadow_mage                   250-370
   # https://elanthipedia.play.net/Adan%27f_blood_warrior                 250-325
   # Spawn is hit or miss


### PR DESCRIPTION
Added two levels of Peccary and two levels of Clouded Arzumos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new hunting areas to Ilithi: Peccary Shard, Peccary Shard Plus, Clouded Arzumos Shard, and Clouded Arzumos Shard Plus. The Plus variants offer higher appraisal values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/dr-scripts/pull/7397)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->