### PR TITLE
[script][combat-trainer] Update Flags regex for last-stance and refactor last_stance method

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -301,11 +301,9 @@ class SetupProcess
   end
 
   def last_stance
-    flag_result = Flags['last-stance']
-    return { 'EVASION' => 0, 'PARRY' => 0, 'SHIELD' => 0, 'SPARE' => 0 } unless flag_result
+    return { 'EVASION' => 0, 'PARRY' => 0, 'SHIELD' => 0, 'SPARE' => 0 } unless Flags['last-stance']
 
-    flag_result[0] =~ /(\d+)%.* (\d+)%.* (\d+)%.* (\d+)/
-    { 'EVASION' => Regexp.last_match(1).to_i, 'PARRY' => Regexp.last_match(2).to_i, 'SHIELD' => Regexp.last_match(3).to_i, 'SPARE' => Regexp.last_match(4).to_i }
+    { 'EVASION' => Flags['last-stance'][:evasion].to_i, 'PARRY' => Flags['last-stance'][:parry].to_i, 'SHIELD' => Flags['last-stance'][:shield].to_i, 'SPARE' => Flags['last-stance'][:spare].to_i }
   end
 
   def build_stance_string(vals)
@@ -4484,7 +4482,7 @@ class CombatTrainer
   def setup(settings)
     Flags.add('ct-spellcast', '^Your formation of a targeting pattern around .+ has completed\.', 'Your target pattern has finished forming around the area', '^You feel fully prepared to cast your spell\.', '^Your spell pattern snaps into shape with little preparation!')
 
-    Flags.add('last-stance', 'Setting your Evasion stance to \d+%, your Parry stance to \d+%, and your Shield stance to \d+%.  You have \d+ stance points left')
+    Flags.add('last-stance', /^Setting your Evasion stance to (?<evasion>\d+)%,.*your Parry stance to (?<parry>\d+)%,.*your Shield stance to (?<shield>\d+)%.*?You have (?<spare>\d+) stance points left/)
 
     DRC.bput("stance set #{settings.default_stance}", 'Setting your')
 


### PR DESCRIPTION
Expands match criteria and anchors the last-stance regex.
Now works when setting attack % as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stance tracking by recording evasion, parry, shield, and spare values in a structured format.
  * Stance calculations now more reliably reflect the player’s last known stance percentages and remaining points.
  * Added safer handling when no previous stance data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->