### PR TITLE
[data][base-town] - Correction for Hara'jaal currency

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -1636,7 +1636,7 @@ Ain Ghazal:
       id: 13663
   #Needs attunement_rooms
 Hara'jaal:
-  currency: lirum
+  currency: lirums
   leather_repair: &ushei
     id: 15313
     name: Ushei


### PR DESCRIPTION
Hara'jaal's currency is listed as lirum instead of lirums, causing problems with DRCM.ensure_copper_on_hand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected currency denomination for Hara'jaal location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/dr-scripts/pull/7408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->