### PR TITLE
Fix contract-case + wood-saw bugs and add carving/shaping/tinkering belts (#4201, #3167, #1420)

### DIFF
--- a/arrows.lic
+++ b/arrows.lic
@@ -7,7 +7,7 @@ class Arrows
     @settings = get_settings
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @belt = @settings.engineering_belt
+    @belt = @settings.shaping_belt || @settings.engineering_belt # arrows are a shaping product; shaping_belt falls back to engineering_belt (#1420)
     @hometown = @settings.force_crafting_town || @settings.hometown
     @engineering_room = @settings.engineering_room
     @hometown_data = get_data('crafting')['shaping'][@hometown]

--- a/bolts.lic
+++ b/bolts.lic
@@ -9,7 +9,7 @@ class Bolts
     @worn_trashcan_verb = @settings.worn_trashcan_verb
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @belt = @settings.engineering_belt
+    @belt = @settings.tinkering_belt || @settings.engineering_belt # bolts are a tinkering product; tinkering_belt falls back to engineering_belt (#1420)
     @hometown = @settings.force_crafting_town || @settings.hometown
     @engineering_room = @settings.engineering_room
     @hometown_data = get_data('crafting')['shaping'][@hometown]

--- a/carve-bead.lic
+++ b/carve-bead.lic
@@ -42,7 +42,7 @@ class CarveBead
     @immortal_aspect = args.aspect || @settings.immortal_aspect
     @crafting_container = @settings.crafting_container
     @crafting_container_items = @settings.crafting_items_in_container
-    @belt = @settings.engineering_belt
+    @belt = @settings.carving_belt || @settings.engineering_belt # carving_belt, falls back to engineering_belt (#1420)
     @water_holder = @settings.water_holder
     @use_primer = args.primer || @settings['carve-bead']['primer'] || false
     @knife_adjective = @settings['carve-bead']['knife-adjective'] || 'carving'

--- a/carve-lockpicks.lic
+++ b/carve-lockpicks.lic
@@ -40,7 +40,7 @@ class CarveLockpicks
     @settings                   = get_settings
     @bag                        = @settings.crafting_container
     @bag_items                  = @settings.crafting_items_in_container
-    @belt                       = @settings.engineering_belt
+    @belt                       = @settings.carving_belt || @settings.engineering_belt # carving_belt, falls back to engineering_belt (#1420)
     @lockpick_carve_settings    = @settings.lockpick_carve_settings
     @master_batch, @grand_batch = [true, true] if args.ring || @lockpick_carve_settings['ring_picks']
     @grands_ring_ready          = (25 - DRCI.count_items_in_container('lockpick', @lockpick_carve_settings['grand_container']))

--- a/carve.lic
+++ b/carve.lic
@@ -7,7 +7,7 @@ class Carve
     @settings = get_settings
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @belt = @settings.engineering_belt
+    @belt = @settings.carving_belt || @settings.engineering_belt # carving_belt, falls back to engineering_belt (#1420)
     @stamp = @settings.mark_crafted_goods
 
     arg_definitions = [

--- a/clean-lumber.lic
+++ b/clean-lumber.lic
@@ -32,14 +32,7 @@ class CleanLumber
         end
         size = DRC.right_hand.split.last
       end
-      unless DRCC.get_crafting_item('saw', @bag, @bag_items, @belt) != /woodcutting saw|wood saw/
-        DRCC.stow_crafting_item('saw', @bag, @belt)
-        case DRC.bput("get saw from #{@bag}", 'You get', 'What were')
-        when /What were/
-          echo('No saw found')
-          exit
-        end
-      end
+      ensure_wood_saw
       until DRC.bput("cut #{size} with my saw", 'roundtime', 'you complete', 'ready to be carved') =~ /you complete|ready to be carved/
         waitrt?
       end
@@ -64,6 +57,26 @@ class CleanLumber
       end
 
       size = 'deed' if was_deed
+    end
+  end
+
+  # Puts a wood-cutting saw in hand, never a bone saw. get_crafting_item('saw')
+  # matches the first item whose noun is "saw", which can be a bone saw; the
+  # original guard compared its String result to a Regexp (always true) so the
+  # check never ran (issue #3167). If the saw in hand is not a wood saw, stow it
+  # and fetch one by name -- "wood saw" matches woodcutting/wood/woodbutt saws
+  # (adjective prefix match) but never a bone saw.
+  # @return [void]
+  def ensure_wood_saw
+    DRCC.get_crafting_item('saw', @bag, @bag_items, @belt)
+    held_saw = [DRC.right_hand, DRC.left_hand].compact.find { |item| item =~ /saw/i }
+    return if held_saw =~ /wood\w* saw/i
+
+    DRCC.stow_crafting_item('saw', @bag, @belt) if held_saw
+    case DRC.bput("get wood saw from my #{@bag}", 'You get', 'What were')
+    when /What were/
+      echo('No wood saw found - check your engineering/carving/shaping belt or bag')
+      exit
     end
   end
 end

--- a/clean-lumber.lic
+++ b/clean-lumber.lic
@@ -15,7 +15,7 @@ class CleanLumber
     settings = get_settings
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container
-    @belt = settings.engineering_belt
+    @belt = settings.shaping_belt || settings.engineering_belt # lumber prep for shaping; shaping_belt falls back to engineering_belt (#1420)
 
     %w[stick log branch limb deed].each { |size| process_size(args, size) }
   end

--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -299,6 +299,18 @@ card_bags:
   specific_descriptions:
     card-collector: Sets bag to draw cards from (fresh) and bag to place duplicates and your case(duplicates)
 
+carving_belt:
+  description: Carving belt name and list of tools; overrides engineering_belt for carving scripts when set (issue #1420).
+  example: https://github.com/elanthia-online/dr-scripts/wiki/Crafting-Setup#tools (see Toolbelts section)
+  referenced_by:
+    - carve
+    - carve-bead
+    - carve-lockpicks
+  specific_descriptions:
+    carve: Use and stow carving tools from here (falls back to engineering_belt).
+    carve-bead: Use and stow bead carving tools from here (falls back to engineering_belt).
+    carve-lockpicks: Use and stow lockpick carving tools from here (falls back to engineering_belt).
+
 circlecheck_prettyprint:
   description: Tells circlecheck to use the pretty print formatting for output.
   example: true/false
@@ -517,22 +529,30 @@ enchanting_tools:
     clerk-tools: Get and store these tools with clerk.
 
 engineering_belt:
-  description: Specify engineering belt name and list of tools.
+  description: Engineering belt name and list of tools. Used by every Engineering sub-discipline; set carving_belt, shaping_belt, or tinkering_belt to override it for those scripts (issue #1420).
   example: https://github.com/elanthia-online/dr-scripts/wiki/Crafting-Setup#tools (see Toolbelts section)
   referenced_by:
     - arrows
     - bolts
     - carve-bead
     - carve
+    - carve-lockpicks
     - clean-lumber
     - clerk-tools
+    - fir
+    - shape
+    - tinker
   specific_descriptions:
-    arrows: Use and stow arrow crafting tools from here.
-    bolts: Use and stow bolt crafting tools from here.
-    carve-bead: Use and stow carve bead tools from here.
-    carve: Use and stow carve tools from here.
-    clean-lumber: Use and stow lumber cleaning tools here.
+    arrows: Use and stow arrow crafting tools from here (fallback for shaping_belt).
+    bolts: Use and stow bolt crafting tools from here (fallback for tinkering_belt).
+    carve-bead: Use and stow carve bead tools from here (fallback for carving_belt).
+    carve: Use and stow carve tools from here (fallback for carving_belt).
+    carve-lockpicks: Use and stow lockpick carving tools from here (fallback for carving_belt).
+    clean-lumber: Use and stow lumber cleaning tools here (fallback for shaping_belt).
     clerk-tools: Get and stow engineering/shaping tools from belt after storing with clerk.
+    fir: Use and stow the carving knife from here (fallback for shaping_belt).
+    shape: Use and stow shaping tools from here (fallback for shaping_belt).
+    tinker: Use and stow tinkering tools from here (fallback for tinkering_belt).
 
 engineering_room:
   description: Room in which to perform engineering training tasks.
@@ -964,6 +984,20 @@ safe_room:
   specific_descriptions:
     athletics: If specified, walks to your safe room first for athletics training.
 
+shaping_belt:
+  description: Shaping belt name and list of tools; overrides engineering_belt for shaping scripts when set (issue #1420).
+  example: https://github.com/elanthia-online/dr-scripts/wiki/Crafting-Setup#tools (see Toolbelts section)
+  referenced_by:
+    - shape
+    - arrows
+    - clean-lumber
+    - fir
+  specific_descriptions:
+    shape: Use and stow shaping tools from here (falls back to engineering_belt).
+    arrows: Use and stow arrow crafting tools from here (falls back to engineering_belt).
+    clean-lumber: Use and stow lumber-cleaning tools from here (falls back to engineering_belt).
+    fir: Use and stow the carving knife from here (falls back to engineering_belt).
+
 shaping_tools:
   description: List of tools used for shaping.
   example: "- carving knife, - shaper, - drawknife"
@@ -1149,6 +1183,16 @@ theurgy_supply_container:
     - carve-bead
   specific_descriptions:
     carve-bead: Holds your bead carving materials.
+
+tinkering_belt:
+  description: Tinkering belt name and list of tools; overrides engineering_belt for tinkering scripts when set (issue #1420).
+  example: https://github.com/elanthia-online/dr-scripts/wiki/Crafting-Setup#tools (see Toolbelts section)
+  referenced_by:
+    - tinker
+    - bolts
+  specific_descriptions:
+    tinker: Use and stow tinkering tools from here (falls back to engineering_belt).
+    bolts: Use and stow bolt crafting tools from here (falls back to engineering_belt).
 
 training_box_list:
   description: Array of daily use training boxes for use with locksmithing

--- a/fir.lic
+++ b/fir.lic
@@ -15,7 +15,7 @@ class FirQuest
     @settings = get_settings
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @belt = @settings.engineering_belt
+    @belt = @settings.shaping_belt || @settings.engineering_belt # uses a carving knife (a shaping tool); shaping_belt falls back to engineering_belt (#1420)
 
     if args.number
       if args.number.to_i > 3

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1011,6 +1011,11 @@ custom_clerk_tools:
 
 forging_belt:
 engineering_belt:
+# carving_belt / shaping_belt / tinkering_belt each override engineering_belt for that
+# Engineering sub-discipline; leave unset to keep using engineering_belt (issue #1420)
+carving_belt:
+shaping_belt:
+tinkering_belt:
 outfitting_belt:
 alchemy_belt:
 enchanting_belt:

--- a/repair.lic
+++ b/repair.lic
@@ -44,12 +44,7 @@ class Repair
     @craft_data     = get_data('crafting')['blacksmithing'][@town]
     @equipmanager   = EquipmentManager.new
 
-    @toolbelts_list = []
-    @toolset_list   = []
-    @disciplines.each do |name|
-      @toolbelts_list << @settings.send(name + '_belt')
-      @toolset_list   << @settings.send(name + '_tools')
-    end
+    @toolbelts_list, @toolset_list = build_tool_lists
 
     if @town == 'Fang Cove' && fang_closed?
       DRC.message('Fang Cove repair personnel are sleeping off their latest hangover, and are not available for repairs at this hour. Try back between mid-morning and sunset')
@@ -239,6 +234,25 @@ class Repair
       pause 0.01 until (item = [DRC.right_hand, DRC.left_hand].compact.first) # waits for repaired item to hit your hand
       smart_stow_gear(item)
     end
+  end
+
+  # Builds the toolbelt and toolset lists from the per-discipline *_belt and
+  # *_tools settings, skipping any discipline that has neither configured.
+  # Excluding nils is required so smart_get_gear/smart_stow_gear never call
+  # belt["items"] or tools.any? on nil -- common now that carving/shaping/
+  # tinkering belts are separate from engineering_belt and are often left
+  # unset (issue #1420).
+  # @return [Array(Array<Hash>, Array<Array>)] the [toolbelts, toolsets] pair
+  def build_tool_lists
+    toolbelts = []
+    toolsets  = []
+    @disciplines.each do |name|
+      belt  = @settings.send(name + '_belt')
+      tools = @settings.send(name + '_tools')
+      toolbelts << belt if belt
+      toolsets  << tools if tools
+    end
+    [toolbelts, toolsets]
   end
 
   def smart_get_gear(gear_item)

--- a/shape.lic
+++ b/shape.lic
@@ -10,7 +10,7 @@ class Shape
     @worn_trashcan_verb = @settings.worn_trashcan_verb
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @belt = @settings.engineering_belt
+    @belt = @settings.shaping_belt || @settings.engineering_belt # shaping_belt, falls back to engineering_belt (#1420)
     @stamp = @settings.mark_crafted_goods
 
     arg_definitions = [

--- a/spec/clean_lumber_spec.rb
+++ b/spec/clean_lumber_spec.rb
@@ -1,0 +1,121 @@
+require 'ostruct'
+
+# Load test harness which provides mock game objects
+load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
+include Harness
+
+# Extract and eval a class from a .lic file without executing top-level code
+def load_lic_class(filename, class_name)
+  return if Object.const_defined?(class_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
+  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
+
+  end_idx = nil
+  (start_idx + 1...lines.size).each do |i|
+    if lines[i] =~ /^end\s*$/
+      end_idx = i
+      break
+    end
+  end
+  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
+
+  class_source = lines[start_idx..end_idx].join
+  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
+# Stub game-interaction modules. Behaviour is set per-example with allow().
+module DRC
+  def self.bput(*_args); end
+
+  def self.right_hand; end
+
+  def self.left_hand; end
+end
+
+module DRCC
+  def self.get_crafting_item(*_args); end
+
+  def self.stow_crafting_item(*_args); end
+end
+
+load_lic_class('clean-lumber.lic', 'CleanLumber')
+
+RSpec.describe CleanLumber do
+  # ensure_wood_saw depends only on @bag / @bag_items / @belt, so a bare
+  # allocated instance with those injected isolates the saw-selection logic.
+  let(:cleaner) { CleanLumber.allocate }
+
+  before(:each) do
+    cleaner.instance_variable_set(:@bag, 'backpack')
+    cleaner.instance_variable_set(:@bag_items, [])
+    cleaner.instance_variable_set(:@belt, nil)
+
+    allow(DRCC).to receive(:get_crafting_item)
+    allow(DRCC).to receive(:stow_crafting_item)
+    allow(DRC).to receive(:bput).and_return('You get')
+    allow(DRC).to receive(:left_hand).and_return(nil)
+    allow(cleaner).to receive(:echo)
+    allow(cleaner).to receive(:exit)
+  end
+
+  def with_saw_in_right_hand(item)
+    allow(DRC).to receive(:right_hand).and_return(item)
+  end
+
+  # Issue #3167: the original guard compared get_crafting_item's String result
+  # to a Regexp (always true), so the wood-saw check never ran and a bone saw
+  # could be used to cut lumber.
+  describe '#ensure_wood_saw' do
+    context 'when a wood-cutting saw is already in hand' do
+      ['a wood saw', 'a woodcutting saw', 'a woodbutt saw'].each do |saw|
+        it "accepts #{saw.inspect} without swapping" do
+          with_saw_in_right_hand(saw)
+          cleaner.ensure_wood_saw
+          expect(DRCC).not_to have_received(:stow_crafting_item)
+          expect(DRC).not_to have_received(:bput)
+        end
+      end
+
+      it 'accepts a wood saw held in the off-hand' do
+        allow(DRC).to receive(:right_hand).and_return(nil)
+        allow(DRC).to receive(:left_hand).and_return('a woodcutting saw')
+        cleaner.ensure_wood_saw
+        expect(DRC).not_to have_received(:bput)
+      end
+    end
+
+    context 'when a bone saw is grabbed instead of a wood saw' do
+      before(:each) { with_saw_in_right_hand('a bone saw') }
+
+      it 'stows the bone saw and fetches a wood saw by name' do
+        cleaner.ensure_wood_saw
+        expect(DRCC).to have_received(:stow_crafting_item).with('saw', 'backpack', nil)
+        expect(DRC).to have_received(:bput).with('get wood saw from my backpack', 'You get', 'What were')
+      end
+
+      it 'exits when no wood saw can be found' do
+        allow(DRC).to receive(:bput).and_return('What were')
+        cleaner.ensure_wood_saw
+        expect(cleaner).to have_received(:echo)
+        expect(cleaner).to have_received(:exit)
+      end
+    end
+
+    context 'when no saw ends up in either hand' do
+      before(:each) do
+        allow(DRC).to receive(:right_hand).and_return(nil)
+        allow(DRC).to receive(:left_hand).and_return(nil)
+      end
+
+      it 'does not try to stow nothing, and fetches a wood saw' do
+        cleaner.ensure_wood_saw
+        expect(DRCC).not_to have_received(:stow_crafting_item)
+        expect(DRC).to have_received(:bput).with('get wood saw from my backpack', 'You get', 'What were')
+      end
+    end
+  end
+end

--- a/spec/repair_spec.rb
+++ b/spec/repair_spec.rb
@@ -1,0 +1,155 @@
+require 'ostruct'
+
+# Load test harness which provides mock game objects
+load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
+include Harness
+
+# Extract and eval a class from a .lic file without executing top-level code
+def load_lic_class(filename, class_name)
+  return if Object.const_defined?(class_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
+  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
+
+  end_idx = nil
+  (start_idx + 1...lines.size).each do |i|
+    if lines[i] =~ /^end\s*$/
+      end_idx = i
+      break
+    end
+  end
+  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
+
+  class_source = lines[start_idx..end_idx].join
+  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
+# Stub crafting-item helpers used by smart_get_gear / smart_stow_gear.
+module DRCC
+  def self.get_crafting_item(*_args); end
+
+  def self.stow_crafting_item(*_args); end
+end
+
+module DRCI
+  def self.get_item?(*_args); end
+
+  def self.put_away_item?(*_args); end
+end
+
+load_lic_class('repair.lic', 'Repair')
+
+RSpec.describe Repair do
+  # The methods under test read only @disciplines / @settings (build_tool_lists)
+  # and @toolbelts_list / @toolset_list / @bag / @bag_items (smart_get/stow), so
+  # a bare allocated instance with those injected isolates the belt logic.
+  let(:repair) { Repair.allocate }
+
+  # Real discipline order from Repair#initialize; the new sub-discipline belts
+  # (carving/shaping/tinkering) live between forging and outfitting.
+  let(:disciplines) { %w[forging tinkering carving shaping outfitting alchemy enchanting engineering] }
+
+  describe '#build_tool_lists' do
+    before(:each) { repair.instance_variable_set(:@disciplines, disciplines) }
+
+    # Issue #1420: carving_belt/shaping_belt/tinkering_belt are new and usually
+    # unset, so @settings.send('carving_belt') is nil. The list must exclude
+    # those nils or smart_get_gear/smart_stow_gear crash on belt["items"].
+    it 'excludes disciplines whose belt is unset (nil), leaving no nil holes' do
+      repair.instance_variable_set(:@settings, OpenStruct.new(
+                                                 forging_belt: { 'name' => 'forging belt', 'items' => ['hammer'] },
+                                                 engineering_belt: { 'name' => 'engineering belt', 'items' => ['shaper'] }
+                                               ))
+      toolbelts, = repair.build_tool_lists
+      expect(toolbelts).not_to include(nil)
+      expect(toolbelts).to contain_exactly(
+        { 'name' => 'forging belt', 'items' => ['hammer'] },
+        { 'name' => 'engineering belt', 'items' => ['shaper'] }
+      )
+    end
+
+    it 'excludes disciplines whose tools are unset (nil)' do
+      repair.instance_variable_set(:@settings, OpenStruct.new(
+                                                 forging_tools: %w[hammer tongs]
+                                               ))
+      _, toolsets = repair.build_tool_lists
+      expect(toolsets).not_to include(nil)
+      expect(toolsets).to eq([%w[hammer tongs]])
+    end
+
+    it 'includes a configured sub-discipline belt (carving_belt)' do
+      carving = { 'name' => 'carving belt', 'items' => ['rasp'] }
+      engineering = { 'name' => 'engineering belt', 'items' => ['shaper'] }
+      repair.instance_variable_set(:@settings, OpenStruct.new(carving_belt: carving, engineering_belt: engineering))
+      toolbelts, = repair.build_tool_lists
+      expect(toolbelts).to contain_exactly(carving, engineering)
+    end
+
+    it 'returns two empty lists when nothing is configured' do
+      repair.instance_variable_set(:@settings, OpenStruct.new)
+      expect(repair.build_tool_lists).to eq([[], []])
+    end
+  end
+
+  describe '#smart_get_gear' do
+    before(:each) do
+      repair.instance_variable_set(:@bag, 'backpack')
+      repair.instance_variable_set(:@bag_items, [])
+      repair.instance_variable_set(:@toolset_list, [])
+      allow(DRCC).to receive(:get_crafting_item)
+    end
+
+    it 'fetches a tool from the belt whose items include it' do
+      belt = { 'name' => 'engineering belt', 'items' => ['shaper', 'carving knife'] }
+      repair.instance_variable_set(:@toolbelts_list, [belt])
+      repair.smart_get_gear('shaper')
+      expect(DRCC).to have_received(:get_crafting_item).with('shaper', 'backpack', [], belt)
+    end
+
+    it 'returns false for a nil gear_item without touching the belts' do
+      repair.instance_variable_set(:@toolbelts_list, [])
+      expect(repair.smart_get_gear(nil)).to be false
+      expect(DRCC).not_to have_received(:get_crafting_item)
+    end
+
+    # End-to-end: a realistic config (only forging + engineering belts set) must
+    # build a nil-free list and resolve a tool without a NoMethodError -- the
+    # crash the #1420 nil-guard prevents.
+    it 'resolves a tool end-to-end from a config with unset sub-belts, without crashing' do
+      repair.instance_variable_set(:@disciplines, disciplines)
+      repair.instance_variable_set(:@settings, OpenStruct.new(
+                                                 forging_belt: { 'name' => 'forging belt', 'items' => ['hammer'] },
+                                                 engineering_belt: { 'name' => 'engineering belt', 'items' => ['shaper'] }
+                                               ))
+      toolbelts, toolsets = repair.build_tool_lists
+      repair.instance_variable_set(:@toolbelts_list, toolbelts)
+      repair.instance_variable_set(:@toolset_list, toolsets)
+      expect { repair.smart_get_gear('shaper') }.not_to raise_error
+      expect(DRCC).to have_received(:get_crafting_item).with('shaper', 'backpack', [], hash_including('name' => 'engineering belt'))
+    end
+  end
+
+  describe '#smart_stow_gear' do
+    before(:each) do
+      repair.instance_variable_set(:@bag, 'backpack')
+      repair.instance_variable_set(:@toolset_list, [])
+      allow(DRCC).to receive(:stow_crafting_item)
+    end
+
+    it 'stows a tool into the belt whose items include it' do
+      belt = { 'name' => 'forging belt', 'items' => %w[hammer tongs] }
+      repair.instance_variable_set(:@toolbelts_list, [belt])
+      repair.smart_stow_gear('hammer')
+      expect(DRCC).to have_received(:stow_crafting_item).with('hammer', 'backpack', belt)
+    end
+
+    it 'returns true for a nil gear_item without touching the belts' do
+      repair.instance_variable_set(:@toolbelts_list, [])
+      expect(repair.smart_stow_gear(nil)).to be true
+      expect(DRCC).not_to have_received(:stow_crafting_item)
+    end
+  end
+end

--- a/spec/trade_spec.rb
+++ b/spec/trade_spec.rb
@@ -1,0 +1,106 @@
+require 'ostruct'
+
+# Load test harness which provides mock game objects
+load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
+include Harness
+
+# Extract and eval a class from a .lic file without executing top-level code
+def load_lic_class(filename, class_name)
+  return if Object.const_defined?(class_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
+  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
+
+  end_idx = nil
+  (start_idx + 1...lines.size).each do |i|
+    if lines[i] =~ /^end\s*$/
+      end_idx = i
+      break
+    end
+  end
+  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
+
+  class_source = lines[start_idx..end_idx].join
+  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
+# Minimal stub modules for game interaction. bput is overridden per-example via
+# allow(); list_to_array and get_noun mirror the real DRC helpers (themselves
+# covered in lich-5 common_spec) so find_contracts' filtering is exercised end
+# to end.
+module DRC
+  def self.bput(*_args); end
+
+  def self.list_to_array(text)
+    return [] if text.nil?
+
+    text.strip.split(/,\s*|\s+and\s+/).map(&:strip).reject(&:empty?)
+  end
+
+  def self.get_noun(long_name)
+    return nil if long_name.nil?
+
+    long_name.strip.scan(/[a-z\-']+$/i).first
+  end
+end
+
+# fput is a top-level game command; record calls so the reopen path is testable.
+$fput_calls = []
+def fput(*args)
+  $fput_calls << args.first
+end
+
+load_lic_class('trade.lic', 'Trade')
+
+RSpec.describe Trade do
+  # find_contracts takes only a container noun; no instance state is needed,
+  # so a bare allocated instance keeps the parse/filter logic isolated.
+  let(:trade) { Trade.allocate }
+
+  before(:each) { $fput_calls = [] }
+
+  # Issue #4201: the container is rummaged and each entry kept only if it is
+  # actually a contract. The bug was a substring match (item.include?('contract'))
+  # that also matched a "contract case", so the fix matches on the item noun.
+  describe '#find_contracts' do
+    def stub_look(*items)
+      sentence = items.join(', ')
+      allow(DRC).to receive(:bput).and_return("you see #{sentence}.")
+    end
+
+    it 'keeps a real contract and rejects a contract case in the same container' do
+      stub_look('a Trading contract', 'a contract case', 'some silver coins')
+      expect(trade.find_contracts('backpack')).to eq(['a Trading contract'])
+    end
+
+    it 'rejects a contract case even when it is the only item (the exact #4201 bug)' do
+      stub_look('a contract case')
+      expect(trade.find_contracts('backpack')).to eq([])
+    end
+
+    it 'returns every contract when several are present' do
+      stub_look('a Trading contract', 'a Trading contract', 'a contract case')
+      expect(trade.find_contracts('backpack')).to eq(['a Trading contract', 'a Trading contract'])
+    end
+
+    it 'returns an empty array when no contracts are present' do
+      stub_look('a contract case', 'a leather duffel bag', 'some grass')
+      expect(trade.find_contracts('backpack')).to eq([])
+    end
+
+    it 'does not match a plural "contracts" noun (only a single contract counts)' do
+      stub_look('a bundle of contracts', 'a Trading contract')
+      expect(trade.find_contracts('backpack')).to eq(['a Trading contract'])
+    end
+
+    it 'reopens a closed container and retries before parsing' do
+      responses = ['That is closed', 'you see a Trading contract.']
+      allow(DRC).to receive(:bput) { responses.shift }
+      expect(trade.find_contracts('contract case')).to eq(['a Trading contract'])
+      expect($fput_calls).to include('open my contract case')
+    end
+  end
+end

--- a/tinker.lic
+++ b/tinker.lic
@@ -8,7 +8,7 @@ class Tinker
     @hometown = @settings.force_crafting_town || @settings.hometown
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
-    @belt = @settings.engineering_belt
+    @belt = @settings.tinkering_belt || @settings.engineering_belt # tinkering_belt, falls back to engineering_belt (#1420)
     @cube = @settings.cube_armor_piece
     @engineering_belt = @settings.engineering_belt
     @stamp = @settings.mark_crafted_goods

--- a/trade.lic
+++ b/trade.lic
@@ -801,7 +801,13 @@ class Trade
     contract
   end
 
-  def find_contracts(container) # returns an array of the contracts in the container
+  # Reads the contract container and returns only actual contracts. Matches on
+  # the item noun rather than a substring so a "contract case" (noun: "case")
+  # is not mistaken for a contract (noun: "contract") -- see issue #4201.
+  # Reopens the container and retries once if it reports as closed.
+  # @param container [String] noun of the worn contract container to search
+  # @return [Array<String>] descriptions of the contracts found (empty if none)
+  def find_contracts(container)
     result = DRC.bput("look in my #{container}", 'That is closed', 'you see .*', 'While it\'s closed', 'I could not find', 'There is nothing')
     case result
     when 'That is closed'
@@ -809,7 +815,7 @@ class Trade
       return find_contracts(container)
     end
     text = result.match(/you see (.*)\.$/).to_a[1]
-    DRC.list_to_array(text).select { |item| item.include?('contract') }
+    DRC.list_to_array(text).select { |item| DRC.get_noun(item) == 'contract' }
   end
 
   def count_grass # sets @current_grass_count of grass in feedbag

--- a/trade.lic
+++ b/trade.lic
@@ -2231,29 +2231,34 @@ class Trade
     return_to_caravan
     inventory = get_storage_inventory
     town = closest_town
-    @crafting_override.select { |_discipline, data| inventory.group_by(&:itself)[data['recipe'].split.last].length > 4 }
-                      .select { |discipline, _data| @crafting_data[discipline][town] && time_to_room(Room.current.id, @crafting_data[discipline][town]['stock-room']) < 10.0 }
-                      .select { |_discipline, data| data['workorder'] }
-                      .each do  |discipline, data|
-      info = @crafting_data[discipline][town]
-      recipes = @recipe_data.crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && /#{@crafting_override[discipline]['recipe']}/ =~ recipe['name'] }
-      echo recipes
-      item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], data['difficulty'])
-      if item_name.nil?
-        @crafting_override[discipline]['workorder'] = false
-        DRC.message('Could not find a workorder for the item')
-        return turn_in_items
-      end
+    # Handle one eligible override per call, then recurse. The previous .each
+    # unconditionally returned on its first iteration (Lint/UnreachableLoop);
+    # taking .first preserves that single-iteration behaviour explicitly.
+    selected = @crafting_override.select { |_discipline, data| inventory.group_by(&:itself)[data['recipe'].split.last].length > 4 }
+                                 .select { |discipline, _data| @crafting_data[discipline][town] && time_to_room(Room.current.id, @crafting_data[discipline][town]['stock-room']) < 10.0 }
+                                 .select { |_discipline, data| data['workorder'] }
+                                 .first
+    return unless selected
 
-      return_to_caravan
-      quantity.times do
-        break unless get_item_from_storage_box?(data['recipe'].split.last)
-
-        DRCC.logbook_item(info['logbook'], data['recipe'].split.last, @craft_bag)
-      end
-      complete_work_order(info)
+    discipline, data = selected
+    info = @crafting_data[discipline][town]
+    recipes = @recipe_data.crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && /#{@crafting_override[discipline]['recipe']}/ =~ recipe['name'] }
+    echo recipes
+    item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], data['difficulty'])
+    if item_name.nil?
+      @crafting_override[discipline]['workorder'] = false
+      DRC.message('Could not find a workorder for the item')
       return turn_in_items
     end
+
+    return_to_caravan
+    quantity.times do
+      break unless get_item_from_storage_box?(data['recipe'].split.last)
+
+      DRCC.logbook_item(info['logbook'], data['recipe'].split.last, @craft_bag)
+    end
+    complete_work_order(info)
+    turn_in_items
   end
 
   def complete_work_order(info)


### PR DESCRIPTION
Revives three issues that were closed as "not planned" years ago but are still valid, plus a lint cleanup on a touched file. Each change is grounded in the current code and covered by adversarial specs.

## #4201 - trade confused by a contract case
`find_contracts` filtered the contract container with `item.include?('contract')`, which also matches "a contract case"; the script then tried to `read` a non-existent contract from it and stalled. Now matches on the item noun (`DRC.get_noun(item) == 'contract'`), keeping "a Trading contract" and rejecting "a contract case". The reporter's original "contract," idea failed because a lone contract has no trailing comma.

## #3167 - clean-lumber used a bone saw
The saw check was dead code: `unless get_crafting_item('saw', ...) != /wood saw/` compared a String/nil to a Regexp (always true), so `unless true` never ran and the first item with noun "saw" (a bone saw qualifies) was used. Extracted `ensure_wood_saw`: fetch a saw, and if the one in hand is not a wood saw (`/wood\w* saw/i` matches woodcutting/wood/woodbutt, not bone), stow it and fetch "wood saw" by name. Per DR item matching, "wood saw" matches woodcutting/wood/woodbutt saws (adjective prefix) but never a bone saw; "woodcutting saw" would miss a plain "wood saw", so the broad noun is deliberate.

## #1420 - split engineering_belt into carving/shaping/tinkering
Carving, shaping, and tinkering use different tool sets (verified on Elanthipedia's Crafting tools page), and dr-scripts already splits `carving_tools`/`shaping_tools`/`tinkering_tools` while forcing a single `engineering_belt`. Adds `carving_belt` / `shaping_belt` / `tinkering_belt`, each falling back to `engineering_belt` so existing configs are untouched (`X_belt || engineering_belt`, the idiom already at restock-shop.lic). Mapping by what each script crafts/delegates to:

- carving: carve, carve-bead, carve-lockpicks
- shaping: shape, arrows (delegates to shape), clean-lumber (prep), fir
- tinkering: tinker, bolts (delegates to tinker)

Forging is intentionally left as one belt: weaponsmithing/armorsmithing/blacksmithing share the same hand tools and forge.lic handles all three.

Also fixes a latent crash this exposes: repair.lic built its toolbelt/toolset lists including `nil` for unset disciplines (carving/shaping/tinkering are usually unset), and `smart_get_gear`/`smart_stow_gear` then called `belt["items"]` / `tools.any?` on nil. Extracted `build_tool_lists`, which skips nils. base.yaml and base-help.yaml document the three new keys.

## trade.lic lint cleanup
Drove trade.lic to zero rubocop offenses. The one non-autocorrectable offense was `Lint/UnreachableLoop` in `turn_in_items` (a select-chain `.each` that unconditionally returned on its first iteration); replaced with `.first` + guard, preserving the single-iteration-then-recurse behaviour.

## Testing
New adversarial specs: `spec/trade_spec.rb`, `spec/clean_lumber_spec.rb`, `spec/repair_spec.rb` (22 examples). All green; touched files are rubocop-clean.

Generated with [Claude Code](https://claude.com/claude-code)
