### PR TITLE
fix(combat-trainer): gate Shield Rush behind is_offense_allowed? for empaths

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -5020,6 +5020,7 @@ class GameState
   end
 
   def rush
+    return false unless is_offense_allowed?
     return if retreating?
     return false if DRC.left_hand # Need your offhand to equip a shield
     return if loaded


### PR DESCRIPTION
## Summary
- Add `is_offense_allowed?` guard to `GameState#rush` so non-permashocked empaths cannot perform an offensive Shield Rush maneuver during `engage()`
- `engage()` is called from the dance path and analyze, both of which are reachable by empaths who should only be doing defensive actions
- Permashocked empaths, construct mode, and undead+Absolution mode are unaffected -- `is_offense_allowed?` returns true for all of them

## Test plan
- [ ] Run combat-trainer as a non-permashocked empath with `maneuver_rush_to_engage: true` and `maneuver_rush_shield` configured -- verify rush does NOT fire
- [ ] Run combat-trainer as a permashocked empath with the same settings -- verify rush still works
- [ ] Run combat-trainer as a non-empath with rush configured -- verify rush still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rush attacks now verify offense permission before proceeding; if offense is not allowed the rush is aborted and will not execute.
  * This prevents unintended rush/shield-rush actions when offensive moves are restricted, ensuring consistent combat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->