### PR TITLE
Fix loot loss: transfer-items coins abort + droughtmans empty-only trash

### DIFF
--- a/droughtmans.lic
+++ b/droughtmans.lic
@@ -499,7 +499,9 @@ class Droughtmans
   # Trash the prize wrapper only when the loot transfer emptied it. If any loot
   # remains (no/full loot container, an item that would not fit), the package is
   # kept instead so a prize is never thrown away. An unreadable package (nil
-  # contents) is treated as "not verified empty" and is likewise kept.
+  # contents) is treated as "not verified empty" and is likewise kept. The kept
+  # package is only re-stowed when still in hand -- by this point stow_hands has
+  # usually already put it away, so stowing again would just echo "Stow what?".
   # @return [void]
   def dispose_empty_package
     contents = DRCI.get_item_list('package', 'look')
@@ -507,7 +509,7 @@ class Droughtmans
       DRCI.dispose_trash('package', @worn_trashcan, @worn_trashcan_verb)
     else
       DRC.message("droughtmans: package still holds loot (check your #{@loot_container}) - keeping it instead of trashing")
-      DRCI.put_away_item?('package')
+      DRCI.put_away_item?('package') if DRCI.in_hands?('package')
     end
   end
 

--- a/droughtmans.lic
+++ b/droughtmans.lic
@@ -110,6 +110,10 @@ class Droughtmans
     @friends = settings.hunting_buddies
     @worn_trashcan = settings.worn_trashcan
     @worn_trashcan_verb = settings.worn_trashcan_verb
+    # Where won loot is deposited when cashing in a package. Defaults to the
+    # canvas sack fetched from the compound dwarf; override with any carried
+    # container (e.g. a worn backpack) via the droughtmans_loot_container setting.
+    @loot_container = settings.droughtmans_loot_container || 'canvas sack'
 
     # Randomize the wall-follow hand so repeated runs explore different paths.
     @current_direction_map = [CLOCKWISE_MAP, COUNTER_CLOCKWISE_MAP].sample
