### PR TITLE
fix(combat-trainer): guard nil dispatch results and gate avtalia by guild

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1585,6 +1585,22 @@ class SpellProcess
     drop_tkt_ammo
     Flags.add('need-tkt-ammo', 'There is nothing here that can be thrown')
 
+    @spell_checks = []
+    @spell_checks << :check_slivers if DRStats.moon_mage? && @tk_spell&.dig('slivers')
+    @spell_checks << :check_regalia if @regalia_array
+    @spell_checks << :check_consume if DRStats.necromancer?
+    @spell_checks << :check_cfw if DRStats.necromancer?
+    @spell_checks << :heal_corpse if DRStats.necromancer?
+    @spell_checks << :check_cfb if DRStats.necromancer?
+    @spell_checks << :check_bless if @buff_spells['Bless']
+    @spell_checks << :check_ignite if @buff_spells['Ignite']
+    @spell_checks << :check_rutilors_edge if @buff_spells["Rutilor's Edge"]
+    @spell_checks << :check_health if DRStats.empath? || DRStats.barbarian?
+    @spell_checks << :check_starlight if DRStats.trader?
+    @spell_checks << :check_avtalia unless settings.avtalia_array.empty?
+    @spell_checks << :check_buffs
+    echo("  @spell_checks: #{@spell_checks}") if $debug_mode_ct
+
     return unless DRStats.trader? && @regalia_array
 
     @regalia_spell = get_data('spells').spell_data['Regalia'] if @regalia_array && @regalia_spell.nil? # get data from the regalia waggle or base-spells
@@ -1660,19 +1676,7 @@ class SpellProcess
       return false
     end
 
-    check_slivers(game_state)
-    check_regalia(game_state)
-    check_consume(game_state)
-    check_cfw(game_state)
-    heal_corpse(game_state)
-    check_cfb(game_state)
-    check_bless(game_state)
-    check_ignite(game_state)
-    check_rutilors_edge(game_state)
-    check_health(game_state)
-    check_starlight(game_state)
-    check_avtalia(game_state)
-    check_buffs(game_state)
+    @spell_checks.each { |check| send(check, game_state) }
     if @prioritize_offensive_spells
       check_offensive(game_state)
       check_training(game_state)
@@ -1987,19 +1991,23 @@ class SpellProcess
     DRCA.release_cyclics if @release_cyclic_on_low_mana && DRStats.mana < @release_cyclic_threshold
     return if DRStats.mana < @training_spell_mana_threshold
 
-    needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic']
-                     .select { |skill| @training_spells[skill] }
-                     .select { |skill| game_state.is_offense_allowed? || @training_spells[skill]['harmless'] }
-                     .select { |skill| ['Warding', 'Utility', 'Augmentation'].include?(skill) || !@training_spells_combat_sorcery && skill == 'Sorcery' || !game_state.npcs.empty? }
-                     .select { |skill| DRSkill.getxp(skill) < @magic_exp_training_max_threshold }
-                     .select { |skill| Time.now > (@training_spells[skill]['cyclic'] ? @training_cyclic_timer : @training_cast_timer) }
-                     .select { |skill| @training_spells[skill]['night'] ? UserVars.sun['night'] : true }
-                     .select { |skill| @training_spells[skill]['day'] ? UserVars.sun['day'] : true }
-                     .select { |skill| @training_spells[skill]['bright_celestial_object'] ? DRCMM.bright_celestial_object? : true }
-                     .select { |skill| @training_spells[skill]['any_celestial_object'] ? DRCMM.any_celestial_object? : true }
-                     .select { |skill| @training_spells[skill]['no_bright_celestial_object'] ? !DRCMM.bright_celestial_object? : true }
-                     .select { |skill| @training_spells[skill]['no_celestial_object'] ? !DRCMM.any_celestial_object? : true }
-                     .select { |skill| @training_spells[skill]['must_be_true'] ? eval(@training_spells[skill]['must_be_true']) : true }
+    needs_training = ['Warding', 'Utility', 'Augmentation', 'Sorcery', 'Debilitation', 'Targeted Magic'].select do |skill|
+      data = @training_spells[skill]
+      next false unless data
+      next false unless game_state.is_offense_allowed? || data['harmless']
+      next false unless %w[Warding Utility Augmentation].include?(skill) || (!@training_spells_combat_sorcery && skill == 'Sorcery') || !game_state.npcs.empty?
+      next false unless DRSkill.getxp(skill) < @magic_exp_training_max_threshold
+      next false unless Time.now > (data['cyclic'] ? @training_cyclic_timer : @training_cast_timer)
+      next false if data['night'] && !UserVars.sun['night']
+      next false if data['day'] && !UserVars.sun['day']
+      next false if data['bright_celestial_object'] && !DRCMM.bright_celestial_object?
+      next false if data['any_celestial_object'] && !DRCMM.any_celestial_object?
+      next false if data['no_bright_celestial_object'] && DRCMM.bright_celestial_object?
+      next false if data['no_celestial_object'] && DRCMM.any_celestial_object?
+      next false if data['must_be_true'] && !eval(data['must_be_true'])
+
+      true
+    end
     DRC.message "all eligible training spells: #{needs_training}" if $debug_mode_ct
     needs_training = game_state.sort_by_rate_then_rank(needs_training).first
     return unless needs_training
