### PR TITLE
Fix empathylink pause deadlock that could freeze the character

### DIFF
--- a/empathylink.lic
+++ b/empathylink.lic
@@ -47,25 +47,40 @@ class Empathylink
   end
 
   def touch(target)
-    p_script
-    waitrt?
-    case DRC.bput("touch #{target}",
-                  "You touch",
-                  "You lay your hand on",
-                  "Touch what",
-                  "I could not find",
-                  "You rest your hand on")
-    when 'You touch', 'You lay your hand on', 'You rest your hand on'
-      if @use_hodierna == true
-        hodierna_heal_patient(target)
-      else
-        heal_patient(target)
-      end
-    when 'Touch what', 'I could not find'
-      DRC.message("Failed to establish link with #{target}")
-      UserVars.empathylink[target] = Time.now.to_i + 1800 # Put them on hold for 30m
+    # Pause other scripts through the shared safe-pause lock ($safe_pause_lock)
+    # so a combat script cannot pause us mid-heal while we have it paused. The
+    # old approach called pause_script('combat-trainer') directly, outside that
+    # lock: if combat-trainer's own safe_pause_list paused empathylink between
+    # p_script and u_script, each ended up pausing the other and neither could
+    # unpause, deadlocking every script and freezing the character. safe_pause_list
+    # makes the two pause requests mutually exclusive, and the ensure guarantees
+    # the unpause (and lock release) even if a heal command raises.
+    until (scripts_to_unpause = DRC.safe_pause_list)
+      echo('Cannot pause, trying again in 5 seconds.')
+      pause 5
     end
-    u_script
+
+    begin
+      waitrt?
+      case DRC.bput("touch #{target}",
+                    "You touch",
+                    "You lay your hand on",
+                    "Touch what",
+                    "I could not find",
+                    "You rest your hand on")
+      when 'You touch', 'You lay your hand on', 'You rest your hand on'
+        if @use_hodierna == true
+          hodierna_heal_patient(target)
+        else
+          heal_patient(target)
+        end
+      when 'Touch what', 'I could not find'
+        DRC.message("Failed to establish link with #{target}")
+        UserVars.empathylink[target] = Time.now.to_i + 1800 # Put them on hold for 30m
+      end
+    ensure
+      DRC.safe_unpause_list(scripts_to_unpause)
+    end
   end
 
   def hodierna_heal_patient(target)
@@ -93,7 +108,6 @@ class Empathylink
       DRC.message("Failing to establish Link Persistent with #{target}")
       UserVars.empathylink[target] = Time.now.to_i + 300 # Put them on hold for 5m
     end
-    # u_script
   end
 
   def heal_patient(target)
@@ -115,15 +129,6 @@ class Empathylink
       DRC.message("Failed to establish healing with #{target}")
       UserVars.empathylink[target] = Time.now.to_i + 1800 # Put them on hold for 30m
     end
-    # u_script
-  end
-
-  def p_script
-    pause_script('combat-trainer') if Script.running?('combat-trainer')
-  end
-
-  def u_script
-    unpause_script('combat-trainer') if Script.running?('combat-trainer')
   end
 end
 Empathylink.new

--- a/spec/empathylink_spec.rb
+++ b/spec/empathylink_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+# Regression coverage for the pause-handling in empathylink's touch(). The
+# script froze a character when its old p_script/u_script helpers paused
+# combat-trainer directly (outside $safe_pause_lock): combat-trainer's own
+# safe_pause_list paused empathylink between the pause and the unpause, so the
+# two scripts paused each other and neither could recover. touch() now uses the
+# shared safe_pause_list/safe_unpause_list protocol and an ensure block so the
+# unpause (and lock release) always happens.
+describe 'Empathylink#touch' do
+  before(:all) { load_lic_class('empathylink.lic', 'Empathylink') }
+
+  let(:link) do
+    instance = Empathylink.allocate
+    instance.instance_variable_set(:@use_hodierna, false)
+    instance.instance_variable_set(:@buddies, ['Buddy'])
+    instance
+  end
+
+  before do
+    UserVars.empathylink = {}
+    allow(DRC).to receive(:safe_pause_list).and_return(['combat-trainer', 'hunting-buddy'])
+    allow(DRC).to receive(:safe_unpause_list)
+  end
+
+  it 'pauses other scripts through the shared safe-pause lock' do
+    allow(DRC).to receive(:bput).and_return('I could not find')
+
+    link.touch('Buddy')
+
+    expect(DRC).to have_received(:safe_pause_list)
+  end
+
+  it 'unpauses exactly the scripts it paused' do
+    allow(DRC).to receive(:bput).and_return('I could not find')
+
+    link.touch('Buddy')
+
+    expect(DRC).to have_received(:safe_unpause_list).with(['combat-trainer', 'hunting-buddy'])
+  end
+
+  it 'still unpauses when the link cannot be established' do
+    allow(DRC).to receive(:bput).and_return('Touch what')
+
+    link.touch('Buddy')
+
+    expect(DRC).to have_received(:safe_unpause_list).with(['combat-trainer', 'hunting-buddy'])
+  end
+
+  it 'releases the pause lock even when a heal command raises mid-touch' do
+    allow(DRC).to receive(:bput).and_raise(StandardError, 'boom')
+
+    expect { link.touch('Buddy') }.to raise_error(StandardError, 'boom')
+    expect(DRC).to have_received(:safe_unpause_list).with(['combat-trainer', 'hunting-buddy'])
+  end
+
+  it 'retries until it acquires the safe-pause lock before healing' do
+    allow(DRC).to receive(:safe_pause_list).and_return(false, false, ['combat-trainer'])
+    allow(link).to receive(:pause)
+    allow(link).to receive(:echo)
+    allow(DRC).to receive(:bput).and_return('I could not find')
+
+    link.touch('Buddy')
+
+    expect(DRC).to have_received(:safe_pause_list).exactly(3).times
+    expect(DRC).to have_received(:safe_unpause_list).with(['combat-trainer'])
+  end
+
+  it 'no longer pauses combat-trainer directly via the removed p_script/u_script helpers' do
+    expect(link).not_to respond_to(:p_script)
+    expect(link).not_to respond_to(:u_script)
+  end
+end

