### PR TITLE
combat-trainer: let sub-300 Theurgy commune Meraud mid-hunt (#7539)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3684,7 +3684,8 @@ class TrainerProcess
   end
 
   def meraud_commune(game_state)
-    unless (DRSkill.getrank('Theurgy') >= 300 || game_state.npcs.empty?) && !game_state.aimed_skill?
+    # Training an aimed weapon skill uses a different stow/wield flow, so skip.
+    if game_state.aimed_skill?
       reset_ability(game_state, 'Meraud')
       return
     end
@@ -3694,6 +3695,14 @@ class TrainerProcess
       return
     end
     waitrt?
+    # The commune is a lengthy, vulnerable ritual (stow weapon, sprinkle holy
+    # water, wave incense, then a ~7s commune). Requiring an empty room meant a
+    # sub-300 Theurgy character almost never got to run it during a hunt, since
+    # the room rarely clears. Retreat out of melee first instead -- the same way
+    # #pray_mat does -- so it can fire mid-hunt. AbilityProcess#execute already
+    # bails when game_state.danger is set, and the 3900s cooldown means this
+    # retreat happens at most once per hunt.
+    DRC.retreat unless game_state.npcs.empty?
     @equipment_manager.stow_weapon(game_state.weapon_name)
     unless DRCTH.sprinkle_holy_water?(@theurgy_supply_container, @water_holder, checkname) && DRCTH.wave_incense?(@theurgy_supply_container, @flint_lighter, checkname)
       DRC.message("Holy water sprinkling, or incense waving routine failed, skipping Meraud commune")

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -4225,6 +4225,95 @@ RSpec.describe 'TrainerProcess#check_heavens' do
   end
 end
 
+# ===================================================================
+# TrainerProcess#meraud_commune (Issue 7539)
+#
+# A sub-300 Theurgy character could only commune in an empty room, so
+# the Meraud commune -- and last_rites, which only fires once the
+# commune sets game_state.blessed_room -- effectively never fired
+# during a hunt (the room rarely clears of npcs). It now retreats out
+# of melee first, the way #pray_mat does, and communes with npcs present.
+# ===================================================================
+RSpec.describe 'TrainerProcess#meraud_commune' do
+  before(:each) { ct_setup }
+
+  def build_meraud_trainer(**overrides)
+    tp = TrainerProcess.allocate
+    defaults = {
+      equipment_manager: double('EquipmentManager', stow_weapon: nil, wield_weapon?: true),
+      theurgy_supply_container: 'sack',
+      water_holder: 'chalice',
+      flint_lighter: 'flint',
+      training_abilities: { 'Meraud' => 3900 }
+    }
+    defaults.merge(overrides).each { |k, v| tp.instance_variable_set(:"@#{k}", v) }
+    tp
+  end
+
+  def build_meraud_state(**attrs)
+    defaults = {
+      aimed_skill?: false,
+      npcs: ['an elder razortusk boar'],
+      weapon_name: 'liscis',
+      weapon_skill: 'Large Edged',
+      cooldown_timers: {}
+    }
+    state = double('GameState', defaults.merge(attrs))
+    allow(state).to receive(:blessed_room=)
+    state
+  end
+
+  before(:each) do
+    allow(DRC).to receive(:retreat)
+    allow(DRC).to receive(:bput)
+    allow(DRC).to receive(:bput).with('commune sense', any_args).and_return('roundtime')
+  end
+
+  it 'retreats past mobs and communes for a hunter (regression: was empty-room-only)' do
+    trainer = build_meraud_trainer
+    state = build_meraud_state
+
+    trainer.send(:meraud_commune, state)
+
+    expect(DRC).to have_received(:retreat)
+    expect(DRC).to have_received(:bput).with('commune meraud', any_args)
+    expect(state).to have_received(:blessed_room=).with(true)
+  end
+
+  it 'does not retreat when the room is already empty' do
+    trainer = build_meraud_trainer
+    state = build_meraud_state(npcs: [])
+
+    trainer.send(:meraud_commune, state)
+
+    expect(DRC).not_to have_received(:retreat)
+    expect(DRC).to have_received(:bput).with('commune meraud', any_args)
+  end
+
+  it 'skips entirely when training an aimed weapon skill' do
+    trainer = build_meraud_trainer
+    state = build_meraud_state(aimed_skill?: true)
+
+    trainer.send(:meraud_commune, state)
+
+    expect(DRC).not_to have_received(:retreat)
+    expect(DRC).not_to have_received(:bput).with('commune meraud', any_args)
+    expect(state.cooldown_timers).to have_key('Meraud')
+  end
+
+  it 'skips the ritual and just marks the room blessed when already a vessel' do
+    trainer = build_meraud_trainer
+    state = build_meraud_state
+    allow(DRC).to receive(:bput).with('commune sense', any_args).and_return('Meraud')
+
+    trainer.send(:meraud_commune, state)
+
+    expect(DRC).not_to have_received(:retreat)
+    expect(DRC).not_to have_received(:bput).with('commune meraud', any_args)
+    expect(state).to have_received(:blessed_room=).with(true)
+  end
+end
+
 # ===========================================================================
 # CombatTrainer plugin system -- registry + hook dispatch
 # ===========================================================================


### PR DESCRIPTION
## Problem

Fixes #7539.

In `combat-trainer.lic`, `meraud_commune` gated the commune on:

```ruby
unless (DRSkill.getrank('Theurgy') >= 300 || game_state.npcs.empty?) && !game_state.aimed_skill?
```

For a character whose Theurgy rank is below 300, that collapses to **"only commune when the room is empty."** During a normal hunt the room rarely clears of npcs (e.g. the reporter's razortusk sows keep breeding), so every tick the guard bailed and re-armed Meraud (with offset 0), and `commune meraud` was never sent. The reporter's logs show `Selected: Meraud` firing 20–59 times with no commune ever issued.

`last_rites` failed for the same root cause: it only runs when `game_state.blessed_room` is true, and `blessed_room` is only ever set inside `meraud_commune`. No commune → no blessed room → no last rites.

(The issue was reported as a Saga-vs-Wrayth front-end problem; on investigation the reporter and I agree the front-end is a red herring — it's the empty-room requirement plus a sub-300 Theurgy rank. The one "working" capture simply started in a clear room before mobs appeared.)

## Fix

Retreat out of melee before the ritual instead of hard-requiring an empty room — the same pattern the sibling Theurgy ritual `pray_mat` already uses. This is safe because `AbilityProcess#execute` already bails when `game_state.danger` is set, and the 3900s cooldown means the retreat happens at most once per hunt. The aimed-weapon-skill skip is preserved.

## Tests

Adds regression specs for `TrainerProcess#meraud_commune`:
- retreats past mobs and communes with npcs present (the regression)
- does not retreat when the room is already empty
- skips entirely when training an aimed weapon skill
- skips the ritual and just marks the room blessed when already a vessel

Full `combat_trainer_spec` passes (327 examples, 0 failures); `rubocop combat-trainer.lic` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)