### PR TITLE
trade: match contracts by noun so a contract case is not a contract (#4201)

### DIFF
--- a/spec/trade_spec.rb
+++ b/spec/trade_spec.rb
@@ -1,0 +1,106 @@
+require 'ostruct'
+
+# Load test harness which provides mock game objects
+load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
+include Harness
+
+# Extract and eval a class from a .lic file without executing top-level code
+def load_lic_class(filename, class_name)
+  return if Object.const_defined?(class_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
+  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
+
+  end_idx = nil
+  (start_idx + 1...lines.size).each do |i|
+    if lines[i] =~ /^end\s*$/
+      end_idx = i
+      break
+    end
+  end
+  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
+
+  class_source = lines[start_idx..end_idx].join
+  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
+# Minimal stub modules for game interaction. bput is overridden per-example via
+# allow(); list_to_array and get_noun mirror the real DRC helpers (themselves
+# covered in lich-5 common_spec) so find_contracts' filtering is exercised end
+# to end.
+module DRC
+  def self.bput(*_args); end
+
+  def self.list_to_array(text)
+    return [] if text.nil?
+
+    text.strip.split(/,\s*|\s+and\s+/).map(&:strip).reject(&:empty?)
+  end
+
+  def self.get_noun(long_name)
+    return nil if long_name.nil?
+
+    long_name.strip.scan(/[a-z\-']+$/i).first
+  end
+end
+
+# fput is a top-level game command; record calls so the reopen path is testable.
+$fput_calls = []
+def fput(*args)
+  $fput_calls << args.first
+end
+
+load_lic_class('trade.lic', 'Trade')
+
+RSpec.describe Trade do
+  # find_contracts takes only a container noun; no instance state is needed,
+  # so a bare allocated instance keeps the parse/filter logic isolated.
+  let(:trade) { Trade.allocate }
+
+  before(:each) { $fput_calls = [] }
+
+  # Issue #4201: the container is rummaged and each entry kept only if it is
+  # actually a contract. The bug was a substring match (item.include?('contract'))
+  # that also matched a "contract case", so the fix matches on the item noun.
+  describe '#find_contracts' do
+    def stub_look(*items)
+      sentence = items.join(', ')
+      allow(DRC).to receive(:bput).and_return("you see #{sentence}.")
+    end
+
+    it 'keeps a real contract and rejects a contract case in the same container' do
+      stub_look('a Trading contract', 'a contract case', 'some silver coins')
+      expect(trade.find_contracts('backpack')).to eq(['a Trading contract'])
+    end
+
+    it 'rejects a contract case even when it is the only item (the exact #4201 bug)' do
+      stub_look('a contract case')
+      expect(trade.find_contracts('backpack')).to eq([])
+    end
+
+    it 'returns every contract when several are present' do
+      stub_look('a Trading contract', 'a Trading contract', 'a contract case')
+      expect(trade.find_contracts('backpack')).to eq(['a Trading contract', 'a Trading contract'])
+    end
+
+    it 'returns an empty array when no contracts are present' do
+      stub_look('a contract case', 'a leather duffel bag', 'some grass')
+      expect(trade.find_contracts('backpack')).to eq([])
+    end
+
+    it 'does not match a plural "contracts" noun (only a single contract counts)' do
+      stub_look('a bundle of contracts', 'a Trading contract')
+      expect(trade.find_contracts('backpack')).to eq(['a Trading contract'])
+    end
+
+    it 'reopens a closed container and retries before parsing' do
+      responses = ['That is closed', 'you see a Trading contract.']
+      allow(DRC).to receive(:bput) { responses.shift }
+      expect(trade.find_contracts('contract case')).to eq(['a Trading contract'])
+      expect($fput_calls).to include('open my contract case')
+    end
+  end
+end

--- a/spec/trade_spec.rb
+++ b/spec/trade_spec.rb
@@ -1,57 +1,8 @@
-require 'ostruct'
-
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
-
-# Minimal stub modules for game interaction. bput is overridden per-example via
-# allow(); list_to_array and get_noun mirror the real DRC helpers (themselves
-# covered in lich-5 common_spec) so find_contracts' filtering is exercised end
-# to end.
-module DRC
-  def self.bput(*_args); end
-
-  def self.list_to_array(text)
-    return [] if text.nil?
-
-    text.strip.split(/,\s*|\s+and\s+/).map(&:strip).reject(&:empty?)
-  end
-
-  def self.get_noun(long_name)
-    return nil if long_name.nil?
-
-    long_name.strip.scan(/[a-z\-']+$/i).first
-  end
-end
-
-# fput is a top-level game command; record calls so the reopen path is testable.
-$fput_calls = []
-def fput(*args)
-  $fput_calls << args.first
-end
+# See spec/spec_helper.rb for the shared harness conventions relied on here:
+# the game/commons doubles (DRC, get_noun, list_to_array, fput) and the
+# load_lic_class extractor are provided centrally, so this spec neither
+# reopens a module nor redefines a top-level method (doing so would clobber
+# the shared doubles for the whole run and break other specs).
 
 load_lic_class('trade.lic', 'Trade')
 
@@ -60,47 +11,54 @@ RSpec.describe Trade do
   # so a bare allocated instance keeps the parse/filter logic isolated.
   let(:trade) { Trade.allocate }
 
-  before(:each) { $fput_calls = [] }
-
   # Issue #4201: the container is rummaged and each entry kept only if it is
   # actually a contract. The bug was a substring match (item.include?('contract'))
   # that also matched a "contract case", so the fix matches on the item noun.
+  # DRC.list_to_array preserves the leading space on non-first items (real game
+  # behaviour), so results are compared after stripping that incidental space.
   describe '#find_contracts' do
     def stub_look(*items)
       sentence = items.join(', ')
       allow(DRC).to receive(:bput).and_return("you see #{sentence}.")
     end
 
+    def contracts_in(container)
+      trade.find_contracts(container).map(&:strip)
+    end
+
     it 'keeps a real contract and rejects a contract case in the same container' do
       stub_look('a Trading contract', 'a contract case', 'some silver coins')
-      expect(trade.find_contracts('backpack')).to eq(['a Trading contract'])
+      expect(contracts_in('backpack')).to eq(['a Trading contract'])
     end
 
     it 'rejects a contract case even when it is the only item (the exact #4201 bug)' do
       stub_look('a contract case')
-      expect(trade.find_contracts('backpack')).to eq([])
+      expect(contracts_in('backpack')).to eq([])
     end
 
     it 'returns every contract when several are present' do
       stub_look('a Trading contract', 'a Trading contract', 'a contract case')
-      expect(trade.find_contracts('backpack')).to eq(['a Trading contract', 'a Trading contract'])
+      expect(contracts_in('backpack')).to eq(['a Trading contract', 'a Trading contract'])
     end
 
     it 'returns an empty array when no contracts are present' do
       stub_look('a contract case', 'a leather duffel bag', 'some grass')
-      expect(trade.find_contracts('backpack')).to eq([])
+      expect(contracts_in('backpack')).to eq([])
     end
 
     it 'does not match a plural "contracts" noun (only a single contract counts)' do
       stub_look('a bundle of contracts', 'a Trading contract')
-      expect(trade.find_contracts('backpack')).to eq(['a Trading contract'])
+      expect(contracts_in('backpack')).to eq(['a Trading contract'])
     end
 
     it 'reopens a closed container and retries before parsing' do
       responses = ['That is closed', 'you see a Trading contract.']
       allow(DRC).to receive(:bput) { responses.shift }
-      expect(trade.find_contracts('contract case')).to eq(['a Trading contract'])
-      expect($fput_calls).to include('open my contract case')
+      expect(contracts_in('contract case')).to eq(['a Trading contract'])
+
+      sent = []
+      sent << $sent_messages.pop until $sent_messages.empty?
+      expect(sent).to include('open my contract case')
     end
   end
 end

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -1142,6 +1142,14 @@ module Harness
       def left_hand_noun; Harness._noun($left_hand); end
       def right_hand_noun; Harness._noun($right_hand); end
       def get_noun(long_name); Harness._noun(long_name); end
+
+      # Mirrors the real DRC.list_to_array: split a game item sentence on the
+      # comma/and separators, keeping the article that begins each item (so
+      # non-first items retain their leading space, exactly like production).
+      def list_to_array(list)
+        list.strip.split(%r{(?:,|(?:, |\s)?and\s?)(?:\s?<pushBold/>\s?)?(?=\s\ba\b|\s\ban\b|\s\bsome\b|\s\bthe\b)}i).reject(&:empty?)
+      end
+
       def get_gems(*_args); []; end
       def get_town_name(name); name; end
       def text2num(text); text; end

--- a/trade.lic
+++ b/trade.lic
@@ -801,7 +801,13 @@ class Trade
     contract
   end
 
-  def find_contracts(container) # returns an array of the contracts in the container
+  # Reads the contract container and returns only actual contracts. Matches on
+  # the item noun rather than a substring so a "contract case" (noun: "case")
+  # is not mistaken for a contract (noun: "contract") -- see issue #4201.
+  # Reopens the container and retries once if it reports as closed.
+  # @param container [String] noun of the worn contract container to search
+  # @return [Array<String>] descriptions of the contracts found (empty if none)
+  def find_contracts(container)
     result = DRC.bput("look in my #{container}", 'That is closed', 'you see .*', 'While it\'s closed', 'I could not find', 'There is nothing')
     case result
     when 'That is closed'
@@ -809,7 +815,7 @@ class Trade
       return find_contracts(container)
     end
     text = result.match(/you see (.*)\.$/).to_a[1]
-    DRC.list_to_array(text).select { |item| item.include?('contract') }
+    DRC.list_to_array(text).select { |item| DRC.get_noun(item) == 'contract' }
   end
 
   def count_grass # sets @current_grass_count of grass in feedbag

--- a/trade.lic
+++ b/trade.lic
@@ -482,7 +482,7 @@ class Trade
     return Room.current.id if outpost_from_name(@emergency_delivery_town) == Room.current.id
 
     rooms = @trading_towns.to_h.values.select { |data| data['trader_outpost'] }
-                          .map { |data| data['trader_outpost']['id'] }
+                                      .map { |data| data['trader_outpost']['id'] }
     target_list = rooms.collect(&:to_i)
     _previous, shortest_distances = Map.dijkstra(outpost_from_name(@emergency_delivery_town))
     target_list.delete_if { |room_num| shortest_distances[room_num].nil? && room_num == Room.current.id }
@@ -1910,7 +1910,7 @@ class Trade
       @crafted_item = 'a cloth artisan\'s belt'
     end
     recipes = @recipe_data.crafting_recipes.select { |recipe| recipe['type'] =~ /tailoring/i }
-                          .reject { |recipe| recipe['chapter'] == 7 }
+                                           .reject { |recipe| recipe['chapter'] == 7 }
     echo @crafted_item
     recipe = DRCC.recipe_lookup(recipes, @crafted_item)
 
@@ -2231,29 +2231,34 @@ class Trade
     return_to_caravan
     inventory = get_storage_inventory
     town = closest_town
-    @crafting_override.select { |_discipline, data| inventory.group_by(&:itself)[data['recipe'].split.last].length > 4 }
-                      .select { |discipline, _data| @crafting_data[discipline][town] && time_to_room(Room.current.id, @crafting_data[discipline][town]['stock-room']) < 10.0 }
-                      .select { |_discipline, data| data['workorder'] }
-                      .each do  |discipline, data|
-      info = @crafting_data[discipline][town]
-      recipes = @recipe_data.crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && /#{@crafting_override[discipline]['recipe']}/ =~ recipe['name'] }
-      echo recipes
-      item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], data['difficulty'])
-      if item_name.nil?
-        @crafting_override[discipline]['workorder'] = false
-        DRC.message('Could not find a workorder for the item')
-        return turn_in_items
-      end
+    # Handle one eligible override per call, then recurse. The previous .each
+    # unconditionally returned on its first iteration (Lint/UnreachableLoop);
+    # taking .first preserves that single-iteration behaviour explicitly.
+    selected = @crafting_override.select { |_discipline, data| inventory.group_by(&:itself)[data['recipe'].split.last].length > 4 }
+                                 .select { |discipline, _data| @crafting_data[discipline][town] && time_to_room(Room.current.id, @crafting_data[discipline][town]['stock-room']) < 10.0 }
+                                 .select { |_discipline, data| data['workorder'] }
+                                 .first
+    return unless selected
 
-      return_to_caravan
-      quantity.times do
-        break unless get_item_from_storage_box?(data['recipe'].split.last)
-
-        DRCC.logbook_item(info['logbook'], data['recipe'].split.last, @craft_bag)
-      end
-      complete_work_order(info)
+    discipline, data = selected
+    info = @crafting_data[discipline][town]
+    recipes = @recipe_data.crafting_recipes.select { |recipe| recipe['type'] =~ /#{discipline}/i && /#{@crafting_override[discipline]['recipe']}/ =~ recipe['name'] }
+    echo recipes
+    item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], data['difficulty'])
+    if item_name.nil?
+      @crafting_override[discipline]['workorder'] = false
+      DRC.message('Could not find a workorder for the item')
       return turn_in_items
     end
+
+    return_to_caravan
+    quantity.times do
+      break unless get_item_from_storage_box?(data['recipe'].split.last)
+
+      DRCC.logbook_item(info['logbook'], data['recipe'].split.last, @craft_bag)
+    end
+    complete_work_order(info)
+    turn_in_items
   end
 
   def complete_work_order(info)


### PR DESCRIPTION
Resolves #4201

Closed as "not planned" but still valid.

`find_contracts` filtered the contract container with `item.include?('contract')`, which also matches "a contract case"; the script then tried to `read` a non-existent contract from it and stalled. Now matches on the item noun (`DRC.get_noun(item) == 'contract'`), keeping "a Trading contract" and rejecting "a contract case". The reporter's original "contract," idea failed because a lone contract has no trailing comma.

The second commit drives trade.lic to zero rubocop offenses (rubocop -A for indentation; the `Lint/UnreachableLoop` in `turn_in_items` -- a select-chain `.each` that always returned on its first iteration -- becomes `.first` + guard, preserving behaviour).

Testing: new `spec/trade_spec.rb` (6 adversarial examples: contract vs contract-case, case-only, multiple, plural "contracts", closed-container reopen). rubocop-clean.

Generated with [Claude Code](https://claude.com/claude-code)

