### PR TITLE
smoke: refactor into testable seams + robustness fixes + spec suite

### DIFF
--- a/smoke.lic
+++ b/smoke.lic
@@ -11,21 +11,57 @@
     - tart
 =end
 
+# Trains smoke-image skills by repeatedly inhaling and exhaling images, and can
+# teach or learn images from another player.
+#
+# Image selection is tier-priority: the script reads "smoke list", groups your
+# trainable images by mastery tier, and practices the lowest (least-skilled)
+# tier first, re-reading the list between rounds to follow advancements.
+#
+# @note Required settings (under the `smoke:` block):
+#   - `container` [String] holds your smoking supplies (required)
+#   - `pipe` [String] pipe noun/adjective (required unless smoking a cigar)
+# @note Optional settings:
+#   - `lighter` [String] preferred lighter; falls back to flint and steel
+#   - `blade` [String] blade used to strike flint (EquipmentManager item)
+#   - `lighter_tied_to` [String] where the lighter is tied
+#   - `time_between_exhales` [Integer] pause between exhales (default 1)
+#   - `clean_list_of_mastered` [Boolean] skip fully mastered images
+#   - `smoke_images` [Array<String>] curated training pool
+#   - `smoke_room` [Integer] room id to walk to before training
+#
+# @example Train one piece of tobacco from your pipe
+#   ;smoke pipe
+# @example Train until you run out of tobacco
+#   ;smoke pipe until_out
+# @example Just light a cigar and stop
+#   ;smoke fine cigar light_only
+# @example Teach the deer image to another player
+#   ;smoke teach pipe Someone deer
 class Smoker
-  VERSION = '1.0'
+  VERSION = '2.0'
 
+  # Maps each skill tier name to its training priority (lower is less skilled).
+  # Olvi (Halflings) use different intermediate names but share `master`/`master*`.
   TIER_ORDER = {
     'learning' => 0,
-    'wheezer' => 1, 'beginner' => 1,
-    'sneezer' => 2, 'amateur' => 2,
-    'whiffler' => 3, 'adequate' => 3,
+    'wheezer'  => 1, 'beginner'  => 1,
+    'sneezer'  => 2, 'amateur'   => 2,
+    'whiffler' => 3, 'adequate'  => 3,
     'streamer' => 4, 'competent' => 4,
-    'master' => 5,
-    'master*' => 6
+    'master'   => 5,
+    'master*'  => 6
   }.freeze
 
+  # Tier name that marks a fully mastered image.
+  MASTERED_TIER = 'master*'.freeze
+
+  # Priority assigned to tiers absent from {TIER_ORDER} (sorts last).
+  UNKNOWN_RANK = 99
+
   def initialize
-    Flags.add('new-cig', 'That was the last of your', 'goes out and crumbles away'); Flags['new-cig'] = true
+    Flags.add('new-cig', 'That was the last of your', 'goes out and crumbles away')
+    Flags['new-cig'] = true
     @full_image_list = ['deer', 'dragon', 'rabbit', 'pixie', 'kitten', 'troll', 'horse', 'paladin', 'whip', 'cloak', 'stump', 'fleas', 'daisies', 'unicorn', 'rams', 'bandit', 'ship', 'grave', 'fish', 'web', 'phoenix', 'bracelet', 'skeleton', 'tart', 'almanac', 'dartboard', 'wolf', 'vine', 'forge', 'moongate', 'mage', 'violin', 'altar', 'trader']
     UserVars.smoke_images_known ||= @full_image_list
     UserVars.smoke_images_mastered ||= []
@@ -65,13 +101,14 @@ class Smoker
       DRC.message("Add a smoke: section with at minimum 'container' set. See the user guide for all options.")
       exit
     end
+
     @equipmanager   = EquipmentManager.new
-    images          = args.image || @smoke_settings['smoke_images'] || UserVars.smoke_images_known
     @bag            = @smoke_settings['container']
     @pipe           = @smoke_settings['pipe']
     @lighter        = @smoke_settings['lighter']
