### PR TITLE
[script][forge.lic] Change logbook category from engineering to forging (fix)

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -28,7 +28,7 @@
 # @example Resume interrupted work
 #   ;forge resume weaponsmithing hammer
 #
-# @example Craft and log to engineering logbook
+# @example Craft and log to forging logbook
 #   ;forge log weaponsmithing 4 "steel throwing hammer" steel hammer
 #
 # @see https://elanthipedia.play.net/Lich_script_repository#forge
@@ -1583,7 +1583,7 @@ class Forge
     case @finish
     when /log/
       DRCC.logbook_item('forging', @item, @bag)
-      info_log("#{@item} logged to engineering logbook.")
+      info_log("#{@item} logged to forging logbook.")
     when /stow/
       if DRCC.stow_crafting_item(@item, @bag, @forging_belt)
         info_log("#{@item} stowed in #{@bag}.")

--- a/forge.lic
+++ b/forge.lic
@@ -1582,7 +1582,7 @@ class Forge
   def finalize_item
     case @finish
     when /log/
-      DRCC.logbook_item('engineering', @item, @bag)
+      DRCC.logbook_item('forging', @item, @bag)
       info_log("#{@item} logged to engineering logbook.")
     when /stow/
       if DRCC.stow_crafting_item(@item, @bag, @forging_belt)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logbook categorization so finished items are recorded to the forging logbook instead of the engineering logbook.
* **Documentation**
  * Updated nearby usage/help text for the forge command to reflect logging to the forging logbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->