### PR TITLE
tendme: fix lift? being called without the item that was lowered

### DIFF
--- a/spec/tendme_spec.rb
+++ b/spec/tendme_spec.rb
@@ -125,4 +125,37 @@ RSpec.describe TendMe do
       expect(DRC).to have_received(:bput).with('tend Muleoak chest', any_args).twice
     end
   end
+
+  describe '#bind_open_wounds?' do
+    subject(:tend_me) { TendMe.allocate }
+
+    def tendme_health_result(overrides = {})
+      { 'lodged' => {}, 'parasites' => {}, 'bleeders' => {} }.merge(overrides)
+    end
+
+    before(:each) do
+      reset_data
+      allow(DRCH).to receive(:check_health).and_return(tendme_health_result)
+    end
+
+    it 'lifts the item back up after lowering it to free a hand for binding' do
+      $left_hand = 'broadsword'
+      $right_hand = 'buckler'
+      allow(DRCI).to receive(:lower_item?).and_return(true)
+
+      expect(DRCI).to receive(:lift?).with('broadsword')
+
+      tend_me.bind_open_wounds?
+    end
+
+    it 'does not lower or lift anything when a hand is free' do
+      $left_hand = 'broadsword'
+      $right_hand = nil
+
+      expect(DRCI).not_to receive(:lower_item?)
+      expect(DRCI).not_to receive(:lift?)
+
+      tend_me.bind_open_wounds?
+    end
+  end
 end

--- a/tendme.lic
+++ b/tendme.lic
@@ -17,14 +17,16 @@ class TendMe
 
   def bind_open_wounds?
     lowered = false
+    lowered_item = nil
     # Pause scripts to prevent interference
     until (scripts_to_unpause = DRC.safe_pause_list)
       echo("Cannot pause, trying again in 30 seconds.")
       pause 30
     end
 
-    if checkleft && checkright && DRCI.lower_item?(DRC.left_hand)
-      lowered = true
+    if checkleft && checkright
+      lowered_item = DRC.left_hand
+      lowered = DRCI.lower_item?(lowered_item)
     end
 
     tended_wounds = false
@@ -39,7 +41,7 @@ class TendMe
       .map { |wound| wound.body_part }
       .uniq
       .each { |body_part| tended_wounds = tend_wound_safely(body_part) || tended_wounds }
-    DRCI.lift? if lowered
+    DRCI.lift?(lowered_item) if lowered
     DRC.safe_unpause_list(scripts_to_unpause)
     return tended_wounds
   end

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -972,6 +972,20 @@ module Harness
     $right_hand
   end
 
+  def checkleft(*hand)
+    return nil if $left_hand.nil?
+
+    hand.flatten!
+    hand.empty? ? $left_hand : hand.find { |instance| $left_hand =~ /#{instance}/i }
+  end
+
+  def checkright(*hand)
+    return nil if $right_hand.nil?
+
+    hand.flatten!
+    hand.empty? ? $right_hand : hand.find { |instance| $right_hand =~ /#{instance}/i }
+  end
+
   def waitrt?; end
 
   def waitcastrt?; end
@@ -1164,6 +1178,8 @@ module Harness
       def retreat(*_args); end
       def rummage(*_args); end
       def log_window(*_args); end
+      def safe_pause_list(*_args); []; end
+      def safe_unpause_list(*_args); end
     end
   end
 


### PR DESCRIPTION
## Summary
- `bind_open_wounds?` lowered an item to free a hand for binding, but the final `DRCI.lift?` call took no argument, relying on whatever the game considers "the" lowered item rather than the specific one that was set down. Track `lowered_item` and pass it through explicitly.

## Test plan
- [x] `rspec spec/tendme_spec.rb` passes (15 examples, 0 failures)
- [x] `ruby -c tendme.lic` syntax check clean