### PR TITLE
Batch steel forging by ingot capacity in restock-shop.lic

### DIFF
--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -3,6 +3,12 @@
 =end
 
 class ShopRestock
+  # Maximum recipe volume that fits within a single steel ingot.
+  # A `makesteel 21 h refine` ingot holds 168 volume, which is also the
+  # largest ingot makesteel can produce (its count arg is capped at 21).
+  # Override per-character with a `max_steel_ingot_volume` YAML setting.
+  MAX_STEEL_INGOT_VOLUME = 168
+
   def initialize
     @settings = get_settings
 
@@ -62,21 +68,75 @@ class ShopRestock
   def restock_steel(missing_items)
     return if missing_items.empty?
 
-    volume = ((total_volume_of(missing_items) * 1.25) / 10.0).ceil
+    max_volume = (@settings.max_steel_ingot_volume || MAX_STEEL_INGOT_VOLUME).to_i
+
+    batches = batch_by_ingot_volume(missing_items, max_volume)
+    return if batches.empty?
+
+    respond "Steel items split into #{batches.length} ingot batch(es)." if batches.length > 1
+
+    batches.each_with_index do |batch, index|
+      respond "-- Steel batch #{index + 1} of #{batches.length} (#{total_volume_of(batch)} volume) --" if batches.length > 1
+      forge_steel_batch(batch)
+    end
+
+    DRC.wait_for_script_to_complete('workorders', %w[blacksmithing repair])
+  end
+
+  # Forge a single batch of steel items from one freshly-made ingot,
+  # then dispose of whatever ingot metal is left over.
+  def forge_steel_batch(batch)
+    volume = ((total_volume_of(batch) * 1.25) / 10.0).ceil
     return if volume.zero?
 
     DRC.wait_for_script_to_complete('makesteel', [volume, 'refine'])
 
-    missing_items.each do |item|
+    batch.each do |item|
       DRC.wait_for_script_to_complete('smith', ['steel', item['recipe'], 'stamp', 'temper'])
       go_to_shop
       sell(item)
     end
 
-    DRC.wait_for_script_to_complete('workorders', %w[blacksmithing repair])
+    dispose_leftover_ingot
+  end
+
+  # Retrieve and trash any leftover steel ingot before starting the next batch,
+  # so ingots from separate batches don't accumulate in the crafting container.
+  def dispose_leftover_ingot
     DRCT.walk_to(get_data('crafting')[:blacksmithing][@town]['trash-room'])
     DRCC.get_crafting_item('steel ingot', @bag, @belt, @belt)
     DRCI.dispose_trash('steel ingot', @worn_trashcan, @worn_trashcan_verb)
+  end
+
+  # Greedily pack the missing items into batches so that no batch's total
+  # recipe volume exceeds a single steel ingot's capacity (max_volume).
+  # Items whose own volume exceeds one ingot cannot be forged from a single
+  # ingot and are skipped with a warning.
+  def batch_by_ingot_volume(items, max_volume)
+    batches = []
+    current = []
+    current_volume = 0
+
+    items.each do |item|
+      item_volume = volume_of(item)
+
+      if item_volume > max_volume
+        respond "*** Skipping #{item['full_name']}: needs #{item_volume} volume, exceeds single steel ingot capacity of #{max_volume}. ***"
+        next
+      end
+
+      if current_volume + item_volume > max_volume
+        batches << current unless current.empty?
+        current = []
+        current_volume = 0
+      end
+
+      current << item
+      current_volume += item_volume
+    end
+
+    batches << current unless current.empty?
+    batches
   end
 
   def restock_burlap(missing_items)
@@ -255,11 +315,14 @@ class ShopRestock
     DRCC.stow_crafting_item('stamp', @bag, @belt)
   end
 
+  def volume_of(item)
+    DRCC.recipe_lookup(@recipes.select { |recipe| recipe['noun'] == item['noun'] }, item['recipe'])['volume']
+  end
+
   def total_volume_of(items)
     return 0 if items.empty?
 
