### PR TITLE
combat-trainer: make main loop tick configurable via combat_trainer_loop_tick (default unchanged)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4497,7 +4497,7 @@ class CombatTrainer
       @combat_processes.each do |process|
         break if process.execute(@game_state)
       end
-      pause 0.1
+      pause 0.01
       if @game_state.done_cleaning_up?
         echo('CombatTrainer::clean_up') if $debug_mode_ct
         @running = false

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4465,6 +4465,7 @@ class CombatTrainer
 
     @stop = false
     @running = true
+    @loop_tick = settings.combat_trainer_loop_tick || 0.1
     $debug_mode_ct = UserVars.combat_trainer_debug || settings.debug_mode
     @game_state = GameState.new(settings, @equipment_manager)
     @safety_process = SafetyProcess.new(settings, @equipment_manager)
@@ -4496,7 +4497,7 @@ class CombatTrainer
       @combat_processes.each do |process|
         break if process.execute(@game_state)
       end
-      pause 0.01
+      pause @loop_tick
       if @game_state.done_cleaning_up?
         echo('CombatTrainer::clean_up') if $debug_mode_ct
         @running = false

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -416,6 +416,8 @@ combat_trainer_offhand_trainables: false
 combat_trainer_focus_threshold: 0
 # roughly number of consecutive spell casts of a single skill (e.g. Targeted Magic)that need to not gain mindstate (mob too low) before it is blacklisted.
 combat_trainer_magic_gain_check: 3
+# seconds to pause at the end of each main combat loop tick. Lower = faster reaction, higher = less idle CPU usage. Default 0.1.
+combat_trainer_loop_tick: 0.1
 
 dual_load: false
 # use_stealth_attacks true will train stealth by hiding and attacking/backstabbing from stealth.  Thieves also use backstab: below


### PR DESCRIPTION
## Summary

Makes the `start_combat` main-loop tick configurable via a new `combat_trainer_loop_tick` setting instead of a hard-coded `pause`.

- `@loop_tick = settings.combat_trainer_loop_tick || 0.1`, used as `pause @loop_tick`.
- **Default is unchanged at 0.1s**, so upstream behavior is identical.
- Documented in `profiles/base.yaml`.

## Why

Addresses the review note on the hard-coded pause: rather than changing the loop rate for everyone, this exposes it as a tunable. Users who want faster reaction can lower it (e.g. 0.01); users on constrained/multi-boxed hosts can raise it to reduce idle CPU - without editing the script.

## Scope

Adaptive active/idle pacing (different tick rates in combat vs. idle) was suggested in review and is deliberately **left for a follow-up PR** to keep this change minimal. A single tunable already covers the reaction-time vs. CPU tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)