### PR TITLE
[scirpt][circlecheck] - Fix for progress bar on Wrayth

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -486,7 +486,10 @@ def progress_bar(pct, width = 10)
   pct = 0 if pct < 0
   pct = 100 if pct > 100
   filled = ((pct / 100.0) * width).round
-  "[" + ("█" * filled) + ("░" * (width - filled)) + "]"
+  # Stormfront / Wrayth mangle UTF-8 block chars; other clients render them fine.
+  # ($frontend reports either name depending on the version installed.)
+  filled_char, empty_char = %w[stormfront wrayth].include?($frontend) ? ['#', '-'] : ['█', '░']
+  "[" + (filled_char * filled) + (empty_char * (width - filled)) + "]"
 end
 
 # Clamp aggregate progress for one skill: how many ranks the player has gained


### PR DESCRIPTION
Wrayth doesn't like the UTF-8 characters used for the progress bar so now the script detects using $frontend and uses hashtags and dashes to display the bar for Wrayth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed progress bar rendering issues on certain frontend clients by automatically selecting appropriate display characters based on client type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elanthia-online/dr-scripts/pull/7409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->