### PR TITLE
[script][attunement] fix sigilwalk already identified sigil issue

### DIFF
--- a/attunement.lic
+++ b/attunement.lic
@@ -183,7 +183,7 @@ class Attunement
 
   def perceived?
     if is_sigil_walk?
-      while /Roundtime/ =~ DRC.bput(get_perceive_command, SECONDARY_SIGILS_PATTERN, 'Having recently been searched, this area contains no traces of sigils', /^You recall having already identified .* sigil in this area/ "Roundtime",)
+      while /Roundtime/ =~ DRC.bput(get_perceive_command, SECONDARY_SIGILS_PATTERN, 'Having recently been searched, this area contains no traces of sigils', /^You recall having already identified .* sigil in this area/, "Roundtime",)
         waitrt?
       end
       return true

--- a/attunement.lic
+++ b/attunement.lic
@@ -183,7 +183,7 @@ class Attunement
 
   def perceived?
     if is_sigil_walk?
-      while /Roundtime/ =~ DRC.bput(get_perceive_command, SECONDARY_SIGILS_PATTERN, 'Having recently been searched, this area contains no traces of sigils', "Roundtime",)
+      while /Roundtime/ =~ DRC.bput(get_perceive_command, SECONDARY_SIGILS_PATTERN, 'Having recently been searched, this area contains no traces of sigils', /^You recall having already identified .* sigil in this area/ "Roundtime",)
         waitrt?
       end
       return true


### PR DESCRIPTION
Prevents endless loop if you somehow end up in a room before the timer expires for sigilwalking a room.

```
[attunement]>perceive sigil
You recall having already identified the antipode secondary sigil in this area.  However, it seems likely the sigil's quality and precision could be improved.
Roundtime: 4 sec.
R> 
[attunement]>perceive sigil
You recall having already identified the antipode secondary sigil in this area.  However, it seems likely the sigil's quality and precision could be improved.
Roundtime: 3 sec.
R> 
[attunement]>perceive sigil
You recall having already identified the antipode secondary sigil in this area.  However, it seems likely the sigil's quality and precision could be improved.
Roundtime: 4 sec.
```