### PR TITLE
dependency: require lich 5.20.0 minimum

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -19,9 +19,9 @@
   and deleted before it duplicates work core now performs.
 =end
 
-$DEPENDENCY_VERSION = '4.2.1'
+$DEPENDENCY_VERSION = '4.2.2'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/f8ne99pVva'
-$MIN_LICH_VERSION = '5.19.1'
+$MIN_LICH_VERSION = '5.20.0'
 
 unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new($MIN_LICH_VERSION)
   10.times do


### PR DESCRIPTION
## Problem

`$MIN_LICH_VERSION` was pinned at `5.19.1`, allowing older core lich installs that lack current native functionality.

## Fix

- Raise `$MIN_LICH_VERSION` to `5.20.0`.
- Tick `$DEPENDENCY_VERSION` to `4.2.2`.

## Tests

No behavioral change beyond the version constants; per maintainer direction, no specs added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)