@@ -2050,15 +2058,18 @@ class SpellProcess
     return if game_state.casting
     return if DRStats.mana < @buff_spell_mana_threshold
 
-    recastable_buffs = @buff_spells
-                       .select { |_name, data| data['recast'] || data['recast_every'] || data['expire'] }
-                       .select { |_name, data| data['expire'] ? Flags["ct-#{data['abbrev']}"] : true }
-                       .select { |name, _data| check_buff_conditions?(name, game_state) }
-                       .select { |_name, data| data['night'] ? UserVars.sun['night'] : true }
-                       .select { |_name, data| data['day'] ? UserVars.sun['day'] : true }
-                       .select { |_name, data| data['starlight_threshold'] ? enough_starlight?(game_state, data) : true }
-                       .select { |_name, data| data['must_be_true'] ? eval(data['must_be_true']) : true }
-                       .reject { |_name, data| data['cyclic'] && DRSpells.active_spells.include?(data['name']) && !data['recast_every'] }
+    recastable_buffs = @buff_spells.select do |name, data|
+      next false unless data['recast'] || data['recast_every'] || data['expire']
+      next false if data['expire'] && !Flags["ct-#{data['abbrev']}"]
+      next false unless check_buff_conditions?(name, game_state)
+      next false if data['night'] && !UserVars.sun['night']
+      next false if data['day'] && !UserVars.sun['day']
+      next false if data['starlight_threshold'] && !enough_starlight?(game_state, data)
+      next false if data['must_be_true'] && !eval(data['must_be_true'])
+      next false if data['cyclic'] && DRSpells.active_spells.include?(data['name']) && !data['recast_every']
+
+      true
+    end
 
     name, data = recastable_buffs.find do |name, data|
       if data['pet_type']
@@ -2285,25 +2296,28 @@ class SpellProcess
     return if DRStats.mana < @offensive_spell_mana_threshold
 
     echo "Figuring out ready offensive spells..." if $debug_mode_ct
-    ready_spells = @offensive_spells
-                   .select { |spell| spell['target_enemy'] ? game_state.npcs.include?(spell['target_enemy']) : true }
-                   .select { |spell| spell['min_threshold'] ? game_state.npcs.length >= spell['min_threshold'] : true }
-                   .select { |spell| spell['max_threshold'] ? game_state.npcs.length <= spell['max_threshold'] : true }
-                   .select { |spell| spell['expire'] ? Flags["ct-#{spell['abbrev']}"] : true }
-                   .select { |spell| game_state.is_offense_allowed? || spell['harmless'] }
-                   .select { |spell| game_state.dancing? ? spell['harmless'] : true }
-                   .select { |spell| spell['recast_every'] ? check_spell_timer?(spell) : true }
-                   .select { |spell| (@cast_only_to_train || spell['cast_only_to_train']) ? DRSkill.getxp(spell['skill']) <= @magic_exp_training_max_threshold : true }
-                   .select { |spell| spell['cyclic'] ? !DRSpells.active_spells[spell['name']] : true }
-                   .select { |spell| spell['night'] ? UserVars.sun['night'] : true }
-                   .select { |spell| spell['day'] ? UserVars.sun['day'] : true }
-                   .select { |spell| spell['slivers'] ? (DRSpells.slivers || @tk_ammo) : true }
-                   .select { |spell| spell['starlight_threshold'] ? enough_starlight?(game_state, spell) : true }
-                   .select { |spell| spell['bright_celestial_object'] ? DRCMM.bright_celestial_object? : true }
-                   .select { |spell| spell['any_celestial_object'] ? DRCMM.any_celestial_object? : true }
-                   .select { |spell| spell['no_bright_celestial_object'] ? !DRCMM.bright_celestial_object? : true }
-                   .select { |spell| spell['no_celestial_object'] ? !DRCMM.any_celestial_object? : true }
-                   .select { |spell| spell['must_be_true'] ? eval(spell['must_be_true']) : true }
+    ready_spells = @offensive_spells.select do |spell|
+      next false if spell['target_enemy'] && !game_state.npcs.include?(spell['target_enemy'])
+      next false if spell['min_threshold'] && game_state.npcs.length < spell['min_threshold']
+      next false if spell['max_threshold'] && game_state.npcs.length > spell['max_threshold']
+      next false if spell['expire'] && !Flags["ct-#{spell['abbrev']}"]
+      next false unless game_state.is_offense_allowed? || spell['harmless']
+      next false if game_state.dancing? && !spell['harmless']
+      next false if spell['recast_every'] && !check_spell_timer?(spell)
+      next false if (@cast_only_to_train || spell['cast_only_to_train']) && DRSkill.getxp(spell['skill']) > @magic_exp_training_max_threshold
+      next false if spell['cyclic'] && DRSpells.active_spells[spell['name']]
+      next false if spell['night'] && !UserVars.sun['night']
+      next false if spell['day'] && !UserVars.sun['day']
+      next false if spell['slivers'] && !DRSpells.slivers && !@tk_ammo
+      next false if spell['starlight_threshold'] && !enough_starlight?(game_state, spell)
+      next false if spell['bright_celestial_object'] && !DRCMM.bright_celestial_object?
+      next false if spell['any_celestial_object'] && !DRCMM.any_celestial_object?
+      next false if spell['no_bright_celestial_object'] && DRCMM.bright_celestial_object?
+      next false if spell['no_celestial_object'] && DRCMM.any_celestial_object?
+      next false if spell['must_be_true'] && !eval(spell['must_be_true'])
+
+      true
+    end
     echo "Ready Spells: #{ready_spells.to_yaml}" if $debug_mode_ct
 
     data = if @offensive_spell_cycle.empty?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1597,7 +1597,7 @@ class SpellProcess
     @spell_checks << :check_rutilors_edge if @buff_spells["Rutilor's Edge"]
     @spell_checks << :check_health if DRStats.empath? || DRStats.barbarian?
     @spell_checks << :check_starlight if DRStats.trader?
