### PR TITLE
dependency.lic cleanup: drop dead helpers, fix SlackBot namespace, require lich 5.18.0

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -3,18 +3,20 @@
 
   As of 4.0.0, all gated class definitions (ArgParser, SetupFiles,
   ScriptManager) and boot-sequence orchestration have been removed.
-  Core lich 5.17.2+ provides these natively via sentinels:
+  Core lich 5.18.0+ provides these natively via sentinels:
     CORE_ARGPARSER, CORE_SETUPFILES, CORE_GET_SETTINGS,
     CORE_SCRIPT_LOADER, CORE_MAP_OVERRIDES, CORE_DR_STARTUP
 
   What remains are runtime helper functions (bankbot, slackbot,
-  reportbot, hometown, verify_script) that dr-scripts still call
-  and have not yet been upstreamed into core lich.
+  hometown) that dr-scripts still call and have not yet been
+  upstreamed into core lich. verify_script now lives in core as
+  DRC.verify_script and the dead reportbot/format helpers have
+  been removed.
 =end
 
-$DEPENDENCY_VERSION = '4.0.0'
+$DEPENDENCY_VERSION = '4.1.0'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/f8ne99pVva'
-$MIN_LICH_VERSION = '5.17.2'
+$MIN_LICH_VERSION = '5.18.0'
 
 unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new($MIN_LICH_VERSION)
   10.times do
@@ -59,18 +61,6 @@ rescue => e
   {}
 end
 
-def save_reportbot_whitelist(whitelist)
-  File.open(File.join(LICH_DIR, 'reportbot-whitelist.yaml'), 'wb') { |file| file.puts(whitelist.to_yaml) }
-end
-
-def load_reportbot_whitelist
-  YAML.unsafe_load_file(File.join(LICH_DIR, 'reportbot-whitelist.yaml'))
-rescue => e
-  echo('*** ERROR PARSING YAML FILE ***')
-  echo(e.message)
-  []
-end
-
 def send_slackbot_message(message)
   return unless message
 
@@ -85,29 +75,7 @@ def register_slackbot(username)
   return if username.nil? || username.to_s.strip.empty?
 
   $slackbot_username = username
-  $slackbot_instance = SlackBot.new
-end
-
-def format_name(name)
-  name =~ /\.lic$/ ? name : "#{name}.lic"
-end
-
-def format_yaml_name(name)
-  name =~ /\.yaml$/ ? name : "#{name}.yaml"
-end
-
-def verify_script(script_names)
-  script_names = [script_names] unless script_names.is_a?(Array)
-  state = true
-  script_names
-    .reject { |name| Script.exists?(name) }
-    .each do |name|
-      echo "Failed to find a script named '#{name}'"
-      echo "Please report this to <https://github.com/elanthia-online/dr-scripts/issues>"
-      echo "or to Discord #{$DR_SCRIPTS_DISCORD_LINK}"
-      state = false
-    end
-  state
+  $slackbot_instance = Lich::DragonRealms::SlackBot.new
 end
 
 def shift_hometown(town_name)

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -4,11 +4,14 @@ require 'tmpdir'
 require 'ostruct'
 require 'yaml'
 
-# Test suite for dependency.lic (v4.0.0+)
+# Test suite for dependency.lic (v4.1.0+)
 #
 # Covers the runtime helper functions that remain after all gated
-# code was removed (core lich 5.17.2+ provides ArgParser, SetupFiles,
+# code was removed (core lich 5.18.0+ provides ArgParser, SetupFiles,
 # ScriptManager, map overrides, and DR startup natively).
+#
+# verify_script now lives in core as DRC.verify_script; the dead
+# reportbot/format helpers were removed in v4.1.0.
 
 # Stub constants and globals before loading methods
 SCRIPT_DIR = Dir.mktmpdir('dr-scripts-test') unless defined?(SCRIPT_DIR)
