### PR TITLE
Tinker workorder update and Bugfixes

### DIFF
--- a/tinker.lic
+++ b/tinker.lic
@@ -232,7 +232,12 @@ class Tinker
         waitrt?
         tool = 'stain'
         command = "apply my stain to my #{@noun}"
-      when /mechanisms must be affixed/, /pulling them into place/
+      when /mechanisms must be affixed/
+        waitrt?
+        assemble_part
+        tool = 'pliers'
+        command = "pull my #{@noun} with my pliers"
+      when /pulling them into place/
         tool = 'pliers'
         command = "pull my #{@noun} with my pliers"
       when /while it is inside of something/, /You fumble around but/

--- a/workorders.lic
+++ b/workorders.lic
@@ -915,7 +915,7 @@ class WorkOrders
       DRCC.stow_crafting_item("#{materials_info['stock-name']} lumber", @bag, @belt)
 
       DRCC.find_shaping_room(@hometown, @engineering_room)
-      DRC.wait_for_script_to_complete('cm_tinker', [recipe['chapter'], recipe['name'], materials_info['stock-name'], recipe['noun']])
+      DRC.wait_for_script_to_complete('tinker', [recipe['chapter'], recipe['name'], materials_info['stock-name'], recipe['noun']])
       bundle_item(recipe['noun'], info['logbook'])
     end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -898,6 +898,11 @@ class WorkOrders
           buy_mechanism_ingots(mechanism_ingot, num_presses)
           DRCC.create_mechanisms(@settings, mechanism_ingot, num_presses, mechanism_press_speed)
           consolidate_mechanisms(mech_name)
+          actual = count_mechanisms
+          if actual < mechanisms_needed
+            Lich::Messaging.msg('bold', "WorkOrders: Only #{actual} #{mechanism_ingot} mechanisms available, need #{mechanisms_needed}. Stopping. Automated buying is only done with bronze.")
+            exit
+          end
         end
       end
     end
@@ -931,7 +936,21 @@ class WorkOrders
               twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen]
     tens = { 'twenty' => 20, 'thirty' => 30, 'forty' => 40, 'fifty' => 50,
              'sixty' => 60, 'seventy' => 70, 'eighty' => 80, 'ninety' => 90 }
-    str.downcase.gsub('-', ' ').split.sum { |w| ones.index(w) || tens[w] || 0 }
+    total = 0
+    current = 0
+    str.downcase.gsub('-', ' ').split.each do |w|
+      if w == 'hundred'
+        current *= 100
+      elsif w == 'thousand'
+        total += current * 1000
+        current = 0
+      elsif (v = ones.index(w))
+        current += v
+      elsif (v = tens[w])
+        current += v
+      end
+    end
+    total + current
   end
 
   def buy_mechanism_ingots(material, count)


### PR DESCRIPTION
Workorders calls the right script instead of looking for a custom script.

Workorders actually stops when failing to find an ingot that you've requested. Instead of DRCC.create_mechanisms exiting and falling back to the script which would still run.

Workorders can now count > 99. Count on mechanisms isn't a numerical output, and I never had mechanisms in the hundreds.

Tinker mechanism assemble update.

Big thanks to Honeyrider for testing with me!