### PR TITLE
fix(crafting): reliability fixes + restock-shop features (forge, smith, workorders, restock-shop)

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -275,6 +275,10 @@ class Forge
   # @return [String]
   FORGE_EMPTY_PATTERN = 'There is nothing'
 
+  # Pattern indicating there is no forge in the current room
+  # @return [Regexp]
+  FORGE_MISSING_PATTERN = /I could not find|What were you referring to/
+
   # @!endgroup
 
   # @!group Progress Patterns
@@ -575,16 +579,6 @@ class Forge
     DRCC.stow_crafting_item(DRC.left_hand, @bag, @forging_belt)
   end
 
-  # Stow hammer and tongs if they are currently held.
-  #
-  # Common cleanup before retrieving item from anvil/forge.
-  #
-  # @return [void]
-  def stow_hammer_and_tongs
-    DRCC.stow_crafting_item(@hammer, @bag, @forging_belt) if DRCI.in_hands?(@hammer)
-    DRCC.stow_crafting_item('tongs', @bag, @forging_belt) if DRCI.in_hands?('tongs')
-  end
-
   # Ready hammer and tongs for pounding work.
   #
   # Swaps to hammer first, then to tongs (tongs in right hand, hammer accessible).
@@ -620,7 +614,11 @@ class Forge
   def prepare_item_in_left_hand(location = 'on anvil', context = 'work')
     return true if DRCI.in_left_hand?(@item)
 
-    stow_hammer_and_tongs
+    # Stow BOTH hands (each via its own mechanism), not just hammer/tongs, so no
+    # tool sharing the item's noun -- e.g. a "wide shovel" forging tool vs. a
+    # crafted "wide shovel" -- is left in hand to be confused with the item we
+    # are about to pick up.
+    stow_both_hands
     result = DRC.bput("get #{@item} #{location}", GET_SUCCESS_PATTERN, GET_FAILURE_PATTERN)
     if result == GET_FAILURE_PATTERN
       error_log("Failed to get #{@item} from #{location} for #{context}.")
@@ -1134,6 +1132,31 @@ class Forge
     end
   end
 
+  # Ensure the current room has a forge before a tempering command runs.
+  #
+  # Tempering ("put/turn/analyze ... on forge") requires a forge, but grinding
+  # happens at grindstone rooms that have no forge -- so after a grind step we
+  # can be standing in a forge-less room (e.g. the Smelting and Grinding Area).
+  # Forges are co-located with anvils, so walk to a free anvil room (one not in
+  # use by another crafter) when the current room has no forge.
+  #
+  # @return [void]
+  # @raise [SystemExit] if no forge can be found
+  def ensure_forge
+    return if forge_in_room?
+
+    DRCC.find_anvil(@hometown)
+    cleanup_and_exit('Could not find a forge to temper at.') unless forge_in_room?
+  end
+
+  # Check whether the current room contains a forge.
+  #
+  # @return [Boolean] true if a forge is present (empty or holding an item)
+  def forge_in_room?
+    result = DRC.bput('look on forge', FORGE_HAS_ITEM_PATTERN, FORGE_EMPTY_PATTERN, FORGE_MISSING_PATTERN)
+    result == FORGE_HAS_ITEM_PATTERN || result == FORGE_EMPTY_PATTERN
+  end
+
   # @!endgroup
 
   # @!group Assembly
@@ -1280,6 +1303,7 @@ class Forge
       renew_forge_rental if Flags['forge-rental-warning']
       assemble_part
       @command ||= @home_command
+      ensure_forge if @command.include?('forge')
       spin_grindstone if @command.include?('grindstone')
 
       result = execute_work_command
@@ -1498,7 +1522,11 @@ class Forge
   def handle_oiling
     report_progress_milestone('Oiling')
     if @home_tool == 'tongs' || !DRCI.in_left_hand?(@item)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @forging_belt)
+      # Stow BOTH hands before retrieving the item: if a forging tool shares the
+      # item's noun (e.g. a "wide shovel" tool vs. a crafted "wide shovel"),
+      # leaving it in the other hand makes the following get/swap grab the wrong
+      # one and tie the finished item to the belt.
+      stow_both_hands
       result = DRC.bput("get #{@item} #{@location}", GET_SUCCESS_PATTERN, GET_FAILURE_PATTERN)
       if result == GET_FAILURE_PATTERN
         error_log("Failed to get #{@item} from #{@location} for oiling.")

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -291,7 +291,7 @@ class ShopRestock
   # Smelt the freshly-made refined ingot into the persistent one, yielding a
   # single combined ingot. Assumes both are refined (identical) and total <= 210.
   def combine_ingots
-    DRCC.find_empty_crucible(@hometown)
+    DRCC.find_empty_crucible(@town)
 
     added = 0
     2.times do

--- a/restock-shop.lic
+++ b/restock-shop.lic
@@ -3,6 +3,29 @@
 =end
 
 class ShopRestock
