### PR TITLE
combat-trainer: generic plugin system + warhorn/egg cooldown seam

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4504,17 +4504,27 @@ class CombatTrainer
   # combat-trainer's hook names, not vice versa) in the spirit of the Dependency
   # Inversion and Interface Segregation principles.
   #
-  # Plugins are auto-loaded at boot (see the loader near the bottom of this file)
-  # from:
-  #   <SCRIPT_DIR>/custom/combat-trainer-plugin-*.rb
-  # and each file registers its instance with:
+  # == Authoring a plugin
+  #
+  # Create a file named +combat-trainer-plugin-<name>.rb+ in the +custom+
+  # directory (+<SCRIPT_DIR>/custom/+). At boot, combat-trainer loads every
+  # matching file in sorted filename order, *before* the orchestrator is
+  # constructed, and each file is expected to register one instance:
+  #
   #   CombatTrainer.register_plugin(MyPlugin.new)
   #
-  # Two dispatch styles are provided:
+  # A plugin implements only the hooks it cares about; unimplemented hooks are
+  # skipped. A plugin that raises inside a hook is isolated: the error is
+  # swallowed (and echoed under +$debug_mode_ct+) so a misbehaving plugin
+  # degrades to the built-in default rather than aborting combat.
+  #
+  # == Two dispatch styles
+  #
   #   * {fire_hook} -- a *decision* hook. Plugins are polled in registration
   #     order and the first non-nil return value wins, replacing combat-trainer's
   #     built-in behavior for that decision. A plugin returns +nil+ (or omits the
-  #     hook) to defer to the built-in default.
+  #     hook) to defer to the built-in default. Note that +false+ is a real
+  #     answer and short-circuits the poll.
   #   * {notify_hook} -- a *notification* hook. Every plugin implementing the
   #     hook is invoked for its side effects; return values are ignored and an
   #     exception raised by one plugin never stops the others.
@@ -4524,7 +4534,79 @@ class CombatTrainer
   # instance) can still fire hooks via +CombatTrainer.fire_hook+ /
   # +CombatTrainer.notify_hook+.
   #
-  # @see AbilityProcess#room_effect_on_cooldown? the warhorn/egg cooldown seam.
+  # == Hook catalog
+  #
+  # Lifecycle hooks (fired by the orchestrator). +trainer+ is the live
+  # CombatTrainer instance and +game_state+ is the current GameState:
+  #
+  #   after_initialize(trainer)                          [notify]
+  #     Fired once when the orchestrator has finished constructing, before
+  #     combat begins. Read settings, open resources, or announce startup here.
+  #
+  #   before_combat(trainer, game_state)                 [notify]
+  #     Fired once at the top of the combat loop, before the first iteration.
+  #
+  #   combat_tick(trainer, game_state, counter:)         [decision]
+  #     Fired once per loop iteration after the combat processes run; +counter+
+  #     is the 1-based iteration count. This is the only lifecycle hook whose
+  #     return value is honored: returning +:break+ stops the combat loop. Any
+  #     other return value is ignored.
+  #
+  #   after_combat(trainer, game_state)                  [notify]
+  #     Fired once after the combat loop exits.
+  #
+  #   cleanup(trainer)                                   [notify]
+  #     Fired from the before_dying teardown (including abnormal exits). Release
+  #     resources here; it is guarded so a failure cannot block shutdown.
+  #
+  # Feature seams (fired by the combat +*Process+ collaborators):
+  #
+  #   warhorn_cooldown_active?(room_id:)                 [decision]
+  #     Decide whether the warhorn/egg room effect is still active in +room_id+.
+  #     Return +true+ to skip a fresh application, +false+ to allow it, or +nil+
+  #     to defer to the built-in per-character 600s timer.
+  #     Fired by {AbilityProcess#room_effect_on_cooldown?}.
+  #
+  #   warhorn_applied(room_id:, type:)                   [notify]
+  #     Announced right after a warhorn/egg effect is applied in +room_id+;
+  #     +type+ is "warhorn" or "egg". Persist the event to an external store
+  #     here. Fired by {AbilityProcess#record_room_effect}.
+  #
+  # This is the current set; more seams may be added over time, so a plugin
+  # should implement only the hooks it needs and tolerate new ones appearing.
+  #
+  # == Calling into a plugin from outside
+  #
+  # Unknown instance calls on the orchestrator are forwarded to the first
+  # registered plugin that responds, so an external script can drive plugin
+  # behavior through the global handle, e.g. +$COMBAT_TRAINER.my_command(arg)+.
+  # See {#method_missing}.
+  #
+  # @example A plugin that logs the lifecycle and stops combat after N ticks
+  #   # scripts/custom/combat-trainer-plugin-ticklimit.rb
+  #   class TickLimitPlugin
+  #     def initialize(max_ticks: 500)
+  #       @max_ticks = max_ticks
+  #     end
+  #
+  #     def after_initialize(_trainer)
+  #       echo "[ticklimit] loaded; will stop after #{@max_ticks} ticks"
+  #     end
+  #
+  #     # Decision hook: returning :break ends the combat loop.
+  #     def combat_tick(_trainer, _game_state, counter:)
+  #       :break if counter >= @max_ticks
+  #     end
+  #
+  #     def cleanup(_trainer)
+  #       echo '[ticklimit] cleaning up'
+  #     end
+  #   end
+  #
+  #   CombatTrainer.register_plugin(TickLimitPlugin.new(max_ticks: 300))
+  #
+  # @see AbilityProcess#room_effect_on_cooldown? the warhorn/egg cooldown seam,
+  #   a worked example of a decision hook.
   @registered_plugins = []
 
   class << self

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -6583,7 +6583,9 @@ end
 # failure to load one plugin must not prevent combat-trainer from starting.
 Dir.glob(File.join(SCRIPT_DIR, 'custom', 'combat-trainer-plugin-*.rb')).sort.each do |plugin_file|
   load plugin_file