@@ -168,7 +172,7 @@ class Droughtmans
   def enter_maze_if_needed
     unless DRRoom.title.match?(/Droughtman's Compound, The Maze/)
       DRC.log_window("Starting run at #{Time.now}", 'familiar', true)
-      get_sack
+      fetch_loot_container_if_needed
       DRCT.walk_to(WAND_ROOM)
       redeem_pass_if_present
       fput('ask spiel about access')
@@ -457,6 +461,14 @@ class Droughtmans
     DRCI.get_item_unsafe('golden key')
   end
 
+  # Fetch the loot destination before a run, but only for the default canvas
+  # sack: a user-configured container is assumed to be carried already, and the
+  # compound dwarf only hands out canvas sacks.
+  # @return [void]
+  def fetch_loot_container_if_needed
+    get_sack if @loot_container == 'canvas sack'
+  end
+
   # Fetch a canvas sack from the compound dwarf unless one is already carried.
   # @return [void]
   def get_sack
@@ -468,22 +480,45 @@ class Droughtmans
     DRCI.put_away_item?('sack')
   end
 
-  # Cash in a won prize package: transfer loot, trash the wrapper, exit the
-  # winner's circle, return to the wand room, and stop the script.
+  # Cash in a won prize package: transfer loot into the configured container,
+  # trash the wrapper only once it is empty, exit the winner's circle, return to
+  # the wand room, and stop the script.
   # @return [void]
   # @note Terminates the script on completion.
   def package
     DRC.bput('open my package', /You open/)
     DRCI.stow_hands
     DRCI.put_away_item?('wand')
-    DRC.wait_for_script_to_complete('transfer-items', ['package', 'canvas sack'])
-    DRCI.dispose_trash('package', @worn_trashcan, @worn_trashcan_verb)
-    if DRRoom.title.match?(/Droughtman's Maze, Winner's Circle/)
-      fput('go oval')
-      fput('go oval')
-    end
+    DRC.wait_for_script_to_complete('transfer-items', ['package', @loot_container])
+    dispose_empty_package
+    leave_winners_circle
     DRCT.walk_to(WAND_ROOM)
     exit
+  end
+
+  # Trash the prize wrapper only when the loot transfer emptied it. If any loot
+  # remains (no/full loot container, an item that would not fit), the package is
+  # kept instead so a prize is never thrown away. An unreadable package (nil
+  # contents) is treated as "not verified empty" and is likewise kept.
+  # @return [void]
+  def dispose_empty_package
+    contents = DRCI.get_item_list('package', 'look')
+    if contents && contents.empty?
+      DRCI.dispose_trash('package', @worn_trashcan, @worn_trashcan_verb)
+    else
+      DRC.message("droughtmans: package still holds loot (check your #{@loot_container}) - keeping it instead of trashing")
+      DRCI.put_away_item?('package')
+    end
+  end
+
+  # Step out of the winner's circle back onto the main maze floor, if we are in
+  # it. No-op when the cash-in happened elsewhere.
+  # @return [void]
+  def leave_winners_circle
+    return unless DRRoom.title.match?(/Droughtman's Maze, Winner's Circle/)
+
+    fput('go oval')
+    fput('go oval')
   end
 
   # Freeze every npc in the room, expanding duplicate types into ordinal targets

--- a/spec/astrology_spec.rb
+++ b/spec/astrology_spec.rb
@@ -17,20 +17,6 @@ class Room
   end
 end unless defined?(Room)
 
-class UserVars
-  class << self
-    def astrology_debug
-      false
-    end
-
-    def astral_plane_exp_timer
-      nil
-    end
-
-    def astral_plane_exp_timer=(_val); end
-  end
-end unless defined?(UserVars)
-
 load_lic_class('astrology.lic', 'Astrology')
 
 RSpec.describe Astrology do

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -17,47 +17,19 @@ require_relative 'spec_helper'
 # Each stub provides the minimum interface combat-trainer calls.
 # Methods default to safe no-ops; tests override via allow().
 
-# Unified UserVars store. Backs every UserVars key the combat-trainer code
-# and the merged specs touch (moons, sun, discerns, friends, warhorn,
-# almanac_last_use, yiamura, paladin_last_badge_use, combat_trainer_debug,
-# ...) via a dynamic data hash. moons reads back a sane default so the
-# slivers specs see { 'visible' => [] } when unset, and _set_moons/_reset
-# match the helpers those specs call.
-class UserVars
-  @data = {}
-
+# The generic UserVars store lives in the harness (Harness::UserVars); reopen it
+# here to add combat-trainer's one domain default: moons reads back an empty
+# visible set so the slivers specs see { 'visible' => [] } when it is unset.
+# _set_moons mirrors the helper those specs call. Everything else (sun, discerns,
+# friends, warhorn, almanac_last_use, ...) is handled by the shared store.
+class Harness::UserVars
   class << self
-    def _data
-      @data ||= {}
-    end
-
-    def _reset
-      @data = {}
-    end
-
     def moons
-      _data[:moons] || { 'visible' => [] }
-    end
-
-    def moons=(val)
-      _data[:moons] = val
+      _store[:moons] || { 'visible' => [] }
     end
 
     def _set_moons(val)
-      _data[:moons] = val
-    end
-
-    def method_missing(name, *args)
-      key = name.to_s
-      if key.end_with?('=')
-        _data[key.chomp('=').to_sym] = args.first
-      else
-        _data[name.to_sym]
-      end
-    end
-
-    def respond_to_missing?(name, _include_private = false)
-      name.to_s.end_with?('=') || _data.key?(name.to_sym) || super
+      _store[:moons] = val
     end
   end
 end

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -11,15 +11,6 @@ require_relative 'spec_helper'
 # self-contained and reads top-to-bottom (DAMP).
 load_lic_class('droughtmans.lic', 'Droughtmans')
 
-# UserVars is per-script config (the harness deliberately omits it), so define it
-# here guarded against the definitions other specs provide. parse_configuration
-# reads droughtmans_debug; examples override it with allow(...) as needed.
-class UserVars
-  def self.droughtmans_debug
-    nil
-  end
-end unless defined?(UserVars)
-
 RSpec.describe Droughtmans do
   let(:bot) { Droughtmans.allocate }
 

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -406,13 +406,34 @@ RSpec.describe Droughtmans do
 
     it 'keeps a package that still holds loot instead of trashing it' do
       allow(DRCI).to receive(:get_item_list).with('package', 'look').and_return(['leaves'])
+      allow(DRCI).to receive(:in_hands?).with('package').and_return(false)
       allow(DRCI).to receive(:dispose_trash)
-      expect(DRCI).to receive(:put_away_item?).with('package')
+      allow(DRCI).to receive(:put_away_item?)
       expect(DRC).to receive(:message).with(/still holds loot/)
 
       bot.dispose_empty_package
 
       expect(DRCI).not_to have_received(:dispose_trash)
+    end
+
+    it 'does not re-stow a kept package that has already been put away' do
+      allow(DRCI).to receive(:get_item_list).with('package', 'look').and_return(['leaves'])
+      allow(DRCI).to receive(:in_hands?).with('package').and_return(false)
+      allow(DRCI).to receive(:dispose_trash)
+      allow(DRC).to receive(:message)
+      expect(DRCI).not_to receive(:put_away_item?)
+
+      bot.dispose_empty_package
+    end
+
+    it 'stows a kept package that is still in hand' do
+      allow(DRCI).to receive(:get_item_list).with('package', 'look').and_return(['leaves'])
+      allow(DRCI).to receive(:in_hands?).with('package').and_return(true)
+      allow(DRCI).to receive(:dispose_trash)
+      allow(DRC).to receive(:message)
+      expect(DRCI).to receive(:put_away_item?).with('package')
+
+      bot.dispose_empty_package
     end
 
     it 'never trashes a package whose contents could not be read (nil)' do

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -11,6 +11,15 @@ require_relative 'spec_helper'
 # self-contained and reads top-to-bottom (DAMP).
 load_lic_class('droughtmans.lic', 'Droughtmans')
 
+# UserVars is per-script config (the harness deliberately omits it), so define it
+# here guarded against the definitions other specs provide. parse_configuration
+# reads droughtmans_debug; examples override it with allow(...) as needed.
+class UserVars
+  def self.droughtmans_debug
+    nil
+  end
+end unless defined?(UserVars)
+
 RSpec.describe Droughtmans do
   let(:bot) { Droughtmans.allocate }
 
@@ -381,6 +390,103 @@ RSpec.describe Droughtmans do
       bot.instance_variable_set(:@current_direction_map, Droughtmans::COUNTER_CLOCKWISE_MAP)
       bot.change_direction_map
       expect(bot.instance_variable_get(:@current_direction_map)).to be(Droughtmans::CLOCKWISE_MAP)
+    end
+  end
+
+  # ===========================================================================
+  # dispose_empty_package: never trash a package that still holds loot
+  # ===========================================================================
+  describe '#dispose_empty_package' do
+    before do
+      bot.instance_variable_set(:@worn_trashcan, 'backpack')
+      bot.instance_variable_set(:@worn_trashcan_verb, 'stuff')
+      bot.instance_variable_set(:@loot_container, 'canvas sack')
+    end
+
+    it 'trashes the wrapper only once the loot transfer has emptied it' do
+      allow(DRCI).to receive(:get_item_list).with('package', 'look').and_return([])
+      allow(DRCI).to receive(:put_away_item?)
+      expect(DRCI).to receive(:dispose_trash).with('package', 'backpack', 'stuff')
+
+      bot.dispose_empty_package
+
+      expect(DRCI).not_to have_received(:put_away_item?)
+    end
+
+    it 'keeps a package that still holds loot instead of trashing it' do
+      allow(DRCI).to receive(:get_item_list).with('package', 'look').and_return(['leaves'])
+      allow(DRCI).to receive(:dispose_trash)
+      expect(DRCI).to receive(:put_away_item?).with('package')
+      expect(DRC).to receive(:message).with(/still holds loot/)
+
+      bot.dispose_empty_package
+
+      expect(DRCI).not_to have_received(:dispose_trash)
+    end
+
+    it 'never trashes a package whose contents could not be read (nil)' do
+      allow(DRCI).to receive(:get_item_list).with('package', 'look').and_return(nil)
+      allow(DRCI).to receive(:put_away_item?)
+      expect(DRCI).not_to receive(:dispose_trash)
+
+      bot.dispose_empty_package
+    end
+  end
+
+  # ===========================================================================
+  # fetch_loot_container_if_needed: only chase the dwarf's sack for the default
+  # ===========================================================================
+  describe '#fetch_loot_container_if_needed' do
+    it 'asks the compound dwarf for a canvas sack when using the default container' do
+      bot.instance_variable_set(:@loot_container, 'canvas sack')
+      expect(bot).to receive(:get_sack)
+
+      bot.fetch_loot_container_if_needed
+    end
+
+    it 'does not fetch a sack when a custom loot container is configured' do
+      bot.instance_variable_set(:@loot_container, 'worn backpack')
+      expect(bot).not_to receive(:get_sack)
+
+      bot.fetch_loot_container_if_needed
+    end
+  end
+
+  # ===========================================================================
+  # parse_configuration: the configurable loot destination
+  # ===========================================================================
+  describe '#parse_configuration (loot container)' do
+    before { allow(UserVars).to receive(:droughtmans_debug).and_return(nil) }
+
+    it 'defaults the loot container to a canvas sack when unset' do
+      $test_settings = OpenStruct.new
+      bot.parse_configuration
+      expect(bot.instance_variable_get(:@loot_container)).to eq('canvas sack')
+    end
+
+    it 'honors a configured droughtmans_loot_container override' do
+      $test_settings = OpenStruct.new(droughtmans_loot_container: 'worn backpack')
+      bot.parse_configuration
+      expect(bot.instance_variable_get(:@loot_container)).to eq('worn backpack')
+    end
+  end
+
+  # ===========================================================================
+  # leave_winners_circle: step out only when actually in the circle
+  # ===========================================================================
+  describe '#leave_winners_circle' do
+    it 'walks out of the oval twice when standing in the winner\'s circle' do
+      DRRoom.title = "Droughtman's Maze, Winner's Circle"
+      expect(bot).to receive(:fput).with('go oval').twice
+
+      bot.leave_winners_circle
+    end
+
+    it 'does nothing when the cash-in happened outside the winner\'s circle' do
+      DRRoom.title = "Droughtman's Compound, The Maze"
+      expect(bot).not_to receive(:fput)
+
+      bot.leave_winners_circle
     end
   end
 end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -11,17 +11,6 @@ require_relative 'spec_helper'
 # predicates, settings validation (which aborts), and the queue reshuffle.
 load_lic_class('smoke.lic', 'Smoker')
 
-# UserVars is per-script config -- provide the constant (only if no other spec
-# defined it) so build_priority_queue's reads/writes can be stubbed per example.
-class UserVars
-  class << self
-    def smoke_images_known; @smoke_images_known; end
-    def smoke_images_known=(value); @smoke_images_known = value; end
-    def smoke_images_mastered; @smoke_images_mastered; end
-    def smoke_images_mastered=(value); @smoke_images_mastered = value; end
-  end
-end unless defined?(UserVars)
-
 RSpec.describe Smoker do
   subject(:smoker) { described_class.allocate }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,9 +46,12 @@
 #   - Need a commons method the harness does not have yet? Add it to
 #     test/test_harness.rb following the conventions above -- do not stub it
 #     locally in one spec.
-#   - UserVars is the deliberate exception: it is per-script configuration (each
-#     script reads different keys with script-specific meanings), so stub it
-#     per-spec, not in the harness.
+#   - UserVars is a generic dynamic store in the harness: any getter reads back
+#     nil until set, any setter stores, and it is cleared before each example.
+#     Override a key with allow(UserVars).to receive(:key)... or set it directly
+#     with UserVars.key = value -- do NOT redefine the class in a spec. A script
+#     that needs a domain default (e.g. combat-trainer's moons) reopens
+#     Harness::UserVars to add just that default (see combat_trainer_spec).
 #   - If a .lic method calls exit on a guard, drive it with
 #     `expect { ... }.to raise_error(SystemExit)` (or stub exit on the instance).
 #     A stray unwrapped exit terminates the whole run, not just the example.

--- a/spec/transfer_items_spec.rb
+++ b/spec/transfer_items_spec.rb
@@ -1,0 +1,196 @@
+require_relative 'spec_helper'
+
+# ItemTransfer#initialize parses command-line args and immediately runs the
+# transfer, so we extract the class with load_lic_class and exercise the pure
+# transfer logic on bare-allocated instances (ItemTransfer.allocate). The game
+# layer (DRC/DRCI) is driven with allow(...).to receive(...) per the harness
+# rules; the fatal-guard paths call exit, so they are asserted with
+# raise_error(SystemExit). Every example reads top-to-bottom (DAMP).
+#
+# The focus is the coins-abort regression (coins auto-deposit into the purse, so
+# GET "fails" and the old code exited the whole transfer) plus the surrounding
+# get/move/trash/pagination branches.
+load_lic_class('transfer-items.lic', 'ItemTransfer')
+
+RSpec.describe ItemTransfer do
+  let(:mover) { ItemTransfer.allocate }
+
+  # Stub the game seams to benign defaults; individual examples override as needed.
+  before do
+    allow(DRC).to receive(:bput).and_return('are now at the top')
+    allow(DRC).to receive(:message)
+    allow(DRC).to receive(:left_hand).and_return(nil)
+    allow(DRC).to receive(:right_hand).and_return(nil)
+    allow(DRCI).to receive(:get_item).and_return(true)
+    allow(DRCI).to receive(:put_away_item?).and_return(true)
+    allow(DRCI).to receive(:dispose_trash)
+  end
+
+  # ===========================================================================
+  # Coins: the regression -- must never abort the transfer
+  # ===========================================================================
+  describe 'coins handling' do
+    it 'pulls coins into the purse and moves on without ever trying to stow them' do
+      allow(DRCI).to receive(:get_item_list).and_return(['some copper coins'])
+
+      expect { mover.transfer_items('package', 'canvas sack', nil) }.not_to raise_error
+      expect(DRCI).to have_received(:get_item).with('coins', 'package')
+      expect(DRCI).not_to have_received(:put_away_item?)
+    end
+
+    it 'does NOT exit even though GET reports failure for coins (auto-purse)' do
+      # This is the exact live bug: "You pick up 5 copper Lirums" then get_item
+      # -> in_hands? -> false. The old code fell into the fatal else and exited.
+      allow(DRCI).to receive(:get_item_list).and_return(['some copper coins'])
+      allow(DRCI).to receive(:get_item).and_return(false)
+
+      expect { mover.transfer_items('package', 'canvas sack', nil) }.not_to raise_error
+    end
+
+    it 'skips coins but still transfers the items listed after them' do
+      allow(DRCI).to receive(:get_item_list).and_return(['some copper coins', 'a shiny gem'])
+
+      mover.transfer_items('package', 'canvas sack', nil)
+
+      expect(DRCI).to have_received(:put_away_item?).with('gem', 'canvas sack')
+    end
+  end
+
+  # ===========================================================================
+  # Normal item movement and the destination-too-small fallback
+  # ===========================================================================
+  describe 'moving items to a container' do
+    it 'puts a retrieved item into the destination container' do
+      allow(DRCI).to receive(:get_item_list).and_return(['a shiny gem'])
+
+      mover.transfer_items('package', 'canvas sack', nil)
+
+      expect(DRCI).to have_received(:put_away_item?).with('gem', 'canvas sack')
+    end
+
+    it 'returns an item to the source when the destination cannot hold it' do
+      allow(DRCI).to receive(:get_item_list).and_return(['a shiny gem'])
+      allow(DRCI).to receive(:put_away_item?).with('gem', 'canvas sack').and_return(false)
+      allow(DRCI).to receive(:put_away_item?).with('gem', 'package').and_return(true)
+
+      mover.transfer_items('package', 'canvas sack', nil)
+
+      expect(DRCI).to have_received(:put_away_item?).with('gem', 'package')
+      expect(DRC).to have_received(:message).with(/Unable to put gem in your canvas sack/)
+    end
+  end
+
+  # ===========================================================================
+  # The deliberate fatal guard for genuinely un-gettable (non-coin) items
+  # ===========================================================================
+  describe 'when a non-coin item cannot be retrieved' do
+    before do
+      allow(DRCI).to receive(:get_item_list).and_return(['a shiny gem'])
+      allow(DRCI).to receive(:get_item).and_return(false)
+    end
+
+    it 'reports the failure and exits the script' do
+      expect(DRC).to receive(:message).with('Unable to get gem from package.')
+
+      expect { mover.transfer_items('package', 'canvas sack', nil) }.to raise_error(SystemExit)
+    end
+
+    it 'warns about full hands when both hands are occupied' do
+      allow(DRC).to receive(:left_hand).and_return('sword')
+      allow(DRC).to receive(:right_hand).and_return('shield')
+      expect(DRC).to receive(:message).with('Your hands are full!')
+
+      expect { mover.transfer_items('package', 'canvas sack', nil) }.to raise_error(SystemExit)
+    end
+  end
+
+  # ===========================================================================
+  # Trash destination routing
+  # ===========================================================================
+  describe 'trashing items' do
+    it 'disposes items instead of stowing them when the destination is trash' do
+      allow(DRCI).to receive(:get_item_list).and_return(['a shiny gem'])
+
+      mover.transfer_items('package', 'trash', nil)
+
+      expect(DRCI).to have_received(:dispose_trash).with('gem')
+      expect(DRCI).not_to have_received(:put_away_item?)
+    end
+  end
+
+  # ===========================================================================
+  # Noun filtering
+  # ===========================================================================
+  describe 'noun filtering' do
+    it 'transfers only items matching the requested noun and sorts them first' do
+      allow(DRCI).to receive(:get_item_list).and_return(['a red gem', 'a blue orb'])
+
+      mover.transfer_items('package', 'canvas sack', 'gem')
+
+      expect(DRC).to have_received(:bput).with(/^sort gem in my package/, any_args)
+      expect(DRCI).to have_received(:get_item).with('gem', 'package')
+      expect(DRCI).not_to have_received(:get_item).with('orb', 'package')
+    end
+  end
+
+  # ===========================================================================
+  # Pagination: "lot of other stuff" forces another LOOK
+  # ===========================================================================
+  describe 'pagination for over-full containers' do
+    it 're-looks once when the list ends in "lot of other stuff" then stops' do
+      allow(DRCI).to receive(:get_item_list)
+        .and_return(['a shiny gem', 'a lot of other stuff'], [])
+
+      mover.transfer_items('package', 'canvas sack', nil)
+
+      expect(DRCI).to have_received(:get_item_list).twice
+    end
+  end
+
+  # ===========================================================================
+  # Empty source is a clean no-op
+  # ===========================================================================
+  describe 'an empty source container' do
+    it 'does nothing and never exits' do
+      allow(DRCI).to receive(:get_item_list).and_return([])
+
+      expect { mover.transfer_items('package', 'canvas sack', nil) }.not_to raise_error
+      expect(DRCI).not_to have_received(:get_item)
+    end
+  end
+
+  # ===========================================================================
+  # move_item in isolation
+  # ===========================================================================
+  describe '#move_item' do
+    it 'does not fall back to the source when the destination accepts the item' do
+      allow(DRCI).to receive(:put_away_item?).with('gem', 'canvas sack').and_return(true)
+
+      mover.move_item('gem', 'package', 'canvas sack')
+
+      expect(DRCI).not_to have_received(:put_away_item?).with('gem', 'package')
+      expect(DRC).not_to have_received(:message)
+    end
+
+    it 'warns and returns the item to the source when the destination refuses it' do
+      allow(DRCI).to receive(:put_away_item?).with('gem', 'canvas sack').and_return(false)
+      allow(DRCI).to receive(:put_away_item?).with('gem', 'package').and_return(true)
+
+      mover.move_item('gem', 'package', 'canvas sack')
+
+      expect(DRC).to have_received(:message).with(/Unable to put gem in your canvas sack/)
+      expect(DRCI).to have_received(:put_away_item?).with('gem', 'package')
+    end
+  end
+
+  # ===========================================================================
+  # trash_item in isolation
+  # ===========================================================================
+  describe '#trash_item' do
+    it 'delegates to the shared trash-disposal helper' do
+      mover.trash_item('gem')
+
+      expect(DRCI).to have_received(:dispose_trash).with('gem')
+    end
+  end
+end

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -695,6 +695,43 @@ module Harness
     $test_data[dummy.to_sym]
   end
 
+  # Generic per-script configuration store (Lich's UserVars). Different scripts
+  # read and write different, script-specific keys (astrology_debug, researcher,
+  # smoke_images_known, almanac_last_use, droughtmans_loot_container, ...), so
+  # this backs any getter/setter dynamically: an unset key reads back nil,
+  # assignment stores the value, and _reset (called by reset_data before every
+  # example) clears the store.
+  #
+  # Override a key for one example with allow(UserVars).to receive(:key)..., or
+  # set a value directly with UserVars.key = value. A script that needs a domain
+  # default (e.g. combat-trainer's moons) reopens Harness::UserVars to add it.
+  class UserVars
+    @store = {}
+
+    class << self
+      def _store
+        @store ||= {}
+      end
+
+      def _reset
+        @store = {}
+      end
+
+      def method_missing(name, *args)
+        key = name.to_s
+        if key.end_with?('=')
+          _store[key.chomp('=').to_sym] = args.first
+        else
+          _store[name.to_sym]
+        end
+      end
+
+      def respond_to_missing?(_name, _include_private = false)
+        true
+      end
+    end
+  end
+
   # After tests run, we need to wipe out/reset
   # constants and other contextual data so that
   # each test doesn't interfere with the others.
@@ -751,6 +788,7 @@ module Harness
     DRRoom._reset
     Map._reset
     XMLData._reset
+    UserVars._reset
   end
 
   def echo(message)

--- a/transfer-items.lic
+++ b/transfer-items.lic
@@ -2,7 +2,13 @@
   Documentation: https://elanthipedia.play.net/Lich_script_repository#transfer-items
 =end
 
+# Bulk-transfers items between containers (or to the trash) from the command line.
+#
+# Usage: +transfer-items <source> <destination> [noun]+, where +destination+ may
+# be the literal "trash". With +noun+, only matching items are moved.
 class ItemTransfer
+  # Parse the source/destination/noun arguments and run the transfer.
+  # @return [void]
   def initialize
     arg_definitions = [
       [
@@ -19,6 +25,21 @@ class ItemTransfer
     transfer_items(args.source, args.destination, args.noun)
   end
 
+  # Move every item (optionally filtered by noun) out of one container and into
+  # another, or into the trash.
+  #
+  # Recurses to page through a container too full for a single LOOK to list, and
+  # is defensive about two game quirks: coins auto-deposit into the coin purse on
+  # GET (so they never reach the hands and their GET "fails"), and a destination
+  # container can be too small/full for a given item.
+  #
+  # @param source [String] source container noun (e.g. "package")
+  # @param destination [String] destination container noun, or "trash" to dispose
+  # @param noun [String, nil] if given, only items whose short name matches this
+  #   noun are transferred
+  # @return [void]
+  # @note Deliberately calls +exit+ when a non-coin item cannot be retrieved
+  #   (typically hands full), since the transfer cannot safely continue.
   def transfer_items(source, destination, noun)
     # If container is very full then LOOK may not list all of them.
     # If you're moving a specific item, then sort those to the top
@@ -36,13 +57,15 @@ class ItemTransfer
         transfer_items(source, destination, noun)
         break
       end
+      # Coins auto-deposit into the coin purse on GET and can never be placed in a
+      # container, so GET "fails" (they never reach the hands). Pull them from the
+      # source to empty it and move on -- do NOT treat this as a fatal failure.
+      if item =~ /coins?/i
+        DRCI.get_item(item, source)
+        next
+      end
       # Attempt to get the item from the source container.
       if DRCI.get_item(item, source)
-        # Coins are automatically picked up and added to coin purse.
-        # Skip trying to transfer them to destination container.
-        if item =~ /coins?/i
-          next
-        end
         if destination == 'trash'
           trash_item(item)
         else
@@ -56,6 +79,14 @@ class ItemTransfer
     end
   end
 
+  # Put a held item into the destination container, returning it to the source if
+  # the destination cannot hold it (full or too small) so the loop can continue
+  # with the next item.
+  #
+  # @param item [String] item noun currently in hand
+  # @param source [String] container to return the item to on failure
+  # @param destination [String] container to put the item into
+  # @return [void]
   def move_item(item, source, destination)
     # Attempt to put the item in the destination container.
     unless DRCI.put_away_item?(item, destination)
@@ -66,6 +97,10 @@ class ItemTransfer
     end
   end
 
+  # Dispose of a held item via the standard trash-handling helper.
+  #
+  # @param item [String] item noun currently in hand
+  # @return [void]
   def trash_item(item)
     DRCI.dispose_trash(item)
   end


### PR DESCRIPTION
## Problem

Cashing in a Droughtman's prize package could throw the loot away with the wrapper. Two independent defects combined:

1. **`transfer-items` aborts on coins.** `transfer_items` treats a `false` return from `DRCI.get_item` as fatal (`exit`). Coins auto-deposit into the coin purse on GET and never reach the hands, so `get_item` -> `in_hands?` reports **false** even though the pickup worked. The existing `if item =~ /coins?/i; next` guard sat *inside* the get-success branch, so it was dead code for coins. Result: the transfer exits the moment it hits coins (which nearly every package contains), abandoning every item after them.

   ```
   [transfer-items]>get my coins from my package
   You pick up 5 copper Lirums.
   Unable to get coins from package.
   --- Lich: transfer-items has exited.
   ```

2. **`droughtmans` trashes a non-empty package.** `package` ran the transfer then unconditionally `DRCI.dispose_trash('package', ...)`. The destination was hard-coded to `canvas sack`, which `get_sack` only fetches in the *not-already-in-maze* branch. Start the bot inside the maze (or lose the sack) and the loot is put back into the package, which is then trashed with everything still inside.

## Fix

**`transfer-items.lic`**
- Move the coins check *ahead of* the fatal get: coins are pulled into the purse and skipped without ever hitting the `exit`, so items after them still transfer. Genuine un-gettable items (hands full) still `exit` deliberately, unchanged.
- Full YARD docs added (the class had none).

**`droughtmans.lic`**
- `dispose_empty_package`: trash the wrapper **only once it is verifiably empty**; otherwise keep the package and warn. A `nil`/unreadable contents read is treated as not-empty, so a prize is never discarded.
- Loot destination is now configurable via a `droughtmans_loot_container` setting (default `canvas sack`); the dwarf sack is only fetched for the default container (`fetch_loot_container_if_needed`).
- `leave_winners_circle` extracted for a clean, testable `package` flow.

## Tests

- New `spec/transfer_items_spec.rb`: coins-abort regression (incl. the `get_item -> false` case), coins-then-item, destination-too-small fallback, non-coin fatal exit, trash routing, noun filter, "lot of other stuff" pagination, empty source, and `move_item`/`trash_item` units.
- Extended `spec/droughtmans_spec.rb`: empty/non-empty/nil-read trash guard, sack-gating, config default/override, winner's-circle exit.

## Test-infra: centralize `UserVars`

While adding the droughtmans config spec, four specs (astrology, combat_trainer, smoke, droughtmans) each hand-rolled a top-level `UserVars` class, and `researcher_spec` defined none -- it silently relied on `combat_trainer_spec`'s being loaded first (it could not run in isolation), the exact load-order fragility `spec_helper` warns about.

- Added one canonical `Harness::UserVars`: a dynamic store (unset getter -> nil, setter stores, `_reset` cleared before each example via `reset_data`).
- Removed the bespoke per-spec definitions; reduced `combat_trainer_spec` to a small reopen adding only its `moons` domain default on top of the shared store.
- Every spec now runs standalone (researcher: 177, smoke: 113, astrology: 179, ...).

## Verification

Full suite: **2225 examples, 0 failures**. `rubocop` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring where Droughtmans prize loot is placed.
  * Prize wrappers are now preserved when contents remain or cannot be verified.
  * Added safer handling when leaving the winner’s circle.

* **Bug Fixes**
  * Improved coin transfers so failed coin retrieval does not interrupt other item transfers.
  * Added safeguards for full hands, unavailable items, rejected destinations, and empty containers.

* **Documentation**
  * Expanded command and workflow documentation for item transfers.

* **Tests**
  * Added comprehensive coverage for prize packaging, loot containers, item transfers, and test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->