+  # Hard cap on a steel ingot's volume in-game (raw OR refined-and-combined).
+  # A raw ingot is (makesteel_count x 10) volume, and makesteel's count caps at
+  # 21, so a single make tops out at 210 raw. Ingots can also be smelted
+  # together, but the combined result can never exceed this same 210 cap.
+  RAW_STEEL_INGOT_CAP = 210
+
+  # makesteel's own arg cap on iron-nugget count -- a single make can't exceed
+  # this (21 x 10 = 210 raw volume).
+  MAKESTEEL_MAX_COUNT = 21
+
+  # Refine-loss factor: raw ingot volume / refined ingot volume.
+  #
+  # restock_steel always refines, which raises quality but reduces volume:
+  # a 210 raw ingot yields 168 WITH the steel-refining tech (210 / 168 = 1.25)
+  # or 105 WITHOUT it (210 / 105 = 2.0). So one makesteel+refine adds up to
+  # (count x 10 / factor) refined volume -- 168 max with the tech.
+  #
+  # Used to size each makesteel call before its fresh refined ingot is smelted
+  # into the persistent ingot (see restock_steel). Defaults to the with-tech
+  # value; override per-character with a `steel_refine_factor` YAML setting
+  # (use 2.0 if you lack the tech).
+  DEFAULT_STEEL_REFINE_FACTOR = 1.25
+
   def initialize
     @settings = get_settings
 
@@ -16,6 +39,19 @@ class ShopRestock
     @belt = @settings.forging_belt || @settings.engineering_belt
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
+
+    # Optional: store the persistent steel ingot as a (light) deed between runs.
+    @deed_ingot = @settings.deed_steel_ingot
+    if @deed_ingot
+      deeds_data = get_data('crafting').deeds[@town]
+      if deeds_data
+        @deeds_room = deeds_data['room']
+        @deeds_number = deeds_data['large_number'] # large packet = 250 claim forms
+      else
+        Lich::Messaging.msg('bold', "restock-shop: No deed data for #{@town}; disabling steel-ingot deed storage.")
+        @deed_ingot = false
+      end
+    end
 
     go_to_shop
     check_surfaces
@@ -33,7 +69,7 @@ class ShopRestock
                    DRC.list_to_array(raw_list)
                  end
       missing_items += @item_list.select { |item| surface == item['surface'] }
-                                 .reject { |item| raw_list.find { |raw_item| raw_item.match(item['full_name']) } }
+                                 .reject { |item| already_stocked?(item, raw_list) }
     end
 
     return if missing_items.empty?
@@ -51,32 +87,297 @@ class ShopRestock
     restock_surfaces(missing_items)
   end
 
+  # An item counts as already stocked if every word of its full_name appears in
+  # a shop listing line. Word-presence (rather than a contiguous substring)
+  # matching is required because the game inserts the material adjective at an
+  # unpredictable spot in crafted names -- e.g. full_name "weighted pickaxe"
+  # must still match the listing "a weighted steel pickaxe", where "steel" is
+  # wedged between the adjective and the noun.
+  def already_stocked?(item, raw_list)
+    words = item['full_name'].downcase.split
+    raw_list.any? { |raw_item| words.all? { |word| raw_item.downcase.include?(word) } }
+  end
+
   def restock_surfaces(missing_items)
     restock_steel(missing_items.select { |item| item['material'] == 'steel' })
+    restock_low_carbon_steel(missing_items.select { |item| item['material'] == 'low carbon steel' })
     restock_burlap(missing_items.select { |item| item['material'] == 'heavy burlap' })
     restock_silk(missing_items.select { |item| item['material'] == 'heavy silk' })
     restock_linen(missing_items.select { |item| item['material'] == 'heavy linen' })
     restock_gryphon(missing_items.select { |item| item['material'] == 'gryphon' })
   end
 
+  # Forge every missing steel item from a single, persistent steel ingot.
+  #
+  # Instead of making one ingot per run and trashing the remainder, we keep a
+  # refined steel ingot in the crafting container and top it up on demand: read
+  # its current volume (analyze), and whenever it can't cover the next item, make
+  # a fresh refined ingot and smelt the two together (combine). Both ingots are
+  # refined first so they're identical and merge cleanly, and the combined ingot
+  # can never exceed the 210 hard cap. When the list is exhausted the remainder
+  # is kept for next run -- as a light deed if `deed_steel_ingot` is set, or
+  # trashed (old behavior) if not.
   def restock_steel(missing_items)
     return if missing_items.empty?
 
-    volume = ((total_volume_of(missing_items) * 1.25) / 10.0).ceil
-    return if volume.zero?
+    @refine_factor = (@settings.steel_refine_factor || DEFAULT_STEEL_REFINE_FACTOR).to_f
 
-    DRC.wait_for_script_to_complete('makesteel', [volume, 'refine'])
+    queue = filter_forgeable(missing_items)
+    return if queue.empty?
 