-    @blade          = @equipmanager.items.find { |gear| gear.short_regex =~ @smoke_settings['blade'] || gear.name =~ /\b#{@smoke_settings['blade']}\b/i }
+    @blade          = find_blade(@smoke_settings['blade'])
     @cigar          = args.cigar
+    @smoker         = @cigar || @pipe
     @time_between   = @smoke_settings['time_between_exhales'] || 1
     # An explicitly requested image is trained even if mastered; otherwise honor the setting.
     @clean_mastered = @smoke_settings['clean_list_of_mastered'] && !args.image
@@ -84,31 +121,48 @@ class Smoker
       exit
     end
 
+    # Array() normalizes a single image arg (String) and the list settings (Array) alike.
+    images = Array(args.image || @smoke_settings['smoke_images'] || UserVars.smoke_images_known)
+
     reset_known if args.reset_known
-    smoke_teach(args, images.to_a) if args.teach
+    smoke_teach(args, images) if args.teach
 
-    unless args.image
-      images = check_images(images)
-      if UserVars.smoke_images_known.size == UserVars.smoke_images_mastered.size
-        DRC.message("=== All #{UserVars.smoke_images_mastered.size} known images have reached master* ===")
-        DRC.message("Mastered: #{UserVars.smoke_images_mastered.join(', ')}")
-        DRC.message("Nothing left to practice. Learn new images and run ;smoke reset_known to continue.")
-        exit
-      elsif images.empty?
-        DRC.message("No valid images selected")
-        exit
+    rounds =
+      if args.until_out
+        :until_out
+      elsif args.repeat
+        args.repeat.to_i
+      else
+        1
       end
-    end
+    smoke_loop(images, rounds)
+  end
 
-    if args.until_out
-      smoke_loop(images.to_a, :until_out)
-    elsif args.repeat
-      smoke_loop(images.to_a, args.repeat.to_i)
-    else
-      smoke_loop(images.to_a, 1)
+  # Treats nil and blank/whitespace strings as "not configured".
+  #
+  # @param value [Object] a setting value (commonly String or nil)
+  # @return [Boolean] true when the value is nil or an empty/whitespace string
+  def blank?(value)
+    value.nil? || (value.respond_to?(:strip) && value.strip.empty?)
+  end
+
+  # Resolves the configured blade to an EquipmentManager item.
+  #
+  # @param setting [String, nil] the configured blade noun/adjective
+  # @return [Object, nil] the matching item, or nil when unset/unmatched
+  def find_blade(setting)
+    return nil if blank?(setting)
+
+    @equipmanager.items.find do |gear|
+      gear.short_regex =~ setting || gear.name =~ /\b#{Regexp.escape(setting)}\b/i
     end
   end
 
+  # Validates the equipment settings for the requested run and aborts with a
+  # helpful summary if anything required is missing or misconfigured.
+  #
+  # @param args [Object] parsed command arguments
+  # @return [void]
   def validate_settings(args)
     # reset_known only needs the smoke settings block to exist (already checked), no equipment
     return if args.reset_known
@@ -116,27 +170,22 @@ class Smoker
     errors = []
     warnings = []
 
-    # Container is required for all equipment modes
-    errors << "'container' is not set. Specify the container holding your smoking supplies (e.g., 'smoking jacket')." unless @bag
+    errors << "'container' is not set. Specify the container holding your smoking supplies (e.g., 'smoking jacket')." if blank?(@bag)
 
-    # Pipe-specific validation. Anything that is not an explicit cigar run uses
-    # the pipe (bare ;smoke, image-only, and ;smoke pipe all default to @pipe).
+    # Anything that is not an explicit cigar run uses the pipe (bare ;smoke,
+    # image-only, and ;smoke pipe all default to @pipe).
     using_cigar = args.cigar || (args.smoke && args.smoke =~ /cigar/i)
-    needs_pipe = !using_cigar
-    errors << "'pipe' is not set. Specify the noun/adjective of your pipe (e.g., 'glitvire pipe')." if needs_pipe && !@pipe
+    errors << "'pipe' is not set. Specify the noun/adjective of your pipe (e.g., 'glitvire pipe')." if !using_cigar && blank?(@pipe)
 
-    # Lighting chain validation - all smoking modes need a way to light
-    unless DRStats.warrior_mage?
-      if @lighter
-        # lighter configured, good
-      elsif @smoke_settings['blade']
-        if @blade
-          warnings << "No 'lighter' configured. Will use flint and steel with '#{@smoke_settings['blade']}'."
-        else
-          errors << "'blade' is set to '#{@smoke_settings['blade']}' but no matching item found in EquipmentManager. Register the item or correct the setting."
-        end
-      else
+    # Lighting chain: warrior mages light innately; everyone else needs a lighter
+    # or a flint-and-steel blade.
+    unless DRStats.warrior_mage? || !blank?(@lighter)
+      if blank?(@smoke_settings['blade'])
         errors << "No way to light tobacco. Set 'lighter', or set 'blade' for flint and steel. Warrior Mages light automatically."
+      elsif @blade
+        warnings << "No 'lighter' configured. Will use flint and steel with '#{@smoke_settings['blade']}'."
+      else
+        errors << "'blade' is set to '#{@smoke_settings['blade']}' but no matching item found in EquipmentManager. Register the item or correct the setting."
       end
     end
 
@@ -150,19 +199,24 @@ class Smoker
     exit
   end
 
+  # Runs the training loop: build a priority queue, then smoke rounds of tobacco
+  # until the requested count is reached or, in until_out mode, supplies run out.
+  #
+  # @param images [Array<String>] the candidate training pool
+  # @param number [Integer, Symbol] round count, or :until_out
+  # @return [void]
   def smoke_loop(images, number)
     @image_pool = images
     @image_queue = build_priority_queue
     if @image_queue.empty?
-      DRC.message("=== All #{UserVars.smoke_images_mastered.size} images have reached master* ===")
-      DRC.message("Mastered: #{UserVars.smoke_images_mastered.join(', ')}")
-      DRC.message("Nothing left to practice. Learn new images and run ;smoke reset_known to continue.")
+      announce_all_mastered
       exit
     end
+
     until_out = (number == :until_out)
     max_rounds = until_out ? Float::INFINITY : number
     DRC.message(until_out ? "Starting smoke loop: until out of tobacco or images" : "Starting smoke loop: #{number} round(s)")
-    DRCT.walk_to(@smoke_settings['smoke_room'])
+    DRCT.walk_to(@smoke_settings['smoke_room']) if @smoke_settings['smoke_room']
     rounds_completed = 0
     round = 0
     while round < max_rounds
@@ -193,19 +247,38 @@ class Smoker
       DRC.message(until_out ? "Round #{rounds_completed} complete, tobacco exhausted." : "Round #{round}/#{number} complete, tobacco exhausted.")
       # Refresh tier data between rounds to detect advancements
       @image_queue = build_priority_queue
-      if @image_queue.empty?
-        DRC.message("=== All #{UserVars.smoke_images_mastered.size} images have reached master* ===")
-        DRC.message("Mastered: #{UserVars.smoke_images_mastered.join(', ')}")
-        DRC.message("Finished #{rounds_completed} round(s). Nothing left to practice.")
-        DRC.message("Learn new images and run ;smoke reset_known to continue.")
-        DRCI.put_away_item?(@pipe, @bag) if DRCI.in_hands?(@pipe)
-        exit
-      end
+      next unless @image_queue.empty?
+
+      announce_all_mastered("Finished #{rounds_completed} round(s). ")
+      stow_pipe
+      exit
     end
-    DRCI.put_away_item?(@pipe, @bag) if DRCI.in_hands?(@pipe)
+    stow_pipe
     DRC.message("Smoker Complete! Finished #{rounds_completed} round(s).")
   end
 
+  # Announces that there is nothing left to practice.
+  #
+  # @param prefix [String] optional lead-in (e.g. round summary)
+  # @return [void]
+  def announce_all_mastered(prefix = "")
+    DRC.message("=== All #{UserVars.smoke_images_mastered.size} images have reached master* ===")
+    DRC.message("Mastered: #{UserVars.smoke_images_mastered.join(', ')}")
+    DRC.message("#{prefix}Nothing left to practice. Learn new images and run ;smoke reset_known to continue.")
+  end
+
+  # Stows the pipe if it is in hand. No-op for cigar runs.
+  #
+  # @return [void]
+  def stow_pipe
+    DRCI.put_away_item?(@pipe, @bag) if @pipe && DRCI.in_hands?(@pipe)
+  end
+
+  # Lights a smoker for until_out mode, reporting (rather than aborting) when
+  # supplies run out.
+  #
+  # @param smoker [String] "pipe" or a cigar noun
+  # @return [Boolean] true if lit, false if out of tobacco/cigars
   def quick_light_safe(smoker)
     case smoker
     when /pipe/
@@ -234,6 +307,11 @@ class Smoker
     end
   end
 
+  # Dispatches to the teaching or learning loop after lighting up.
+  #
+  # @param args [Object] parsed command arguments (uses args.smoke, args.player, args.teach)
+  # @param images [Array<String>] images to teach (ignored when learning)
+  # @return [void]
   def smoke_teach(args, images)
     Flags.add('smoke-image-learned', /finally catches on to your instructions on how to make the .* smoke image/, /^You now know the basics of making the .* smoke image/)
     Flags.add('teacher-smoked', /^#{args.player.capitalize} takes a long drag off of/)
@@ -249,6 +327,11 @@ class Smoker
     send(args.teach + '_loop', images, args.player.capitalize)
   end
 
+  # Teaches each image to a student, demonstrating until they learn it.
+  #
+  # @param images [Array<String>] images to teach in order
+  # @param player [String] student name (already capitalized)
+  # @return [void]
   def teach_loop(images, player)
     @time_between = 0
     images.each do |image|
@@ -267,36 +350,27 @@ class Smoker
     exit
   end
 
+  # Learns images from a teacher, copying each demonstrated image until learned.
+  # Aborts if the teacher leaves the room.
+  #
+  # @param _images [Array<String>] unused (kept for the teach/learn dispatch arity)
+  # @param player [String] teacher name (already capitalized)
+  # @return [void]
   def learn_loop(_images, player)
     @time_between = 0
     loop do
-      unless DRRoom.pcs.include?(player)
-        DRC.message("=== #{player} is no longer in the room ===")
-        DRC.message("Learning session ended. Stowing equipment.")
-        DRCI.put_away_item?(@smoker, @bag) if @smoker && DRCI.in_hands?(@smoker)
-        exit
-      end
+      abort_lesson("#{player} is no longer in the room") unless DRRoom.pcs.include?(player)
       if /make a (?<image>\w+) smoke image/ =~ DRC.bput("Listen #{player}", /^You start paying attention to #{player.capitalize}'s advice on how to make a (?<image>\w+) smoke image/, /^#{player.capitalize} isn't teaching a class/)
         image = Regexp.last_match[:image]
       else
         pause 1 until Flags['time-to-listen'] || !DRRoom.pcs.include?(player)
-        unless DRRoom.pcs.include?(player)
-          DRC.message("=== #{player} is no longer in the room ===")
-          DRC.message("Learning session ended. Stowing equipment.")
-          DRCI.put_away_item?(@smoker, @bag) if @smoker && DRCI.in_hands?(@smoker)
-          exit
-        end
+        abort_lesson("#{player} is no longer in the room") unless DRRoom.pcs.include?(player)
         image = Flags['time-to-listen'][:image]
         DRC.bput("Listen #{player}", /You start paying attention to/)
       end
       until Flags['smoke-image-learned']
         pause 1 until Flags['teacher-smoked'] || Flags['smoke-image-learned'] || !DRRoom.pcs.include?(player)
-        unless DRRoom.pcs.include?(player)
-          DRC.message("=== #{player} left the room mid-lesson ===")
-          DRC.message("Learning session ended. Stowing equipment.")
-          DRCI.put_away_item?(@smoker, @bag) if @smoker && DRCI.in_hands?(@smoker)
-          exit
-        end
+        abort_lesson("#{player} left the room mid-lesson") unless DRRoom.pcs.include?(player)
         Flags.reset('teacher-smoked')
         break if Flags['smoke-image-learned']
 
@@ -309,6 +383,22 @@ class Smoker
     end
   end
 
+  # Ends a teaching/learning session cleanly, stowing the active smoker.
+  #
+  # @param reason [String] why the session is ending
+  # @return [void]
+  def abort_lesson(reason)
+    DRC.message("=== #{reason} ===")
+    DRC.message("Learning session ended. Stowing equipment.")
+    DRCI.put_away_item?(@smoker, @bag) if @smoker && DRCI.in_hands?(@smoker)
+    exit
+  end
+
+  # Offers a lesson on a single image to a student.
+  #
+  # @param image [String] image to teach
+  # @param player [String] student name
+  # @return [Boolean] true if the student is attending, false if they already know it
   def offer_lesson(image, player)
     case DRC.bput("smoke teach #{image} #{player}", { 'timeout' => 45, 'suppress_no_match' => true }, /^#{player.capitalize} starts paying attention to your advice on how to make/, /^#{player.capitalize} nods to you/, /already knows how to make that smoke image/)
     when /paying attention/, /nods to you/
@@ -321,6 +411,9 @@ class Smoker
     end
   end
 
+  # Retrieves the pipe, ensures it holds tobacco, and lights it.
+  #
+  # @return [void]
   def load_pipe
     unless DRCI.get_item_if_not_held?(@pipe, @bag)
       DRC.message("Could not get #{@pipe} from #{@bag}.")
@@ -341,6 +434,10 @@ class Smoker
     light_tobacco("tobacco in pipe")
   end
 
+  # Retrieves and lights a smoker, aborting on failure.
+  #
+  # @param smoker [String] "pipe" or a cigar noun
+  # @return [void]
   def quick_light(smoker)
     Flags.reset('new-cig')
     case smoker
@@ -355,44 +452,71 @@ class Smoker
     end
   end
 
+  # Lights the target via the best available method.
+  #
+  # @param target [String] loaded pipe contents or a cigar in hand
+  # @return [void]
   def light_tobacco(target) # loaded pipe or cigar in hand, ends with either in hand, ready to rip
-    if DRStats.warrior_mage?
-      DRC.bput("prep c b t", /^You are now prepared/)
-      DRC.bput("gesture #{target}", /^You touch/, /^That's already burning/)
-    elsif @lighter
-      if @smoke_settings['lighter_tied_to']
-        unless DRCI.untie_item?(@lighter, @smoke_settings['lighter_tied_to'])
-          DRC.message("#{@lighter} could not be untied, going to try flint and steel")
-          @lighter = false
-          return light_tobacco(target)
-        end
-      else
-        unless DRCI.get_item?(@lighter)
-          DRC.message("#{@lighter} could not get lighter, going to try flint and steel")
-          @lighter = false
-          return light_tobacco(target)
-        end
-      end
+    return light_warrior_mage(target) if DRStats.warrior_mage?
+    return light_with_lighter(target) if @lighter
 
-      DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
-      return if @smoke_settings['lighter_tied_to'] && DRCI.tie_item?(@lighter, @smoke_settings['lighter_tied_to'])
-
-      DRCI.put_away_item?(@lighter, @bag)
-    else # flint
-      unless DRCI.get_item?("flint")
-        DRC.message("Could not get flint. Buy flint from a general store.")
-        DRCI.put_away_item?(DRC.right_hand, @bag)
-        exit
-      end
-      DRCI.lower_item?(target.split.last)
-      @equipmanager.get_item?(@blade)
-      DRC.bput("light #{target} with my flint", /^Roundtime/, /^That's already burning/)
-      DRCI.stow_item?("flint")
-      @equipmanager.return_held_gear
-      DRCI.lift?
-    end
+    light_with_flint(target)
   end
 
+  # Lights using the warrior mage cantrip.
+  #
+  # @param target [String] thing to light
+  # @return [void]
+  def light_warrior_mage(target)
+    DRC.bput("prep c b t", /^You are now prepared/)
+    DRC.bput("gesture #{target}", /^You touch/, /^That's already burning/)
+  end
+
+  # Lights using the configured lighter, falling back to flint on failure.
+  #
+  # @param target [String] thing to light
+  # @return [void]
+  def light_with_lighter(target)
+    if @smoke_settings['lighter_tied_to']
+      unless DRCI.untie_item?(@lighter, @smoke_settings['lighter_tied_to'])
+        DRC.message("#{@lighter} could not be untied, going to try flint and steel")
+        @lighter = false
+        return light_tobacco(target)
+      end
+    elsif !DRCI.get_item?(@lighter)
+      DRC.message("#{@lighter} could not get lighter, going to try flint and steel")
+      @lighter = false
+      return light_tobacco(target)
+    end
+
+    DRC.bput("point my #{@lighter} at #{target}", /making the .* quickly catch fire/, /^That's already burning/)
+    return if @smoke_settings['lighter_tied_to'] && DRCI.tie_item?(@lighter, @smoke_settings['lighter_tied_to'])
+
+    DRCI.put_away_item?(@lighter, @bag)
+  end
+
+  # Lights using flint and steel (the configured blade).
+  #
+  # @param target [String] thing to light
+  # @return [void]
+  def light_with_flint(target)
+    unless DRCI.get_item?("flint")
+      DRC.message("Could not get flint. Buy flint from a general store.")
+      DRCI.put_away_item?(DRC.right_hand, @bag)
+      exit
+    end
+    DRCI.lower_item?(target.split.last)
+    @equipmanager.get_item?(@blade)
+    DRC.bput("light #{target} with my flint", /^Roundtime/, /^That's already burning/)
+    DRCI.stow_item?("flint")
+    @equipmanager.return_held_gear
+    DRCI.lift?
+  end
+
+  # Exhales a single image, handling the untrained and just-learned outcomes.
+  #
+  # @param image [String] image to exhale
+  # @return [void]
   def exhale_smoke(image)
     case DRC.bput("exhale line #{image}", /^Roundtime/, /^You are untrained in the ways of making that image./, /^You now know the basics of making/)
     when /untrained/
@@ -405,6 +529,10 @@ class Smoker
     end
   end
 
+  # Inhales from the active smoker, clearing the lungs first if needed.
+  #
+  # @param image [String] image being practiced (exhaled if lungs must be cleared)
+  # @return [void]
   def inhale(image)
     if /out of your lungs first/ =~ DRC.bput("inhale my #{@smoker}", /^You take/, /out of your lungs first/)
       exhale_smoke(image)
@@ -412,70 +540,10 @@ class Smoker
     end
   end
 
-  def parse_smoke_list
-    entries = []
-    fput 'smoke list'
-    loop do
-      line = get
-      break if line =~ /Total images known/
-      break if line =~ /You don't know any smoke images/
-      next if line.include?('IMAGE - SKILL')
-      entries.concat(line.scan(/(\w+)\s+-\s+(\w+\*?)/))
-    end
-    entries # array of [image_name, tier_name] pairs
-  end
-
-  def build_priority_queue
-    entries = parse_smoke_list
-    known_names = entries.map(&:first)
-    UserVars.smoke_images_known = known_names
-
-    # Filter pool to only images we actually know
-    unknown = @image_pool - known_names
-    DRC.message("Removing unknown images: #{unknown.join(', ')}") unless unknown.empty?
-    @image_pool &= known_names
-
-    # Filter mastered if configured, but never drop an explicitly requested image.
-    if @clean_mastered
-      mastered = entries
-                 .select { |_, tier| tier == 'master*' }
-                 .map(&:first)
-                 .select { |name| @image_pool.include?(name) }
-      DRC.message("Removing mastered images: #{mastered.join(', ')}") unless mastered.empty?
-      UserVars.smoke_images_mastered |= mastered
-      @image_pool -= mastered
-    end
-
-    return [] if @image_pool.empty?
-
-    # Group by tier
-    pool_entries = entries.select { |name, _| @image_pool.include?(name) }
-    grouped = pool_entries.group_by { |_, tier| TIER_ORDER[tier.downcase] || 99 }
-    sorted_tiers = grouped.sort_by(&:first)
-
-    # Log all tiers for visibility
-    tier_summary = sorted_tiers.map { |_, imgs|
-      "#{imgs.first[1]}(#{imgs.size})"
-    }.join(' > ')
-    DRC.message("Image tiers: #{tier_summary}")
-
-    # Build queue from ONLY the lowest tier
-    _, lowest_imgs = sorted_tiers.first
-    @lowest_tier_pool = lowest_imgs.map(&:first)
-    queue = @lowest_tier_pool.shuffle
-    DRC.message("Practicing #{lowest_imgs.first[1]} tier: #{queue.join(', ')}")
-
-    queue
-  end
-
-  def next_image
-    if @image_queue.empty?
-      @image_queue = @lowest_tier_pool.shuffle
-      DRC.message("Reshuffled: #{@image_queue.join(', ')}")
-    end
-    @image_queue.shift
-  end
-
+  # Performs one inhale/exhale cycle for an image.
+  #
+  # @param image [String, nil] image to practice; pulled from the queue when nil
+  # @return [void]
   def smoke(image = nil)
     image ||= next_image
     DRC.message("Practicing image: #{image}")
@@ -486,63 +554,172 @@ class Smoker
     pause @time_between
   end
 
-  def reset_known
-    # Resetting our known images to the master list
-    UserVars.smoke_images_known = @full_image_list
-    # and our mastered images to an empty list
-    UserVars.smoke_images_mastered = []
-    # Then cleaning out images we don't know, getting a list of images we've mastered
-    # and providing a list of images to train
-    training_list = check_images(@full_image_list)
-    if training_list.empty?
-      DRC.message("All known images are mastered. Set a list under smoke_images in your yaml, or smoker will select from your known images at random")
-    else
-      DRC.message("New Training List: #{training_list.join(' ')}")
-    end
-    exit
-  end
-
-  def check_images(images)
-    # If we master everything during our loop, this variable will be empty, so we'll revert to just broad sampling.
-    return UserVars.smoke_images_known unless images
-    # Here we're returning IF the provided list of images is identical to our known image size, and the follow-on comparison suggests we've mastered everything we know.
-    return images if images.size == UserVars.smoke_images_known.size && UserVars.smoke_images_known.size == UserVars.smoke_images_mastered.size
-
-    smoke_list = []
+  # Sends "smoke list" and gathers its raw output lines.
+  #
+  # @return [Array<String>] lines up to (excluding) the terminator line
+  def collect_smoke_list_lines
+    lines = []
     fput 'smoke list'
     loop do
       line = get
-      break if line =~ /Total images known/ # last line after smoke list
-      break if line =~ /You don't know any smoke images/ # last line of empty smoke list
-      next if line.include?('IMAGE - SKILL') # topline that would normally match
+      break if line.nil?
+      break if line =~ /Total images known/
+      break if line =~ /You don't know any smoke images/
 
-      smoke_list << line.scan(/\w+\s-\s\w+\*?/) # grabbing lines: "<image> - <mastery level>       <image> - <mastery level>        <image> - <mastery level>"
+      lines << line
     end
-    smoke_list.flatten!
-    # This draws off our array of known images, creating a new array of images found on our smoke list.
-    # effectively comparing the two, and removing images we don't know
-    # smoke_images_known, unless already defined, contains a list of all possible images, so this is important
-    images_you_know = UserVars.smoke_images_known.select { |image| smoke_list.any? { |image_and_mastery| image_and_mastery.include?(image) } }
-    # smoke_images_known, unless already defined, contains a list of all possible images, so this is important
-    UserVars.smoke_images_known = images_you_know
-    unless (images - images_you_know).empty? # skip if we haven't asked to smoke any images we don't know
-      DRC.message("Removing images you do not know: #{(images - images_you_know).join(' ')}") # prints out a string representing the difference between what images we know and what images we wanted to smoke
-      images -= (images - images_you_know) # creates an array of images we don't know, and removes them from our list of images we were hoping to smoke
-    end
-    # Here we might want to just smoke a curated list of images, regardless of whether we've mastered one or more
-    # Note: Olvi (Halflings) use different intermediate tier names but share the 'master*' indicator with all races
-    return images unless @smoke_settings['clean_list_of_mastered']
+    lines
+  end
 
-    # Here we're using the originally generated list like a hash
-    images_mastered = smoke_list
-                      .select { |image_and_mastery| image_and_mastery.include?('master*') } # selecting only those images we've fully mastered.
-                      .join(' ') # making a string of image names, dashes, and 'master*'
-                      .split # creating a new array with all of those items as elements
-                      .reject { |item| item =~ /-|master\*/ } # removing the dashes and 'master*' elements, leaving us with just an array of images we've mastered
-                      .select { |image| images.include?(image) } # then comparing our original images list to the list of mastered images, and removing any matches.
-    DRC.message("Removing already mastered images: #{images_mastered.join(' ')}") unless images_mastered.empty? # images_mastered here means images from our variable 'images' that we sent this method
-    UserVars.smoke_images_mastered |= images_mastered # here we're adding any mastered images we found on our list of mastered to our uservar, but only if they're not already present.
-    images - UserVars.smoke_images_mastered # Finally, we return our original list minus any images we've mastered.
+  # Parses "smoke list" output into image/tier pairs. Pure: no game I/O.
+  #
+  # @param lines [Array<String>] raw "smoke list" output lines
+  # @return [Array<Array(String, String)>] [image, tier] pairs
+  # @example
+  #   parse_smoke_list(["deer    - learning     tart    - master*"])
+  #   # => [["deer", "learning"], ["tart", "master*"]]
+  def parse_smoke_list(lines)
+    lines.reject { |line| line.to_s.include?('IMAGE - SKILL') }
+         .flat_map { |line| line.to_s.scan(/(\w+)\s+-\s+(\w+\*?)/) }
+  end
+
+  # Reads and parses the current smoke list.
+  #
+  # @return [Array<Array(String, String)>] [image, tier] pairs
+  def read_smoke_list
+    parse_smoke_list(collect_smoke_list_lines)
+  end
+
+  # Training priority of a tier. Pure.
+  #
+  # @param tier [String] a tier name
+  # @return [Integer] {TIER_ORDER} rank, or {UNKNOWN_RANK} if unrecognized
+  def tier_rank(tier)
+    TIER_ORDER[tier.to_s.downcase] || UNKNOWN_RANK
+  end
+
+  # Whether a tier name is recognized. Pure.
+  #
+  # @param tier [String] a tier name
+  # @return [Boolean]
+  def known_tier?(tier)
+    TIER_ORDER.key?(tier.to_s.downcase)
+  end
+
+  # Whether a tier represents full mastery. Case-insensitive. Pure.
+  #
+  # @param tier [String] a tier name
+  # @return [Boolean]
+  def mastered?(tier)
+    tier.to_s.downcase == MASTERED_TIER
+  end
+
+  # Computes a training plan from a smoke list. Pure: no I/O, no state writes,
+  # deterministic (does not shuffle).
+  #
+  # @param entries [Array<Array(String, String)>] [image, tier] pairs
+  # @param pool [Array<String>] candidate images to train
+  # @param clean_mastered [Boolean] drop fully mastered images from the pool
+  # @return [Hash] plan with keys:
+  #   :known [Array<String>] every image the list reports
+  #   :unknown [Array<String>] pool images not on the list
+  #   :mastered [Array<String>] pool images at {MASTERED_TIER} (when clean_mastered)
+  #   :pool [Array<String>] surviving training pool
+  #   :unknown_tiers [Array<String>] tier names absent from {TIER_ORDER}
+  #   :lowest_tier [String, nil] display name of the lowest surviving tier
+  #   :lowest_images [Array<String>] images at the lowest surviving tier
+  #   :summary [String] human-readable tier breakdown
+  def prioritize(entries, pool, clean_mastered:)
+    known = entries.map(&:first)
+    unknown = pool - known
+    survivors = pool & known
+
+    mastered = []
+    if clean_mastered
+      mastered = entries.select { |_, tier| mastered?(tier) }
+                        .map(&:first)
+                        .select { |name| survivors.include?(name) }
+      survivors -= mastered
+    end
+
+    pool_entries = entries.select { |name, _| survivors.include?(name) }
+    unknown_tiers = pool_entries.map { |_, tier| tier }.reject { |tier| known_tier?(tier) }.uniq
+    grouped = pool_entries.group_by { |_, tier| tier_rank(tier) }
+    sorted = grouped.sort_by(&:first)
+    summary = sorted.map { |_, imgs| "#{imgs.first[1]}(#{imgs.size})" }.join(' > ')
+
+    if sorted.empty?
+      lowest_name = nil
+      lowest_images = []
+    else
+      _, lowest_entries = sorted.first
+      lowest_name = lowest_entries.first[1]
+      lowest_images = lowest_entries.map(&:first)
+    end
+
+    {
+      known: known,
+      unknown: unknown,
+      mastered: mastered,
+      pool: survivors,
+      unknown_tiers: unknown_tiers,
+      lowest_tier: lowest_name,
+      lowest_images: lowest_images,
+      summary: summary
+    }
+  end
+
+  # Reads the smoke list, updates UserVars, and returns a shuffled queue of the
+  # lowest trainable tier. Reports unknown/mastered/unrecognized-tier removals.
+  #
+  # @return [Array<String>] the next round's image queue ([] when nothing to train)
+  def build_priority_queue
+    plan = prioritize(read_smoke_list, @image_pool, clean_mastered: @clean_mastered)
+
+    UserVars.smoke_images_known = plan[:known]
+    UserVars.smoke_images_mastered |= plan[:mastered]
+
+    DRC.message("Removing unknown images: #{plan[:unknown].join(', ')}") unless plan[:unknown].empty?
+    DRC.message("Removing mastered images: #{plan[:mastered].join(', ')}") unless plan[:mastered].empty?
+    DRC.message("Unrecognized tiers (training last): #{plan[:unknown_tiers].join(', ')}") unless plan[:unknown_tiers].empty?
+
+    @image_pool = plan[:pool]
+    @lowest_tier_pool = plan[:lowest_images]
+    return [] if @lowest_tier_pool.empty?
+
+    DRC.message("Image tiers: #{plan[:summary]}")
+    queue = @lowest_tier_pool.shuffle
+    DRC.message("Practicing #{plan[:lowest_tier]} tier: #{queue.join(', ')}")
+    queue
+  end
+
+  # Returns the next image to practice, reshuffling the lowest tier when the
+  # queue is exhausted.
+  #
+  # @return [String, nil] the next image
+  def next_image
+    if @image_queue.nil? || @image_queue.empty?
+      @image_queue = (@lowest_tier_pool || []).shuffle
+      DRC.message("Reshuffled: #{@image_queue.join(', ')}")
+    end
+    @image_queue.shift
+  end
+
+  # Rebuilds UserVars from the master image list and reports the training list.
+  #
+  # @return [void]
+  def reset_known
+    UserVars.smoke_images_known = @full_image_list
+    UserVars.smoke_images_mastered = []
+    plan = prioritize(read_smoke_list, @full_image_list, clean_mastered: true)
+    UserVars.smoke_images_known = plan[:known]
+    UserVars.smoke_images_mastered = plan[:mastered]
+    if plan[:pool].empty?
+      DRC.message("All known images are mastered. Set a list under smoke_images in your yaml, or smoker will select from your known images at random")
+    else
+      DRC.message("New Training List: #{plan[:pool].join(' ')}")
+    end
+    exit
   end
 end
 

--- a/smoke.lic
+++ b/smoke.lic
@@ -518,7 +518,11 @@ class Smoker
   # @param image [String] image to exhale
   # @return [void]
   def exhale_smoke(image)
-    case DRC.bput("exhale line #{image}", /^Roundtime/, /^You are untrained in the ways of making that image./, /^You now know the basics of making/)
+    case DRC.bput("exhale line #{image}",
+                  /^Roundtime/,
+                  /^You are untrained in the ways of making that image./,
+                  /You need to observe your teacher performing/,
+                  /^You now know the basics of making/)
     when /untrained/
       fput 'exhale ring'
     when /You need to observe your teacher performing/

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -471,4 +471,397 @@ RSpec.describe Smoker do
       expect(smoker.build_priority_queue).to eq([])
     end
   end
+
+  # ===========================================================================
+  # Smoke-list I/O helpers -- collect_smoke_list_lines / read_smoke_list
+  # ===========================================================================
+  describe '#collect_smoke_list_lines' do
+    before { allow(smoker).to receive(:fput) }
+
+    it 'collects lines up to the "Total images known" terminator' do
+      allow(smoker).to receive(:get).and_return('deer - learning', 'tart - master*', 'Total images known: 2')
+      expect(smoker.collect_smoke_list_lines).to eq(['deer - learning', 'tart - master*'])
+    end
+
+    it 'stops on a nil line (stream end) rather than looping forever' do
+      allow(smoker).to receive(:get).and_return('deer - learning', nil)
+      expect(smoker.collect_smoke_list_lines).to eq(['deer - learning'])
+    end
+
+    it 'stops immediately when no smoke images are known' do
+      allow(smoker).to receive(:get).and_return("You don't know any smoke images")
+      expect(smoker.collect_smoke_list_lines).to eq([])
+    end
+  end
+
+  describe '#read_smoke_list' do
+    it 'parses the collected lines into image/tier pairs' do
+      allow(smoker).to receive(:collect_smoke_list_lines).and_return(['deer - learning', 'tart - master*'])
+      expect(smoker.read_smoke_list).to eq([%w[deer learning], %w[tart master*]])
+    end
+  end
+
+  # ===========================================================================
+  # Lighting dispatch -- light_tobacco routes to the right method
+  # ===========================================================================
+  describe '#light_tobacco' do
+    it 'uses the warrior mage cantrip when applicable' do
+      allow(DRStats).to receive(:warrior_mage?).and_return(true)
+      expect(smoker).to receive(:light_warrior_mage).with('tobacco in pipe')
+      smoker.light_tobacco('tobacco in pipe')
+    end
+
+    it 'uses the configured lighter for non-warrior-mages' do
+      allow(DRStats).to receive(:warrior_mage?).and_return(false)
+      smoker.instance_variable_set(:@lighter, 'lava drake')
+      expect(smoker).to receive(:light_with_lighter).with('fine cigar')
+      smoker.light_tobacco('fine cigar')
+    end
+
+    it 'falls back to flint when there is no lighter and no cantrip' do
+      allow(DRStats).to receive(:warrior_mage?).and_return(false)
+      smoker.instance_variable_set(:@lighter, nil)
+      expect(smoker).to receive(:light_with_flint).with('fine cigar')
+      smoker.light_tobacco('fine cigar')
+    end
+  end
+
+  describe '#light_warrior_mage' do
+    it 'preps the cantrip then gestures at the target' do
+      expect(DRC).to receive(:bput).with('prep c b t', anything).ordered
+      expect(DRC).to receive(:bput).with('gesture tobacco in pipe', anything, anything).ordered
+      smoker.light_warrior_mage('tobacco in pipe')
+    end
+  end
+
+  # ===========================================================================
+  # light_with_lighter -- success paths AND the flint fallbacks
+  # ===========================================================================
+  describe '#light_with_lighter' do
+    before do
+      smoker.instance_variable_set(:@lighter, 'lava drake')
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      allow(DRStats).to receive(:warrior_mage?).and_return(false)
+      allow(DRC).to receive(:bput) # the "point" command
+    end
+
+    it 'points an untied lighter and stows it on success' do
+      smoker.instance_variable_set(:@smoke_settings, {})
+      allow(DRCI).to receive(:get_item?).with('lava drake').and_return(true)
+      expect(smoker).not_to receive(:light_with_flint)
+      expect(DRCI).to receive(:put_away_item?).with('lava drake', 'smoking jacket')
+      smoker.light_with_lighter('fine cigar')
+    end
+
+    it 'reties a tied lighter and does not stow it' do
+      smoker.instance_variable_set(:@smoke_settings, { 'lighter_tied_to' => 'belt' })
+      allow(DRCI).to receive(:untie_item?).and_return(true)
+      allow(DRCI).to receive(:tie_item?).and_return(true)
+      expect(DRCI).not_to receive(:put_away_item?)
+      smoker.light_with_lighter('fine cigar')
+    end
+
+    it 'stows the lighter when re-tying fails' do
+      smoker.instance_variable_set(:@smoke_settings, { 'lighter_tied_to' => 'belt' })
+      allow(DRCI).to receive(:untie_item?).and_return(true)
+      allow(DRCI).to receive(:tie_item?).and_return(false)
+      expect(DRCI).to receive(:put_away_item?).with('lava drake', 'smoking jacket')
+      smoker.light_with_lighter('fine cigar')
+    end
+
+    it 'falls back to flint (and disables the lighter) when it cannot be retrieved' do
+      smoker.instance_variable_set(:@smoke_settings, {})
+      allow(DRCI).to receive(:get_item?).with('lava drake').and_return(false)
+      expect(smoker).to receive(:light_with_flint).with('fine cigar')
+      smoker.light_with_lighter('fine cigar')
+      expect(smoker.instance_variable_get(:@lighter)).to be(false)
+    end
+
+    it 'falls back to flint when a tied lighter cannot be untied' do
+      smoker.instance_variable_set(:@smoke_settings, { 'lighter_tied_to' => 'belt' })
+      allow(DRCI).to receive(:untie_item?).and_return(false)
+      expect(smoker).to receive(:light_with_flint).with('fine cigar')
+      smoker.light_with_lighter('fine cigar')
+    end
+  end
+
+  describe '#light_with_flint' do
+    before do
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      smoker.instance_variable_set(:@blade, double('blade'))
+      smoker.instance_variable_set(:@equipmanager, double('eq', get_item?: true, return_held_gear: nil))
+      allow(DRC).to receive(:bput)
+      allow(DRCI).to receive(:lower_item?)
+      allow(DRCI).to receive(:stow_item?)
+      allow(DRCI).to receive(:lift?)
+    end
+
+    it 'aborts when flint cannot be obtained' do
+      allow(DRCI).to receive(:get_item?).with('flint').and_return(false)
+      allow(DRC).to receive(:right_hand).and_return('right thing')
+      allow(DRCI).to receive(:put_away_item?)
+      expect { smoker.light_with_flint('fine cigar') }.to raise_error(SystemExit)
+    end
+
+    it 'strikes flint against the blade and cleans up on success' do
+      allow(DRCI).to receive(:get_item?).with('flint').and_return(true)
+      expect(DRCI).to receive(:stow_item?).with('flint')
+      expect { smoker.light_with_flint('tobacco in pipe') }.not_to raise_error
+    end
+  end
+
+  # ===========================================================================
+  # load_pipe / quick_light -- retrieval, tobacco, and abort paths
+  # ===========================================================================
+  describe '#load_pipe' do
+    before do
+      smoker.instance_variable_set(:@pipe, 'glitvire pipe')
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      allow(smoker).to receive(:light_tobacco)
+      allow(DRCI).to receive(:put_away_item?)
+    end
+
+    it 'aborts when the pipe cannot be retrieved' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(false)
+      expect { smoker.load_pipe }.to raise_error(SystemExit)
+    end
+
+    it 'returns true when the pipe is already burning' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      allow(DRC).to receive(:bput).and_return('In the pipe you see a burning wad of tobacco')
+      expect(smoker.load_pipe).to be(true)
+    end
+
+    it 'aborts when empty and no tobacco remains' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      allow(DRC).to receive(:bput).and_return('There is nothing in there')
+      allow(DRCI).to receive(:get_item?).with('tobacco', 'smoking jacket').and_return(false)
+      expect { smoker.load_pipe }.to raise_error(SystemExit)
+    end
+
+    it 'loads tobacco and lights when empty but tobacco remains' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      allow(DRC).to receive(:bput).and_return('There is nothing in there')
+      allow(DRCI).to receive(:get_item?).with('tobacco', 'smoking jacket').and_return(true)
+      expect(smoker).to receive(:light_tobacco).with('tobacco in pipe')
+      smoker.load_pipe
+    end
+  end
+
+  describe '#quick_light' do
+    before { smoker.instance_variable_set(:@bag, 'smoking jacket') }
+
+    it 'loads the pipe for a pipe smoker' do
+      smoker.instance_variable_set(:@pipe, 'glitvire pipe')
+      expect(smoker).to receive(:load_pipe)
+      smoker.quick_light('pipe')
+    end
+
+    it 'aborts when a cigar cannot be retrieved' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(false)
+      expect { smoker.quick_light('fine cigar') }.to raise_error(SystemExit)
+    end
+
+    it 'lights a retrieved cigar' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      expect(smoker).to receive(:light_tobacco).with('fine cigar')
+      smoker.quick_light('fine cigar')
+    end
+  end
+
+  # ===========================================================================
+  # inhale -- clears the lungs (recursing) then inhales cleanly
+  # ===========================================================================
+  describe '#inhale' do
+    before { smoker.instance_variable_set(:@smoker, 'glitvire pipe') }
+
+    it 'exhales and re-inhales when the lungs must be cleared first' do
+      allow(DRC).to receive(:bput).and_return('out of your lungs first', 'You take')
+      expect(smoker).to receive(:exhale_smoke).with('deer')
+      smoker.inhale('deer')
+    end
+
+    it 'does nothing extra on a clean inhale' do
+      allow(DRC).to receive(:bput).and_return('You take a long draw')
+      expect(smoker).not_to receive(:exhale_smoke)
+      smoker.inhale('deer')
+    end
+  end
+
+  # ===========================================================================
+  # smoke -- one practice cycle, pulling from the queue only when needed
+  # ===========================================================================
+  describe '#smoke' do
+    before do
+      smoker.instance_variable_set(:@time_between, 0)
+      allow(smoker).to receive(:inhale)
+      allow(smoker).to receive(:exhale_smoke)
+    end
+
+    it 'pulls the next image from the queue when none is given' do
+      allow(smoker).to receive(:next_image).and_return('deer')
+      expect(smoker).to receive(:inhale).with('deer')
+      expect(smoker).to receive(:exhale_smoke).with('deer')
+      smoker.smoke
+    end
+
+    it 'practices the given image without touching the queue' do
+      expect(smoker).not_to receive(:next_image)
+      expect(smoker).to receive(:exhale_smoke).with('tart')
+      smoker.smoke('tart')
+    end
+  end
+
+  # ===========================================================================
+  # stow_pipe / announce_all_mastered -- small state/reporting helpers
+  # ===========================================================================
+  describe '#stow_pipe' do
+    before { smoker.instance_variable_set(:@bag, 'smoking jacket') }
+
+    it 'stows the pipe when it is in hand' do
+      smoker.instance_variable_set(:@pipe, 'glitvire pipe')
+      allow(DRCI).to receive(:in_hands?).and_return(true)
+      expect(DRCI).to receive(:put_away_item?).with('glitvire pipe', 'smoking jacket')
+      smoker.stow_pipe
+    end
+
+    it 'does nothing when the pipe is not in hand' do
+      smoker.instance_variable_set(:@pipe, 'glitvire pipe')
+      allow(DRCI).to receive(:in_hands?).and_return(false)
+      expect(DRCI).not_to receive(:put_away_item?)
+      smoker.stow_pipe
+    end
+
+    it 'does nothing on a cigar run (no pipe configured)' do
+      smoker.instance_variable_set(:@pipe, nil)
+      expect(DRCI).not_to receive(:put_away_item?)
+      smoker.stow_pipe
+    end
+  end
+
+  describe '#announce_all_mastered' do
+    it 'reports the mastered set and includes the optional prefix' do
+      allow(UserVars).to receive(:smoke_images_mastered).and_return(%w[deer tart])
+      expect(DRC).to receive(:message).with(/All 2 images have reached master/)
+      expect(DRC).to receive(:message).with(/Mastered: deer, tart/)
+      expect(DRC).to receive(:message).with(/Finished 3 round\(s\)\. Nothing left/)
+      smoker.announce_all_mastered('Finished 3 round(s). ')
+    end
+  end
+
+  # ===========================================================================
+  # abort_lesson -- clean teardown of a teach/learn session
+  # ===========================================================================
+  describe '#abort_lesson' do
+    it 'stows the active smoker and exits' do
+      smoker.instance_variable_set(:@smoker, 'glitvire pipe')
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      allow(DRCI).to receive(:in_hands?).and_return(true)
+      expect(DRCI).to receive(:put_away_item?).with('glitvire pipe', 'smoking jacket')
+      expect { smoker.abort_lesson('teacher gone') }.to raise_error(SystemExit)
+    end
+
+    it 'exits even when nothing is held' do
+      smoker.instance_variable_set(:@smoker, nil)
+      expect(DRCI).not_to receive(:put_away_item?)
+      expect { smoker.abort_lesson('teacher gone') }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # smoke_teach -- lights up and dispatches to the teach/learn loop
+  # ===========================================================================
+  describe '#smoke_teach' do
+    before { smoker.instance_variable_set(:@pipe, 'glitvire pipe') }
+
+    it 'dispatches to learn_loop for a learn request' do
+      args = OpenStruct.new(smoke: 'pipe', teach: 'learn', player: 'bob')
+      expect(smoker).to receive(:learn_loop).with(['deer'], 'Bob')
+      smoker.smoke_teach(args, ['deer'])
+    end
+
+    it 'dispatches to teach_loop for a teach request' do
+      args = OpenStruct.new(smoke: 'pipe', teach: 'teach', player: 'bob')
+      expect(smoker).to receive(:teach_loop).with(['deer'], 'Bob')
+      smoker.smoke_teach(args, ['deer'])
+    end
+  end
+
+  # ===========================================================================
+  # teach_loop -- image iteration + completion exit
+  # ===========================================================================
+  describe '#teach_loop' do
+    it 'completes and exits when there is nothing to teach' do
+      expect { smoker.teach_loop([], 'Bob') }.to raise_error(SystemExit)
+    end
+
+    it 'skips an image the student already knows, then completes' do
+      allow(smoker).to receive(:offer_lesson).with('deer', 'Bob').and_return(false)
+      expect(smoker).not_to receive(:smoke)
+      expect { smoker.teach_loop(['deer'], 'Bob') }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # learn_loop -- the teacher-leaves-the-room guards (its whole reason to exist)
+  # ===========================================================================
+  describe '#learn_loop' do
+    before do
+      smoker.instance_variable_set(:@smoker, 'glitvire pipe')
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      allow(DRCI).to receive(:in_hands?).and_return(true)
+      allow(DRCI).to receive(:put_away_item?)
+    end
+
+    it 'aborts immediately when the teacher is not in the room' do
+      allow(DRRoom).to receive(:pcs).and_return([])
+      expect { smoker.learn_loop([], 'Bob') }.to raise_error(SystemExit)
+    end
+
+    it 'aborts when the teacher leaves while waiting to be taught' do
+      allow(DRRoom).to receive(:pcs).and_return(['Bob'], [])
+      allow(DRC).to receive(:bput).and_return("Bob isn't teaching a class")
+      expect { smoker.learn_loop([], 'Bob') }.to raise_error(SystemExit)
+    end
+
+    it 'aborts when the teacher leaves mid-lesson' do
+      allow(DRRoom).to receive(:pcs).and_return(['Bob'], [])
+      allow(DRC).to receive(:bput).and_return("You start paying attention to Bob's advice on how to make a deer smoke image")
+      expect { smoker.learn_loop([], 'Bob') }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # reset_known -- rebuild from the master list and report (then exit)
+  # ===========================================================================
+  describe '#reset_known' do
+    before do
+      smoker.instance_variable_set(:@full_image_list, %w[deer tart])
+      allow(UserVars).to receive(:smoke_images_known=)
+      allow(UserVars).to receive(:smoke_images_mastered=)
+    end
+
+    it 'reports the new training list and exits' do
+      allow(smoker).to receive(:read_smoke_list).and_return([%w[deer learning], %w[tart master*]])
+      expect(DRC).to receive(:message).with(/New Training List/)
+      expect { smoker.reset_known }.to raise_error(SystemExit)
+    end
+
+    it 'reports when everything is already mastered and exits' do
+      allow(smoker).to receive(:read_smoke_list).and_return([%w[deer master*], %w[tart master*]])
+      expect(DRC).to receive(:message).with(/All known images are mastered/)
+      expect { smoker.reset_known }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # smoke_loop -- the nothing-to-train boundary (full round loop is integration)
+  # ===========================================================================
+  describe '#smoke_loop' do
+    it 'announces and exits when the first queue is already empty' do
+      allow(smoker).to receive(:build_priority_queue).and_return([])
+      expect(smoker).to receive(:announce_all_mastered)
+      expect { smoker.smoke_loop(%w[deer], 1) }.to raise_error(SystemExit)
+    end
+  end
 end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -1,0 +1,311 @@
+require_relative 'spec_helper'
+
+# Smoker#initialize depends on the full Lich runtime (parse_args, get_settings,
+# EquipmentManager, live smoking I/O), so we extract the class with
+# load_lic_class and exercise the pure, side-effect-free seams on bare-allocated
+# instances (Smoker.allocate). Every example is self-contained (DAMP).
+#
+# The emphasis is adversarial: the tier-priority planner (prioritize) is the
+# brain of the script, so its selection, filtering, mastered/unknown handling,
+# and tier ordering are stress-tested; plus the smoke-list parser, the tier
+# predicates, settings validation (which aborts), and the queue reshuffle.
+load_lic_class('smoke.lic', 'Smoker')
+
+RSpec.describe Smoker do
+  subject(:smoker) { described_class.allocate }
+
+  # ===========================================================================
+  # blank? -- the nil/whitespace predicate the settings logic leans on
+  # ===========================================================================
+  describe '#blank?' do
+    it 'treats nil and empty/whitespace strings as blank' do
+      expect(smoker.blank?(nil)).to be(true)
+      expect(smoker.blank?('')).to be(true)
+      expect(smoker.blank?('   ')).to be(true)
+    end
+
+    it 'treats a real string and a non-string as present' do
+      expect(smoker.blank?('glitvire pipe')).to be(false)
+      expect(smoker.blank?(42)).to be(false)
+    end
+  end
+
+  # ===========================================================================
+  # Tier predicates -- tier_rank / known_tier? / mastered?
+  # ===========================================================================
+  describe '#tier_rank' do
+    it 'ranks known tiers by skill, lowest first' do
+      expect(smoker.tier_rank('learning')).to eq(0)
+      expect(smoker.tier_rank('master')).to eq(5)
+      expect(smoker.tier_rank('master*')).to eq(6)
+    end
+
+    it 'ranks Olvi intermediate tier names the same as the common names' do
+      expect(smoker.tier_rank('wheezer')).to eq(smoker.tier_rank('beginner'))
+      expect(smoker.tier_rank('streamer')).to eq(smoker.tier_rank('competent'))
+    end
+
+    it 'is case-insensitive' do
+      expect(smoker.tier_rank('MASTER*')).to eq(6)
+    end
+
+    it 'ranks an unknown tier (and nil) last' do
+      expect(smoker.tier_rank('bogus')).to eq(Smoker::UNKNOWN_RANK)
+      expect(smoker.tier_rank(nil)).to eq(Smoker::UNKNOWN_RANK)
+    end
+  end
+
+  describe '#known_tier?' do
+    it 'recognizes configured tiers and rejects unknown/nil' do
+      expect(smoker.known_tier?('adequate')).to be(true)
+      expect(smoker.known_tier?('bogus')).to be(false)
+      expect(smoker.known_tier?(nil)).to be(false)
+    end
+  end
+
+  describe '#mastered?' do
+    it 'is true only for master* (not master), case-insensitively' do
+      expect(smoker.mastered?('master*')).to be(true)
+      expect(smoker.mastered?('MASTER*')).to be(true)
+      expect(smoker.mastered?('master')).to be(false)
+      expect(smoker.mastered?(nil)).to be(false)
+    end
+  end
+
+  # ===========================================================================
+  # parse_smoke_list -- pure parsing of "smoke list" output lines
+  # ===========================================================================
+  describe '#parse_smoke_list' do
+    it 'parses multiple image/tier pairs from a single line' do
+      line = 'deer      - learning        tart      - master*'
+      expect(smoker.parse_smoke_list([line])).to eq([%w[deer learning], %w[tart master*]])
+    end
+
+    it 'captures the master* asterisk in the tier' do
+      expect(smoker.parse_smoke_list(['wolf      - master*'])).to eq([%w[wolf master*]])
+    end
+
+    it 'skips the IMAGE - SKILL header line' do
+      expect(smoker.parse_smoke_list(['IMAGE - SKILL', 'deer - learning'])).to eq([%w[deer learning]])
+    end
+
+    it 'flattens pairs across multiple lines' do
+      lines = ['deer - learning', 'tart - master']
+      expect(smoker.parse_smoke_list(lines)).to eq([%w[deer learning], %w[tart master]])
+    end
+
+    it 'is safe against nil and unmatched lines' do
+      expect(smoker.parse_smoke_list([nil, 'no pairs here'])).to eq([])
+    end
+  end
+
+  # ===========================================================================
+  # prioritize -- the pure training planner (the brain). No I/O, no shuffle.
+  # ===========================================================================
+  describe '#prioritize' do
+    it 'selects only the lowest surviving tier and reports the breakdown' do
+      entries = [%w[deer learning], %w[wolf streamer], %w[tart master*]]
+      plan = smoker.prioritize(entries, %w[deer wolf tart], clean_mastered: true)
+
+      expect(plan[:lowest_tier]).to eq('learning')
+      expect(plan[:lowest_images]).to eq(['deer'])
+      expect(plan[:mastered]).to eq(['tart'])
+      expect(plan[:pool]).to eq(%w[deer wolf])
+      expect(plan[:summary]).to eq('learning(1) > streamer(1)')
+    end
+
+    it 'keeps mastered images when clean_mastered is false (explicit image runs)' do
+      entries = [%w[tart master*], %w[deer learning]]
+      plan = smoker.prioritize(entries, %w[tart deer], clean_mastered: false)
+
+      expect(plan[:mastered]).to eq([])
+      expect(plan[:pool]).to eq(%w[tart deer])
+      expect(plan[:lowest_images]).to eq(['deer'])
+    end
+
+    it 'trains a master (not master*) image -- mastery is exact' do
+      entries = [%w[deer master], %w[tart master*]]
+      plan = smoker.prioritize(entries, %w[deer tart], clean_mastered: true)
+
+      expect(plan[:mastered]).to eq(['tart'])
+      expect(plan[:pool]).to eq(['deer'])
+      expect(plan[:lowest_images]).to eq(['deer'])
+      expect(plan[:lowest_tier]).to eq('master')
+    end
+
+    it 'reports pool images absent from the smoke list as unknown and drops them' do
+      entries = [%w[deer learning]]
+      plan = smoker.prioritize(entries, %w[deer xyzzy], clean_mastered: true)
+
+      expect(plan[:unknown]).to eq(['xyzzy'])
+      expect(plan[:pool]).to eq(['deer'])
+      expect(plan[:known]).to eq(['deer'])
+    end
+
+    it 'flags unrecognized tiers and still ranks them last' do
+      entries = [%w[deer wobble], %w[wolf learning]]
+      plan = smoker.prioritize(entries, %w[deer wolf], clean_mastered: true)
+
+      expect(plan[:unknown_tiers]).to eq(['wobble'])
+      expect(plan[:lowest_tier]).to eq('learning') # rank 0 beats the unknown rank 99
+      expect(plan[:lowest_images]).to eq(['wolf'])
+    end
+
+    it 'groups every image sharing the lowest tier, in list order (deterministic)' do
+      entries = [%w[deer learning], %w[rabbit learning], %w[wolf master]]
+      plan = smoker.prioritize(entries, %w[deer rabbit wolf], clean_mastered: true)
+
+      expect(plan[:lowest_images]).to eq(%w[deer rabbit])
+    end
+
+    it 'returns an empty plan when the whole pool is mastered' do
+      entries = [%w[deer master*], %w[tart master*]]
+      plan = smoker.prioritize(entries, %w[deer tart], clean_mastered: true)
+
+      expect(plan[:pool]).to eq([])
+      expect(plan[:lowest_images]).to eq([])
+      expect(plan[:lowest_tier]).to be_nil
+      expect(plan[:summary]).to eq('')
+    end
+
+    it 'handles an empty pool and empty entries without error' do
+      expect(smoker.prioritize([], [], clean_mastered: true)[:lowest_images]).to eq([])
+      plan = smoker.prioritize([%w[deer learning]], [], clean_mastered: false)
+      expect(plan[:pool]).to eq([])
+      expect(plan[:known]).to eq(['deer'])
+    end
+
+    it 'ranks by tier regardless of list order (streamer trains before master)' do
+      entries = [%w[tart master], %w[deer streamer]]
+      plan = smoker.prioritize(entries, %w[tart deer], clean_mastered: true)
+
+      expect(plan[:lowest_tier]).to eq('streamer')
+      expect(plan[:lowest_images]).to eq(['deer'])
+    end
+  end
+
+  # ===========================================================================
+  # find_blade -- EquipmentManager resolution (with Regexp.escape safety)
+  # ===========================================================================
+  describe '#find_blade' do
+    let(:blade) { double('blade', short_regex: /paraz/, name: 'serrated parazonium') }
+
+    before { smoker.instance_variable_set(:@equipmanager, double('eq', items: [blade])) }
+
+    it 'returns nil for a blank setting without touching equipment' do
+      expect(smoker.find_blade(nil)).to be_nil
+      expect(smoker.find_blade('  ')).to be_nil
+    end
+
+    it 'matches an item by short_regex' do
+      expect(smoker.find_blade('serrated parazonium')).to eq(blade)
+    end
+
+    it 'returns nil when nothing matches' do
+      expect(smoker.find_blade('nonexistent halberd')).to be_nil
+    end
+
+    it 'does not raise when the setting contains regex-special characters' do
+      expect { smoker.find_blade('blade (fancy) [+2]') }.not_to raise_error
+    end
+  end
+
+  # ===========================================================================
+  # validate_settings -- aborts (exit) on missing/invalid config
+  # ===========================================================================
+  describe '#validate_settings' do
+    def args(**opts)
+      OpenStruct.new(opts)
+    end
+
+    before do
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      smoker.instance_variable_set(:@pipe, 'glitvire pipe')
+      smoker.instance_variable_set(:@lighter, 'lava drake')
+      smoker.instance_variable_set(:@blade, nil)
+      smoker.instance_variable_set(:@smoke_settings, {})
+      allow(DRStats).to receive(:warrior_mage?).and_return(false)
+    end
+
+    it 'returns early for reset_known even when nothing is configured' do
+      smoker.instance_variable_set(:@bag, nil)
+      expect { smoker.validate_settings(args(reset_known: true)) }.not_to raise_error
+    end
+
+    it 'aborts when the container is not set' do
+      smoker.instance_variable_set(:@bag, nil)
+      expect { smoker.validate_settings(args) }.to raise_error(SystemExit)
+    end
+
+    it 'aborts a pipe run when the pipe is not set' do
+      smoker.instance_variable_set(:@pipe, nil)
+      expect { smoker.validate_settings(args) }.to raise_error(SystemExit)
+    end
+
+    it 'does not require a pipe for an explicit cigar run' do
+      smoker.instance_variable_set(:@pipe, nil)
+      expect { smoker.validate_settings(args(cigar: 'fine cigar')) }.not_to raise_error
+    end
+
+    it 'passes for a warrior mage with no lighter or blade' do
+      smoker.instance_variable_set(:@lighter, nil)
+      allow(DRStats).to receive(:warrior_mage?).and_return(true)
+      expect { smoker.validate_settings(args) }.not_to raise_error
+    end
+
+    it 'passes with a configured lighter' do
+      expect { smoker.validate_settings(args) }.not_to raise_error
+    end
+
+    it 'warns but passes when falling back to a found blade' do
+      smoker.instance_variable_set(:@lighter, nil)
+      smoker.instance_variable_set(:@smoke_settings, { 'blade' => 'serrated parazonium' })
+      smoker.instance_variable_set(:@blade, double('blade'))
+      expect { smoker.validate_settings(args) }.not_to raise_error
+    end
+
+    it 'aborts when a blade is configured but not found in EquipmentManager' do
+      smoker.instance_variable_set(:@lighter, nil)
+      smoker.instance_variable_set(:@smoke_settings, { 'blade' => 'ghost blade' })
+      smoker.instance_variable_set(:@blade, nil)
+      expect { smoker.validate_settings(args) }.to raise_error(SystemExit)
+    end
+
+    it 'aborts when there is no lighter and no blade (non-warrior-mage)' do
+      smoker.instance_variable_set(:@lighter, nil)
+      smoker.instance_variable_set(:@smoke_settings, {})
+      expect { smoker.validate_settings(args) }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # next_image -- queue consumption with lowest-tier reshuffle
+  # ===========================================================================
+  describe '#next_image' do
+    it 'shifts the next image off a non-empty queue' do
+      smoker.instance_variable_set(:@image_queue, %w[deer tart])
+      smoker.instance_variable_set(:@lowest_tier_pool, %w[deer tart])
+      expect(smoker.next_image).to eq('deer')
+      expect(smoker.instance_variable_get(:@image_queue)).to eq(['tart'])
+    end
+
+    it 'reshuffles the lowest tier when the queue is empty' do
+      smoker.instance_variable_set(:@image_queue, [])
+      smoker.instance_variable_set(:@lowest_tier_pool, %w[x y])
+      expect(%w[x y]).to include(smoker.next_image)
+      expect(smoker.instance_variable_get(:@image_queue).size).to eq(1)
+    end
+
+    it 'reshuffles when the queue is nil' do
+      smoker.instance_variable_set(:@image_queue, nil)
+      smoker.instance_variable_set(:@lowest_tier_pool, ['z'])
+      expect(smoker.next_image).to eq('z')
+    end
+
+    it 'returns nil when there is nothing left to reshuffle' do
+      smoker.instance_variable_set(:@image_queue, [])
+      smoker.instance_variable_set(:@lowest_tier_pool, nil)
+      expect(smoker.next_image).to be_nil
+    end
+  end
+end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -11,6 +11,17 @@ require_relative 'spec_helper'
 # predicates, settings validation (which aborts), and the queue reshuffle.
 load_lic_class('smoke.lic', 'Smoker')
 
+# UserVars is per-script config -- provide the constant (only if no other spec
+# defined it) so build_priority_queue's reads/writes can be stubbed per example.
+class UserVars
+  class << self
+    def smoke_images_known; @smoke_images_known; end
+    def smoke_images_known=(value); @smoke_images_known = value; end
+    def smoke_images_mastered; @smoke_images_mastered; end
+    def smoke_images_mastered=(value); @smoke_images_mastered = value; end
+  end
+end unless defined?(UserVars)
+
 RSpec.describe Smoker do
   subject(:smoker) { described_class.allocate }
 
@@ -201,6 +212,18 @@ RSpec.describe Smoker do
       expect(smoker.find_blade('serrated parazonium')).to eq(blade)
     end
 
+    it 'matches an item by name when the short_regex does not match' do
+      dagger = double('dagger', short_regex: /nomatch/, name: 'fine steel dagger')
+      smoker.instance_variable_set(:@equipmanager, double('eq', items: [dagger]))
+      expect(smoker.find_blade('dagger')).to eq(dagger)
+    end
+
+    it 'does not match a name substring across a word boundary' do
+      dagger = double('dagger', short_regex: /nomatch/, name: 'fine steel dagger')
+      smoker.instance_variable_set(:@equipmanager, double('eq', items: [dagger]))
+      expect(smoker.find_blade('dagg')).to be_nil
+    end
+
     it 'returns nil when nothing matches' do
       expect(smoker.find_blade('nonexistent halberd')).to be_nil
     end
@@ -245,6 +268,11 @@ RSpec.describe Smoker do
     it 'does not require a pipe for an explicit cigar run' do
       smoker.instance_variable_set(:@pipe, nil)
       expect { smoker.validate_settings(args(cigar: 'fine cigar')) }.not_to raise_error
+    end
+
+    it 'does not require a pipe when the cigar is given via the smoke arg' do
+      smoker.instance_variable_set(:@pipe, nil)
+      expect { smoker.validate_settings(args(smoke: 'fine cigar')) }.not_to raise_error
     end
 
     it 'passes for a warrior mage with no lighter or blade' do
@@ -306,6 +334,141 @@ RSpec.describe Smoker do
       smoker.instance_variable_set(:@image_queue, [])
       smoker.instance_variable_set(:@lowest_tier_pool, nil)
       expect(smoker.next_image).to be_nil
+    end
+  end
+
+  # ===========================================================================
+  # exhale_smoke -- outcome branches, including the observe-teacher abort
+  # ===========================================================================
+  describe '#exhale_smoke' do
+    it 'exhales a ring when untrained in the image' do
+      allow(DRC).to receive(:bput).and_return('You are untrained in the ways of making that image.')
+      expect(smoker).to receive(:fput).with('exhale ring')
+      smoker.exhale_smoke('deer')
+    end
+
+    it 'reports when the image is just learned' do
+      allow(DRC).to receive(:bput).and_return('You now know the basics of making')
+      expect(DRC).to receive(:message).with(/Image learned/)
+      smoker.exhale_smoke('deer')
+    end
+
+    it 'registers the observe-teacher line as a bput match (so the branch is reachable)' do
+      captured = nil
+      allow(DRC).to receive(:bput) { |_cmd, *patterns| captured = patterns; 'Roundtime' }
+      smoker.exhale_smoke('deer')
+      expect(captured.any? { |p| p.is_a?(Regexp) && p =~ 'You need to observe your teacher performing to do that' }).to be(true)
+    end
+
+    it 'aborts when told to observe the teacher first' do
+      allow(DRC).to receive(:bput).and_return('You need to observe your teacher performing')
+      expect { smoker.exhale_smoke('deer') }.to raise_error(SystemExit)
+    end
+
+    it 'does nothing extra on a normal roundtime exhale' do
+      allow(DRC).to receive(:bput).and_return('Roundtime: 3 sec.')
+      expect(smoker).not_to receive(:fput)
+      expect { smoker.exhale_smoke('deer') }.not_to raise_error
+    end
+  end
+
+  # ===========================================================================
+  # offer_lesson -- teaching handshake branches, including the unresponsive exit
+  # ===========================================================================
+  describe '#offer_lesson' do
+    it 'is true when the student starts paying attention' do
+      allow(DRC).to receive(:bput).and_return('Bob starts paying attention to your advice on how to make')
+      expect(smoker.offer_lesson('deer', 'Bob')).to be(true)
+    end
+
+    it 'is true when the student nods' do
+      allow(DRC).to receive(:bput).and_return('Bob nods to you')
+      expect(smoker.offer_lesson('deer', 'Bob')).to be(true)
+    end
+
+    it 'is false when the student already knows the image' do
+      allow(DRC).to receive(:bput).and_return('already knows how to make that smoke image')
+      expect(smoker.offer_lesson('deer', 'Bob')).to be(false)
+    end
+
+    it 'aborts when the student is unresponsive (no match)' do
+      allow(DRC).to receive(:bput).and_return('')
+      expect { smoker.offer_lesson('deer', 'Bob') }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # quick_light_safe -- the true/false returns that drive the until_out break
+  # ===========================================================================
+  describe '#quick_light_safe' do
+    before do
+      smoker.instance_variable_set(:@pipe, 'glitvire pipe')
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      allow(smoker).to receive(:light_tobacco) # isolate: don't run real lighting I/O
+    end
+
+    it 'returns false when the pipe cannot be retrieved' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(false)
+      expect(smoker.quick_light_safe('pipe')).to be(false)
+    end
+
+    it 'returns true when the pipe is already burning' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      allow(DRC).to receive(:bput).and_return('In the pipe you see a burning wad of tobacco')
+      expect(smoker.quick_light_safe('pipe')).to be(true)
+    end
+
+    it 'loads tobacco and returns true when the pipe is empty but tobacco remains' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      allow(DRC).to receive(:bput).and_return('There is nothing in there')
+      allow(DRCI).to receive(:get_item?).with('tobacco', 'smoking jacket').and_return(true)
+      allow(DRCI).to receive(:put_away_item?).and_return(true)
+      expect(smoker.quick_light_safe('pipe')).to be(true)
+    end
+
+    it 'returns false when the pipe is empty and no tobacco remains' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      allow(DRC).to receive(:bput).and_return('There is nothing in there')
+      allow(DRCI).to receive(:get_item?).with('tobacco', 'smoking jacket').and_return(false)
+      expect(smoker.quick_light_safe('pipe')).to be(false)
+    end
+
+    it 'returns false when out of cigars' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(false)
+      expect(smoker.quick_light_safe('fine cigar')).to be(false)
+    end
+
+    it 'returns true when a cigar is retrieved' do
+      allow(DRCI).to receive(:get_item_if_not_held?).and_return(true)
+      expect(smoker.quick_light_safe('fine cigar')).to be(true)
+    end
+  end
+
+  # ===========================================================================
+  # build_priority_queue -- the I/O wrapper's UserVars writes + empty return
+  # ===========================================================================
+  describe '#build_priority_queue' do
+    before do
+      smoker.instance_variable_set(:@clean_mastered, true)
+      allow(UserVars).to receive(:smoke_images_known=)
+      allow(UserVars).to receive(:smoke_images_mastered).and_return([])
+      allow(UserVars).to receive(:smoke_images_mastered=)
+    end
+
+    it 'returns the lowest trainable tier and records known images' do
+      smoker.instance_variable_set(:@image_pool, %w[deer tart])
+      allow(smoker).to receive(:read_smoke_list).and_return([%w[deer learning], %w[tart master*]])
+
+      expect(UserVars).to receive(:smoke_images_known=).with(%w[deer tart])
+      expect(smoker.build_priority_queue).to eq(['deer'])
+      expect(smoker.instance_variable_get(:@lowest_tier_pool)).to eq(['deer'])
+    end
+
+    it 'returns an empty queue when everything is mastered' do
+      smoker.instance_variable_set(:@image_pool, %w[deer tart])
+      allow(smoker).to receive(:read_smoke_list).and_return([%w[deer master*], %w[tart master*]])
+
+      expect(smoker.build_priority_queue).to eq([])
     end
   end
 end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -855,13 +855,126 @@ RSpec.describe Smoker do
   end
 
   # ===========================================================================
-  # smoke_loop -- the nothing-to-train boundary (full round loop is integration)
+  # smoke_loop -- the full round loop, driving the new-cig tobacco flag
   # ===========================================================================
   describe '#smoke_loop' do
+    before do
+      smoker.instance_variable_set(:@pipe, 'glitvire pipe')
+      smoker.instance_variable_set(:@cigar, nil)
+      smoker.instance_variable_set(:@bag, 'smoking jacket')
+      smoker.instance_variable_set(:@smoke_settings, {})
+      allow(smoker).to receive(:quick_light)
+      allow(smoker).to receive(:stow_pipe)
+      allow(DRC).to receive(:message)
+      Flags['new-cig'] = true # a fresh, unlit smoker
+    end
+
     it 'announces and exits when the first queue is already empty' do
       allow(smoker).to receive(:build_priority_queue).and_return([])
       expect(smoker).to receive(:announce_all_mastered)
       expect { smoker.smoke_loop(%w[deer], 1) }.to raise_error(SystemExit)
+    end
+
+    it 'runs exactly the requested number of rounds then completes' do
+      allow(smoker).to receive(:build_priority_queue).and_return(['deer'])
+      # Each smoke cycle ends by exhausting the tobacco (sets new-cig), ending the
+      # inner `smoke until Flags['new-cig']` after one call per round.
+      expect(smoker).to(receive(:smoke).exactly(2).times { Flags['new-cig'] = true })
+      expect(smoker).to receive(:stow_pipe)
+      expect(DRC).to receive(:message).with(/Smoker Complete! Finished 2 round/)
+      expect { smoker.smoke_loop(['deer'], 2) }.not_to raise_error
+    end
+
+    it 'walks to the configured smoke room before training' do
+      smoker.instance_variable_set(:@smoke_settings, { 'smoke_room' => 1234 })
+      allow(smoker).to receive(:build_priority_queue).and_return(['deer'])
+      allow(smoker).to receive(:smoke) { Flags['new-cig'] = true }
+      expect(DRCT).to receive(:walk_to).with(1234)
+      smoker.smoke_loop(['deer'], 1)
+    end
+
+    it 'stops in until_out mode when tobacco runs out' do
+      allow(smoker).to receive(:build_priority_queue).and_return(['deer'])
+      allow(smoker).to receive(:quick_light_safe).and_return(false)
+      expect(smoker).not_to receive(:smoke)
+      expect { smoker.smoke_loop(['deer'], :until_out) }.not_to raise_error
+    end
+
+    it 'exits in until_out mode once everything becomes mastered' do
+      allow(smoker).to receive(:build_priority_queue).and_return(['deer'], [])
+      allow(smoker).to receive(:quick_light_safe).and_return(true)
+      allow(smoker).to receive(:smoke) { Flags['new-cig'] = true }
+      expect(smoker).to receive(:announce_all_mastered).with(/Finished 1 round/)
+      expect { smoker.smoke_loop(['deer'], :until_out) }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # initialize -- argument routing / dispatch (collaborators stubbed)
+  # ===========================================================================
+  describe '#initialize (dispatch)' do
+    let(:yaml_smoke) { { 'container' => 'smoking jacket', 'pipe' => 'glitvire pipe', 'smoke_images' => %w[deer tart] } }
+
+    # Build a bare instance with every collaborator stubbed, then run initialize.
+    def boot(args_opts, smoke: yaml_smoke)
+      instance = described_class.allocate
+      allow(instance).to receive(:parse_args).and_return(OpenStruct.new(args_opts))
+      allow(instance).to receive(:get_settings).and_return(double('settings', smoke: smoke))
+      allow(EquipmentManager).to receive(:new).and_return(double('eq'))
+      allow(instance).to receive(:find_blade).and_return(nil)
+      allow(instance).to receive(:validate_settings)
+      allow(instance).to receive(:quick_light)
+      allow(instance).to receive(:reset_known)
+      allow(instance).to receive(:smoke_teach)
+      allow(instance).to receive(:smoke_loop)
+      instance
+    end
+
+    it 'aborts when there is no smoke settings block' do
+      instance = boot({}, smoke: nil)
+      expect { instance.send(:initialize) }.to raise_error(SystemExit)
+    end
+
+    it 'light_only lights the requested utensil and exits' do
+      instance = boot({ light_only: 'light_only', smoke: 'pipe' })
+      expect(instance).to receive(:quick_light).with('pipe')
+      expect { instance.send(:initialize) }.to raise_error(SystemExit)
+    end
+
+    it 'defaults to a single round' do
+      instance = boot({})
+      expect(instance).to receive(:smoke_loop).with(%w[deer tart], 1)
+      instance.send(:initialize)
+    end
+
+    it 'passes :until_out through to the loop' do
+      instance = boot({ until_out: 'until_out' })
+      expect(instance).to receive(:smoke_loop).with(%w[deer tart], :until_out)
+      instance.send(:initialize)
+    end
+
+    it 'passes an explicit repeat count through to the loop' do
+      instance = boot({ repeat: '3' })
+      expect(instance).to receive(:smoke_loop).with(%w[deer tart], 3)
+      instance.send(:initialize)
+    end
+
+    it 'runs reset_known when requested' do
+      instance = boot({ reset_known: 'reset_known' })
+      expect(instance).to receive(:reset_known)
+      instance.send(:initialize)
+    end
+
+    it 'dispatches to teaching when requested' do
+      instance = boot({ teach: 'teach' })
+      expect(instance).to receive(:smoke_teach)
+      instance.send(:initialize)
+    end
+
+    it 'trains a single explicitly-requested image' do
+      instance = boot({ image: 'deer' })
+      expect(instance).to receive(:smoke_loop).with(['deer'], 1)
+      instance.send(:initialize)
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #7440 / #7441, which landed tier-priority training, settings
validation, and graceful failures. This keeps that behavior but refactors
`smoke.lic` into pure, unit-testable seams, adds the spec suite the script
currently lacks, and folds in a few small robustness fixes. No new
user-facing features and no settings changes.

## Refactor (same behavior, now testable)
- **`prioritize(entries, pool, clean_mastered:)`** -- a pure planner that returns
  the training plan (known / unknown / mastered / surviving pool / lowest tier /
  summary) with **no I/O and no shuffle**. `build_priority_queue` becomes a thin
  wrapper that does the `smoke list` I/O, UserVars writes, and the shuffle.
- Split list reading (`collect_smoke_list_lines`) from parsing
  (`parse_smoke_list(lines)`, pure); added `tier_rank` / `known_tier?` /
  `mastered?` predicates over `TIER_ORDER`.
- Decomposed `light_tobacco` into `light_warrior_mage` / `light_with_lighter` /
  `light_with_flint`; extracted `announce_all_mastered` / `abort_lesson` /
  `stow_pipe` / `find_blade` / `blank?` (each removed a block duplicated ~3x).
- Replaced the legacy `check_images` filter with `prioritize`.
- Full YARD on every method.

## Robustness fixes over current `main`
- `walk_to(smoke_room)` now runs only when `smoke_room` is configured (main calls
  it unconditionally, even when the setting is nil).
- `find_blade` `Regexp.escape`s the configured blade before interpolating it into
  a regex (main interpolates it raw, which breaks on regex-special characters).
- Whitespace-aware `blank?` validation; unrecognized smoke-list tiers are now
  reported (and still trained last) instead of silently bucketed.

## Tests
New `spec/smoke_spec.rb` (39 examples), all against the pure seams:
- **planner**: lowest-tier selection, mastered/unknown filtering, `master` vs
  `master*` (exact mastery), unknown-tier handling, list-order determinism,
  empty pools, `clean_mastered` on/off;
- **parsing**: multi-pair lines, header skip, master* capture, nil/unmatched
  safety;
- **predicates**: `tier_rank` / `known_tier?` / `mastered?` (case-insensitive,
  Olvi tier names, unknown/nil);
- **find_blade**: match, no-match, blank, regex-special settings;
- **validate_settings**: every abort path and pass path (container, pipe vs
  cigar, warrior mage, lighter, blade fallback found/not-found, reset_known);
- **next_image**: shift, reshuffle on empty/nil queue, nothing-left.

`ruby -c` clean, `rubocop` clean, full `rspec spec/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)