### PR TITLE
droughtmans: five solver-logic fixes (gender, injury, nemesis, exits, npcs)

### DIFF
--- a/droughtmans.lic
+++ b/droughtmans.lic
@@ -720,6 +720,11 @@ class Droughtmans
     DRC.fix_standing
     handle_package_if_held
     ensure_wand
+    # Retry the dowse while latched injured: once a wound is tended, search_wand
+    # succeeds and clears @injured/@norope, re-enabling rope pulls mid-run. Without
+    # this the tarzan-rope retry is unreachable (pull_rope early-returns on
+    # @norope), so the latch would otherwise persist until the next boot.
+    search_wand if @injured
     absorb_unfrozen_npcs
     handle_dark_room
     set_or_unset_nemesis

--- a/droughtmans.lic
+++ b/droughtmans.lic
@@ -417,7 +417,7 @@ class Droughtmans
   #   which means the wand has been lost and the bot can no longer function.
   def wave(person)
     case DRC.bput("wave wand at #{person}",
-                  /^Roundtime/, /already frozen/, /drops his golden key/,
+                  /^Roundtime/, /already frozen/, /drops (?:his|her|its) golden key/,
                   /Wave at what\?/, /I could not find/, /I do not understand/)
     when /golden key/
       @nemesis = nil
@@ -541,13 +541,21 @@ class Droughtmans
 
   # Freeze every npc in the room, expanding duplicate types into ordinal targets
   # (e.g. two guards -> "guard", "second guard").
+  #
+  # After freezing all instances of a type, drop that type from the live npc
+  # list: wave can delete a base name it froze but not an ordinal alias ("second
+  # guard"), so without this the extra instances lingered and were re-waved
+  # ("already frozen") every tick.
   # @return [void]
   def check_for_npcs
     return unless DRRoom.npcs.any?
 
-    DRRoom.npcs.group_by(&:itself).flat_map { |npc_type, quantity|
-      quantity.size.times.map { |number| number.zero? ? npc_type : "#{$ORDINALS[number]} #{npc_type}" }
-    }.each { |npc| wave(npc) }
+    DRRoom.npcs.group_by(&:itself).each do |npc_type, instances|
+      instances.each_index do |number|
+        wave(number.zero? ? npc_type : "#{$ORDINALS[number]} #{npc_type}")
+      end
+      DRRoom.npcs.delete(npc_type)
+    end
   end
 
   # Dowse the wand to reveal the key location, ensuring the wand is in hand first.
@@ -557,16 +565,23 @@ class Droughtmans
     search_wand
   end
 
-  # Dowse the wand for the key. Latches an injured state on failure so we stop
-  # searching and pulling ropes while wounded.
+  # Dowse the wand for the key, re-evaluating the injured state each time.
+  #
+  # A failed dowse (too wounded) sets the injured/no-rope latches so we stop
+  # dowsing and pulling ropes; a successful dowse clears them. This is
+  # deliberately re-evaluated on every call (rather than a permanent latch that
+  # never recovered) so that once a crossbow wound is tended, the next dowse --
+  # at boot or after a tarzan-rope reset -- lifts the latch and rope-pulling
+  # resumes for the rest of the run.
   # @return [void]
   def search_wand
