### PR TITLE
droughtmans: freeze rivals before acting each tick (lever guard + early-tick freeze)

### DIFF
--- a/droughtmans.lic
+++ b/droughtmans.lic
@@ -678,34 +678,48 @@ class Droughtmans
   # Main loop and its per-tick steps.
   # ---------------------------------------------------------------------------
 
-  # Drive the maze forever: each tick recovers state, handles the key/nemesis,
-  # traverses doors, and then either backtracks (key in hand, white door seen) or
-  # wanders. Exits via {#package} on a win or {#wave} on wand loss.
+  # Drive the maze forever by running one {#run_tick} per iteration. Exits via
+  # {#package} on a win or {#wave} on wand loss.
   # @return [void]
   def main_loop
-    loop do
-      waitrt?
-      DRC.fix_standing
-      handle_package_if_held
-      ensure_wand
-      absorb_unfrozen_npcs
-      handle_dark_room
-      zap_nemesis
-      track_white_door
-      handle_key_or_search
-      handle_lever
-      set_or_unset_nemesis
-      handle_doors
-      handle_reposition
-      maintain_khri_buffs
-      maybe_change_direction
-      check_for_npcs
+    loop { run_tick }
+  end
 
-      if @backtrack_to_white_door
-        backtrack
-      else
-        wander
-      end
+  # One pass of the main loop: recover state, freeze rivals, act on the room
+  # (key/nemesis, lever, doors), then either backtrack (key in hand, white door
+  # seen) or wander. Extracted from {#main_loop} so the per-tick sequence is
+  # unit-testable without the infinite loop.
+  #
+  # Rivals are frozen (via {#check_for_npcs}) BEFORE any provocative action --
+  # not at the end of the tick as before. On arrival {#do_move} only froze the
+  # previous room's occupants, so a rival waiting in the new room could wand-
+  # freeze us while we pulled a rope/lever or stepped through a door (and even in
+  # a room with nothing to pull). Freezing first closes that window; the per-
+  # action guards in {#handle_key_or_search}/{#handle_lever} remain as the tight
+  # freeze right before the key drops, and {#do_move} still freezes before moving.
+  # @return [void]
+  def run_tick
+    waitrt?
+    DRC.fix_standing
+    handle_package_if_held
+    ensure_wand
+    absorb_unfrozen_npcs
+    handle_dark_room
+    zap_nemesis
+    check_for_npcs
+    track_white_door
+    handle_key_or_search
+    handle_lever
+    set_or_unset_nemesis
+    handle_doors
+    handle_reposition
+    maintain_khri_buffs
+    maybe_change_direction
+
+    if @backtrack_to_white_door
+      backtrack
+    else
+      wander
     end
   end
 

--- a/droughtmans.lic
+++ b/droughtmans.lic
@@ -591,11 +591,16 @@ class Droughtmans
     DRRoom.room_objs.delete(rope)
   end
 
-  # Pull a lever if one is present, then forget it so we do not re-pull this tick.
+  # Freeze any rivals, pull a lever if one is present, then forget it so we do
+  # not re-pull this tick.
   # @return [void]
   def handle_lever
     return unless (lever = DRRoom.room_objs.find { |obj| obj =~ /lever/ })
 
+    # Freeze any rivals in the room BEFORE pulling: like the key-dropping rope,
+    # lingering on a lever pull lets a present rival wand-freeze us first (and
+    # then flee before we can wave back).
+    check_for_npcs
     fput("Pull #{lever}")
     DRRoom.room_objs.delete(lever)
   end

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -688,6 +688,38 @@ RSpec.describe Droughtmans do
   end
 
   # ===========================================================================
+  # handle_lever: wand rivals BEFORE pulling (mirrors the rope guard)
+  # ===========================================================================
+  describe '#handle_lever' do
+    it 'freezes rivals in the room BEFORE pulling the lever' do
+      DRRoom.room_objs = ['blue lever']
+      allow(bot).to receive(:fput)
+      expect(bot).to receive(:check_for_npcs).ordered
+      expect(bot).to receive(:fput).with('Pull blue lever').ordered
+
+      bot.handle_lever
+    end
+
+    it 'does not wand the room when there is no lever to pull' do
+      DRRoom.room_objs = ['rope']
+      expect(bot).not_to receive(:check_for_npcs)
+      expect(bot).not_to receive(:fput)
+
+      bot.handle_lever
+    end
+
+    it 'forgets the lever after pulling so it is not re-pulled this tick' do
+      DRRoom.room_objs = ['blue lever']
+      allow(bot).to receive(:check_for_npcs)
+      allow(bot).to receive(:fput)
+
+      bot.handle_lever
+
+      expect(DRRoom.room_objs).not_to include('blue lever')
+    end
+  end
+
+  # ===========================================================================
   # leave_winners_circle: step out only when actually in the circle
   # ===========================================================================
   describe '#leave_winners_circle' do

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -720,6 +720,57 @@ RSpec.describe Droughtmans do
   end
 
   # ===========================================================================
