### PR TITLE
fix(combat-trainer): drop bput timeout:0 on attack/ambush to stop roundtime resend spam

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3592,7 +3592,7 @@ class TrainerProcess
     end
 
     if DRC.hide?
-      DRC.bput('ambush stun', { 'timeout' => 0, 'suppress_no_match' => true }, 'Wouldn\'t it be better if you used a melee weapon?', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime', 'is already out cold')
+      DRC.bput('ambush stun', 'Wouldn\'t it be better if you used a melee weapon?', 'You must be hidden or invisible to ambush', 'You aren\'t close enough to attack', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'Roundtime', 'is already out cold')
       waitrt?
     end
 
@@ -3963,7 +3963,7 @@ class AttackProcess
         end
       end
 
-      DRC.bput(command, { 'timeout' => 0, 'suppress_no_match' => true }, 'Wouldn\'t it be better if you used a melee weapon?', 'You need two hands to wield this weapon', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
+      DRC.bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You need two hands to wield this weapon', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'You can\'t backstab that', 'is already out cold')
     end
 
     waitrt?


### PR DESCRIPTION
## Summary

The melee `attack` and `ambush stun` bputs in `attack_melee`/`ambush_stun` passed `{ 'timeout' => 0, 'suppress_no_match' => true }`. `timeout => 0` makes `DRC.bput` return the instant its stream buffer drains rather than blocking until the swing's `Roundtime` line matches. The just-incurred roundtime is usually not yet registered in XMLData when bput returns, so the main loop re-enters and fires another `attack` into the active roundtime, which the game bounces with "...wait N seconds." The result is a burst of repeated `attack` commands per roundtime (observed in a live session: a swing lands with `[Roundtime 5 sec.]`, then 7+ `attack` echoes each answered by "...wait N seconds").

## Fix

Remove `timeout => 0` so the bput uses the default 15s timeout. bput then stays in its poll loop until it reads the swing and matches `Roundtime`, returning exactly once after the roundtime registers, so the leading `waitrt?` paces one attack per roundtime. Every melee swing emits a `Roundtime` line, so the 15s default never actually waits the full window; it blocks only the few ms until the result flushes (no stall risk).

Also in this change:
- Drop `suppress_no_match`. It only existed to silence the no-match diagnostic that `timeout => 0` produced on essentially every attack. With the 15s default a true no-match is rare, and when one occurs the diagnostic is useful (it names the unmatched response so the match list can be completed).
- Add "You can't backstab that" to the attack match list. That message was handled only by a `reget` after the bput and was absent from the match list, so once the 15s timeout is in effect a failed backstab would block the full 15s. Adding it lets bput return immediately; the existing reget still marks the mob unstabbable.

## Scope

This fixes the roundtime-resend spam only. There is a separate, structural cause of repeated attacks while out of range (the script re-sends `attack` every tick while still advancing to melee, via the post-bput `reget('aren't close enough') -> engage` path that returns mid-advance). That is not addressed here and would need a positioning change (wait until melee range / an "advancing" guard).

## Testing

`ruby -c` clean, rubocop clean, `spec/combat_trainer_spec.rb` unchanged (no spec exercises the bput timeout; the change is to lich-core bput timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combat message processing for ambush stun and melee attack actions to enhance system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->