### PR TITLE
smelt: fall back to a default stirring rod when forging_tools lists none

### DIFF
--- a/smelt.lic
+++ b/smelt.lic
@@ -18,6 +18,10 @@ class Smelt
     @bag_items = settings.crafting_items_in_container
     @belt = settings.forging_belt
     @rod = settings.forging_tools.find { |item| /rod/ =~ item }
+    unless @rod
+      DRC.message('*** No stirring rod in your forging_tools setting; assuming "stirring rod". Add it to your YAML to silence this. ***')
+      @rod = 'stirring rod'
+    end
     DRCI.stow_hands
     if settings.adjustable_tongs
       adjustable_tongs = DRCC.get_adjust_tongs?('reset shovel', @bag, @bag_items, @belt)


### PR DESCRIPTION
## Problem

`smelt.lic` picks the stirring rod out of the `forging_tools` YAML setting:

```ruby
@rod = settings.forging_tools.find { |item| /rod/ =~ item }
```

If no entry matches `/rod/`, `@rod` is `nil` and the failure is silent. Every command that interpolates it loses the tool name, so `swap_tool` stows the rod and then asks for nothing:

```
[smelt]>put my stirring rod in my canvas backpack
You put your rod in your canvas backpack.
[smelt]>get my  from my canvas backpack
Please rephrase that command.
DRC: No match was found after 15 seconds for command 'get my  from my canvas backpack'
```

The script stalls there rather than smelting.

This is easy to hit: `profiles/base.yaml` ships a `forging_tools` list with no stirring rod in it, so any character inheriting the base list is affected even though they own a rod. The first `stir crucible with my rod` on line 31 uses a hardcoded literal, which masks the problem until the loop falls through to the `else` branch and interpolates `@rod`.

## Fix

Warn once and default to `"stirring rod"` when `forging_tools` has no rod entry. Character YAML that already lists a rod is unaffected.

## Test plan

- [x] `rubocop smelt.lic` — clean
- [x] `ruby -c smelt.lic` — Syntax OK
- [x] Run `,smelt` with a `forging_tools` list containing no rod: message is emitted, rod is retrieved, smelting proceeds
- [x] Run `,smelt` with `stirring rod` present in `forging_tools`: no message, behaviour unchanged