### PR TITLE
[script][sell-loot] - Updated so if town specified it does banking in…

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -123,7 +123,7 @@ class SellLoot
     if @bankbot_enabled
       give_money_to_bankbot(@local_currency, @bankbot_deposit_threshold)
     else
-      DRCM.deposit_coins(keep_coppers_bank, @settings)
+      DRCM.deposit_coins(keep_coppers_bank, @settings, @character_hometown)
     end
   end
 


### PR DESCRIPTION
… that town

Current behavior:
If you specify a town that's not your hometown:
It sells gems, bundles, etc, then goes to your hometown to exchange and deposit.

Updated behavior:
If you specify a town that's not your hometown, it uses the bank in that town as well.