-    return if @injured
-
     case DRC.bput('search wand', /^Roundtime/, /You're not in any condition to be searching around/)
     when /not in any condition/
       @injured = true
       @norope = true
+    else
+      @injured = false
+      @norope = false
     end
   end
 
@@ -668,10 +683,12 @@ class Droughtmans
   end
 
   # Convert a comma-separated long-direction exit list into short directions.
+  # Unknown tokens (not in SHORTDIR) are dropped rather than left as nil, so
+  # @exits never feeds a nil into a move.
   # @param text [String] e.g. "north, southeast, out"
   # @return [Array<String>] e.g. ["n", "se", "out"]
   def parse_exits(text)
-    text.split(', ').map { |dir| SHORTDIR[dir] }
+    text.split(', ').map { |dir| SHORTDIR[dir] }.compact
   end
 
   # ---------------------------------------------------------------------------
@@ -705,12 +722,12 @@ class Droughtmans
     ensure_wand
     absorb_unfrozen_npcs
     handle_dark_room
+    set_or_unset_nemesis
     zap_nemesis
     check_for_npcs
     track_white_door
     handle_key_or_search
     handle_lever
-    set_or_unset_nemesis
     handle_doors
     handle_reposition
     maintain_khri_buffs

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -165,8 +165,12 @@ RSpec.describe Droughtmans do
       expect(bot.parse_exits('west')).to eq(%w[w])
     end
 
-    it 'yields nil for an unknown direction token (documents the SHORTDIR gap)' do
-      expect(bot.parse_exits('north, sideways')).to eq(['n', nil])
+    it 'drops an unknown direction token rather than leaking a nil' do
+      expect(bot.parse_exits('north, sideways')).to eq(['n'])
+    end
+
+    it 'drops every token when none are recognized (empty, not [nil, nil])' do
+      expect(bot.parse_exits('sideways, yonder')).to eq([])
     end
   end
 
@@ -201,6 +205,28 @@ RSpec.describe Droughtmans do
 
       bot.wave('Bandit')
 
+      expect(bot.instance_variable_get(:@nemesis)).to be_nil
+    end
+
+    it 'listens for a key-drop of any gender, not just "his"' do
+      # bput only returns a line it was asked to match; verify the patterns
+      # cover her/its drops so a female/neuter rival's dropped key is caught
+      # in-game (a plain and_return stub would pass even with the old pattern).
+      captured = nil
+      allow(DRC).to receive(:bput) { |_cmd, *patterns| captured = patterns; 'Roundtime' }
+
+      bot.wave('Bandit')
+
+      expect(captured.any? { |p| 'Bandit drops her golden key!' =~ p }).to be(true)
+      expect(captured.any? { |p| 'The owlbear drops its golden key!' =~ p }).to be(true)
+    end
+
+    it 'still handles the male drop line' do
+      bot.instance_variable_set(:@nemesis, 'Bandit')
+      DRRoom.room_objs = []
+      allow(DRC).to receive(:bput).and_return('drops his golden key')
+
+      expect { bot.wave('Bandit') }.not_to raise_error
       expect(bot.instance_variable_get(:@nemesis)).to be_nil
     end
 
@@ -720,6 +746,82 @@ RSpec.describe Droughtmans do
   end
 
   # ===========================================================================
+  # search_wand: self-correcting injury latch (no permanent give-up)
+  # ===========================================================================
+  describe '#search_wand' do
+    it 'latches injured/no-rope when the dowse fails for condition' do
+      bot.instance_variable_set(:@injured, false)
+      bot.instance_variable_set(:@norope, false)
+      allow(DRC).to receive(:bput).and_return("You're not in any condition to be searching around")
+
+      bot.search_wand
+
+      expect(bot.instance_variable_get(:@injured)).to be(true)
+      expect(bot.instance_variable_get(:@norope)).to be(true)
+    end
+
+    it 'clears the injury latch when a dowse succeeds (recovers after healing)' do
+      bot.instance_variable_set(:@injured, true)
+      bot.instance_variable_set(:@norope, true)
+      allow(DRC).to receive(:bput).and_return('Roundtime: 5 sec.')
+
+      bot.search_wand
+
+      expect(bot.instance_variable_get(:@injured)).to be(false)
+      expect(bot.instance_variable_get(:@norope)).to be(false)
+    end
+
+    it 'still attempts the dowse when previously injured (not a permanent latch)' do
+      bot.instance_variable_set(:@injured, true)
+      expect(DRC).to receive(:bput).and_return('Roundtime')
+
+      bot.search_wand
+    end
+  end
+
+  # ===========================================================================
+  # check_for_npcs: ordinal expansion + full removal of frozen duplicates
+  # ===========================================================================
+  describe '#check_for_npcs' do
+    it 'is a no-op when the room has no npcs' do
+      DRRoom.npcs = []
+      expect(bot).not_to receive(:wave)
+
+      bot.check_for_npcs
+    end
+
+    it 'waves at a single npc by its base name' do
+      DRRoom.npcs = %w[hunter]
+      allow(bot).to receive(:wave)
+
+      bot.check_for_npcs
+
+      expect(bot).to have_received(:wave).with('hunter')
+    end
+
+    it 'expands duplicates into ordinal targets' do
+      DRRoom.npcs = %w[guard guard]
+      allow(bot).to receive(:wave)
+
+      bot.check_for_npcs
+
+      expect(bot).to have_received(:wave).with('guard')
+      expect(bot).to have_received(:wave).with('second guard')
+    end
+
+    it 'fully clears frozen duplicates so they are not re-waved next tick' do
+      # Regression: wave cannot delete an ordinal alias ("second guard"), so the
+      # extra instances used to linger in DRRoom.npcs.
+      DRRoom.npcs = %w[guard guard troll]
+      allow(bot).to receive(:wave)
+
+      bot.check_for_npcs
+
+      expect(DRRoom.npcs).to be_empty
+    end
+  end
+
+  # ===========================================================================
   # run_tick: one pass of the main loop -- rivals frozen before any action
   # ===========================================================================
   describe '#run_tick' do
@@ -746,7 +848,14 @@ RSpec.describe Droughtmans do
       bot.run_tick
     end
 
-    it 'freezes rivals after resolving the nemesis (so a fresh nemesis is set first)' do
+    it 'resolves the nemesis flag BEFORE zapping (so a freshly-announced nemesis is zapped this tick)' do
+      expect(bot).to receive(:set_or_unset_nemesis).ordered
+      expect(bot).to receive(:zap_nemesis).ordered
+
+      bot.run_tick
+    end
+
+    it 'freezes rivals after resolving/zapping the nemesis' do
       expect(bot).to receive(:zap_nemesis).ordered
       expect(bot).to receive(:check_for_npcs).ordered
 

--- a/spec/droughtmans_spec.rb
+++ b/spec/droughtmans_spec.rb
@@ -877,6 +877,43 @@ RSpec.describe Droughtmans do
 
       bot.run_tick
     end
+
+    it 'does not re-dowse when not injured' do
+      bot.instance_variable_set(:@injured, false)
+      expect(bot).not_to receive(:search_wand)
+
+      bot.run_tick
+    end
+
+    it 'retries the dowse each tick while injured' do
+      bot.instance_variable_set(:@injured, true)
+      expect(bot).to receive(:search_wand)
+
+      bot.run_tick
+    end
+
+    # End-to-end: injury latch -> recovery via the per-tick retry -> rope pull
+    # works again. search_wand runs for real here (it is not stubbed) so the
+    # latch is genuinely cleared, then pull_rope is exercised against it.
+    it 'recovers from the injury latch mid-run so rope pulls resume' do
+      bot.instance_variable_set(:@injured, true)
+      bot.instance_variable_set(:@norope, true)
+      # Character has recovered: the dowse now succeeds.
+      allow(DRC).to receive(:bput).with('search wand', any_args).and_return('Roundtime: 5 sec.')
+
+      bot.run_tick
+
+      expect(bot.instance_variable_get(:@injured)).to be(false)
+      expect(bot.instance_variable_get(:@norope)).to be(false)
+
+      # A subsequent rope pull now proceeds instead of early-returning on @norope.
+      DRRoom.room_objs = ['rope']
+      allow(DRC).to receive(:bput).with('pull rope', any_args).and_return('A loud CLICK echoes from above')
+
+      bot.pull_rope('rope')
+
+      expect(DRC).to have_received(:bput).with('pull rope', any_args)
+    end
   end
 
   # ===========================================================================


### PR DESCRIPTION
Follow-up review pass on the maze solver -- five independent fixes, each spec'd.

## 1. `wave` only detected a *male* key-drop (bug)

The freeze-response patterns included `/drops his golden key/`. A rival who *"drops her golden key"* (or *its*) matched none of the listed patterns, so `bput` waited out its full timeout and the branch that grabs the freed key never fired. Broadened to `/drops (?:his|her|its) golden key/`.

## 2. The injury latch never recovered (bug)

`search_wand` set `@injured` / `@norope` on a failed dowse and then `return`ed early on every subsequent call -- permanently. So a single crossbow wound stopped both dowsing and rope-pulling (the main key source) for the rest of the run, even after `tendme` healed you. `search_wand` now re-evaluates each call: a failed dowse latches, a **successful one clears**, so once the wound is tended the next dowse (boot or tarzan-rope reset) lifts the latch and rope-pulling resumes.

## 3. A freshly-announced nemesis was acted on a tick late (logic)

In `run_tick`, `set_or_unset_nemesis` (which reads the *"X just found a golden key!"* flag and sets `@nemesis`) ran **after** `zap_nemesis` and `handle_key_or_search`. So the tick a nemesis was announced you didn't zap them. Moved `set_or_unset_nemesis` above `zap_nemesis` so the announced key-holder is frozen the same tick.

## 4. `parse_exits` leaked `nil` for unknown tokens (robustness)

`SHORTDIR[dir]` returns `nil` for any exit word not in the table, and that `nil` flowed into `@exits` -> `@exits.first` could feed `do_move(nil)`. Now `.compact`ed out.

## 5. `check_for_npcs` left frozen duplicates behind (efficiency/correctness)

`wave` can delete a base name it froze but not an ordinal alias (`"second guard"`), so the extra instances lingered in `DRRoom.npcs` and were re-waved (*"already frozen"*, burning roundtime) every tick. `check_for_npcs` now drops each fully-processed npc type from the live list.

## Tests

New/updated specs for all five: gendered **and** male key-drop (the gendered one verifies the *pattern list* matches her/its lines, since a plain return-stub would pass even with the old pattern); injury latch set/clear/no-permanent-latch; nemesis resolution ordered before zap; `parse_exits` compaction (partial and all-unknown); and `check_for_npcs` ordinal expansion + full duplicate removal.

Full suite: **2278 examples, 0 failures**. `rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of key drops across different pronouns and NPC types.
  * Prevented invalid exit directions from affecting navigation.
  * NPC freezing now handles duplicate NPCs correctly and avoids repeated targeting.
  * Wand dowsing can resume after injuries are treated or rope conditions reset.
  * Adjusted action sequencing for more reliable nemesis handling and NPC freezing.

* **Tests**
  * Expanded coverage for navigation, key-drop detection, wand behavior, NPC targeting, and action ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->