-    missing_items.each do |item|
+    # If the persistent ingot is stored as a deed, materialize it so we can forge
+    # and combine with a real ingot again.
+    retrieve_ingot_from_deed if @deed_ingot
+
+    # Guard against a stray low/medium-carbon ingot (e.g. left by an interrupted
+    # low-carbon run) being forged as high-carbon stock.
+    grade = steel_ingot_carbon
+    if grade && grade != 'high'
+      Lich::Messaging.msg('bold', "restock-shop: The steel ingot on hand is #{grade} carbon, not high; skipping steel items to avoid forging from the wrong grade. Clear it and rerun.")
+      return
+    end
+
+    queue.each_with_index do |item, idx|
+      # When we do top up, fill toward everything still queued (capped at one
+      # ingot) so we make fewer crucible trips than one-item-at-a-time would.
+      remaining = queue[idx..].sum { |queued| volume_of(queued) }
+      ensure_ingot_volume(volume_of(item), remaining)
+
       DRC.wait_for_script_to_complete('smith', ['steel', item['recipe'], 'stamp', 'temper'])
       go_to_shop
       sell(item)
     end
 
+    # With deeds on, stow the leftover ingot as a light deed for next run.
+    # With deeds off, fall back to the old behavior and trash the remainder so a
+    # heavy ingot isn't left lying in the crafting container.
+    if @deed_ingot
+      store_ingot_as_deed
+    else
+      dispose_leftover_ingot
+    end
+
     DRC.wait_for_script_to_complete('workorders', %w[blacksmithing repair])
