### PR TITLE
[profile][base] remove less than symbol from inventory_manager_ignores

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2302,7 +2302,6 @@ sorter:
 # https://elanthipedia.play.net/Lich_script_repository#inventory-manager
 inventory_manager_ignores:
   - '['
-  - '<'
   - 'Roundtime'
   - 'You have'
   - 'Vault Inventory'


### PR DESCRIPTION
this is preventing top-level worn items from being added, because they start with `<d cmd` with recent upstream changes

```
[custom/inventory-manager: <d cmd='remove #18374270'>a hide trapper's duffel stitched with fox fur</d>]
[custom/inventory-manager: -<d cmd='get #18374283 in #18374270'>a large packet of deed claim forms</d>]
[custom/inventory-manager: -<d cmd='get #18374282 in #18374270'>a forked diamondique stirring rod</d>]   
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected inventory manager filtering to properly process all inventory entries without incorrect exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->