### PR TITLE
chore(dependency): v4.2.1 require Lich 5.19.1

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -19,9 +19,9 @@
   and deleted before it duplicates work core now performs.
 =end
 
-$DEPENDENCY_VERSION = '4.2.0'
+$DEPENDENCY_VERSION = '4.2.1'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/f8ne99pVva'
-$MIN_LICH_VERSION = '5.18.0'
+$MIN_LICH_VERSION = '5.19.1'
 
 unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new($MIN_LICH_VERSION)
   10.times do

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -234,12 +234,12 @@ end
 
 RSpec.describe 'Dependency Structure' do
   describe 'version' do
-    it 'declares version 4.2.0' do
-      expect(DEP_SOURCE).to include("$DEPENDENCY_VERSION = '4.2.0'")
+    it 'declares version 4.2.1' do
+      expect(DEP_SOURCE).to include("$DEPENDENCY_VERSION = '4.2.1'")
     end
 
-    it 'requires minimum lich version 5.18.0' do
-      expect(DEP_SOURCE).to include("$MIN_LICH_VERSION = '5.18.0'")
+    it 'requires minimum lich version 5.19.1' do
+      expect(DEP_SOURCE).to include("$MIN_LICH_VERSION = '5.19.1'")
     end
   end
 


### PR DESCRIPTION
## Summary

Bumps the dependency guard to require Lich **5.19.1**.

- `$MIN_LICH_VERSION`: `5.18.0` -> `5.19.1`
- `$DEPENDENCY_VERSION`: `4.2.0` -> `4.2.1`

No other changes. The startup guard already interpolates `$MIN_LICH_VERSION` into the "no longer supported" banner, so the message updates automatically.

## Testing

- `ruby -c dependency.lic` -> Syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)