### PR TITLE
Backwards compatibility

### DIFF
--- a/carve.lic
+++ b/carve.lic
@@ -35,9 +35,9 @@ class Carve
     @training_spells = @settings.crafting_training_spells
 
     @main_tool = if @type == 'stack' || @type == 'bone'
-                   @settings.engineering_tools.find { |item| /\bsaw/i =~ item }
+                   (@settings.engineering_tools || @settings.carving_tools).find { |item| /\bsaw/i =~ item }
                  else
-                   @settings.engineering_tools.find { |item| /\bchisel/i =~ item }
+                   (@settings.engineering_tools || @settings.carving_tools).find { |item| /\bchisel/i =~ item }
                  end
 
     DRC.wait_for_script_to_complete('buff', ['carve'])

--- a/clerk-tools.lic
+++ b/clerk-tools.lic
@@ -39,7 +39,7 @@ class Clerk
       area = settings.custom_clerk_tools[custom_toolset][:area]
       @belt = nil
     elsif args.toolset == 'engineering'
-      tools = settings.engineering_tools
+      tools = settings.engineering_tools || settings.shaping_tools
       area = 'shaping'
       @belt = settings.engineering_belt
     elsif args.toolset == 'outfitting'


### PR DESCRIPTION
Adding backwards compatibility with clerk-tools and carve.
This should mimic the previous versions while adding in ability to use engineering_tools