### PR TITLE
spec: make the full RSpec suite run green in one process

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/astrology_spec.rb
+++ b/spec/astrology_spec.rb
@@ -2,32 +2,7 @@
 
 require 'ostruct'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Define stub modules only if not already defined
 module DRC
@@ -90,28 +65,12 @@ module Lich
       def issue_command(*_args); end
     end
   end
-end unless defined?(Lich::Messaging)
-
-# Define Lich::Util separately in case Lich::Messaging was already defined
-module Lich
-  module Util
-    class << self
-      def issue_command(*_args); end
-    end
-  end
-end unless defined?(Lich::Util)
+end
 
 # Add methods to Harness classes that astrology.lic needs
 Harness::EquipmentManager.class_eval do
   def empty_hands; end
 end
-
-# DRSkill needs getxp for training routines
-# Use singleton methods to avoid class variable issues in Ruby 4.0
-Harness::DRSkill.define_singleton_method(:_xp_store) { @_xp_store ||= {} }
-Harness::DRSkill.define_singleton_method(:_set_xp) { |skillname, val| _xp_store[skillname] = val }
-Harness::DRSkill.define_singleton_method(:_reset_xp) { @_xp_store = {} }
-Harness::DRSkill.define_singleton_method(:getxp) { |skillname| _xp_store[skillname] || 0 }
 
 class Room
   class << self
@@ -134,16 +93,6 @@ class UserVars
     def astral_plane_exp_timer=(_val); end
   end
 end unless defined?(UserVars)
-
-def sitting?
-  false
-end
-
-def stunned?
-  false
-end
-
-def pause(*_args); end
 
 load_lic_class('astrology.lic', 'Astrology')
 

--- a/spec/athletics_spec.rb
+++ b/spec/athletics_spec.rb
@@ -2,30 +2,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 module DRC
   class << self
@@ -40,16 +17,6 @@ module DRCT
     def walk_to(_room_id); end
   end
 end unless defined?(DRCT)
-
-Harness::DRSkill.define_singleton_method(:_xp_store) { @_xp_store ||= {} }
-Harness::DRSkill.define_singleton_method(:_set_xp) { |skillname, val| _xp_store[skillname] = val }
-Harness::DRSkill.define_singleton_method(:_reset_xp) { @_xp_store = {} }
-Harness::DRSkill.define_singleton_method(:getxp) { |skillname| _xp_store[skillname] || 0 }
-
-Harness::DRSkill.define_singleton_method(:_modrank_store) { @_modrank_store ||= {} }
-Harness::DRSkill.define_singleton_method(:_set_modrank) { |skillname, val| _modrank_store[skillname] = val }
-Harness::DRSkill.define_singleton_method(:_reset_modrank) { @_modrank_store = {} }
-Harness::DRSkill.define_singleton_method(:getmodrank) { |skillname| _modrank_store[skillname] || 0 }
 
 load_lic_class('athletics.lic', 'Athletics')
 

--- a/spec/charge_elemental_charge_spec.rb
+++ b/spec/charge_elemental_charge_spec.rb
@@ -2,30 +2,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 module DRC
   class << self
@@ -58,12 +35,6 @@ module DRCS
 end
 
 load_lic_class('charge-elemental-charge.lic', 'ChargeElementalCharge')
-
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data
-  end
-end
 
 RSpec.describe ChargeElementalCharge do
   def build_instance(**overrides)

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -11,30 +11,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # -- Module stubs --
 # Each stub provides the minimum interface combat-trainer calls.
@@ -140,10 +117,6 @@ module DRCTH
   end
 end
 
-module Script
-  def self.running?(*_args) = false
-end
-
 # Unified UserVars store. Backs every UserVars key the combat-trainer code
 # and the merged specs touch (moons, sun, discerns, friends, warhorn,
 # almanac_last_use, yiamura, paladin_last_badge_use, combat_trainer_debug,
@@ -242,12 +215,6 @@ load_lic_class('combat-trainer.lic', 'SafetyProcess')
 load_lic_class('combat-trainer.lic', 'SpellProcess')
 load_lic_class('combat-trainer.lic', 'PetProcess')
 load_lic_class('combat-trainer.lic', 'TrainerProcess')
-
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data
-  end
-end
 
 # Shared setup for combat-trainer tests that need game state stubs.
 # Include in each describe block via: before(:each) { ct_setup }

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -27,30 +27,7 @@ module Lich
   end
 end
 
-$respond_messages = []
-def _respond(msg)
-  $respond_messages << msg
-end
-
-module Script
-  def self.current
-    OpenStruct.new(name: 'test-script')
-  end
-
-  def self.exists?(_name)
-    false
-  end
-end
-
 $clean_lich_char = ';'
-
-def checkname
-  'Testchar'
-end
-
-def echo(_msg)
-  # no-op in tests
-end
 
 # --- Extract methods from dependency.lic ---
 dep_path = File.join(File.dirname(__FILE__), '..', 'dependency.lic')

--- a/spec/enchant_spec.rb
+++ b/spec/enchant_spec.rb
@@ -2,32 +2,7 @@
 
 require 'ostruct'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Minimal stub modules for game interaction
 module DRC
