### PR TITLE
[script][combat-trainer] Implement 'Confidence' with restriction for Thieves

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3351,6 +3351,13 @@ class TrainerProcess
       end
     when /^Stealth$/i
       hide_action(game_state)
+     when /^Confidence$/i
+      if DRStats.guild == 'Thief'
+        hide_action(game_state)
+      else
+        DRC.message("Confidence is only for thieves, removing from training_abilities.")
+        @training_abilities.delete('Confidence')
+      end
     when /^(Ret|Retreat) Stealth$/i
       DRC.retreat
       hide_action(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3423,8 +3423,6 @@ class TrainerProcess
   private
 
   def hide_action(game_state)
-    return if DRSkill.getxp('Stealth') >= 34
-
     if DRC.hide?(@hide_type) && !@dont_stalk && !game_state.npcs.empty? && @hide_type == 'hide'
       stalked = DRC.bput('stalk', 'Stalk what',
                          'Try being out of sight',

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3351,7 +3351,7 @@ class TrainerProcess
       end
     when /^Stealth$/i
       hide_action(game_state)
-     when /^Confidence$/i
+    when /^Confidence$/i
       if DRStats.guild == 'Thief'
         hide_action(game_state)
       else

--- a/validate.lic
+++ b/validate.lic
@@ -587,6 +587,7 @@ class DRYamlValidator
       'Barb Research Warding',
       'Charged Maneuver',
       'Collect',
+      'Confidence',
       'Favor Orb',
       'Flee',
       'Herbs',


### PR DESCRIPTION
Add 'Confidence' training_ability for thieves.  

Useful when capped on stealth or when stealth stays at high mind states so that they can continue to keep confidence high.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **“Confidence”** training ability.
  * Availability is restricted to **Thief**-guild characters.

* **Bug Fixes / Behavior Changes**
  * If a non-Thief tries to select **Confidence**, it’s blocked after the first attempt for the rest of the session.
  * The hide/stalk/unhide training flow no longer stops based on Stealth skill rank.

* **Documentation / Validation**
  * Updated validation to allow **“Confidence”** in YAML training-ability configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->