### PR TITLE
Fix train.lic: nil-safe inner_room guard and drop vestigial 'out'

### DIFF
--- a/train.lic
+++ b/train.lic
@@ -86,11 +86,10 @@ class CrossingTrain
 
   def train(info, count)
     DRCT.walk_to info['outer_room']
-    fput "go #{info['inner_room']}" unless info['inner_room'].empty?
+    fput "go #{info['inner_room']}" unless info['inner_room'].to_s.empty?
     target = info['current'] + count
     fput "train #{target}"
     fput "train #{target}"
-    fput 'out'
   end
 
   def find_train(args)


### PR DESCRIPTION
## Summary

The inner/outer training-room split in `train.lic` no longer reflects the mapdb. Every town's actual training room (what used to be the unreachable "inner" room) is now mapped and reachable, and its ID lives in `outer_room`; `inner_room` is `nil` for all six towns × eight stats in `data/base-town.yaml`.

This surfaces two small issues in `CrossingTrain#train`:

1. **Bogus `go ` command every train.** `info['inner_room'].empty?` only worked because Lich's `NilClass#method_missing` patch makes `nil.empty?` return `nil` (falsy) instead of raising. The `unless` guard was written to skip on an empty *string*, but `nil` slips through, so it fired `go ` (bare `go`) on every train — a harmless but pointless "Go where?" error. Guarding on `.to_s.empty?` makes `nil` correctly skip the hop while preserving it for any town that ever populates `inner_room`.

2. **Vestigial `out`.** `walk_to(outer_room)` now lands you directly in the training room, so the trailing `fput 'out'` was a spurious movement. The next stat's `walk_to` navigates from wherever you are, so it's unnecessary. Removed.

## Verification

- Confirmed against the current live mapdb that all 48 `outer_room` IDs (6 towns × 8 stats) resolve to mapped, reachable, thematically-correct training rooms.
- `rubocop` clean on `train.lic`.
- No `train_spec.rb` exists, so no specs are affected.
- Staged on a personal Lich instance for in-game testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)