### PR TITLE
Adding tinkering into Workorders

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -35,9 +35,9 @@ class Carve
     @training_spells = @settings.crafting_training_spells
 
     @main_tool = if @type == 'stack' || @type == 'bone'
-                   @settings.carving_tools.find { |item| /\bsaw/i =~ item }
+                   @settings.engineering_tools.find { |item| /\bsaw/i =~ item }
                  else
-                   @settings.carving_tools.find { |item| /\bchisel/i =~ item }
+                   @settings.engineering_tools.find { |item| /\bchisel/i =~ item }
                  end
 
     DRC.wait_for_script_to_complete('buff', ['carve'])

--- a/clerk-tools.lic
+++ b/clerk-tools.lic
@@ -32,7 +32,7 @@ class Clerk
       area = settings.custom_clerk_tools[custom_toolset][:area]
       @belt = nil
     elsif args.toolset == 'engineering'
-      tools = settings.shaping_tools
+      tools = settings.engineering_tools
       area = 'shaping'
       @belt = settings.engineering_belt
     elsif args.toolset == 'outfitting'

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1043,6 +1043,7 @@ workorders_materials:
   metal_type: bronze
   stone_type: alabaster
   wood_type: maple
+  mechanism_ingot_type: bronze # Currently the only automatic one for the Tinkering workorder.
 
 # Following settings, including herb_container:, are required to override workorders for remedies
 # container used for raw herbs foraged - used by alchemy.lic script

--- a/taskmaster.lic
+++ b/taskmaster.lic
@@ -250,7 +250,7 @@ class TaskMaster
     elsif base == 'lumber'
       buy_stackables(item, count, volume_per_item, base)
       shape_item(item, count, base, type)
-      repair(@settings.shaping_tools, @settings.engineering_belt)
+      repair(@settings.engineering_tools, @settings.engineering_belt)
       trash(item, base, type)
       return
     elsif volume_per_item == 10 # exactly one ingot per item, so no scrap, no smelting

--- a/tinker.lic
+++ b/tinker.lic
@@ -40,25 +40,28 @@ class Tinker
         { name: 'skip', regex: /skip/i, optional: true, description: 'Optional setting to skip restocking consumables if low (glue/stain)' }
       ],
       [
-        { name: 'mechanisms', regex: /mechanisms/i, description: 'Walk to an open gear press and make a single stack of mechanisms from an existing ingot.' },
+        { name: 'mechanisms', regex: /mechanisms/i, description: 'Walk to a gear press and press ingots already in your bag into mechanisms. 5vol is consumed per press.' },
         { name: 'material', regex: /\w+/i, variable: true, description: 'What type of metal ingot to use' },
-        { name: 'number', regex: /\d+/i, optional: true, variable: true, description: 'How many sets of mechanisms to make (optional)' }
+        { name: 'number', regex: /\d+/i, optional: true, variable: true, description: 'How many sets of mechanisms to make (optional)' },
+        { name: 'speed', regex: /s\d+/i, optional: true, variable: true, description: 'Gear press speed/difficulty 1-12, prefix with s (e.g. s5). Optional, default 6.' }
       ]
     ]
     echo
     args = parse_args(arg_definitions)
     @chapter = args.chapter
     @material = args.material
-    @mechanism = args.mechanism
+    workorders_materials = @settings.workorders_materials || {}
+    @mechanism = args.mechanism || workorders_materials['mechanism_ingot_type'] || 'bronze'
     @chapter = args.chapter ? args.chapter.to_i : 8
     @noun = args.noun
     @info = get_data('crafting')['shaping'][@hometown]
-    args.number = args.number.to_i || 1
+    args.number = (args.number || 1).to_i
     @training_spells = @settings.crafting_training_spells
     args.recipe_name.sub!("lighten", "crossbow lightening")
     args.recipe_name.sub!("laminate", "crossbow lamination")
     args.recipe_name.sub!("cable", "crossbow cable-backing")
     @recipe_name = args.recipe_name
+    @mechanisms_per_item = compute_mechanisms_per_item
 
     DRC.wait_for_script_to_complete('buff', ['tinker'])
     Flags.add('tinkering-assembly', /with.*(backer) material/, /You need another bone, wood or horn (backing) material/, /another finished bow (string)/, /another finished (long|short) wooden (pole)/, /another .* leather (strip|cord)/, /need another (lenses)/, /another finished (mechanism)/, /You must assemble the (strips)/, /^You need another (.* boltheads)/, /You need another (bolt flights)/)
