### PR TITLE
[script] capture-critter premium festival tweaks

### DIFF
--- a/capture-critter.lic
+++ b/capture-critter.lic
@@ -18,7 +18,7 @@ class CaptureCritter
     args = parse_args(arg_definitions)
 
     # Each capture event may have different "game over" messages. They seem similar, but this may not capture all of them.
-    Flags.add("critter-done", '^[PW]hew!  All of the')
+    Flags.add("critter-done", '^(?:TWEET:\s+)?[PW]hew! +All of the')
 
     # Set the target event
     @event_info = event_data[args.event]
@@ -28,7 +28,7 @@ class CaptureCritter
       exit
     end
 
-    @critter_regexp = /\b(#{Regexp.union(@event_info["critter_names"]).source})\b/i
+    @critter_regexp = /\b(#{Regexp.union(@event_info["critter_names"]).source})\z/i
 
     run
   end

--- a/data/base-capture.yaml
+++ b/data/base-capture.yaml
@@ -29,3 +29,10 @@ taffelberry_faire:
     - ram
     - crow
     - tankard
+
+premium_festival:
+  return_room: 15908
+  return_surface: ocean-blue cart
+  room_list: [15891, 15890, 15897, 15899, 15902, 15910, 15908, 15906, 15913, 15914, 15926]
+  critter_names:
+    - seagull

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2859,6 +2859,7 @@ capture_critter_settings:
     # List of items to dispose of
     junk:
       - sharkskin
+      - seagull feather
     # Where to store rewards\prizes for turning in captured critters
     reward_container: 
     # Optional custom game settings, if base-capture.yaml is out of date. Should match the format of an entry in base-capture.yaml


### PR DESCRIPTION
* Added premium_festival details to base-critter
* Added "seagull feather" to default junk in base.yaml's capture-critter settings
* Tweaked object matching regex in capture-critter.lic (seagull feathers on the ground were causing issues)
* Tweaked end-of-game regex in capture-critter.lic (this game is ending with a TWEET)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capture configuration for premium festival encounters.

* **Improvements**
  * Enhanced capture completion detection with improved message pattern recognition.
  * Refined critter identification matching for increased accuracy.
  * Seagull feathers are now automatically classified as junk items during captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->