### PR TITLE
tendme: guard lodged-item disposal against trashing your own ammo

### DIFF
--- a/spec/tendme_spec.rb
+++ b/spec/tendme_spec.rb
@@ -1,0 +1,128 @@
+require_relative 'spec_helper'
+
+# TendMe#initialize runs the full tend loop (pausing scripts, checking health,
+# looping), so we extract the class with load_lic_class and exercise the guarded
+# tend on a bare-allocated instance (TendMe.allocate). The game layer (DRC/DRCI/
+# DRCH/get_settings/waitrt?) comes from the shared test harness; individual
+# examples override return values with allow(...). Every example reads
+# top-to-bottom (DAMP).
+#
+# The focus is tend_wound_safely: a guarded copy of DRCH.bind_wound that only
+# disposes a dislodged item while it is in hand, so a maze eject (which clears
+# your hands the instant a bolt drops) can never make dispose_trash's blind GET
+# grab and trash the character's own like-named ammunition.
+load_lic_class('tendme.lic', 'TendMe')
+
+RSpec.describe TendMe do
+  let(:tender) { TendMe.allocate }
+
+  describe '#tend_wound_safely' do
+    let(:removed_abdomen) do
+      'You skillfully remove the crossbow bolt from your abdomen leaving the wound no worse than it was before.'
+    end
+    let(:tended) { 'That area is not bleeding.' }
+
+    # -- Terminal (non-dislodge) results ------------------------------------
+    it 'returns true on a successful tend' do
+      allow(DRC).to receive(:bput).and_return('You work carefully at tending your wound.')
+      expect(tender.tend_wound_safely('right arm')).to be true
+    end
+
+    it 'returns true when the area is already tended' do
+      allow(DRC).to receive(:bput).and_return('That area has already been tended to.')
+      expect(tender.tend_wound_safely('right arm')).to be true
+    end
+
+    it 'returns false when the tend fumbles' do
+      allow(DRC).to receive(:bput).and_return('You fumble around with the bandages.')
+      expect(tender.tend_wound_safely('right arm')).to be false
+    end
+
+    it 'returns false when too injured to tend' do
+      allow(DRC).to receive(:bput).and_return('You are too injured for you to do that.')
+      expect(tender.tend_wound_safely('right arm')).to be false
+    end
+
+    it 'passes the person argument through to the tend command' do
+      expect(DRC).to receive(:bput).with('tend Muleoak right arm', any_args).and_return('You work carefully at tending')
+      tender.tend_wound_safely('right arm', 'Muleoak')
+    end
+
+    # -- Dislodged lodged items --------------------------------------------
+    it 'disposes a dislodged item that is in hand, then re-tends to a terminal' do
+      allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+      allow(DRCI).to receive(:in_hands?).with('crossbow bolt').and_return(true)
+      expect(DRCI).to receive(:dispose_trash).with('crossbow bolt', anything, anything)
+
+      expect(tender.tend_wound_safely('abdomen')).to be true
+    end
+
+    it 'does NOT dispose (never grabs a like-named item) when the dislodged item is gone from hand' do
+      # The regression: the maze eject clears the hand before disposal runs.
+      allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+      allow(DRCI).to receive(:in_hands?).with('crossbow bolt').and_return(false)
+      expect(DRCI).not_to receive(:dispose_trash)
+
+      tender.tend_wound_safely('abdomen')
+    end
+
+    it 'treats a nil in-hands result as not-in-hand and skips disposal' do
+      allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+      allow(DRCI).to receive(:in_hands?).and_return(nil)
+      expect(DRCI).not_to receive(:dispose_trash)
+
+      tender.tend_wound_safely('abdomen')
+    end
+
+    it 'checks in-hands against the exact removed item, not the whole message' do
+      allow(DRC).to receive(:bput).and_return(removed_abdomen, tended)
+      allow(DRCI).to receive(:in_hands?).and_return(false)
+
+      tender.tend_wound_safely('abdomen')
+
+      expect(DRCI).to have_received(:in_hands?).with('crossbow bolt')
+    end
+
+    it 'captures a "some"-quantified dislodged item' do
+      removed_plural = 'You deftly remove some crossbow bolts from your abdomen leaving the wound no worse than it was before.'
+      allow(DRC).to receive(:bput).and_return(removed_plural, tended)
+      allow(DRCI).to receive(:in_hands?).with('crossbow bolts').and_return(true)
+      expect(DRCI).to receive(:dispose_trash).with('crossbow bolts', anything, anything)
+
+      tender.tend_wound_safely('abdomen')
+    end
+
+    it 'keeps dislodging and disposing each removed item until the area yields a terminal' do
+      removed_bolt = 'You deftly remove a crossbow bolt from your chest leaving the wound no worse than it was before.'
+      removed_arrow = 'You skillfully remove the arrow from your chest leaving the wound no worse than it was before.'
+      allow(DRC).to receive(:bput).and_return(removed_bolt, removed_arrow, 'You work carefully at tending your wound.')
+      allow(DRCI).to receive(:in_hands?).and_return(true)
+      expect(DRCI).to receive(:dispose_trash).with('crossbow bolt', anything, anything).ordered
+      expect(DRCI).to receive(:dispose_trash).with('arrow', anything, anything).ordered
+
+      expect(tender.tend_wound_safely('chest')).to be true
+    end
+
+    it 'does not attempt disposal (or an in-hands check) for a dislodge line with no removable item' do
+      # The clay-fragment dislodge line matches TEND_DISLODGE_PATTERNS but has no
+      # "remove <item> from" capture, so there is nothing to dispose.
+      allow(DRC).to receive(:bput).and_return('As you reach for the clay fragment it crumbles to dust.', tended)
+      expect(DRCI).not_to receive(:in_hands?)
+      expect(DRCI).not_to receive(:dispose_trash)
+
+      tender.tend_wound_safely('chest')
+    end
+
+    it 'preserves the person argument across dislodge recursion' do
+      allow(DRCI).to receive(:in_hands?).and_return(false)
+      allow(DRC).to receive(:bput).and_return(
+        'You skillfully remove the crossbow bolt from your chest leaving the wound no worse than it was before.',
+        tended
+      )
+
+      tender.tend_wound_safely('chest', 'Muleoak')
+
+      expect(DRC).to have_received(:bput).with('tend Muleoak chest', any_args).twice
+    end
+  end
+end

