### PR TITLE
droughtmans: pace movement, survive dark colored-door rooms, wand before rope

### DIFF
--- a/droughtmans.lic
+++ b/droughtmans.lic
@@ -114,6 +114,12 @@ class Droughtmans
     # canvas sack fetched from the compound dwarf; override with any carried
     # container (e.g. a worn backpack) via the droughtmans_loot_container setting.
     @loot_container = settings.droughtmans_loot_container || 'canvas sack'
+    # Optional pause (seconds) after each successful step. Movement is otherwise
+    # throttled only by roundtime, which in the maze is often near-zero, so the
+    # solver can move fast enough to stumble/fall every few rooms. Set
+    # droughtmans_step_delay to a small value (e.g. 1) to pace it; 0 keeps the
+    # historical un-throttled behavior.
+    @step_delay = (settings.droughtmans_step_delay || 0).to_f
 
     # Randomize the wall-follow hand so repeated runs explore different paths.
     @current_direction_map = [CLOCKWISE_MAP, COUNTER_CLOCKWISE_MAP].sample
@@ -291,6 +297,7 @@ class Droughtmans
       waitrt?
       zap_nemesis
       @wandercounter += 1 if log_move
+      throttle_movement
     when /^Rushing through/, /^Noticing your attempt to leave/
       waitrt?
       DRC.fix_standing
@@ -309,6 +316,7 @@ class Droughtmans
       waitrt?
       zap_nemesis
       @wandercounter += 1 if log_move
+      throttle_movement
     else
       echo('move failed - clearing exits and retrying next tick')
       @last_move = ''
@@ -319,6 +327,14 @@ class Droughtmans
       waitrt?
       zap_nemesis
     end
+  end
+
+  # Pause briefly after a successful step when a step delay is configured, so the
+  # solver does not move fast enough to stumble and fall (which is especially
+  # costly while carrying the key). No-op when droughtmans_step_delay is 0.
+  # @return [void]
+  def throttle_movement
+    pause @step_delay if @step_delay.positive?
   end
 
   # Choose and execute the next wander step using the wall-follow rules, with
@@ -712,6 +728,12 @@ class Droughtmans
   def handle_dark_room
     return unless Flags['dark-room']
 
+    relight_room
+  end
+
+  # Shake the wand for light and clear the dark-room flag.
+  # @return [void]
+  def relight_room
     fput('shake wand')
     Flags.reset('dark-room')
   end
@@ -747,6 +769,9 @@ class Droughtmans
 
       check_key_holders unless DRRoom.pcs.empty?
       if (rope = DRRoom.room_objs.find { |obj| obj =~ /rope/ })
+        # Freeze any rivals in the room BEFORE pulling: the rope drops the key on
+        # the floor, and an unfrozen npc will snatch it before we can grab it.
+        check_for_npcs
         pull_rope(rope)
       end
     end
@@ -762,11 +787,18 @@ class Droughtmans
     @last_door_entered ||= door
     return unless @last_door_entered != door || @wandercounter > 40 || have_key?
 
