### PR TITLE
Use namespaced DRC.verify_script in hunting-buddy and trigger-watcher

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -564,7 +564,7 @@ class HuntingBuddy
 
     fput('flag description off') if @disable_room_descriptions
 
-    verify_script('combat-trainer')
+    DRC.verify_script('combat-trainer')
     start_script('combat-trainer', args)
 
     # This pause "fixes" a race condition with combat starting and the monitors below trying to kill

--- a/trigger-watcher.lic
+++ b/trigger-watcher.lic
@@ -13,7 +13,7 @@ $debug_mode_tw = UserVars.trigger_watcher_debug || args.debug
 
 # When trigger command =exec has been used. Executes a specified script with no wait to complete.
 def execute_script(name, args = [], flags = {})
-  verify_script(name)
+  DRC.verify_script(name)
   echo "Starting script #{name}, don't wait to complete" if $debug_mode_tw
   waitrt?
   start_script(name, args.map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg }, flags)
@@ -21,7 +21,7 @@ end
 
 # When trigger command =execw has been used. Executes a specified script and waits until complete.
 def execute_script_wait(name, args = [])
-  verify_script(name)
+  DRC.verify_script(name)
   echo "Starting script #{name}, wait to complete" if $debug_mode_tw
   waitrt?
   DRC.wait_for_script_to_complete(name, args)


### PR DESCRIPTION
## What

Replaces the bare global `verify_script(...)` calls with the namespaced `DRC.verify_script(...)` in:

- `hunting-buddy.lic` (1 call site)
- `trigger-watcher.lic` (2 call sites)

## Why

The bare `verify_script` resolves to the top-level global defined in `dependency.lic`. Core lich-5 already provides the canonical `Lich::DragonRealms::DRC.verify_script`, which `DRC.wait_for_script_to_complete` uses internally. The two implementations have diverged (the core version uses `Lich::Messaging`; the dependency global echoes a GitHub/Discord report link), so which one runs depends purely on call syntax - a namespace footgun.

Calling the namespaced method directly:
- removes reliance on the `dependency.lic` global,
- gives a single source of truth (core), and
- is a step toward retiring the duplicate definition in `dependency.lic`.

## Behavior

No functional change. `DRC.verify_script` has the same `true`/`false` contract based on `Script.exists?`. `DRC` is already available in both scripts (both call other `DRC.*` methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated script verification routing within utility modules to use standardized module-based calls, improving code organization and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->