--- a/tendme.lic
+++ b/tendme.lic
@@ -38,10 +38,43 @@ class TendMe
       .sort_by { |wound| wound.severity * -1 } # sort descending
       .map { |wound| wound.body_part }
       .uniq
-      .each { |body_part| tended_wounds = DRCH.bind_wound(body_part) || tended_wounds }
+      .each { |body_part| tended_wounds = tend_wound_safely(body_part) || tended_wounds }
     DRCI.lift? if lowered
     DRC.safe_unpause_list(scripts_to_unpause)
     return tended_wounds
+  end
+
+  # Tend a wound, guarding the lodged-item disposal.
+  #
+  # This mirrors DRCH.bind_wound but disposes a dislodged item (a crossbow bolt,
+  # arrow, ...) ONLY while it is still in hand. Upstream's bind_wound calls
+  # dispose_trash unconditionally, and dispose_trash falls back to a blind
+  # "get <item>" that reaches into worn containers -- so if the dislodged item
+  # has left your hand before disposal runs (the Droughtman's Maze can yank you
+  # out and clear your hands the instant a bolt drops), it GETs and trashes the
+  # character's own like-named ammunition. Guarding on in_hands? avoids that.
+  #
+  # @note Temporary shim: remove and revert to DRCH.bind_wound once lich-5 PR
+  #   #1469 (the same in-hand guard, in commons) has shipped to players.
+  # @param body_part [String] the wound location to tend
+  # @param person [String] whose wound (defaults to "my")
+  # @return [Boolean] true if tended/no longer bleeding, false on a tend failure
+  def tend_wound_safely(body_part, person = 'my')
+    result = DRC.bput("tend #{person} #{body_part}",
+                      *DRCH::TEND_SUCCESS_PATTERNS, *DRCH::TEND_FAILURE_PATTERNS, *DRCH::TEND_DISLODGE_PATTERNS)
+    waitrt?
+    case result
+    when *DRCH::TEND_DISLODGE_PATTERNS
+      dislodge_match = result.match(/^You \w+ remove (?:a|the|some) (?<item>.+) from/)
+      if dislodge_match && DRCI.in_hands?(dislodge_match[:item])
+        DRCI.dispose_trash(dislodge_match[:item], get_settings.worn_trashcan, get_settings.worn_trashcan_verb)
+      end
+      tend_wound_safely(body_part, person)
+    when *DRCH::TEND_FAILURE_PATTERNS
+      false
+    else
+      true
+    end
   end
 
   # Monitor for wounds to begin bleeding again then tend them.

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -1181,6 +1181,28 @@ module Harness
   end
 
   module DRCH