-    @spell_checks << :check_avtalia unless settings.avtalia_array.empty?
+    @spell_checks << :check_avtalia if DRStats.trader? && !settings.avtalia_array.empty?
     @spell_checks << :check_buffs
     echo("  @spell_checks: #{@spell_checks}") if $debug_mode_ct
 
@@ -2082,6 +2082,9 @@ class SpellProcess
         !DRSpells.active_spells[name] || DRSpells.active_spells[name].to_i <= data['recast']
       end
     end
+    # No buff is due for recasting (all healthy or still on timer): nothing to do.
+    return unless data
+
     echo("found buff missing: #{name}") if $debug_mode_ct && name
     game_state.casting_weapon_buff = $weapon_buffs.include?(name)
     if data['ritual']
@@ -2329,6 +2332,8 @@ class SpellProcess
              @offensive_spell_cycle.rotate!
              ready_spells.find { |spell| spell['name'] == name }
            end
+    # No offensive spell survived the filter this tick: no-op instead of crashing.
+    return unless data
 
     game_state.hide_on_cast = true if data['use_stealth']
 
@@ -2345,8 +2350,8 @@ class SpellProcess
     else
       # track last spell for magic_gain_check
       @magic_last_spell = data
-      # if there is a spell to cast, snapshot the relevant skill's mindstate
-      @magic_last_exp = data.nil? ? -1 : DRSkill.getxp(data['skill'])
+      # snapshot the relevant skill's mindstate for the spell to cast
+      @magic_last_exp = DRSkill.getxp(data['skill'])
 
       prepare_spell(data, game_state)
     end


### PR DESCRIPTION
Follow-up to #7421, based on that branch. Addresses three of CodeRabbit's out-of-diff findings on that PR.

> Note: this branch is stacked on #7421. The diff will only show these three changes once #7421 merges to `main`.

## Fixes

**1. `check_buffs` nil-dereference (CodeRabbit Critical)**
`recastable_buffs.find` returns `nil` when every buff is healthy or still on its timer (the `.select` can match buffs the `.find` then rejects on timer checks). The next line read `data['ritual']`, raising `NoMethodError` on idle ticks. Now returns early when no buff is due. (Latent, pre-existing -- not introduced by #7421.)

**2. `check_offensive` nil-dereference (CodeRabbit Critical)**
When `ready_spells` is empty, `data` stays `nil` and `data['use_stealth']` raised instead of no-opping. Now returns early. The now-redundant `data.nil? ? -1 : ...` ternary on `@magic_last_exp` is simplified. (Latent, pre-existing -- not introduced by #7421.)

**3. `check_avtalia` dispatch gate (CodeRabbit Minor)**
Gated on `DRStats.trader?` to match the adjacent `check_starlight` entry, so a shared config with `avtalia_array` set no longer queues Trader-only maintenance on non-Traders.

## Not included
CodeRabbit's fourth finding (break the `@spell_checks` loop on cast start, Major) was evaluated and **declined**: every dispatched check that casts already self-guards with `return if game_state.casting`, the named example `check_starlight` only reads aura (does not cast), and the base code was a flat call sequence with no break -- so the loop is behavior-equivalent and there is no correctness issue.

## Validation
- `ruby -c` passes
- `rubocop` reports zero offenses on the touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added safety guards to prevent casting errors when no eligible spells are available during combat.

* **Improvements**
  * Refactored spell checking logic to dynamically adapt based on character configuration and spell data.
  * Enhanced spell selection filtering for more reliable spell casting behavior across training, buff, and offensive spell actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->