### PR TITLE
[data][ingredients] - Added new herbs to file

### DIFF
--- a/data/base-ingredients.yaml
+++ b/data/base-ingredients.yaml
@@ -122,3 +122,31 @@ ingredients:
   output: dried dioica
   Crossing: 8860
   ranks: 380
+- name: shining clubmoss
+  output: dried clubmoss
+  Crossing: 8860
+  ranks: 625
+- name: marsh woundwort
+  output: crushed woundwort
+  Crossing: 8860
+  ranks: 750
+- name: ashen flamestalk
+  output: crushed flamestalk
+  Crossing: 8860
+  ranks: 625
+- name: marram grass
+  output: dried marram
+  Crossing: 8860
+  ranks: 650
+- name: purple blossom
+  output: purple alyssum
+  Crossing: 8860
+  ranks: 1000
+- name: white blossom
+  output: white alyssum
+  Crossing: 8860
+  ranks: 1000
+- name: pink blossom
+  output: pink alyssum
+  Crossing: # Ratha only
+  ranks: 1000


### PR DESCRIPTION
I added information for shining clubmoss, marsh woundwort, ashen flamestalk, marram grass, purple alyssum blossom, white alyssum blossom, and pink alyssum blossom.

I used the ranks required from elanthipedia for all but the alyssum blossoms, as there is no information there.

I used the room number of one of the press/grinder rooms in the Crossing alchemy society for all but pink alyssum blossom as I don't know of any rooms for them in Crossing currently.  Pink alyssum blossom is only able to be found on Ratha as far as we're aware (per GMs Paklin and Zadraes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seven new ingredients to the game system, including various herbs and flora with associated configuration properties and attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->