### PR TITLE
fix(combat-trainer): allow opting out of slivers for TKT/TKS ammo

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1684,7 +1684,7 @@ class SpellProcess
   def check_slivers(game_state)
     return unless DRSpells.known_spells.include?('Moonblade')
     return unless DRStats.moon_mage?
-    return unless @tk_spell
+    return unless @tk_spell&.dig('slivers')
     return if game_state.casting
     return if DRSpells.slivers
 

--- a/validate.lic
+++ b/validate.lic
@@ -286,7 +286,7 @@ class DRYamlValidator
     return unless settings.crafting_training_spells
 
     settings.crafting_training_spells.select { |_spell, data| data['cambrinth'] }
-            .each_key { |spell| warn("#{spell} in crafting_training_spells uses cambrinth which increases crafting time, you may want to remove it.") }
+                                     .each_key { |spell| warn("#{spell} in crafting_training_spells uses cambrinth which increases crafting time, you may want to remove it.") }
   end
 
   def assert_that_cycle_armors_are_skills(settings)
@@ -302,6 +302,15 @@ class DRYamlValidator
     return if settings.tk_ammo
 
     warn("You are using slivers for Telekenetic spells but have no backup tk_ammo! If there are no moons, you will not cast the spell!")
+  end
+
+  def assert_that_tk_spells_have_ammo_source(settings)
+    tk_spells = settings.offensive_spells.select { |spell| spell['abbrev'] =~ /tkt|tks/i }
+    return if tk_spells.empty?
+    return if settings.tk_ammo
+    return if tk_spells.any? { |spell| spell['slivers'] }
+
+    warn("You have TKT/TKS configured but neither slivers: true nor tk_ammo is set. The spell will have no ammo and fail every cast.")
   end
 
   def assert_that_summoned_weapons_are_skills(settings)
@@ -863,12 +872,12 @@ class DRYamlValidator
     return unless settings.buff_spells
 
     settings.buff_spells.select { |_name, data| data['pet_type'] }
-            .reject { |_name, data| data.include? 'recast_every' }
-            .each_key { |name| error("Pet buffs require a custom recast timer. Please include a \"recast_every:\" setting for #{name}.") }
+                        .reject { |_name, data| data.include? 'recast_every' }
+                        .each_key { |name| error("Pet buffs require a custom recast timer. Please include a \"recast_every:\" setting for #{name}.") }
 
     settings.buff_spells.select { |_name, data| data['pet_type'] }
-            .reject { |_name, data| data.include? 'cast' }
-            .each_key { |name| error("Pet buffs require a custom cast message. Please include a \"cast:\" setting for #{name}.") }
+                        .reject { |_name, data| data.include? 'cast' }
+                        .each_key { |name| error("Pet buffs require a custom cast message. Please include a \"cast:\" setting for #{name}.") }
   end
 
   def assert_that_restock_shop_items_recipes_are_valid(settings)
@@ -975,11 +984,11 @@ class DRYamlValidator
             .each { |skill, _cooldown| error("caravan_training_skills has an invalid cooldown at skill: '#{skill}'") }
 
     settings.caravan_training_skills.reject { |skill, _cooldown| @valid_caravan_skills.include?(skill) }
-            .each { |skill, _cooldown| error("caravan_training_skills: skills not recognized as valid skills '#{skill}'") }
+                                    .each { |skill, _cooldown| error("caravan_training_skills: skills not recognized as valid skills '#{skill}'") }
 
     settings.caravan_training_skills.select { |skill, _cooldown| %w[Augmentation Utility Warding].include?(skill) }
-            .reject { |skill, _cooldown| settings.crafting_training_spells.keys.include?(skill) }
-            .each { |skill, _cooldown| error("caravan_training_skills: #{skill} is included, but no corresponding spell in crafting_training_spells!") }
+                                    .reject { |skill, _cooldown| settings.crafting_training_spells.keys.include?(skill) }
+                                    .each { |skill, _cooldown| error("caravan_training_skills: #{skill} is included, but no corresponding spell in crafting_training_spells!") }
   end
 
   def assert_that_avtalia_array_is_valid(settings)


### PR DESCRIPTION
## Summary
- `check_slivers` now only fires when the TKT/TKS spell entry has `slivers: true`, not just when a TKT/TKS spell exists
- Users who want only `tk_ammo` (physical fallback) no longer get unwanted Moonblade casts every tick
- New `validate.lic` assertion warns when TKT/TKS is configured with neither `slivers: true` nor `tk_ammo`

## Behavior change
- **Before:** Any Moon Mage with TKT/TKS in `offensive_spells` would always attempt to create slivers, no opt-out
- **After:** Slivers are only created when `slivers: true` is set on the spell entry. Existing configs with `slivers: true` are unaffected

## Test plan
- [ ] Moon Mage with TKT + `slivers: true` -- verify slivers are still created as before
- [ ] Moon Mage with TKT + `tk_ammo` but no `slivers: true` -- verify no Moonblade cast, tk_ammo used instead
- [ ] Moon Mage with TKT, no `slivers: true`, no `tk_ammo` -- run `validate` and verify warning message
- [ ] Non-Moon Mage with TKT/TKS -- verify `check_slivers` still bails early (Moon Mage guard unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)