### PR TITLE
[data][hunting] - Added new dryanoxie hunting area: TT#329

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -2587,6 +2587,12 @@ hunting_zones:
   - 10811
   - 10812
   # - 11006 Issue with day/night descriptions
+  # No elanthipeida page yet - dryanoxie                                 475-680? (lvl 85 +/- 2)
+  dryanoxie:
+  - 51837
+  - 51838
+  - 51839
+  - 51840
   # https://elanthipedia.play.net/Sky_giant                              500-700
   # Good for boxes, lightning/wind magic
   sky_giants:


### PR DESCRIPTION
Added the new hunting area, they are critter level 85 +/- 2 levels, I estimated the ranks.  If anyone has the formula for CLVL to ranks, please update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Dryanoxie hunting zone with four new areas now available in Therengia for exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->