### PR TITLE
Fix fenvol-puzzle noun extraction for flavor-text adjectives

### DIFF
--- a/fenvol-puzzle.lic
+++ b/fenvol-puzzle.lic
@@ -258,12 +258,19 @@ class FenvolPuzzle
     text.downcase.gsub(/[^a-z0-9\s-]/, ' ').squeeze(' ').strip
   end
 
+  # Strips leading article (a, an, the, some) from an item description.
+  # @param text [String]
+  # @return [String]
+  def strip_article(text)
+    text.sub(/\A(?:a|an|the|some) /i, '')
+  end
+
   # Checks whether an item description appears in the poem.
   # @param item_text [String]
   # @return [Boolean]
   def in_poem?(item_text)
     phrase = normalize_text(item_text)
-    phrase = phrase.sub(/\A(?:a|an|the) /, '')
+    phrase = strip_article(phrase)
     @poem.include?(phrase)
   end
 
@@ -365,7 +372,7 @@ class FenvolPuzzle
   # @param container [String] container noun phrase used to open it
   # @param item_text [String] item description
   def turn_item(container, item_text)
-    item_noun = DRC.get_noun(item_text)
+    item_noun = DRC.get_noun(strip_article(item_text))
     echo "#{container}: \"#{item_text}\" -- IN POEM, turning."
     turn_result = DRC.bput("turn #{item_noun} in #{container}", TURN_SUCCESS_PATTERN, TURN_FAILURE_PATTERN)
     return unless turn_result =~ TURN_SUCCESS_PATTERN
@@ -455,7 +462,7 @@ class FenvolPuzzle
     return true unless item && !item.to_s.empty?
 
     item_text = item.to_s.downcase
-    noun = DRC.get_noun(item_text)
+    noun = GameObj.right_hand&.noun || item_text.split.last
 
     if @discard_list.any? { |pattern| item_text.include?(pattern) }
       echo "Discarding #{item} (matches discard list)."

--- a/spec/fenvol_puzzle_spec.rb
+++ b/spec/fenvol_puzzle_spec.rb
@@ -82,6 +82,14 @@ module DRC
   end
 end
 
+module GameObj
+  @right_hand = nil
+
+  class << self
+    attr_accessor :right_hand
+  end
+end
+
 module DRCI
   def self.get_item?(*_args)
     true
@@ -142,6 +150,12 @@ end
 
 def before_dying(&_block); end
 
+def set_right_hand(name, noun = nil)
+  $right_hand = name
+  noun ||= name&.to_s&.split&.last
+  GameObj.right_hand = noun ? OpenStruct.new(noun: noun) : nil
+end
+
 load_lic_class('fenvol-puzzle.lic', 'FenvolPuzzle')
 
 RSpec.configure do |config|
@@ -149,6 +163,7 @@ RSpec.configure do |config|
     reset_data
     $right_hand = nil
     $left_hand = nil
+    GameObj.right_hand = nil
     XMLData.room_title = 'Test Room'
   end
 end
@@ -684,38 +699,38 @@ RSpec.describe FenvolPuzzle do
   # -------------------------------------------------------------------
   describe '#stow_reward' do
     it 'returns true when right hand is empty' do
-      $right_hand = nil
+      set_right_hand(nil)
       expect(instance.send(:stow_reward)).to be true
     end
 
     it 'returns true when right hand is empty string' do
-      $right_hand = ''
+      set_right_hand('')
       expect(instance.send(:stow_reward)).to be true
     end
 
     it 'discards item via put_away_item_unsafe? into room bucket (no "my" prefix)' do
-      $right_hand = 'silk dress'
+      set_right_hand('silk dress', 'dress')
       instance.instance_variable_set(:@discard_list, ['dress'])
       expect(DRCI).to receive(:put_away_item_unsafe?).with('my dress', 'bucket').and_return(true)
       expect(instance.send(:stow_reward)).to be true
     end
 
     it 'stows item via DRCI.put_away_item? into configured containers' do
-      $right_hand = 'silver ring'
+      set_right_hand('silver ring', 'ring')
       instance.instance_variable_set(:@containers, ['canvas sack in my back'])
       expect(DRCI).to receive(:put_away_item?).with('ring', ['canvas sack in my back']).and_return(true)
       expect(instance.send(:stow_reward)).to be true
     end
 
     it 'returns true when no discard list and no container set' do
-      $right_hand = 'silver ring'
+      set_right_hand('silver ring', 'ring')
       instance.instance_variable_set(:@discard_list, [])
       instance.instance_variable_set(:@containers, [])
       expect(instance.send(:stow_reward)).to be true
     end
 
     it 'prefers discarding over stowing when both match' do
-      $right_hand = 'old dress'
+      set_right_hand('old dress', 'dress')
       instance.instance_variable_set(:@discard_list, ['dress'])
       instance.instance_variable_set(:@containers, ['backpack'])
       expect(DRCI).to receive(:put_away_item_unsafe?).with('my dress', 'bucket').and_return(true)
@@ -723,20 +738,20 @@ RSpec.describe FenvolPuzzle do
     end
 
     it 'returns true when container is empty string (no-op)' do
-      $right_hand = 'silver ring'
+      set_right_hand('silver ring', 'ring')
       instance.instance_variable_set(:@containers, [])
       expect(instance.send(:stow_reward)).to be true
     end
 
     it 'matches discard list case-insensitively via downcase' do
