### PR TITLE
[data][spells] - Added custom invoke message

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -36,6 +36,7 @@ invoke_messages:
   - You reach for its center
   - You reach for their centers
   - You stare intently at your
+  - As you run the delicate chain through your hands, you remind
   - You'll have to hold it
   - Your link to the
   - almost magically null


### PR DESCRIPTION
Someone had their ritual focus altered needed it added to base-spells so they don't get a bput timeout on the invoke every time.

Full invoke message:
`As you run the delicate chain through your hands, you remind yourself of the relationship each charm represents. Each charm responds to your touch by emanating a gentle glow that wraps itself around you in a supportive embrace, lending its aid to your magical pattern. `

Part added to the array
`As you run the delicate chain through your hands, you remind`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Added a new charge message line to the spell text, giving players an additional variation during charge interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->