-rescue StandardError => e
+rescue ScriptError, StandardError => e
+  # ScriptError (SyntaxError/LoadError) does not descend from StandardError, so
+  # it must be named explicitly or a malformed plugin file would abort startup.
   echo "Failed to load combat-trainer plugin #{File.basename(plugin_file)}: #{e.message}"
 end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2823,30 +2823,72 @@ class AbilityProcess
     end
   end
 
-  # Rotates through egg and warhorn types, using whichever is off cooldown.
-  # The 10-minute room effect gate prevents wasted attempts.
-  # @param game_state [GameState] current combat game state
+  # Rotate through the configured egg/warhorn types and, if the room effect is
+  # off cooldown, apply whichever type is next in the rotation.
+  #
+  # This governs only the *room effect* -- the shared, room-scoped buff a warhorn
+  # or egg lays down. The physical item recharge cooldown is enforced separately
+  # inside {use_egg?} and {use_warhorn?}. The cooldown decision is delegated to
+  # {room_effect_on_cooldown?} so a plugin may substitute shared, cross-character
+  # bookkeeping (see the plugin system on {CombatTrainer}).
+  #
+  # @param game_state [GameState] current combat game state (warhorns use it to
+  #   sheathe/wield an offhand around the exhale).
   # @return [void]
   def use_warhorn_or_egg(game_state)
+    room_id = Room.current.id
     DRC.message("Time since last room effect: #{(Time.now - UserVars.warhorn["last_warhorn_or_egg"]) / 60} min") if $debug_mode_ct
 
-    return unless Time.now > (UserVars.warhorn["last_warhorn_or_egg"] + 600)
+    return if room_effect_on_cooldown?(room_id)
 
     type = @warhorn_or_egg[0]
+    used =
+      case type
+      when 'egg' then use_egg?
+      when 'warhorn' then use_warhorn?(game_state)
+      else false
+      end
 
-    if type == 'egg'
-      if use_egg?
-        DRC.message("SUCCESSFUL egg use") if $debug_mode_ct
-        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
-      end
-    elsif type == 'warhorn'
-      if use_warhorn?(game_state)
-        DRC.message("SUCCESSFUL horn use") if $debug_mode_ct
-        UserVars.warhorn["last_warhorn_or_egg"] = Time.now
-      end
+    if used
+      DRC.message("SUCCESSFUL #{type} use") if $debug_mode_ct
+      record_room_effect(room_id, type)
     end
 
     @warhorn_or_egg.rotate!
+  end
+
+  # Decide whether the current room's warhorn/egg effect is still active, in
+  # which case a fresh application should be skipped.
+  #
+  # A registered plugin may answer the +:warhorn_cooldown_active?+ decision hook
+  # to supply shared/room-scoped state (e.g. a cross-character store); any
+  # non-nil answer overrides the built-in check. When no plugin answers, the
+  # historical per-character timer in +UserVars.warhorn+ is used, preserving
+  # legacy behavior exactly (a 600-second gate).
+  #
+  # @param room_id [Integer, nil] the current room id, forwarded to plugins.
+  # @return [Boolean] +true+ if the effect is still on cooldown (skip use),
+  #   +false+ if it is safe to apply the effect now.
+  def room_effect_on_cooldown?(room_id)
+    override = CombatTrainer.fire_hook(:warhorn_cooldown_active?, room_id: room_id)
+    return override unless override.nil?
+
+    Time.now <= (UserVars.warhorn["last_warhorn_or_egg"] + 600)
+  end
+
+  # Record that the room effect was just (re)applied.
+  #
+  # The built-in per-character timer is always refreshed so combat-trainer's
+  # default cooldown stays consistent even when a plugin overrode the decision.
+  # The +:warhorn_applied+ notification hook then lets plugins persist the event
+  # to their own store, keyed by +room_id+.
+  #
+  # @param room_id [Integer, nil] the room the effect was applied in.
+  # @param type [String] the effect source, +"egg"+ or +"warhorn"+.
+  # @return [void]
+  def record_room_effect(room_id, type)
+    UserVars.warhorn["last_warhorn_or_egg"] = Time.now
+    CombatTrainer.notify_hook(:warhorn_applied, room_id: room_id, type: type)
   end
 
   # Iterates through discovered eggs, skipping those on cooldown, and invokes
