### PR TITLE
spec: document the shared game-double conventions in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,28 +14,67 @@
 #
 # Lich runtime isolation:
 #   - Scripts (.lic files) cannot be required directly -- they depend on the full
-#     Lich runtime. Extract constants and methods via eval of specific line ranges
-#     (see load_lic_class below and dependency_spec.rb for the method-level pattern).
-#   - Mock only what you need: UserVars, Settings, Script.current, _respond, etc.
-#   - Use the test harness (test/test_harness.rb) for specs that need game objects.
+#     Lich runtime. Extract the class or a single constant via eval of specific
+#     line ranges with load_lic_class / load_lic_constant (defined below; see
+#     dependency_spec.rb for the method-level extraction pattern).
 #
-# Shared setup:
+# Shared game doubles -- READ THIS before adding or copying a spec:
+#   The game/commons layer is stubbed ONCE, centrally, so the whole suite can run
+#   in a single process without specs clobbering each other's doubles. Follow
+#   these rules or you WILL reintroduce order-dependent failures (a duplicate
+#   top-level definition wins for the entire process by load order, so a stub
+#   added in one spec silently changes another spec that ran first or last):
+#
+#   - Game objects (DRStats, DRSkill, DRSpells, DRRoom, GameObj, Flags, Room,
+#     Map, Script, XMLData, EquipmentManager), the commons command modules (DRC,
+#     DRCI, DRCC, DRCM, DRCT, DRCH, DRCA, DRCS, DRCMM, DRCTH) and Lich all live
+#     in test/test_harness.rb. Do NOT redefine or reopen them in a spec file
+#     (no `module DRC ... end`).
+#   - To change what a stub returns for one example, override it there with
+#     `allow(DRC).to receive(:bput).and_return(...)` -- never by reopening the
+#     module. `allow` adds the method even if the harness lacks it.
+#   - Harness default returns follow these conventions -- they are heuristics,
+#     not guarantees, so check test/test_harness.rb for the exact value:
+#       * presence / "did it happen" predicates (in_hands?, exists?) -> false
+#       * "did the action succeed" checks (get_item?, cast_spell?, walk_to) -> true
+#       * collection / count accessors -> [] / 0 / {}
+#         (e.g. get_item_list -> [], count_* -> 0, get_total_wealth -> {})
+#       * most other methods -> nil (an inert seam)
+#     Some methods return domain values instead of nil -- notably
+#     DRC.bput -> 'Roundtime' and DRCH.check_health -> a health Hash -- so do not
+#     assume nil for a method you have not checked.
+#   - Need a commons method the harness does not have yet? Add it to
+#     test/test_harness.rb following the conventions above -- do not stub it
+#     locally in one spec.
+#   - UserVars is the deliberate exception: it is per-script configuration (each
+#     script reads different keys with script-specific meanings), so stub it
+#     per-spec, not in the harness.
+#   - If a .lic method calls exit on a guard, drive it with
+#     `expect { ... }.to raise_error(SystemExit)` (or stub exit on the instance).
+#     A stray unwrapped exit terminates the whole run, not just the example.
+#
+# Shared setup / why reset_data lives here (do not move it):
 #   - This file is loaded before every spec via .rspec (--require spec_helper). It
 #     loads the test harness, includes Harness at the top level, provides the
-#     load_lic_class extraction helper, and registers the single global
-#     before(:each) { reset_data } hook.
-#   - Registering reset_data here (rather than in individual specs via
-#     RSpec.configure) is deliberate: config-level before hooks registered while a
-#     spec file loads run AFTER that spec's own group-level before hooks. A
-#     per-spec global reset_data would therefore run last and clobber the
-#     per-example world (guild, settings, hands, room) that other specs set up in
-#     their own before blocks. Because spec_helper is required first, its hook
-#     registers first and always runs before every group hook.
+#     load_lic_class / load_lic_constant extraction helpers, and registers the
+#     single global before(:each) { reset_data } hook.
+#   - Do NOT register a global RSpec.configure { config.before } in a spec.
+#     Same-scope before(:each) hooks run in the order they are registered, so a
+#     config.before(:each) runs before a group's own before hooks only when it
+#     was registered before that group was defined. spec_helper is required
+#     first (via .rspec), so its single reset_data hook is registered before
+#     every group and always runs first -- which is exactly why reset_data
+#     belongs here, not in a spec. A config.before added inside a spec file is
+#     registered AFTER the groups of already-loaded specs, so it runs AFTER
+#     their before hooks and clobbers the per-example world (guild, settings,
+#     hands, room) they set up (and it also runs for every example in every
+#     other file). Put spec-specific world setup in a describe-scoped before
+#     instead.
 
 require 'ostruct'
 