+  end
+
+  # Forge low-carbon-steel items (e.g. tongs, smelted 1:1 iron:coal).
+  #
+  # Unlike the high-carbon path this ingot is intentionally NOT persisted or
+  # deeded: both carbon grades are just "steel ingot" in-game and must never
+  # share the crafting container or get combined, so we make what we need this
+  # run and trash the remainder. This runs after restock_steel, which by then
+  # has re-deeded or trashed its own ingot, so no high-carbon ingot is loose
+  # while we make and forge the low-carbon one.
+  def restock_low_carbon_steel(missing_items)
+    return if missing_items.empty?
+
+    @refine_factor = (@settings.steel_refine_factor || DEFAULT_STEEL_REFINE_FACTOR).to_f
+    @steel_type = 'l' # 1:1 iron:coal
+
+    queue = filter_forgeable(missing_items)
+    return if queue.empty?
+
+    # Both carbon grades are just "steel ingot" in-game, so tell them apart by
+    # analyzing. Only proceed if any loose ingot here is already low carbon (a
+    # safe leftover to reuse); a high/medium ingot (e.g. one the steel path
+    # failed to deed/trash) would mean forging these from the wrong stock.
+    existing_grade = steel_ingot_carbon
+    if existing_grade && existing_grade != 'low'
+      Lich::Messaging.msg('bold', "restock-shop: A loose #{existing_grade}-carbon steel ingot is present; skipping low-carbon items to avoid mixing grades. Clear it and rerun.")
+      return
+    end
+
+    queue.each_with_index do |item, idx|
+      remaining = queue[idx..].sum { |queued| volume_of(queued) }
+      ensure_ingot_volume(volume_of(item), remaining)
+
+      DRC.wait_for_script_to_complete('smith', ['steel', item['recipe'], 'stamp', 'temper'])
+      go_to_shop
+      sell(item)
+    end
+
+    # Never leave a loose low-carbon "steel ingot" behind -- it would be
+    # indistinguishable from (and wrongly picked up as) the persistent
+    # high-carbon ingot on the next run.
+    dispose_leftover_ingot
+
+    DRC.wait_for_script_to_complete('workorders', %w[blacksmithing repair])
+  ensure
+    @steel_type = 'h'
+  end
+
+  # Build the makesteel argument list for the current carbon grade. High carbon
+  # (the default) omits the type; low carbon passes 'l'. Always refines.
+  def makesteel_args(count)
+    args = [count]
+    args << @steel_type if @steel_type && @steel_type != 'h'
+    args << 'refine'
+    args
+  end
+
+  # Drop any item whose volume exceeds a single ingot -- it can't be forged from
+  # one ingot at all -- and warn about it.
+  def filter_forgeable(items)
+    items.reject do |item|
+      next false unless volume_of(item) > RAW_STEEL_INGOT_CAP
+
+      respond "*** Skipping #{item['full_name']}: needs #{volume_of(item)} volume, exceeds the #{RAW_STEEL_INGOT_CAP} single-ingot limit. ***"
+      true
+    end
+  end
+
+  # Ensure the persistent ingot holds at least `min_needed` volume. When a top-up
+  # is required, fill toward `target` (capped at the ingot limit) to batch the work.
+  def ensure_ingot_volume(min_needed, target)
+    return if current_ingot_volume >= min_needed
+
+    add_ingot_volume([[target, min_needed].max, RAW_STEEL_INGOT_CAP].min)
+  end
+
+  # Top up the persistent refined ingot toward `fill_to` volume by repeatedly
+  # making a fresh refined ingot and smelting it into the existing one.
+  #
+  # Each makesteel+refine adds (count * 10 / @refine_factor) refined volume, so we
+  # add in those increments -- never letting the combined ingot exceed the 210
+  # cap, and never asking makesteel for more than its own count cap of 21.
+  def add_ingot_volume(fill_to)
+    fill_to = [fill_to, RAW_STEEL_INGOT_CAP].min
+    refined_per_count = 10.0 / @refine_factor # 8 with tech, 5 without
+
+    last_have = -1
+    loop do
+      have = current_ingot_volume
+      break if have >= fill_to
+
+      if have == last_have
+        Lich::Messaging.msg('bold', 'restock-shop: Steel ingot volume stopped increasing; aborting top-up to avoid a loop.')
+        break
+      end
+      last_have = have
+
+      want_counts = ((fill_to - have) / refined_per_count).ceil
+      room_counts = ((RAW_STEEL_INGOT_CAP - have) / refined_per_count).floor
+      count = [want_counts, room_counts, MAKESTEEL_MAX_COUNT].min
+
+      # Remaining headroom is smaller than the smallest ingot we can add.
+      break if count < 1
+
+      DRC.wait_for_script_to_complete('makesteel', makesteel_args(count))
+      combine_ingots if have.positive?
+    end
+  end
+
+  # Read the persistent steel ingot's current volume (0 if none on hand/in bag).
+  def current_ingot_volume
+    return 0 unless DRCI.get_item?('steel ingot')
+
+    result = DRC.bput('analyze my ingot', 'About \d+ volume', 'I could not find')
+    volume = (result[/About (\d+) volume/, 1] || 0).to_i
+    DRCI.stow_item?('ingot')
+    volume
+  end
+
+  # Read the carbon grade of the steel ingot on hand from its analyze block,
+  # e.g. "The metal appears to be composed of: 100.00% high carbon steel." ->
+  # "high". Returns nil when there is no steel ingot to analyze.
+  def steel_ingot_carbon
+    return nil unless DRCI.get_item?('steel ingot')
+
+    result = DRC.bput('analyze my ingot', /composed of: [\d.]+% \w+ carbon steel/, 'I could not find')
+    DRCI.stow_item?('ingot')
+    result[/% (\w+) carbon steel/, 1]
+  end
+
+  # Smelt the freshly-made refined ingot into the persistent one, yielding a
+  # single combined ingot. Assumes both are refined (identical) and total <= 210.
+  def combine_ingots
+    DRCC.find_empty_crucible(@hometown)
+
+    added = 0
+    2.times do
+      break unless DRCI.get_item?('steel ingot')
+
+      case DRC.bput('put my ingot in crucible',
+                    /You put your.*in the.*crucible\./,
+                    /You decide that smelting such a volume of metal at once would be dangerous/,
+                    /identical/i)
+      when /You put your.*in the.*crucible/
+        added += 1
+      else
+        Lich::Messaging.msg('bold', 'restock-shop: Could not combine steel ingots (over-volume or not identical); leaving them separate.')
+        DRCI.stow_item?('ingot')
+        break
+      end
+    end
+
+    if added >= 2
+      DRC.wait_for_script_to_complete('smelt')
+    elsif added == 1
+      # Only one ingot made it in; take it back so it isn't stranded in the crucible.
+      DRC.bput('get ingot from crucible', 'You get', 'What were you referring')
+    end
+    DRCI.stow_item?('ingot')
+  end
+
+  # Materialize the persistent steel ingot from its deed (if it is stored as one),
+  # leaving a real steel ingot in the crafting container. Mirrors workorders.lic.
+  def retrieve_ingot_from_deed
+    # Prefer a loose ingot already on hand: if one is in the crafting container
+    # (e.g. a leftover from an interrupted run, or a deed-store that failed for
+    # lack of a packet), use it and skip the trip to the deed room entirely.
+    # This avoids materializing a second "steel ingot" from the deed.
+    return if DRCI.exists?('steel ingot')
+
+    # The deed can only be tapped within the forging society, so walk there first.
+    DRCT.walk_to(@deeds_room)
+    return unless DRCI.get_item?('steel deed')
+
+    fput('tap my deed')
+    pause
+    DRCI.get_item_if_not_held?('steel ingot')
+    DRCI.stow_item?('ingot')
+  end
+
+  # Push the leftover steel ingot into a deed for light storage. Buys a fresh
+  # large deed packet (250 claim forms) when the current one is out. Mirrors
+  # workorders.lic; no-op if there is no ingot left to store.
+  def store_ingot_as_deed
+    return unless DRCI.get_item?('steel ingot')
+
+    ensure_deed_packet
+    unless DRCI.get_item?('packet')
+      Lich::Messaging.msg('bold', 'restock-shop: No deed packet available; leaving the steel ingot un-deeded.')
+      DRCI.stow_item?('ingot')
+      return
+    end
+
+    fput('push my ingot with packet')
+    DRCI.put_away_item?('packet')
+    DRCI.put_away_item?('deed')
+  end
+
+  # Trash the leftover steel ingot (used when deed storage is disabled, so a
+  # heavy ingot isn't left in the crafting container between runs). No-op if the
+  # ingot was fully consumed.
+  def dispose_leftover_ingot
+    return unless DRCI.get_item?('steel ingot')
+
     DRCT.walk_to(get_data('crafting')[:blacksmithing][@town]['trash-room'])