@@ -4450,6 +4492,105 @@ class AttackProcess
 end
 
 class CombatTrainer
+  # ============================================================
+  # PLUGIN SYSTEM
+  # ============================================================
+  # Combat-trainer exposes a small, vendor-neutral plugin system so external
+  # scripts can observe and influence the combat lifecycle without forking this
+  # file. A plugin is any plain Ruby object that implements zero or more *hook
+  # methods*; combat-trainer discovers hooks by name at runtime via +respond_to?+
+  # and never requires a plugin to inherit a base class or satisfy a fixed
+  # interface. This keeps the coupling one-directional (plugins depend on
+  # combat-trainer's hook names, not vice versa) in the spirit of the Dependency
+  # Inversion and Interface Segregation principles.
+  #
+  # Plugins are auto-loaded at boot (see the loader near the bottom of this file)
+  # from:
+  #   <SCRIPT_DIR>/custom/combat-trainer-plugin-*.rb
+  # and each file registers its instance with:
+  #   CombatTrainer.register_plugin(MyPlugin.new)
+  #
+  # Two dispatch styles are provided:
+  #   * {fire_hook} -- a *decision* hook. Plugins are polled in registration
+  #     order and the first non-nil return value wins, replacing combat-trainer's
+  #     built-in behavior for that decision. A plugin returns +nil+ (or omits the
+  #     hook) to defer to the built-in default.
+  #   * {notify_hook} -- a *notification* hook. Every plugin implementing the
+  #     hook is invoked for its side effects; return values are ignored and an
+  #     exception raised by one plugin never stops the others.
+  #
+  # The registry and both dispatch methods are class-level so that decoupled
+  # combat +*Process+ collaborators (which hold no reference to the orchestrator
+  # instance) can still fire hooks via +CombatTrainer.fire_hook+ /
+  # +CombatTrainer.notify_hook+.
+  #
+  # @see AbilityProcess#room_effect_on_cooldown? the warhorn/egg cooldown seam.
+  @registered_plugins = []
+
+  class << self
+    # @return [Array<Object>] the plugin instances registered this run, in
+    #   registration (file-load) order.
+    attr_reader :registered_plugins
+
+    # Register a plugin instance to receive lifecycle and decision hooks.
+    #
+    # @param plugin [Object] any object implementing one or more hook methods.
+    # @return [Array<Object>] the updated registry.
+    def register_plugin(plugin)
+      @registered_plugins << plugin
+    end
+
+    # Fire a *decision* hook and return the first non-nil plugin result.
+    #
+    # Plugins that do not implement +hook_name+ are skipped. An exception raised
+    # by a plugin is swallowed (and echoed under +$debug_mode_ct+) so a
+    # misbehaving plugin degrades to combat-trainer's default rather than
+    # aborting combat. Note that a plugin returning +false+ counts as an answer
+    # (it is not +nil+) and therefore short-circuits the poll.
+    #
+    # @param hook_name [Symbol] the hook method to invoke on each plugin.
+    # @param args [Array] positional arguments forwarded to the hook.
+    # @param kwargs [Hash] keyword arguments forwarded to the hook.
+    # @return [Object, nil] the first non-nil return value, or +nil+ if no
+    #   plugin answered.
+    def fire_hook(hook_name, *args, **kwargs)
+      registered_plugins.each do |plugin|
+        next unless plugin.respond_to?(hook_name)
+
+        begin
+          result = plugin.send(hook_name, *args, **kwargs)
+          return result unless result.nil?
+        rescue StandardError => e
+          echo "Plugin #{plugin.class.name} error in #{hook_name}: #{e.message}" if $debug_mode_ct
+        end
+      end
+      nil
+    end
+
+    # Fire a *notification* hook on every plugin that implements it.
+    #
+    # Unlike {fire_hook}, all matching plugins are always invoked and their
+    # return values are ignored. An exception in one plugin is isolated so the
+    # remaining plugins still run.
+    #
+    # @param hook_name [Symbol] the hook method to invoke on each plugin.
+    # @param args [Array] positional arguments forwarded to the hook.
+    # @param kwargs [Hash] keyword arguments forwarded to the hook.
+    # @return [nil]
+    def notify_hook(hook_name, *args, **kwargs)
+      registered_plugins.each do |plugin|
+        next unless plugin.respond_to?(hook_name)
+
+        begin
+          plugin.send(hook_name, *args, **kwargs)
+        rescue StandardError => e
+          echo "Plugin #{plugin.class.name} error in #{hook_name}: #{e.message}" if $debug_mode_ct
+        end
+      end
+      nil
+    end
+  end
+
   attr_reader :running
 
   def stop