-# Load the test harness which provides mock game objects:
-# Flags, DRStats, DRSkill, DRRoom, Room, Map, GameObj, Script, XMLData, etc.
+# Load the test harness, which provides the mock game objects and commons
+# command modules listed in the "Shared game doubles" section above.
 load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
 
 include Harness

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -998,15 +998,20 @@ module Harness
   # Commons command-module stubs (DRC, DRCI, DRCC, ...).
   #
   # The commons layer cannot be loaded in specs, so these modules provide the
-  # union of the methods the scripts call, with neutral defaults:
-  #   - "is it present / did it happen" predicates default to false,
-  #   - "did the action succeed" predicates default to true,
-  #   - list/count accessors default to [] / 0,
-  #   - everything else is an inert nil-returning seam.
+  # union of the methods the scripts call, with neutral defaults (heuristics --
+  # a few methods return domain values like DRC.bput -> 'Roundtime'):
+  #   - presence / "did it happen" predicates default to false,
+  #   - "did the action succeed" checks default to true,
+  #   - collection / count accessors default to [] / 0 / {},
+  #   - most other methods are an inert nil-returning seam.
   # Individual specs override the handful of returns they assert on with
   # per-example `allow(...).to receive(...)`. Centralizing them here (rather
   # than redefining them in each spec) keeps a single, consistent stub surface
   # so co-running specs cannot clobber each other's game doubles.
+  #
+  # Add new commons methods here (matching the default conventions above); do
+  # not stub them in a single spec. See the "Shared game doubles" section in
+  # spec/spec_helper.rb for the full rationale.
   # ---------------------------------------------------------------------------
 
   # Derive the trailing noun of an item long-name (mirrors DRC.get_noun).


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #7471 and #7474.

The suite now runs green in a single process because the game/commons layer is stubbed **once**, centrally, in `test/test_harness.rb`. Nothing spelled out the rules that keep it that way, so it was easy for a new (or copy-pasted) spec to reintroduce a top-level `module DRC`, a global `RSpec.configure` before hook, or a leaked `exit` and quietly bring back the order-dependent failures we removed.

This expands the `spec/spec_helper.rb` header with a **"Shared game doubles"** section aimed at both human and AI contributors, documenting:

- game objects, the commons command modules (`DRC`, `DRCI`, ...), and `Lich` live only in the harness -- do not redefine/reopen them in a spec;
- override per-example with `allow(...).to receive(...)`, never by reopening the module;
- the harness default-return conventions (presence predicates -> `false`, success predicates -> `true`, list/count accessors -> `[]` / `0` / `{}`, else `nil`);
- add a missing commons method to the harness, not to one spec;
- `UserVars` is the deliberate per-spec exception (per-script config);
- drive `.lic` exit guards with `raise_error(SystemExit)` so a stray exit can't kill the run;
- don't register a global `RSpec.configure { config.before }` (reset_data is centralized here, with the existing rationale).

Also fixes the now-stale "mock only what you need" line, notes `load_lic_constant` alongside `load_lic_class`, and adds a back-pointer from the harness command-stub section to this rationale.

No behavior change. Full suite stays green (`2048 examples, 0 failures`); touched files are rubocop-clean and ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance in the test helper docs on shared game doubles, including where the stubs are defined and how to avoid redefining them in individual specs.
  - Clarified the recommended pattern for per-example overrides of stubbed behavior.
  - Improved explanation of test setup loading and hook ordering to help keep spec initialization consistent.
  - Refined contributor guidance on extending the shared commons command-module stubs surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->