### PR TITLE
[script][validate] Implement gem pouch adjective validation

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -191,6 +191,14 @@ class DRYamlValidator
     warn('Full pouch container cannot be the same as the spare pouch container')
   end
 
+  def assert_that_gem_pouch_adj_is_valid(settings)
+    error("The setting gem_pouch_adjective: should be exactly 1 word" if settings.gem_pouch_adjective.include?(' ')
+    error("Do not use the word 'gem' in your gem_pouch_adjective:") if settings.gem_pouch_adjective.include?('gem')
+    
+    valid_gem_pouch_adjectives = %w(black blue dark fuzzy green indigo purple red soft suede)
+    error("You have set your gem_pouch_adjective to #{settings.gem_pouch_adjective}.  Valid gem pouch adjectives are #{valid_gem_pouch_adjectives.join(', ')}") if !valid_pouch_adjective.include?(settings.gem_pouch_adjective)
+  end
+
   def assert_that_aspects_are_neutral_if_not_using_altars(settings)
     return if settings.use_favor_altars
     return if @neutral_aspects.include?(settings.favor_god.capitalize)

--- a/validate.lic
+++ b/validate.lic
@@ -194,7 +194,7 @@ class DRYamlValidator
   def assert_that_gem_pouch_adj_is_valid(settings)
     error("The setting gem_pouch_adjective: should be exactly 1 word") if settings.gem_pouch_adjective.include?(' ')
     error("Do not use the word 'gem' in your gem_pouch_adjective:") if settings.gem_pouch_adjective.include?('gem')
-    
+
     valid_gem_pouch_adjectives = %w(black blue dark fuzzy green indigo purple red soft suede)
     error("You have set your gem_pouch_adjective to #{settings.gem_pouch_adjective}.  Valid gem pouch adjectives are #{valid_gem_pouch_adjectives.join(', ')}") if !valid_pouch_adjective.include?(settings.gem_pouch_adjective)
   end

--- a/validate.lic
+++ b/validate.lic
@@ -192,7 +192,7 @@ class DRYamlValidator
   end
 
   def assert_that_gem_pouch_adj_is_valid(settings)
-    error("The setting gem_pouch_adjective: should be exactly 1 word" if settings.gem_pouch_adjective.include?(' ')
+    error("The setting gem_pouch_adjective: should be exactly 1 word") if settings.gem_pouch_adjective.include?(' ')
     error("Do not use the word 'gem' in your gem_pouch_adjective:") if settings.gem_pouch_adjective.include?('gem')
     
     valid_gem_pouch_adjectives = %w(black blue dark fuzzy green indigo purple red soft suede)


### PR DESCRIPTION
Add validation for gem pouch adjectives in settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for gem pouch adjective settings: disallows spaces, the substring "gem", and requires an approved adjective.

* **Bug Fixes**
  * Corrected a validation logic error that could erroneously accept or reject adjectives, ensuring the approved-list check works as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->