### PR TITLE
moonwatch: fix Documentation header URL (point at wiki)

### DIFF
--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 =begin
-  Documentation: https://elanthipedia.play.net/Lich_script_repository#moonwatch
+  Documentation: https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-moonwatch.lic
 
   Moonwatch v4.5.0 - Bresenham Moons + Empirical Sun Table + Lunar Phase
   ======================================================================


### PR DESCRIPTION
## Summary

The `moonwatch.lic` header merged in #7480 points `Documentation:` at
`https://elanthipedia.play.net/Lich_script_repository#moonwatch`, whose
`#moonwatch` anchor does not exist. The moonwatch documentation now lives in the
dr-scripts wiki, matching the convention already used by `stack-scrolls.lic` and
`sigilharvest.lic`.

This one-line change points the header at the user guide:
`https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-moonwatch.lic`

Wiki pages (published):
- [Documentation-for-moonwatch.lic](https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-moonwatch.lic) (user guide)
- [Moonwatch-Technical-Reference](https://github.com/elanthia-online/dr-scripts/wiki/Moonwatch-Technical-Reference)
- [Moonwatch-Design-History](https://github.com/elanthia-online/dr-scripts/wiki/Moonwatch-Design-History)

No code behavior change; comment/header only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)