### PR TITLE
fix(circlecheck.lic): use ASCII only characters set filled and empty …

### DIFF
--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -486,8 +486,7 @@ def progress_bar(pct, width = 10)
   pct = 0 if pct < 0
   pct = 100 if pct > 100
   filled = ((pct / 100.0) * width).round
-  # Stormfront / Wrayth mangle UTF-8 block chars; other clients render them fine.
-  # ($frontend reports either name depending on the version installed.)
+  # Various frontends expect ASCII only characters, UTF-8 not supported
   filled_char, empty_char = ['#', '-']
   "[" + (filled_char * filled) + (empty_char * (width - filled)) + "]"
 end

--- a/circlecheck.lic
+++ b/circlecheck.lic
@@ -488,7 +488,7 @@ def progress_bar(pct, width = 10)
   filled = ((pct / 100.0) * width).round
   # Stormfront / Wrayth mangle UTF-8 block chars; other clients render them fine.
   # ($frontend reports either name depending on the version installed.)
-  filled_char, empty_char = %w[stormfront wrayth].include?($frontend) ? ['#', '-'] : ['█', '░']
+  filled_char, empty_char = ['#', '-']
   "[" + (filled_char * filled) + (empty_char * (width - filled)) + "]"
 end
 


### PR DESCRIPTION
…characters to '#' and '-'

Replace filled and empty characters with fixed values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized progress bar characters to ensure consistent, predictable visual rendering across all environments and interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->