### PR TITLE
(scripts)[moonwatch]: emit moonWindow stream atomically to stop text leaking

### DIFF
--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -2232,26 +2232,60 @@ class MoonwatchUI
 
   # Update the moon status window if enabled.
   #
-  # @return [void]
+  # Repaints the +moonWindow+ side stream with the current three-moon summary,
+  # skipping the write when the content is unchanged within
+  # {WINDOW_REFRESH_INTERVAL} (see {#window_content_fresh?}).
   #
+  # The stream open, its content, and the stream close are emitted as a
+  # *single* +_respond+ so the frontend receives them on one indivisible line.
+  # Because +update_window+ runs on moonwatch's timer thread while the game's
+  # own output is written by another thread, splitting the open and close
+  # across separate +_respond+ calls opens a race: a line-based frontend such
+  # as ProfanityFE keeps a single "current stream" pointer, so any game line
+  # that arrives between a bare +<pushStream id="moonWindow"/>+ and a later
+  # bare +<popStream/>+ is captured into the moon window and left stranded
+  # there until the next refresh. Keeping push/content/pop atomic closes that
+  # window entirely. See {#moon_stream_message} for the emitted payload.
+  #
+  # @return [void]
   def update_window
     return unless @window_enabled
 
-    new_message = [
-      UserVars.moons['katamba']['short'],
-      UserVars.moons['yavash']['short'],
-      UserVars.moons['xibar']['short']
-    ].join(' ')
-
-    if @window_cache == new_message && Time.now - @last_window_refresh < WINDOW_REFRESH_INTERVAL
-      return
-    end
+    new_message = moon_stream_summary
+    return unless window_content_fresh?(new_message)
 
     @window_cache = new_message
     @last_window_refresh = Time.now
     _respond('<clearStream id="moonWindow"/>')
-    _respond("<pushStream id=\"moonWindow\"/>#{new_message}")
-    _respond('<popStream/>')
+    _respond(moon_stream_message(new_message))
+  end
+
+  # Build the space-joined short-form summary for the three tracked moons.
+  #
+  # @return [String] e.g. +"Katamba full Yavash rising Xibar set"+
+  def moon_stream_summary
+    %w[katamba yavash xibar].map { |moon| UserVars.moons[moon]['short'] }.join(' ')
+  end
+
+  # Wrap the moon summary in a self-contained +moonWindow+ stream payload.
+  #
+  # Open tag, content, and close tag are concatenated so a single +_respond+
+  # delivers them atomically and no foreign line can be routed into the moon
+  # window mid-update. See {#update_window} for the race this prevents.
+  #
+  # @param message [String] the moon summary to display
+  # @return [String] one-line +<pushStream .../>...<popStream/>+ payload
+  def moon_stream_message(message)
+    "<pushStream id=\"moonWindow\"/>#{message}<popStream/>"
+  end
+
+  # Whether the given content should be repainted now, i.e. it differs from the
+  # cached content or the refresh interval has elapsed since the last paint.
+  #
+  # @param message [String] the candidate moon summary
+  # @return [Boolean] true when a repaint is warranted
+  def window_content_fresh?(message)
+    @window_cache != message || Time.now - @last_window_refresh >= WINDOW_REFRESH_INTERVAL
   end
 
   # Log initial status for debug mode.

--- a/spec/moonwatch_spec.rb
+++ b/spec/moonwatch_spec.rb
@@ -1049,6 +1049,92 @@ RSpec.describe 'moonwatch.lic' do
       end
     end
 