-    case DRC.bput("go #{door}", /^Obvious/, /^You can't go there/, /You smash your nose/)
+    case DRC.bput("go #{door}", /^Obvious/, /^You can't go there/, /You smash your nose/, /It's pitch dark and you can't see a thing/)
     when /^Obvious/
       echo('went through a colored door')
       DRRoom.room_objs.delete(door)
       init_maze
+    when /It's pitch dark and you can't see a thing/
+      # A dark room makes GO resolve to nothing, so bput would otherwise block for
+      # its full timeout (the reported 15-second hang). Re-light and skip this
+      # tick; the door is retried once the room is lit again.
+      echo('colored door in the dark - relighting, will retry once lit')
+      relight_room
+      return
     when /^You can't go there/
       echo("Couldn't go through the #{door}")
     end

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -465,7 +465,7 @@ RSpec.describe Droughtmans do
   end
 
   # ===========================================================================
-  # parse_configuration: the configurable loot destination
+  # parse_configuration: the configurable loot destination and step pacing
   # ===========================================================================
   describe '#parse_configuration (loot container)' do
     before { allow(UserVars).to receive(:droughtmans_debug).and_return(nil) }
@@ -480,6 +480,210 @@ RSpec.describe Droughtmans do
       $test_settings = OpenStruct.new(droughtmans_loot_container: 'worn backpack')
       bot.parse_configuration
       expect(bot.instance_variable_get(:@loot_container)).to eq('worn backpack')
+    end
+  end
+
+  describe '#parse_configuration (step delay)' do
+    before { allow(UserVars).to receive(:droughtmans_debug).and_return(nil) }
+
+    it 'defaults the step delay to 0 (unthrottled) when unset' do
+      $test_settings = OpenStruct.new
+      bot.parse_configuration
+      expect(bot.instance_variable_get(:@step_delay)).to eq(0.0)
+    end
+
+    it 'coerces a configured droughtmans_step_delay to a float' do
+      $test_settings = OpenStruct.new(droughtmans_step_delay: 2)
+      bot.parse_configuration
+      expect(bot.instance_variable_get(:@step_delay)).to eq(2.0)
+    end
+
+    it 'accepts a fractional step delay' do
+      $test_settings = OpenStruct.new(droughtmans_step_delay: 0.5)
+      bot.parse_configuration
+      expect(bot.instance_variable_get(:@step_delay)).to eq(0.5)
+    end
+  end
+
+  # ===========================================================================
+  # throttle_movement: opt-in pacing so the solver stops falling every few rooms
+  # ===========================================================================
+  describe '#throttle_movement' do
+    it 'pauses for the configured delay when one is set' do
+      bot.instance_variable_set(:@step_delay, 1.5)
+      expect(bot).to receive(:pause).with(1.5)
+
+      bot.throttle_movement
+    end
+
+    it 'does not pause at all when the delay is zero (default)' do
+      bot.instance_variable_set(:@step_delay, 0.0)
+      expect(bot).not_to receive(:pause)
+
+      bot.throttle_movement
+    end
+
+    it 'does not pause on a negative (misconfigured) delay' do
+      bot.instance_variable_set(:@step_delay, -1.0)
+      expect(bot).not_to receive(:pause)
+
+      bot.throttle_movement
+    end
+  end
+
+  # ===========================================================================
+  # do_move: pacing is applied end-to-end only on a genuinely successful step
+  # ===========================================================================
+  describe '#do_move pacing' do
+    before do
+      bot.instance_variable_set(:@wandercounter, 0)
+      bot.instance_variable_set(:@move_history_short, [])
+      bot.instance_variable_set(:@move_history_since_init, [])
+      bot.instance_variable_set(:@backtrack_to_white_door, false)
+      bot.instance_variable_set(:@reverse_dir, false)
+      bot.instance_variable_set(:@next_move, '')
+      bot.instance_variable_set(:@nemesis, nil)
+      bot.instance_variable_set(:@step_delay, 2.0)
+      DRRoom.room_objs = []
+      DRRoom.npcs = []
+      allow(DRCI).to receive(:in_hands?).and_return(false)
+    end
+
+    it 'paces a successful step by the configured delay' do
+      allow(DRC).to receive(:bput).and_return('Obvious paths: north, south.')
+      expect(bot).to receive(:pause).with(2.0)
+
+      bot.do_move('n')
+    end
+
+    it 'does not pace a failed step (no matching move response)' do
+      allow(DRC).to receive(:bput).and_return('You slam into a wall.')
+      expect(bot).not_to receive(:pause)
+
+      bot.do_move('n')
+    end
+  end
+
+  # ===========================================================================
+  # relight_room / handle_dark_room: shared wand-relight behavior
+  # ===========================================================================
+  describe '#relight_room' do
+    it 'shakes the wand for light' do
+      expect(bot).to receive(:fput).with('shake wand')
+
+      bot.relight_room
+    end
+  end
+
+  describe '#handle_dark_room' do
+    it 'relights the room when the dark-room flag is set' do
+      allow(Flags).to receive(:[]).with('dark-room').and_return(true)
+      expect(bot).to receive(:relight_room)
+
+      bot.handle_dark_room
+    end
+
+    it 'does nothing when the room is not dark' do
+      allow(Flags).to receive(:[]).with('dark-room').and_return(nil)
+      expect(bot).not_to receive(:relight_room)
+
+      bot.handle_dark_room
+    end
+  end
+
+  # ===========================================================================
+  # handle_doors: colored-door traversal, plus the dark-room hang fix
+  # ===========================================================================
+  describe '#handle_doors' do
+    before do
+      # wandercounter > 40 forces an attempt regardless of the anti-repeat guard.
+      bot.instance_variable_set(:@wandercounter, 41)
+      bot.instance_variable_set(:@last_door_entered, 'green door')
+      DRRoom.room_objs = ['green door']
+      allow(DRCI).to receive(:in_hands?).and_return(false)
+    end
+
+    it 'reinitializes the map after stepping through a colored door' do
+      allow(DRC).to receive(:bput).and_return('Obvious exits: north, south.')
+      expect(bot).to receive(:init_maze)
+
+      bot.handle_doors
+
+      expect(DRRoom.room_objs).not_to include('green door')
+    end
+
+    it 'relights and skips (never hangs) when the colored-door room is dark' do
+      allow(DRC).to receive(:bput).and_return("It's pitch dark and you can't see a thing!")
+      expect(bot).to receive(:relight_room)
+      expect(bot).not_to receive(:init_maze)
+
+      bot.handle_doors
+    end
+
+    it 'does not reinitialize when the door refuses entry' do
+      allow(DRC).to receive(:bput).and_return("You can't go there.")
+      expect(bot).not_to receive(:init_maze)
+
+      bot.handle_doors
+    end
+
+    it 'does nothing before enough rooms have been explored (wandercounter <= 15)' do
+      bot.instance_variable_set(:@wandercounter, 10)
+      expect(DRC).not_to receive(:bput)
+
+      bot.handle_doors
+    end
+
+    it 'does nothing when no colored door is present' do
+      DRRoom.room_objs = ['rope']
+      expect(DRC).not_to receive(:bput)
+
+      bot.handle_doors
+    end
+
+    it 'avoids re-entering the same colored door until wandering further' do
+      # Same door as last entered, and not yet past the wandercounter-40 threshold.
+      bot.instance_variable_set(:@wandercounter, 20)
+      bot.instance_variable_set(:@last_door_entered, 'green door')
+      expect(DRC).not_to receive(:bput)
+
+      bot.handle_doors
+    end
+  end
+
+  # ===========================================================================
+  # handle_key_or_search: wand rivals BEFORE pulling the key-dropping rope
+  # ===========================================================================
+  describe '#handle_key_or_search (rope branch)' do
+    before do
+      bot.instance_variable_set(:@nemesis, nil)
+      bot.instance_variable_set(:@whitedoorseen, -1)
+      DRRoom.pcs = []
+      DRRoom.room_objs = ['rope']
+      allow(DRCI).to receive(:in_hands?).and_return(false) # no key in hand
+    end
+
+    it 'freezes rivals in the room BEFORE pulling the rope' do
+      expect(bot).to receive(:check_for_npcs).ordered
+      expect(bot).to receive(:pull_rope).with('rope').ordered
+
+      bot.handle_key_or_search
+    end
+
+    it 'does not wand the room when there is no rope to pull' do
+      DRRoom.room_objs = []
+      expect(bot).not_to receive(:check_for_npcs)
+      expect(bot).not_to receive(:pull_rope)
+
+      bot.handle_key_or_search
+    end
+
+    it 'skips pulling (and wanding) entirely while a nemesis is set' do
+      bot.instance_variable_set(:@nemesis, 'Cherisse')
+      expect(bot).not_to receive(:check_for_npcs)
+      expect(bot).not_to receive(:pull_rope)
+
+      bot.handle_key_or_search
     end
   end
 


### PR DESCRIPTION
Follow-up to #7484 (merged). Three robustness fixes for the autonomous maze solver, each driven by an in-game report and covered by specs. Opt-in and non-breaking: default behavior is unchanged unless the new setting is used.

## 1. Movement pacing (stop falling every few rooms)

Maze steps carry near-zero roundtime, so `waitrt?` returns immediately and the solver fires the next `go` at once. It moves fast enough to stumble and fall every few rooms -- especially bad while carrying the key.

- New setting **`droughtmans_step_delay`** (seconds, default `0` = historical un-throttled behavior).
- New `throttle_movement` helper pauses after each *genuinely successful* step (failed/retried moves are not paced).

## 2. Dark colored-door rooms no longer hang 15s

`handle_doors` matched only `Obvious` / `You can't go there` / `You smash your nose`. A `go <door>` issued in a pitch-dark room returns an unmatched line, so `bput` blocked for its **full 15-second timeout** -- during which a rival waved a wand, froze the character, and stole the dropped golden key.

- Match `It's pitch dark and you can't see a thing`, `relight_room` (shake wand), and skip the tick; the door is retried once the room is lit.
- Extracts `relight_room`, now shared with `handle_dark_room` (DRY).

## 3. Wand rivals BEFORE pulling the rope

Pulling the rope drops the key on the floor. `handle_key_or_search` pulled it while room NPCs were still unfrozen, so a mage snatched the key before we could grab it:

```
You give a rope a sharp tug.  A golden key falls to the floor with a loud CLANK.
Cackling with glee, the Rakash mage snatches up the golden key! ... rushing away
get golden key
What were you referring to?
```

- Call `check_for_npcs` (freeze everyone present) immediately before `pull_rope`. No-ops when the room is empty.

## Tests

New specs cover: `throttle_movement` (positive/zero/negative delay); `do_move` end-to-end pacing (paces a success, not a failure); `relight_room` + `handle_dark_room`; `handle_doors` (obvious traversal, dark-room relight/skip, refused entry, and all three guard branches -- wandercounter threshold, no-door, same-door anti-repeat); and the wand-before-rope ordering (rivals frozen before the pull, no wand when there is no rope, and nemesis short-circuit).

Full suite: **2247 examples, 0 failures**. `rubocop` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)