### PR TITLE
[script][combat-trainer] include ranged check for blowguns in wield_weapon

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -5147,7 +5147,7 @@ class GameState
   # @returns name of the wielded weapon
   def wield_weapon(skill = weapon_skill, equip_main_hand = !offhand?)
     return unless skill
-    return if skill.eql?('Brawling')
+    return if skill.eql?('Brawling') && !is_brawling_ranged?
     return if skill.eql?('Tactics')
 
     weapon_name = weapon_training[skill]

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -52,6 +52,9 @@ t2_startup_delay: 0
 # Combat settings
 # https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 aim_fillers:
+  Brawling:
+    - bob
+    - bob
   Crossbow:
     - bob
     - bob


### PR DESCRIPTION
The hard return if brawling on 5150 prevented blowgun use.  Leveraging the !is_brawling_ranged? function allows both ranged and melee cases to function correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored weapon selection so ranged brawling attacks now follow the normal weapon-wielding flow, fixing cases where ranged brawling couldn’t select or equip weapons and improving combat reliability.

* **New Features / Configuration**
  * Added explicit aim-filler entries for brawling so ranged brawling uses the same aim-filler behavior as other ranged weapon types, improving consistency in aiming and attack preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->