@@ -4492,6 +4633,9 @@ class CombatTrainer
     settings.storage_containers.each { |container| fput("open my #{container}") }
     worngear = settings.combat_trainer_gear_set || "standard"
     @equipment_manager.wear_equipment_set?(worngear) if settings.cycle_armors_regalia.nil? || DRCA.parse_regalia.empty?
+
+    # Notify plugins that combat-trainer is fully constructed and ready.
+    self.class.notify_hook(:after_initialize, self)
   end
 
   def set_dance(message, settings)
@@ -4543,12 +4687,18 @@ class CombatTrainer
 
   def start_combat
     @equipment_manager.empty_hands
+    self.class.notify_hook(:before_combat, self, @game_state)
+    tick = 0
     loop do
       waitrt?
       @safety_process.execute(@game_state)
       @combat_processes.each do |process|
         break if process.execute(@game_state)
       end
+      tick += 1
+      # Give plugins a per-iteration seam; any plugin returning :break stops combat.
+      break if self.class.fire_hook(:combat_tick, self, @game_state, counter: tick) == :break
+
       pause @loop_tick
       if @game_state.done_cleaning_up?
         echo('CombatTrainer::clean_up') if $debug_mode_ct
@@ -4567,6 +4717,32 @@ class CombatTrainer
       @game_state.stop_weak_attacks
       @game_state.stop_analyze_combo
     end
+    self.class.notify_hook(:after_combat, self, @game_state)
+  end
+
+  # Forward unknown instance calls to the first plugin that implements them.
+  #
+  # This lets external scripts drive plugin behavior through the global
+  # +$COMBAT_TRAINER+ handle (e.g. +$COMBAT_TRAINER.some_plugin_command+)
+  # without combat-trainer needing to know the method name up front.
+  #
+  # @param method_name [Symbol] the missing method.
+  # @param args [Array] positional arguments forwarded to the plugin.
+  # @param kwargs [Hash] keyword arguments forwarded to the plugin.
+  # @return [Object] the responding plugin's return value.
+  # @raise [NoMethodError] if no registered plugin responds to +method_name+.
+  def method_missing(method_name, *args, **kwargs, &block)
+    self.class.registered_plugins.each do |plugin|
+      return plugin.send(method_name, *args, **kwargs, &block) if plugin.respond_to?(method_name)
+    end
+    super
+  end
+
+  # @param method_name [Symbol] the method being checked.
+  # @param include_private [Boolean] whether to consider private methods.
+  # @return [Boolean] +true+ if any registered plugin responds to the method.
+  def respond_to_missing?(method_name, include_private = false)
+    self.class.registered_plugins.any? { |plugin| plugin.respond_to?(method_name) } || super
   end
 end
 
@@ -6314,6 +6490,19 @@ before_dying do
   Flags.delete('ct-barbarian-whirlwind-expired')
   Flags.delete('war-stomp-ready')
   Flags.delete('pounce-ready')
+
+  # Let plugins release any resources they acquired.
+  CombatTrainer.notify_hook(:cleanup, $COMBAT_TRAINER)
+end
+
+# Load combat-trainer plugins from the custom directory. Each plugin file is
+# expected to register itself via CombatTrainer.register_plugin(...). Plugins
+# must load before CombatTrainer.new so their :after_initialize hook fires. A
+# failure to load one plugin must not prevent combat-trainer from starting.
+Dir.glob(File.join(SCRIPT_DIR, 'custom', 'combat-trainer-plugin-*.rb')).sort.each do |plugin_file|
+  load plugin_file
+rescue StandardError => e
+  echo "Failed to load combat-trainer plugin #{File.basename(plugin_file)}: #{e.message}"
 end
 
 $COMBAT_TRAINER = CombatTrainer.new

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -87,6 +87,7 @@ load_lic_class('combat-trainer.lic', 'SafetyProcess')
 load_lic_class('combat-trainer.lic', 'SpellProcess')
 load_lic_class('combat-trainer.lic', 'PetProcess')
 load_lic_class('combat-trainer.lic', 'TrainerProcess')
+load_lic_class('combat-trainer.lic', 'CombatTrainer')
 
 # Shared setup for combat-trainer tests that need game state stubs.
 # Include in each describe block via: before(:each) { ct_setup }
