### PR TITLE
Fix base-theurgy to work with Riverhaven

### DIFF
--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -270,7 +270,7 @@ Riverhaven:
     id: 7792
     price: 115
   altar:
-    id: 438
+    id: 440
   favor_altars:
     Divyaush:
       id: 440

--- a/data/base-theurgy.yaml
+++ b/data/base-theurgy.yaml
@@ -254,7 +254,7 @@ Crossing:
     noun: basin
   primer_npc: shaman
 
-Haven:
+Riverhaven:
   wine_shop:
     id: 12048
     price: 300


### PR DESCRIPTION
the old "haven" key did not match up with base-towns.yaml "Riverhaven"

the altar at 438 couldn't have devotionals done there, so updated it to the closest altar