### PR TITLE
fix(combat-trainer): add missing waitrt? in analyze massive-opening branch

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3633,6 +3633,7 @@ class TrainerProcess
     when 'You must be closer'
       game_state.engage
     when 'Your analysis reveals a massive opening'
+      waitrt?
       return
     when 'You fail to find any holes'
       analyze(game_state, fail_count + 1)


### PR DESCRIPTION
## Summary

- The `'Your analysis reveals a massive opening'` case in `analyze` returns early, skipping the `waitrt?` at the end of the method. This leaves residual roundtime that bleeds into the next command (e.g. dance actions getting "...wait 1 seconds").

## Test plan
- [ ] Run combat-trainer with Tactics training enabled
- [ ] Observe that after analyze finds a massive opening, the next action (bob/weave/circle/attack) does not get a "wait N seconds" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)