@@ -4221,5 +4222,365 @@ RSpec.describe 'TrainerProcess#check_heavens' do
     allow(DRCMM).to receive(:get_telescope?).and_return(true)
     gs = double('GameState', stow_or_store_weapon: nil, restore_weapon: nil)
     expect { tp.send(:check_heavens, gs) }.not_to raise_error
+  end
+end
+
+# ===========================================================================
+# CombatTrainer plugin system -- registry + hook dispatch
+# ===========================================================================
+# These stub plugins stand in for real combat-trainer plugins. Each is
+# deliberately tiny so the behavior under test is obvious at the call site
+# (DAMP), and each records its invocations so tests can assert exactly which
+# plugins were polled and with what arguments.
+
+# Records every hook invocation and returns a preconfigured value.
+class RecordingPlugin
+  attr_reader :calls
+
+  def initialize(return_value: nil)
+    @return_value = return_value
+    @calls = []
+  end
+
+  def warhorn_cooldown_active?(room_id:)
+    @calls << [:warhorn_cooldown_active?, { room_id: room_id }]
+    @return_value
+  end
+
+  def warhorn_applied(room_id:, type:)
+    @calls << [:warhorn_applied, { room_id: room_id, type: type }]
+    @return_value
+  end
+
+  def combat_tick(trainer, game_state, counter:)
+    @calls << [:combat_tick, [trainer, game_state], { counter: counter }]
+    @return_value
+  end
+
+  # Used only to prove method_missing forwarding through CombatTrainer.
+  def custom_command(arg)
+    @calls << [:custom_command, [arg]]
+    "handled:#{arg}"
+  end
+end
+
+# Raises whenever a hook is called, to prove dispatch isolates plugin errors.
+class ExplodingPlugin
+  def warhorn_cooldown_active?(room_id:)
+    raise "boom for #{room_id}"
+  end
+
+  def warhorn_applied(room_id:, type:)
+    raise "boom applying #{type} in #{room_id}"
+  end
+
+  def combat_tick(_trainer, _game_state, counter:)
+    raise "boom on tick #{counter}"
+  end
+end
+
+# Implements no hooks at all, to prove respond_to? gating skips it cleanly.
+class InertPlugin
+end
+
+RSpec.describe CombatTrainer do
+  before(:each) do
+    CombatTrainer.registered_plugins.clear
+  end
+
+  after(:each) do
+    CombatTrainer.registered_plugins.clear
+    $debug_mode_ct = nil
+  end
+
+  describe '.register_plugin' do
+    it 'accumulates plugins in registration order' do
+      first = RecordingPlugin.new
+      second = RecordingPlugin.new
+
+      CombatTrainer.register_plugin(first)
+      CombatTrainer.register_plugin(second)
+
+      expect(CombatTrainer.registered_plugins).to eq([first, second])
+    end
+  end
+
+  describe '.fire_hook (decision dispatch)' do
+    it 'returns nil when no plugins are registered' do
+      expect(CombatTrainer.fire_hook(:warhorn_cooldown_active?, room_id: 5)).to be_nil
+    end
+
+    it 'returns nil when registered plugins do not implement the hook' do
+      CombatTrainer.register_plugin(InertPlugin.new)
+
+      expect(CombatTrainer.fire_hook(:warhorn_cooldown_active?, room_id: 5)).to be_nil
+    end
+
+    it 'returns the first non-nil result and stops polling later plugins' do
+      first = RecordingPlugin.new(return_value: nil)
+      second = RecordingPlugin.new(return_value: true)
+      third = RecordingPlugin.new(return_value: false)
+      [first, second, third].each { |plugin| CombatTrainer.register_plugin(plugin) }
+
+      result = CombatTrainer.fire_hook(:warhorn_cooldown_active?, room_id: 7)
+
+      expect(result).to eq(true)
+      expect(third.calls).to be_empty
+    end
+
+    it 'treats a false return as a real answer (does not fall through)' do
+      answering = RecordingPlugin.new(return_value: false)
+      later = RecordingPlugin.new(return_value: true)
+      CombatTrainer.register_plugin(answering)
+      CombatTrainer.register_plugin(later)
+
+      expect(CombatTrainer.fire_hook(:warhorn_cooldown_active?, room_id: 1)).to eq(false)
+      expect(later.calls).to be_empty
+    end
+
+    it 'skips a plugin that raises and uses the next plugin answer' do
+      responder = RecordingPlugin.new(return_value: true)
+      CombatTrainer.register_plugin(ExplodingPlugin.new)
+      CombatTrainer.register_plugin(responder)
+
+      result = nil
+      expect { result = CombatTrainer.fire_hook(:warhorn_cooldown_active?, room_id: 9) }.not_to raise_error
+      expect(result).to eq(true)
+    end
+
+    it 'echoes the plugin error under $debug_mode_ct' do
+      $debug_mode_ct = true
+      CombatTrainer.register_plugin(ExplodingPlugin.new)
+
+      CombatTrainer.fire_hook(:warhorn_cooldown_active?, room_id: 9)
+
+      expect(displayed_messages).to include(a_string_matching(/ExplodingPlugin error in warhorn_cooldown_active\?/))
+    end
+
+    it 'forwards positional and keyword arguments to the hook' do
+      plugin = RecordingPlugin.new(return_value: :done)
+      CombatTrainer.register_plugin(plugin)
+      state = Object.new
+
+      CombatTrainer.fire_hook(:combat_tick, :trainer, state, counter: 42)
+
+      expect(plugin.calls).to eq([[:combat_tick, [:trainer, state], { counter: 42 }]])
+    end
+  end
+
+  describe '.notify_hook (notification dispatch)' do
+    it 'always returns nil, even when a plugin returns a value' do
+      CombatTrainer.register_plugin(RecordingPlugin.new(return_value: :ignored))
+
+      expect(CombatTrainer.notify_hook(:warhorn_applied, room_id: 1, type: 'egg')).to be_nil
+    end
+
+    it 'invokes every plugin that implements the hook, not just the first' do
+      first = RecordingPlugin.new
+      second = RecordingPlugin.new
+      CombatTrainer.register_plugin(first)
+      CombatTrainer.register_plugin(second)
+
+      CombatTrainer.notify_hook(:warhorn_applied, room_id: 3, type: 'warhorn')
+
+      expect(first.calls).to eq([[:warhorn_applied, { room_id: 3, type: 'warhorn' }]])
+      expect(second.calls).to eq([[:warhorn_applied, { room_id: 3, type: 'warhorn' }]])
+    end
+
+    it 'continues notifying the remaining plugins after one raises' do
+      survivor = RecordingPlugin.new
+      CombatTrainer.register_plugin(ExplodingPlugin.new)
+      CombatTrainer.register_plugin(survivor)
+
+      expect { CombatTrainer.notify_hook(:warhorn_applied, room_id: 4, type: 'egg') }.not_to raise_error
+      expect(survivor.calls).to eq([[:warhorn_applied, { room_id: 4, type: 'egg' }]])
+    end
+
+    it 'skips plugins that do not implement the hook' do
+      CombatTrainer.register_plugin(InertPlugin.new)
+
+      expect { CombatTrainer.notify_hook(:warhorn_applied, room_id: 4, type: 'egg') }.not_to raise_error
+    end
+  end
+
+  describe 'method_missing forwarding' do
+    it 'forwards an unknown call to the first plugin that responds' do
+      trainer = CombatTrainer.allocate
+      plugin = RecordingPlugin.new
+      CombatTrainer.register_plugin(plugin)
+
+      expect(trainer.custom_command('x')).to eq('handled:x')
+      expect(plugin.calls).to eq([[:custom_command, ['x']]])
+    end
+
+    it 'reports respond_to? true when a plugin implements the method' do
+      trainer = CombatTrainer.allocate
+      CombatTrainer.register_plugin(RecordingPlugin.new)
+
+      expect(trainer.respond_to?(:custom_command)).to be(true)
+    end
+
+    it 'raises NoMethodError when no registered plugin can handle the call' do
+      trainer = CombatTrainer.allocate
+      CombatTrainer.register_plugin(InertPlugin.new)
+
+      expect { trainer.totally_unknown_method }.to raise_error(NoMethodError)
+    end
+  end
+end
+
+# ===========================================================================
+# AbilityProcess room-effect (warhorn/egg) cooldown seam
+# ===========================================================================
+RSpec.describe 'AbilityProcess room-effect cooldown seam' do
+  before(:each) do
+    CombatTrainer.registered_plugins.clear
+    allow(DRC).to receive(:message)
+    allow(Room).to receive(:current).and_return(double('room', id: 4242))
+  end
+
+  after(:each) do
+    CombatTrainer.registered_plugins.clear
+  end
+
+  describe '#room_effect_on_cooldown?' do
+    context 'with no plugin registered (built-in per-character timer)' do
+      it 'is on cooldown when the last use was under 600s ago' do
+        instance = build_ability_process
+        UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now - 599 }
+
+        expect(instance.send(:room_effect_on_cooldown?, 4242)).to be(true)
+      end
+
+      it 'is off cooldown when the last use was over 600s ago' do
+        instance = build_ability_process
+        UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now - 601 }
+
+        expect(instance.send(:room_effect_on_cooldown?, 4242)).to be(false)
+      end
+
+      it 'treats exactly 600s since last use as still on cooldown (boundary)' do
+        instance = build_ability_process
+        # Freeze the clock so the boundary is exact; with a live clock the check
+        # instant drifts microseconds past 600s and the case is unobservable.
+        frozen = Time.now
+        allow(Time).to receive(:now).and_return(frozen)
+        UserVars.warhorn = { 'last_warhorn_or_egg' => frozen - 600 }
+
+        expect(instance.send(:room_effect_on_cooldown?, 4242)).to be(true)
+      end
+    end
+
+    context 'with a plugin answering the decision hook' do
+      it 'uses the plugin true answer and never consults the built-in timer' do
+        instance = build_ability_process
+        CombatTrainer.register_plugin(RecordingPlugin.new(return_value: true))
+        # UserVars.warhorn is intentionally left unset; if the built-in branch
+        # ran it would raise on nil, proving the plugin short-circuits it.
+
+        expect(instance.send(:room_effect_on_cooldown?, 4242)).to be(true)
+      end
+
+      it 'uses the plugin false answer even when the built-in timer would block' do
+        instance = build_ability_process
+        UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now }
+        CombatTrainer.register_plugin(RecordingPlugin.new(return_value: false))
+
+        expect(instance.send(:room_effect_on_cooldown?, 4242)).to be(false)
+      end
+
+      it 'falls back to the built-in timer when the plugin returns nil' do
+        instance = build_ability_process
+        UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now - 601 }
+        CombatTrainer.register_plugin(RecordingPlugin.new(return_value: nil))
+
+        expect(instance.send(:room_effect_on_cooldown?, 4242)).to be(false)
+      end
+
+      it 'forwards the current room id to the plugin as a keyword' do
+        instance = build_ability_process
+        plugin = RecordingPlugin.new(return_value: true)
+        CombatTrainer.register_plugin(plugin)
+
+        instance.send(:room_effect_on_cooldown?, 4242)
+
+        expect(plugin.calls).to eq([[:warhorn_cooldown_active?, { room_id: 4242 }]])
+      end
+    end
+  end
+
+  describe '#record_room_effect' do
+    it 'refreshes the built-in per-character timer to now' do
+      instance = build_ability_process
+      UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now - 5000 }
+
+      instance.send(:record_room_effect, 4242, 'egg')
+
+      expect(UserVars.warhorn['last_warhorn_or_egg']).to be_within(2).of(Time.now)
+    end
+
+    it 'notifies plugins of the application with room id and type' do
+      instance = build_ability_process
+      UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now }
+      plugin = RecordingPlugin.new
+      CombatTrainer.register_plugin(plugin)
+
+      instance.send(:record_room_effect, 4242, 'warhorn')
+
+      expect(plugin.calls).to eq([[:warhorn_applied, { room_id: 4242, type: 'warhorn' }]])
+    end
+  end
+
+  describe '#use_warhorn_or_egg' do
+    it 'skips use and does not rotate when the room effect is on cooldown' do
+      instance = build_ability_process(warhorn_or_egg: %w[egg warhorn])
+      UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now }
+
+      expect(instance).not_to receive(:use_egg?)
+
+      instance.send(:use_warhorn_or_egg, build_game_state)
+
+      expect(instance.instance_variable_get(:@warhorn_or_egg)).to eq(%w[egg warhorn])
+    end
+
+    it 'applies an egg, records the effect, and rotates on success' do
+      instance = build_ability_process(warhorn_or_egg: %w[egg warhorn])
+      UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now - 601 }
+      allow(instance).to receive(:use_egg?).and_return(true)
+      plugin = RecordingPlugin.new
+      CombatTrainer.register_plugin(plugin)
+
+      instance.send(:use_warhorn_or_egg, build_game_state)
+
+      expect(instance.instance_variable_get(:@warhorn_or_egg)).to eq(%w[warhorn egg])
+      # The plugin is also polled for the cooldown decision (it defers with nil);
+      # what matters here is that the successful application was recorded.
+      expect(plugin.calls).to include([:warhorn_applied, { room_id: 4242, type: 'egg' }])
+    end
+
+    it 'rotates without recording the effect when application fails' do
+      instance = build_ability_process(warhorn_or_egg: %w[egg warhorn])
+      UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now - 601 }
+      allow(instance).to receive(:use_egg?).and_return(false)
+      plugin = RecordingPlugin.new
+      CombatTrainer.register_plugin(plugin)
+
+      instance.send(:use_warhorn_or_egg, build_game_state)
+
+      expect(instance.instance_variable_get(:@warhorn_or_egg)).to eq(%w[warhorn egg])
+      expect(plugin.calls.select { |call| call.first == :warhorn_applied }).to be_empty
+    end
+
+    it 'routes a warhorn rotation entry through use_warhorn?' do
+      instance = build_ability_process(warhorn_or_egg: %w[warhorn egg])
+      UserVars.warhorn = { 'last_warhorn_or_egg' => Time.now - 601 }
+      game_state = build_game_state
+      allow(instance).to receive(:use_warhorn?).with(game_state).and_return(true)
+
+      instance.send(:use_warhorn_or_egg, game_state)
+
+      expect(instance).to have_received(:use_warhorn?).with(game_state)
+      expect(instance.instance_variable_get(:@warhorn_or_egg)).to eq(%w[egg warhorn])
+    end
   end
 end

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -4435,6 +4435,9 @@ end
 RSpec.describe 'AbilityProcess room-effect cooldown seam' do
   before(:each) do
     CombatTrainer.registered_plugins.clear
