### PR TITLE
fix(healer): stop scar/self-death stalls; controlled-stacking vitality heal

### DIFF
--- a/healer.lic
+++ b/healer.lic
@@ -73,6 +73,17 @@ class Healer
   EMERGENCY_VIT_THRESHOLD = 30 # Fall to break all links if health drops below this %
   PATIENT_VIT_THRESHOLD = 80   # Only transfer vit if patient below this % (100 = always)
 
+  # Resume another vit round once own health recovers to this % (was hard-coded 90;
+  # a lower gate keeps throughput up without dipping toward the floor).
+  VIT_RESUME_THRESHOLD = 75
+
+  # Controlled stacking: run up to this many concurrent vit-transfer streams to
+  # speed healing. Stacking multiplies drain speed, so the count scales with spare
+  # vitality -- each extra stream requires VIT_STACK_HEADROOM% of headroom above the
+  # floor. When headroom is thin we fall back to a single, safe stream.
+  MAX_VIT_STACKS = 3
+  VIT_STACK_HEADROOM = 12
+
   # Spell slot timeout (seconds) - prevents permanent lock on stuck tasks
   SPELL_SLOT_TIMEOUT = 45
 
@@ -159,6 +170,7 @@ class Healer
     @last_health_check = nil
     @last_ready_result = false
     @emergency_recovery = false
+    @self_dead = false
     @drain_landed = false
     @healing_waggle_set = @settings.healer_waggle_set || 'healme'
     @cambrinth_item = Array(@settings.cambrinth).first
@@ -213,13 +225,15 @@ class Healer
     Lich::Messaging.msg('bold', 'Healer: Link Unity available') if @unity_available
   end
 
-  # Checks if character knows Heal + Adaptive Curing for passive healing.
+  # Checks for a passive self-heal: Regenerate (the empath capstone self-heal,
+  # which supersedes Heal), or Heal + Adaptive Curing together.
   # @return [Boolean] true if passive healing is available
   def validate_healing_spells
+    knows_regenerate = DRSpells.known_spells['Regenerate']
     knows_heal = DRSpells.known_spells['Heal']
     knows_adc = DRSpells.known_spells['Adaptive Curing']
 
-    if knows_heal && knows_adc
+    if knows_regenerate || (knows_heal && knows_adc)
       spell = active_healing_spell
       if spell
         Lich::Messaging.msg('bold', "Healer: Using passive healing (#{spell})")
@@ -228,10 +242,7 @@ class Healer
       end
       true
     else
-      missing = []
-      missing << 'Heal' unless knows_heal
-      missing << 'Adaptive Curing' unless knows_adc
-      Lich::Messaging.msg('bold', "Healer: Using healme script (missing: #{missing.join(', ')})")
+      Lich::Messaging.msg('bold', 'Healer: Using healme script (no Regenerate, or missing Heal + Adaptive Curing)')
       false
     end
   end
@@ -301,6 +312,39 @@ class Healer
   # @return [Symbol] normalized key
   def name_key(name)
     name.to_s.downcase.to_sym
+  end
+
+  # A scar is cosmetic -- it never impairs taking, redirecting, or transferring
+  # wounds, and passive healing (Regenerate/Heal) fades it on its own. Excluding
+  # scars keeps the healer from stalling while it waits for its own scars to fade.
+  # @param wound [Wound, #scar?] a wound object
+  # @return [Boolean] true if the wound is only a scar
+  def cosmetic_wound?(wound)
+    wound.respond_to?(:scar?) && wound.scar?
+  end
+
+  # True for a real (non-cosmetic) wound severe enough to block taking more wounds.
+  # Ignores scars entirely and trivial severity-1 abrasions, which self-heal in
+  # seconds and never impede a transfer.
+  # @param wound [Wound] a wound object
+  # @return [Boolean] true if the wound should block wound transfers
+  def blocking_self_wound?(wound)
+    return false unless wound.respond_to?(:severity) && wound.severity
+    return false if cosmetic_wound?(wound)
+
+    wound.severity > 1
+  end
+
+  # Weighted score counting only real (non-cosmetic) wounds. Used so passive-heal
+  # waits resolve as soon as real wounds are gone, not lingering on scars.
+  # @param health [HealthResult, nil] a health result
+  # @return [Integer] weighted real-wound score
+  def real_wound_score(health)
+    return 0 unless health.respond_to?(:wounds) && health.wounds
+
+    health.wounds.values.flatten.reject { |w| cosmetic_wound?(w) }.sum do |w|
+      w.respond_to?(:severity) && w.severity ? w.severity**2 : 0
+    end
   end
 
   # ============================================================