+    # Mirrors the tend-response pattern constants from lich-5 common-healing-data.rb
+    # so scripts that reimplement a guarded tend (e.g. tendme's tend_wound_safely)
+    # can reference them in tests.
+    TEND_SUCCESS_PATTERNS = [
+      /You work carefully at tending/,
+      /You work carefully at binding/,
+      /That area has already been tended to/,
+      /That area is not bleeding/
+    ].freeze
+
+    TEND_FAILURE_PATTERNS = [
+      /You fumble/,
+      /too injured for you to do that/,
+      /TEND allows for the tending of wounds/,
+      /^You must have a hand free/
+    ].freeze
+
+    TEND_DISLODGE_PATTERNS = [
+      /^You \w+ remove (a|the|some) (.*) from/,
+      /^As you reach for the clay fragment/
+    ].freeze
+
     class << self
       def check_health(*_args); { 'score' => 0, 'bleeders' => [], 'poisoned' => false, 'diseased' => false }; end
       def has_tendable_bleeders?(*_args); false; end


### PR DESCRIPTION
Script-side defense-in-depth for the lich-5 healing bug fixed in [elanthia-online/lich-5#1469](https://github.com/elanthia-online/lich-5/pull/1469).

## Problem

Tending out a lodged item (crossbow bolt, arrow, ...) can destroy the character's **own ammunition**. `DRCH.bind_wound` disposes the dislodged item via `dispose_trash`, whose fallback is a blind `get <item>` that reaches into worn containers. Normally the tended-out item is in a free hand, so the right item is trashed. But if it has left the hand before disposal runs, that GET matches a same-named item in a rucksack/quiver.

Real reproduction (Droughtman's Maze crossbow trap): the maze yanked the character out (`the floor grating underfoot swings open... refreshed and reattired at...`) between the tend removing the bolt and the disposal, clearing the hands:

```
tend my abdomen
You skillfully remove the crossbow bolt from your abdomen ...
(ejected to the Recovery Room)
get my crossbow bolt
You get some crossbow bolts from inside your fighter's rucksack.   <- own ammo
put my crossbow bolt in bucket
You drop some crossbow bolts in a bucket of viscous gloop.          <- destroyed
```

## Why the guard lives here

The destructive `get` -> `put in bucket` is **atomic inside `DRCH.bind_wound`**, and tendme delegates entirely to that method:

```ruby
.each { |body_part| tended_wounds = DRCH.bind_wound(body_part) || tended_wounds }
```

By the time control returns to tendme the ammo is already in the gloop (which destroys it). tendme cannot intercept mid-call, so to guard it must own the tend command.

## Fix

Add `tend_wound_safely` -- a guarded copy of `bind_wound` that disposes a dislodged item **only while it is in hand** -- and point `bind_open_wounds?` at it. When the item is in hand (normal), behavior is unchanged; when it is gone, disposal is skipped instead of grabbing a like-named item.

**This is a temporary shim.** It is marked in-code to be reverted to `DRCH.bind_wound` (and `tend_wound_safely` deleted) once #1469 ships to players -- at which point the commons method is the single source of truth.

## Tests

New `spec/tendme_spec.rb` (13 examples): terminal results (success / already-tended / fumble / too-injured), person passthrough, and the dislodge cases -- in-hand disposal + re-tend, the **not-in-hand regression** (no grab, no dispose), nil in-hands, exact-item in-hands check, `"some"`-quantified items, multi-item recursion, the no-removable-item (clay fragment) line, and person preservation across recursion. Adds `DRCH::TEND_*` pattern constants to the test harness (mirroring `common-healing-data.rb`).

Full suite: **2240 examples, 0 failures**. `rubocop` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved wound tending to safely handle dislodged items and retry treatment automatically.
  * Supports tending on behalf of a specified person.
  * Correctly reports successful, already-treated, and failed tending outcomes.

* **Bug Fixes**
  * Prevents disposal of dislodged items unless they are confirmed to be in hand.

* **Tests**
  * Added coverage for repeated dislodges, failure states, item handling, and person forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->