### PR TITLE
[script][sort-scrolls] - Removed unused variables

### DIFF
--- a/sort-scrolls.lic
+++ b/sort-scrolls.lic
@@ -15,11 +15,8 @@ class ScrollSorter
     @default_container = @settings.default_container
     @stacker = @settings.scroll_sorter['stacker']
     @stacker_container = @settings.scroll_sorter['stacker_container']
-    @custom_nouns = @settings.scroll_sorter['scroll_nouns']
-    @scroll_nouns = get_data('items').scroll_nouns + @custom_nouns
     @unleash_mana = @settings.scroll_sorter['unleash_mana']
-    @unleash_harnesses = @settings.scroll_sorter['unleash_harnesses']
-    @unleash_harnesses ||= 1
+    @unleash_harnesses = @settings.scroll_sorter['unleash_harnesses'] || 1
 
     arg_definitions =
       [


### PR DESCRIPTION
@scroll_nouns and @custom_nouns haven't been used since I updated this script to use the `rummage /sc` option to find all of the scrolls in a container so I've removed them.

I also consolidated the `@unleash_harnesses` line from 2 lines to 1. Now it automatically defaults to 1 instead of needing a second line for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code initialization logic for improved maintainability.

**Note:** This release contains no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->