@@ -69,11 +72,6 @@ class Tinker
       work("analyze my #{@noun}")
     elsif args.mechanisms
       DRCC.get_adjust_tongs?('reset shovel', @bag, @bag_items, @belt, true) if @settings.adjustable_tongs
-      if @bag_items == nil
-        @bag_items = ["mechanisms"]
-      else
-        @bag_items.push("mechanisms") unless @bag_items.any? { |item| /mechanism/.match(item) }
-      end
       mechanisms(args)
     else
       DRCC.check_consumables('stain', @info['tool-room'], @info['stain-number'], @bag, @bag_items, @belt) unless args.skip
@@ -104,6 +102,7 @@ class Tinker
       DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
       DRCC.get_crafting_item(next_tool, @bag, @bag_items, @belt, skip)
     end
+    exit unless skip || DRCI.in_hands?(next_tool)
   end
 
   def prep
@@ -142,27 +141,26 @@ class Tinker
     end
   end
 
+  def compute_mechanisms_per_item
+    return 0 unless @recipe_name
+    recipe = get_data('recipes').crafting_recipes.find { |r| r['name'].to_s =~ /#{Regexp.escape(@recipe_name)}/i }
+    return 0 unless recipe && recipe['part']
+    recipe['part'].count { |p| p =~ /mechanism/i }
+  end
+
   def mechanisms(args)
-    DRCC.find_shaping_room(@hometown)
-    fput("turn press to 4")
-    count = args.number
-    count.times do
-      DRCC.get_crafting_item("#{args.material} ingot", @bag, @bag_items, @belt)
-      check_hand("#{args.material} ingot")
-      swap_tool("shovel")
-      DRC.bput("push fuel with my #{DRC.right_hand}", /^Roundtime/)
-      swap_tool("pliers")
-      @noun = "mechanisms"
-      work('push my ingot with press')
-      if args.number > 1 && count < args.number
-        DRCC.get_crafting_item('mechanisms', @bag, @bag_items, @belt, true)
-        fput('combine')
-      end
-      DRCC.stow_crafting_item('mechanisms', @bag, nil)
-      count -= 1
+    speed = args.speed ? args.speed.scan(/\d+/).first.to_i : 6
+    DRCC.create_mechanisms(@settings, args.material, args.number, speed)
+    consolidate_mechanisms("#{args.material} mechanisms")
+  end
+
+  def consolidate_mechanisms(mech_name)
+    return unless DRC.bput("get my #{mech_name} from my #{@bag}", /^You get/, /^I could not find/, /^What were/) =~ /^You get/
+    loop do
+      break unless DRC.bput("get my #{mech_name} from my #{@bag}", /^You get/, /^I could not find/, /^What were/) =~ /^You get/
+      fput('combine')
     end
-    DRCC.get_crafting_item("#{args.material} ingot", nil, nil, nil, true)
-    DRCC.stow_crafting_item("#{args.material} ingot", @bag, nil) if DRC.right_hand
+    DRCC.stow_crafting_item(mech_name, @bag, nil)
   end
 
   def assemble_part
@@ -173,8 +171,10 @@ class Tinker
     part.sub!("mechanism", "#{@mechanism} #{part}")
     swap_tool(part)
     if part.include?("mechanism")
-      until /is not required to continue crafting/ =~ DRC.bput("assemble my mechanism with my #{@noun}", /^You place your mechanisms/, /is not required to continue crafting/)
-        pause 0.05
+      (@mechanisms_per_item.positive? ? @mechanisms_per_item : 1).times do
+        DRC.bput("assemble my mechanism with my #{@noun}",
+                 /^You place your mechanisms/,
+                 /is not required to continue crafting/)
       end
     else
       DRC.bput("assemble my #{@noun} with my #{part}",

--- a/workorders.lic
+++ b/workorders.lic
@@ -76,7 +76,7 @@ class WorkOrders
   def initialize
     arg_definitions = [
       [
-        { name: 'discipline', options: %w[blacksmithing weaponsmithing tailoring shaping carving remedies artificing], description: 'What type of workorder to do?' },
+        { name: 'discipline', options: %w[blacksmithing weaponsmithing tailoring shaping carving remedies artificing tinkering], description: 'What type of workorder to do?' },
         { name: 'repair', regex: /repair/i, optional: true, description: 'repair tools instead of crafting' },
         { name: 'turnin', regex: /turnin/i, optional: true, description: 'get work order and turn it in immediately with items already on hand' }
       ]
@@ -117,6 +117,8 @@ class WorkOrders
 
     info = crafting_data[discipline][@hometown]
     info = crafting_data['blacksmithing'][@hometown] if discipline == 'weaponsmithing'
+    # Tinkering uses the Engineering guild (shaping) NPC and logbook
+    info = crafting_data['shaping'][@hometown] if discipline == 'tinkering'
 
     recipes = if @recipe_overrides[discipline]
                 get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && @recipe_overrides[discipline].find { |name| recipe['name'] =~ /#{name}/i } }
@@ -175,7 +177,7 @@ class WorkOrders
       materials_info = crafting_data['stock'][@workorders_materials['wood_type']]
       skill = 'Engineering'
       @engineering_room = @settings.engineering_room
-      tools = @settings.shaping_tools
+      tools = @settings.engineering_tools
       @belt = @settings.engineering_belt
       craft_method = :shape_items
     when 'carving'
@@ -186,7 +188,7 @@ class WorkOrders
                        end
       skill = 'Engineering'
       @engineering_room = @settings.engineering_room
-      tools = @settings.carving_tools
+      tools = @settings.engineering_tools
       @belt = @settings.engineering_belt
       craft_method = :carve_items
     when 'remedies'
@@ -201,6 +203,13 @@ class WorkOrders
       tools = @settings.enchanting_tools
       @belt = @settings.enchanting_belt
       craft_method = :enchanting_items
+    when 'tinkering'
+      materials_info = crafting_data['stock'][@workorders_materials['wood_type'] || 'maple']
+      skill = 'Engineering'
+      @engineering_room = @settings.engineering_room
+      tools = @settings.engineering_tools
+      @belt = @settings.engineering_belt
+      craft_method = :tinker_items
     else
       Lich::Messaging.msg('bold', 'WorkOrders: No discipline found')
       return
@@ -255,6 +264,9 @@ class WorkOrders
   end
 
   def repair_items(info, tools)
+    skip = Array(@settings.workorders_no_repair_tools)
+    tools = tools.reject { |t| skip.any? { |s| t.include?(s) } } unless skip.empty?
+
     if @settings.workorders_repair_own_tools
       current = Room.current.id
       DRCM.ensure_copper_on_hand(1500, @settings, @hometown)
@@ -806,6 +818,108 @@ class WorkOrders
     unless DRCI.put_away_item?('deed')
       Lich::Messaging.msg('bold', 'WorkOrders: Failed to stow deed')
     end
+  end
+
+  def tinker_items(info, materials_info, item, quantity)
+    recipe = find_recipe(materials_info, item, quantity).first
+    mechanism_ingot = @workorders_materials['mechanism_ingot_type'] || 'bronze'
+
+    info['trash-room'] = nil if @worn_trashcan && @worn_trashcan_verb
+
+    DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
+
+    if recipe['part']
+      recipe['part'].reject { |p| p =~ /mechanism/i }.uniq.each do |part|
+        total_needed = recipe['part'].count { |p| p == part } * quantity
+        existing = DRCI.count_items_in_container(part, @bag)
+        deficit = total_needed - existing
+        order_parts([part], deficit) if deficit.positive?
+      end
+
+      mechanisms_needed = recipe['part'].count { |p| p =~ /mechanism/i } * quantity
+      if mechanisms_needed.positive?
+        mech_name = "#{mechanism_ingot} mechanisms"
+        consolidate_mechanisms(mech_name)
+        existing = count_mechanisms
+        deficit = mechanisms_needed - existing
+        if deficit > 0
+          mechanism_press_speed = (@workorders_materials['mechanism_press_speed'] || 5).to_i
+          num_presses = (deficit.to_f / 3).ceil
+          buy_mechanism_ingots(mechanism_ingot, num_presses)
+          DRCC.create_mechanisms(@settings, mechanism_ingot, num_presses, mechanism_press_speed)
+          consolidate_mechanisms(mech_name)
+        end
+      end
+    end
+
+    quantity.times do |count|
+      DRCI.stow_hands if count.positive?
+
+      DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
+      DRCT.order_item(info['stock-room'], materials_info['stock-number'])
+      while DRC.bput("count my #{materials_info['stock-name']} lumber", 'You count.*\d+', 'I could not find').scan(/\d+/).first.to_i < recipe['volume']
+        DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
+        DRCT.order_item(info['stock-room'], materials_info['stock-number'])
+        DRC.bput('combine', 'combine')
+      end
+      DRCC.stow_crafting_item("#{materials_info['stock-name']} lumber", @bag, @belt)
+
+      DRCC.find_shaping_room(@hometown, @engineering_room)
+      DRC.wait_for_script_to_complete('cm_tinker', [recipe['chapter'], recipe['name'], materials_info['stock-name'], recipe['noun']])
+      bundle_item(recipe['noun'], info['logbook'])
+    end
+
+    DRCI.stow_hands
+    lumber_name = "#{materials_info['stock-name']} lumber"
+    while DRCI.exists?(lumber_name)
+      DRCT.dispose(lumber_name, info['trash-room'], @worn_trashcan, @worn_trashcan_verb)
+    end
+  end
+
+  def word_count_to_i(str)
+    ones = %w[zero one two three four five six seven eight nine ten eleven
+              twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]
+    tens = { 'twenty' => 20, 'thirty' => 30, 'forty' => 40, 'fifty' => 50,
+             'sixty' => 60, 'seventy' => 70, 'eighty' => 80, 'ninety' => 90 }
+    str.downcase.gsub('-', ' ').split.sum { |w| ones.index(w) || tens[w] || 0 }
+  end
+
+  def buy_mechanism_ingots(material, count)
+    crafting_data = get_data('crafting')
+    stock = crafting_data['stock'] || {}
+    candidates = stock.select { |_k, v| v.is_a?(Hash) && v['stock-name'] == material }
+    return if candidates.empty?
+    _key, entry = candidates.min_by { |_k, v| (v['volume'].to_i - 5).abs }
+    stock_room = crafting_data['blacksmithing'][@hometown]['stock-room']
+    existing = DRCI.count_items_in_container("#{material} ingot", @bag).to_i
+    to_buy = count - existing
+    to_buy.times do
+      DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
+      DRCT.order_item(stock_room, entry['stock-number'])
+      DRCC.stow_crafting_item("#{material} ingot", @bag, nil)
+    end
+  end
+
+  def consolidate_mechanisms(mech_name)
+    loop do
+      break unless DRC.bput("get my #{mech_name} from my #{@bag}", /^You get/, /^I could not find/, /^What were/) =~ /^You get/
+      got_second = DRC.bput("get my #{mech_name} from my #{@bag}", /^You get/, /^I could not find/, /^What were/) =~ /^You get/
+      fput('combine') if got_second
+      DRCC.stow_crafting_item(mech_name, @bag, nil)
+      break unless got_second
+    end
+  end
+
+  def count_mechanisms
+    material = @workorders_materials['mechanism_ingot_type'] || 'bronze'
+    result = DRC.bput("count #{material} mechanisms in my #{@bag}",
+                      /There are .+ mechanisms left/i,
+                      /There is .+ mechanism left/i,
+                      /I could not find/i,
+                      /What were/i)
+    return 0 unless result =~ /There are (.+?) mechanisms left|There is (.+?) mechanism/i
+
+    word_count_to_i((Regexp.last_match(1) || Regexp.last_match(2)).strip)
   end
 
   def enchanting_items(info, _materials_info, recipe, quantity)


### PR DESCRIPTION
This adds the tinkering option to the workorders script. Bronze mechanisms will be automatically crafted for the workorders. Other mechanisms are able to be selected, but the ingot must be provided.

Tinkering has had some updates that incorporate the recent update to DRCC's create_mechanisms.

It also corrects the naming convention in a few of the files that specify shaping_tools or carving_tools and updates to the same naming of the other Professions and uses engineering_tools. This happens in clerk-tools, carve, and taskmaster.

Base.yaml gets the update of mechanism_ingot_type: bronze in order to specify the type of mechanism that will be made for the tinkering workorders.

This change would require a yaml update of changing shaping_tools or carving_tools over to the newly named engineering_tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tinkering workorder type with dedicated crafting workflow.

* **Changes**
  * Updated tool selection logic for crafting disciplines.
  * Enhanced mechanism crafting workflow with improved consolidation and ordering.
  * Added new configuration option for mechanism material type.
  * Modified tool repair behavior to allow excluding specific tools from repair operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->