### PR TITLE
paladin-quests: auto-select known Glyph of Bonding fountain reward

### DIFF
--- a/paladin-quests.lic
+++ b/paladin-quests.lic
@@ -3,6 +3,26 @@
 =end
 
 class PaladinQuests
+  # Game response confirming the paladin selected the correct reward from the
+  # Glyph of Bonding fountain. Used both to auto-detect a successful `get` and
+  # to wait out a manual selection.
+  #
+  # @see #choose_fountain_item
+  # @see #bonding
+  CHOSE_WISELY = 'chosen wisely'.freeze
+
+  # Nouns of the known-correct rewards to take from the Glyph of Bonding
+  # fountain. The quest presents an ornate/valuable item alongside a humble one,
+  # and the paladin must "choose wisely" by taking the humble reward.
+  #
+  # Nouns are gathered from player-reported quest logs. For example, GitHub
+  # issue #7461 reported a plain lead "cup" as correct over "The Helm of
+  # Awakening". Add new confirmed-correct nouns here as they are reported.
+  #
+  # @see #choose_fountain_item
+  # @see https://github.com/elanthia-online/dr-scripts/issues/7461
+  BONDING_FOUNTAIN_ITEMS = %w[cup].freeze
+
   def initialize
     unless DRStats.paladin?
       DRC.message '***MUST BE A PALADIN***'
@@ -118,11 +138,32 @@ class PaladinQuests
       exit
     end
 
-    DRC.message '***YOU ARE TAKING CHARGE AGAIN!. You need to look at each item in the fountain and choose wisely between them.' \
-         ' Clue: Paladin defend those that are unable to defend themselves***'
-    waitfor('chosen wisely')
-    DRC.message '***PLEASE SUBMIT AN ISSUE ON GITHUB WITH YOUR FOUNTAIN ITEMS***'
-    DRC.message '***CONGRATS YOU NOW KNOW THE GLYPH OF BONDING***'
+    if choose_fountain_item
+      DRC.message '***CONGRATS YOU NOW KNOW THE GLYPH OF BONDING***'
+    else
+      DRC.message '***COULD NOT AUTO-SELECT A KNOWN REWARD. YOU ARE TAKING CHARGE AGAIN!. You need to look at each item in the' \
+           ' fountain and choose wisely between them. Clue: Paladin defend those that are unable to defend themselves***'
+      waitfor(CHOSE_WISELY)
+      DRC.message '***PLEASE SUBMIT AN ISSUE ON GITHUB WITH YOUR FOUNTAIN ITEMS SO THEY CAN BE ADDED TO THE AUTO-SELECT LIST***'
+      DRC.message '***CONGRATS YOU NOW KNOW THE GLYPH OF BONDING***'
+    end
+  end
+
+  # Attempts to take a known-correct reward from the Glyph of Bonding fountain.
+  #
+  # Each noun in {BONDING_FOUNTAIN_ITEMS} is offered to the game in turn; the
+  # first one present is taken, completing the quest. Nouns that are absent from
+  # this particular fountain fail harmlessly and are skipped, letting the caller
+  # fall back to a manual selection when none of the known items are found.
+  #
+  # @return [Boolean] true once the paladin has "chosen wisely"; false when none
+  #   of the known items were present.
+  # @see BONDING_FOUNTAIN_ITEMS
+  def choose_fountain_item
+    BONDING_FOUNTAIN_ITEMS.any? do |item|
+      result = DRC.bput("get #{item}", CHOSE_WISELY, 'What were you referring', 'I could not find')
+      result&.include?(CHOSE_WISELY)
+    end
   end
 
   def light

