### PR TITLE
data(base-town): add Forfedhdar services (Raven's Point, Ratha locksmith, Hara'jaal pawnshop)

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -1016,6 +1016,8 @@ Ratha:
   tannery:
     id: 10753
     name: Lysskava'an
+  locksmithing:
+    id: 51654
   npc_empath:
     id: 10741
   debt_office:
@@ -1400,6 +1402,17 @@ Raven's Point:
     id: 14642
   trader_outpost:
     id: 4440
+  deposit:
+    id: 9425
+  exchange:
+    id: 9426
+    fee: 0.05
+  gemshop:
+    id: 9430
+    name: Gimsta
+  tannery:
+    id: 9431
+    name: Stedh
 Boar Clan:
   currency: dokoras
   vault:
@@ -1590,6 +1603,9 @@ Hara'jaal:
   gemshop:
     id: 15293
     name: Abira
+  pawnshop:
+    id: 15278
+    name: Dumi
   tannery:
     id: 15307
     name: assistant


### PR DESCRIPTION
Cross-referencing the game map's service tags against `data/base-town.yaml` surfaced a handful of **functional** service rooms base-town was missing. Each was verified in-game (standing in the room / confirmed the shopkeeper), not just map-tagged.

### Added
- **Raven's Point** (previously a trade-only stub — nexus/trader outpost only):
  - `deposit` 9425 — Bank of Raven's Point, Depository (real bank; links into the Hibarnhvidar/Forfedhdar network)
  - `exchange` 9426 (fee 0.05, matching the Forfedhdar rate)
  - `gemshop` 9430 — Gimsta's Gimstaan (Gimsta)
  - `tannery` 9431 — Stedh's Furs (Stedh)
- **Ratha**: `locksmithing` 51654 — The Rusted Tumbler
- **Hara'jaal**: `pawnshop` 15278 — Sh'aar's Trove (Dumi)

### Notes
- Raven's Point isn't in the game's remote `bank` town-list, but the physical depository is functional in person, which is what base-town navigation uses.
- YAML validated (`YAML.load_file(..., aliases: true)` parses; 30 towns intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)