--- a/spec/empathylink_spec.rb
+++ b/spec/empathylink_spec.rb
@@ -66,8 +66,9 @@ describe 'Empathylink#touch' do
     expect(DRC).to have_received(:safe_unpause_list).with(['combat-trainer'])
   end
 
-  it 'no longer pauses combat-trainer directly via the removed p_script/u_script helpers' do
-    expect(link).not_to respond_to(:p_script)
-    expect(link).not_to respond_to(:u_script)
+  it 'no longer defines the p_script/u_script helpers that paused combat-trainer directly' do
+    # include_all: true so a re-added private/protected helper is still caught
+    expect(link.respond_to?(:p_script, true)).to be(false)
+    expect(link.respond_to?(:u_script, true)).to be(false)
   end
 end


### PR DESCRIPTION
## Problem

empathylink's `touch()` paused combat-trainer directly with `pause_script('combat-trainer')` (`p_script`) and unpaused it afterward (`u_script`), operating entirely **outside** the shared `$safe_pause_lock` that the combat scripts coordinate through via `DRC.safe_pause_list`.

Lich pausing is cooperative — a script flagged paused keeps running until its next checkpoint. When combat-trainer's almanac routine acquired `$safe_pause_lock` and paused empathylink, empathylink (in that grace window) ran on into `touch()` → `p_script` and paused combat-trainer, then suspended at its next `bput` **before** reaching `u_script`. Result:

- combat-trainer was left paused (by empathylink) while still holding `$safe_pause_lock` and having paused the other scripts, so it never reached `safe_unpause_list`.
- empathylink was left paused (by combat-trainer), so it never reached `u_script`.

The two pinned each other, `$safe_pause_lock` was never released, every later script that called `safe_pause_list` spun forever on "Cannot pause, trying again", and the character froze in place.

Observed in a live log: `DRC: Pausing [...] to run combat-trainer` (combat-trainer's almanac study, running in its thread) immediately followed by `--- Lich: combat-trainer paused.` (empathylink's `p_script`) with no matching unpause, then endless `Cannot pause` from other scripts.

## Fix

Replace `p_script`/`u_script` with the `DRC.safe_pause_list` / `DRC.safe_unpause_list` protocol already used by `tarantula` and `tome`. Sharing `$safe_pause_lock` makes the two pause requests mutually exclusive, so neither script can pause the other mid-routine. The heal is wrapped in `begin/ensure` so the unpause and lock release always run, even if a heal command raises.

Behavior note: like tarantula/tome, empathylink now briefly pauses all other safe scripts (not just combat-trainer) for the duration of a heal touch. That window is short and matches the established idiom.

## Tests

Adds `spec/empathylink_spec.rb` covering:
- lock acquisition and retry-until-acquired
- the paused set is always unpaused, including the link-failed branch
- the unpause/lock-release still happens when a heal command raises mid-touch (the core deadlock regression)
- the deadlock-prone `p_script`/`u_script` helpers are gone

Full suite green locally (2907 examples, 0 failures); `rubocop -A` clean on `empathylink.lic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Healing now safely pauses conflicting activities before starting and reliably resumes them afterward.
  * Improved recovery when linking fails or a command encounters an error.
  * Added retries when the safe pause is temporarily unavailable.
* **Tests**
  * Expanded coverage for healing, pause handling, retries, and error cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->