### PR TITLE
[data][spells]add expire match for Dragon's Breath

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -3447,6 +3447,7 @@ spell_data:
     guild: Warrior Mage
     mana_type: elemental
     prep: prepare # This is a buff that trains TM, you 'spit' to use it
+    expire: Your throat contracts suddenly, growing cooler as your Dragon's Breath spell dissipates. # for combat-trainer rebuffing when consumed
   Electric Charge:
     skill: cantrip
     abbrev: C E C


### PR DESCRIPTION
Combat-trainer is not handling Dragon's Breath correctly as a buff without the expire message.