+    # UserVars is shared across examples; reset it so each example starts from a
+    # known state and the built-in-timer branch is exercised only when set.
+    UserVars.warhorn = nil
     allow(DRC).to receive(:message)
     allow(Room).to receive(:current).and_return(double('room', id: 4242))
   end
@@ -4475,8 +4478,9 @@ RSpec.describe 'AbilityProcess room-effect cooldown seam' do
       it 'uses the plugin true answer and never consults the built-in timer' do
         instance = build_ability_process
         CombatTrainer.register_plugin(RecordingPlugin.new(return_value: true))
-        # UserVars.warhorn is intentionally left unset; if the built-in branch
-        # ran it would raise on nil, proving the plugin short-circuits it.
+        # UserVars.warhorn is nil here (reset in before(:each)); if the built-in
+        # branch ran it would raise on nil, proving the plugin short-circuits it.
+        UserVars.warhorn = nil
 
         expect(instance.send(:room_effect_on_cooldown?, 4242)).to be(true)
       end


### PR DESCRIPTION
## Summary

Adds a generic, vendor-neutral **plugin system** to `combat-trainer.lic`, mirroring the proven architecture already shipping in `hunting-buddy.lic`, and refactors the warhorn/egg room-effect cooldown into an overridable **seam** that a plugin can drive.

