### PR TITLE
feat(combat-trainer): follow up War Stomp with second stomp when Heitak is active

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -5061,6 +5061,11 @@ class GameState
       false
     else
       Flags.reset('war-stomp-ready')
+      if DRSpells.active_spells.include?('Heitak')
+        waitrt?
+        fput('face next')
+        fput('stomp')
+      end
       true
     end
   end


### PR DESCRIPTION
## Summary
- After a successful War Stomp, check if Heitak is active
- If so, wait for RT, face the next target, and stomp again

## Test plan
- [ ] Run combat-trainer as a barbarian with War Stomp configured and Heitak active -- verify second stomp fires after the first
- [ ] Run combat-trainer as a barbarian with War Stomp configured and Heitak NOT active -- verify no second stomp
- [ ] Verify no RT issues between first stomp and face next

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combat stomp behavior enhanced: when a specific combat spell is active, successful stomps now automatically wait, retarget the next foe and perform an additional stomp, enabling more consecutive strikes within a single encounter. This change preserves existing eligibility and return behavior while improving follow-up attack flow for extended battles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->