### PR TITLE
spec: move load_lic_constant into the shared spec_helper

### DIFF
--- a/spec/researcher_spec.rb
+++ b/spec/researcher_spec.rb
@@ -2,18 +2,6 @@
 
 require_relative 'spec_helper'
 
-def load_lic_constant(filename, const_name)
-  return if Object.const_defined?(const_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  line = lines.find { |l| l =~ /^#{const_name}\s*=/ }
-  raise "Could not find '#{const_name}' in #{filename}" unless line
-
-  eval(line, TOPLEVEL_BINDING, filepath)
-end
-
 module DRC
   class << self
     def bput(*_args); end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,21 @@ def load_lic_class(filename, class_name)
   eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
 end
 
+# Extract and eval a single top-level constant assignment (CONST = ...) from a
+# .lic file without executing the rest of the file. The const_defined? guard
+# makes repeated calls (across co-running specs) idempotent.
+def load_lic_constant(filename, const_name)
+  return if Object.const_defined?(const_name)
+
+  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  lines = File.readlines(filepath)
+
+  line = lines.find { |l| l =~ /^#{const_name}\s*=/ }
+  raise "Could not find '#{const_name}' in #{filename}" unless line
+
+  eval(line, TOPLEVEL_BINDING, filepath)
+end
+
 RSpec.configure do |config|
   config.before(:each) do
     reset_data


### PR DESCRIPTION
## Summary

Follow-up to #7471 addressing a CodeRabbit nitpick.

`load_lic_class` already lives in `spec/spec_helper.rb`. `load_lic_constant` is the same kind of `.lic`-parsing utility (it extracts a single top-level `CONST = ...` assignment without executing the rest of the file) but was defined locally in `researcher_spec.rb`. This moves it alongside `load_lic_class` so all Lich script-extraction helpers live in one place and it's available to any future spec that needs it.

No behavior change.

## Testing

- `RBENV_VERSION=4.0.1 rspec spec/researcher_spec.rb` -> `177 examples, 0 failures`
- `RBENV_VERSION=4.0.1 rspec` (full suite, one process) -> `2048 examples, 0 failures`
- `rubocop --no-server` on touched files -> no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for loading license-based constants.
  * Prevented repeated constant definitions during test execution.
  * Ensured only the required constant assignment is evaluated from license files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->