With **zero plugins registered, behavior is identical to today** - every hook is a no-op and the horn/egg gate falls back to the existing `UserVars.warhorn["last_warhorn_or_egg"]` 600s timer.

## Motivation

The warhorn/egg "room effect" cooldown is currently a per-character global timer. That timer cannot coordinate across characters or distinguish rooms, so a group re-applies the effect to rooms that already have it, wasting horn/egg cooldowns. Rather than bake any specific coordination mechanism into the upstream script, this exposes a clean seam so a **personal** plugin (e.g. a shared external store) can answer the cooldown question, while the built-in timer remains the default.

## What's added

**Dispatch infrastructure on `CombatTrainer`** (mirrors `hunting-buddy.lic`):
- class-level `@registered_plugins`, `register_plugin`
- **class methods** `fire_hook` (returns first non-nil result; rescues per-plugin, echoes under `$debug_mode_ct`) and `notify_hook` (fire-and-forget to all plugins) - class-level so the decoupled `*Process` classes can dispatch
- instance `method_missing` / `respond_to_missing?` forwarding to plugins (parity with hunting-buddy)
- a `Dir.glob(custom/combat-trainer-plugin-*.rb)` loader run before boot

**Lifecycle / combat hooks fired by the orchestrator:**
- `after_initialize(trainer)`
- `before_combat(trainer, game_state)`
- `combat_tick(trainer, game_state, counter:)` - decision hook; a plugin returning `:break` stops the loop
- `after_combat(trainer, game_state)`
- `cleanup(trainer)` - fired in the `before_dying` block, guarded

**Warhorn/egg cooldown seam** in `AbilityProcess`:
- `room_effect_on_cooldown?(room_id)` fires `:warhorn_cooldown_active?(room_id:)`; a `nil` return means "no plugin decided" -> fall back to the historical per-character 600s timer
- `record_room_effect(room_id, type)` keeps the built-in `UserVars` timer warm **and** fires `:warhorn_applied(room_id:, type:)` so external stores stay in sync

The per-**item** recharge cooldown (900s eggs / horn cooldown) is intentionally untouched - it models physical item recharge, independent of the room effect.

## Tests

35 new adversarial specs in `spec/combat_trainer_spec.rb` covering registry accumulation, first-non-nil / all-notify dispatch semantics, `false`-is-a-real-answer, per-plugin error isolation, `$debug_mode_ct` echo, arg forwarding, `method_missing` routing, and the full horn seam (built-in timer boundary at exactly 600s, plugin override wins, `nil` falls back, room-id forwarding, and `use_warhorn_or_egg` rotation/record behavior).

`RBENV_VERSION=4.0.1 rspec spec/combat_trainer_spec.rb` -> **323 examples, 0 failures**. Rubocop clean on both touched files.