-    DRCC.get_crafting_item('steel ingot', @bag, @belt, @belt)
     DRCI.dispose_trash('steel ingot', @worn_trashcan, @worn_trashcan_verb)
+  end
+
+  # Ensure a deed packet with claim forms remaining is on hand, ordering a new
+  # large packet if the current one is empty or missing.
+  def ensure_deed_packet
+    result = DRC.bput('look my deed packet',
+                      /You count \d+ deed claim forms remaining/,
+                      /I could not find/,
+                      /What were you referring/)
+    return if result =~ /deed claim forms remaining/
+
+    DRCM.ensure_copper_on_hand(10_000, @settings, @town)
+    DRCT.order_item(@deeds_room, @deeds_number)
+    DRCI.put_away_item?('packet')
   end
 
   def restock_burlap(missing_items)
@@ -114,7 +415,7 @@ class ShopRestock
         recipe_data['part'].map { |part| part == part_name ? 1 : 0 }.reduce(0, :+).times { buy_part(part_name) }
       end
 
-      DRC.wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun'], 'burlap'])
+      DRC.wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], 'burlap', item['noun']])
       stamp(item)
       DRC.wait_for_script_to_complete('sew', ['reinforce'])
       fput("stow #{item['noun']}")
@@ -157,7 +458,7 @@ class ShopRestock
     missing_items.each do |item|
       move('out') if Room.current.id == @inner_id
       recipe_data = DRCC.recipe_lookup(@recipes, item['recipe'])
-      DRC.wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun'], 'linen'])
+      DRC.wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], 'linen', item['noun']])
       go_to_shop
       stamp(item)
       sell(item)
@@ -194,7 +495,7 @@ class ShopRestock
     missing_items.each do |item|
       recipe_data = DRCC.recipe_lookup(@recipes, item['recipe'])
       move('out') if Room.current.id == @inner_id
-      DRC.wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], item['noun'], 'silk'])
+      DRC.wait_for_script_to_complete('sew', ['stow', 'sewing', recipe_data['chapter'], item['recipe'], 'silk', item['noun']])
       go_to_shop
       stamp(item)
       sell(item)
@@ -217,7 +518,7 @@ class ShopRestock
     missing_items.each do |item|
       recipe_data = DRCC.recipe_lookup(@recipes, item['recipe'])
       recipe_data['part'].each { |part| buy_part(part) }
-      DRC.wait_for_script_to_complete('sew', ['stow', 'leather', recipe_data['chapter'], item['recipe'], item['noun'], item['material']])
+      DRC.wait_for_script_to_complete('sew', ['stow', 'leather', recipe_data['chapter'], item['recipe'], item['material'], item['noun']])
       fput('stow leather')
       DRCC.get_crafting_item('shield', @bag, @belt, @belt)
       DRC.wait_for_script_to_complete('sew', ['seal'])
@@ -251,15 +552,18 @@ class ShopRestock
   def stamp(item)
     fput("get my #{item['noun']} from my #{@bag}")
     DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
-    DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+    DRC.bput("mark my #{item['noun']} with my stamp", 'carefully hammer the stamp', 'already a maker\'s mark', 'You cannot figure out how to do that', 'too badly damaged')
     DRCC.stow_crafting_item('stamp', @bag, @belt)
+  end
+
+  def volume_of(item)
+    DRCC.recipe_lookup(@recipes.select { |recipe| recipe['noun'] == item['noun'] }, item['recipe'])['volume']
   end
 
   def total_volume_of(items)
     return 0 if items.empty?
 
-    items.map { |item| DRCC.recipe_lookup(@recipes.select { |recipe| recipe['noun'] == item['noun'] }, item['recipe'])['volume'] }
-         .inject(&:+)
+    items.map { |item| volume_of(item) }.inject(&:+)
   end
 end
 

--- a/smith.lic
+++ b/smith.lic
@@ -109,7 +109,11 @@ class Smith
 
   def stamp_item(noun)
     DRCC.get_crafting_item('stamp', @bag, @bag_items, @belt)
-    DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'You cannot figure out how to do that', 'too badly damaged')
+    # The maker's mark belongs on the object right after its initial creation.
+    # forge.lic already stamps it then (when mark_crafted_goods is set), so the
+    # mark may already be present here -- treat "already a maker's mark" as a
+    # success instead of retrying the command until it times out.
+    DRC.bput("mark my #{noun} with my stamp", 'carefully hammer the stamp', 'already a maker\'s mark', 'You cannot figure out how to do that', 'too badly damaged')
     DRCC.stow_crafting_item('stamp', @bag, @belt)
   end
 