@@ -114,6 +89,9 @@ RSpec.describe Enchant do
     instance.instance_variable_set(:@bag_items, ['burin'])
     instance.instance_variable_set(:@belt, 'toolbelt')
     instance.instance_variable_set(:@brazier, 'brazier')
+    # @brazier_ref is derived in initialize (which these specs bypass); the
+    # command-building methods interpolate it directly.
+    instance.instance_variable_set(:@brazier_ref, 'brazier')
     instance.instance_variable_set(:@fount, 'fount')
     instance.instance_variable_set(:@loop, 'aug loop')
     instance.instance_variable_set(:@imbue_wand, 'rod')

--- a/spec/fenvol_puzzle_spec.rb
+++ b/spec/fenvol_puzzle_spec.rb
@@ -2,8 +2,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
+require_relative 'spec_helper'
 
 def stub_flags_class
   stub_const('Flags', Class.new do
@@ -42,28 +41,6 @@ def stub_flags_class
   end)
 end
 
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
-
 module DRC
   def self.right_hand
     $right_hand
@@ -79,14 +56,6 @@ module DRC
 
   def self.get_noun(long_name)
     long_name.to_s.strip.scan(/[a-z\-']+$/i).first
-  end
-end
-
-module GameObj
-  @right_hand = nil
-
-  class << self
-    attr_accessor :right_hand
   end
 end
 
@@ -116,62 +85,27 @@ module Lich
   end
 end
 
-module XMLData
-  @room_title = 'Test Room'
-
-  class << self
-    attr_accessor :room_title
-  end
-end
-
-def fput(*_args); end
-
-def echo(*_args); end
-
-def _respond(*_args); end
-
-def get
-  ''
-end
-
-def move(*_args); end
-
-def pause(*_args); end
-
-def waitfor(*_args); end
-
-def parse_args(*_args)
-  OpenStruct.new
-end
-
-def get_settings
-  OpenStruct.new
-end
-
-def before_dying(&_block); end
-
 def set_right_hand(name, noun = nil)
   $right_hand = name
   noun ||= name&.to_s&.split&.last
-  GameObj.right_hand = noun ? OpenStruct.new(noun: noun) : nil
+  # fenvol-puzzle.lic reads GameObj.right_hand&.noun and treats a nil hand as
+  # empty, so stub it directly rather than routing through the harness wrapper
+  # (which reports an empty hand as an 'Empty' OpenStruct, never nil).
+  allow(GameObj).to receive(:right_hand).and_return(noun ? OpenStruct.new(noun: noun) : nil)
 end
 
 load_lic_class('fenvol-puzzle.lic', 'FenvolPuzzle')
-
-RSpec.configure do |config|
-  config.before do
-    reset_data
-    $right_hand = nil
-    $left_hand = nil
-    GameObj.right_hand = nil
-    XMLData.room_title = 'Test Room'
-  end
-end
 
 RSpec.describe FenvolPuzzle do
   let(:instance) { FenvolPuzzle.allocate }
 
   before do
+    # World state this spec assumes (reset_data runs first, via spec_helper).
+    $right_hand = nil
+    $left_hand = nil
+    allow(GameObj).to receive(:right_hand).and_return(nil)
+    XMLData.room_title = 'Test Room'
+
     instance.instance_variable_set(:@repeat_mode, nil)
     instance.instance_variable_set(:@repeat_count, nil)
     instance.instance_variable_set(:@containers, [])
@@ -366,14 +300,17 @@ RSpec.describe FenvolPuzzle do
     end
 
     it 'normalizes curly quotes and apostrophes to spaces' do
-      result = instance.send(:normalize_text, "author’s tome")
-      expect(result).not_to include("’")
+      # Build the non-ASCII input at runtime so the source stays ASCII-only.
+      curly_apostrophe = 0x2019.chr(Encoding::UTF_8)
+      result = instance.send(:normalize_text, "author#{curly_apostrophe}s tome")
+      expect(result).not_to include(curly_apostrophe)
       expect(result).to eq('author s tome')
     end
 
     it 'normalizes em dashes to spaces' do
-      result = instance.send(:normalize_text, "fire—water")
-      expect(result).not_to include("—")
+      em_dash = 0x2014.chr(Encoding::UTF_8)
+      result = instance.send(:normalize_text, "fire#{em_dash}water")
+      expect(result).not_to include(em_dash)
     end
   end
 
@@ -1678,7 +1615,7 @@ RSpec.describe FenvolPuzzle do
 
       it 'falls back to split.last when GameObj.right_hand is nil' do
         $right_hand = 'ornate silver ring'
-        GameObj.right_hand = nil
+        allow(GameObj).to receive(:right_hand).and_return(nil)
         instance.instance_variable_set(:@containers, ['backpack'])
         expect(DRCI).to receive(:put_away_item?).with('ring', ['backpack']).and_return(true)
         instance.send(:stow_reward)
@@ -1800,7 +1737,7 @@ RSpec.describe FenvolPuzzle do
         obj = double('item', to_s: 'fancy dress', empty?: false)
         allow(obj).to receive(:downcase).and_return('fancy dress')
         $right_hand = obj
-        GameObj.right_hand = OpenStruct.new(noun: 'dress')
+        allow(GameObj).to receive(:right_hand).and_return(OpenStruct.new(noun: 'dress'))
         instance.instance_variable_set(:@discard_list, ['dress'])
         allow(instance).to receive(:echo)
         expect(DRCI).to receive(:put_away_item_unsafe?).with('my dress', 'bucket').and_return(true)

--- a/spec/forge_spec.rb
+++ b/spec/forge_spec.rb
@@ -3,9 +3,7 @@
 require 'ostruct'
 require 'time'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
+require_relative 'spec_helper'
 
 # Helper to create a Flags stub for tests that need it
 # Use stub_const to avoid conflicts with other specs (e.g., workorders_spec.rb)
@@ -44,30 +42,6 @@ def stub_flags_class
       end
     end
   end)
-end
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  # Find the matching 'end' at column 0 (same level as class definition)
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
 end
 
 # Minimal stub modules for game interaction
@@ -156,12 +130,6 @@ class MockRoom
   end
 end
 
-module DRSkill
-  def self.getrank(*_args)
-    100
-  end
-end
-
 # Lich messaging mock
 module Lich
   module Messaging
@@ -171,12 +139,6 @@ end
 
 # Load the Forge class
 load_lic_class('forge.lic', 'Forge')
-
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data
-  end
-end
 
 RSpec.describe Forge do
   describe 'class constants' do
@@ -829,6 +791,12 @@ RSpec.describe Forge do
     end
 
     describe '#swap_tool' do
+      # swap_tool ends by calling verify_tool_in_hand, which exits the script if
+      # the tool is not in hand. These examples exercise the tool-selection
+      # branches (the DRCC calls), not the post-swap verification, so neutralize
+      # the verify step to keep a failed check from terminating the run.
+      before { allow(forge_instance).to receive(:verify_tool_in_hand) }
+
       it 'uses adjustable tongs when switching to tongs' do
         forge_instance.instance_variable_set(:@adjustable_tongs, true)
         expect(DRCC).to receive(:get_adjust_tongs?).with('tongs', 'backpack', [], nil, true)
@@ -903,10 +871,10 @@ RSpec.describe Forge do
         allow(forge_instance).to receive(:magic_cleanup)
       end
 
-      it 'logs item to engineering logbook when finish is log' do
+      it 'logs item to forging logbook when finish is log' do
         forge_instance.instance_variable_set(:@finish, 'log')
-        expect(DRCC).to receive(:logbook_item).with('engineering', 'sword', 'backpack')
-        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: sword logged to engineering logbook.')
+        expect(DRCC).to receive(:logbook_item).with('forging', 'sword', 'backpack')
+        expect(Lich::Messaging).to receive(:msg).with('plain', 'Forge: sword logged to forging logbook.')
         expect { forge_instance.send(:complete_crafting) }.to raise_error(SystemExit)
       end
 
@@ -999,13 +967,13 @@ RSpec.describe Forge do
         allow(DRCM).to receive(:ensure_copper_on_hand).and_return(true)
         allow(DRCT).to receive(:walk_to)
         allow(Room).to receive(:current).and_return(MockRoom.new(12_345))
-        expect(DRC).to receive(:bput).and_return("You don't have enough")
+        allow(DRC).to receive(:bput).and_return("You don't have enough")
         expect(Lich::Messaging).to receive(:msg).with('bold', 'Forge: BLOCKED from entering private forge!')
         expect(Lich::Messaging).to receive(:msg).with('bold', /sentry won't let you in/)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Not enough money/)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Forge is already rented/)
         expect(Lich::Messaging).to receive(:msg).with('bold', /Other restriction/)
-        expect(Lich::Messaging).to receive(:msg).with('bold', /Exiting/)
+        expect(Lich::Messaging).to receive(:msg).with('bold', /Use a public forge or resolve the issue/)
         expect { forge_instance.send(:go_to_private_forge) }.to raise_error(SystemExit)
       end
 
@@ -1043,6 +1011,9 @@ RSpec.describe Forge do
           allow(DRCC).to receive(:find_recipe2)
           allow(DRCC).to receive(:stow_crafting_item)
           allow(forge_instance).to receive(:swap_tool)
+          # prep runs the recipe-book flow before fetching the ingot; default the
+          # book check to success so examples can focus on the ingot handling.
+          allow(DRCI).to receive(:in_hands?).and_return(true)
         end
 
         it 'uses DRCC.get_crafting_item to fetch ingot' do

--- a/spec/healer_spec.rb
+++ b/spec/healer_spec.rb
@@ -2,30 +2,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Minimal module stubs for modules not provided by the test harness
 module DRC
@@ -64,13 +41,7 @@ module Lich
       []
     end
   end
-end unless defined?(Lich)
-
-# Provide start_script and DRSpells.known_spells if not already defined
-def start_script(*_args); end unless defined?(start_script)
-
-Harness::DRSpells.define_singleton_method(:known_spells) { @_known_spells || {} } unless Harness::DRSpells.respond_to?(:known_spells)
-Harness::DRSpells.define_singleton_method(:_set_known_spells) { |val| @_known_spells = val }
+end
 
 load_lic_class('healer.lic', 'Healer')
 
@@ -870,7 +841,8 @@ RSpec.describe Healer do
       healer.add_patient('Tenuk')
       healer.instance_variable_set(:@vh_available, true)
       healer.instance_variable_set(:@vh_spell, { name: 'Vitality Healing', mana: 5, cambrinth: [], prep_time: 0 })
-      DRStats.health = 65 # just above floor -> only 1 stream
+      healer.instance_variable_set(:@self_vit_floor, 60)
+      DRStats.health = 65 # just above the 60% floor -> thin headroom -> only 1 stream
 
       healer.claim_spell_slot('Tenuk', :vitality)
       task = healer.instance_variable_get(:@spell_task)

--- a/spec/knackstone_spec.rb
+++ b/spec/knackstone_spec.rb
@@ -2,32 +2,7 @@
 
 require 'ostruct'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Minimal stub modules for game interaction
 module DRC
@@ -78,12 +53,6 @@ end
 
 # Load Knackstone class definition (without executing top-level code)
 load_lic_class('knackstone.lic', 'Knackstone')
-
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data
-  end
-end
 
 RSpec.describe Knackstone do
   let(:settings) do

--- a/spec/outdoorsmanship_spec.rb
+++ b/spec/outdoorsmanship_spec.rb
@@ -2,30 +2,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 module DRC
   class << self

--- a/spec/paladin_quests_spec.rb
+++ b/spec/paladin_quests_spec.rb
@@ -11,36 +11,7 @@
 # @see PaladinQuests#choose_fountain_item
 # @see https://github.com/elanthia-online/dr-scripts/issues/7461
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Loads a class definition out of a .lic file without executing the top-level
-# code (e.g. `PaladinQuests.new`) that would otherwise drive the live quest.
-#
-# @param filename [String] the .lic file relative to the repo root
-# @param class_name [String] the class to extract and eval
-# @return [void]
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 module DRC
   class << self

--- a/spec/pick_spec.rb
+++ b/spec/pick_spec.rb
@@ -2,32 +2,7 @@
 
 require 'ostruct'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Define stub modules only if not already defined
 module DRC
@@ -96,7 +71,7 @@ module Lich
       def msg(*_args); end
     end
   end
-end unless defined?(Lich::Messaging)
+end
 
 class EquipmentManager
   def empty_hands; end
@@ -104,14 +79,6 @@ class EquipmentManager
   def wear_items(_items); end
   def wear_equipment_set?(_set_name); end
 end unless defined?(EquipmentManager)
-
-def sitting?
-  false
-end
-
-def stunned?
-  false
-end
 
 load_lic_class('pick.lic', 'Pick')
 

--- a/spec/plantheal_spec.rb
+++ b/spec/plantheal_spec.rb
@@ -1,31 +1,6 @@
 require 'ostruct'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Minimal stub modules for game interaction.
 module DRC

--- a/spec/researcher_spec.rb
+++ b/spec/researcher_spec.rb
@@ -1,29 +1,6 @@
 # frozen_string_literal: true
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 def load_lic_constant(filename, const_name)
   return if Object.const_defined?(const_name)

--- a/spec/restock_spec.rb
+++ b/spec/restock_spec.rb
@@ -2,32 +2,7 @@
 
 require 'ostruct'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Minimal stub modules for game interaction
 module DRC
@@ -77,12 +52,6 @@ end
 $ORDINALS = %w[first second third fourth fifth sixth seventh eighth ninth tenth].freeze
 
 load_lic_class('restock.lic', 'Restock')
-
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data
-  end
-end
 
 RSpec.describe Restock do
   # Build a Restock instance without calling initialize (avoids game I/O).

--- a/spec/safe_room_spec.rb
+++ b/spec/safe_room_spec.rb
@@ -2,30 +2,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Stub modules
 module DRC
@@ -80,27 +57,6 @@ class UserVars
     false
   end
 end unless defined?(UserVars)
-
-# Lich runtime stubs
-$bleeding = false
-$started_scripts = []
-$stopped_scripts = []
-
-def bleeding?
-  $bleeding || false
-end
-
-def checkname
-  'Testchar'
-end
-
-def start_script(name, *args)
-  $started_scripts << [name, *args]
-end
-
-def stop_script(name)
-  $stopped_scripts << name
-end
 
 load_lic_class('safe-room.lic', 'SafeRoom')
 

--- a/spec/sell_loot_spec.rb
+++ b/spec/sell_loot_spec.rb
@@ -2,37 +2,7 @@
 
 require 'ostruct'
 
-# Load the shared test harness (Flags, DRStats, DRRoom, GameObj, fput, pause, ...).
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval the SellLoot class from sell-loot.lic without running the
-# top-level code (before_dying block and SellLoot.new) at the bottom of the file.
-#
-# @param filename [String] path to the .lic file relative to the repo root
-# @param class_name [String] the class to extract
-# @return [void]
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # The commons layer (DRC/DRCT/DRCI/DRCM) is not loadable in specs, so provide
 # minimal stub modules with safe defaults. Individual tests override specific
@@ -91,15 +61,18 @@ end
 
 load_lic_class('sell-loot.lic', 'SellLoot')
 
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data
+RSpec.describe SellLoot do
+  # World state this spec assumes (reset_data runs first, via spec_helper).
+  before(:each) do
     $CURRENCIES = %w[kronars lirums dokoras]
     $HOMETOWN_REGEX = /Crossing|Riverhaven/i
-  end
-end
 
-RSpec.describe SellLoot do
+    # Default navigation to succeed so shop-visit flows proceed. Examples that
+    # assert on walk_to override this; stubbing here (rather than relying on the
+    # module base) keeps the flow deterministic when other specs are co-loaded.
+    allow(DRCT).to receive(:walk_to).and_return(true)
+  end
+
   # -- fixtures ---------------------------------------------------------------
 
   # Build a fully-shaped hometown hash with every shop the script may query.

--- a/spec/sew_spec.rb
+++ b/spec/sew_spec.rb
@@ -1,32 +1,7 @@
 require 'ostruct'
 require 'time'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Minimal stub modules for game interaction.
 # These must be defined before loading the Sew class so that
@@ -85,12 +60,6 @@ module DRCA
   def self.crafting_magic_routine(*_args); end
 end
 
-module DRSkill
-  def self.getrank(*_args)
-    0
-  end
-end
-
 module Lich
   module Messaging
     def self.msg(*_args); end
@@ -105,12 +74,6 @@ end
 
 # Load Sew class definition (without executing top-level code)
 load_lic_class('sew.lic', 'Sew')
-
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data
-  end
-end
 
 RSpec.describe Sew do
   # Allocate a bare instance without calling initialize, then inject
@@ -128,6 +91,9 @@ RSpec.describe Sew do
     sew.instance_variable_set(:@worn_trashcan_verb, nil)
     sew.instance_variable_set(:@settings, OpenStruct.new(crafting_training_spells: []))
     sew.instance_variable_set(:@info, { 'tool-room' => 1, 'stock-room' => 2 })
+
+    # Default skill rank of 0 (individual examples override via .with(...)).
+    allow(DRSkill).to receive(:getrank).and_return(0)
 
     # Prevent actual exit and stub helper methods
     allow(sew).to receive(:exit)
@@ -429,7 +395,7 @@ RSpec.describe Sew do
       $left_hand = nil
       allow(DRCC).to receive(:stow_crafting_item)
       allow(DRCC).to receive(:logbook_item)
-      expect(Lich::Messaging).to receive(:msg).with('plain', 'Sew script finished (rucksack, finish: log).')
+      expect(Lich::Messaging).to receive(:msg).with('plain', a_string_matching(/\Asew: Completed .*rucksack.* finish: log\z/))
 
       sew.send(:finish)
     end
@@ -1625,7 +1591,7 @@ RSpec.describe Sew do
     it '#finish always prints a finish message' do
       allow(DRCC).to receive(:stow_crafting_item)
       allow(DRCC).to receive(:logbook_item)
-      expect(Lich::Messaging).to receive(:msg).with('plain', 'Sew script finished (rucksack, finish: log).')
+      expect(Lich::Messaging).to receive(:msg).with('plain', a_string_matching(/\Asew: Completed .*rucksack.* finish: log\z/))
 
       sew.send(:finish)
     end
@@ -1682,7 +1648,7 @@ RSpec.describe Sew do
       $left_hand = nil
       allow(DRCC).to receive(:logbook_item)
 
-      expect(Lich::Messaging).to receive(:msg).with('plain', 'Sew script finished (rucksack, finish: log).')
+      expect(Lich::Messaging).to receive(:msg).with('plain', a_string_matching(/\Asew: Completed .*rucksack.* finish: log\z/))
 
       sew.send(:finish)
     end

--- a/spec/sigilharvest_spec.rb
+++ b/spec/sigilharvest_spec.rb
@@ -1,5 +1,7 @@
 require_relative 'spec_helper'
 
+load_lic_class('sigilharvest.lic', 'SigilHarvest')
+
 # SigilHarvest's initialize method interacts heavily with the game environment
 # (DRC.bput, get_settings, parse_args, etc.), so we cannot call .new directly.
 # Instead, we allocate a bare instance and inject the minimum instance variables

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,23 +15,37 @@
 # Lich runtime isolation:
 #   - Scripts (.lic files) cannot be required directly -- they depend on the full
 #     Lich runtime. Extract constants and methods via eval of specific line ranges
-#     (see dependency_spec.rb for the pattern).
+#     (see load_lic_class below and dependency_spec.rb for the method-level pattern).
 #   - Mock only what you need: UserVars, Settings, Script.current, _respond, etc.
 #   - Use the test harness (test/test_harness.rb) for specs that need game objects.
+#
+# Shared setup:
+#   - This file is loaded before every spec via .rspec (--require spec_helper). It
+#     loads the test harness, includes Harness at the top level, provides the
+#     load_lic_class extraction helper, and registers the single global
+#     before(:each) { reset_data } hook.
+#   - Registering reset_data here (rather than in individual specs via
+#     RSpec.configure) is deliberate: config-level before hooks registered while a
+#     spec file loads run AFTER that spec's own group-level before hooks. A
+#     per-spec global reset_data would therefore run last and clobber the
+#     per-example world (guild, settings, hands, room) that other specs set up in
+#     their own before blocks. Because spec_helper is required first, its hook
+#     registers first and always runs before every group hook.
 
 require 'ostruct'
 
 # Load the test harness which provides mock game objects:
-# Flags, DRStats, DRSkill, DRRoom, Room, Map, GameObj, etc.
+# Flags, DRStats, DRSkill, DRRoom, Room, Map, GameObj, Script, XMLData, etc.
 load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
 
 include Harness
 
-# Load SigilHarvest class definition without executing the top-level code
-# (before_dying block and SigilHarvest.new) at the bottom of the .lic file.
+# Extract and eval a class from a .lic file without executing the top-level code
+# (before_dying blocks, Klass.new, etc.) that sits outside the class body.
 #
-# Strategy: read the file, extract lines from the `class SigilHarvest` opening
-# through the matching `end` at column 0, then eval only that slice.
+# Strategy: read the file, extract lines from the `class <ClassName>` opening
+# through the matching `end` at column 0, then eval only that slice. The
+# const_defined? guard makes repeated calls (across co-running specs) idempotent.
 def load_lic_class(filename, class_name)
   return if Object.const_defined?(class_name)
 
@@ -41,7 +55,6 @@ def load_lic_class(filename, class_name)
   start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
   raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
 
-  # Find the matching end: first line after start that is exactly "end" at column 0
   end_idx = nil
   (start_idx + 1...lines.size).each do |i|
     if lines[i] =~ /^end\s*$/
@@ -54,8 +67,6 @@ def load_lic_class(filename, class_name)
   class_source = lines[start_idx..end_idx].join
   eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
 end
-
-load_lic_class('sigilharvest.lic', 'SigilHarvest')
 
 RSpec.configure do |config|
   config.before(:each) do

--- a/spec/t2_spec.rb
+++ b/spec/t2_spec.rb
@@ -13,43 +13,7 @@
 
 require 'ostruct'
 
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
-
-# -- Module/method stubs --
-# T2's cleanup path calls Script.running? and the top-level stop_script.
-# Both default to safe values; individual tests override via allow().
-
-module Script
-  # Default to "running" so #stop_launched_scripts attempts a kill unless a
-  # test says otherwise. This makes the "spares"/"stops" assertions meaningful.
-  def self.running?(*_args) = true
-end
-
-# Top-level Lich global. Defined so it can be stubbed on a specific instance.
-def stop_script(*_args) = nil
+require_relative 'spec_helper'
 
 load_lic_class('t2.lic', 'T2')
 
@@ -126,6 +90,10 @@ end
 # T2#stop_launched_scripts -- the shutdown cleanup behavior
 # ===================================================================
 RSpec.describe 'T2#stop_launched_scripts' do
+  # Treat every launched script as running so stop_launched_scripts attempts a
+  # kill unless the spare logic opts out.
+  before(:each) { allow(Script).to receive(:running?).and_return(true) }
+
   # Wire a fresh instance whose stop_script calls are recorded.
   def build_and_watch(no_kill: nil, launched: [])
     t2 = build_t2(no_kill: no_kill, launched: launched)

--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -3,33 +3,7 @@
 require 'ostruct'
 require 'time'
 
-# Load test harness which provides mock game objects
-load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
-include Harness
-
-# Extract and eval a class from a .lic file without executing top-level code
-def load_lic_class(filename, class_name)
-  return if Object.const_defined?(class_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
-  raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
-
-  # Find the matching 'end' at column 0 (same level as class definition)
-  end_idx = nil
-  (start_idx + 1...lines.size).each do |i|
-    if lines[i] =~ /^end\s*$/
-      end_idx = i
-      break
-    end
-  end
-  raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
-
-  class_source = lines[start_idx..end_idx].join
-  eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+require_relative 'spec_helper'
 
 # Minimal stub modules for game interaction
 module DRC
@@ -126,35 +100,6 @@ module DRCM
   def self.ensure_copper_on_hand(*_args); end
 end
 
-module DRSkill
-  def self.getxp(*_args)
-    0
-  end
-end
-
-module DRRoom
-  def self.npcs
-    $room_npcs || []
-  end
-end
-
-class Room
-  def self.current
-    OpenStruct.new(id: $room_id || 1)
-  end
-end
-
-module XMLData
-  def self.room_title
-    $room_title || ''
-  end
-end
-
-module Flags
-  def self.add(*_args); end
-  def self.delete(*_args); end
-end
-
 module Lich
   module Messaging
     def self.msg(*_args); end
@@ -178,22 +123,17 @@ $ORDINALS = %w[first second third fourth fifth sixth seventh eighth ninth tenth 
 # Load WorkOrders class definition (without executing top-level code)
 load_lic_class('workorders.lic', 'WorkOrders')
 
-RSpec.configure do |config|
-  config.before(:each) do
-    reset_data if defined?(reset_data)
-    $right_hand = nil
-    $left_hand = nil
-    $room_npcs = []
-    $room_id = 1
-    $room_title = ''
-  end
-end
-
 RSpec.describe WorkOrders do
   # Allocate a bare instance without calling initialize
   let(:workorders) { described_class.allocate }
 
   before(:each) do
+    # World state this spec assumes (reset_data runs first, via spec_helper).
+    $right_hand = nil
+    $left_hand = nil
+    DRRoom.npcs = []
+    XMLData.room_title = ''
+
     workorders.instance_variable_set(:@settings, OpenStruct.new(
                                                    crafting_container: 'backpack',
                                                    crafting_items_in_container: [],
@@ -343,7 +283,7 @@ RSpec.describe WorkOrders do
     let(:room_list) { [100, 101, 102] }
 
     context 'when NPC is in current room' do
-      before { $room_npcs = ['Jakke'] }
+      before { DRRoom.npcs = ['Jakke'] }
 
       it 'returns true without walking' do
         expect(DRCT).not_to receive(:walk_to)
@@ -367,7 +307,7 @@ RSpec.describe WorkOrders do
     end
 
     context 'when NPC is not in any room' do
-      before { $room_npcs = [] }
+      before { DRRoom.npcs = [] }
 
       it 'walks to all rooms and returns false' do
         expect(DRCT).to receive(:walk_to).exactly(3).times

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -22,6 +22,14 @@ module Harness
     def self.active_spells
       @@_data_store['active_spells'] || {}
     end
+
+    def self._set_known_spells(val)
+      @@_data_store['known_spells'] = val
+    end
+
+    def self.known_spells
+      @@_data_store['known_spells'] || {}
+    end
   end
 
   class DRStats
@@ -275,9 +283,13 @@ module Harness
 
   class DRSkill
     @@_data_store = {}
+    @@_xp_store = {}
+    @@_modrank_store = {}
 
     def self._reset
       @@_data_store = {}
+      @@_xp_store = {}
+      @@_modrank_store = {}
     end
 
     def self._set_rank(skillname, val)
@@ -286,6 +298,30 @@ module Harness
 
     def self.getrank(skillname)
       @@_data_store[skillname] || 100
+    end
+
+    def self._set_xp(skillname, val)
+      @@_xp_store[skillname] = val
+    end
+
+    def self._reset_xp
+      @@_xp_store = {}
+    end
+
+    def self.getxp(skillname)
+      @@_xp_store[skillname] || 0
+    end
+
+    def self._set_modrank(skillname, val)
+      @@_modrank_store[skillname] = val
+    end
+
+    def self._reset_modrank
+      @@_modrank_store = {}
+    end
+
+    def self.getmodrank(skillname)
+      @@_modrank_store[skillname] || 0
     end
   end
 
@@ -450,6 +486,14 @@ module Harness
       $running_scripts.include?(script_name)
     end
 
+    def self.current
+      OpenStruct.new(name: 'test-script')
+    end
+
+    def self.exists?(_name)
+      false
+    end
+
     def self.at_exit(&_block); end
   end
 
@@ -524,12 +568,19 @@ module Harness
   end
 
   class EquipmentManager
+    def empty_hands; end
+
+    def remove_gear_by; end
+
+    def wear_items(_items); end
+
+    def wear_equipment_set?(_set_name); end
   end
 
   class Room
     def self.current
       Map.new(
-        :id => 1,
+        :id    => 1,
         :wayto => {
           2 => nil
         }
@@ -567,8 +618,18 @@ module Harness
   end
 
   class XMLData
+    @@_room_title = nil
+
+    def self._reset
+      @@_room_title = nil
+    end
+
     def self.room_title
-      'Middle of Nowhere'
+      @@_room_title || 'Middle of Nowhere'
+    end
+
+    def self.room_title=(val)
+      @@_room_title = val
     end
   end
 
@@ -598,7 +659,7 @@ module Harness
     # See test_bput as an example.
   end
 
-  def parse_args(data, flex_args = false)
+  def parse_args(_data, _flex_args = false)
     args = OpenStruct.new($parsed_args.dup || {})
     args.flex = 'test'
     args
@@ -637,6 +698,17 @@ module Harness
     $displayed_messages = []
     $running_scripts = []
 
+    # Captures for the Lich script seams (respond/start_script/stop_script).
+    $respond_messages = []
+    $started_scripts = []
+    $stopped_scripts = []
+
+    # Overridable character/state flags (default to a safe, inert value).
+    $sitting = false
+    $stunned = false
+    $bleeding = false
+    $charname = nil
+
     # Uses a queue for thread safety.
     # See assert_sends_messages method for usage.
     $sent_messages = Queue.new
@@ -658,6 +730,7 @@ module Harness
     DRSkill._reset
     DRRoom._reset
     Map._reset
+    XMLData._reset
   end
 
   def echo(message)
@@ -724,6 +797,43 @@ module Harness
 
   def sent_messages
     $sent_messages
+  end
+
+  # Raw Lich respond. Captured so specs can assert on script output.
+  def _respond(message = '')
+    $respond_messages << message
+  end
+
+  # Script lifecycle helpers. start_script/stop_script capture their calls so
+  # specs can assert which scripts were launched or killed; move/waitfor are
+  # inert seams that scripts call during navigation.
+  def start_script(name, *args)
+    $started_scripts << [name, *args]
+  end
+
+  def stop_script(name)
+    $stopped_scripts << name
+  end
+
+  def move(*_args); end
+
+  def waitfor(*_args); end
+
+  # Character/state seams with test-overridable globals.
+  def checkname
+    $charname || 'Testchar'
+  end
+
+  def sitting?
+    $sitting || false
+  end
+
+  def stunned?
+    $stunned || false
+  end
+
+  def bleeding?
+    $bleeding || false
   end
 
   def health=(health)
@@ -798,10 +908,6 @@ module Harness
 
   def send_slackbot_message(message); end
 
-  def get
-    get?
-  end
-
   def clear; end
 
   def get_character_setting
@@ -841,7 +947,7 @@ module Harness
   end
 
   # Copied from lich.rbw
-  def force_start_script(script_name, cli_vars=[], flags={})
+  def force_start_script(script_name, cli_vars = [], flags = {})
   end
 
   def assert_sends_messages(expected_messages)
@@ -871,7 +977,7 @@ module Harness
   end
 
   def assert_displayed_messages_include_any(phrases)
-    proc do |error|
+    proc do |_error|
       result = $displayed_messages.any? do |message|
         phrases.any? do |phrase|
           message.include?(phrase)
@@ -887,5 +993,4 @@ module Harness
       assert(error.message.include?(error_message))
     end
   end
-
 end


### PR DESCRIPTION
## Summary

Running `rspec` with no args executed only ~44 of the ~2048 collected examples and was not reliably green. This PR makes the whole suite run green in a single process, consolidates duplicated test scaffolding, and fixes the pre-existing failures that the early abort had been hiding.

Before: `rspec` -> 44 examples executed, process exits mid-run.
After: `rspec` -> 2048 examples, 0 failures. Every spec also passes individually, and every touched file is rubocop-clean.

## Root causes fixed

1. **Hostile process-global hooks.** Nine specs registered `RSpec.configure { config.before(:each) { reset_data ... } }` at file-load time. RSpec runs a config-level `before` hook *after* a group's own `before` when the `configure` block is evaluated later than the group is defined (which is exactly what happens as spec files load alphabetically). A later spec's `reset_data` therefore ran last and clobbered the per-example world (guild, settings, hands, room) that an earlier spec had set in its own `before`; astrology's `#initialize` then hit its Moon-Mage guard and called a bare `exit`, killing the whole process. The single `reset_data` hook now lives in `spec_helper` (loaded first via a new `.rspec` `--require spec_helper`), so it always registers/runs before every group hook. Spec-specific world setup that lived in those global hooks moved into each spec's own describe-scoped `before`.

2. **Early aborts from leaked exits.** forge's `#swap_tool` reached `verify_tool_in_hand` -> `cleanup_and_exit` during real (non-dry) runs, leaking a `SystemExit` that terminated the process (only 78 of 108 forge examples ever ran, even alone). The swap_tool examples now neutralize the post-swap verification.

3. **Cross-spec stub pollution.** Specs each redefined the same top-level game stubs (`module DRC/DRCI/GameObj/Flags/DRSkill/Script/XMLData`, `def fput/echo/get/_respond/start_script/stop_script/sitting?/...`, and a copy of `load_lic_class` in 21 files) with conflicting behavior; whichever loaded last won for the whole process. The shared game-object mocks and lifecycle seams are consolidated into `test/test_harness.rb` (DRSkill xp/modrank, DRSpells known_spells, XMLData room_title, EquipmentManager, Script current/exists?, `_respond`/`start_script`/`stop_script`/`move`/`waitfor`/`checkname`/`sitting?`/`stunned?`/`bleeding?`), and `load_lic_class` now lives once in `spec_helper`. Specs rely on the shared harness plus per-example `allow()` stubs.

## Pre-existing genuine failures fixed (were hidden by the abort)

- **sew (3):** finish-message format drift; specs expected an old string.
- **forge (6):** logbook name (`forging` not `engineering`), sentry-block message text, and the recipe-book prep flow that now runs before ingot fetch.
- **enchant (3):** `@brazier_ref` (derived in `initialize`, which these specs bypass) is now set in the builder.
- **healer (1):** the "thin headroom" vit-transfer test now pins `@self_vit_floor` instead of assuming health 65 is above the computed floor.

## Testing

- `RBENV_VERSION=4.0.1 rspec` -> `2048 examples, 0 failures` (single process)
- Each `spec/*_spec.rb` run alone -> green
- `rubocop --no-server` on every touched file -> no offenses; ASCII only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected forging completion logs and related confirmation messages.
  - Improved guidance shown when access or funds prevent entering a private forge.
  - Updated sewing completion messages for consistent formatting.
  - Preserved text normalization for curly apostrophes and em dashes.

- **Tests**
  - Improved test isolation and shared setup across gameplay features.
  - Added coverage for script cleanup, equipment handling, room state, and character state.
  - Strengthened edge-case coverage for puzzle, healing, work order, and item interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->