### PR TITLE
Add auto-update instructions to dependency.lic version warning

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -30,6 +30,9 @@ unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new($MIN_LICH_VERSION)
     _respond("<pushBold/>* #{"Lich versions prior to #{$MIN_LICH_VERSION} are no longer supported.".ljust(103)} *<popBold/>")
     _respond("<pushBold/>* #{"See https://github.com/elanthia-online/lich-5/wiki/Documentation-for-Installing-and-Upgrading-Lich".ljust(103)} *<popBold/>")
     _respond("<pushBold/>* #{"For update instructions.".ljust(103)} *<popBold/>")
+    if LICH_VERSION.start_with?('5')
+      _respond("<pushBold/>* #{"Or to automatically update, run '#{$clean_lich_char}lich5-update --update'.".ljust(103)} *<popBold/>")
+    end
     _respond("<pushBold/>* #{"Exiting Dependency now. Nothing much will work from here...".ljust(103)} *<popBold/>")
     _respond("<pushBold/>#{border}<popBold/>")
     pause 10


### PR DESCRIPTION
The version warning in dependency.lic doesn't include the most straightforward way to fix the problem, which is to use Lich 5's auto-updater. Lich itself shows the auto-update instructions right at login, but by the time dependency.lic's warnings are being sent, that's usually off-screen and the user needs to know where to look for it.

This PR simply adds the Lich 5 auto-updater instructions to the version warning in dependency.lic.