-      $right_hand = 'Fancy DRESS'
+      set_right_hand('Fancy DRESS', 'dress')
       instance.instance_variable_set(:@discard_list, ['dress'])
       expect(DRCI).to receive(:put_away_item_unsafe?).with('my dress', 'bucket').and_return(true)
       instance.send(:stow_reward)
     end
 
     it 'matches multi-word discard patterns against full item text' do
-      $right_hand = 'a heavy iron battle axe'
+      set_right_hand('a heavy iron battle axe', 'axe')
       instance.instance_variable_set(:@discard_list, ['battle axe'])
       allow(instance).to receive(:echo)
       expect(DRCI).to receive(:put_away_item_unsafe?).with('my axe', 'bucket').and_return(true)
@@ -744,7 +759,7 @@ RSpec.describe FenvolPuzzle do
     end
 
     it 'does not discard when multi-word pattern does not match' do
-      $right_hand = 'a woodcutter axe'
+      set_right_hand('a woodcutter axe', 'axe')
       instance.instance_variable_set(:@discard_list, ['battle axe'])
       instance.instance_variable_set(:@containers, ['backpack'])
       allow(DRCI).to receive(:put_away_item?).and_return(true)
@@ -753,7 +768,7 @@ RSpec.describe FenvolPuzzle do
     end
 
     it 'matches single-word discard pattern as substring of full item text' do
-      $right_hand = 'a brilliant scarlet camlet cloak'
+      set_right_hand('a brilliant scarlet camlet cloak', 'cloak')
       instance.instance_variable_set(:@discard_list, ['cloak'])
       allow(instance).to receive(:echo)
       expect(DRCI).to receive(:put_away_item_unsafe?).with('my cloak', 'bucket').and_return(true)
@@ -761,14 +776,14 @@ RSpec.describe FenvolPuzzle do
     end
 
     it 'returns false when DRCI.put_away_item? fails (all containers full)' do
-      $right_hand = 'silver ring'
+      set_right_hand('silver ring', 'ring')
       instance.instance_variable_set(:@containers, ['backpack'])
       allow(DRCI).to receive(:put_away_item?).with('ring', ['backpack']).and_return(false)
       expect(instance.send(:stow_reward)).to be false
     end
 
     it 'passes multiple containers to DRCI.put_away_item? which tries each' do
-      $right_hand = 'quarterstaff'
+      set_right_hand('quarterstaff', 'quarterstaff')
       instance.instance_variable_set(:@containers, ['sack', 'rucksack'])
       expect(DRCI).to receive(:put_away_item?).with('quarterstaff', ['sack', 'rucksack']).and_return(true)
       expect(instance.send(:stow_reward)).to be true
@@ -1647,15 +1662,23 @@ RSpec.describe FenvolPuzzle do
     end
 
     describe '#stow_reward with tricky item names' do
-      it 'extracts noun from multi-word item' do
-        $right_hand = 'ornate silver ring'
+      it 'uses GameObj.right_hand.noun for multi-word item' do
+        set_right_hand('ornate silver ring', 'ring')
         instance.instance_variable_set(:@containers, ['backpack'])
         expect(DRCI).to receive(:put_away_item?).with('ring', ['backpack']).and_return(true)
         instance.send(:stow_reward)
       end
 
       it 'handles single-word item' do
-        $right_hand = 'ring'
+        set_right_hand('ring', 'ring')
+        instance.instance_variable_set(:@containers, ['backpack'])
+        expect(DRCI).to receive(:put_away_item?).with('ring', ['backpack']).and_return(true)
+        instance.send(:stow_reward)
+      end
+
+      it 'falls back to split.last when GameObj.right_hand is nil' do
+        $right_hand = 'ornate silver ring'
+        GameObj.right_hand = nil
         instance.instance_variable_set(:@containers, ['backpack'])
         expect(DRCI).to receive(:put_away_item?).with('ring', ['backpack']).and_return(true)
         instance.send(:stow_reward)
@@ -1777,6 +1800,7 @@ RSpec.describe FenvolPuzzle do
         obj = double('item', to_s: 'fancy dress', empty?: false)
         allow(obj).to receive(:downcase).and_return('fancy dress')
         $right_hand = obj
+        GameObj.right_hand = OpenStruct.new(noun: 'dress')
         instance.instance_variable_set(:@discard_list, ['dress'])
         allow(instance).to receive(:echo)
         expect(DRCI).to receive(:put_away_item_unsafe?).with('my dress', 'bucket').and_return(true)


### PR DESCRIPTION
## Summary
- Fixes `turn a in bisque carton` bug where `DRC.get_noun` stripped puzzle adjectives like "striped" via `FLAVOR_TEXT_PATTERN`, leaving only the article "a" as the noun
- Uses `GameObj.right_hand.noun` for held reward items (game-authoritative), falls back to `split.last`
- Strips leading article before `DRC.get_noun` for container items, since the article triggers the flavor text pattern match
- Extracts `strip_article` helper, reused by `in_poem?`

## Root cause
`FLAVOR_TEXT_PATTERN` matches 9 of 27 observed puzzle adjectives: striped, mottled, tooled, stamped, stained, embossed, speckled, flecked, lacquered. When preceded by an article ("a striped sunny yellow binder"), the entire description after "a" is stripped as flavor text.

## Test plan
- [x] 210 RSpec examples, 0 failures
- [x] Rubocop clean
- [ ] Manual test with items using affected adjectives (striped, mottled, tooled, stamped, stained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item description parsing and normalization for more consistent item identification and referencing.
  * Enhanced reward stowing mechanics to better recognize items in hand and properly categorize them for storage.
  * Better handling of edge cases in noun extraction, case sensitivity, and discard vs. stow precedence rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/dr-scripts/pull/7405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->