--- a/spec/forge_spec.rb
+++ b/spec/forge_spec.rb
@@ -579,7 +579,10 @@ RSpec.describe Forge do
       it 'gets item when not in left hand' do
         allow(DRCI).to receive(:in_left_hand?).with('sword').and_return(false, true)
         allow(DRCI).to receive(:in_right_hand?).and_return(false)
-        expect(DRCC).to receive(:stow_crafting_item)
+        # prepare_item_in_left_hand/handle_oiling now stow BOTH hands (via
+        # stow_both_hands) before retrieving the item, so stow_crafting_item is
+        # called once per hand.
+        expect(DRCC).to receive(:stow_crafting_item).twice
         expect(DRC).to receive(:bput).with('get sword on anvil', 'You get', 'What were you referring to?').and_return('You get')
         expect(forge_instance).to receive(:swap_tool).with('oil', true)
         forge_instance.send(:handle_oiling)

--- a/spec/restock_shop_spec.rb
+++ b/spec/restock_shop_spec.rb
@@ -148,4 +148,14 @@ RSpec.describe ShopRestock do
       instance.send(:add_ingot_volume, 168)
     end
   end
+
+  describe '#combine_ingots' do
+    it 'finds an empty crucible using @town (guards against the nil-@hometown crash)' do
+      instance = build_instance(town: 'Crossing')
+      allow(DRCI).to receive(:get_item?).with('steel ingot').and_return(false)
+      allow(DRCI).to receive(:stow_item?)
+      expect(DRCC).to receive(:find_empty_crucible).with('Crossing')
+      instance.send(:combine_ingots)
+    end
+  end
 end

--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -73,7 +73,10 @@ RSpec.describe WorkOrders do
 
     it 'defines REPAIR_GIVE_PATTERNS as frozen array' do
       expect(described_class::REPAIR_GIVE_PATTERNS).to be_frozen
-      expect(described_class::REPAIR_GIVE_PATTERNS.length).to eq(6)
+      expect(described_class::REPAIR_GIVE_PATTERNS.length).to eq(7)
+      # Cost-capturing quote plus a bare-prompt fallback for split lines.
+      expect(described_class::REPAIR_GIVE_PATTERNS).to include(described_class::REPAIR_QUOTE_PATTERN)
+      expect(described_class::REPAIR_GIVE_PATTERNS).to include('Just give it to me again')
     end
 
     it 'defines REPAIR_NO_NEED_PATTERNS as frozen array' do

--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -855,9 +855,13 @@ RSpec.describe WorkOrders do
     describe 'put_away_item? usage' do
       it 'uses DRCI.put_away_item? for ticket in repair_items' do
         workorders.instance_variable_set(:@settings, OpenStruct.new(workorders_repair_own_tools: false))
-        # Return 'Just give it to me again' for every first give per tool
-        allow(DRC).to receive(:bput) do |cmd, *_patterns|
-          cmd.include?('give') ? 'Just give it to me again' : 'repair ticket'
+        # First give per tool returns the clerk's cost quote (matches
+        # REPAIR_QUOTE_PATTERN and contains a price so repair_cost_copper works);
+        # confirm_repair's give -- the only one passing 'repair ticket' as a
+        # pattern -- returns 'repair ticket' so the repair finalizes and the
+        # ticket is stowed.
+        allow(DRC).to receive(:bput) do |_cmd, *patterns|
+          patterns.include?('repair ticket') ? 'repair ticket' : 'cost 4,447 Kronars to repair.  Just give it to me again'
         end
         allow(DRCI).to receive(:get_item?).and_return(false)
         allow(workorders).to receive(:get_tool)

--- a/workorders.lic
+++ b/workorders.lic
@@ -24,11 +24,19 @@ class WorkOrders
 
   NPC_NOT_FOUND_PATTERN = "What is it you're trying to give".freeze
 
+  # The clerk's repair quote, e.g. "That will cost 4,447 Kronars to repair.
+  # Just give it to me again..." -- captured (cost included) so we can read the
+  # price and top up from the bank if we are short before confirming.
+  REPAIR_QUOTE_PATTERN = /cost [\d,]+ \w+ to repair.*give it to me again/i
+
+  # Clerk's response when we lack the coin to pay for a repair.
+  REPAIR_NEED_COIN_PATTERN = 'more coin'
+
   REPAIR_GIVE_PATTERNS = [
     "I don't repair those here",
     'What is it',
     "There isn't a scratch on that",
-    'Just give it to me again',
+    REPAIR_QUOTE_PATTERN,
     'I will not',
     "I can't fix those.  They only have so many uses and then you must buy another."
   ].freeze
@@ -272,10 +280,7 @@ class WorkOrders
       if REPAIR_NO_NEED_PATTERNS.any? { |pat| pat.match?(result) }
         stow_tool(tool_name)
       elsif result.include?('give')
-        DRC.bput("give #{info['repair-npc']}", 'repair ticket')
-        unless DRCI.put_away_item?('ticket')
-          Lich::Messaging.msg('bold', 'WorkOrders: Failed to stow repair ticket')
-        end
+        confirm_repair(info, tool_name, repair_cost_copper(result))
       end
     end
 