@@ -68,13 +71,8 @@ end
 %w[
   save_bankbot_transaction
   load_bankbot_ledger
-  save_reportbot_whitelist
-  load_reportbot_whitelist
   register_slackbot
   send_slackbot_message
-  format_name
-  format_yaml_name
-  verify_script
   shift_hometown
   clear_hometown
 ].each { |fn| extract_method(dep_lines, dep_path, fn) }
@@ -143,46 +141,6 @@ RSpec.describe 'Bankbot Functions' do
   end
 end
 
-# --- Reportbot ---
-
-RSpec.describe 'Reportbot Functions' do
-  let(:whitelist_path) { File.join(LICH_DIR, 'reportbot-whitelist.yaml') }
-
-  after do
-    File.delete(whitelist_path) if File.exist?(whitelist_path)
-  end
-
-  describe '#save_reportbot_whitelist' do
-    it 'writes the whitelist to YAML' do
-      whitelist = %w[Player1 Player2 Player3]
-      save_reportbot_whitelist(whitelist)
-
-      saved = YAML.unsafe_load_file(whitelist_path)
-      expect(saved).to eq(whitelist)
-    end
-  end
-
-  describe '#load_reportbot_whitelist' do
-    context 'when the whitelist file exists' do
-      before do
-        File.open(whitelist_path, 'w') { |f| f.puts(%w[Alpha Beta].to_yaml) }
-      end
-
-      it 'returns the whitelist as an array' do
-        result = load_reportbot_whitelist
-        expect(result).to eq(%w[Alpha Beta])
-      end
-    end
-
-    context 'when the whitelist file does not exist' do
-      it 'returns an empty array' do
-        result = load_reportbot_whitelist
-        expect(result).to eq([])
-      end
-    end
-  end
-end
-
 # --- Slackbot ---
 
 RSpec.describe 'Slackbot Functions' do
@@ -193,7 +151,7 @@ RSpec.describe 'Slackbot Functions' do
 
   describe '#register_slackbot' do
     before do