+    # Regression guard for the moon-window text-leak bug. update_window runs on
+    # moonwatch's timer thread while game output is written by another thread.
+    # If the stream open and close ship as separate _respond lines, a game line
+    # can land between them and a line-based frontend (e.g. ProfanityFE) routes
+    # it into the moon window, where it stays stranded until the next refresh.
+    # The open, content, and close must therefore travel as one atomic message.
+    describe '#update_window (atomic moon stream)' do
+      let(:ui) do
+        instance = described_class.new(window_enabled: true)
+        instance.update_moon_vars(offset_manager, now)
+        $respond_messages.clear
+        instance
+      end
+
+      it 'emits the pushStream and popStream tags in one indivisible message' do
+        ui.update_window
+        atomic = $respond_messages.find { |m| m.include?('<pushStream id="moonWindow"/>') }
+        expect(atomic).to include('<popStream/>')
+      end
+
+      it 'never emits a bare popStream on a line by itself' do
+        ui.update_window
+        expect($respond_messages).not_to include('<popStream/>')
+      end
+
+      it 'wraps the moon content between the open and close tags of that message' do
+        ui.update_window
+        atomic = $respond_messages.find { |m| m.start_with?('<pushStream id="moonWindow"/>') }
+        expect(atomic).to match(%r{\A<pushStream id="moonWindow"/>.+<popStream/>\z})
+      end
+
+      it 'still clears the stream before repainting it' do
+        ui.update_window
+        expect($respond_messages).to include('<clearStream id="moonWindow"/>')
+      end
+    end
+
+    describe '#moon_stream_message' do
+      let(:ui) { described_class.new(window_enabled: false) }
+
+      it 'returns a self-contained push/content/pop payload' do
+        expect(ui.moon_stream_message('Katamba full')).to eq(
+          '<pushStream id="moonWindow"/>Katamba full<popStream/>'
+        )
+      end
+
+      it 'keeps the opening and closing tags in the same string for any content' do
+        payload = ui.moon_stream_message('anything at all')
+        expect(payload).to start_with('<pushStream id="moonWindow"/>')
+        expect(payload).to end_with('<popStream/>')
+      end
+    end
+
+    describe '#moon_stream_summary' do
+      it 'joins the three moon short forms in katamba, yavash, xibar order' do
+        @moons['katamba']['short'] = 'K-short'
+        @moons['yavash']['short']  = 'Y-short'
+        @moons['xibar']['short']   = 'X-short'
+        ui = described_class.new(window_enabled: false)
+        expect(ui.moon_stream_summary).to eq('K-short Y-short X-short')
+      end
+    end
+
+    describe '#window_content_fresh?' do
+      let(:ui) { described_class.new(window_enabled: false) }
+
+      it 'is fresh when the content differs from the cached content' do
+        ui.instance_variable_set(:@window_cache, 'old summary')
+        ui.instance_variable_set(:@last_window_refresh, Time.now)
+        expect(ui.window_content_fresh?('new summary')).to be true
+      end
+
+      it 'is stale when the content matches the cache within the refresh interval' do
+        ui.instance_variable_set(:@window_cache, 'same summary')
+        ui.instance_variable_set(:@last_window_refresh, Time.now)
+        expect(ui.window_content_fresh?('same summary')).to be false
+      end
+
+      it 'is fresh again once the refresh interval has elapsed' do
+        ui.instance_variable_set(:@window_cache, 'same summary')
+        stale_at = Time.now - MoonwatchUI::WINDOW_REFRESH_INTERVAL - 1
+        ui.instance_variable_set(:@last_window_refresh, stale_at)
+        expect(ui.window_content_fresh?('same summary')).to be true
+      end
+    end
+
     describe '#log_initial_status' do
       it 'emits nothing when debug is off' do
         ui = described_class.new(window_enabled: false)


### PR DESCRIPTION
update_window runs on moonwatch's timer thread while the game's own output is written by another thread. Emitting the moon stream as three separate _respond calls (clearStream, pushStream+content, popStream) left
a race: any game line arriving between the bare <pushStream id="moonWindow"/>
and the later bare <popStream/> is captured by line-based frontends (e.g. ProfanityFE, which tracks a single current stream) and stranded in the moon window until the next refresh a minute later.

Emit the open tag, content, and close tag in a single _respond so they travel as one indivisible line and nothing can interleave. Extract moon_stream_summary / moon_stream_message / window_content_fresh? for clarity and unit testing, with full YARD.