### PR TITLE
t2: make shutdown cleanup opt-out via t2_no_kill setting

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -49,6 +49,13 @@ t2_skip_awaken: false
 # This allows one to auto-start t2 safely.
 t2_startup_delay: 0
 
+# Scripts T2 launched that should NOT be stopped when T2 exits. Works like
+# cyclic_no_release: by default T2 stops every script it started itself on
+# shutdown (it never touches scripts you started independently). List script
+# names here to spare them, or use the case-sensitive keyword ALL to spare
+# every script T2 launched.
+t2_no_kill: []
+
 # Combat settings
 # https://elanthipedia.play.net/Lich_script_repository#combat-trainer
 aim_fillers:

--- a/spec/t2_spec.rb
+++ b/spec/t2_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+# T2 spec suite.
+#
+# Focused on shutdown cleanup: T2 must stop only the scripts it launched
+# itself, must honor the t2_no_kill opt-out list, and must never kill a
+# script the operator started independently.
+#
+# Tests are split per method:
+#   - Validation: expected behavior for known-good inputs
+#   - Bug-finding: nil/empty/typed settings, case-sensitivity of the ALL
+#     keyword, running-vs-stopped state, and repeated (idempotent) calls
+
+require 'ostruct'
+
+load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
+include Harness
+
+def load_lic_class(filename, class_name)
+  return if Object.const_defined?(class_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
+  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
+
+  end_idx = nil
+  (start_idx + 1...lines.size).each do |i|
+    if lines[i] =~ /^end\s*$/
+      end_idx = i
+      break
+    end
+  end
+  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
+
+  class_source = lines[start_idx..end_idx].join
+  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
+# -- Module/method stubs --
+# T2's cleanup path calls Script.running? and the top-level stop_script.
+# Both default to safe values; individual tests override via allow().
+
+module Script
+  # Default to "running" so #stop_launched_scripts attempts a kill unless a
+  # test says otherwise. This makes the "spares"/"stops" assertions meaningful.
+  def self.running?(*_args) = true
+end
+
+# Top-level Lich global. Defined so it can be stubbed on a specific instance.
+def stop_script(*_args) = nil
+
+load_lic_class('t2.lic', 'T2')
+
+# Builds a T2 without running the (Lich-dependent) initializer.
+#
+# @param no_kill [Object] value for the t2_no_kill setting (nil, String, Array, ...)
+# @param launched [Array<String>] scripts T2 is treated as having launched
+# @return [T2]
+def build_t2(no_kill: nil, launched: [])
+  t2 = T2.allocate
+  t2.instance_variable_set(:@settings, OpenStruct.new(t2_no_kill: no_kill))
+  t2.instance_variable_set(:@launched_scripts, launched)
+  t2
+end
+
+# ===================================================================
+# T2#scripts_to_spare -- normalizes the t2_no_kill setting to an array
+# ===================================================================
+RSpec.describe 'T2#scripts_to_spare' do
+  it 'returns an empty array when t2_no_kill is unset (nil)' do
+    expect(build_t2(no_kill: nil).scripts_to_spare).to eq([])
+  end
+
+  it 'wraps a bare string value into a single-element array' do
+    expect(build_t2(no_kill: 'magic').scripts_to_spare).to eq(['magic'])
+  end
+
+  it 'passes a list value through unchanged' do
+    expect(build_t2(no_kill: %w[magic pick]).scripts_to_spare).to eq(%w[magic pick])
+  end
+
+  it 'wraps the bare ALL keyword into a single-element array' do
+    expect(build_t2(no_kill: 'ALL').scripts_to_spare).to eq(['ALL'])
+  end
+
+  it 'returns an empty array for an explicitly empty list' do
+    expect(build_t2(no_kill: []).scripts_to_spare).to eq([])
+  end
+end
+
+# ===================================================================
+# T2#spare_all_scripts? -- detects the case-sensitive ALL keyword
+# ===================================================================
+RSpec.describe 'T2#spare_all_scripts?' do
+  it 'is false when t2_no_kill is unset' do
+    expect(build_t2(no_kill: nil).spare_all_scripts?).to be false
+  end
+
+  it 'is true for the bare ALL keyword' do
+    expect(build_t2(no_kill: 'ALL').spare_all_scripts?).to be true
+  end
+
+  it 'is true when ALL appears in a list alongside other names' do
+    expect(build_t2(no_kill: %w[magic ALL]).spare_all_scripts?).to be true
+  end
+
+  it 'is false for a normal script name' do
+    expect(build_t2(no_kill: 'magic').spare_all_scripts?).to be false
+  end
+
+  # BUG-FINDING: ALL is a reserved keyword only in exact upper case. A script
+  # literally named "all" must be treated as a normal name, not a wildcard.
+  it 'is false for lowercase "all" (keyword is case-sensitive)' do
+    expect(build_t2(no_kill: 'all').spare_all_scripts?).to be false
+  end
+
+  # BUG-FINDING: mixed-case variants must not trip the wildcard either.
+  it 'is false for mixed-case "All"' do
+    expect(build_t2(no_kill: 'All').spare_all_scripts?).to be false
+  end
+end
+
+# ===================================================================
+# T2#stop_launched_scripts -- the shutdown cleanup behavior
+# ===================================================================
+RSpec.describe 'T2#stop_launched_scripts' do
+  # Wire a fresh instance whose stop_script calls are recorded.
+  def build_and_watch(no_kill: nil, launched: [])
+    t2 = build_t2(no_kill: no_kill, launched: launched)
+    allow(t2).to receive(:stop_script)
+    t2
+  end
+
+  context 'with no opt-out configured' do
+    it 'stops every script it launched' do
+      t2 = build_and_watch(launched: %w[magic pick foragetask])
+      t2.stop_launched_scripts
+      expect(t2).to have_received(:stop_script).with('magic')
+      expect(t2).to have_received(:stop_script).with('pick')
+      expect(t2).to have_received(:stop_script).with('foragetask')
+    end
+
+    it 'launches nothing to kill when it launched nothing' do
+      t2 = build_and_watch(launched: [])
+      t2.stop_launched_scripts
+      expect(t2).not_to have_received(:stop_script)
+    end
+
+    # BUG-FINDING: a stale entry that is no longer running must be skipped,
+    # not killed (stop_script on a dead script is pointless and noisy).
+    it 'skips launched scripts that are no longer running' do
+      t2 = build_and_watch(launched: %w[magic pick])
+      allow(Script).to receive(:running?).with('magic').and_return(true)
+      allow(Script).to receive(:running?).with('pick').and_return(false)
+      t2.stop_launched_scripts
+      expect(t2).to have_received(:stop_script).with('magic')
+      expect(t2).not_to have_received(:stop_script).with('pick')
+    end
+  end
+
+  context 'with a t2_no_kill list' do
+    it 'spares listed scripts and stops the rest' do
+      t2 = build_and_watch(no_kill: ['magic'], launched: %w[magic pick])
+      t2.stop_launched_scripts
+      expect(t2).not_to have_received(:stop_script).with('magic')
+      expect(t2).to have_received(:stop_script).with('pick')
+    end
+
+    it 'spares multiple listed scripts' do
+      t2 = build_and_watch(no_kill: %w[magic pick], launched: %w[magic pick foragetask])
+      t2.stop_launched_scripts
+      expect(t2).not_to have_received(:stop_script).with('magic')
+      expect(t2).not_to have_received(:stop_script).with('pick')
+      expect(t2).to have_received(:stop_script).with('foragetask')
+    end
+
+    # BUG-FINDING: a spare-list entry for a script T2 never launched is a
+    # harmless no-op and must not raise or affect other scripts.
+    it 'ignores spare-list entries for scripts it never launched' do
+      t2 = build_and_watch(no_kill: %w[hunting-buddy], launched: %w[magic])
+      expect { t2.stop_launched_scripts }.not_to raise_error
+      expect(t2).to have_received(:stop_script).with('magic')
+    end
+  end
+
+  context 'with the ALL keyword' do
+    it 'stops nothing when t2_no_kill is exactly ALL' do
+      t2 = build_and_watch(no_kill: 'ALL', launched: %w[magic pick])
+      t2.stop_launched_scripts
+      expect(t2).not_to have_received(:stop_script)
+    end
+
+    it 'stops nothing when ALL appears anywhere in the list' do
+      t2 = build_and_watch(no_kill: %w[magic ALL], launched: %w[magic pick])
+      t2.stop_launched_scripts
+      expect(t2).not_to have_received(:stop_script)
+    end
+
+    # BUG-FINDING: lowercase "all" is a real script name, not the wildcard,
+    # so everything (including a script named "all") should still be stopped.
+    it 'treats lowercase "all" as a normal name and still stops scripts' do
+      t2 = build_and_watch(no_kill: 'all', launched: %w[magic all])
+      t2.stop_launched_scripts
+      expect(t2).to have_received(:stop_script).with('magic')
+    end
+  end
+
+  context 'adversarial setting shapes' do
+    # BUG-FINDING: a mistyped scalar (number/hash) must not crash cleanup;
+    # it simply matches no script names, so everything is stopped.
+    it 'does not crash on a numeric t2_no_kill and still stops scripts' do
+      t2 = build_and_watch(no_kill: 5, launched: %w[magic])
+      expect { t2.stop_launched_scripts }.not_to raise_error
+      expect(t2).to have_received(:stop_script).with('magic')
+    end
+
+    it 'does not crash when t2_no_kill is unset and nothing was launched' do
+      t2 = build_and_watch(no_kill: nil, launched: [])
+      expect { t2.stop_launched_scripts }.not_to raise_error
+    end
+  end
+
+  context 'called more than once (idempotency)' do
+    # BUG-FINDING: cleanup may run more than once; once a script has stopped,
+    # Script.running? goes false and the second pass must not re-kill it.
+    it 'does not re-stop a script that stopped after the first pass' do
+      t2 = build_and_watch(launched: %w[magic])
+      running = true
+      allow(Script).to receive(:running?).with('magic') { running }
+
+      t2.stop_launched_scripts
+      running = false
+      t2.stop_launched_scripts
+
+      expect(t2).to have_received(:stop_script).with('magic').once
+    end
+  end
+end

--- a/t2.lic
+++ b/t2.lic
@@ -6,7 +6,12 @@
 =end
 
 class T2
+  # Seconds T2 sleeps when it finds nothing to train on a given tick.
   IDLE_SLEEP_DURATION = 60
+
+  # Case-sensitive keyword accepted in the +t2_no_kill+ setting. When present,
+  # every script this T2 instance launched is spared from cleanup on shutdown.
+  KILL_ALL_KEYWORD = 'ALL'
 
   def initialize
     arg_definitions = [
@@ -22,6 +27,9 @@ class T2
     @shutdown = false
 
     @counter = 0
+    # Names of scripts this T2 instance has started, in launch order. Used by
+    # #stop_launched_scripts during shutdown so T2 only ever cleans up after
+    # itself and never kills scripts the user started independently.
     @launched_scripts = []
     @equipment_manager = EquipmentManager.new
 
@@ -194,15 +202,47 @@ class T2
     DRC.message("T2 training_list reloaded.")
     echo @settings.training_list.to_yaml if debug
   end
+
+  # Script names the operator has opted out of shutdown cleanup, taken from the
+  # +t2_no_kill+ setting. The setting mirrors +cyclic_no_release+: it accepts a
+  # single value or a list, either of which is normalized to an array here so
+  # every shape (unset, scalar, list) is handled uniformly.
+  #
+  # @return [Array<String>] script names to spare, or +[KILL_ALL_KEYWORD]+ when
+  #   the operator asked to spare everything.
+  def scripts_to_spare
+    Array(@settings.t2_no_kill)
+  end
+
+  # Whether the operator asked to spare every launched script from cleanup via
+  # the case-sensitive {KILL_ALL_KEYWORD} keyword in +t2_no_kill+.
+  #
+  # @return [Boolean]
+  def spare_all_scripts?
+    scripts_to_spare.include?(KILL_ALL_KEYWORD)
+  end
+
+  # Stops the scripts this T2 instance launched, honoring +t2_no_kill+.
+  #
+  # T2 only ever stops scripts it started itself; scripts the operator started
+  # independently are never touched because they are absent from
+  # +@launched_scripts+. Within that set, any script named in +t2_no_kill+ is
+  # spared, and the {KILL_ALL_KEYWORD} keyword spares all of them. Scripts that
+  # are not currently running are skipped.
+  #
+  # @return [void]
+  def stop_launched_scripts
+    return if spare_all_scripts?
+
+    spared = scripts_to_spare
+    @launched_scripts
+      .reject { |script_name| spared.include?(script_name) }
+      .each { |script_name| stop_script(script_name) if Script.running?(script_name) }
+  end
 end
 
 before_dying do
-  # Clean up only the scripts this T2 instance actually launched
-  if $T2 && $T2.instance_variable_defined?(:@launched_scripts)
-    $T2.instance_variable_get(:@launched_scripts).each do |script_name|
-      stop_script(script_name) if Script.running?(script_name)
-    end
-  end
+  $T2&.stop_launched_scripts
   DRCA.release_cyclics(get_settings.cyclic_no_release)
 end
 


### PR DESCRIPTION
## Summary

When T2 exits it stops the scripts it launched. This PR makes that cleanup opt-out configurable via a new `t2_no_kill` setting, and refactors the logic out of the top-level `before_dying` block so it can be unit-tested.

`t2_no_kill` mirrors `cyclic_no_release`:

- Unset / empty (default): T2 stops every script it launched, exactly as before.
- A list of script names: those scripts are spared; the rest are still stopped.
- The case-sensitive keyword `ALL`: every script T2 launched is spared (T2 death kills nothing).

T2 still only ever touches scripts it started itself (tracked in `@launched_scripts`) - scripts the operator started independently are never stopped, unchanged from current behavior.

## Changes

- `t2.lic`
  - Extract cleanup into `T2#stop_launched_scripts` with `scripts_to_spare` / `spare_all_scripts?` helpers (SRP; testable). `before_dying` now delegates: `$T2&.stop_launched_scripts`.
  - `KILL_ALL_KEYWORD = 'ALL'` constant; `Array(...)` normalizes the setting whether it is unset, a scalar, or a list.
  - YARD docs on the new members.
- `profiles/base.yaml` - documents `t2_no_kill` (default `[]`) next to the other `t2_*` settings.
- `spec/t2_spec.rb` - new suite (23 examples) covering normalization, the case-sensitive `ALL` keyword, spare lists, running-vs-stopped state, adversarial setting shapes (numeric/nil), and idempotent repeated cleanup.

## Testing

- `rspec spec/t2_spec.rb` -> 23 examples, 0 failures
- `rubocop t2.lic spec/t2_spec.rb` -> no offenses
- `ruby -c t2.lic` -> Syntax OK; `base.yaml` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to keep selected launched scripts running when T2 exits.
  * Supports sparing specific script names or all launched scripts with the exact `ALL` value.

* **Bug Fixes**
  * Shutdown cleanup now only stops scripts launched by the current T2 instance.
  * Improves handling of empty, missing, or unusual configuration values during cleanup.

* **Tests**
  * Added coverage for spare-list handling and shutdown behavior, including repeated cleanup calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->