-      stub_const('SlackBot', Class.new {
+      stub_const('Lich::DragonRealms::SlackBot', Class.new {
         define_method(:initialize) {}
         define_method(:direct_message) { |_user, _msg| }
       })
@@ -250,7 +208,7 @@ RSpec.describe 'Slackbot Functions' do
     end
 
     context 'when slackbot is registered' do
-      let(:mock_slackbot) { instance_double('SlackBot') }
+      let(:mock_slackbot) { instance_double('Lich::DragonRealms::SlackBot') }
 
       before do
         $slackbot_instance = mock_slackbot
@@ -268,41 +226,6 @@ end
 # --- Utility helpers ---
 
 RSpec.describe 'Utility Functions' do
-  describe '#format_name' do
-    it 'appends .lic if missing' do
-      expect(format_name('dependency')).to eq('dependency.lic')
-    end
-
-    it 'does not double-append .lic' do
-      expect(format_name('dependency.lic')).to eq('dependency.lic')
-    end
-  end
-
-  describe '#format_yaml_name' do
-    it 'appends .yaml if missing' do
-      expect(format_yaml_name('base-spells')).to eq('base-spells.yaml')
-    end
-
-    it 'does not double-append .yaml' do
-      expect(format_yaml_name('base-spells.yaml')).to eq('base-spells.yaml')
-    end
-  end
-
-  describe '#verify_script' do
-    it 'returns true when script exists' do
-      allow(Script).to receive(:exists?).and_return(true)
-      expect(verify_script('present-script')).to be true
-    end
-
-    it 'returns false when script does not exist' do
-      expect(verify_script('nonexistent-script')).to be false
-    end
-
-    it 'accepts an array of script names' do
-      expect(verify_script(%w[nonexistent1 nonexistent2])).to be false
-    end
-  end
-
   describe '#shift_hometown' do
     after { $HOMETOWN = nil }
 
@@ -325,12 +248,12 @@ end
 
 RSpec.describe 'Dependency Structure' do
   describe 'version' do
-    it 'declares version 4.0.0' do
-      expect(DEP_SOURCE).to include("$DEPENDENCY_VERSION = '4.0.0'")
+    it 'declares version 4.1.0' do
+      expect(DEP_SOURCE).to include("$DEPENDENCY_VERSION = '4.1.0'")
     end
 
-    it 'requires minimum lich version 5.17.2' do
-      expect(DEP_SOURCE).to include("$MIN_LICH_VERSION = '5.17.2'")
+    it 'requires minimum lich version 5.18.0' do
+      expect(DEP_SOURCE).to include("$MIN_LICH_VERSION = '5.18.0'")
     end
   end
 
@@ -364,18 +287,27 @@ RSpec.describe 'Dependency Structure' do
     %w[
       save_bankbot_transaction
       load_bankbot_ledger
-      save_reportbot_whitelist
-      load_reportbot_whitelist
       send_slackbot_message
       register_slackbot
-      format_name
-      format_yaml_name
-      verify_script
       shift_hometown
       clear_hometown
     ].each do |fn_name|
       it "defines #{fn_name}" do
         expect(DEP_SOURCE).to match(/^def #{Regexp.escape(fn_name)}[\s(]/)
+      end
+    end
+  end
+
+  describe 'removed helpers are absent' do
+    %w[
+      save_reportbot_whitelist
+      load_reportbot_whitelist
+      format_name
+      format_yaml_name
+      verify_script
+    ].each do |fn_name|
+      it "does not define #{fn_name}" do
+        expect(DEP_SOURCE).not_to match(/^def #{Regexp.escape(fn_name)}[\s(]/)
       end
     end
   end


### PR DESCRIPTION
## What

Continues the dependency.lic slimming now that core lich owns most of its former responsibilities.

- **Remove `verify_script` global.** It now lives in core as `Lich::DragonRealms::DRC.verify_script` (already used internally by `DRC.wait_for_script_to_complete`). The only dr-scripts callers - `hunting-buddy.lic` and `trigger-watcher.lic` - were migrated to `DRC.verify_script` in #7436.
- **Remove `save_reportbot_whitelist` / `load_reportbot_whitelist`.** There is no `reportbot.lic` anywhere in the repo; these had zero callers.
- **Remove `format_name` / `format_yaml_name`.** Dead code, no callers in dr-scripts.
- **Fix `register_slackbot` namespace.** Use the fully-qualified `Lich::DragonRealms::SlackBot.new` instead of bare `SlackBot`.
- **Bump** `$MIN_LICH_VERSION` -> `5.18.0`, `$DEPENDENCY_VERSION` -> `4.1.0`.

## Why

Two namespace hazards motivated this:

1. **Dual definition of `verify_script`.** The bare global (here) and `DRC.verify_script` (core) had diverged - the global echoed a GitHub/Discord report link, core uses `Lich::Messaging` - so which ran depended purely on call syntax. With callers migrated, the global is now redundant; removing it leaves a single source of truth.
2. **Bare `SlackBot` constant.** `register_slackbot` referenced `SlackBot` unqualified, which only resolves because `main.rb` runs `include Lich::DragonRealms` into `Object` at DR boot. The fully-qualified reference removes reliance on that side-effect. (Pre-4.0.0 code was already fully-qualified; 4.0.0 silently regressed it.)

The reportbot/format helpers are simply unused.

## Compatibility

- `verify_script`: any third-party personal script calling the bare global will need to switch to `DRC.verify_script`. All in-repo callers are already migrated.
- The slackbot wrappers (`register_slackbot` / `send_slackbot_message`) and their `$slackbot_instance` singleton are unchanged - they have many live callers (afk, status-monitor, knackstone) and stay.

## Testing

`spec/dependency_spec.rb` updated: extract/presence lists trimmed, reportbot + format/verify_script describe blocks removed, SlackBot stub and `instance_double` namespaced, plus a new "removed helpers are absent" guard. **34 examples, 0 failures.** rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency version to 4.1.0 with minimum Lich version requirement of 5.18.0
  * Removed legacy reportbot whitelist management features
  * Optimized Slackbot integration initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->