--- a/spec/paladin_quests_spec.rb
+++ b/spec/paladin_quests_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# Specs for paladin-quests.lic, focused on the Glyph of Bonding fountain
+# auto-selection logic (PaladinQuests#choose_fountain_item).
+#
+# The quest presents an ornate item alongside a humble one and the paladin must
+# "choose wisely" by taking the humble reward. The script keeps a list of
+# known-correct nouns (gathered from player-reported logs) and takes the first
+# one that the fountain accepts, falling back to a manual selection otherwise.
+#
+# @see PaladinQuests#choose_fountain_item
+# @see https://github.com/elanthia-online/dr-scripts/issues/7461
+
+require 'ostruct'
+
+load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
+include Harness
+
+# Loads a class definition out of a .lic file without executing the top-level
+# code (e.g. `PaladinQuests.new`) that would otherwise drive the live quest.
+#
+# @param filename [String] the .lic file relative to the repo root
+# @param class_name [String] the class to extract and eval
+# @return [void]
+def load_lic_class(filename, class_name)
+  return if Object.const_defined?(class_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
+  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
+
+  end_idx = nil
+  (start_idx + 1...lines.size).each do |i|
+    if lines[i] =~ /^end\s*$/
+      end_idx = i
+      break
+    end
+  end
+  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
+
+  class_source = lines[start_idx..end_idx].join
+  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
+module DRC
+  class << self
+    def bput(*_args); end
+    def message(_msg); end
+  end
+end unless defined?(DRC)
+
+load_lic_class('paladin-quests.lic', 'PaladinQuests')
+
+RSpec.describe PaladinQuests do
+  # Build the instance without running the constructor, which would otherwise
+  # drive the entire quest (guild checks, walking, and interactive prompts).
+  subject(:quest) { described_class.allocate }
+
+  before(:each) do
+    reset_data
+    allow(DRC).to receive(:bput)
+    allow(DRC).to receive(:message)
+  end
+
+  describe 'BONDING_FOUNTAIN_ITEMS' do
+    it 'records the lead cup as a known-correct reward (GitHub issue #7461)' do
+      expect(described_class::BONDING_FOUNTAIN_ITEMS).to include('cup')
+    end
+  end
+
+  describe '#choose_fountain_item' do
+    # The fountain confirms a correct selection with a "chosen wisely" line;
+    # any other line means the item was not in this particular fountain.
+    let(:chosen_wisely_response) do
+      'The cup disappears in a flash of white. A voice says to you, "You have chosen wisely. Receive your reward."'
+    end
+    let(:item_absent_response) { 'What were you referring to?' }
+
+    context 'when a known-correct item is present in the fountain' do
+      before do
+        allow(DRC).to receive(:bput)
+          .with('get cup', 'chosen wisely', anything, anything)
+          .and_return(chosen_wisely_response)
+      end
+
+      it 'returns true once the paladin has chosen wisely' do
+        expect(quest.choose_fountain_item).to be true
+      end
+
+      it 'takes the item by issuing a get for its noun' do
+        quest.choose_fountain_item
+        expect(DRC).to have_received(:bput).with('get cup', 'chosen wisely', anything, anything)
+      end
+    end
+
+    context 'when none of the known items are present in the fountain' do
+      before do
+        allow(DRC).to receive(:bput).and_return(item_absent_response)
+      end
+
+      it 'returns false so the caller can fall back to a manual selection' do
+        expect(quest.choose_fountain_item).to be false
+      end
+    end
+
+    context 'when the fountain gives no recognized response' do
+      before do
+        allow(DRC).to receive(:bput).and_return(nil)
+      end
+
+      it 'returns false rather than raising on a nil response' do
+        expect(quest.choose_fountain_item).to be false
+      end
+    end
+
+    context 'when several known items are configured' do
+      # Verify the iteration and short-circuit behavior independently of the
+      # currently shipped data by substituting a multi-item list.
+      before do
+        stub_const("#{described_class}::BONDING_FOUNTAIN_ITEMS", %w[helm cup goblet])
+        allow(DRC).to receive(:bput).with('get helm', any_args).and_return(item_absent_response)
+        allow(DRC).to receive(:bput).with('get cup', any_args).and_return(chosen_wisely_response)
+        allow(DRC).to receive(:bput).with('get goblet', any_args).and_return(item_absent_response)
+      end
+
+      it 'takes the first item the fountain accepts and stops trying the rest' do
+        expect(quest.choose_fountain_item).to be true
+        expect(DRC).to have_received(:bput).with('get helm', any_args)
+        expect(DRC).to have_received(:bput).with('get cup', any_args)
+        expect(DRC).not_to have_received(:bput).with('get goblet', any_args)
+      end
+    end
+  end
+end

--- a/spec/paladin_quests_spec.rb
+++ b/spec/paladin_quests_spec.rb
@@ -11,8 +11,6 @@
 # @see PaladinQuests#choose_fountain_item
 # @see https://github.com/elanthia-online/dr-scripts/issues/7461
 
-require 'ostruct'
-
 load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
 include Harness
 


### PR DESCRIPTION
## Summary

The Glyph of Bonding quest in `paladin-quests.lic` presents two items in a fountain and the paladin must "choose wisely" by taking the humble item over the ornate one. Until now the script punted this step to a manual handoff (`waitfor('chosen wisely')`) and asked the player to file a GitHub issue listing the items they saw.

This PR starts turning those reports into automation:

- Adds `BONDING_FOUNTAIN_ITEMS`, a list of known-correct reward nouns (seeded with `cup`).
- Adds `#choose_fountain_item`, which offers each known noun to the fountain (`get <noun>`) and takes the first one accepted. Nouns absent from a given fountain fail harmlessly and are skipped.
- Falls back to the existing manual handoff when none of the known items are present, and still asks the player to report their items so the list can grow.

The `get` command and the `"You have chosen wisely"` success response are taken **verbatim** from the player log in #7461, not guessed. The auto-select only ever attempts items on the curated known-correct list, so it cannot grab a wrong item and blow the (irreversible) choice.

Closes #7461.

## Design notes

- DRY: the `"chosen wisely"` match is extracted to a `CHOSE_WISELY` constant shared by the auto-detect path and the manual `waitfor` fallback.
- The not-found matches (`What were you referring` / `I could not find`) are included so `bput` returns cleanly instead of hanging when a known item isn't in that fountain instance.
- Only one confirmed data point exists so far (`cup`). Correctness could in theory depend on the item pairing rather than the item alone, but the manual fallback covers any unknown fountain.

## Testing

Added `spec/paladin_quests_spec.rb` covering:
- the known item present -> returns true and issues the correct `get`,
- no known item present / nil response -> returns false (manual fallback),
- short-circuit iteration when multiple items are configured.

```
6 examples, 0 failures
```

`rubocop -A` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically selects the correct reward at the Glyph of Bonding fountain when a known item is available.
  * Falls back to manual selection when automatic selection cannot identify a valid reward.
  * Confirms successful reward selection before continuing the quest.

* **Tests**
  * Added coverage for successful selection, fallback behavior, unavailable responses, and stopping after the first valid item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->