@@ -388,8 +432,11 @@ class Healer
     wounds = health.wounds
     return HEAL_LOCATIONS.dup unless wounds&.any?
 
+    # Prefer parts with no real wounds. Scars are ignored -- redirecting onto a
+    # scarred part is fine, and counting scars would spread wounds across every
+    # part until none are "available".
     wounded_parts = wounds.values.flatten.select { |w|
-      w.respond_to?(:body_part) && w.respond_to?(:severity) && w.severity > 0
+      w.respond_to?(:body_part) && w.respond_to?(:severity) && w.severity && w.severity > 0 && !cosmetic_wound?(w)
     }.map(&:body_part)
 
     available = HEAL_LOCATIONS.reject { |loc| wounded_parts.include?(loc) }
@@ -517,7 +564,7 @@ class Healer
       return false
     end
 
-    has_wounds = health.wounds&.values&.flatten&.any? { |w| w.respond_to?(:severity) && w.severity > 0 }
+    has_wounds = health.wounds&.values&.flatten&.any? { |w| blocking_self_wound?(w) }
 
     ready = !(
       health.diseased ||
@@ -544,11 +591,12 @@ class Healer
   # @return [void]
   def heal_self
     return if Script.running?('healme')
+    return if dead? # can't heal while a ghost -- avoids spamming dead commands
 
-    # If vitality is low but no wounds, cast VH on self
+    # If vitality is low but no real wounds, cast VH on self
     if DRStats.health < 70 && @vh_available && !spell_conflict?
       health = DRCH.check_health
-      has_wounds = health&.wounds&.values&.flatten&.any? { |w| w.respond_to?(:severity) && w.severity > 0 }
+      has_wounds = health&.wounds&.values&.flatten&.any? { |w| blocking_self_wound?(w) }
       unless has_wounds || health&.poisoned || health&.diseased
         heal_own_vitality
         return
@@ -589,15 +637,15 @@ class Healer
   def wait_for_passive_healing
     elapsed = 0
     health = DRCH.check_health
-    initial_score = health&.score || 0
+    initial_score = real_wound_score(health)
 
     return if initial_score.zero?
 
-    log("Waiting for passive healing (score: #{initial_score})")
+    log("Waiting for passive healing (real-wound score: #{initial_score})")
 
     loop do
       health = DRCH.check_health
-      current_score = health&.score || 0
+      current_score = real_wound_score(health)
 
       break if current_score.zero?
 
@@ -623,6 +671,7 @@ class Healer
   # @return [void]
   def heal_own_vitality
     return unless @vh_available
+    return if dead? # can't prep/cast while a ghost
 
     log("Own vitality low (#{DRStats.health}%), casting VH on self")
     Lich::Messaging.msg('bold', "Healer: Healing own vitality (#{DRStats.health}%)")
@@ -1004,9 +1053,24 @@ class Healer
     end
   end
 
+  # Number of concurrent vit-transfer streams to run this round. Stacking transfers
+  # multiplies drain speed, so the count scales with how much spare vitality we have
+  # above the floor (each stream needs VIT_STACK_HEADROOM% of headroom), capped at
+  # MAX_VIT_STACKS. Thin headroom -> a single, safe stream.
+  # @return [Integer] stacks between 1 and MAX_VIT_STACKS
+  def vit_stack_count
+    headroom = DRStats.health - SELF_VIT_FLOOR
+    return 1 if headroom <= 0
+
+    [[headroom / VIT_STACK_HEADROOM, 1].max, MAX_VIT_STACKS].min
+  end
+
   # State machine for vitality healing via VH spell.
   # Prep-first approach: preps VH before transferring so it can cast immediately
-  # when damage lands. Single transfer per round to prevent runaway drain.
+  # when damage lands. Controlled stacking: runs 1..MAX_VIT_STACKS concurrent drain
+  # streams scaled to spare vitality, then casts VH to refill and re-rounds once own
+  # health recovers to VIT_RESUME_THRESHOLD -- faster than one-per-round without
+  # letting the drain outrun the refill.
   # Phases: :start -> :prepping -> :awaiting_drain -> :recovering (loops)
   # @return [void]
   def process_vitality_slot
@@ -1045,8 +1109,10 @@ class Healer
         return
       end
 
-      # Send vit transfer and check result before advancing.
+      # Controlled stacking: open as many drain streams as our headroom allows.
+      # The first transfer must land; if the patient is gone, bail immediately.
       @drain_landed = false
+      stacks = vit_stack_count
       result = DRC.bput("transfer #{task[:patient]} vit quick", *TRANSFER_RESPONSES)
 
       if result =~ TRANSFER_NOT_FOUND_PATTERN
@@ -1055,8 +1121,16 @@ class Healer
         return
       end
 
-      log("Transferred vitality from #{task[:patient]}, waiting for drain to land")
-      DRC.log_window("Healer: Transferring vitality from #{task[:patient]}", "familiar")
+      # Additional streams (only while still above the floor) to speed the heal.
+      (stacks - 1).times do
+        break if DRStats.health < SELF_VIT_FLOOR
+
+        waitrt?
+        DRC.bput("transfer #{task[:patient]} vit quick", *TRANSFER_RESPONSES)
+      end
+
+      log("Transferred vitality from #{task[:patient]} (#{stacks} stream(s)), waiting for drain to land")
+      DRC.log_window("Healer: Transferring vitality from #{task[:patient]} (#{stacks}x)", "familiar")
       @spell_task[:phase] = :awaiting_drain
       @spell_task[:drain_sent_at] = Time.now
       @spell_task[:timer] = Time.now
@@ -1072,8 +1146,8 @@ class Healer
       end
 
     when :recovering
-      if DRStats.health >= 90
-        # Stable -- check if patient needs more vitality
+      if DRStats.health >= VIT_RESUME_THRESHOLD
+        # Recovered enough -- check if patient needs another round
         victim_health = DRCH.perceive_health_other(task[:patient])
         needs_more = victim_health &&
                      victim_health.vitality &&
@@ -1103,17 +1177,23 @@ class Healer
   end
 
   # Preps the VH spell with mana and cambrinth charges.
-  # Uses fput for each step (brief blocking per command, not full-cycle blocking).
+  # Waits out roundtime/cast-RT before each step so preps aren't swallowed by a
+  # "...wait N seconds" (which previously left nothing prepared and caused repeated
+  # prep attempts). Brief blocking per command, not full-cycle blocking.
   # @return [void]
   def prep_vh_spell
     return unless @vh_spell
 
+    waitrt?
+    waitcastrt?
     fput("prep #{VH_ABBREVIATION} #{@vh_spell[:mana]}")
 
     if @vh_spell[:cambrinth]&.any? && @cambrinth_item
       @vh_spell[:cambrinth].each do |charge|
+        waitrt?
         fput("charge my #{@cambrinth_item} #{charge}")
       end
+      waitrt?
       fput("invoke my #{@cambrinth_item}")
     end
   end
@@ -1164,6 +1244,27 @@ class Healer
   #   2. Wound/patient processing (gated by ready_to_heal_wounds?)
   # @return [void]
   def process_queue
+    # Self-death mode: while a ghost we can't cast, transfer, fall, or perceive --
+    # every command bounces off "You are a ghost!". Idle until resurrected instead
+    # of spamming failed commands (health/prep/cast).
+    if dead?
+      unless @self_dead
+        @self_dead = true
+        Lich::Messaging.msg('bold', 'Healer: You are dead -- waiting for resurrection.')
+        DRC.log_window('Healer: DEAD -- waiting for resurrection', 'familiar')
+      end
+      return
+    end
+
+    if @self_dead
+      @self_dead = false
+      @last_health_check = nil
+      @spell_task = nil
+      @spell_queue.clear
+      Lich::Messaging.msg('bold', 'Healer: Resurrected -- resuming healing.')
+      DRC.log_window('Healer: Resurrected -- resuming', 'familiar')
+    end
+
     # Emergency check -- break all links if health is critically low
     check_emergency_fall
 

--- a/spec/healer_spec.rb
+++ b/spec/healer_spec.rb
@@ -111,6 +111,11 @@ def wound(body_part:, severity: 1, is_internal: false)
   OpenStruct.new(body_part: body_part, severity: severity, is_internal: is_internal)
 end
 
+# Builds a scar-like object (cosmetic; scar? => true)
+def scar(body_part:, severity: 1)
+  OpenStruct.new(body_part: body_part, severity: severity, :scar? => true)
+end
+
 # ============================================================
 # SPECS
 # ============================================================
@@ -118,6 +123,7 @@ end
 RSpec.describe Healer do
   before(:each) do
     reset_data
+    $dead = false
     DRStats.health = 100
     DRStats.guild = 'Empath'
     Harness::DRSpells._set_active_spells({})
@@ -634,6 +640,17 @@ RSpec.describe Healer do
       expect(result).to include('right arm', 'head', 'abdomen', 'back')
     end
 
+    it 'does not exclude a part that only has a scar' do
+      scarred = health_result(
+        wounds: { 1 => [scar(body_part: 'left arm', severity: 1)] },
+        score: 1
+      )
+      allow(DRCH).to receive(:check_health).and_return(scarred)
+
+      result = healer.send(:available_heal_locations)
+      expect(result).to include('left arm')
+    end
+
     it 'returns empty when all heal locations are wounded' do
       all_wounded = Healer::HEAL_LOCATIONS.map.with_index do |part, i|
         wound(body_part: part, severity: (i % 3) + 1)
@@ -807,7 +824,7 @@ RSpec.describe Healer do
       expect(healer.get_patient('Tenuk')[:vh_attempted]).to be true
     end
 
-    it 'waits in recovering phase when health is between floor and stable threshold' do
+    it 'waits in recovering phase when health is between floor and resume threshold' do
       healer = build_healer
       healer.add_patient('Tenuk')
 
@@ -816,12 +833,59 @@ RSpec.describe Healer do
       task = healer.instance_variable_get(:@spell_task)
       task[:phase] = :recovering
       task[:timer] = Time.now
-      DRStats.health = 75
+      DRStats.health = 70 # between SELF_VIT_FLOOR (60) and VIT_RESUME_THRESHOLD (75)
 
       healer.send(:process_vitality_slot)
 
       task = healer.instance_variable_get(:@spell_task)
       expect(task[:phase]).to eq(:recovering)
+    end
+
+    it 'stacks multiple vit-transfer streams when own vitality is high' do
+      healer = build_healer
+      healer.add_patient('Tenuk')
+      healer.instance_variable_set(:@vh_available, true)
+      healer.instance_variable_set(:@vh_spell, { name: 'Vitality Healing', mana: 5, cambrinth: [], prep_time: 0 })
+      DRStats.health = 100 # full headroom -> MAX_VIT_STACKS
+
+      healer.claim_spell_slot('Tenuk', :vitality)
+      task = healer.instance_variable_get(:@spell_task)
+      task[:phase] = :prepping
+      task[:prep_start] = Time.now - 5
+
+      transfers = 0
+      allow(DRC).to receive(:bput) do |cmd, *_|
+        transfers += 1 if cmd == 'transfer Tenuk vit quick'
+        ''
+      end
+
+      healer.send(:process_vitality_slot)
+
+      expect(transfers).to eq(Healer::MAX_VIT_STACKS)
+      expect(healer.instance_variable_get(:@spell_task)[:phase]).to eq(:awaiting_drain)
+    end
+
+    it 'uses a single vit-transfer stream when headroom is thin' do
+      healer = build_healer
+      healer.add_patient('Tenuk')
+      healer.instance_variable_set(:@vh_available, true)
+      healer.instance_variable_set(:@vh_spell, { name: 'Vitality Healing', mana: 5, cambrinth: [], prep_time: 0 })
+      DRStats.health = 65 # just above floor -> only 1 stream
+
+      healer.claim_spell_slot('Tenuk', :vitality)
+      task = healer.instance_variable_get(:@spell_task)
+      task[:phase] = :prepping
+      task[:prep_start] = Time.now - 5
+
+      transfers = 0
+      allow(DRC).to receive(:bput) do |cmd, *_|
+        transfers += 1 if cmd == 'transfer Tenuk vit quick'
+        ''
+      end
+
+      healer.send(:process_vitality_slot)
+
+      expect(transfers).to eq(1)
     end
   end
 
@@ -909,6 +973,30 @@ RSpec.describe Healer do
 
       healer.instance_variable_set(:@last_health_check, nil)
       expect(healer.ready_to_heal_wounds?).to be false
+    end
+
+    it 'stays ready when healer only has cosmetic scars' do
+      scarred = health_result(
+        wounds: { 2 => [scar(body_part: 'left arm', severity: 2)] },
+        score: 4
+      )
+      allow(DRCH).to receive(:check_health).and_return(scarred)
+      DRStats.health = 100
+
+      healer.instance_variable_set(:@last_health_check, nil)
+      expect(healer.ready_to_heal_wounds?).to be true
+    end
+
+    it 'stays ready when healer only has trivial severity-1 abrasions' do
+      abraded = health_result(
+        wounds: { 1 => [wound(body_part: 'left arm', severity: 1)] },
+        score: 1
+      )
+      allow(DRCH).to receive(:check_health).and_return(abraded)
+      DRStats.health = 100
+
+      healer.instance_variable_set(:@last_health_check, nil)
+      expect(healer.ready_to_heal_wounds?).to be true
     end
 
     it 'returns false when healer is poisoned' do
@@ -1115,6 +1203,78 @@ RSpec.describe Healer do
 
       expect(healer.get_patient('Tenuk')[:unity_linked]).to be false
       expect(healer.get_patient('Navesi')[:unity_linked]).to be false
+    end
+  end
+
+  # ============================================================
+  # Self-Death Handling (idle while a ghost, resume on resurrection)
+  # ============================================================
+
+  describe 'self-death handling' do
+    it 'idles instead of processing when the healer is dead' do
+      healer = build_healer
+      healer.add_patient('Tenuk')
+      DRRoom.pcs = ['Tenuk']
+      $dead = true
+
+      expect(DRC).not_to receive(:fix_standing)
+
+      healer.send(:process_queue)
+
+      expect(healer.instance_variable_get(:@self_dead)).to be true
+    end
+
+    it 'skips self-VH prep spam while dead' do
+      healer = build_healer
+      healer.instance_variable_set(:@vh_available, true)
+      healer.instance_variable_set(:@vh_spell, { name: 'Vitality Healing', mana: 5, cambrinth: [], prep_time: 3 })
+      DRStats.health = 0
+      $dead = true
+
+      $sent_messages = []
+      healer.send(:heal_self)
+
+      expect($sent_messages).to be_empty
+    end
+
+    it 'clears self_dead and resumes after resurrection' do
+      healer = build_healer
+      healer.instance_variable_set(:@self_dead, true)
+      $dead = false
+
+      healer.send(:process_queue)
+
+      expect(healer.instance_variable_get(:@self_dead)).to be false
+    end
+  end
+
+  # ============================================================
+  # Passive Heal Detection (recognizes Regenerate)
+  # ============================================================
+
+  describe '#validate_healing_spells' do
+    it 'treats Regenerate as passive healing' do
+      healer = build_healer
+      allow(healer).to receive(:validate_healing_spells).and_call_original
+      Harness::DRSpells._set_known_spells('Regenerate' => true)
+
+      expect(healer.send(:validate_healing_spells)).to be true
+    end
+
+    it 'treats Heal + Adaptive Curing as passive healing' do
+      healer = build_healer
+      allow(healer).to receive(:validate_healing_spells).and_call_original
+      Harness::DRSpells._set_known_spells('Heal' => true, 'Adaptive Curing' => true)
+
+      expect(healer.send(:validate_healing_spells)).to be true
+    end
+
+    it 'falls back to healme without Regenerate or Heal + Adaptive Curing' do
+      healer = build_healer
+      allow(healer).to receive(:validate_healing_spells).and_call_original
+      Harness::DRSpells._set_known_spells('Heal' => true)
+
+      expect(healer.send(:validate_healing_spells)).to be false
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes three failure modes observed in live empath healing sessions, all validated against session logs and the DRCH health parser.

### 1. Stuck spamming `HEALTH` instead of healing
Redirected/Unity wound transfers dump the patient's wounds onto the empath; passive healing then clears them into cosmetic **scars**. The `HEALTH` parser tags scars *and* severity-1 abrasions as real wounds (`common-healing-data.rb`), so `ready_to_heal_wounds?` (which blocked on any `severity > 0`) gated **all** patient work until the empath's own scars faded — polling `HEALTH` every loop the whole time.

- `ready_to_heal_wounds?` and `available_heal_locations` now ignore scars; the ready gate also ignores trivial severity-1 abrasions (they self-heal in seconds).
- `validate_healing_spells` now recognizes **Regenerate** as passive healing (previously only `Heal + Adaptive Curing`), so empaths using the capstone self-heal aren't forced onto the healme fallback.
- `wait_for_passive_healing` now waits on a real (non-scar) wound score, so it resolves when real wounds are gone rather than lingering on scars.

### 2. Stuck repeatedly trying to prep VH
- **No self-death detection:** when the empath died, `DRStats.health` read `0` and it spammed `prep`/`charge`/`invoke`/`cast`, every command bouncing off *"You are a ghost!"*. `process_queue`/`heal_self`/`heal_own_vitality` now bail via `dead?` and idle until resurrection, then resume cleanly.
- **Preps swallowed by roundtime:** `prep_vh_spell` fired `prep`/`charge`/`invoke` with no `waitrt?`/`waitcastrt?`, so a pending *"...wait N seconds"* ate the prep and left nothing to cast, forcing repeated prep attempts. It now waits out RT before each step.

### 3. Vitality flow too slow
`process_vitality_slot` did one transfer per round and waited for own health to reach 90% before the next round. It now runs **controlled stacking**: `1..MAX_VIT_STACKS` concurrent drain streams scaled to spare vitality above the floor (each stream needs `VIT_STACK_HEADROOM`% headroom), casts VH to refill, and re-rounds at `VIT_RESUME_THRESHOLD` (75%) instead of 90% — faster without letting the drain outrun the refill. Thin headroom falls back to a single, safe stream.

## Tests
- Added specs: scar/abrasion gating, scarred parts still available for redirect, self-death idle/resume, Regenerate detection, and stack-count scaling (high vs thin headroom).
- `rspec spec/healer_spec.rb` — 94 examples, 0 failures.
- `rubocop healer.lic spec/healer_spec.rb` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)