### PR TITLE
inventory-manager: suppress no-match characters in search output

### DIFF
--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -508,13 +508,14 @@ class InventoryManager
   end
 
   def search_for_item(item, nested)
+    needle = item.downcase
     @item_data.each do |k, v|
       next if k == @version_string
 
       matches = []
       v.each do |data|
         data = strip_nesting(data) unless nested
-        matches << data if data.downcase.include?(item)
+        matches << data if data.downcase.include?(needle)
       end
       # Only report characters that actually have a match, otherwise a large
       # multi-character database spams a "Checking/Found 0 matches" block per

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -508,22 +508,22 @@ class InventoryManager
   end
 
   def search_for_item(item, nested)
-    total_found = 0
     @item_data.each do |k, v|
       next if k == @version_string
 
-      total_found = 0
+      matches = []
+      v.each do |data|
+        data = strip_nesting(data) unless nested
+        matches << data if data.downcase.include?(item)
+      end
+      # Only report characters that actually have a match, otherwise a large
+      # multi-character database spams a "Checking/Found 0 matches" block per
+      # character on every search.
+      next if matches.empty?
+
       DRC.message("Checking #{k}:")
-      v.each { |data|
-        if !nested
-          data = strip_nesting(data)
-        end
-        if data.downcase.include?(item)
-          total_found += 1
-          DRC.message("Match #{total_found}): #{data}")
-        end
-      }
-      DRC.message("Found #{total_found} match#{(total_found > 1 ? 'es' : '')} on #{k}\n")
+      matches.each_with_index { |data, index| DRC.message("Match #{index + 1}): #{data}") }
+      DRC.message("Found #{matches.length} match#{(matches.length > 1 ? 'es' : '')} on #{k}\n")
     end
   end
 


### PR DESCRIPTION
## What

`search_for_item` (`;inventory-manager search <item>`) currently prints a `Checking <char>:` line and a `Found 0 matches on <char>` line for **every** character in the database on every search. For a database with many saved characters, the actual hits get buried in per-character "0 matches" noise.

This buffers matches per character and skips output entirely when a character has no matches. The output format for characters that *do* match is unchanged.

## Before
```
Checking Alice:
Match 1): a blue pouch (character)
Found 1 match on Alice
Checking Bob:
Found 0 matches on Bob
Checking Carol:
Found 0 matches on Carol
...
```

## After
```
Checking Alice:
Match 1): a blue pouch (character)
Found 1 match on Alice
```

## Notes
- Pure display change; no data/format changes, no new settings.
- `ruby -c` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result reporting to display only characters with matching items and adjusted match numbering per character for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->