-    items.map { |item| DRCC.recipe_lookup(@recipes.select { |recipe| recipe['noun'] == item['noun'] }, item['recipe'])['volume'] }
-         .inject(&:+)
+    items.map { |item| volume_of(item) }.inject(&:+)
   end
 end
 

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -4,8 +4,19 @@
 
 class ShopRestock
   # Maximum recipe volume that fits within a single steel ingot.
-  # A `makesteel 21 h refine` ingot holds 168 volume, which is also the
-  # largest ingot makesteel can produce (its count arg is capped at 21).
+  #
+  # makesteel produces a raw ingot of (count x 10) volume: `makesteel 1 h` -> 10,
+  # `makesteel 21 h` -> 210. 210 is the game's hard cap on ingot volume, so the
+  # largest raw ingot makesteel can make is 210 (count 21).
+  #
+  # restock_steel always refines the ingot, which raises quality but reduces
+  # volume. With the steel-refining tech a 210 ingot yields 168; without that
+  # tech it yields only 105. This cap assumes the tech (168), and the count
+  # formula in forge_steel_batch bakes in the same assumption -- its x1.25
+  # factor is 210/168, the reciprocal of the refine loss. A character without
+  # the tech should set max_steel_ingot_volume: 105 (and would need the factor
+  # raised to 2.0, since 210/105 = 2.0).
+  #
   # Override per-character with a `max_steel_ingot_volume` YAML setting.
   MAX_STEEL_INGOT_VOLUME = 168
 


### PR DESCRIPTION
Problem
`restock_steel `sized a single steel ingot for the entire list of missing steel items via `makesteel`. `makesteel` produces a raw ingot of `count × 10` volume (`makesteel 1 h` → 10, `makesteel 21 h` → 210), and 210 is the game's hard cap on ingot volume (count 21). `restock_steel `always refines the ingot, and refining trades volume for quality: a 210 ingot yields 168 with the steel-refining tech, or 105 without it. So the metal actually available to forge from is the refined ingot — at most 168 volume for a tech'd character. When the combined recipe volume of the missing items exceeds that refined capacity (or the derived count exceeds `makesteel`'s cap of 21), forging fails partway through the list.
Change
`restock_steel` now packs the missing steel items into batches whose total recipe volume stays within one steel ingot (168, matching `makesteel 21 h refine`), and forges each batch from its own freshly-made ingot until the list is exhausted.

Added `batch_by_ingot_volume `— greedy packing that closes a batch before any item would push it past the cap. An item whose own volume exceeds one ingot is skipped with a warning instead of failing mid-forge (currently none exist, highest is 120, but future-proofs).
Added `forge_steel_batch `— runs the original per-batch flow (`makesteel [count] refine` → smith + sell each item → dispose leftover), with count still derived by the existing `ceil(volume × 1.25 / 10)` formula.
Added `dispose_leftover_ingot `— moved leftover-ingot disposal to run per batch so ingots from separate batches don't accumulate in the crafting container. workorders still runs once at the end.
Added `MAX_STEEL_INGOT_VOLUME = 168` constant, overridable per-character via an optional `max_steel_ingot_volume` YAML setting. Note: `makesteel`'s count caps at 21, producing a raw 210-volume ingot; `restock_steel` always refines it, which raises quality but reduces usable volume to 168. Since this path always refines, 168 is the effective cap (it would be 210 if refine were dropped, or if further combining logic is added in the future).
Refactored the per-item volume lookup into a `volume_of` helper; `total_volume_of` now reuses it (logic unchanged).

Scope / impact

Steel only. The `restock_burlap`, `restock_linen`, `restock_silk`, and `restock_gryphon` handlers and the `restock_surfaces` dispatcher are unchanged; `total_volume_of` is behavior-preserving, so cloth/leather volume math is identical.
`ruby -c` passes.

Note for reviewers
Leftover-ingot disposal now runs once per batch rather than once per invocation. If a batch's volume lands on an exact multiple that leaves no remnant, `get_crafting_item('steel ingot', ...)` could come up empty — same call the original used, just exercised more often.