### PR TITLE
fix(profiles): make Azad-setup.yaml valid YAML (fixes #7502)

### DIFF
--- a/profiles/Samples/Trader/Azad-setup.yaml
+++ b/profiles/Samples/Trader/Azad-setup.yaml
@@ -127,7 +127,7 @@ listen_observe: false
 ##################################################################
 #                                                                #
 ################################################### Athletics ####
-athletics_outdoorsmanship_rooms: [#####, #####, #####, #####, #####, #####]
+athletics_outdoorsmanship_rooms: []   # e.g. [1234, 5678]
 held_athletics_items: ['stone shard', 'arrows']
 
 ##################################################################


### PR DESCRIPTION
## Summary

`profiles/Samples/Trader/Azad-setup.yaml` was the only one of 231 profile YAML files in the repo that failed to parse.

Line 130 used `#####` room-id placeholders inside a flow sequence:

```yaml
athletics_outdoorsmanship_rooms: [#####, #####, #####, #####, #####, #####]
```

Inside `[...]`, `#` starts a comment, so the closing `]` was swallowed and the flow sequence was never terminated (`Psych::SyntaxError: did not find expected ',' or ']'`). The pattern is only safe in block style (`room: ####` on its own line), which is likely why it was copied here without anyone noticing.

## Fix

Replace with an empty sequence plus an example comment, matching the suggestion in the issue and keeping the placeholder intent:

```yaml
athletics_outdoorsmanship_rooms: []   # e.g. [1234, 5678]
```

Verified the file now parses cleanly.

Fixes #7502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)