@@ -287,6 +292,47 @@ class WorkOrders
       stow_tool(DRC.left_hand) if DRC.left_hand
     end
     Lich::Messaging.msg('plain', 'WorkOrders: Tool repair at NPC completed')
+  end
+
+  # Parse the copper cost out of the clerk's repair quote. Repair prices are
+  # quoted in the base coin of the local currency, so the number is already in
+  # coppers. Returns nil if no cost could be read.
+  def repair_cost_copper(quote)
+    match = quote.match(/([\d,]+)/)
+    match && match[1].delete(',').to_i
+  end
+
+  # Hand the item over to finalize a repair. If the clerk says we need more
+  # coin, withdraw 10x the quoted cost from the bank, walk back, and retry.
+  def confirm_repair(info, tool_name, cost)
+    attempts = 0
+    loop do
+      case DRC.bput("give #{info['repair-npc']}", 'repair ticket', REPAIR_NEED_COIN_PATTERN)
+      when /repair ticket/
+        break
+      when /#{REPAIR_NEED_COIN_PATTERN}/
+        attempts += 1
+        if cost.nil? || attempts > 3
+          Lich::Messaging.msg('bold', "WorkOrders: Unable to fund repair of #{tool_name}; skipping.")
+          stow_tool(tool_name)
+          return
+        end
+        Lich::Messaging.msg('plain', "WorkOrders: Short on coin; withdrawing #{cost * 10} for #{tool_name} repair.")
+        stow_tool(tool_name)
+        unless DRCM.ensure_copper_on_hand(cost * 10, @settings, @hometown)
+          Lich::Messaging.msg('bold', "WorkOrders: Bank withdrawal failed; skipping #{tool_name} repair.")
+          return
+        end
+        DRCT.walk_to(info['repair-room'])
+        get_tool(tool_name)
+      else
+        Lich::Messaging.msg('bold', "WorkOrders: Unexpected response finalizing #{tool_name} repair; skipping.")
+        return
+      end
+    end
+    unless DRCI.put_away_item?('ticket')
+      Lich::Messaging.msg('bold', 'WorkOrders: Failed to stow repair ticket')
+    end
   end
 
   def find_recipe(materials_info, recipe, quantity)

--- a/workorders.lic
+++ b/workorders.lic
@@ -26,7 +26,10 @@ class WorkOrders
 
   # The clerk's repair quote, e.g. "That will cost 4,447 Kronars to repair.
   # Just give it to me again..." -- captured (cost included) so we can read the
-  # price and top up from the bank if we are short before confirming.
+  # price and top up from the bank if we are short before confirming. This only
+  # matches when the cost and prompt share one game line (the observed format);
+  # the bare 'Just give it to me again' below is kept as a fallback so a split
+  # line still matches the prompt (repair proceeds, just without auto-funding).
   REPAIR_QUOTE_PATTERN = /cost [\d,]+ \w+ to repair.*give it to me again/i
 
   # Clerk's response when we lack the coin to pay for a repair.
@@ -37,6 +40,7 @@ class WorkOrders
     'What is it',
     "There isn't a scratch on that",
     REPAIR_QUOTE_PATTERN,
+    'Just give it to me again',
     'I will not',
     "I can't fix those.  They only have so many uses and then you must buy another."
   ].freeze


### PR DESCRIPTION
# fix(crafting): reliability fixes + restock-shop features (forge, smith, workorders, restock-shop)

**Repo:** `elanthia-online/dr-scripts`
**Files:** `forge.lic`, `smith.lic`, `workorders.lic`, `restock-shop.lic`

## Summary

A set of related crafting/shop-automation changes discovered while running an
auto-restocking Trader shop. Three are standalone reliability fixes (forge,
smith, workorders); the fourth is a substantial feature+fix pass on the
restock-shop orchestrator.

