### PR TITLE
[scripts][lichbot] Add lichbot_service_mode for a passive idle-only bot

### DIFF
--- a/lichbot.lic
+++ b/lichbot.lic
@@ -16,7 +16,8 @@ class Lichbot
     @last_dump_junk = Time.now
     @last_teacher = nil
     @inventory = []
-    refresh_inventory
+    # Only needed to answer whisper inventory/give commands (service mode).
+    refresh_inventory if @settings.lichbot_service_mode
 
     fput('avoid !all')
     fput('avoid whispering')
@@ -225,6 +226,8 @@ arg_definitions = [
 
 args = parse_args(arg_definitions)
 
+service_mode = get_settings.lichbot_service_mode
+
 lichbot = Lichbot.new(args.sleep)
 validator = CharacterValidator.new(args.announce, args.sleep, args.greet, 'Lichbot')
 
@@ -232,6 +235,21 @@ validator = CharacterValidator.new(args.announce, args.sleep, args.greet, 'Lichb
 loop do
   line = script.gets?
   pause 0.05 unless line
+
+  # The Slack-token handshake is always answered, even for a passive bot.
+  if line =~ /^\[Private\]-.*:(.*): "RequestSlackToken"/
+    character = Regexp.last_match(1)
+    validator.confirm(character)
+    validator.send_slack_token(character)
+    next
+  end
+
+  # Passive mode: only train while idle. Skip occupant validation, item offers,
+  # and whisper command handling.
+  unless service_mode
+    lichbot.ping
+    next
+  end
 
   if DRRoom.pcs != @last_room_list
     (DRRoom.pcs - @last_room_list).each { |name| validator.validate(name) }
@@ -294,10 +312,6 @@ loop do
     character = Regexp.last_match(1)
 
     validator.confirm(character)
-  when /^\[Private\]-.*:(.*): "RequestSlackToken"/
-    character = Regexp.last_match(1)
-    validator.confirm(character)
-    validator.send_slack_token(character)
   else
     lichbot.ping
   end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1632,6 +1632,12 @@ line_similarity_percentage: 70
 lichbot_buffs:
 lichbot_train_when_idle: false
 lichbot_compost: false
+# When true (default), lichbot runs as a full service bot: it validates room
+# occupants, accepts item offers, and answers whisper commands (help/inv/give/
+# buff). Set false for a passive bot that only trains while idle and answers the
+# Slack-token handshake -- it will not validate occupants, accept items, or
+# respond to whispers.
+lichbot_service_mode: true
 
 lockpick_buff_bot:
 


### PR DESCRIPTION
## What

Adds a `lichbot_service_mode` setting (default `true`) so lichbot can run as a **passive idle-only bot** without maintaining a fork.

- **`true` (default):** unchanged behavior — validates room occupants, accepts item offers, and answers whisper commands (help/inv/give/buff).
- **`false`:** lichbot only trains while idle and dumps junk. It skips occupant validation, item-offer acceptance, and all whisper handlers. The `RequestSlackToken` handshake and idle training still run.

## Why

Some operators want lichbot purely as an idle trainer / token responder and specifically do **not** want it accepting random item offers or responding to whisper commands (a public bot that accepts and hands back items is easy to abuse). Today that requires running a hand-edited fork. This makes it a config toggle.

## How

- The `RequestSlackToken` handshake is hoisted above the service handlers so it always runs regardless of mode.
- A short passive-mode branch calls `ping` and returns early, bypassing occupant validation and the whole command `case`.
- Startup `refresh_inventory` (only needed to answer inventory/give whispers) is skipped in passive mode.
- `profiles/base.yaml` documents the new setting and defaults it to `true`, so existing behavior is preserved.

## Testing

- `ruby -c lichbot.lic` clean; `rubocop lichbot.lic` no offenses; `base.yaml` parses.
- Default path is behaviorally identical (the hoisted token handler is mutually exclusive with the other matchers and `next`s, so nothing else changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)