### PR TITLE
sell-loot: decouple spare gem pouch restocking from having loot to sell

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -66,7 +66,6 @@ class SellLoot
     # -- e.g. no bundle -- could take the whole run down with it.)
     if has_loot_to_sell?
       sell_gems("#{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}") if @settings.sell_loot_pouch
-      check_spare_pouch(@settings.spare_gem_pouch_container, @settings.gem_pouch_adjective) if @settings.spare_gem_pouch_container
 
       if @settings.sell_loot_metals_and_stones
         if @settings.sell_loot_metals_and_stones_container.is_a?(String)
@@ -90,6 +89,15 @@ class SellLoot
     else
       DRC.message("No loot to sell")
     end
+
+    # Restock spare gem pouches independently of whether there was loot to sell.
+    # Each thing sell-loot does has to be checked on its own -- pouch restocking
+    # must not be gated behind having gems/metals/etc. to sell, or the pouches
+    # silently run dry on any run that happens to have nothing to sell.
+    # check_spare_pouch short-circuits (no travel) when already at target and
+    # walks itself to the gem shop when it does need to restock, so calling it
+    # unconditionally here is safe.
+    check_spare_pouch(@settings.spare_gem_pouch_container, @settings.gem_pouch_adjective) if @settings.spare_gem_pouch_container
 
     # Handle banking
     return if skip_bank && !@bankbot_enabled

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -96,8 +96,13 @@ class SellLoot
     # silently run dry on any run that happens to have nothing to sell.
     # check_spare_pouch short-circuits (no travel) when already at target and
     # walks itself to the gem shop when it does need to restock, so calling it
-    # unconditionally here is safe.
-    check_spare_pouch(@settings.spare_gem_pouch_container, @settings.gem_pouch_adjective) if @settings.spare_gem_pouch_container
+    # unconditionally here is safe. Require gem_pouch_adjective too: unlike the
+    # sell_loot_pouch path, validate_settings does not guarantee it is set when
+    # only spare_gem_pouch_container is configured, and a nil adjective would ask
+    # the clerk for " pouch" and count " gem pouch" -- malformed game commands.
+    if @settings.spare_gem_pouch_container && @settings.gem_pouch_adjective
+      check_spare_pouch(@settings.spare_gem_pouch_container, @settings.gem_pouch_adjective)
+    end
 
     # Handle banking
     return if skip_bank && !@bankbot_enabled

--- a/spec/sell_loot_spec.rb
+++ b/spec/sell_loot_spec.rb
@@ -873,6 +873,19 @@ RSpec.describe SellLoot do
       SellLoot.new
     end
 
+    it 'does not restock when a spare container is set but the gem pouch adjective is unset' do
+      # validate_settings only guarantees gem_pouch_adjective when sell_loot_pouch
+      # is on; a nil adjective would ask the clerk for " pouch" and count
+      # " gem pouch" -- malformed commands -- so restocking must be skipped.
+      $test_settings = make_settings(spare_gem_pouch_container: 'sack', gem_pouch_adjective: nil)
+      $test_data.town = { 'Crossing' => make_hometown }
+      $test_data.items = items_data
+      allow(DRC).to receive(:get_town_name).and_return('Crossing')
+      allow_any_instance_of(SellLoot).to receive(:has_loot_to_sell?).and_return(false)
+      expect_any_instance_of(SellLoot).not_to receive(:check_spare_pouch)
+      SellLoot.new
+    end
+
     it 'still exchanges and deposits excess coins even when there is no loot to sell' do
       # Regression: the old preflight bailed the whole run on no loot, stranding
       # coins already on hand instead of banking them.

--- a/spec/sell_loot_spec.rb
+++ b/spec/sell_loot_spec.rb
@@ -860,6 +860,19 @@ RSpec.describe SellLoot do
       SellLoot.new
     end
 
+    it 'restocks spare gem pouches even when there is no loot to sell' do
+      # Regression: pouch restocking used to live inside the has_loot_to_sell?
+      # branch, so a run with nothing to sell silently let the spare pouches run
+      # dry. Restocking must be checked on its own, independent of selling.
+      $test_settings = make_settings(spare_gem_pouch_container: 'sack')
+      $test_data.town = { 'Crossing' => make_hometown }
+      $test_data.items = items_data
+      allow(DRC).to receive(:get_town_name).and_return('Crossing')
+      allow_any_instance_of(SellLoot).to receive(:has_loot_to_sell?).and_return(false)
+      expect_any_instance_of(SellLoot).to receive(:check_spare_pouch).with('sack', 'soft')
+      SellLoot.new
+    end
+
     it 'still exchanges and deposits excess coins even when there is no loot to sell' do
       # Regression: the old preflight bailed the whole run on no loot, stranding
       # coins already on hand instead of banking them.


### PR DESCRIPTION
## Problem

Spare gem pouch restocking (`check_spare_pouch`) lived inside the `if has_loot_to_sell?` branch. On any run where there was nothing to sell -- no gems in the pouch, no metals/stones, no bundle, no traps -- sell-loot took the `else` (`No loot to sell`) path and skipped the entire selling block, so the pouch restock never ran. The spare pouches silently run dry until a run happens to have loot.

This surfaced in practice: a bare `;sell-loot` with an empty pouch reported `No loot to sell` and never topped up the spare pouches, even though restocking should be independent of whether anything sold.

## Fix

Move the `check_spare_pouch` call out of the loot branch so it runs on every invocation. Each thing sell-loot does has to be evaluated on its own; restocking must not be gated behind selling gems/metals/etc.

The call is safe to make unconditionally:
- `check_spare_pouch` short-circuits and does no travel when already at the target count.
- It walks itself to the gem shop only when it actually needs to restock.

## Tests

Adds an orchestration-level regression test asserting `check_spare_pouch` fires even when `has_loot_to_sell?` is false.

- `rspec spec/sell_loot_spec.rb`: 83 examples, 0 failures
- `rubocop sell-loot.lic spec/sell_loot_spec.rb`: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spare gem pouches are now restocked even when there is no loot to sell.
  * Restocking continues to occur during the normal selling and banking workflow.

* **Tests**
  * Added coverage to verify spare pouch restocking when no sellable loot is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->