### PR TITLE
shockquest: fix silent mid-quest failure from cooldown handling

### DIFF
--- a/shockquest.lic
+++ b/shockquest.lic
@@ -1,102 +1,316 @@
 =begin
-  Original Author: Damiza Nihshyde
-  Version: 1.16
+  shockquest.lic - Automates the Empath "shock" quest (bonding a vela'tohr seed).
+
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#shockquest
+  Walkthrough:   https://elanthipedia.play.net/Shock_quest_walkthrough
+
+  The quest: Nadigo (in the vela'tohr woods) gives the empath a vela'tohr seed on
+  a medallion. The empath must MEDITATE on the seed in a series of qualifying
+  outdoor locations, each in a different zone, waiting out a per-seed cooldown
+  between successful meditations, until the seed is fully charged. The charged
+  seed is then returned to Nadigo to complete the quest.
+
+  Original Author: Damiza Nihshyde (v1.16)
+  Rewrite: preserves the curated meditation route while fixing the two failure
+  modes that caused the original to silently give up mid-quest:
+
+    1. A successful meditation puts the seed on a randomised 56-65 minute
+       cooldown. The original waited a flat 60 minutes, so whenever the roll
+       landed above 60 the next spot returned "still processing the energy" -
+       and the original treated that as a wasted spot, advancing to the next
+       location instead of retrying. With a fixed list of spots and up to eight
+       successful meditations required, losing even one spot to a cooldown could
+       leave the seed uncharged when the list ran out.
+
+    2. The original ran off the end of its fixed list and exited silently with
+       no indication that the seed was not yet full. This rewrite retries
+       cooldowns in place (never wasting a spot), skips genuinely-unusable
+       spots, and prints an explicit message if the route is exhausted before
+       the seed is full (progress is saved on the seed - just re-run later).
 =end
 
+# Automates the Empath vela'tohr "shock" quest end to end.
+#
+# The class is deliberately decomposed into small, single-responsibility methods
+# so that the decision logic (classifying a MEDITATE response, choosing how to
+# react to each outcome) can be unit-tested in isolation from the game I/O.
+#
+# @example Run with default settings
+#   ShockQuest.new
+#
+# @example Override the meditation route and timing via character settings
+#   # In your YAML settings:
+#   # shockquest_meditation_spots:
+#   #   - { room: '8741', safe: '4105' }
+#   #   - { room: '4111' }
+#   # shockquest_cooldown_seconds: 3900
 class ShockQuest
-  def initialize
-    unless DRStats.empath?
-      echo "Wait... You're no Empath!  Bye!!"
-      exit
-    end
+  # @return [String] semantic version of this script
+  VERSION = '2.0.0'
 
-    check_seed
-    DRCT.walk_to('8741')
-    seed_meditate(true, '4105')
-    DRCT.walk_to('4111')
-    seed_meditate
-    DRCT.walk_to('3996')
-    seed_meditate
-    DRCT.walk_to('6226')
-    seed_meditate(true, '6272')
-    DRCT.walk_to('6260')
-    seed_meditate(true, '6272')
-    DRCT.walk_to('2837')
-    seed_meditate
-    DRCT.walk_to('2701')
-    seed_meditate(true, '2780')
-    DRCT.walk_to('1951')
-    seed_meditate
+  # Map room used to reach Nadigo and the seed vendor / turn-in.
+  # @return [String]
+  NADIGO_ROOM = '15017'
+
+  # The default curated meditation route, preserved from the original script.
+  #
+  # Each entry is a Hash with a mandatory "room" (map id to meditate in) and an
+  # optional "safe" (map id to retreat to while waiting out the cooldown, for
+  # spots that are not safe to idle in). Zones must differ between successful
+  # meditations, so the route deliberately spans widely separated rooms.
+  #
+  # @return [Array<Hash>]
+  DEFAULT_MEDITATION_SPOTS = [
+    { 'room' => '8741', 'safe' => '4105' },
+    { 'room' => '4111' },
+    { 'room' => '3996' },
+    { 'room' => '6226', 'safe' => '6272' },
+    { 'room' => '6260', 'safe' => '6272' },
+    { 'room' => '2837' },
+    { 'room' => '2701', 'safe' => '2780' },
+    { 'room' => '1951' }
+  ].freeze
+
+  # Default time to wait after a successful bond before moving on. The in-game
+  # cooldown is a random 56-65 minutes; this default sits near the top of that
+  # range so the next spot rarely reports a cooldown, and the in-place retry
+  # loop (see {#meditate_at_spot}) absorbs any remaining overage.
+  # @return [Integer] seconds
+  DEFAULT_COOLDOWN_SECONDS = 63 * 60
+
+  # How long to wait between in-place retries when a spot is still on cooldown.
+  # @return [Integer] seconds
+  DEFAULT_RETRY_INTERVAL_SECONDS = 2 * 60
+
+  # Upper bound on in-place cooldown/distraction retries before abandoning a
+  # spot. At the default interval this covers ~20 minutes of overage, far more
+  # than the 56-65 minute cooldown window can ever require after the base wait.
+  # @return [Integer]
+  DEFAULT_MAX_COOLDOWN_RETRIES = 10
+
+  # Granularity of the countdown messages emitted while waiting out a cooldown.
+  # @return [Integer] seconds
+  COOLDOWN_PROGRESS_INTERVAL = 5 * 60
+
+  # Ordered classification table for MEDITATE SEED responses.
+  #
+  # Order matters: the fully-charged ("full") message and the seed-destroyed
+  # message are checked first so that a single response line is never
+  # misclassified as a lesser outcome. Every pattern is anchored on a phrase
+  # confirmed either in live quest logs or on the Elanthipedia walkthrough.
+  #
+  # @return [Array<Array(Symbol, Regexp)>] outcome symbol paired with its matcher
+  MEDITATION_RESPONSES = [
+    [:full,         /germination to complete your quest/i],
+    [:destroyed,    /shriveling and crumbling away|vegetative agony/i],
+    [:bonded,       /strange sensations subside/i],
+    [:cooldown,     /still processing the energy/i],
+    [:familiar,     /already familiar with this area/i],
+    [:too_close,    /still too close to the area where the tainted vela'tohr grow/i],
+    [:bad_location, /nothing more happens despite your concentration/i],
+    [:distracted,   /trouble concentrating/i]
+  ].freeze
+
+  # Outcomes that mean "this spot cannot bond the seed right now, move on to
+  # the next spot in the route without retrying".
+  # @return [Array<Symbol>]
+  SKIP_OUTCOMES = %i[familiar too_close bad_location unknown].freeze
+
+  # Outcomes that warrant retrying the exact same spot after a wait rather than
+  # advancing (the seed is simply not ready, not the location's fault).
+  # @return [Array<Symbol>]
+  RETRY_OUTCOMES = %i[cooldown distracted].freeze
+
+  # Builds configuration from settings and runs the quest.
+  #
+  # @param settings [Object] object responding to the shockquest_* accessors
+  #   (defaults to the character's live settings via +get_settings+).
+  # @return [void]
+  def initialize(settings = get_settings)
+    load_settings(settings)
+    run
   end
 
-  def check_seed
-    case DRC.bput('tap my vela seed', /You tap a .+ vela\'tohr seed.*/, /I could not find what you were referring to./)
-    when /I could not find what you were referring to./
-      echo 'No seed detected!  Heading to Nadigo.'
-      DRCT.walk_to('15017')
-      get_seed
-    end
+  # Reads and normalises configuration, falling back to the module defaults.
+  #
+  # @param settings [Object] settings object (see {#initialize}).
+  # @return [void]
+  def load_settings(settings)
+    @meditation_spots = settings.shockquest_meditation_spots || DEFAULT_MEDITATION_SPOTS
+    @cooldown_seconds = settings.shockquest_cooldown_seconds || DEFAULT_COOLDOWN_SECONDS
+    @retry_interval   = settings.shockquest_retry_interval_seconds || DEFAULT_RETRY_INTERVAL_SECONDS
+    @max_retries      = settings.shockquest_max_retries || DEFAULT_MAX_COOLDOWN_RETRIES
   end
 
-  def get_seed
-    case DRC.bput('ask nadigo for shock', /Nadigo gazes at you searchingly, then nods.*/, /Nadigo gives a slight nod of his head.*/, /Nadigo closes his eyes and grows still.*/, /Nadigo gazes at you searchingly, then nods.*/, /Nadigo glances at you, "It is still too soon.*/)
-    when /Nadigo (closes his eyes and grows still|gives a slight nod of his head).*/
-      get_seed
-    when /Nadigo (gazes at you searchingly, then nods|gives a slight nod of his head).*/
-      waitfor 'Nadigo says, "It\'s strung on a medallion.'
-    when /Nadigo glances at you, "It is still too soon.*/
-      echo 'You cannot start this quest again so soon!'
-      exit
-    end
+  # Top-level orchestration: guard the guild, obtain a seed if needed, charge it.
+  #
+  # @return [void]
+  def run
+    return unless ensure_empath
+    ensure_seed
+    charge_seed
   end
 
-  def seed_meditate(has_safe = false, safe_room = '')
-    case DRC.bput('meditate seed', /.*to Nadigo for germination to complete your quest.*/, /As the strange sensations subside.*/, /You attempt to meditate, but have trouble concentrating./, /You close your eyes and breathe deeply.*/, /.*seed is still processing the energy.*/)
-    when /.*to Nadigo for germination to complete your quest.*/
-      waitrt?
-      nadigo_return
-    when /You attempt to meditate, but have trouble concentrating./
-      if has_safe then
-        DRCT.walk_to(safe_room)
+  # Verifies the character is an Empath (only empaths and former empaths can
+  # bond a seed).
+  #
+  # @return [Boolean] true if the quest may proceed.
+  def ensure_empath
+    return true if DRStats.empath?
+
+    DRC.message("Wait... You're no Empath! Bye!")
+    false
+  end
+
+  # Ensures a vela'tohr seed is on hand, fetching one from Nadigo if absent.
+  #
+  # @return [void]
+  def ensure_seed
+    return if seed_on_hand?
+
+    DRC.message('No seed detected - heading to Nadigo.')
+    DRCT.walk_to(NADIGO_ROOM)
+    acquire_seed
+  end
+
+  # Checks whether the character is already carrying/wearing the seed.
+  #
+  # @return [Boolean]
+  def seed_on_hand?
+    response = DRC.bput('tap my vela seed',
+                        /You tap a .+ vela'tohr seed/,
+                        /I could not find what you were referring to/)
+    response.include?('You tap')
+  end
+
+  # Asks Nadigo for the seed, handling his multi-step dialogue and the
+  # "too soon to try again" refusal.
+  #
+  # @return [void]
+  def acquire_seed
+    @max_retries.times do
+      case DRC.bput('ask nadigo for shock',
+                    /gazes at you searchingly, then nods/,
+                    /gives a slight nod of his head/,
+                    /closes his eyes and grows still/,
+                    /It is still too soon/)
+      when /gazes at you searchingly, then nods/
+        waitfor 'strung on a medallion'
+        return
+      when /It is still too soon/
+        DRC.message('You cannot start this quest again so soon - exiting.')
+        return exit
       end
-      echo 'Unable to determine time, waiting 10 minutes and trying again.'
-      pause 600
-    when /.*seed is still processing the energy.*/
-      if has_safe then
-        DRCT.walk_to(safe_room)
-      end
-      echo 'Unable to determine time, waiting 10 minutes and trying again.'
-      pause 600
-    when /As the strange sensations subside.*/
-      if has_safe then
-        DRCT.walk_to(safe_room)
-      end
-      echo 'Success!  Waiting 1 hour...'
-      pause 600
-      echo '10 minutes down, 50 minutes remaining!'
-      pause 600
-      echo '20 minutes down, 40 minutes remaining!'
-      pause 600
-      echo '30 minutes down, 30 minutes remaining!'
-      pause 600
-      echo '40 minutes down, 20 minutes remaining!'
-      pause 600
-      echo '50 minutes down, 10 minutes remaining!'
-      pause 600
-      echo 'Wait time done!  Continuing...'
-    when /You close your eyes and breathe deeply.*/
-      waitrt
     end
   end
 
-  def nadigo_return
-    echo 'Your seed is full!  Returning to Nadigo!'
-    DRCT.walk_to('15017')
-    fput('remove my seed')
-    fput('give nadigo')
-    waitfor 'Nadigo smiles at you, then turns away, gazing off into the woods.'
-    echo 'Your quest is completed!'
-    exit
+  # Walks the meditation route, bonding the seed until it is full or the route
+  # is exhausted.
+  #
+  # @return [void]
+  def charge_seed
+    @meditation_spots.each do |spot|
+      case meditate_at_spot(spot)
+      when :full
+        return deliver_seed
+      when :destroyed
+        return DRC.message('The seed was destroyed - the quest cannot continue.')
+      when :bonded
+        rest_after_bond(spot)
+      end
+      # SKIP_OUTCOMES fall through and continue to the next spot.
+    end
+
+    announce_incomplete
+  end
+
+  # Travels to a spot and meditates, retrying in place while the only obstacle
+  # is the seed's cooldown (or a transient distraction). Never advances the
+  # route on a retryable outcome - that was the core bug in the original.
+  #
+  # @param spot [Hash] a meditation-route entry (see {DEFAULT_MEDITATION_SPOTS}).
+  # @return [Symbol] a terminal outcome from {MEDITATION_RESPONSES} (never
+  #   +:cooldown+ or +:distracted+).
+  def meditate_at_spot(spot)
+    DRCT.walk_to(spot['room'])
+
+    (@max_retries + 1).times do |attempt|
+      outcome = classify_meditation(perform_meditation)
+      return outcome unless RETRY_OUTCOMES.include?(outcome)
+      return :unknown if attempt >= @max_retries
+
+      DRC.message("Seed not ready here (#{outcome}); waiting #{@retry_interval / 60} min then retrying this spot.")
+      pause @retry_interval
+    end
+
+    :unknown
+  end
+
+  # Sends the MEDITATE command and returns the decisive response line.
+  #
+  # @return [String] the matched response text (empty string on timeout).
+  def perform_meditation
+    DRC.bput('meditate seed', *MEDITATION_RESPONSES.map { |_outcome, pattern| pattern })
+  end
+
+  # Classifies a raw MEDITATE SEED response into a single outcome symbol.
+  #
+  # @param response [String, nil] the response text from {#perform_meditation}.
+  # @return [Symbol] one of the outcome symbols in {MEDITATION_RESPONSES}, or
+  #   +:unknown+ when nothing matches.
+  def classify_meditation(response)
+    return :unknown if response.nil? || response.empty?
+
+    MEDITATION_RESPONSES.each do |outcome, pattern|
+      return outcome if response =~ pattern
+    end
+    :unknown
+  end
+
+  # Retreats to the spot's safe room (if any) and waits out the seed cooldown.
+  #
+  # @param spot [Hash] the spot that was just bonded.
+  # @return [void]
+  def rest_after_bond(spot)
+    DRC.message('Bond formed! Waiting out the seed cooldown.')
+    DRCT.walk_to(spot['safe']) if spot['safe']
+    wait_cooldown
+  end
+
+  # Sleeps for the configured cooldown, emitting periodic countdown messages.
+  #
+  # @return [void]
+  def wait_cooldown
+    remaining = @cooldown_seconds
+    while remaining > 0
+      chunk = [COOLDOWN_PROGRESS_INTERVAL, remaining].min
+      pause chunk
+      remaining -= chunk
+      DRC.message("Cooldown: #{remaining / 60} minutes remaining.") if remaining > 0
+    end
+    DRC.message('Cooldown complete - continuing.')
+  end
+
+  # Returns the fully-charged seed to Nadigo and waits for the germination
+  # ceremony to finish.
+  #
+  # @return [void]
+  def deliver_seed
+    DRC.message('Seed is full! Returning to Nadigo.')
+    DRCT.walk_to(NADIGO_ROOM)
+    DRC.bput('remove my seed', /You remove a .+ vela'tohr seed/, /You aren't wearing/)
+    DRC.bput('give nadigo', /brushes the proffered seed/, /Excellent work/)
+    waitfor 'turns away, gazing off into the woods'
+    DRC.message('Your quest is complete!')
+  end
+
+  # Explains that the route was used up before the seed charged. Progress is
+  # stored on the seed itself, so simply re-running later resumes the quest.
+  #
+  # @return [void]
+  def announce_incomplete
+    DRC.message('Ran out of meditation spots before the seed was full.')
+    DRC.message('Progress is saved on the seed - re-run later (respecting the cooldown), or add more spots to shockquest_meditation_spots.')
   end
 end
 

--- a/shockquest.lic
+++ b/shockquest.lic
@@ -147,12 +147,12 @@ class ShockQuest
   # @return [void]
   def run
     return unless ensure_empath
-    ensure_seed
+    return unless ensure_seed
     charge_seed
   end
 
-  # Verifies the character is an Empath (only empaths and former empaths can
-  # bond a seed).
+  # Verifies the character is an Empath. Guild membership cannot change in
+  # DragonRealms, so this is the only eligibility check the quest needs.
   #
   # @return [Boolean] true if the quest may proceed.
   def ensure_empath
@@ -164,13 +164,17 @@ class ShockQuest
 
   # Ensures a vela'tohr seed is on hand, fetching one from Nadigo if absent.
   #
-  # @return [void]
+  # @return [Boolean] true if a seed is available to charge; false if one could
+  #   not be obtained (the quest must not continue in a no-seed state).
   def ensure_seed
-    return if seed_on_hand?
+    return true if seed_on_hand?
 
     DRC.message('No seed detected - heading to Nadigo.')
     DRCT.walk_to(NADIGO_ROOM)
-    acquire_seed
+    return true if acquire_seed
+
+    DRC.message('Could not obtain a seed from Nadigo - aborting quest.')
+    false
   end
 
   # Checks whether the character is already carrying/wearing the seed.
@@ -186,7 +190,9 @@ class ShockQuest
   # Asks Nadigo for the seed, handling his multi-step dialogue and the
   # "too soon to try again" refusal.
   #
-  # @return [void]
+  # @return [Boolean] true once Nadigo hands over the seed; false if he never
+  #   agrees within the retry budget. Exits the script outright on the
+  #   "too soon" refusal.
   def acquire_seed
     @max_retries.times do
       case DRC.bput('ask nadigo for shock',
@@ -196,12 +202,13 @@ class ShockQuest
                     /It is still too soon/)
       when /gazes at you searchingly, then nods/
         waitfor 'strung on a medallion'
-        return
+        return true
       when /It is still too soon/
         DRC.message('You cannot start this quest again so soon - exiting.')
         return exit
       end
     end
+    false
   end
 
   # Walks the meditation route, bonding the seed until it is full or the route

--- a/spec/shockquest_spec.rb
+++ b/spec/shockquest_spec.rb
@@ -1,0 +1,471 @@
+require_relative 'spec_helper'
+
+# ShockQuest#initialize drives the whole quest through game I/O (DRC.bput,
+# DRCT.walk_to, waitfor, pause), so we never call .new in these specs. Instead
+# we allocate a bare instance and exercise the decision logic directly, stubbing
+# the thin game-facing seams (DRC, DRCT, pause, waitfor, exit).
+#
+# The classification specs are the heart of the suite: every pattern is fed the
+# exact response text captured from live quest logs and the Elanthipedia
+# walkthrough, plus adversarial near-misses designed to break naive matchers.
+load_lic_class('shockquest.lic', 'ShockQuest')
+
+RSpec.describe ShockQuest do
+  # A bare instance with no initialize side effects. Individual specs inject the
+  # handful of ivars the method under test actually reads.
+  let(:quest) { ShockQuest.allocate }
+
+  # Stub the game-facing modules. Doubles start permissive (message/walk_to are
+  # no-ops); specs that care about bput responses override it locally.
+  let(:drc)  { double('DRC') }
+  let(:drct) { double('DRCT') }
+
+  before(:each) do
+    allow(drc).to receive(:message)
+    allow(drc).to receive(:bput).and_return('')
+    allow(drct).to receive(:walk_to)
+    stub_const('DRC', drc)
+    stub_const('DRCT', drct)
+  end
+
+  # ===========================================================================
+  # Verbatim response text captured from live quest logs (2026-07-05/06).
+  # Kept as named helpers so each classification assertion reads as a sentence.
+  # ===========================================================================
+  let(:log_bonded) do
+    'As the strange sensations subside, you feel suddenly fatigued and unsteady.  ' \
+      'You sense that something is moving between you and the seed as a vast quantity ' \
+      'of life energy is rapidly drawn from you to nurture the infant plant growing within the seed.'
+  end
+
+  let(:log_cooldown) do
+    "As you direct your senses toward your vela'tohr seed, your fingers seem to tingle in " \
+      'sympathy with the abundance of energy recently transferred from you to the nascent plant.  ' \
+      "Bewildering images briefly flash through your mind's eye as the world seems to lurch around " \
+      'you.  As the confusing sensations subside, you sense that the seed is still processing the ' \
+      'energy and experiences it took from you during your last meditation.'
+  end
+
+  let(:log_full) do
+    "As you direct your senses toward your vela'tohr seed, you perceive that it pulses with life " \
+      'energy; the manifestation so powerful that your fingers nearly seem to tingle where they ' \
+      'grasp the nascent seed.  A burgeoning feeling of vegetable bliss washes over you, and you ' \
+      "sense that your bond with the vela'tohr seed is complete.  You recall that you should return " \
+      'the seed to Nadigo for germination to complete your quest.'
+  end
+
+  let(:log_familiar) do
+    'You close your eyes and breathe deeply, directing your mental and magical senses toward the ' \
+      "vela'tohr seed dangling from the cord around your neck.  You brush the seed with your " \
+      'fingers, attempting to form a bond with the infant plant.  Bewildering alien visions flash ' \
+      "through your mind's eye, and you sense that the nascent consciousness growing within the seed " \
+      'is already familiar with this area.  A brief surge of vegetable contentment courses through you.'
+  end
+
+  let(:log_distracted) { 'You attempt to meditate, but have trouble concentrating.' }
+
+  # ===========================================================================
+  # Response text from the Elanthipedia walkthrough (conditions never hit in the
+  # captured logs because the default route is all-valid, but that the rewrite
+  # must handle for custom routes or map drift).
+  # ===========================================================================
+  let(:wiki_too_close) do
+    "you realize that you are still too close to the area where the tainted vela'tohr grow."
+  end
+
+  let(:wiki_bad_location) do
+    'You sense some magical stirring within the seed, but nothing more happens despite your concentration.'
+  end
+
+  let(:wiki_destroyed) do
+    'The seed grows dull and lusterless, before shriveling and crumbling away.'
+  end
+
+  # ===========================================================================
+  # #classify_meditation
+  # ===========================================================================
+  describe '#classify_meditation' do
+    context 'with exact text captured from live quest logs' do
+      it 'classifies a successful bond as :bonded' do
+        expect(quest.classify_meditation(log_bonded)).to eq(:bonded)
+      end
+
+      it 'classifies the cooldown response as :cooldown' do
+        expect(quest.classify_meditation(log_cooldown)).to eq(:cooldown)
+      end
+
+      it 'classifies the fully-charged response as :full' do
+        expect(quest.classify_meditation(log_full)).to eq(:full)
+      end
+
+      it 'classifies the already-visited-zone response as :familiar' do
+        expect(quest.classify_meditation(log_familiar)).to eq(:familiar)
+      end
+
+      it 'classifies the distraction response as :distracted' do
+        expect(quest.classify_meditation(log_distracted)).to eq(:distracted)
+      end
+    end
+
+    context 'with walkthrough-documented failure conditions' do
+      it 'classifies proximity to the tainted woods as :too_close' do
+        expect(quest.classify_meditation(wiki_too_close)).to eq(:too_close)
+      end
+
+      it 'classifies an unsuitable location as :bad_location' do
+        expect(quest.classify_meditation(wiki_bad_location)).to eq(:bad_location)
+      end
+
+      it 'classifies a destroyed seed as :destroyed' do
+        expect(quest.classify_meditation(wiki_destroyed)).to eq(:destroyed)
+      end
+    end
+
+    context 'adversarial near-misses' do
+      it 'does NOT treat the cooldown response as a bond despite "confusing sensations subside"' do
+        # The cooldown flavor text ends "As the confusing sensations subside" - a
+        # single character class away from the success phrase. This is the exact
+        # trap that would corrupt cooldown handling if the matcher were sloppy.
+        expect(quest.classify_meditation(log_cooldown)).not_to eq(:bonded)
+      end
+
+      it 'prefers :full over :distracted when a single line contains both phrases' do
+        # In the logs the germination line is immediately followed by "trouble
+        # concentrating"; if both ever collapse into one response, completion wins.
+        combined = 'return the seed to Nadigo for germination to complete your quest. ' \
+                   'You attempt to meditate, but have trouble concentrating.'
+        expect(quest.classify_meditation(combined)).to eq(:full)
+      end
+
+      it 'prefers :destroyed over any lesser outcome' do
+        combined = 'the seed is still processing the energy ... shriveling and crumbling away.'
+        expect(quest.classify_meditation(combined)).to eq(:destroyed)
+      end
+    end
+
+    context 'with unrecognized or empty input' do
+      it 'returns :unknown for an empty string (bput timeout)' do
+        expect(quest.classify_meditation('')).to eq(:unknown)
+      end
+
+      it 'returns :unknown for nil' do
+        expect(quest.classify_meditation(nil)).to eq(:unknown)
+      end
+
+      it 'returns :unknown for unrelated game noise' do
+        expect(quest.classify_meditation('Rage of the Clans  (30 roisaen)')).to eq(:unknown)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # #meditate_at_spot -- the core bug fix: cooldowns retry in place, they do
+  # not consume a route spot.
+  # ===========================================================================
+  describe '#meditate_at_spot' do
+    let(:spot) { { 'room' => '8741', 'safe' => '4105' } }
+
+    before(:each) do
+      quest.instance_variable_set(:@max_retries, 3)
+      quest.instance_variable_set(:@retry_interval, 120)
+      allow(quest).to receive(:pause)
+    end
+
+    it 'walks to the spot room before meditating' do
+      allow(quest).to receive(:perform_meditation).and_return(log_bonded)
+      quest.meditate_at_spot(spot)
+      expect(drct).to have_received(:walk_to).with('8741')
+    end
+
+    it 'returns :bonded immediately on a first-try success without waiting' do
+      allow(quest).to receive(:perform_meditation).and_return(log_bonded)
+      expect(quest.meditate_at_spot(spot)).to eq(:bonded)
+      expect(quest).not_to have_received(:pause)
+    end
+
+    it 'retries the SAME spot on cooldown and succeeds without advancing' do
+      allow(quest).to receive(:perform_meditation).and_return(log_cooldown, log_cooldown, log_bonded)
+      expect(quest.meditate_at_spot(spot)).to eq(:bonded)
+      # Walked to the spot exactly once; two cooldowns => two waits.
+      expect(drct).to have_received(:walk_to).once
+      expect(quest).to have_received(:pause).with(120).twice
+    end
+
+    it 'retries a transient distraction in place then succeeds' do
+      allow(quest).to receive(:perform_meditation).and_return(log_distracted, log_bonded)
+      expect(quest.meditate_at_spot(spot)).to eq(:bonded)
+      expect(quest).to have_received(:pause).once
+    end
+
+    it 'gives up as :unknown after exhausting retries on a permanent cooldown' do
+      allow(quest).to receive(:perform_meditation).and_return(log_cooldown)
+      expect(quest.meditate_at_spot(spot)).to eq(:unknown)
+      # max_retries=3 => three waits, then bail (never loops forever).
+      expect(quest).to have_received(:pause).exactly(3).times
+    end
+
+    it 'returns :full straight through without retrying' do
+      allow(quest).to receive(:perform_meditation).and_return(log_full)
+      expect(quest.meditate_at_spot(spot)).to eq(:full)
+      expect(quest).not_to have_received(:pause)
+    end
+
+    it 'returns :familiar immediately so the caller can skip the spot' do
+      allow(quest).to receive(:perform_meditation).and_return(log_familiar)
+      expect(quest.meditate_at_spot(spot)).to eq(:familiar)
+      expect(quest).not_to have_received(:pause)
+    end
+  end
+
+  # ===========================================================================
+  # #charge_seed -- route dispatch
+  # ===========================================================================
+  describe '#charge_seed' do
+    let(:route) do
+      [{ 'room' => '1' }, { 'room' => '2' }, { 'room' => '3' }]
+    end
+
+    before(:each) do
+      quest.instance_variable_set(:@meditation_spots, route)
+      allow(quest).to receive(:rest_after_bond)
+      allow(quest).to receive(:deliver_seed)
+      allow(quest).to receive(:announce_incomplete)
+    end
+
+    it 'delivers the seed and stops the route the moment it is full' do
+      allow(quest).to receive(:meditate_at_spot).and_return(:full)
+      quest.charge_seed
+      expect(quest).to have_received(:deliver_seed).once
+      expect(quest).to have_received(:meditate_at_spot).once
+    end
+
+    it 'rests after a bond and continues to the next spot until full' do
+      allow(quest).to receive(:meditate_at_spot).and_return(:bonded, :full)
+      quest.charge_seed
+      expect(quest).to have_received(:rest_after_bond).once
+      expect(quest).to have_received(:deliver_seed).once
+      expect(quest).to have_received(:meditate_at_spot).twice
+    end
+
+    it 'skips unusable spots without resting or delivering' do
+      allow(quest).to receive(:meditate_at_spot).and_return(:familiar, :too_close, :bad_location)
+      quest.charge_seed
+      expect(quest).not_to have_received(:rest_after_bond)
+      expect(quest).not_to have_received(:deliver_seed)
+    end
+
+    it 'announces an incomplete quest when the route is exhausted unfilled' do
+      allow(quest).to receive(:meditate_at_spot).and_return(:familiar, :familiar, :familiar)
+      quest.charge_seed
+      expect(quest).to have_received(:announce_incomplete).once
+    end
+
+    it 'aborts on a destroyed seed without announcing incomplete or delivering' do
+      allow(quest).to receive(:meditate_at_spot).and_return(:destroyed)
+      quest.charge_seed
+      expect(quest).not_to have_received(:deliver_seed)
+      expect(quest).not_to have_received(:announce_incomplete)
+      expect(quest).to have_received(:meditate_at_spot).once
+    end
+  end
+
+  # ===========================================================================
+  # #wait_cooldown -- chunked countdown
+  # ===========================================================================
+  describe '#wait_cooldown' do
+    before(:each) { allow(quest).to receive(:pause) }
+
+    it 'sleeps in progress-interval chunks and a final remainder' do
+      quest.instance_variable_set(:@cooldown_seconds, 12 * 60)
+      quest.wait_cooldown
+      expect(quest).to have_received(:pause).with(5 * 60).twice
+      expect(quest).to have_received(:pause).with(2 * 60).once
+    end
+
+    it 'waits exactly the configured duration when evenly divisible' do
+      quest.instance_variable_set(:@cooldown_seconds, 10 * 60)
+      quest.wait_cooldown
+      expect(quest).to have_received(:pause).with(5 * 60).twice
+    end
+
+    it 'does not pause at all for a zero cooldown' do
+      quest.instance_variable_set(:@cooldown_seconds, 0)
+      quest.wait_cooldown
+      expect(quest).not_to have_received(:pause)
+    end
+  end
+
+  # ===========================================================================
+  # #rest_after_bond -- safe-room retreat is conditional
+  # ===========================================================================
+  describe '#rest_after_bond' do
+    before(:each) do
+      quest.instance_variable_set(:@cooldown_seconds, 0)
+      allow(quest).to receive(:wait_cooldown)
+    end
+
+    it 'retreats to the safe room when one is configured' do
+      quest.rest_after_bond({ 'room' => '8741', 'safe' => '4105' })
+      expect(drct).to have_received(:walk_to).with('4105')
+    end
+
+    it 'stays put when the spot has no safe room' do
+      quest.rest_after_bond({ 'room' => '4111' })
+      expect(drct).not_to have_received(:walk_to)
+    end
+
+    it 'always waits out the cooldown' do
+      quest.rest_after_bond({ 'room' => '4111' })
+      expect(quest).to have_received(:wait_cooldown)
+    end
+  end
+
+  # ===========================================================================
+  # #seed_on_hand?
+  # ===========================================================================
+  describe '#seed_on_hand?' do
+    it 'is true when the seed can be tapped' do
+      allow(drc).to receive(:bput).and_return("You tap a lumpy vela'tohr seed dangling from a twisted jute cord")
+      expect(quest.seed_on_hand?).to be true
+    end
+
+    it 'is false when the seed cannot be found' do
+      allow(drc).to receive(:bput).and_return('I could not find what you were referring to')
+      expect(quest.seed_on_hand?).to be false
+    end
+  end
+
+  # ===========================================================================
+  # #ensure_seed
+  # ===========================================================================
+  describe '#ensure_seed' do
+    it 'does nothing when the seed is already on hand' do
+      allow(quest).to receive(:seed_on_hand?).and_return(true)
+      allow(quest).to receive(:acquire_seed)
+      quest.ensure_seed
+      expect(drct).not_to have_received(:walk_to)
+      expect(quest).not_to have_received(:acquire_seed)
+    end
+
+    it 'travels to Nadigo and acquires a seed when none is on hand' do
+      allow(quest).to receive(:seed_on_hand?).and_return(false)
+      allow(quest).to receive(:acquire_seed)
+      quest.ensure_seed
+      expect(drct).to have_received(:walk_to).with(ShockQuest::NADIGO_ROOM)
+      expect(quest).to have_received(:acquire_seed)
+    end
+  end
+
+  # ===========================================================================
+  # #acquire_seed -- Nadigo's dialogue tree
+  # ===========================================================================
+  describe '#acquire_seed' do
+    before(:each) do
+      quest.instance_variable_set(:@max_retries, 5)
+      allow(quest).to receive(:waitfor)
+      allow(quest).to receive(:exit)
+    end
+
+    it 'waits for the medallion line when Nadigo agrees' do
+      allow(drc).to receive(:bput).and_return('gazes at you searchingly, then nods')
+      quest.acquire_seed
+      expect(quest).to have_received(:waitfor).with('strung on a medallion')
+      expect(quest).not_to have_received(:exit)
+    end
+
+    it 'exits when Nadigo says it is still too soon' do
+      allow(drc).to receive(:bput).and_return('It is still too soon')
+      quest.acquire_seed
+      expect(quest).to have_received(:exit)
+    end
+
+    it 'keeps asking through the intro dialogue until Nadigo agrees' do
+      allow(drc).to receive(:bput).and_return(
+        'gives a slight nod of his head',
+        'gazes at you searchingly, then nods'
+      )
+      quest.acquire_seed
+      expect(drc).to have_received(:bput).twice
+      expect(quest).to have_received(:waitfor).with('strung on a medallion')
+    end
+  end
+
+  # ===========================================================================
+  # #ensure_empath -- guild guard
+  # ===========================================================================
+  describe '#ensure_empath' do
+    it 'returns true for an Empath' do
+      DRStats.guild = 'Empath'
+      expect(quest.ensure_empath).to be true
+    end
+
+    it 'returns false and warns for a non-Empath' do
+      DRStats.guild = 'Barbarian'
+      expect(quest.ensure_empath).to be false
+      expect(drc).to have_received(:message).with(/Empath/)
+    end
+  end
+
+  # ===========================================================================
+  # #load_settings -- defaults and overrides
+  # ===========================================================================
+  describe '#load_settings' do
+    it 'falls back to module defaults when settings are blank' do
+      quest.load_settings(OpenStruct.new)
+      expect(quest.instance_variable_get(:@meditation_spots)).to eq(ShockQuest::DEFAULT_MEDITATION_SPOTS)
+      expect(quest.instance_variable_get(:@cooldown_seconds)).to eq(ShockQuest::DEFAULT_COOLDOWN_SECONDS)
+      expect(quest.instance_variable_get(:@retry_interval)).to eq(ShockQuest::DEFAULT_RETRY_INTERVAL_SECONDS)
+      expect(quest.instance_variable_get(:@max_retries)).to eq(ShockQuest::DEFAULT_MAX_COOLDOWN_RETRIES)
+    end
+
+    it 'honors caller-provided overrides' do
+      custom_spots = [{ 'room' => '9999' }]
+      settings = OpenStruct.new(
+        shockquest_meditation_spots: custom_spots,
+        shockquest_cooldown_seconds: 3900,
+        shockquest_retry_interval_seconds: 90,
+        shockquest_max_retries: 4
+      )
+      quest.load_settings(settings)
+      expect(quest.instance_variable_get(:@meditation_spots)).to eq(custom_spots)
+      expect(quest.instance_variable_get(:@cooldown_seconds)).to eq(3900)
+      expect(quest.instance_variable_get(:@retry_interval)).to eq(90)
+      expect(quest.instance_variable_get(:@max_retries)).to eq(4)
+    end
+  end
+
+  # ===========================================================================
+  # #perform_meditation -- sends the command with every classifier pattern
+  # ===========================================================================
+  describe '#perform_meditation' do
+    it 'issues MEDITATE SEED against all classifier patterns' do
+      quest.perform_meditation
+      patterns = ShockQuest::MEDITATION_RESPONSES.map { |_outcome, pattern| pattern }
+      expect(drc).to have_received(:bput).with('meditate seed', *patterns)
+    end
+  end
+
+  # ===========================================================================
+  # Constants and version
+  # ===========================================================================
+  describe 'constants' do
+    it 'exposes a semver VERSION' do
+      expect(ShockQuest::VERSION).to match(/^\d+\.\d+\.\d+$/)
+    end
+
+    it 'defaults the cooldown near the top of the 56-65 minute window' do
+      minutes = ShockQuest::DEFAULT_COOLDOWN_SECONDS / 60.0
+      expect(minutes).to be_between(56, 66)
+    end
+
+    it 'keeps retry and skip outcome sets disjoint' do
+      expect(ShockQuest::RETRY_OUTCOMES & ShockQuest::SKIP_OUTCOMES).to be_empty
+    end
+
+    it 'every classifier outcome is terminal, retryable, or a completion state' do
+      terminal = ShockQuest::SKIP_OUTCOMES + ShockQuest::RETRY_OUTCOMES + %i[bonded full destroyed]
+      classifier_outcomes = ShockQuest::MEDITATION_RESPONSES.map { |outcome, _pattern| outcome }
+      expect(classifier_outcomes - terminal).to be_empty
+    end
+  end
+end

--- a/spec/shockquest_spec.rb
+++ b/spec/shockquest_spec.rb
@@ -339,20 +339,27 @@ RSpec.describe ShockQuest do
   # #ensure_seed
   # ===========================================================================
   describe '#ensure_seed' do
-    it 'does nothing when the seed is already on hand' do
+    it 'succeeds without travelling when the seed is already on hand' do
       allow(quest).to receive(:seed_on_hand?).and_return(true)
       allow(quest).to receive(:acquire_seed)
-      quest.ensure_seed
+      expect(quest.ensure_seed).to be true
       expect(drct).not_to have_received(:walk_to)
       expect(quest).not_to have_received(:acquire_seed)
     end
 
-    it 'travels to Nadigo and acquires a seed when none is on hand' do
+    it 'travels to Nadigo and succeeds when a seed is acquired' do
       allow(quest).to receive(:seed_on_hand?).and_return(false)
-      allow(quest).to receive(:acquire_seed)
-      quest.ensure_seed
+      allow(quest).to receive(:acquire_seed).and_return(true)
+      expect(quest.ensure_seed).to be true
       expect(drct).to have_received(:walk_to).with(ShockQuest::NADIGO_ROOM)
       expect(quest).to have_received(:acquire_seed)
+    end
+
+    it 'fails fast when Nadigo never hands over a seed' do
+      allow(quest).to receive(:seed_on_hand?).and_return(false)
+      allow(quest).to receive(:acquire_seed).and_return(false)
+      expect(quest.ensure_seed).to be false
+      expect(drc).to have_received(:message).with(/aborting/i)
     end
   end
 
@@ -366,9 +373,9 @@ RSpec.describe ShockQuest do
       allow(quest).to receive(:exit)
     end
 
-    it 'waits for the medallion line when Nadigo agrees' do
+    it 'waits for the medallion line and reports success when Nadigo agrees' do
       allow(drc).to receive(:bput).and_return('gazes at you searchingly, then nods')
-      quest.acquire_seed
+      expect(quest.acquire_seed).to be true
       expect(quest).to have_received(:waitfor).with('strung on a medallion')
       expect(quest).not_to have_received(:exit)
     end
@@ -384,9 +391,17 @@ RSpec.describe ShockQuest do
         'gives a slight nod of his head',
         'gazes at you searchingly, then nods'
       )
-      quest.acquire_seed
+      expect(quest.acquire_seed).to be true
       expect(drc).to have_received(:bput).twice
       expect(quest).to have_received(:waitfor).with('strung on a medallion')
+    end
+
+    it 'reports failure when Nadigo never agrees within the retry budget' do
+      quest.instance_variable_set(:@max_retries, 3)
+      allow(drc).to receive(:bput).and_return('gives a slight nod of his head')
+      expect(quest.acquire_seed).to be false
+      expect(drc).to have_received(:bput).exactly(3).times
+      expect(quest).not_to have_received(:waitfor)
     end
   end
 
@@ -395,12 +410,12 @@ RSpec.describe ShockQuest do
   # ===========================================================================
   describe '#ensure_empath' do
     it 'returns true for an Empath' do
-      DRStats.guild = 'Empath'
+      allow(DRStats).to receive(:empath?).and_return(true)
       expect(quest.ensure_empath).to be true
     end
 
     it 'returns false and warns for a non-Empath' do
-      DRStats.guild = 'Barbarian'
+      allow(DRStats).to receive(:empath?).and_return(false)
       expect(quest.ensure_empath).to be false
       expect(drc).to have_received(:message).with(/Empath/)
     end


### PR DESCRIPTION
## Problem

The Empath shock quest (`shockquest.lic`) bonds a vela'tohr seed by meditating in a series of qualifying locations. Each successful meditation puts the seed on a **randomised 56-65 minute cooldown** (per the [walkthrough](https://elanthipedia.play.net/Shock_quest_walkthrough)); the seed needs up to **8 successful meditations** to fully charge.

The old script had two compounding bugs:

1. **Flat 60-minute wait vs. a 56-65 minute cooldown.** Whenever the cooldown rolled above 60 minutes, the next spot returned *"the seed is still processing the energy"*.
2. **A cooldown wasted the spot.** On that response the script paused 10 minutes and then advanced to the *next* location in a fixed list of 8 - it never retried. With up to 8 successful meditations required and only 8 spots, losing even one spot to a cooldown could leave the seed uncharged. The script then ran off the end of its list and **exited silently**, with no indication the quest was incomplete.

This was reproduced from live logs: a run made all 8 meditation attempts but 3 hit the cooldown and were wasted, yielding only 5 bonds. The seed persists across runs, so a second run finished it - but the first run's silent give-up is the bug.

## Fix

- **Retry cooldowns (and transient distractions) in place** - a not-ready seed never burns a route spot.
- **Wait near the top of the cooldown window by default**, with the in-place retry loop as a safety net. Cooldown, retry interval, retry cap, and the meditation route are all configurable via settings.
- **Single ordered classifier for every documented MEDITATE outcome**: `bonded`, `full`, `cooldown`, `familiar` (already-bonded zone), `too_close` (tainted woods), `bad_location` (wrong biome / water / indoors / low mana), `destroyed`, `distracted`. Patterns verified against live logs and the walkthrough - including the adversarial near-miss where the cooldown flavor text ends *"as the **confusing** sensations subside"*, one word off the success phrase.
- **Skip genuinely-unusable spots**, and if the route is exhausted before the seed is full, **print an explicit message** (progress is saved on the seed - just re-run later) instead of exiting silently.
- SOLID/DRY decomposition with copious YARD docs.

## Tests

New `spec/shockquest_spec.rb` (48 examples, SOLID/DAMP) covering the classifier (verbatim log/wiki text plus adversarial near-misses), the in-place cooldown-retry logic, route dispatch, cooldown chunking, settings defaults/overrides, and Nadigo's dialogue tree. `rubocop -A` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end automated flow for the Empath shock quest, including seed acquisition, meditation routing, and quest completion.
  * Added configurable meditation spots, retry timing, cooldown handling, and an optional safe-room rest period.
  * Added clearer progress messages when a seed can’t be fully charged in one run, allowing players to resume later.

* **Bug Fixes**
  * Improved handling of meditation outcomes so temporary setbacks retry in place instead of advancing too early.
  * Added better checks for eligibility and seed availability before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->