+  # run_tick: one pass of the main loop -- rivals frozen before any action
+  # ===========================================================================
+  describe '#run_tick' do
+    before do
+      # Neutralize every per-tick collaborator; each example asserts only the
+      # ordering/branch it cares about.
+      %i[
+        waitrt? handle_package_if_held ensure_wand absorb_unfrozen_npcs
+        handle_dark_room zap_nemesis check_for_npcs track_white_door
+        handle_key_or_search handle_lever set_or_unset_nemesis handle_doors
+        handle_reposition maintain_khri_buffs maybe_change_direction
+        wander backtrack
+      ].each { |m| allow(bot).to receive(m) }
+      allow(DRC).to receive(:fix_standing)
+      bot.instance_variable_set(:@backtrack_to_white_door, false)
+    end
+
+    it 'freezes rivals BEFORE acting on the room (key/rope, lever, doors)' do
+      expect(bot).to receive(:check_for_npcs).ordered
+      expect(bot).to receive(:handle_key_or_search).ordered
+      expect(bot).to receive(:handle_lever).ordered
+      expect(bot).to receive(:handle_doors).ordered
+
+      bot.run_tick
+    end
+
+    it 'freezes rivals after resolving the nemesis (so a fresh nemesis is set first)' do
+      expect(bot).to receive(:zap_nemesis).ordered
+      expect(bot).to receive(:check_for_npcs).ordered
+
+      bot.run_tick
+    end
+
+    it 'wanders when not backtracking to the white door' do
+      bot.instance_variable_set(:@backtrack_to_white_door, false)
+      expect(bot).to receive(:wander)
+      expect(bot).not_to receive(:backtrack)
+
+      bot.run_tick
+    end
+
+    it 'backtracks (not wanders) when armed for the white door' do
+      bot.instance_variable_set(:@backtrack_to_white_door, true)
+      expect(bot).to receive(:backtrack)
+      expect(bot).not_to receive(:wander)
+
+      bot.run_tick
+    end
+  end
+
+  # ===========================================================================
   # leave_winners_circle: step out only when actually in the circle
   # ===========================================================================
   describe '#leave_winners_circle' do


### PR DESCRIPTION
Follow-up to #7486. Closes the "rival wand-freezes you before you can act" gap comprehensively.

## Problem

#7486 added a wand-before-rope guard, but the same footgun applied to **levers** and, more generally, to **any room you arrive in with a rival present**. In `main_loop` the only unconditional `check_for_npcs` ran at the *end* of the tick, after `handle_key_or_search` / `handle_lever` / `handle_doors`. On arrival `do_move` had only frozen the *previous* room's occupants, so a rival waiting in the new room was still unfrozen when you pulled/traversed -- it wand-froze you first and fled:

```
[Droughtman's Compound, The Maze]
  You also see a Prydaen hunter, a black door and a blue lever.
Pull blue lever
Spotting you with a triumphant "aha!", the Prydaen hunter waves an icy blue wand at you! ... freeze in your tracks.
The Prydaen hunter dashes south, chuckling.
...wait 14 seconds.
wave wand at hunter
Wave at what?
```

This even affects rooms with nothing to pull (just a colored door, or empty) -- you're exposed on arrival until the end-of-tick freeze.

## Fix

Two parts:

1. **Wand before the lever pull** in `handle_lever`, mirroring the merged rope guard.
2. **Freeze rivals at the START of each tick** -- move `check_for_npcs` to right after `zap_nemesis`, so rivals are frozen before *any* provocative action or door traversal, and before you simply stand in a room a rival occupies. `do_move` still freezes before moving, and the per-action guards remain as the tightest freeze right before the key drops.

To make the tick sequence unit-testable (the old `main_loop` was an untestable infinite loop), the per-tick body is extracted into `run_tick`; `main_loop` is now just `loop { run_tick }`.

## Tests

- `#handle_lever`: rivals frozen before the pull (ordered); no wand without a lever; lever forgotten after pulling.
- `#run_tick`: `check_for_npcs` ordered before `handle_key_or_search` / `handle_lever` / `handle_doors`; freeze ordered after `zap_nemesis` (so a freshly-set nemesis is resolved first); and the wander-vs-backtrack branch.

Full suite: **2267 examples, 0 failures**. `rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)