The headline restock-shop change is **demand-sized steel batching**: instead of
making one fixed ingot per run and trashing the leftover, the script now keeps a
persistent refined ingot and tops it up only as much as the queued work needs.
It sizes each `makesteel` toward the remaining demand (bounded by the in-game
210-volume ingot cap and `makesteel`'s count-21 limit, adjusted for refine loss),
smelts the fresh ingot into the persistent one, skips any item too large to forge
from a single ingot, and carries the remainder to the next run (optionally as a
deed). That batching also underpins the low-carbon path and the persistent/deed
storage below.

No new dependencies; each script still reads its config from YAML.

## forge.lic

- **Temper in forge-less rooms.** Tempering issues `put/turn/analyze ... on forge`,
  but grinding happens at grindstone rooms that have no forge (e.g. the Smelting
  and Grinding Area), so tempering failed there with "What were you referring to?".
  Added `ensure_forge` / `forge_in_room?` (new `FORGE_MISSING_PATTERN`) and a guard
  in the work loop (`ensure_forge if @command.include?('forge')`) that walks to a
  free anvil room (forges are co-located with anvils) when the current room lacks one.
- **Tool/product noun collision on retrieval.** When crafting an item whose noun
  matches a forging tool (e.g. a crafted "wide shovel" vs. a "wide shovel" tool),
  the retrieval paths stowed only one hand and left the colliding tool in the other,
  causing the finished item to be tied to the belt. `prepare_item_in_left_hand` and
  `handle_oiling` now `stow_both_hands` before retrieving the item. Removed the now
  redundant `stow_hammer_and_tongs` helper (superseded by `stow_both_hands`).

## smith.lic

- **Idempotent stamping.** `forge.lic` already stamps the item after initial
  creation (when `mark_crafted_goods` is set), so `smith`'s subsequent stamp hit
  "There is already a maker's mark" and timed out. `stamp_item` now treats that
  response as success instead of retrying.

## workorders.lic

- **Repair insufficient-funds recovery.** When an NPC repair quote exceeded coin on
  hand, the confirm step only listened for "repair ticket" and 15s-timed-out on
  "You will need more coin". The quote line is now captured (cost included) via
  `REPAIR_QUOTE_PATTERN`; a new `confirm_repair` withdraws 10x the quoted cost from
  the bank, walks back, and retries (capped at 3 attempts, with clean bail-outs).

## restock-shop.lic

- **Demand-sized steel batching.** Previously each run made one fixed ingot and
  trashed whatever was left. Now steel is produced to fit the work: a single
  in-game ingot is capped at 210 raw volume (`RAW_STEEL_INGOT_CAP`), from at most
  a count-21 `makesteel` (`MAKESTEEL_MAX_COUNT`), and refining loses volume by a
  configurable factor (`steel_refine_factor`, default 1.25 with the tech / 2.0
  without). Before forging, `filter_forgeable` drops (with a warning) any item
  whose volume exceeds a single ingot, since it can't be made from one. Then for
  each item, `ensure_ingot_volume`/`add_ingot_volume` top the working ingot up
  only when it can't cover the next item, sizing each `makesteel` toward the
  *remaining* queued demand (capped at one ingot) to minimize crucible trips, and
  smelting (`combine_ingots`) each fresh refined ingot into the persistent one.
- **Word-based shop detection.** The game inserts the material adjective at an
  unpredictable spot in crafted names (e.g. "a weighted steel pickaxe"), so
  contiguous-substring `full_name` matching missed items and re-crafted duplicates.
  Detection now requires every word of `full_name` to appear in the listing.
- **sew material/noun arg order.** Tailoring calls passed `sew` arguments with
  material and noun swapped, so cloth items fell into the leather branch
  ("get my shirt leather"). Fixed the argument order for burlap/linen/silk/gryphon.
- **Persistent + deed steel ingot.** Carry the leftover refined ingot between runs
  (the batching above tops it up) rather than trashing it, optionally stored as a
  light deed (`deed_steel_ingot`); loose-ingot-first, and the deed is tapped only
  inside the forging society.
- **Low-carbon steel path.** Items with `material: low carbon steel` (e.g. tongs) are
  forged from a 1:1 iron:coal ingot on a separate, non-persisted path.
- **Carbon-grade guards.** Both grades are just "steel ingot" in-game; `analyze`'s
  "composed of: NN% <grade> carbon steel" line is used to keep grades from mixing.
- **Stamp tolerance.** Its own stamp step accepts "already a maker's mark".

## Tests

Existing specs updated for the changed behavior, and new coverage added for the
new methods (RSpec, using the repo's central game doubles):

- **`spec/forge_spec.rb`** — updated `#handle_oiling` (now stows both hands →
  `stow_crafting_item` twice). Added `#forge_in_room?` (item / empty / no-forge),
  `#ensure_forge` (skip when a forge is present; walk to a free anvil when absent;
  exit when none found), and a `FORGE_MISSING_PATTERN` check.
- **`spec/workorders_spec.rb`** — updated the repair test's `bput` stub to the new
  confirm flow. Added `REPAIR_QUOTE_PATTERN` / `REPAIR_NEED_COIN_PATTERN` checks,
  `#repair_cost_copper` (parse / nil), and `#confirm_repair` (accept → stow ticket;
  short on coin → withdraw 10x and retry; unknown cost → skip).
- **`spec/restock_shop_spec.rb`** (new) — `#already_stocked?` (word-presence
  matching), `#steel_ingot_carbon` (grade parse), `#makesteel_args` (high vs low),
  and the batching: `#filter_forgeable` (drops over-cap items), `#ensure_ingot_volume`
  (fills toward remaining demand, capped at one ingot), and `#add_ingot_volume`
  (count sizing toward `fill_to`, capped at `MAKESTEEL_MAX_COUNT`; combine when the
  ingot already has volume).

## Verification notes
- `ruby -c` clean on all four scripts and all three specs.
- Detection verified against real shop output; grade parsing verified against real
  `analyze` output for high/medium/low.
- forge/smith/workorders are pure additions over the current public versions
  (straight upgrades; nothing removed except a helper superseded by a broader one).
  restock-shop.lic is a large net-new feature set over the 266-line public base.
