### PR TITLE
smoke: add Documentation header linking to the wiki

### DIFF
--- a/smoke.lic
+++ b/smoke.lic
@@ -1,4 +1,6 @@
 =begin
+  Documentation: https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-smoke.lic
+
   smoke:
     container: smoking jacket
     pipe: glitvire pipe


### PR DESCRIPTION
## Summary

`smoke.lic` has no `Documentation:` header line, so it does not link to its wiki
documentation. This adds one pointing at the user guide, matching the convention
already used by `stack-scrolls.lic`, `sigilharvest.lic`, and `moonwatch.lic`:

`Documentation: https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-smoke.lic`

The wiki page ([Documentation-for-smoke.lic](https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-smoke.lic))
is a user guide validated against the merged v2.0 code (YAML settings, defaults,
and the mastery-tier table).

Comment/header only; no code behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)